### PR TITLE
fix(smoke-test): disable actions-container CLI telemetry in test bringups

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/MCLItem.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/MCLItem.java
@@ -11,7 +11,7 @@ import java.lang.reflect.InvocationTargetException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** An item that  a change that has been written to primary storage. */
+/** An item that represents a change that has been written to primary storage. */
 public interface MCLItem extends BatchItem {
 
   @Nonnull

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/MCLItem.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/MCLItem.java
@@ -11,7 +11,7 @@ import java.lang.reflect.InvocationTargetException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/** An item that represents a change that has been written to primary storage. */
+/** An item that  a change that has been written to primary storage. */
 public interface MCLItem extends BatchItem {
 
   @Nonnull

--- a/smoke-test/test_resources/actions/actions.env
+++ b/smoke-test/test_resources/actions/actions.env
@@ -4,3 +4,9 @@
 DATAHUB_ACTIONS_DOC_PROPAGATION_RATE_LIMIT_PROPAGATED_WRITES=1500
 DATAHUB_ACTIONS_DOC_PROPAGATION_RATE_LIMIT_PROPAGATED_WRITES_PERIOD=1
 DATAHUB_ACTIONS_DOC_PROPAGATION_MAX_PROPAGATION_FANOUT=20
+
+## Disable CLI telemetry in the actions container. The executor spawns `datahub ingest`
+## subprocesses; with track.datahubproject.io unreachable, telemetry pings add ~380s per
+## execution and time out the Playwright ingestion tests. Scoped to test bringups only
+## (this file is loaded via DATAHUB_LOCAL_ACTIONS_ENV) so real quickstart users keep telemetry on.
+DATAHUB_TELEMETRY_ENABLED=false


### PR DESCRIPTION
Turn off telemetry flag in playwrite tests
https://github.com/datahub-project/datahub/actions/runs/30385398310/job/90365244882 passing job.