### PR TITLE
docs: Standardize documentation page titles OBS-2050

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -415,6 +415,7 @@ module.exports = {
           collapsed: true,
           items: [
             {
+              label: "Overview",
               type: "doc",
               id: "docs/features/feature-guides/compliance-forms/overview",
             },
@@ -616,6 +617,7 @@ module.exports = {
           collapsed: true,
           items: [
             {
+              label: "Overview",
               type: "doc",
               id: "docs/features/feature-guides/properties/overview",
             },

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -1,5 +1,5 @@
 ---
-title: Domains Overview
+title: Domains
 description: "Use DataHub Domains to group related data assets into curated, top-level collections owned by business units or teams."
 ---
 

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -1,5 +1,5 @@
 ---
-title: Business Glossary Guide
+title: Business Glossary
 description: "Build a Business Glossary in DataHub to define a shared vocabulary of business terms and link them to physical data assets."
 ---
 

--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -1,5 +1,5 @@
 ---
-title: Search Overview
+title: Search
 description: "Use the DataHub search bar to find datasets, columns, dashboards, charts, and pipelines across your data ecosystem."
 ---
 

--- a/docs/incidents/incidents.md
+++ b/docs/incidents/incidents.md
@@ -1,5 +1,5 @@
 ---
-title: Incidents Overview
+title: Incidents
 description: This page provides an overview of working with the DataHub Incidents API.
 ---
 

--- a/docs/managed-datahub/observe/data-contract.md
+++ b/docs/managed-datahub/observe/data-contract.md
@@ -1,5 +1,5 @@
 ---
-title: Data Contracts Monitoring
+title: Data Contracts
 description: "Define Data Contracts in DataHub Cloud Observe as agreements between producers and consumers covering schema, freshness, and quality."
 ---
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,5 +1,5 @@
 ---
-title: Tags Overview
+title: Tags
 description: "Use Tags in DataHub as informal, loosely-controlled labels to classify and search for datasets, schemas, and containers."
 ---
 


### PR DESCRIPTION
## Description

This PR standardizes documentation page titles across the DataHub docs by removing redundant suffixes like "Overview", "Guide", and "Monitoring" from page titles. The descriptions already provide context, so these suffixes are unnecessary and create inconsistency.

## Changes

- **sidebars.js**: Added explicit "Overview" labels to sidebar items for compliance-forms and properties sections to maintain clarity in navigation
- **Documentation titles**: Simplified titles across multiple pages:
  - `Domains Overview` → `Domains`
  - `Business Glossary Guide` → `Business Glossary`
  - `Search Overview` → `Search`
  - `Incidents Overview` → `Incidents`
  - `Data Contracts Monitoring` → `Data Contracts`
  - `Tags Overview` → `Tags`

## Rationale

This change improves documentation consistency and readability by:
1. Removing redundant title suffixes while preserving context through descriptions
2. Making sidebar navigation clearer with explicit "Overview" labels where needed
3. Creating a more uniform documentation structure

## Test Plan

N/A - Documentation and configuration changes only. No functional code modifications.

https://claude.ai/code/session_01Lvur3XkYqAMVtoJJfpa1Xf