### PR TITLE
docs(incidents): list the entity types that support incidents

### DIFF
--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -86,7 +86,8 @@ input RaiseIncidentInput {
   description: String
 
   """
-  The resource (dataset, dashboard, chart, dataFlow, etc) that the incident is associated with.
+  The resource that the incident is associated with. See the supported entity
+  types below.
   """
   resourceUrn: String!
 
@@ -96,6 +97,33 @@ input RaiseIncidentInput {
   source: IncidentSourceInput
 }
 ```
+
+### Supported entity types
+
+Incidents are stored on the entity named by `resourceUrn`, so that entity must
+carry the `incidentsSummary` aspect. As of the current entity registry, that is:
+
+| Entity | URN prefix |
+| --- | --- |
+| Dataset | `urn:li:dataset:` |
+| Data Job | `urn:li:dataJob:` |
+| Data Flow | `urn:li:dataFlow:` |
+| Chart | `urn:li:chart:` |
+| Dashboard | `urn:li:dashboard:` |
+| Service | `urn:li:service:` |
+| AI Agent | `urn:li:aiAgent:` |
+
+Anything else is rejected at the entity layer, and nothing is written:
+
+```
+"urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD) is not a valid destination"
+```
+
+ML entities are worth calling out because they are a natural thing to reach for.
+`mlModel`, `mlModelGroup`, `mlFeatureTable` and `mlFeature` do **not** support
+incidents. For an issue concerning a model, raise the incident on the dataset
+the model was trained on, which is reachable from the model in one hop of
+lineage, and name the model in the title.
 
 ### Examples
 

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -87,9 +87,15 @@ input RaiseIncidentInput {
 
   """
   The resource that the incident is associated with. See the supported entity
-  types below.
+  types below. Must be present if resourceUrns is not defined.
   """
-  resourceUrn: String!
+  resourceUrn: String
+
+  """
+  The resources that the incident is associated with, for a multi-resource
+  incident. Must be present and not empty if resourceUrn is not defined.
+  """
+  resourceUrns: [String!]
 
   """
   The source of the incident, i.e. how it was generated
@@ -113,11 +119,11 @@ set today. Every entity passed in `resourceUrn`, and every entity in the
    Without it, the incident exists but the entity has no rolled-up state.
 3. **Can it be read back?** An `extend type` block in `incident.graphql` is what
    gives the entity an `incidents` field. Without it, the incident cannot be
-   fetched through the GraphQL API for that entity.
+   listed from that entity, though it can still be fetched on its own by URN.
 
 An entity can clear layer 1 and fail the other two. That is a worse outcome than a
 clean rejection, because the call succeeds and returns an incident URN while the
-incident is effectively unreadable.
+entity it names never shows the incident.
 
 The table below is generated at docs build time from those three files, so it
 cannot drift from the code the way a hand-maintained list does.
@@ -141,8 +147,10 @@ ML entities are worth calling out, because they are a natural thing to reach for
 and because a write to one can look like it worked. `mlModel` and `mlFeature` are
 on the `IncidentOn` list, so the write is accepted and returns an incident URN,
 but neither carries `incidentsSummary` and neither exposes an `incidents` field in
-GraphQL. Nothing reads the incident back and nothing renders it on the entity
-page. Closing that gap is tracked in
+GraphQL. The incident itself is still readable: `Incident` implements `Entity`, so
+the returned URN can be passed to the generic `entity(urn: ...)` query. What is
+missing is the asset side. Nothing lists the incident from the model or feature,
+and nothing renders it on the entity page. Closing that gap is tracked in
 [#18911](https://github.com/datahub-project/datahub/issues/18911).
 
 Until it closes, raise the incident on a training dataset linked to the model,

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -106,10 +106,11 @@ input RaiseIncidentInput {
 
 ### Supported entity types
 
-Incident support is not a single switch. Three separate layers decide what happens
-to an incident raised on a given entity type, and they do not all cover the same
-set today. Every entity passed in `resourceUrn`, and every entity in the
-`resourceUrns` list for a multi-resource incident, goes through all three.
+Incident support is not a single switch. It is declared independently in several
+places, and they do not all cover the same set. Four of them are backend and decide
+what happens to an incident raised through the API. Every entity passed in
+`resourceUrn`, and every entity in the `resourceUrns` list for a multi-resource
+incident, goes through all four.
 
 1. **Can it be raised?** The `IncidentOn` relationship in `IncidentInfo.pdl` lists
    the entity types accepted as incident resources. A type not on this list is
@@ -117,21 +118,27 @@ set today. Every entity passed in `resourceUrn`, and every entity in the
 2. **Is it summarised?** The `incidentsSummary` aspect on the entity in
    `entity-registry.yml` is what keeps an entity's active incident count current.
    Without it, the incident exists but the entity has no rolled-up state.
-3. **Can it be read back?** An `extend type` block in `incident.graphql` is what
-   gives the entity an `incidents` field. Without it, the incident cannot be
-   listed from that entity, though it can still be fetched on its own by URN.
+3. **Is the field declared?** An `extend type` block in `incident.graphql` is what
+   gives the entity an `incidents` field in the schema.
+4. **Is the field wired?** The entity's GraphQL type has to appear in the
+   `entitiesWithIncidents` list in `GmsGraphQLEngine.java`, which is what attaches
+   the resolver behind that field.
 
-An entity can clear layer 1 and fail the other two. That is a worse outcome than a
-clean rejection, because the call succeeds and returns an incident URN while the
-entity it names never shows the incident.
+Gates 3 and 4 are reported separately because declaring the field without wiring a
+resolver behind it does not fail. The query is valid and `incidents` comes back
+null, which reads as an entity with no incidents rather than as an unsupported one.
 
-The table below is generated at docs build time from those three files, so it
-cannot drift from the code the way a hand-maintained list does.
+An entity can clear gate 1 and fail the rest. That is a worse outcome than a clean
+rejection, because the call succeeds and returns an incident URN while the entity
+it names never shows the incident.
+
+The table below is generated at docs build time from those four files, so it cannot
+drift from the code the way a hand-maintained list does.
 
 {{ inline /docs/generated/incidents/entity-support.md.snippet }}
 
-Any type absent from the table, including `mlModelGroup`, `mlFeatureTable` and
-`dataProcessInstance`, is rejected at layer 1 and nothing is written.
+Any type absent from the table, including `mlModelGroup`, `mlModelDeployment` and
+`dataProcessInstance`, is rejected at gate 1 and nothing is written.
 
 A rejected destination fails the whole mutation, including any other entity sent
 in the same call. The wording has changed between releases, so search for the
@@ -143,24 +150,28 @@ java.lang.RuntimeException: Invalid format for aspect: incident
         Entity type for urn: <urn> is not a valid destination for field path: /entities/*
 ```
 
-ML entities are worth calling out, because they are a natural thing to reach for
-and because a write to one can look like it worked. `mlModel` and `mlFeature` are
-on the `IncidentOn` list, so the write is accepted and returns an incident URN,
-but neither carries `incidentsSummary` and neither exposes an `incidents` field in
-GraphQL. The incident itself is still readable: `Incident` implements `Entity`, so
-the returned URN can be passed to the generic `entity(urn: ...)` query. What is
-missing is the asset side. Nothing lists the incident from the model or feature,
-and nothing renders it on the entity page. Closing that gap is tracked in
-[#18911](https://github.com/datahub-project/datahub/issues/18911).
+`service` and `aiAgent` are the two types where a write can look like it worked and
+then go nowhere. Both are on the `IncidentOn` list and both carry
+`incidentsSummary`, so the call is accepted and returns an incident URN, but
+neither has a GraphQL type to hang an `incidents` field on in the first place. The
+incident itself is still readable: `Incident` implements `Entity`, so the returned
+URN can be passed to the generic `entity(urn: ...)` query. What is missing is the
+asset side. Nothing lists the incident from the service or agent, and nothing
+renders it. Until that closes, raise the incident on a dataset the service reads or
+writes and name the service in the title.
 
-Until it closes, raise the incident on a training dataset linked to the model,
-directly or through a training run, and name the model in the title.
+`schemaField` is a deliberate half. All four backend gates are closed, so field
+level incidents can be raised, summarised and listed through the API, but there is
+no Incidents tab on a field today, so the UI will not show them. Treat it as an API
+feature.
 
-The frontend adds two further copies of the same list, in the `activeIncidents`
-badge alias and in the per-type inline fragments of `getEntityIncidents`. They are
-not derived here because they live outside the metadata model, and keeping them
-from drifting is the subject of
-[#19097](https://github.com/datahub-project/datahub/pull/19097).
+Three further copies of the same list live outside the metadata model, so they are
+not derived here: the `activeIncidents` badge alias and the per-type inline
+fragments of `getEntityIncidents` in the frontend, and the fragments in the MCP
+`list_incidents` query. Keeping the frontend two from drifting is the subject of
+[#19097](https://github.com/datahub-project/datahub/pull/19097), and the wider
+entity-support plan is tracked in
+[#19322](https://github.com/datahub-project/datahub/issues/19322).
 
 ### Examples
 

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -113,10 +113,18 @@ carry the `incidentsSummary` aspect. As of the current entity registry, that is:
 | Service | `urn:li:service:` |
 | AI Agent | `urn:li:aiAgent:` |
 
-Anything else is rejected at the entity layer, and nothing is written:
+Anything else is rejected and nothing is written. Two different messages come
+back for the same failure, depending on which validation the request trips
+first, so both are listed here:
 
 ```
 "urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD) is not a valid destination"
+```
+
+```
+java.lang.RuntimeException: Invalid format for aspect: incident
+ Cause: ERROR :: /entities/0 :: "Provided urn urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD)" is invalid:
+        Entity type for urn urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD) is not supported
 ```
 
 ML entities are worth calling out because they are a natural thing to reach for.

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -100,38 +100,58 @@ input RaiseIncidentInput {
 
 ### Supported entity types
 
-Incidents are stored on the entity named by `resourceUrn`, so that entity must
-carry the `incidentsSummary` aspect. As of the current entity registry, that is:
+Whether an entity supports incidents is decided in three separate places, and
+they do not all agree today. Every entity passed in `resourceUrn`, and every
+entity in the `resourceUrns` list for a multi-resource incident, is subject to
+all three.
 
-| Entity | URN prefix |
-| --- | --- |
-| Dataset | `urn:li:dataset:` |
-| Data Job | `urn:li:dataJob:` |
-| Data Flow | `urn:li:dataFlow:` |
-| Chart | `urn:li:chart:` |
-| Dashboard | `urn:li:dashboard:` |
-| Service | `urn:li:service:` |
-| AI Agent | `urn:li:aiAgent:` |
+1. **Accepts a write.** The `IncidentOn` relationship on `IncidentInfo.pdl`
+   lists the entity types `raiseIncident` will accept as a destination.
+2. **Carries a summary.** The `incidentsSummary` aspect, declared per entity in
+   the entity registry, is what `IncidentsSummaryHook` maintains on the asset.
+3. **Can be read back.** GraphQL exposes `incidents` only on the types that
+   `incident.graphql` extends and that are wired to a resolver.
 
-Anything else is rejected and nothing is written. Two different messages come
-back for the same failure, depending on which validation the request trips
-first, so both are listed here:
+As of the current entity registry:
 
-```
-"urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD) is not a valid destination"
-```
+| Entity       | URN prefix            | Accepts a write | Carries a summary | Readable in GraphQL |
+| ------------ | --------------------- | --------------- | ----------------- | ------------------- |
+| Dataset      | `urn:li:dataset:`     | yes             | yes               | yes                 |
+| Data Job     | `urn:li:dataJob:`     | yes             | yes               | yes                 |
+| Data Flow    | `urn:li:dataFlow:`    | yes             | yes               | yes                 |
+| Chart        | `urn:li:chart:`       | yes             | yes               | yes                 |
+| Dashboard    | `urn:li:dashboard:`   | yes             | yes               | yes                 |
+| Service      | `urn:li:service:`     | yes             | yes               | no                  |
+| AI Agent     | `urn:li:aiAgent:`     | yes             | yes               | no                  |
+| ML Model     | `urn:li:mlModel:`     | yes             | no                | no                  |
+| ML Feature   | `urn:li:mlFeature:`   | yes             | no                | no                  |
+| Schema Field | `urn:li:schemaField:` | yes             | no                | no                  |
+
+Only the first five are supported end to end. Any type not listed at all,
+including `mlModelGroup`, `mlFeatureTable` and `dataProcessInstance`, is
+rejected outright and nothing is written.
+
+A rejected destination fails the whole mutation, including any other entity
+sent in the same call. The wording has changed between releases, so search for
+the entity type rather than the sentence:
 
 ```
 java.lang.RuntimeException: Invalid format for aspect: incident
- Cause: ERROR :: /entities/0 :: "Provided urn urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD)" is invalid:
-        Entity type for urn urn:li:mlModel:(urn:li:dataPlatform:mlflow,my-model,PROD) is not supported
+ Cause: ERROR :: /entities/0 :: "Provided urn <urn>" is invalid:
+        Entity type for urn: <urn> is not a valid destination for field path: /entities/*
 ```
 
-ML entities are worth calling out because they are a natural thing to reach for.
-`mlModel`, `mlModelGroup`, `mlFeatureTable` and `mlFeature` do **not** support
-incidents. For an issue concerning a model, raise the incident on the dataset
-the model was trained on, which is reachable from the model in one hop of
-lineage, and name the model in the title.
+ML entities are worth calling out, because they are a natural thing to reach
+for and because a write to one can look like it worked. On a build that
+includes [#18478](https://github.com/datahub-project/datahub/pull/18478),
+`mlModel` and `mlFeature` accept the write and return an incident URN, but
+neither type exposes an `incidents` field in GraphQL, so nothing reads it back
+and nothing renders it on the entity page. On earlier builds the same call is
+rejected. Closing that gap is tracked in
+[#18911](https://github.com/datahub-project/datahub/issues/18911).
+
+Until it closes, raise the incident on a training dataset linked to the model,
+directly or through a training run, and name the model in the title.
 
 ### Examples
 

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -100,40 +100,36 @@ input RaiseIncidentInput {
 
 ### Supported entity types
 
-Whether an entity supports incidents is decided in three separate places, and
-they do not all agree today. Every entity passed in `resourceUrn`, and every
-entity in the `resourceUrns` list for a multi-resource incident, is subject to
-all three.
+Incident support is not a single switch. Three separate layers decide what happens
+to an incident raised on a given entity type, and they do not all cover the same
+set today. Every entity passed in `resourceUrn`, and every entity in the
+`resourceUrns` list for a multi-resource incident, goes through all three.
 
-1. **Accepts a write.** The `IncidentOn` relationship on `IncidentInfo.pdl`
-   lists the entity types `raiseIncident` will accept as a destination.
-2. **Carries a summary.** The `incidentsSummary` aspect, declared per entity in
-   the entity registry, is what `IncidentsSummaryHook` maintains on the asset.
-3. **Can be read back.** GraphQL exposes `incidents` only on the types that
-   `incident.graphql` extends and that are wired to a resolver.
+1. **Can it be raised?** The `IncidentOn` relationship in `IncidentInfo.pdl` lists
+   the entity types accepted as incident resources. A type not on this list is
+   rejected and nothing is written.
+2. **Is it summarised?** The `incidentsSummary` aspect on the entity in
+   `entity-registry.yml` is what keeps an entity's active incident count current.
+   Without it, the incident exists but the entity has no rolled-up state.
+3. **Can it be read back?** An `extend type` block in `incident.graphql` is what
+   gives the entity an `incidents` field. Without it, the incident cannot be
+   fetched through the GraphQL API for that entity.
 
-As of the current entity registry:
+An entity can clear layer 1 and fail the other two. That is a worse outcome than a
+clean rejection, because the call succeeds and returns an incident URN while the
+incident is effectively unreadable.
 
-| Entity       | URN prefix            | Accepts a write | Carries a summary | Readable in GraphQL |
-| ------------ | --------------------- | --------------- | ----------------- | ------------------- |
-| Dataset      | `urn:li:dataset:`     | yes             | yes               | yes                 |
-| Data Job     | `urn:li:dataJob:`     | yes             | yes               | yes                 |
-| Data Flow    | `urn:li:dataFlow:`    | yes             | yes               | yes                 |
-| Chart        | `urn:li:chart:`       | yes             | yes               | yes                 |
-| Dashboard    | `urn:li:dashboard:`   | yes             | yes               | yes                 |
-| Service      | `urn:li:service:`     | yes             | yes               | no                  |
-| AI Agent     | `urn:li:aiAgent:`     | yes             | yes               | no                  |
-| ML Model     | `urn:li:mlModel:`     | yes             | no                | no                  |
-| ML Feature   | `urn:li:mlFeature:`   | yes             | no                | no                  |
-| Schema Field | `urn:li:schemaField:` | yes             | no                | no                  |
+The table below is generated at docs build time from those three files, so it
+cannot drift from the code the way a hand-maintained list does.
 
-Only the first five are supported end to end. Any type not listed at all,
-including `mlModelGroup`, `mlFeatureTable` and `dataProcessInstance`, is
-rejected outright and nothing is written.
+{{ inline /docs/generated/incidents/entity-support.md.snippet }}
 
-A rejected destination fails the whole mutation, including any other entity
-sent in the same call. The wording has changed between releases, so search for
-the entity type rather than the sentence:
+Any type absent from the table, including `mlModelGroup`, `mlFeatureTable` and
+`dataProcessInstance`, is rejected at layer 1 and nothing is written.
+
+A rejected destination fails the whole mutation, including any other entity sent
+in the same call. The wording has changed between releases, so search for the
+entity type rather than for the exact sentence. On v1.5.0.6 the rejection reads:
 
 ```
 java.lang.RuntimeException: Invalid format for aspect: incident
@@ -141,17 +137,22 @@ java.lang.RuntimeException: Invalid format for aspect: incident
         Entity type for urn: <urn> is not a valid destination for field path: /entities/*
 ```
 
-ML entities are worth calling out, because they are a natural thing to reach
-for and because a write to one can look like it worked. On a build that
-includes [#18478](https://github.com/datahub-project/datahub/pull/18478),
-`mlModel` and `mlFeature` accept the write and return an incident URN, but
-neither type exposes an `incidents` field in GraphQL, so nothing reads it back
-and nothing renders it on the entity page. On earlier builds the same call is
-rejected. Closing that gap is tracked in
+ML entities are worth calling out, because they are a natural thing to reach for
+and because a write to one can look like it worked. `mlModel` and `mlFeature` are
+on the `IncidentOn` list, so the write is accepted and returns an incident URN,
+but neither carries `incidentsSummary` and neither exposes an `incidents` field in
+GraphQL. Nothing reads the incident back and nothing renders it on the entity
+page. Closing that gap is tracked in
 [#18911](https://github.com/datahub-project/datahub/issues/18911).
 
 Until it closes, raise the incident on a training dataset linked to the model,
 directly or through a training run, and name the model in the title.
+
+The frontend adds two further copies of the same list, in the `activeIncidents`
+badge alias and in the per-type inline fragments of `getEntityIncidents`. They are
+not derived here because they live outside the metadata model, and keeping them
+from drifting is the subject of
+[#19097](https://github.com/datahub-project/datahub/pull/19097).
 
 ### Examples
 

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -142,17 +142,24 @@ task modelDocGen(type: Exec, dependsOn: [codegen]) {
   def schemasRoot = "${datahubRoot}/metadata-events/mxe-schemas/src/mainGeneratedAvroSchema/avro/"
   def entityRegistry = "${datahubRoot}/metadata-models/src/main/resources/entity-registry.yml"
   def metadataModelDocsRoot = "${datahubRoot}/metadata-models/docs"
-  
+  def incidentSupportOutput = "${datahubRoot}/docs/generated/incidents/entity-support.md.snippet"
+  def incidentPdl = "${datahubRoot}/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl"
+  def incidentSdl = "${datahubRoot}/datahub-graphql-core/src/main/resources/incident.graphql"
+
   inputs.files(
     file('scripts/modeldocgen.py'),
     project.fileTree(dir: "../metadata-models/docs/entities/", include: "**/*.md"),
     file("../metadata-models/docs/entity_descriptions.yaml"),
     project.fileTree(dir: "examples/", include: "**/*.py"),
-    project.fileTree(dir: "../metadata-events/mxe-schemas/src/", include: "**/*.avsc")
+    project.fileTree(dir: "../metadata-events/mxe-schemas/src/", include: "**/*.avsc"),
+    file(entityRegistry),
+    file(incidentPdl),
+    file(incidentSdl)
   )
   outputs.dir('../docs/generated/metamodel')
-  
-  commandLine 'bash', '-c', "${venv_activate_command} python scripts/modeldocgen.py ${schemasRoot} --registry ${entityRegistry} --generated-docs-dir ${docsOutdir} --file ${outdir}/metadata_model_mces.json --extra-docs ${metadataModelDocsRoot}"
+  outputs.file(incidentSupportOutput)
+
+  commandLine 'bash', '-c', "${venv_activate_command} python scripts/modeldocgen.py ${schemasRoot} --registry ${entityRegistry} --generated-docs-dir ${docsOutdir} --file ${outdir}/metadata_model_mces.json --extra-docs ${metadataModelDocsRoot} --incident-support-output ${incidentSupportOutput}"
 }
 
 task lineageGen(type: Exec, dependsOn: [codegen]) {

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -145,6 +145,7 @@ task modelDocGen(type: Exec, dependsOn: [codegen]) {
   def incidentSupportOutput = "${datahubRoot}/docs/generated/incidents/entity-support.md.snippet"
   def incidentPdl = "${datahubRoot}/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl"
   def incidentSdl = "${datahubRoot}/datahub-graphql-core/src/main/resources/incident.graphql"
+  def incidentEngine = "${datahubRoot}/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java"
 
   inputs.files(
     file('scripts/modeldocgen.py'),
@@ -154,7 +155,8 @@ task modelDocGen(type: Exec, dependsOn: [codegen]) {
     project.fileTree(dir: "../metadata-events/mxe-schemas/src/", include: "**/*.avsc"),
     file(entityRegistry),
     file(incidentPdl),
-    file(incidentSdl)
+    file(incidentSdl),
+    file(incidentEngine)
   )
   outputs.dir('../docs/generated/metamodel')
   outputs.file(incidentSupportOutput)

--- a/metadata-ingestion/scripts/modeldocgen.py
+++ b/metadata-ingestion/scripts/modeldocgen.py
@@ -1458,21 +1458,45 @@ def get_sorted_entity_names(
     return sorted_entities
 
 
-# Incident support is declared independently in three backend files, and they do not
+# Incident support is declared independently in four backend files, and they do not
 # all agree. Deriving the table means the docs cannot drift from the code the way a
 # hand-maintained list does; see https://github.com/datahub-project/datahub/pull/18685.
+#
+# Declaring the incidents field in the SDL is not enough on its own. A type with the
+# field but no entry in entitiesWithIncidents has no resolver attached to it, so the
+# field resolves to null rather than failing, which is why the last two columns are
+# reported separately instead of being folded into one "readable" claim.
 _REPO_ROOT = Path(__file__).parent.parent.parent
 _INCIDENT_PDL = (
     _REPO_ROOT
     / "metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl"
 )
 _INCIDENT_SDL = _REPO_ROOT / "datahub-graphql-core/src/main/resources/incident.graphql"
+_INCIDENT_ENGINE = (
+    _REPO_ROOT
+    / "datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java"
+)
 
 # Entity names whose GraphQL type is not just the capitalised entity name. A decoy
 # type named SchemaField also exists, so matching on the entity name alone is wrong.
 _INCIDENT_GRAPHQL_TYPE_OVERRIDES: Dict[str, str] = {
     "schemaField": "SchemaFieldEntity",
 }
+
+
+def _incident_graphql_type(entity: str) -> str:
+    """The GraphQL type name for an entity name in the write gate.
+
+    Capitalising the first letter is right for most entities and wrong for the ml
+    family, whose types spell the prefix ML: mlFeatureTable is MLFeatureTable, not
+    MlFeatureTable. Getting this wrong reports a supported entity as unsupported,
+    which is a quiet failure rather than a loud one.
+    """
+    if entity in _INCIDENT_GRAPHQL_TYPE_OVERRIDES:
+        return _INCIDENT_GRAPHQL_TYPE_OVERRIDES[entity]
+    if entity.startswith("ml") and len(entity) > 2 and entity[2].isupper():
+        return "ML" + entity[2:]
+    return entity[0:1].upper() + entity[1:]
 
 
 def _strip_line_comments(text: str) -> str:
@@ -1543,25 +1567,40 @@ def _incident_graphql_types() -> Set[str]:
     return found
 
 
+def _incident_resolver_types() -> Set[str]:
+    """GraphQL types the engine attaches an incidents data fetcher to.
+
+    The list is declared once, as the entitiesWithIncidents literal that
+    configureIncidentResolvers loops over, so read it up to the end of its statement
+    rather than guessing at the surrounding formatting.
+    """
+    text = _strip_line_comments(_INCIDENT_ENGINE.read_text(encoding="utf-8"))
+    match = re.search(r"entitiesWithIncidents\s*=(.*?);", text, re.DOTALL)
+    if not match:
+        return set()
+    return set(re.findall(r'"([A-Za-z][A-Za-z0-9_]*)"', match.group(1)))
+
+
 def generate_incident_support_table(registry_file: str) -> str:
     summaries = _incident_summary_entities(
         Path(registry_file).read_text(encoding="utf-8")
     )
     graphql_types = _incident_graphql_types()
+    resolver_types = _incident_resolver_types()
 
     tick = {True: "Yes", False: "No"}
     rows = [
-        "| Entity type | Incident can be raised | `incidentsSummary` aspect | Readable in GraphQL |",
-        "| --- | --- | --- | --- |",
+        "| Entity type | Incident can be raised | `incidentsSummary` aspect"
+        " | `incidents` field in the SDL | `incidents` resolver wired |",
+        "| --- | --- | --- | --- | --- |",
     ]
     for entity in _incident_write_gate():
-        gql = _INCIDENT_GRAPHQL_TYPE_OVERRIDES.get(
-            entity, entity[0:1].upper() + entity[1:]
-        )
+        gql = _incident_graphql_type(entity)
         rows.append(
             f"| `{entity}` | Yes"
             f" | {tick[entity in summaries]}"
-            f" | {tick[gql in graphql_types]} |"
+            f" | {tick[gql in graphql_types]}"
+            f" | {tick[gql in resolver_types]} |"
         )
     return "\n".join(rows) + "\n"
 

--- a/metadata-ingestion/scripts/modeldocgen.py
+++ b/metadata-ingestion/scripts/modeldocgen.py
@@ -9,7 +9,7 @@ from dataclasses import Field, dataclass, field
 from datetime import datetime, timezone
 from enum import auto
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import avro.schema
 import click
@@ -1458,6 +1458,114 @@ def get_sorted_entity_names(
     return sorted_entities
 
 
+# Incident support is declared independently in three backend files, and they do not
+# all agree. Deriving the table means the docs cannot drift from the code the way a
+# hand-maintained list does; see https://github.com/datahub-project/datahub/pull/18685.
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_INCIDENT_PDL = (
+    _REPO_ROOT
+    / "metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl"
+)
+_INCIDENT_SDL = _REPO_ROOT / "datahub-graphql-core/src/main/resources/incident.graphql"
+
+# Entity names whose GraphQL type is not just the capitalised entity name. A decoy
+# type named SchemaField also exists, so matching on the entity name alone is wrong.
+_INCIDENT_GRAPHQL_TYPE_OVERRIDES: Dict[str, str] = {
+    "schemaField": "SchemaFieldEntity",
+}
+
+
+def _strip_line_comments(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        stripped = line.split("//")[0]
+        if stripped.lstrip().startswith("#"):
+            stripped = ""
+        lines.append(stripped)
+    return "\n".join(lines)
+
+
+def _matching_brace(text: str, open_brace: int) -> int:
+    depth, i = 1, open_brace + 1
+    while i < len(text) and depth:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    return i
+
+
+def _incident_write_gate() -> List[str]:
+    """Entity types accepted by the IncidentOn relationship, in declaration order."""
+    match = re.search(
+        r'"entityTypes"\s*:\s*\[(.*?)\]',
+        _INCIDENT_PDL.read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+    return re.findall(r'"([A-Za-z]+)"', match.group(1)) if match else []
+
+
+def _incident_summary_entities(registry_text: str) -> Set[str]:
+    """Entity types whose registry aspect list declares incidentsSummary."""
+    found: Set[str] = set()
+    current: Optional[str] = None
+    in_aspects = False
+    for raw in registry_text.splitlines():
+        line = raw.split("#")[0].rstrip()
+        if not line.strip():
+            continue
+        entity = re.match(r"\s*-\s*name:\s*([A-Za-z][A-Za-z0-9_]*)\s*$", line)
+        if entity:
+            current, in_aspects = entity.group(1), False
+            continue
+        if re.match(r"\s*aspects:\s*$", line):
+            in_aspects = True
+            continue
+        if in_aspects:
+            aspect = re.match(r"\s*-\s*([A-Za-z][A-Za-z0-9_]*)\s*$", line)
+            if aspect and current:
+                if aspect.group(1) == "incidentsSummary":
+                    found.add(current)
+            elif not aspect:
+                in_aspects = False
+    return found
+
+
+def _incident_graphql_types() -> Set[str]:
+    """GraphQL types given an incidents field by an extend type block in the SDL."""
+    text = _strip_line_comments(_INCIDENT_SDL.read_text(encoding="utf-8"))
+    found: Set[str] = set()
+    for match in re.finditer(r"extend\s+type\s+([A-Za-z][A-Za-z0-9_]*)\s*\{", text):
+        body = text[match.end() : _matching_brace(text, match.end() - 1)]
+        if re.search(r"\bincidents\s*\(", body):
+            found.add(match.group(1))
+    return found
+
+
+def generate_incident_support_table(registry_file: str) -> str:
+    summaries = _incident_summary_entities(
+        Path(registry_file).read_text(encoding="utf-8")
+    )
+    graphql_types = _incident_graphql_types()
+
+    tick = {True: "Yes", False: "No"}
+    rows = [
+        "| Entity type | Incident can be raised | `incidentsSummary` aspect | Readable in GraphQL |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entity in _incident_write_gate():
+        gql = _INCIDENT_GRAPHQL_TYPE_OVERRIDES.get(
+            entity, entity[0:1].upper() + entity[1:]
+        )
+        rows.append(
+            f"| `{entity}` | Yes"
+            f" | {tick[entity in summaries]}"
+            f" | {tick[gql in graphql_types]} |"
+        )
+    return "\n".join(rows) + "\n"
+
+
 @click.command()
 @click.argument("schemas_root", type=click.Path(exists=True), required=True)
 @click.option("--registry", type=click.Path(exists=True), required=True)
@@ -1472,6 +1580,12 @@ def get_sorted_entity_names(
 @click.option(
     "--lineage-output", type=str, required=False, help="generate lineage JSON file"
 )
+@click.option(
+    "--incident-support-output",
+    type=str,
+    required=False,
+    help="generate the incident entity-support table snippet",
+)
 def generate(  # noqa: C901
     schemas_root: str,
     registry: str,
@@ -1482,6 +1596,7 @@ def generate(  # noqa: C901
     png: Optional[str],
     extra_docs: Optional[str],
     lineage_output: Optional[str],
+    incident_support_output: Optional[str],
 ) -> None:
     logger.info(f"server = {server}")
     logger.info(f"file = {file}")
@@ -1511,6 +1626,12 @@ def generate(  # noqa: C901
                 loaded = yaml.safe_load(df) or {}
             if isinstance(loaded, dict):
                 entity_descriptions = {k: str(v) for k, v in loaded.items() if v}
+
+    if incident_support_output:
+        logger.info(f"Generating incident support table to {incident_support_output}")
+        incident_path = Path(incident_support_output)
+        incident_path.parent.mkdir(parents=True, exist_ok=True)
+        incident_path.write_text(generate_incident_support_table(registry))
 
     # registry file
     load_registry_file(registry)


### PR DESCRIPTION
The `raiseIncident` docs describe `resourceUrn` as "dataset, dashboard, chart,
dataFlow, etc". I read the "etc" as open-ended and tried to raise an incident on
an `mlModel`, which is rejected at the entity layer:

```
"urn:li:mlModel:(urn:li:dataPlatform:mlflow,workforce-classifier_3,PROD) is not a valid destination"
```

The set is not open-ended. It is whichever entities declare the
`incidentsSummary` aspect, and from `metadata-models/src/main/resources/entity-registry.yml`
on master that is exactly:

`dataset`, `dataJob`, `dataFlow`, `chart`, `dashboard`, `service`, `aiAgent`.

So this replaces the "etc" with the actual list, shows the error you get
otherwise, and adds a short note that ML entities are not included.

The ML note is the reason I bothered. Raising an incident on a model is a
natural thing to reach for when the thing that went wrong is a model, and the
current wording gives no reason to think it will not work. The workaround is
easy once you know: raise it on the dataset the model trained on, which is one
lineage hop away, and name the model in the title.

Two smaller things I noticed while working on this, not included here because
I am less sure they are documentation problems rather than intentional. Happy
to open separate issues if either is useful:

- `service` and `aiAgent` support incidents but do not appear in any docs I
  could find.
- There is no mutation to delete an incident, only to resolve one, so anything
  raised while testing stays in the instance.

Docs only, no code changes.
