### PR TITLE
docs: nest SMTP Email Notifications under Subscriptions & Notifications

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -648,15 +648,20 @@ module.exports = {
         },
         {
           label: "Subscriptions & Notifications",
-          type: "doc",
-          id: "docs/managed-datahub/subscription-and-notification",
+          type: "category",
           className: "saasOnly",
-        },
-        {
-          label: "SMTP Email Notifications",
-          type: "doc",
-          id: "docs/managed-datahub/smtp-email",
-          className: "saasOnly",
+          link: {
+            type: "doc",
+            id: "docs/managed-datahub/subscription-and-notification",
+          },
+          items: [
+            {
+              label: "SMTP Email Notifications",
+              type: "doc",
+              id: "docs/managed-datahub/smtp-email",
+              className: "saasOnly",
+            },
+          ],
         },
         {
           label: "Sync Status",


### PR DESCRIPTION
## Summary
- Nest the SMTP Email Notifications feature guide under Subscriptions & Notifications in the docs sidebar
- Reduces top-level clutter in Feature Guides while keeping doc URLs unchanged

## Test plan
- [ ] Confirm Feature Guides sidebar shows SMTP nested under Subscriptions & Notifications
- [ ] Confirm clicking Subscriptions & Notifications still opens the parent guide
- [ ] Confirm SMTP Email Notifications page still loads at the same URL


Made with [Cursor](https://cursor.com)