### PR TITLE
fix(cli): surface failing container logs when quickstart fails

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_check.py
+++ b/metadata-ingestion/src/datahub/cli/docker_check.py
@@ -221,6 +221,17 @@ class QuickstartStatus:
         else:
             return set()
 
+    def errored_containers(self) -> List[str]:
+        """Names of the containers that are not OK (exited, died, unhealthy, …).
+
+        Used to surface the root-cause logs for just the failing services.
+        """
+        return [
+            container.name
+            for container in self.containers
+            if container.status != ContainerStatus.OK
+        ]
+
 
 def detect_legacy_quickstart_compose(containers: Set[str]) -> bool:
     return "zookeeper" in containers

--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -833,6 +833,30 @@ def quickstart(
             click.echo("Dumping docker compose logs:")
             click.echo(pathlib.Path(log_file.name).read_text())
             click.echo()
+        else:
+            # Surface *why* it failed by default: print the tail of the logs for
+            # the containers that actually errored, so the root cause (e.g. a
+            # required env var) is visible without re-running with
+            # --dump-logs-on-failure.
+            for container in status.errored_containers():
+                try:
+                    tail = subprocess.run(
+                        base_command + ["logs", "--tail", "25", container],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        env=_docker_subprocess_env(),
+                    ).stdout.decode(errors="replace")
+                except Exception:
+                    continue
+                if tail.strip():
+                    click.secho(
+                        f"\n----- last logs: {container} -----", fg="yellow"
+                    )
+                    click.echo(tail)
+            click.secho(
+                "Re-run with --dump-logs-on-failure for the full compose logs.",
+                fg="yellow",
+            )
 
         raise status.to_exception(
             header="Unable to run quickstart - the following issues were detected:",


### PR DESCRIPTION
## Summary

When `datahub docker quickstart` times out waiting for the stack to become healthy, it currently reports only:

```
Unable to run quickstart - the following issues were detected:
- datahub-gms-quickstart is not running
- system-update-quickstart exited with an error
```

The actual cause is written to a temp file but **only printed if you re-run with the non-default `--dump-logs-on-failure` flag**. So the default experience gives no hint of *why* it failed. This is the exact frustration reported in #18594 (and #18688).

## Change

On failure, print the **last 25 log lines of each errored container by default**, so the root cause is visible immediately — e.g.:

```
----- last logs: system-update-quickstart -----
Caused by: java.lang.IllegalArgumentException: authentication.tokenService.signingKey must be set and not be empty
...
Re-run with --dump-logs-on-failure for the full compose logs.
```

Full compose logs remain available behind `--dump-logs-on-failure` (unchanged).

- `docker_check.py`: add `QuickstartStatus.errored_containers()` — the non-OK service names (reuses the same `status != OK` predicate as `errors()`).
- `docker_cli.py`: in the health-timeout failure branch, when not dumping all logs, `docker compose logs --tail 25 <service>` for each errored container and echo it. Best-effort (wrapped in try/except) so log retrieval never masks the original failure.

## Why this scope

- **Minimal & safe:** no change on success; only enriches the existing failure path. +35 lines, no new deps.
- **Broadly useful:** helps every quickstart failure (port conflicts, OOM, missing required env vars), not one specific case.
- **Directly addresses #18594**, whose entire complaint is the opaque message.

## Test plan

- Induce a failure (e.g. unset a required env var / bad image tag) → confirm the failing container's log tail is printed by default and shows the real error.
- `--dump-logs-on-failure` still prints the full logs.
- Healthy quickstart is unaffected.
- `python -m py_compile` passes on both files.

Fixes #18688