### PR TITLE
docs(mcp): two self-hosted troubleshooting entries

### DIFF
--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -622,3 +622,51 @@ The full stack trace might look like this:
 ```
 
 Solution: Replace the `uvx` bit of the command with the output of `which uvx`.
+
+#### The server starts, but never answers `initialize`
+
+The client shows no error and no response, just a stall of roughly forty seconds
+before anything happens. Running the server by hand shows why:
+
+```
+WARNING:urllib3.connectionpool:Retrying (Retry(total=3, ...)) after connection broken by
+  'ConnectTimeoutError(<HTTPSConnection(host='track.datahubproject.io', port=443)>,
+   'Connection to track.datahubproject.io timed out. (connect timeout=10)')': /mp/engage
+```
+
+The startup usage ping is sent before the MCP handshake completes, so on a host
+that cannot reach `track.datahubproject.io` the retries block the handshake
+itself. Because the protocol has not started yet, the client has nothing to
+report and simply waits.
+
+This is common on air-gapped hosts, and on cloud instances whose security group
+or egress proxy allows the DataHub GMS endpoint but not outbound HTTPS in
+general.
+
+Solution: disable telemetry in the server's environment.
+
+```json
+"env": {
+  "DATAHUB_GMS_URL": "<your-datahub-url>",
+  "DATAHUB_GMS_TOKEN": "<your-datahub-token>",
+  "DATAHUB_TELEMETRY_ENABLED": "false"
+}
+```
+
+#### `type` is missing from `search` results
+
+Tool responses are trimmed so that an answer fits inside a model's context
+window, and entity `type` is one of the fields dropped from `search` results.
+The same call made through the in-process `datahub-agent-context` SDK does
+return it.
+
+This matters when a client filters results by entity kind. The filter works
+against the SDK and matches nothing over MCP, without raising an error.
+
+Solution: derive the entity kind from the URN rather than the field, since the
+URN is the identifier and is always present.
+
+```python
+# urn:li:dataset:(urn:li:dataPlatform:postgres,db.schema.table,PROD) -> dataset
+kind = urn.split(":")[2]
+```


### PR DESCRIPTION
Two entries for the self-hosted troubleshooting section, both hit while running
`mcp-server-datahub` against a self-hosted DataHub Core instance (GMS v1.5.0.6,
server `datahub 3.4.5`) on an EC2 host with restricted egress.

Both fail silently, which is why they seemed worth writing down. Neither
produces an error a client can surface.

**1. The server never answers `initialize`.**

The startup usage ping to `track.datahubproject.io` is sent before the MCP
handshake completes. On a host that cannot reach it, urllib3 retries four times
at a ten second connect timeout, and because this happens before the protocol
starts the client has nothing to report and just waits. My first session looked
like a hang with no output at all; it took running the server by hand and
reading stderr to see the retries.

This is not exotic: it is the default state of an air-gapped host, and of any
cloud instance whose egress rules allow the GMS endpoint but not general
outbound HTTPS.

The fix is `DATAHUB_TELEMETRY_ENABLED=false`, which is documented for the CLI
but easy to miss here, since nothing about the symptom points at telemetry.

**2. `type` is absent from `search` results over MCP.**

Responses are trimmed to fit a model's context window, and entity `type` is one
of the dropped fields. The same call through `datahub-agent-context` in process
does return it. A client that filters search results by entity kind therefore
works against the SDK and matches nothing over MCP, with no error either way.
Suggesting the URN as the source instead, since it is the identifier and cannot
be trimmed.

Docs only, no code changes.
