### PR TITLE
test(smoke): make user-add test URN unique to fix xdist collision with jdoe seed

### DIFF
--- a/smoke-test/tests/cli/user_cmd/test_user_add.py
+++ b/smoke-test/tests/cli/user_cmd/test_user_add.py
@@ -6,7 +6,7 @@ import pytest
 
 from datahub.ingestion.graph.client import DataHubGraph
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import run_datahub_cmd
+from tests.utils import run_datahub_cmd, unique_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -294,8 +294,12 @@ def test_user_add_id_different_from_email(
     auth_session: Any, test_users_cleanup: Any
 ) -> None:
     """Test creating a user where ID is different from email."""
-    email = "john.doe@company.com"
-    user_id = "jdoe"
+    # Use a unique id/email so this test never collides with the shared
+    # `urn:li:corpuser:jdoe` seed used by other modules (containers, domains),
+    # which run on parallel xdist workers against the same GMS.
+    unique = unique_suffix()
+    email = f"john.doe-{unique}@company.com"
+    user_id = f"jdoe-{unique}"
     display_name = "John Doe"
     password = "securepass123"
 


### PR DESCRIPTION
## Summary

`test_user_add_id_different_from_email` fails intermittently in the smoke-test
Batch 1 job with `assert result.exit_code == 0` (`assert 1 == 0`).

Failure: https://github.com/datahub-project/datahub/actions/runs/30369629182/job/90311860260?pr=18650

## Root cause

The test hardcodes `user_id = "jdoe"` → `urn:li:corpuser:jdoe`. That URN is also
seeded by other test modules (`tests/containers/data.json`, `tests/domains/data.json`)
via module-scoped ingest fixtures. Under `pytest-xdist -n 3 --dist=loadscope`, those
modules run on parallel workers against the same GMS. When a seeding module holds
`jdoe` while this test runs, the CLI's pre-create existence check
(`graph.exists("urn:li:corpuser:jdoe")` → `True`) short-circuits with
"User with ID jdoe already exists" and exits 1. No server-side error — purely a
shared-URN race between concurrent modules.

Every other test in this file already uses a per-run unique id/email; this one was
the outlier.

## Changes

- Generate a run-unique `user_id`/`email` using the existing `unique_suffix()` helper
  (`smoke-test/tests/utils.py`), matching the isolation pattern from #18560.