### PR TITLE
fix(ingest/snowflake): preserve native CLL for single-target stream queries

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -434,12 +434,14 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                     stored_proc_tracker.add_stored_proc_call(query)
                     continue
 
-                if not (
-                    isinstance(query, PreparsedQuery)
-                    and stored_proc_tracker.add_related_query(query)
-                ):
-                    # Only add to aggregator if it's not part of a stored procedure.
-                    self.aggregator.add(query)
+                # Stored-proc child queries go to both the tracker (for synthetic
+                # proc-level lineage) and the aggregator (for per-query CLL).
+                # The tracker produces table-level-only lineage; without the
+                # aggregator copy, native column-level lineage from the audit
+                # log would be discarded for queries inside stored procs.
+                if isinstance(query, PreparsedQuery):
+                    stored_proc_tracker.add_related_query(query)
+                self.aggregator.add(query)
 
             # Generate and add stored procedure lineage entries.
             for lineage_entry in stored_proc_tracker.build_merged_lineage_entries():
@@ -703,9 +705,8 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
         is_create_view = query_type == QueryType.CREATE_VIEW
         is_create_temp_view = is_create_view and self._has_temp_keyword(query_text)
 
-        stream_clean_multi_target: bool = (
+        stream_clean: bool = (
             has_stream_objects
-            and is_multi_target
             and not has_corrupt_object_names
             and not has_unknown_dollar_prefix
         )
@@ -713,14 +714,11 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
         # Stream-bypass: Snowflake leaks $SYS_VIEW_<id> placeholder names into the
         # audit log for some stream-driven queries (undocumented; observed empirically).
         # URNs built from those names are unusable, so we fall back to sqlglot parsing
-        # via ObservedQuery.  Single-target stream queries also stay on this path
-        # because PR #15391's per-downstream logic only helps multi-target INSERT ALL;
-        # routing a single-target query through it would add no value.
+        # via ObservedQuery.  Clean stream queries (no placeholders, no unknown $-prefix)
+        # proceed to the PreparsedQuery path to preserve native CLL from directSources.
         # CREATE TEMPORARY VIEW takes the bypass regardless of stream presence because
         # sqlglot resolves temp-view references correctly without audit-log metadata.
-        if (
-            has_stream_objects and not stream_clean_multi_target
-        ) or is_create_temp_view:
+        if (has_stream_objects and not stream_clean) or is_create_temp_view:
             if has_stream_objects:
                 self.report.num_stream_queries_observed += 1
                 self.report.num_stream_bypass_by_query_type[snowflake_query_type] = (
@@ -755,10 +753,24 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
             )
             return
 
-        # Reaching here with has_stream_objects=True means stream_clean_multi_target
-        # is True (the bypass above returned early for all other stream cases).
-        if stream_clean_multi_target:
+        # Reaching here with has_stream_objects=True means stream_clean is True
+        # (the bypass above returned early for all other stream cases).
+        if stream_clean:
             self.report.num_stream_queries_clean_fast_path += 1
+            n_cll_cols = sum(
+                len(col.get("directSources") or [])
+                for obj in objects_modified
+                for col in obj.get("columns") or []
+            )
+            downstream_names = [obj.get("objectName", "?") for obj in objects_modified]
+            logger.info(
+                "Stream query preserved on PreparsedQuery path: "
+                "query_id=%s, query_type=%s, cll_columns=%d, downstreams=%s",
+                res["query_id"],
+                snowflake_query_type,
+                n_cll_cols,
+                downstream_names,
+            )
 
         if snowflake_query_type == "CALL" and res["root_query_id"] is None:
             yield StoredProcCall(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -213,9 +213,13 @@ class SnowflakeQueriesExtractorReport(Report):
     num_ddl_queries_dropped: int = 0
     num_stream_queries_observed: int = 0
     num_stream_queries_clean_fast_path: int = 0
+    num_stream_bypass_by_query_type: Dict[str, int] = dataclasses.field(
+        default_factory=dict
+    )
     num_create_temp_view_queries_observed: int = 0
     num_audit_rows_missing_object_name: int = 0
     num_audit_rows_unknown_dollar_prefix: int = 0
+    num_query_type_counts: Dict[str, int] = dataclasses.field(default_factory=dict)
     num_users: int = 0
     num_queries_with_empty_column_name: int = 0
     queries_with_empty_column_name: LossyList[str] = dataclasses.field(
@@ -616,6 +620,10 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
             snowflake_query_type, QueryType.UNKNOWN
         )
 
+        self.report.num_query_type_counts[snowflake_query_type] = (
+            self.report.num_query_type_counts.get(snowflake_query_type, 0) + 1
+        )
+
         direct_objects_accessed = res["direct_objects_accessed"] or []
         objects_modified = res["objects_modified"] or []
         object_modified_by_ddl = res["object_modified_by_ddl"]
@@ -715,10 +723,17 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
         ) or is_create_temp_view:
             if has_stream_objects:
                 self.report.num_stream_queries_observed += 1
-                logger.debug(
+                self.report.num_stream_bypass_by_query_type[snowflake_query_type] = (
+                    self.report.num_stream_bypass_by_query_type.get(
+                        snowflake_query_type, 0
+                    )
+                    + 1
+                )
+                logger.info(
                     "Snowflake stream-bypass fired for query_id=%s "
-                    "(corrupt=%s, unknown_dollar=%s, multi_target=%s)",
+                    "(query_type=%s, corrupt=%s, unknown_dollar=%s, multi_target=%s)",
                     res["query_id"],
+                    snowflake_query_type,
                     has_corrupt_object_names,
                     has_unknown_dollar_prefix,
                     is_multi_target,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -727,7 +727,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                     )
                     + 1
                 )
-                logger.info(
+                logger.debug(
                     "Snowflake stream-bypass fired for query_id=%s "
                     "(query_type=%s, corrupt=%s, unknown_dollar=%s, multi_target=%s)",
                     res["query_id"],
@@ -763,7 +763,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                 for col in obj.get("columns") or []
             )
             downstream_names = [obj.get("objectName", "?") for obj in objects_modified]
-            logger.info(
+            logger.debug(
                 "Stream query preserved on PreparsedQuery path: "
                 "query_id=%s, query_type=%s, cll_columns=%d, downstreams=%s",
                 res["query_id"],

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/stored_proc_lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/stored_proc_lineage.py
@@ -103,7 +103,7 @@ class StoredProcLineageTracker(Closeable):
             if query.downstream is not None:
                 stored_proc_execution.outputs.append(query.downstream)
             self.report.num_related_queries += 1
-            logger.info(
+            logger.debug(
                 "Stored proc tracker captured query: root_id=%s, "
                 "downstream=%s, num_upstreams=%d, query_type=%s",
                 snowflake_root_query_id,
@@ -121,7 +121,7 @@ class StoredProcLineageTracker(Closeable):
         # create dataJobInputOutput lineage instead.
 
         for stored_proc_execution in self._stored_proc_execution_lineage.values():
-            logger.info(
+            logger.debug(
                 "Stored proc %s: inputs=%d, outputs=%d, call=%.120s",
                 stored_proc_execution.call.snowflake_root_query_id,
                 len(stored_proc_execution.inputs),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/stored_proc_lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/stored_proc_lineage.py
@@ -1,4 +1,5 @@
 import dataclasses
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Iterable, List, Optional
@@ -11,6 +12,8 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
 )
 from datahub.sql_parsing.sqlglot_utils import get_query_fingerprint
 from datahub.utilities.file_backed_collections import FileBackedDict
+
+logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -100,6 +103,14 @@ class StoredProcLineageTracker(Closeable):
             if query.downstream is not None:
                 stored_proc_execution.outputs.append(query.downstream)
             self.report.num_related_queries += 1
+            logger.info(
+                "Stored proc tracker captured query: root_id=%s, "
+                "downstream=%s, num_upstreams=%d, query_type=%s",
+                snowflake_root_query_id,
+                query.downstream,
+                len(query.upstreams),
+                (query.extra_info or {}).get("snowflake_query_type"),
+            )
             return True
 
         return False
@@ -110,6 +121,13 @@ class StoredProcLineageTracker(Closeable):
         # create dataJobInputOutput lineage instead.
 
         for stored_proc_execution in self._stored_proc_execution_lineage.values():
+            logger.info(
+                "Stored proc %s: inputs=%d, outputs=%d, call=%.120s",
+                stored_proc_execution.call.snowflake_root_query_id,
+                len(stored_proc_execution.inputs),
+                len(stored_proc_execution.outputs),
+                stored_proc_execution.call.query_text,
+            )
             if not stored_proc_execution.inputs:
                 self.report.num_stored_proc_calls_with_no_inputs += 1
                 continue

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_queries.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_queries.py
@@ -2234,8 +2234,8 @@ class TestStreamUpstreamMultiTableInsert:
         assert isinstance(results[0], ObservedQuery)
         assert extractor.report.num_create_temp_view_queries_observed == 1
 
-    def test_single_target_stream_falls_back_unchanged(self):
-        """Single-target stream INSERT -> bypass (only multi-target uses fast path)."""
+    def test_single_target_clean_stream_uses_preparsed_path(self):
+        """Single-target stream INSERT with clean metadata -> PreparsedQuery with CLL."""
         extractor = self._create_mock_extractor()
         single_target = [
             {
@@ -2269,9 +2269,15 @@ class TestStreamUpstreamMultiTableInsert:
         results = list(extractor._parse_audit_log_row(row, {}))
 
         assert len(results) == 1
-        assert isinstance(results[0], ObservedQuery)
-        assert extractor.report.num_stream_queries_observed == 1
-        assert extractor.report.num_stream_queries_clean_fast_path == 0
+        assert isinstance(results[0], PreparsedQuery)
+        assert results[0].downstream == self.DOWNSTREAM_PROFILE_URN
+        assert results[0].upstreams == [self.UPSTREAM_STREAM_URN]
+        assert results[0].column_lineage and len(results[0].column_lineage) == 1
+        cl = results[0].column_lineage[0]
+        assert len(cl.upstreams) == 1
+        assert cl.upstreams[0].table == self.UPSTREAM_STREAM_URN
+        assert extractor.report.num_stream_queries_observed == 0
+        assert extractor.report.num_stream_queries_clean_fast_path == 1
 
     def test_multi_target_stream_with_unknown_dollar_prefix_falls_back(self):
         """$-prefix objectName that isn't $SYS_VIEW_ -> bypass + drift counter."""


### PR DESCRIPTION
## Summary

The stream bypass unconditionally routed all single-target stream-driven queries (MERGE, INSERT, UPDATE, DELETE) through sqlglot via `ObservedQuery`, discarding Snowflake's native column-level lineage from `objects_modified.columns.directSources`. sqlglot cannot produce CLL for MERGE INTO, so these queries lost CLL entirely despite clean audit log data.

**Changes:**

- **Relax stream bypass** — only fires when there are actual `$SYS_VIEW_*` placeholders or unknown `$`-prefixed names. Clean single-target stream queries now flow through the `PreparsedQuery` path, preserving native CLL.
- **Forward stored-proc child queries to aggregator** — `PreparsedQuery` entries from stored procs now go to both the tracker (for proc-level lineage) and the SQL aggregator (for per-query CLL). Previously the tracker captured them exclusively and produced table-level-only synthetic lineage, stripping CLL.
- **Instrumentation** — `num_stream_bypass_by_query_type` and `num_query_type_counts` report counters for production observability. All per-query logs at DEBUG level.

## Test plan
- [x] `lintFix` passes
- [x] `TestStreamUpstreamMultiTableInsert` — 11 tests pass (updated test asserts `PreparsedQuery` with CLL for single-target clean stream)
- [x] `test_stored_proc_lineage.py` — 7 tests pass
- [x] All 632 snowflake unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes Snowflake query audit routing so **native column-level lineage** from `access_history` is kept in more cases, and adds **report counters and debug logs** to debug stream MERGE and stored-proc gaps.
> 
> **Stream queries:** The stream “fast path” no longer requires **multi-target** `objects_modified`. Any stream-backed row with **clean** metadata (no `$SYS_VIEW_*` or unknown `$` names) goes through **`PreparsedQuery`** and `directSources`, including **single-target** stream INSERTs that previously always fell through to **`ObservedQuery`/sqlglot**. Bypass still applies when metadata is corrupt or for **CREATE TEMPORARY VIEW**.
> 
> **Stored procedures:** Child **`PreparsedQuery`** rows are still registered on the stored-proc tracker, but are **always** passed to the SQL aggregator as well, so per-query CLL is not dropped when synthetic proc-level lineage is built.
> 
> **Observability:** New report fields `num_query_type_counts` and `num_stream_bypass_by_query_type`, richer stream-bypass / fast-path **debug** logging, and stored-proc capture/merge **debug** lines in `StoredProcLineageTracker`. Unit test updated for single-target clean stream → `PreparsedQuery` with CLL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cacbe56052dc40050dc941d89a21728f83479ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->