### PR TITLE
feat(ingest): add high-level SDK builders for Semantic Models, Metrics, and Logical Datasets

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1336,6 +1336,7 @@ module.exports = {
         "docs/api/tutorials/dashboard-chart",
         "docs/api/tutorials/dataflow-datajob",
         "docs/api/tutorials/mlmodel-mlmodelgroup",
+        "docs/api/tutorials/semantic-models",
         "docs/api/tutorials/applications",
         "docs/api/tutorials/agent-registry",
         "docs/api/tutorials/service-catalog",

--- a/docs-website/sphinx/apidocs/sdk-v2/entities.rst
+++ b/docs-website/sphinx/apidocs/sdk-v2/entities.rst
@@ -27,3 +27,9 @@ The DataHub SDK provides a set of entities that can be used to interact with Dat
 
 .. automodule:: datahub.sdk.dataflow
    :member-order: alphabetical
+
+.. automodule:: datahub.sdk.semantic_model
+   :member-order: alphabetical
+
+.. automodule:: datahub.sdk.metric
+   :member-order: alphabetical

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -1,0 +1,94 @@
+---
+description: "Tutorial for emitting Semantic Models, Metrics, and Logical Datasets in DataHub using the Python SDK (datahub.sdk)."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Semantic Models & Metrics
+
+## Why Would You Use Semantic Models and Metrics?
+
+Semantic Models and Metrics let you describe a **logical layer** over your physical data: a
+`semanticModel` groups one or more logical `dataset`s (each a "Semantic Model Dataset" subtype),
+exposes dimensions and measures via schema-field-anchored `semanticFieldAnnotation`s, and
+serves as the backing model for `metric` entities. Together they form the lineage chain
+`Metric → SemanticModel → Logical Dataset → Physical Dataset`, giving consumers a stable,
+source-agnostic surface for analytics, governance, and AI-assisted exploration.
+
+This mirrors modeling that already exists inside the Snowflake connector, lifted into the
+high-level SDK so any producer (connector or direct SDK user) can emit the same entities
+without re-implementing the aspect wiring.
+
+### Goal Of This Guide
+
+This guide will show you how to:
+
+- Build a `SemanticModel` with two logical datasets, schema fields, and a relationship.
+- Emit `metric` entities backed by the model, including one metric derived from another.
+- Serialize every emitted MCP to a file and inspect the resulting aspect shapes.
+
+## Prerequisites
+
+For this tutorial, you need DataHub SDK v2 (`datahub.sdk.*`) installed. If you are running
+the example from the `metadata-ingestion` package, the venv is set up by
+`../gradlew :metadata-ingestion:installDev`.
+
+## Build a Semantic Model with Logical Datasets and Metrics
+
+The example below builds the full lineage chain
+`Metric -> SemanticModel -> Logical Dataset -> Physical Dataset` using the high-level
+`datahub.sdk` builders, then writes every emitted MCP to a JSON file so the resulting
+aspect shapes can be inspected.
+
+```python
+{{ inline /metadata-ingestion/examples/library/semantic_model_create.py show_path_as_comment }}
+```
+
+### What the SDK emits for you
+
+When you call `entity.as_mcps()` on each builder, the SDK produces the full aspect set and
+wires the lineage chain automatically:
+
+- **`semanticModel`**: a `Status`, a `SemanticModelInfo` (with `datasets` preserving
+  insertion order, plus optional `relationships`), and a model-level `AiContext` **only when
+  non-empty**.
+- **Logical `dataset`s**: each gets `Status`, `SubTypes([SEMANTIC_MODEL_DATASET])`, a
+  `SemanticModelProperties(alias, semanticModel=<model urn>)` back-ref, a
+  `SchemaMetadata` with the declared fields, and an `UpstreamLineage` to the physical
+  datasets. For every field, the SDK emits a `schemaField`-anchored
+  `semanticFieldAnnotation` (with `expression` auto-synthesized as `f"{alias}.{field_path}"`
+  when not provided) and, when non-empty, a field-anchored `aiContext`.
+- **`metric`s**: each gets `Status`, `MetricInfo` (with `semanticModel=<model urn>` back-ref
+  and an optional `expression`; the expression is **never** fabricated when omitted),
+  `MetricRelationships` (**always** emitted, even with empty `derivedFrom`, so
+  `hasParentMetric` indexes as false), and an `AiContext` only when non-empty.
+
+Note that the SDK **does not** populate `metricUpstreams` for semantic-model-backed
+metrics — the lineage chain is expressed entirely through `metricInfo.semanticModel`,
+`semanticModelInfo.datasets`, and the logical dataset's own `upstreamLineage`.
+
+### Expected Output
+
+Running the example writes `semantic_model_create.json` in the working directory. Open it
+and verify the aspect shapes match the producer contract:
+
+- URN patterns: `urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)`,
+  `urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,total_revenue)`, and
+  `urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.orders_model.orders_ds,PROD)`.
+- Logical datasets carry the `Semantic Model Dataset` subtype.
+- Each logical dataset's `semanticModelProperties` points back at the model URN with the
+  right `alias`.
+- `semanticFieldAnnotation` MCPs are anchored on `schemaField` URNs and the `expression`
+  falls back to `ORDERS.order_id` when not explicitly provided.
+- `aiContext` is only present on fields/entities that had non-empty inputs.
+- No `metricUpstreams` aspect is emitted for the metrics.
+
+## API Reference
+
+For the full surface area of each builder, see the
+[SDK Entities Reference](/docs/stdlib/sdk-v2/entities).
+
+- `SemanticModel` — `datahub.sdk.semantic_model.SemanticModel`
+- `SemanticModelDataset` — `datahub.sdk.semantic_model.SemanticModelDataset`
+- `Metric` — `datahub.sdk.metric.Metric`

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -53,7 +53,7 @@ wires the lineage chain automatically:
 - **`semanticModel`**: a `Status`, a `SemanticModelInfo` (with `datasets` preserving
   insertion order, plus optional `relationships`), and a model-level `AiContext` **only when
   non-empty**.
-- **Logical `dataset`s**: each gets `Status`, `SubTypes([SEMANTIC_MODEL_DATASET])`, a
+- **Logical `dataset`s**: each gets `SubTypes([SEMANTIC_MODEL_DATASET])`, a
   `SemanticModelProperties(alias, semanticModel=<model urn>)` back-ref, a
   `SchemaMetadata` with the declared fields, and an `UpstreamLineage` to the physical
   datasets. For every field, the SDK emits a `schemaField`-anchored
@@ -114,7 +114,7 @@ opt-in preflight helper before emitting:
 from datahub.sdk import DataHubClient, require_metrics_support
 
 client = DataHubClient(server="...", token="...")
-require_metrics_support(client.graph)  # raises on old SaaS; no-op on OSS
+require_metrics_support(client)  # raises on old SaaS; no-op on OSS
 ```
 
 The helper mirrors the Snowflake connector gate's asymmetry: it version-checks
@@ -125,8 +125,10 @@ when you want the preflight.
 ### Read-modify-write caveat for logical datasets
 
 Per-field `semanticFieldAnnotation` and field-level `aiContext` on a
-`SemanticModelDataset` are **create-only**. A graph read of a logical dataset
-returns a `SemanticModelDataset`, but its per-field annotation store is empty,
-so re-emitting the read result drops every field-anchored annotation. To
-preserve them on an update, re-attach the fields via the `schema` constructor
-kwarg.
+`SemanticModelDataset` are **create-only**. A logical dataset shares the
+`dataset` entity type, so `client.entities.get(<dataset urn>)` hydrates it as a
+base `Dataset` — the field-anchored annotations live on `schemaField` URNs, not
+in the dataset's aspect bag, and are not carried back on a read. To update a
+logical dataset, rebuild a fresh `SemanticModelDataset` and re-attach its fields
+via the `schema` constructor kwarg rather than read-modify-writing the fetched
+`Dataset`.

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -92,3 +92,41 @@ For the full surface area of each builder, see the
 - `SemanticModel` — `datahub.sdk.semantic_model.SemanticModel`
 - `SemanticModelDataset` — `datahub.sdk.semantic_model.SemanticModelDataset`
 - `Metric` — `datahub.sdk.metric.Metric`
+
+## Server compatibility
+
+The `semanticModel`, `metric`, and logical-`dataset` entities require a GMS
+build that understands the semantic-model metadata model.
+
+- **DataHub Cloud (SaaS):** requires server version **>= v2.1.0** with the
+  Metrics feature enabled (the `metricsEnabled` kill-switch flag must not be
+  `false`). Emitting to an older SaaS server fails loudly — the server rejects
+  the unregistered aspect and `emit_mcps` raises.
+- **Self-hosted / OSS:** there is no automatic version probe. The operator is
+  responsible for running a GMS build that includes the
+  `semanticModel`/`metric` model. The SDK does **not** gate emission on an OSS
+  version check.
+
+For a clear, actionable error instead of a server-side rejection, call the
+opt-in preflight helper before emitting:
+
+```python
+from datahub.sdk import DataHubClient, require_metrics_support
+
+client = DataHubClient(server="...", token="...")
+require_metrics_support(client.graph)  # raises on old SaaS; no-op on OSS
+```
+
+The helper mirrors the Snowflake connector gate's asymmetry: it version-checks
+DataHub Cloud and fails open on OSS (no version signal exists to probe). It is
+**not** wired into `DataHubClient.upsert` automatically — call it explicitly
+when you want the preflight.
+
+### Read-modify-write caveat for logical datasets
+
+Per-field `semanticFieldAnnotation` and field-level `aiContext` on a
+`SemanticModelDataset` are **create-only**. A graph read of a logical dataset
+returns a `SemanticModelDataset`, but its per-field annotation store is empty,
+so re-emitting the read result drops every field-anchored annotation. To
+preserve them on an update, re-attach the fields via the `schema` constructor
+kwarg.

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -87,7 +87,7 @@ and verify the aspect shapes match the producer contract:
 ## API Reference
 
 For the full surface area of each builder, see the
-[SDK Entities Reference](/docs/stdlib/sdk-v2/entities).
+[SDK Entities Reference](../../../python-sdk/sdk-v2/entities.mdx).
 
 - `SemanticModel` — `datahub.sdk.semantic_model.SemanticModel`
 - `SemanticModelDataset` — `datahub.sdk.semantic_model.SemanticModelDataset`

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -95,17 +95,10 @@ For the full surface area of each builder, see the
 
 ## Server compatibility
 
-The `semanticModel`, `metric`, and logical-`dataset` entities require a GMS
-build that understands the semantic-model metadata model.
-
-- **DataHub Cloud (SaaS):** requires server version **>= v2.1.0** with the
-  Metrics feature enabled (the `metricsEnabled` kill-switch flag must not be
-  `false`). Emitting to an older SaaS server fails loudly — the server rejects
-  the unregistered aspect and `emit_mcps` raises.
-- **Self-hosted / OSS:** there is no automatic version probe. The operator is
-  responsible for running a GMS build that includes the
-  `semanticModel`/`metric` model. The SDK does **not** gate emission on an OSS
-  version check.
+The `semanticModel`, `metric`, and logical-`dataset` entities require a server
+build that registers the semantic-model metadata model. Emitting to a server
+that does not register these aspects fails loudly — the server rejects the
+unregistered aspect and `emit_mcps` raises.
 
 For a clear, actionable error instead of a server-side rejection, call the
 opt-in preflight helper before emitting:
@@ -114,13 +107,15 @@ opt-in preflight helper before emitting:
 from datahub.sdk import DataHubClient, require_metrics_support
 
 client = DataHubClient(server="...", token="...")
-require_metrics_support(client)  # raises on old SaaS; no-op on OSS
+require_metrics_support(client)  # raises if the server version is too old
 ```
 
-The helper mirrors the Snowflake connector gate's asymmetry: it version-checks
-DataHub Cloud and fails open on OSS (no version signal exists to probe). It is
-**not** wired into `DataHubClient.upsert` automatically — call it explicitly
-when you want the preflight.
+The helper delegates to `RestServiceConfig.supports_feature`: it raises when the
+server reports a version that does not support these entities, and fails open
+when there is no version signal to check (the operator is then responsible for
+running a build that includes the model). It is **not** wired into
+`DataHubClient.upsert` automatically — call it explicitly when you want the
+preflight.
 
 ### Read-modify-write caveat for logical datasets
 

--- a/docs/api/tutorials/semantic-models.md
+++ b/docs/api/tutorials/semantic-models.md
@@ -55,8 +55,8 @@ wires the lineage chain automatically:
   non-empty**.
 - **Logical `dataset`s**: each gets `SubTypes([SEMANTIC_MODEL_DATASET])`, a
   `SemanticModelProperties(alias, semanticModel=<model urn>)` back-ref, a
-  `SchemaMetadata` with the declared fields, and an `UpstreamLineage` to the physical
-  datasets. For every field, the SDK emits a `schemaField`-anchored
+  `SchemaMetadata` with the declared fields, and — when `upstreams` is provided —
+  an `UpstreamLineage` to the physical datasets. For every field, the SDK emits a `schemaField`-anchored
   `semanticFieldAnnotation` (with `expression` auto-synthesized as `f"{alias}.{field_path}"`
   when not provided) and, when non-empty, a field-anchored `aiContext`.
 - **`metric`s**: each gets `Status`, `MetricInfo` (with `semanticModel=<model urn>` back-ref

--- a/metadata-ingestion/examples/library/semantic_model_create.py
+++ b/metadata-ingestion/examples/library/semantic_model_create.py
@@ -166,11 +166,11 @@ def main() -> None:
     print(f"Wrote {len(all_mcps)} MCPs to semantic_model_create.json")
 
     # When emitting to a live server instead of a file, call the opt-in
-    # preflight helper first to get a clear error on an unsupported GMS:
+    # preflight helper first to get a clear error on an unsupported server:
     #
     #   from datahub.sdk import DataHubClient, require_metrics_support
     #   client = DataHubClient(server=..., token=...)
-    #   require_metrics_support(client)  # raises on old SaaS; no-op on OSS
+    #   require_metrics_support(client)  # raises if the server version is too old
     #   for entity in [model, *entities]:
     #       client.entities.upsert(entity)
 

--- a/metadata-ingestion/examples/library/semantic_model_create.py
+++ b/metadata-ingestion/examples/library/semantic_model_create.py
@@ -1,0 +1,162 @@
+"""Emit a semantic model with two logical datasets and two metrics.
+
+This example builds the full lineage chain
+``Metric -> SemanticModel -> Logical Dataset -> Physical Dataset`` using the
+high-level ``datahub.sdk`` builders, then writes every emitted MCP to a JSON
+file so the resulting aspect shapes can be inspected.
+
+Run with::
+
+    python -m examples.library.semantic_model_create
+
+The output is written to ``semantic_model_create.json`` in the current
+directory. Inspect it to confirm the aspect shapes match the producer contract:
+URN patterns, the ``Semantic Model Dataset`` subtype, the
+``semanticModelProperties`` back-refs, the schemaField-anchored
+``semanticFieldAnnotation`` MCPs, the required-expression fallback
+(``ORDERS.order_id``), aiContext-only-when-non-empty, and the absence of
+``metricUpstreams`` for semantic-model-backed metrics.
+"""
+
+import json
+from typing import Any
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DialectClass,
+    ERModelRelationshipCardinalityClass,
+    SemanticFieldTypeClass,
+)
+from datahub.sdk import Metric, SemanticModel, SemanticModelDataset
+from datahub.sdk.semantic_model import (
+    AiContextInput,
+    DialectExpressionInput,
+    SemanticFieldInput,
+    SemanticModelRelationshipInput,
+)
+
+
+def build_graph() -> tuple[SemanticModel, list]:
+    platform = "snowflake"
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+
+    orders_ds = SemanticModelDataset(
+        platform=platform,
+        name="analytics.orders_model.orders_ds",
+        semantic_model=model_urn,
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_part_of_key=True,
+            ),
+            SemanticFieldInput(
+                field_path="order_ts",
+                type="timestamp",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_time_dimension=True,
+            ),
+            SemanticFieldInput(
+                field_path="amount",
+                type="float",
+                semantic_type=SemanticFieldTypeClass.MEASURE,
+                expression=DialectExpressionInput(
+                    expression="SUM(amount)", dialect=DialectClass.SNOWFLAKE
+                ),
+                aggregation_function="SUM",
+                ai_context=AiContextInput(synonyms=["revenue"]),
+            ),
+        ],
+        upstreams=[make_dataset_urn(platform, "raw.orders")],
+    )
+
+    customers_ds = SemanticModelDataset(
+        platform=platform,
+        name="analytics.orders_model.customers_ds",
+        semantic_model=model_urn,
+        alias="CUSTOMERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_part_of_key=True,
+            ),
+            SemanticFieldInput(
+                field_path="customer_name",
+                type="varchar",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            ),
+        ],
+        upstreams=[make_dataset_urn(platform, "raw.customers")],
+    )
+
+    model = SemanticModel(
+        platform=platform,
+        path="analytics",
+        id="orders_model",
+        name="Orders Model",
+        description="A semantic model over the raw orders and customers tables.",
+        datasets=[orders_ds, customers_ds],
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="CUSTOMERS",
+                to_columns=["customer_id"],
+                name="orders_to_customers",
+                cardinality=ERModelRelationshipCardinalityClass.N_ONE,
+            )
+        ],
+        ai_context=AiContextInput(
+            synonyms=["orders model"],
+            instructions="Use for revenue and customer analytics.",
+        ),
+    )
+
+    total_revenue = Metric(
+        platform=platform,
+        path="analytics",
+        id="total_revenue",
+        semantic_model=str(model.urn),
+        name="Total Revenue",
+        description="Sum of all order amounts.",
+        expression=DialectExpressionInput(
+            expression="SUM(ORDERS.amount)", dialect=DialectClass.SNOWFLAKE
+        ),
+        ai_context=AiContextInput(synonyms=["revenue"]),
+    )
+    double_revenue = Metric(
+        platform=platform,
+        path="analytics",
+        id="double_revenue",
+        semantic_model=str(model.urn),
+        name="Double Revenue",
+        expression="2 * total_revenue",
+        derived_from=[total_revenue.urn],
+    )
+
+    return model, [orders_ds, customers_ds, total_revenue, double_revenue]
+
+
+def main() -> None:
+    model, entities = build_graph()
+
+    all_mcps: list[MetadataChangeProposalWrapper] = []
+    all_mcps.extend(model.as_mcps())
+    for entity in entities:
+        all_mcps.extend(entity.as_mcps())
+
+    records: list[dict[str, Any]] = [dict(mcp.to_obj()) for mcp in all_mcps]
+    with open("semantic_model_create.json", "w") as f:
+        json.dump(records, f, indent=2, default=str)
+    print(f"Wrote {len(all_mcps)} MCPs to semantic_model_create.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/metadata-ingestion/examples/library/semantic_model_create.py
+++ b/metadata-ingestion/examples/library/semantic_model_create.py
@@ -19,7 +19,7 @@ URN patterns, the ``Semantic Model Dataset`` subtype, the
 """
 
 import json
-from typing import Any
+from typing import Any, List
 
 from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -28,20 +28,22 @@ from datahub.metadata.schema_classes import (
     ERModelRelationshipCardinalityClass,
     SemanticFieldTypeClass,
 )
-from datahub.sdk import Metric, SemanticModel, SemanticModelDataset
-from datahub.sdk.semantic_model import (
+from datahub.metadata.urns import SemanticModelUrn
+from datahub.sdk import (
     AiContextInput,
     DialectExpressionInput,
+    Metric,
     SemanticFieldInput,
+    SemanticModel,
+    SemanticModelDataset,
     SemanticModelRelationshipInput,
 )
+from datahub.sdk.entity import Entity
 
 
-def build_graph() -> tuple[SemanticModel, list]:
+def build_graph() -> tuple[SemanticModel, List[Entity]]:
     platform = "snowflake"
-    model_urn = (
-        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
-    )
+    model_urn = SemanticModelUrn(platform=platform, path="analytics", id="orders_model")
 
     orders_ds = SemanticModelDataset(
         platform=platform,
@@ -156,6 +158,15 @@ def main() -> None:
     with open("semantic_model_create.json", "w") as f:
         json.dump(records, f, indent=2, default=str)
     print(f"Wrote {len(all_mcps)} MCPs to semantic_model_create.json")
+
+    # When emitting to a live server instead of a file, call the opt-in
+    # preflight helper first to get a clear error on an unsupported GMS:
+    #
+    #   from datahub.sdk import DataHubClient, require_metrics_support
+    #   client = DataHubClient(server=..., token=...)
+    #   require_metrics_support(client.graph)  # raises on old SaaS; no-op on OSS
+    #   for mcp in all_mcps:
+    #       client.graph.emit_mcp(mcp)
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/examples/library/semantic_model_create.py
+++ b/metadata-ingestion/examples/library/semantic_model_create.py
@@ -57,6 +57,12 @@ def build_graph() -> tuple[SemanticModel, List[Entity]]:
                 semantic_type=SemanticFieldTypeClass.DIMENSION,
                 is_part_of_key=True,
             ),
+            # Foreign key the ORDERS -> CUSTOMERS relationship joins on.
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            ),
             SemanticFieldInput(
                 field_path="order_ts",
                 type="timestamp",
@@ -164,9 +170,9 @@ def main() -> None:
     #
     #   from datahub.sdk import DataHubClient, require_metrics_support
     #   client = DataHubClient(server=..., token=...)
-    #   require_metrics_support(client.graph)  # raises on old SaaS; no-op on OSS
-    #   for mcp in all_mcps:
-    #       client.graph.emit_mcp(mcp)
+    #   require_metrics_support(client)  # raises on old SaaS; no-op on OSS
+    #   for entity in [model, *entities]:
+    #       client.entities.upsert(entity)
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/src/datahub/sdk/__init__.py
+++ b/metadata-ingestion/src/datahub/sdk/__init__.py
@@ -17,7 +17,9 @@ from datahub.metadata.urns import (
     DomainUrn,
     GlossaryNodeUrn,
     GlossaryTermUrn,
+    MetricUrn,
     SchemaFieldUrn,
+    SemanticModelUrn,
     TagUrn,
 )
 from datahub.sdk.chart import Chart
@@ -30,9 +32,11 @@ from datahub.sdk.document import Document
 from datahub.sdk.glossary_node import GlossaryNode
 from datahub.sdk.glossary_term import GlossaryTerm
 from datahub.sdk.main_client import DataHubClient
+from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
 from datahub.sdk.search_filters import Filter, FilterDsl
+from datahub.sdk.semantic_model import SemanticModel, SemanticModelDataset
 from datahub.sdk.tag import Tag
 
 # We want to print out the warning if people do `from datahub.sdk import X`.

--- a/metadata-ingestion/src/datahub/sdk/__init__.py
+++ b/metadata-ingestion/src/datahub/sdk/__init__.py
@@ -22,6 +22,12 @@ from datahub.metadata.urns import (
     SemanticModelUrn,
     TagUrn,
 )
+from datahub.sdk._semantic_shared import (
+    AiContextInput,
+    DialectExpressionInput,
+    MetricExpressionInputType,
+    require_metrics_support,
+)
 from datahub.sdk.chart import Chart
 from datahub.sdk.container import Container
 from datahub.sdk.dashboard import Dashboard
@@ -36,7 +42,12 @@ from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
 from datahub.sdk.search_filters import Filter, FilterDsl
-from datahub.sdk.semantic_model import SemanticModel, SemanticModelDataset
+from datahub.sdk.semantic_model import (
+    SemanticFieldInput,
+    SemanticModel,
+    SemanticModelDataset,
+    SemanticModelRelationshipInput,
+)
 from datahub.sdk.tag import Tag
 
 # We want to print out the warning if people do `from datahub.sdk import X`.

--- a/metadata-ingestion/src/datahub/sdk/_all_entities.py
+++ b/metadata-ingestion/src/datahub/sdk/_all_entities.py
@@ -13,7 +13,7 @@ from datahub.sdk.glossary_term import GlossaryTerm
 from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
-from datahub.sdk.semantic_model import SemanticModel
+from datahub.sdk.semantic_model import SemanticModel, SemanticModelDataset
 from datahub.sdk.tag import Tag
 
 # Base entity classes that don't have circular dependencies
@@ -33,6 +33,7 @@ ENTITY_CLASSES_LIST: List[Type[Entity]] = [
     GlossaryTerm,
     Tag,
     SemanticModel,
+    SemanticModelDataset,
     Metric,
 ]
 

--- a/metadata-ingestion/src/datahub/sdk/_all_entities.py
+++ b/metadata-ingestion/src/datahub/sdk/_all_entities.py
@@ -10,8 +10,10 @@ from datahub.sdk.document import Document
 from datahub.sdk.entity import Entity
 from datahub.sdk.glossary_node import GlossaryNode
 from datahub.sdk.glossary_term import GlossaryTerm
+from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
+from datahub.sdk.semantic_model import SemanticModel
 from datahub.sdk.tag import Tag
 
 # Base entity classes that don't have circular dependencies
@@ -30,6 +32,8 @@ ENTITY_CLASSES_LIST: List[Type[Entity]] = [
     GlossaryNode,
     GlossaryTerm,
     Tag,
+    SemanticModel,
+    Metric,
 ]
 
 # Create the mapping of entity types to classes

--- a/metadata-ingestion/src/datahub/sdk/_all_entities.py
+++ b/metadata-ingestion/src/datahub/sdk/_all_entities.py
@@ -13,7 +13,7 @@ from datahub.sdk.glossary_term import GlossaryTerm
 from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
-from datahub.sdk.semantic_model import SemanticModel, SemanticModelDataset
+from datahub.sdk.semantic_model import SemanticModel
 from datahub.sdk.tag import Tag
 
 # Base entity classes that don't have circular dependencies
@@ -33,7 +33,11 @@ ENTITY_CLASSES_LIST: List[Type[Entity]] = [
     GlossaryTerm,
     Tag,
     SemanticModel,
-    SemanticModelDataset,
+    # NOTE: SemanticModelDataset is intentionally NOT registered here. It is a
+    # Dataset subtype sharing the "dataset" entity type, so registering it would
+    # overwrite Dataset in the ENTITY_CLASSES map below (last write wins) and
+    # every dataset URN would hydrate as a SemanticModelDataset. Reading logical
+    # datasets back as Dataset is the correct behavior.
     Metric,
 ]
 

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 from typing_extensions import TypeAlias
 
@@ -16,22 +16,17 @@ from datahub.metadata.schema_classes import (
     MetricExpressionClass,
 )
 from datahub.sdk._utils import DEFAULT_ACTOR_URN
+from datahub.utilities.server_config_util import ServiceFeature
 
 __all__ = [
     "AiContextInput",
     "DialectExpressionInput",
-    "METRICS_MIN_SAAS_VERSION",
     "MetricExpressionInputType",
     "build_ai_context",
     "build_metric_expression",
     "make_audit_stamp",
     "require_metrics_support",
 ]
-
-# Minimum DataHub Cloud (SaaS) version supporting semanticModel/metric entities.
-# Mirrors the connector gate (snowflake_semantic_model_gate._MIN_SAAS_VERSION);
-# do not import from the connector — keep this in the shared SDK location.
-METRICS_MIN_SAAS_VERSION: Tuple[int, int, int] = (2, 1, 0)
 
 
 @dataclass
@@ -146,21 +141,18 @@ def make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
 
 
 def require_metrics_support(client_or_graph: object) -> None:
-    """Opt-in preflight check that the connected GMS supports the
+    """Opt-in preflight check that the connected server supports the
     ``semanticModel``/``metric``/logical-``dataset`` entities.
 
     Accepts either a :class:`~datahub.sdk.main_client.DataHubClient` or a raw
     ``DataHubGraph``; the client's underlying graph is unwrapped automatically.
 
-    Mirrors the Snowflake connector gate's asymmetry:
-
-    - **DataHub Cloud (SaaS):** raises :class:`SdkUsageError` when the server
-      version is below :data:`METRICS_MIN_SAAS_VERSION`. Does not probe the
-      ``metricsEnabled`` kill-switch (an explicit false there surfaces as a
-      server-side rejection at emit time, which is loud, not silent).
-    - **OSS / self-hosted:** no version signal exists, so this is a no-op (fail
-      open). The operator is responsible for running a GMS build that includes
-      the semanticModel/metric model.
+    Delegates the version/deployment logic to
+    :meth:`RestServiceConfig.supports_feature` (``ServiceFeature.SEMANTIC_MODELS``).
+    Raises :class:`SdkUsageError` when the server reports a version that does not
+    support these entities, and fails open (no-op) when there is no version
+    signal to check — the operator is then responsible for running a build that
+    includes the semanticModel/metric model.
 
     Call this before emitting entities when you want a clear, actionable error
     instead of a server-side rejection::
@@ -184,20 +176,16 @@ def require_metrics_support(client_or_graph: object) -> None:
     if server_config is None:
         # No server config available (e.g. offline/emitter-only); fail open.
         return
-    if not server_config.is_datahub_cloud:
-        # OSS / self-hosted: no version gate, operator's responsibility.
-        return
     try:
-        supported = server_config.is_version_at_least(*METRICS_MIN_SAAS_VERSION)
+        supported = server_config.supports_feature(ServiceFeature.SEMANTIC_MODELS)
     except ValueError:
-        # Non-semver Cloud build (dev/snapshot/sha tag) — no reliable version
-        # signal to gate on. Fail open rather than surfacing a raw parse error
-        # from a helper whose whole purpose is a clear, actionable message.
+        # Non-semver build (dev/snapshot/sha tag) — no reliable version signal
+        # to gate on; fail open rather than leaking a raw parse error.
         return
     if not supported:
-        version = server_config.service_version
+        version = getattr(server_config, "service_version", None)
         raise SdkUsageError(
-            f"This DataHub Cloud server (v{version}) does not support "
-            f"semanticModel/metric entities; requires >= v"
-            f"{'.'.join(str(v) for v in METRICS_MIN_SAAS_VERSION)}."
+            f"This DataHub server (v{version}) does not support "
+            "semanticModel/metric entities. Upgrade to a server build that "
+            "includes the semanticModel/metric model."
         )

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Sequence as AbcSequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import Any, List, Optional, TypeVar, Union, overload
 
 from typing_extensions import TypeAlias
 
@@ -15,18 +16,69 @@ from datahub.metadata.schema_classes import (
     DialectExpressionClass,
     MetricExpressionClass,
 )
+from datahub.metadata.urns import SemanticModelUrn
 from datahub.sdk._utils import DEFAULT_ACTOR_URN
 from datahub.utilities.server_config_util import ServiceFeature
+from datahub.utilities.urns.error import InvalidUrnError
 
 __all__ = [
     "AiContextInput",
     "DialectExpressionInput",
     "MetricExpressionInputType",
+    "as_input_list",
     "build_ai_context",
     "build_metric_expression",
     "make_audit_stamp",
     "require_metrics_support",
+    "validate_semantic_model_urn",
 ]
+
+_T = TypeVar("_T")
+
+
+@overload
+def as_input_list(value: "AbcSequence[_T]") -> List[_T]: ...
+
+
+@overload
+def as_input_list(value: _T) -> List[_T]: ...
+
+
+def as_input_list(value: Any) -> List[Any]:
+    # Implementation for the typed overloads above.
+    """Normalize a scalar or sequence into a list.
+
+    A bare ``str`` is a ``Sequence[str]`` and a single URN object is not a
+    sequence at all; iterating either where a list is expected misbehaves (a
+    URN string gets split character-by-character). Wrap scalars into one-element
+    lists so that can't happen.
+    """
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, AbcSequence):
+        return list(value)
+    return [value]
+
+
+def validate_semantic_model_urn(value: object) -> str:
+    """Reject a blank or malformed semantic-model back-reference.
+
+    The reference is required and must parse as a ``SemanticModelUrn``; an empty
+    string is typed-valid but would emit a metric/dataset with no ``ModeledBy``
+    edge.
+    """
+    text = str(value).strip()
+    if not text:
+        raise SdkUsageError(
+            "semantic_model is required and must be a non-empty SemanticModelUrn."
+        )
+    try:
+        SemanticModelUrn.from_string(text)
+    except InvalidUrnError as e:
+        raise SdkUsageError(
+            f"semantic_model must be a valid SemanticModelUrn; got {text!r}."
+        ) from e
+    return text
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -77,6 +77,18 @@ def build_ai_context(ai: Optional[AiContextInput]) -> Optional[AiContextClass]:
     )
 
 
+def _require_nonempty_expression(expression: str) -> str:
+    # An empty or whitespace-only expression produces a structurally valid but
+    # semantically empty annotation/metric (no SQL to evaluate). Reject it here
+    # rather than silently emitting it.
+    if not expression or not expression.strip():
+        raise SdkUsageError(
+            "Metric/field expression must be a non-empty string; got an empty "
+            "or whitespace-only value."
+        )
+    return expression
+
+
 def build_metric_expression(
     expression: MetricExpressionInputType,
     *,
@@ -87,16 +99,23 @@ def build_metric_expression(
     if isinstance(expression, DialectExpressionInput):
         dialects = [
             DialectExpressionClass(
-                dialect=expression.dialect, expression=expression.expression
+                dialect=expression.dialect,
+                expression=_require_nonempty_expression(expression.expression),
             )
         ]
     elif isinstance(expression, str):
         dialects = [
-            DialectExpressionClass(dialect=default_dialect, expression=expression)
+            DialectExpressionClass(
+                dialect=default_dialect,
+                expression=_require_nonempty_expression(expression),
+            )
         ]
     elif isinstance(expression, list):
         dialects = [
-            DialectExpressionClass(dialect=item.dialect, expression=item.expression)
+            DialectExpressionClass(
+                dialect=item.dialect,
+                expression=_require_nonempty_expression(item.expression),
+            )
             for item in expression
         ]
     else:  # pragma: no cover - defensive
@@ -139,7 +158,14 @@ def require_metrics_support(graph: object) -> None:
     if not server_config.is_datahub_cloud:
         # OSS / self-hosted: no version gate, operator's responsibility.
         return
-    if not server_config.is_version_at_least(*METRICS_MIN_SAAS_VERSION):
+    try:
+        supported = server_config.is_version_at_least(*METRICS_MIN_SAAS_VERSION)
+    except ValueError:
+        # Non-semver Cloud build (dev/snapshot/sha tag) — no reliable version
+        # signal to gate on. Fail open rather than surfacing a raw parse error
+        # from a helper whose whole purpose is a clear, actionable message.
+        return
+    if not supported:
         version = server_config.service_version
         raise SdkUsageError(
             f"This DataHub Cloud server (v{version}) does not support "

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -89,12 +89,28 @@ def _require_nonempty_expression(expression: str) -> str:
     return expression
 
 
+def _require_dialects(
+    dialects: List[DialectExpressionClass],
+) -> List[DialectExpressionClass]:
+    # A MetricExpression with no dialects carries no evaluable SQL. Require at
+    # least one so an empty list input can't silently produce an empty aspect.
+    if not dialects:
+        raise SdkUsageError(
+            "Metric/field expression must contain at least one dialect expression."
+        )
+    return dialects
+
+
 def build_metric_expression(
     expression: MetricExpressionInputType,
     *,
     default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
 ) -> MetricExpressionClass:
     if isinstance(expression, MetricExpressionClass):
+        # A pre-built aspect still has to satisfy the same invariants.
+        _require_dialects(expression.dialects)
+        for dialect in expression.dialects:
+            _require_nonempty_expression(dialect.expression)
         return expression
     if isinstance(expression, DialectExpressionInput):
         dialects = [
@@ -120,7 +136,7 @@ def build_metric_expression(
         ]
     else:  # pragma: no cover - defensive
         raise TypeError(f"Unsupported expression input type: {type(expression)!r}")
-    return MetricExpressionClass(dialects=dialects)
+    return MetricExpressionClass(dialects=_require_dialects(dialects))
 
 
 def make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
@@ -129,9 +145,12 @@ def make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
     return AuditStampClass(time=make_ts_millis(ts), actor=DEFAULT_ACTOR_URN)
 
 
-def require_metrics_support(graph: object) -> None:
+def require_metrics_support(client_or_graph: object) -> None:
     """Opt-in preflight check that the connected GMS supports the
     ``semanticModel``/``metric``/logical-``dataset`` entities.
+
+    Accepts either a :class:`~datahub.sdk.main_client.DataHubClient` or a raw
+    ``DataHubGraph``; the client's underlying graph is unwrapped automatically.
 
     Mirrors the Snowflake connector gate's asymmetry:
 
@@ -149,8 +168,18 @@ def require_metrics_support(graph: object) -> None:
         from datahub.sdk import DataHubClient, require_metrics_support
 
         client = DataHubClient(server=..., token=...)
-        require_metrics_support(client.graph)
+        require_metrics_support(client)
     """
+    # DataHubClient keeps its DataHubGraph private (behind entities/resolve
+    # facades); unwrap it here so callers can pass the client they already hold.
+    # Imported lazily to avoid a module-load cycle (main_client -> entity_client
+    # -> _all_entities -> semantic_model -> _semantic_shared).
+    from datahub.sdk.main_client import DataHubClient
+
+    if isinstance(client_or_graph, DataHubClient):
+        graph: object = client_or_graph._graph
+    else:
+        graph = client_or_graph
     server_config = getattr(graph, "server_config", None)
     if server_config is None:
         # No server config available (e.g. offline/emitter-only); fail open.

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional, Tuple, Union
+
+from typing_extensions import TypeAlias
+
+from datahub.emitter.mce_builder import make_ts_millis
+from datahub.errors import SdkUsageError
+from datahub.metadata.schema_classes import (
+    AiContextClass,
+    AuditStampClass,
+    DialectClass,
+    DialectExpressionClass,
+    MetricExpressionClass,
+)
+from datahub.sdk._utils import DEFAULT_ACTOR_URN
+
+__all__ = [
+    "AiContextInput",
+    "DialectExpressionInput",
+    "METRICS_MIN_SAAS_VERSION",
+    "MetricExpressionInputType",
+    "build_ai_context",
+    "build_metric_expression",
+    "make_audit_stamp",
+    "require_metrics_support",
+]
+
+# Minimum DataHub Cloud (SaaS) version supporting semanticModel/metric entities.
+# Mirrors the connector gate (snowflake_semantic_model_gate._MIN_SAAS_VERSION);
+# do not import from the connector — keep this in the shared SDK location.
+METRICS_MIN_SAAS_VERSION: Tuple[int, int, int] = (2, 1, 0)
+
+
+@dataclass
+class AiContextInput:
+    """Input container for the first-class ``aiContext`` aspect.
+
+    The aspect is only emitted when at least one field carries content; an
+    all-empty ``AiContextInput`` produces no aspect.
+    """
+
+    synonyms: Optional[List[str]] = None
+    instructions: Optional[str] = None
+    examples: Optional[List[str]] = None
+    custom_instructions: Optional[str] = None
+
+
+@dataclass
+class DialectExpressionInput:
+    """A single (dialect, expression) pair for a metric or field expression."""
+
+    expression: str
+    dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL
+
+
+MetricExpressionInputType: TypeAlias = Union[
+    str,
+    DialectExpressionInput,
+    List[DialectExpressionInput],
+    MetricExpressionClass,
+]
+
+
+def build_ai_context(ai: Optional[AiContextInput]) -> Optional[AiContextClass]:
+    if ai is None or not (
+        ai.synonyms or ai.instructions or ai.examples or ai.custom_instructions
+    ):
+        return None
+    return AiContextClass(
+        synonyms=list(ai.synonyms) if ai.synonyms else None,
+        instructions=ai.instructions,
+        examples=list(ai.examples) if ai.examples else None,
+        customInstructions=ai.custom_instructions,
+    )
+
+
+def build_metric_expression(
+    expression: MetricExpressionInputType,
+    *,
+    default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
+) -> MetricExpressionClass:
+    if isinstance(expression, MetricExpressionClass):
+        return expression
+    if isinstance(expression, DialectExpressionInput):
+        dialects = [
+            DialectExpressionClass(
+                dialect=expression.dialect, expression=expression.expression
+            )
+        ]
+    elif isinstance(expression, str):
+        dialects = [
+            DialectExpressionClass(dialect=default_dialect, expression=expression)
+        ]
+    elif isinstance(expression, list):
+        dialects = [
+            DialectExpressionClass(dialect=item.dialect, expression=item.expression)
+            for item in expression
+        ]
+    else:  # pragma: no cover - defensive
+        raise TypeError(f"Unsupported expression input type: {type(expression)!r}")
+    return MetricExpressionClass(dialects=dialects)
+
+
+def make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
+    if ts is None:
+        return None
+    return AuditStampClass(time=make_ts_millis(ts), actor=DEFAULT_ACTOR_URN)
+
+
+def require_metrics_support(graph: object) -> None:
+    """Opt-in preflight check that the connected GMS supports the
+    ``semanticModel``/``metric``/logical-``dataset`` entities.
+
+    Mirrors the Snowflake connector gate's asymmetry:
+
+    - **DataHub Cloud (SaaS):** raises :class:`SdkUsageError` when the server
+      version is below :data:`METRICS_MIN_SAAS_VERSION`. Does not probe the
+      ``metricsEnabled`` kill-switch (an explicit false there surfaces as a
+      server-side rejection at emit time, which is loud, not silent).
+    - **OSS / self-hosted:** no version signal exists, so this is a no-op (fail
+      open). The operator is responsible for running a GMS build that includes
+      the semanticModel/metric model.
+
+    Call this before emitting entities when you want a clear, actionable error
+    instead of a server-side rejection::
+
+        from datahub.sdk import DataHubClient, require_metrics_support
+
+        client = DataHubClient(server=..., token=...)
+        require_metrics_support(client.graph)
+    """
+    server_config = getattr(graph, "server_config", None)
+    if server_config is None:
+        # No server config available (e.g. offline/emitter-only); fail open.
+        return
+    if not server_config.is_datahub_cloud:
+        # OSS / self-hosted: no version gate, operator's responsibility.
+        return
+    if not server_config.is_version_at_least(*METRICS_MIN_SAAS_VERSION):
+        version = server_config.service_version
+        raise SdkUsageError(
+            f"This DataHub Cloud server (v{version}) does not support "
+            f"semanticModel/metric entities; requires >= v"
+            f"{'.'.join(str(v) for v in METRICS_MIN_SAAS_VERSION)}."
+        )

--- a/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_semantic_shared.py
@@ -199,11 +199,13 @@ def require_metrics_support(client_or_graph: object) -> None:
     Accepts either a :class:`~datahub.sdk.main_client.DataHubClient` or a raw
     ``DataHubGraph``; the client's underlying graph is unwrapped automatically.
 
-    Delegates the version/deployment logic to
-    :meth:`RestServiceConfig.supports_feature` (``ServiceFeature.SEMANTIC_MODELS``).
-    Raises :class:`SdkUsageError` when the server reports a version that does not
-    support these entities, and fails open (no-op) when there is no version
-    signal to check — the operator is then responsible for running a build that
+    Delegates version detection to
+    :meth:`RestServiceConfig.supports_feature`
+    (``ServiceFeature.SEMANTIC_MODEL_ENTITIES``). Raises :class:`SdkUsageError`
+    only when a managed (Cloud) server reports a version below the minimum.
+    OSS/self-hosted deployments are not version-gated by the SDK (matching the
+    Snowflake connector gate in #18395), and an absent/unreadable version signal
+    fails open — the operator is then responsible for running a build that
     includes the semanticModel/metric model.
 
     Call this before emitting entities when you want a clear, actionable error
@@ -229,15 +231,23 @@ def require_metrics_support(client_or_graph: object) -> None:
         # No server config available (e.g. offline/emitter-only); fail open.
         return
     try:
-        supported = server_config.supports_feature(ServiceFeature.SEMANTIC_MODELS)
+        supported = server_config.supports_feature(
+            ServiceFeature.SEMANTIC_MODEL_ENTITIES
+        )
     except ValueError:
         # Non-semver build (dev/snapshot/sha tag) — no reliable version signal
         # to gate on; fail open rather than leaking a raw parse error.
         return
-    if not supported:
-        version = getattr(server_config, "service_version", None)
-        raise SdkUsageError(
-            f"This DataHub server (v{version}) does not support "
-            "semanticModel/metric entities. Upgrade to a server build that "
-            "includes the semanticModel/metric model."
-        )
+    if supported:
+        return
+    if not getattr(server_config, "is_datahub_cloud", False):
+        # OSS/self-hosted: not version-gated by the SDK (SEMANTIC_MODEL_ENTITIES
+        # defines no "core" requirement); the operator is responsible for the
+        # server build. Fail open rather than block every OSS emit.
+        return
+    version = getattr(server_config, "service_version", None)
+    raise SdkUsageError(
+        f"This DataHub server (v{version}) does not support "
+        "semanticModel/metric entities. Upgrade to a server build that "
+        "includes the semanticModel/metric model."
+    )

--- a/metadata-ingestion/src/datahub/sdk/dataset.py
+++ b/metadata-ingestion/src/datahub/sdk/dataset.py
@@ -534,7 +534,7 @@ class Dataset(
         domain: Optional[DomainInputType] = None,
         # Dataset-specific aspects.
         schema: Optional[SchemaFieldsInputType] = None,
-        upstreams: Optional[models.UpstreamLineageClass] = None,
+        upstreams: Optional[UpstreamLineageInputType] = None,
         structured_properties: Optional[StructuredPropertyInputType] = None,
         extra_aspects: ExtraAspectsType = None,
         # View lineage parsing option.

--- a/metadata-ingestion/src/datahub/sdk/entity_client.py
+++ b/metadata-ingestion/src/datahub/sdk/entity_client.py
@@ -19,8 +19,10 @@ from datahub.metadata.urns import (
     DocumentUrn,
     GlossaryNodeUrn,
     GlossaryTermUrn,
+    MetricUrn,
     MlModelGroupUrn,
     MlModelUrn,
+    SemanticModelUrn,
     Urn,
 )
 from datahub.sdk._all_entities import ENTITY_CLASSES
@@ -35,8 +37,10 @@ from datahub.sdk.document import Document
 from datahub.sdk.entity import Entity
 from datahub.sdk.glossary_node import GlossaryNode
 from datahub.sdk.glossary_term import GlossaryTerm
+from datahub.sdk.metric import Metric
 from datahub.sdk.mlmodel import MLModel
 from datahub.sdk.mlmodelgroup import MLModelGroup
+from datahub.sdk.semantic_model import SemanticModel
 
 if TYPE_CHECKING:
     from datahub.sdk.main_client import DataHubClient
@@ -85,6 +89,10 @@ class EntityClient:
     def get(self, urn: GlossaryNodeUrn) -> GlossaryNode: ...
     @overload
     def get(self, urn: GlossaryTermUrn) -> GlossaryTerm: ...
+    @overload
+    def get(self, urn: SemanticModelUrn) -> SemanticModel: ...
+    @overload
+    def get(self, urn: MetricUrn) -> Metric: ...
     @overload
     def get(self, urn: Union[Urn, str]) -> Entity: ...
     def get(self, urn: UrnOrStr) -> Entity:

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional, Sequence, Type, Union
+
+from typing_extensions import Self, TypeAlias
+
+from datahub.emitter.mce_builder import make_ts_millis, parse_ts_millis
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    AiContextClass,
+    AuditStampClass,
+    ChangeTypeClass,
+    DerivedMetricInputClass,
+    MetricExpressionClass,
+    MetricInfoClass,
+    MetricRelationshipsClass,
+    StatusClass,
+)
+from datahub.metadata.urns import MetricUrn, SemanticModelUrn, Urn
+from datahub.sdk._shared import (
+    DomainInputType,
+    HasDomain,
+    HasOwnership,
+    HasPlatformInstance,
+    HasStructuredProperties,
+    HasTags,
+    HasTerms,
+    LinksInputType,
+    OwnersInputType,
+    StructuredPropertyInputType,
+    TagsInputType,
+    TermsInputType,
+)
+from datahub.sdk.entity import Entity, ExtraAspectsType
+from datahub.sdk.semantic_model import (
+    AiContextInput,
+    DialectExpressionInput,
+    MetricExpressionInputType,
+    _build_ai_context,
+    _build_metric_expression,
+)
+
+_DEFAULT_ACTOR_URN = "urn:li:corpuser:__ingestion"
+
+SemanticModelInputType: TypeAlias = Union[str, SemanticModelUrn]
+DerivedFromInputType: TypeAlias = Union[str, MetricUrn]
+
+
+class Metric(
+    HasPlatformInstance,
+    HasOwnership,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasStructuredProperties,
+    Entity,
+):
+    """A metric: a business measure calculated over a semantic model.
+
+    A semantic-model-backed metric points at its owning model via
+    ``metricInfo.semanticModel`` (the ``ModeledBy`` lineage edge). Its lineage
+    flows ``Metric -> SemanticModel -> Logical Dataset -> Physical Dataset``;
+    do not populate ``metricUpstreams`` for these metrics.
+
+    ``metricRelationships`` is always emitted (even with empty ``derivedFrom``)
+    so ``hasParentMetric`` indexes as false. ``metricInfo.expression`` is
+    optional and is omitted when not provided.
+    """
+
+    __slots__ = ()
+
+    @classmethod
+    def get_urn_type(cls) -> Type[MetricUrn]:
+        return MetricUrn
+
+    def __init__(
+        self,
+        *,
+        platform: str,
+        path: str,
+        id: str,
+        semantic_model: SemanticModelInputType,
+        platform_instance: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        created: Optional[datetime] = None,
+        last_modified: Optional[datetime] = None,
+        expression: Optional[MetricExpressionInputType] = None,
+        derived_from: Optional[Sequence[DerivedFromInputType]] = None,
+        ai_context: Optional[AiContextInput] = None,
+        owners: Optional[OwnersInputType] = None,
+        links: Optional[LinksInputType] = None,
+        tags: Optional[TagsInputType] = None,
+        terms: Optional[TermsInputType] = None,
+        domain: Optional[DomainInputType] = None,
+        structured_properties: Optional[StructuredPropertyInputType] = None,
+        extra_aspects: ExtraAspectsType = None,
+    ):
+        urn = MetricUrn(platform=platform, path=path, id=id)
+        super().__init__(urn)
+        self._set_extra_aspects(extra_aspects)
+        self._set_platform_instance(urn.platform, platform_instance)
+        # Status is part of the producer contract for this entity.
+        self._set_aspect(StatusClass(removed=False))
+        self._ensure_metric_props(semantic_model=str(semantic_model))
+
+        if name is not None:
+            self.set_name(name)
+        if description is not None:
+            self.set_description(description)
+        if created is not None:
+            self.set_created(created)
+        if last_modified is not None:
+            self.set_last_modified(last_modified)
+        if expression is not None:
+            self.set_expression(expression)
+        if ai_context is not None:
+            self.set_ai_context(ai_context)
+        # Always emit metricRelationships so hasParentMetric indexes as false.
+        self.set_derived_from(derived_from or [])
+        if owners is not None:
+            self.set_owners(owners)
+        if links is not None:
+            self.set_links(links)
+        if tags is not None:
+            self.set_tags(tags)
+        if terms is not None:
+            self.set_terms(terms)
+        if domain is not None:
+            self.set_domain(domain)
+        if structured_properties is not None:
+            for key, value in structured_properties.items():
+                self.set_structured_property(property_urn=key, values=value)
+
+    @classmethod
+    def _new_from_graph(cls, urn: Urn, current_aspects: object) -> Self:  # type: ignore[override]
+        assert isinstance(urn, MetricUrn)
+        entity = cls(
+            platform=urn.platform,
+            path=urn.path,
+            id=urn.id,
+            # semantic_model is required on metricInfo; the graph-loaded
+            # aspect will overwrite this placeholder during _init_from_graph.
+            semantic_model="urn:li:semanticModel:__placeholder__",
+        )
+        return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
+
+    @property
+    def urn(self) -> MetricUrn:
+        return self._urn  # type: ignore
+
+    def _ensure_metric_props(
+        self, *, semantic_model: Optional[str] = None
+    ) -> MetricInfoClass:
+        props = self._get_aspect(MetricInfoClass)
+        if props is None:
+            # name is required on the aspect; default to the URN id. semanticModel
+            # is also required by the contract; use the provided value or a
+            # placeholder that _init_from_graph will overwrite.
+            props = MetricInfoClass(
+                name=self.urn.id,
+                semanticModel=semantic_model,
+            )
+            self._set_aspect(props)
+        return props
+
+    @property
+    def name(self) -> str:
+        return self._ensure_metric_props().name
+
+    def set_name(self, name: str) -> None:
+        self._ensure_metric_props().name = name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._ensure_metric_props().description
+
+    def set_description(self, description: str) -> None:
+        self._ensure_metric_props().description = description
+
+    @property
+    def created(self) -> Optional[datetime]:
+        stamp = self._ensure_metric_props().created
+        if stamp is None or stamp.time == 0:
+            return None
+        return parse_ts_millis(stamp.time)
+
+    def set_created(self, created: datetime) -> None:
+        self._ensure_metric_props().created = _make_audit_stamp(created)
+
+    @property
+    def last_modified(self) -> Optional[datetime]:
+        stamp = self._ensure_metric_props().lastModified
+        if stamp is None or stamp.time == 0:
+            return None
+        return parse_ts_millis(stamp.time)
+
+    def set_last_modified(self, last_modified: datetime) -> None:
+        self._ensure_metric_props().lastModified = _make_audit_stamp(last_modified)
+
+    @property
+    def semantic_model(self) -> Optional[str]:
+        return self._ensure_metric_props().semanticModel
+
+    def set_semantic_model(self, semantic_model: SemanticModelInputType) -> None:
+        self._ensure_metric_props().semanticModel = str(semantic_model)
+
+    @property
+    def expression(self) -> Optional[MetricExpressionClass]:
+        return self._ensure_metric_props().expression
+
+    def set_expression(
+        self,
+        expression: MetricExpressionInputType,
+        *,
+        default_dialect: Union[str, "object"] = ...,  # type: ignore[assignment]
+    ) -> None:
+        from datahub.metadata.schema_classes import DialectClass
+
+        dialect = DialectClass.ANSI_SQL if default_dialect is ... else default_dialect
+        self._ensure_metric_props().expression = _build_metric_expression(
+            expression, default_dialect=dialect
+        )
+
+    @property
+    def derived_from(self) -> List[DerivedMetricInputClass]:
+        rels = self._get_aspect(MetricRelationshipsClass)
+        if rels is None or rels.derivedFrom is None:
+            return []
+        return list(rels.derivedFrom)
+
+    def set_derived_from(self, derived_from: Sequence[DerivedFromInputType]) -> None:
+        # Always emit metricRelationships (even with empty derivedFrom) so
+        # hasParentMetric indexes as false. parentMetric is left unset: these
+        # metrics have no parent.
+        self._set_aspect(
+            MetricRelationshipsClass(
+                derivedFrom=[
+                    DerivedMetricInputClass(destinationUrn=str(d)) for d in derived_from
+                ]
+            )
+        )
+
+    def add_derived_from(self, metric: DerivedFromInputType) -> None:
+        current = self.derived_from
+        dest = str(metric)
+        if all(d.destinationUrn != dest for d in current):
+            current.append(DerivedMetricInputClass(destinationUrn=dest))
+        self._set_aspect(MetricRelationshipsClass(derivedFrom=current))
+
+    @property
+    def ai_context(self) -> Optional[AiContextClass]:
+        return self._get_aspect(AiContextClass)
+
+    def set_ai_context(self, ai_context: AiContextInput) -> None:
+        built = _build_ai_context(ai_context)
+        if built is None:
+            # Don't emit an empty aiContext; drop any previously set one.
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore[union-attr]
+            return
+        self._set_aspect(built)
+
+    def as_mcps(
+        self,
+        change_type: Union[str, ChangeTypeClass] = ChangeTypeClass.UPSERT,
+    ) -> List[MetadataChangeProposalWrapper]:  # type: ignore[override]
+        return super().as_mcps(change_type=change_type)
+
+
+def _make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
+    if ts is None:
+        return None
+    return AuditStampClass(time=make_ts_millis(ts), actor=_DEFAULT_ACTOR_URN)
+
+
+__all__ = [
+    "AiContextInput",
+    "DialectExpressionInput",
+    "DerivedFromInputType",
+    "Metric",
+    "SemanticModelInputType",
+]

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -5,12 +5,9 @@ from typing import List, Optional, Sequence, Type, Union
 
 from typing_extensions import Self, TypeAlias
 
-from datahub.emitter.mce_builder import make_ts_millis, parse_ts_millis
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.mce_builder import parse_ts_millis
 from datahub.metadata.schema_classes import (
     AiContextClass,
-    AuditStampClass,
-    ChangeTypeClass,
     DerivedMetricInputClass,
     DialectClass,
     MetricExpressionClass,
@@ -19,6 +16,14 @@ from datahub.metadata.schema_classes import (
     StatusClass,
 )
 from datahub.metadata.urns import MetricUrn, SemanticModelUrn, Urn
+from datahub.sdk._semantic_shared import (
+    AiContextInput,
+    DialectExpressionInput,
+    MetricExpressionInputType,
+    build_ai_context,
+    build_metric_expression,
+    make_audit_stamp,
+)
 from datahub.sdk._shared import (
     DomainInputType,
     HasDomain,
@@ -35,15 +40,15 @@ from datahub.sdk._shared import (
     TermsInputType,
 )
 from datahub.sdk.entity import Entity, ExtraAspectsType
-from datahub.sdk.semantic_model import (
-    AiContextInput,
-    DialectExpressionInput,
-    MetricExpressionInputType,
-    _build_ai_context,
-    _build_metric_expression,
-)
 
-_DEFAULT_ACTOR_URN = "urn:li:corpuser:__ingestion"
+__all__ = [
+    "AiContextInput",
+    "DialectExpressionInput",
+    "DerivedFromInputType",
+    "Metric",
+    "MetricExpressionInputType",
+    "SemanticModelInputType",
+]
 
 SemanticModelInputType: TypeAlias = Union[str, SemanticModelUrn]
 DerivedFromInputType: TypeAlias = Union[str, MetricUrn]
@@ -66,9 +71,18 @@ class Metric(
     flows ``Metric -> SemanticModel -> Logical Dataset -> Physical Dataset``;
     do not populate ``metricUpstreams`` for these metrics.
 
+    This builder emits semantic-model-backed metrics; ``semantic_model`` is
+    required. Standalone/`metricUpstreams` metrics are out of scope for now.
+
     ``metricRelationships`` is always emitted (even with empty ``derivedFrom``)
     so ``hasParentMetric`` indexes as false. ``metricInfo.expression`` is
     optional and is omitted when not provided.
+
+    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
+    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    semanticModel/metric model (operator's responsibility — no automatic
+    check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
+    preflight helper.
     """
 
     __slots__ = ()
@@ -139,14 +153,12 @@ class Metric(
     @classmethod
     def _new_from_graph(cls, urn: Urn, current_aspects: object) -> Self:  # type: ignore[override]
         assert isinstance(urn, MetricUrn)
-        entity = cls(
-            platform=urn.platform,
-            path=urn.path,
-            id=urn.id,
-            # semantic_model is required on metricInfo; the graph-loaded
-            # aspect will overwrite this placeholder during _init_from_graph.
-            semantic_model="urn:li:semanticModel:__placeholder__",
-        )
+        # Construct without routing through the strict __init__ (which requires
+        # semantic_model). _init_from_graph resets self._aspects = {} before
+        # repopulating from the graph, so the placeholder props created here
+        # are discarded.
+        entity = cls.__new__(cls)
+        Entity.__init__(entity, urn)  # type: ignore[arg-type]
         return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
 
     @property
@@ -159,8 +171,9 @@ class Metric(
         props = self._get_aspect(MetricInfoClass)
         if props is None:
             # name is required on the aspect; default to the URN id. semanticModel
-            # is also required by the contract; use the provided value or a
-            # placeholder that _init_from_graph will overwrite.
+            # is also required by the contract; use the provided value or None
+            # (only the _new_from_graph path passes None, and it resets aspects
+            # before repopulating).
             props = MetricInfoClass(
                 name=self.urn.id,
                 semanticModel=semantic_model,
@@ -190,7 +203,7 @@ class Metric(
         return parse_ts_millis(stamp.time)
 
     def set_created(self, created: datetime) -> None:
-        self._ensure_metric_props().created = _make_audit_stamp(created)
+        self._ensure_metric_props().created = make_audit_stamp(created)
 
     @property
     def last_modified(self) -> Optional[datetime]:
@@ -200,7 +213,7 @@ class Metric(
         return parse_ts_millis(stamp.time)
 
     def set_last_modified(self, last_modified: datetime) -> None:
-        self._ensure_metric_props().lastModified = _make_audit_stamp(last_modified)
+        self._ensure_metric_props().lastModified = make_audit_stamp(last_modified)
 
     @property
     def semantic_model(self) -> Optional[str]:
@@ -219,7 +232,7 @@ class Metric(
         *,
         default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
     ) -> None:
-        self._ensure_metric_props().expression = _build_metric_expression(
+        self._ensure_metric_props().expression = build_metric_expression(
             expression, default_dialect=default_dialect
         )
 
@@ -254,30 +267,9 @@ class Metric(
         return self._get_aspect(AiContextClass)
 
     def set_ai_context(self, ai_context: AiContextInput) -> None:
-        built = _build_ai_context(ai_context)
+        built = build_ai_context(ai_context)
         if built is None:
             # Don't emit an empty aiContext; drop any previously set one.
             self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
             return
         self._set_aspect(built)
-
-    def as_mcps(
-        self,
-        change_type: Union[str, ChangeTypeClass] = ChangeTypeClass.UPSERT,
-    ) -> List[MetadataChangeProposalWrapper]:  # type: ignore[override]
-        return super().as_mcps(change_type=change_type)
-
-
-def _make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
-    if ts is None:
-        return None
-    return AuditStampClass(time=make_ts_millis(ts), actor=_DEFAULT_ACTOR_URN)
-
-
-__all__ = [
-    "AiContextInput",
-    "DialectExpressionInput",
-    "DerivedFromInputType",
-    "Metric",
-    "SemanticModelInputType",
-]

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -20,9 +20,11 @@ from datahub.sdk._semantic_shared import (
     AiContextInput,
     DialectExpressionInput,
     MetricExpressionInputType,
+    as_input_list,
     build_ai_context,
     build_metric_expression,
     make_audit_stamp,
+    validate_semantic_model_urn,
 )
 from datahub.sdk._shared import (
     DomainInputType,
@@ -119,7 +121,9 @@ class Metric(
         self._set_platform_instance(urn.platform, platform_instance)
         # Status is part of the producer contract for this entity.
         self._set_aspect(StatusClass(removed=False))
-        self._ensure_metric_props(semantic_model=str(semantic_model))
+        self._ensure_metric_props(
+            semantic_model=validate_semantic_model_urn(semantic_model)
+        )
 
         if name is not None:
             self.set_name(name)
@@ -219,7 +223,9 @@ class Metric(
         return self._ensure_metric_props().semanticModel
 
     def set_semantic_model(self, semantic_model: SemanticModelInputType) -> None:
-        self._ensure_metric_props().semanticModel = str(semantic_model)
+        self._ensure_metric_props().semanticModel = validate_semantic_model_urn(
+            semantic_model
+        )
 
     @property
     def expression(self) -> Optional[MetricExpressionClass]:
@@ -254,8 +260,10 @@ class Metric(
 
     def set_derived_from(self, derived_from: Sequence[DerivedFromInputType]) -> None:
         # Mutate only derivedFrom; leave parentMetric/relatedMetrics untouched.
+        # Normalize so a bare URN string isn't iterated character-by-character.
         self._ensure_metric_relationships().derivedFrom = [
-            DerivedMetricInputClass(destinationUrn=str(d)) for d in derived_from
+            DerivedMetricInputClass(destinationUrn=str(d))
+            for d in as_input_list(derived_from)
         ]
 
     def add_derived_from(self, metric: DerivedFromInputType) -> None:
@@ -270,8 +278,14 @@ class Metric(
 
     def set_ai_context(self, ai_context: AiContextInput) -> None:
         built = build_ai_context(ai_context)
-        if built is None:
-            # Don't emit an empty aiContext; drop any previously set one.
-            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
+        if built is not None:
+            self._set_aspect(built)
             return
-        self._set_aspect(built)
+        # Empty input clears it. On a graph-hydrated metric that previously had
+        # an aiContext, emit an empty aspect to overwrite the server value —
+        # as_mcps only emits present aspects, so a plain pop would leave the
+        # server copy intact.
+        if AiContextClass.ASPECT_NAME in (self._prev_aspects or {}):
+            self._set_aspect(AiContextClass())
+        else:
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -12,6 +12,7 @@ from datahub.metadata.schema_classes import (
     AuditStampClass,
     ChangeTypeClass,
     DerivedMetricInputClass,
+    DialectClass,
     MetricExpressionClass,
     MetricInfoClass,
     MetricRelationshipsClass,
@@ -21,6 +22,7 @@ from datahub.metadata.urns import MetricUrn, SemanticModelUrn, Urn
 from datahub.sdk._shared import (
     DomainInputType,
     HasDomain,
+    HasInstitutionalMemory,
     HasOwnership,
     HasPlatformInstance,
     HasStructuredProperties,
@@ -50,6 +52,7 @@ DerivedFromInputType: TypeAlias = Union[str, MetricUrn]
 class Metric(
     HasPlatformInstance,
     HasOwnership,
+    HasInstitutionalMemory,
     HasTags,
     HasTerms,
     HasDomain,
@@ -214,13 +217,10 @@ class Metric(
         self,
         expression: MetricExpressionInputType,
         *,
-        default_dialect: Union[str, "object"] = ...,  # type: ignore[assignment]
+        default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
     ) -> None:
-        from datahub.metadata.schema_classes import DialectClass
-
-        dialect = DialectClass.ANSI_SQL if default_dialect is ... else default_dialect
         self._ensure_metric_props().expression = _build_metric_expression(
-            expression, default_dialect=dialect
+            expression, default_dialect=default_dialect
         )
 
     @property
@@ -257,7 +257,7 @@ class Metric(
         built = _build_ai_context(ai_context)
         if built is None:
             # Don't emit an empty aiContext; drop any previously set one.
-            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore[union-attr]
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
             return
         self._set_aspect(built)
 

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -243,24 +243,27 @@ class Metric(
             return []
         return list(rels.derivedFrom)
 
+    def _ensure_metric_relationships(self) -> MetricRelationshipsClass:
+        # Always present so hasParentMetric indexes as false; on a graph-hydrated
+        # metric this preserves server-set parentMetric/relatedMetrics instead of
+        # clobbering them when only derivedFrom changes.
+        rels = self._get_aspect(MetricRelationshipsClass)
+        if rels is None:
+            rels = MetricRelationshipsClass()
+            self._set_aspect(rels)
+        return rels
+
     def set_derived_from(self, derived_from: Sequence[DerivedFromInputType]) -> None:
-        # Always emit metricRelationships (even with empty derivedFrom) so
-        # hasParentMetric indexes as false. parentMetric is left unset: these
-        # metrics have no parent.
-        self._set_aspect(
-            MetricRelationshipsClass(
-                derivedFrom=[
-                    DerivedMetricInputClass(destinationUrn=str(d)) for d in derived_from
-                ]
-            )
-        )
+        # Mutate only derivedFrom; leave parentMetric/relatedMetrics untouched.
+        self._ensure_metric_relationships().derivedFrom = [
+            DerivedMetricInputClass(destinationUrn=str(d)) for d in derived_from
+        ]
 
     def add_derived_from(self, metric: DerivedFromInputType) -> None:
-        current = self.derived_from
+        rels = self._ensure_metric_relationships()
         dest = str(metric)
-        if all(d.destinationUrn != dest for d in current):
-            current.append(DerivedMetricInputClass(destinationUrn=dest))
-        self._set_aspect(MetricRelationshipsClass(derivedFrom=current))
+        if all(d.destinationUrn != dest for d in rels.derivedFrom):
+            rels.derivedFrom.append(DerivedMetricInputClass(destinationUrn=dest))
 
     @property
     def ai_context(self) -> Optional[AiContextClass]:

--- a/metadata-ingestion/src/datahub/sdk/metric.py
+++ b/metadata-ingestion/src/datahub/sdk/metric.py
@@ -78,8 +78,7 @@ class Metric(
     so ``hasParentMetric`` indexes as false. ``metricInfo.expression`` is
     optional and is omitted when not provided.
 
-    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
-    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    Server compatibility: requires a server build that includes the
     semanticModel/metric model (operator's responsibility — no automatic
     check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
     preflight helper.

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -18,7 +18,6 @@ from datahub.metadata.schema_classes import (
     GlobalTagsClass,
     MetricExpressionClass,
     SchemaFieldClass,
-    SchemaMetadataClass,
     SemanticFieldAnnotationClass,
     SemanticFieldTypeClass,
     SemanticModelInfoClass,
@@ -336,14 +335,14 @@ class SemanticModel(
         self._ensure_model_props().relationships = [
             self._build_relationship(rel) for rel in relationships
         ]
-        self._validate_relationship_aliases()
+        self._validate_relationships()
 
     def add_relationship(self, relationship: SemanticModelRelationshipInput) -> None:
         props = self._ensure_model_props()
         if props.relationships is None:
             props.relationships = []
         props.relationships.append(self._build_relationship(relationship))
-        self._validate_relationship_aliases()
+        self._validate_relationships()
 
     @staticmethod
     def _build_relationship(
@@ -359,44 +358,81 @@ class SemanticModel(
             aiContext=build_ai_context(rel.ai_context),
         )
 
-    def _attached_dataset_aliases(self) -> Set[str]:
-        return {ds.alias for ds in self._attached_logical_datasets}
+    def _attached_datasets_by_urn(self) -> Dict[str, "SemanticModelDataset"]:
+        # Keyed by URN so duplicate attachments of the same dataset collapse,
+        # matching how props.datasets dedupes URNs.
+        return {str(ds.urn): ds for ds in self._attached_logical_datasets}
 
-    def _validate_relationship_aliases(self, *, strict: bool = False) -> None:
-        """Warn — or, when ``strict``, raise — when a relationship alias has no
-        matching attached dataset.
+    def _attached_dataset_aliases(self) -> Set[str]:
+        return {ds.alias for ds in self._attached_datasets_by_urn().values()}
+
+    def _validate_relationships(self, *, strict: bool = False) -> None:
+        """Warn — or, when ``strict``, raise — when a relationship references an
+        alias with no matching attached dataset, or a join column absent from
+        that dataset's schema.
 
         Datasets are commonly attached *after* relationships, so at construction
-        time the set of known aliases may still be empty/incomplete and this can
-        only flag what it can see. Re-run with ``strict=True`` at emit time
-        (:meth:`as_mcps`), when all datasets and relationships are known.
+        time this can only flag what it can see. Re-run with ``strict=True`` at
+        emit time (:meth:`as_mcps`).
 
-        ``strict`` only raises when we have *full* alias coverage: every dataset
-        listed on the model is an attached :class:`SemanticModelDataset` (so its
-        alias is known). Datasets attached as raw URN strings carry no alias, so
-        a definitive mismatch cannot be proven and we fall back to a warning.
+        Alias checks raise (under ``strict``) only under *full* alias coverage:
+        every declared dataset URN is an attached :class:`SemanticModelDataset`,
+        so all aliases are known. Datasets attached as raw URN strings carry no
+        alias/schema, so mismatches there downgrade to a warning. Column checks
+        run only for aliases whose dataset is attached with a non-empty schema.
         """
-        rels = self._ensure_model_props().relationships
+        props = self._ensure_model_props()
+        rels = props.relationships
         if not rels:
             return
-        known = self._attached_dataset_aliases()
-        if not known:
+        attached_by_urn = self._attached_datasets_by_urn()
+        by_alias = {ds.alias: ds for ds in attached_by_urn.values()}
+        known_aliases = set(by_alias)
+        # Non-strict callers are construction-time setters that commonly run
+        # before datasets are attached; stay quiet until there is something to
+        # check. Strict (emit-time) validation still runs with no aliases so the
+        # relationships-without-datasets case is caught.
+        if not known_aliases and not strict:
             return
-        props = self._ensure_model_props()
-        full_coverage = len(self._attached_logical_datasets) == len(
-            props.datasets or []
-        )
+        # Subset check (not a length comparison): duplicates and instance/URN
+        # mixes no longer break coverage detection. An empty declared set with
+        # relationships present is full coverage too — the aliases can't match
+        # anything, which is exactly the broken case we want to raise on.
+        declared_urns = set(props.datasets or [])
+        full_coverage = declared_urns <= set(attached_by_urn)
+
+        def flag(message: str, *, definitive: bool) -> None:
+            if strict and definitive:
+                raise SdkUsageError(message)
+            logger.warning(message)
+
         for rel in rels:
-            for alias in (rel.from_, rel.to):
-                if alias and alias not in known:
-                    msg = (
+            for alias, columns in (
+                (rel.from_, rel.fromColumns),
+                (rel.to, rel.toColumns),
+            ):
+                if not alias:
+                    continue
+                if alias not in known_aliases:
+                    flag(
                         f"SemanticModel {str(self.urn)}: relationship alias "
                         f"{alias!r} does not match any attached dataset alias "
-                        f"(known: {sorted(known)}). Join path may be broken."
+                        f"(known: {sorted(known_aliases)}). Join path may be "
+                        f"broken.",
+                        definitive=full_coverage,
                     )
-                    if strict and full_coverage:
-                        raise SdkUsageError(msg)
-                    logger.warning(msg)
+                    continue
+                field_paths = {f.field_path for f in by_alias[alias].schema}
+                if not field_paths:
+                    continue  # schema unavailable; cannot validate columns
+                missing = [c for c in (columns or []) if c not in field_paths]
+                if missing:
+                    flag(
+                        f"SemanticModel {str(self.urn)}: relationship join "
+                        f"column(s) {missing} not found in dataset {alias!r} "
+                        f"(known: {sorted(field_paths)}).",
+                        definitive=True,
+                    )
 
     @property
     def ai_context(self) -> Optional[AiContextClass]:
@@ -417,7 +453,7 @@ class SemanticModel(
         # By emit time all datasets and relationships are attached, so validate
         # join-path aliases against the full picture (a construction-time check
         # sees an incomplete set when datasets are attached after relationships).
-        self._validate_relationship_aliases(strict=True)
+        self._validate_relationships(strict=True)
         return super().as_mcps(change_type=change_type)
 
 
@@ -435,11 +471,12 @@ class SemanticModelDataset(Dataset):
     logical datasets stay unique across semantic models.
 
     Per-field ``semanticFieldAnnotation`` and field-level ``aiContext`` are
-    **create-only**: they are not preserved on a read-modify-write cycle. A
-    graph read returns a :class:`SemanticModelDataset` but its
-    ``_semantic_field_annotations`` is empty, so re-emitting the result drops
-    every field-anchored annotation. Re-attach fields via the ``schema``
-    constructor kwarg to preserve them.
+    **create-only**: they are field-anchored (on ``schemaField`` URNs), not part
+    of the dataset aspect bag. A logical dataset shares the ``dataset`` entity
+    type, so ``client.entities.get(...)`` hydrates it as a base :class:`Dataset`
+    and the annotations are not carried back on a read. To update one, rebuild a
+    fresh ``SemanticModelDataset`` and re-attach its fields via the ``schema``
+    constructor kwarg rather than read-modify-writing the fetched ``Dataset``.
 
     Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
     Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
@@ -609,27 +646,7 @@ class SemanticModelDataset(Dataset):
         entity = cls.__new__(cls)
         Entity.__init__(entity, urn)  # type: ignore[arg-type]
         entity._semantic_field_annotations = {}
-        entity = entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
-        # Field annotations are create-only: a graph read never repopulates
-        # them. When the read-back carries schema fields, a subsequent
-        # read-modify-upsert cycle silently drops every semanticFieldAnnotation
-        # and aiContext. Warn so the loss is at least traceable.
-        schema_meta = entity._get_aspect(SchemaMetadataClass)
-        if (
-            schema_meta is not None
-            and schema_meta.fields
-            and not entity._semantic_field_annotations
-        ):
-            logger.warning(
-                "SemanticModelDataset %s was read from the graph with %d schema "
-                "field(s) but no field annotations (semanticFieldAnnotation and "
-                "field-level aiContext are create-only). Re-emitting this "
-                "instance will NOT preserve them; re-attach fields via the "
-                "`schema` constructor kwarg to retain them.",
-                str(urn),
-                len(schema_meta.fields),
-            )
-        return entity
+        return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
 
     def as_mcps(
         self,

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -35,9 +35,11 @@ from datahub.sdk._semantic_shared import (
     AiContextInput,
     DialectExpressionInput,
     MetricExpressionInputType,
+    as_input_list,
     build_ai_context,
     build_metric_expression,
     make_audit_stamp,
+    validate_semantic_model_urn,
 )
 from datahub.sdk._shared import (
     DomainInputType,
@@ -224,8 +226,7 @@ class SemanticModel(
         # datasets last so add_dataset can reconcile back-refs against the
         # already-populated alias on each SemanticModelDataset.
         if datasets is not None:
-            for dataset in datasets:
-                self.add_dataset(dataset)
+            self.set_datasets(datasets)
 
     @classmethod
     def _new_from_graph(cls, urn: Urn, current_aspects: object) -> Self:  # type: ignore[override]
@@ -321,7 +322,8 @@ class SemanticModel(
     def set_datasets(self, datasets: Sequence[SemanticModelDatasetInputType]) -> None:
         self._ensure_model_props().datasets = []
         self._attached_logical_datasets = []
-        for dataset in datasets:
+        # Normalize so a bare dataset URN string isn't iterated character-by-char.
+        for dataset in as_input_list(datasets):
             self.add_dataset(dataset)
 
     @property
@@ -385,6 +387,48 @@ class SemanticModel(
         if not rels:
             return
         attached_by_urn = self._attached_datasets_by_urn()
+
+        def flag(message: str, *, definitive: bool) -> None:
+            if strict and definitive:
+                raise SdkUsageError(message)
+            logger.warning(message)
+
+        # Structural checks on the relationship inputs themselves — always
+        # definitive (independent of which datasets are attached).
+        for rel in rels:
+            if not (rel.from_ or "").strip() or not (rel.to or "").strip():
+                flag(
+                    f"SemanticModel {str(self.urn)}: relationship has a blank "
+                    f"from/to alias (from={rel.from_!r}, to={rel.to!r}).",
+                    definitive=True,
+                )
+            if not rel.fromColumns or not rel.toColumns:
+                flag(
+                    f"SemanticModel {str(self.urn)}: relationship "
+                    f"{rel.from_!r}->{rel.to!r} has an empty join column list.",
+                    definitive=True,
+                )
+            elif len(rel.fromColumns) != len(rel.toColumns):
+                flag(
+                    f"SemanticModel {str(self.urn)}: relationship "
+                    f"{rel.from_!r}->{rel.to!r} joins {len(rel.fromColumns)} "
+                    f"column(s) to {len(rel.toColumns)}; counts must match.",
+                    definitive=True,
+                )
+
+        # Distinct datasets must not share an alias — the by-alias resolution
+        # below would otherwise silently collapse them.
+        alias_to_urn: Dict[str, str] = {}
+        for ds_urn, ds in attached_by_urn.items():
+            prior = alias_to_urn.get(ds.alias)
+            if prior is not None and prior != ds_urn:
+                flag(
+                    f"SemanticModel {str(self.urn)}: alias {ds.alias!r} is "
+                    f"assigned to multiple datasets ({prior}, {ds_urn}).",
+                    definitive=True,
+                )
+            alias_to_urn[ds.alias] = ds_urn
+
         by_alias = {ds.alias: ds for ds in attached_by_urn.values()}
         known_aliases = set(by_alias)
         # Non-strict callers are construction-time setters that commonly run
@@ -400,18 +444,13 @@ class SemanticModel(
         declared_urns = set(props.datasets or [])
         full_coverage = declared_urns <= set(attached_by_urn)
 
-        def flag(message: str, *, definitive: bool) -> None:
-            if strict and definitive:
-                raise SdkUsageError(message)
-            logger.warning(message)
-
         for rel in rels:
             for alias, columns in (
                 (rel.from_, rel.fromColumns),
                 (rel.to, rel.toColumns),
             ):
-                if not alias:
-                    continue
+                if not alias or not alias.strip():
+                    continue  # blank aliases are handled structurally above
                 if alias not in known_aliases:
                     flag(
                         f"SemanticModel {str(self.urn)}: relationship alias "
@@ -439,11 +478,17 @@ class SemanticModel(
 
     def set_ai_context(self, ai_context: AiContextInput) -> None:
         built = build_ai_context(ai_context)
-        if built is None:
-            # Don't emit an empty aiContext; drop any previously set one.
-            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
+        if built is not None:
+            self._set_aspect(built)
             return
-        self._set_aspect(built)
+        # Empty input clears it. On a graph-hydrated model that previously had
+        # an aiContext, emit an empty aspect to overwrite the server value —
+        # as_mcps only emits present aspects, so a plain pop would leave the
+        # server copy intact.
+        if AiContextClass.ASPECT_NAME in (self._prev_aspects or {}):
+            self._set_aspect(AiContextClass())
+        else:
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
 
     def as_mcps(
         self,
@@ -535,16 +580,17 @@ class SemanticModelDataset(Dataset):
         semantic_model: Union[str, SemanticModelUrn],
         alias: str,
     ) -> None:
+        semantic_model_urn = validate_semantic_model_urn(semantic_model)
         existing = self._get_aspect(SemanticModelPropertiesClass)
         if existing is None:
             self._set_aspect(
                 SemanticModelPropertiesClass(
-                    alias=alias, semanticModel=str(semantic_model)
+                    alias=alias, semanticModel=semantic_model_urn
                 )
             )
         else:
             existing.alias = alias
-            existing.semanticModel = str(semantic_model)
+            existing.semanticModel = semantic_model_urn
 
     def _set_semantic_model_back_ref(
         self, semantic_model: Union[str, SemanticModelUrn]

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -106,7 +106,7 @@ class SemanticModelRelationshipInput:
     to_alias: str
     to_columns: List[str]
     name: Optional[str] = None
-    cardinality: Optional[ERModelRelationshipCardinalityClass] = None
+    cardinality: Optional[str] = None
     ai_context: Optional[AiContextInput] = None
 
 
@@ -132,19 +132,15 @@ class SemanticFieldInput:
     ai_context: Optional[AiContextInput] = None
 
 
-def _ai_context_is_empty(ai: Optional[AiContextInput]) -> bool:
-    if ai is None:
-        return True
-    return not (ai.synonyms or ai.instructions or ai.examples or ai.custom_instructions)
-
-
 def _build_ai_context(ai: Optional[AiContextInput]) -> Optional[AiContextClass]:
-    if _ai_context_is_empty(ai):
+    if ai is None or not (
+        ai.synonyms or ai.instructions or ai.examples or ai.custom_instructions
+    ):
         return None
     return AiContextClass(
-        synonyms=list(ai.synonyms) if ai.synonyms else None,  # type: ignore[union-attr]
+        synonyms=list(ai.synonyms) if ai.synonyms else None,
         instructions=ai.instructions,
-        examples=list(ai.examples) if ai.examples else None,  # type: ignore[union-attr]
+        examples=list(ai.examples) if ai.examples else None,
         customInstructions=ai.custom_instructions,
     )
 
@@ -427,7 +423,7 @@ class SemanticModel(
         built = _build_ai_context(ai_context)
         if built is None:
             # Don't emit an empty aiContext; drop any previously set one.
-            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore[union-attr]
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
             return
         self._set_aspect(built)
 

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -18,6 +18,7 @@ from datahub.metadata.schema_classes import (
     GlobalTagsClass,
     MetricExpressionClass,
     SchemaFieldClass,
+    SchemaMetadataClass,
     SemanticFieldAnnotationClass,
     SemanticFieldTypeClass,
     SemanticModelInfoClass,
@@ -361,11 +362,19 @@ class SemanticModel(
     def _attached_dataset_aliases(self) -> Set[str]:
         return {ds.alias for ds in self._attached_logical_datasets}
 
-    def _validate_relationship_aliases(self) -> None:
-        """Best-effort warn when a relationship alias has no matching attached
-        dataset. Datasets are often attached after relationships, so this only
-        flags aliases that are still unmatched at the time it runs; it never
-        raises.
+    def _validate_relationship_aliases(self, *, strict: bool = False) -> None:
+        """Warn — or, when ``strict``, raise — when a relationship alias has no
+        matching attached dataset.
+
+        Datasets are commonly attached *after* relationships, so at construction
+        time the set of known aliases may still be empty/incomplete and this can
+        only flag what it can see. Re-run with ``strict=True`` at emit time
+        (:meth:`as_mcps`), when all datasets and relationships are known.
+
+        ``strict`` only raises when we have *full* alias coverage: every dataset
+        listed on the model is an attached :class:`SemanticModelDataset` (so its
+        alias is known). Datasets attached as raw URN strings carry no alias, so
+        a definitive mismatch cannot be proven and we fall back to a warning.
         """
         rels = self._ensure_model_props().relationships
         if not rels:
@@ -373,17 +382,21 @@ class SemanticModel(
         known = self._attached_dataset_aliases()
         if not known:
             return
+        props = self._ensure_model_props()
+        full_coverage = len(self._attached_logical_datasets) == len(
+            props.datasets or []
+        )
         for rel in rels:
             for alias in (rel.from_, rel.to):
                 if alias and alias not in known:
-                    logger.warning(
-                        "SemanticModel %s: relationship alias %r does not match "
-                        "any attached dataset alias (known: %s). Join path may "
-                        "be broken.",
-                        str(self.urn),
-                        alias,
-                        sorted(known),
+                    msg = (
+                        f"SemanticModel {str(self.urn)}: relationship alias "
+                        f"{alias!r} does not match any attached dataset alias "
+                        f"(known: {sorted(known)}). Join path may be broken."
                     )
+                    if strict and full_coverage:
+                        raise SdkUsageError(msg)
+                    logger.warning(msg)
 
     @property
     def ai_context(self) -> Optional[AiContextClass]:
@@ -396,6 +409,16 @@ class SemanticModel(
             self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
             return
         self._set_aspect(built)
+
+    def as_mcps(
+        self,
+        change_type: Union[str, ChangeTypeClass] = ChangeTypeClass.UPSERT,
+    ) -> List[MetadataChangeProposalWrapper]:
+        # By emit time all datasets and relationships are attached, so validate
+        # join-path aliases against the full picture (a construction-time check
+        # sees an incomplete set when datasets are attached after relationships).
+        self._validate_relationship_aliases(strict=True)
+        return super().as_mcps(change_type=change_type)
 
 
 class SemanticModelDataset(Dataset):
@@ -586,26 +609,52 @@ class SemanticModelDataset(Dataset):
         entity = cls.__new__(cls)
         Entity.__init__(entity, urn)  # type: ignore[arg-type]
         entity._semantic_field_annotations = {}
-        return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
+        entity = entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
+        # Field annotations are create-only: a graph read never repopulates
+        # them. When the read-back carries schema fields, a subsequent
+        # read-modify-upsert cycle silently drops every semanticFieldAnnotation
+        # and aiContext. Warn so the loss is at least traceable.
+        schema_meta = entity._get_aspect(SchemaMetadataClass)
+        if (
+            schema_meta is not None
+            and schema_meta.fields
+            and not entity._semantic_field_annotations
+        ):
+            logger.warning(
+                "SemanticModelDataset %s was read from the graph with %d schema "
+                "field(s) but no field annotations (semanticFieldAnnotation and "
+                "field-level aiContext are create-only). Re-emitting this "
+                "instance will NOT preserve them; re-attach fields via the "
+                "`schema` constructor kwarg to retain them.",
+                str(urn),
+                len(schema_meta.fields),
+            )
+        return entity
 
     def as_mcps(
         self,
         change_type: Union[str, ChangeTypeClass] = ChangeTypeClass.UPSERT,
     ) -> List[MetadataChangeProposalWrapper]:  # type: ignore[override]
         mcps = super().as_mcps(change_type=change_type)
-        # Emit schemaField-anchored semanticFieldAnnotation + aiContext MCPs.
+        # Emit schemaField-anchored semanticFieldAnnotation + aiContext MCPs,
+        # propagating change_type so field aspects stay consistent with the
+        # dataset-anchored ones (e.g. EntityClient.create requests CREATE).
         ds_urn = str(self.urn)
         for field_path, field_ann in self._semantic_field_annotations.items():
             field_urn = SchemaFieldUrn(ds_urn, field_path).urn()
             mcps.append(
                 MetadataChangeProposalWrapper(
-                    entityUrn=field_urn, aspect=field_ann.annotation
+                    entityUrn=field_urn,
+                    aspect=field_ann.annotation,
+                    changeType=change_type,
                 )
             )
             if field_ann.ai_context is not None:
                 mcps.append(
                     MetadataChangeProposalWrapper(
-                        entityUrn=field_urn, aspect=field_ann.ai_context
+                        entityUrn=field_urn,
+                        aspect=field_ann.ai_context,
+                        changeType=change_type,
                     )
                 )
         return mcps

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Optional, Sequence, Type, Union
+from typing import Dict, List, Optional, Sequence, Set, Type, Union
 
 from typing_extensions import Self, TypeAlias
 
-from datahub.emitter.mce_builder import DEFAULT_ENV, make_ts_millis, parse_ts_millis
+from datahub.emitter.mce_builder import DEFAULT_ENV, parse_ts_millis
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.errors import SdkUsageError
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.schema_classes import (
     AiContextClass,
-    AuditStampClass,
     ChangeTypeClass,
-    DialectClass,
-    DialectExpressionClass,
     DimensionClass,
-    ERModelRelationshipCardinalityClass,
     GlobalTagsClass,
     MetricExpressionClass,
     SchemaFieldClass,
@@ -26,13 +24,20 @@ from datahub.metadata.schema_classes import (
     SemanticModelPropertiesClass,
     SemanticModelRelationshipClass,
     StatusClass,
-    TagAssociationClass,
 )
 from datahub.metadata.urns import (
     DatasetUrn,
     SchemaFieldUrn,
     SemanticModelUrn,
     Urn,
+)
+from datahub.sdk._semantic_shared import (
+    AiContextInput,
+    DialectExpressionInput,
+    MetricExpressionInputType,
+    build_ai_context,
+    build_metric_expression,
+    make_audit_stamp,
 )
 from datahub.sdk._shared import (
     DomainInputType,
@@ -49,47 +54,20 @@ from datahub.sdk._shared import (
     TagsInputType,
     TermsInputType,
 )
-from datahub.sdk.dataset import Dataset
+from datahub.sdk.dataset import Dataset, UpstreamLineageInputType
 from datahub.sdk.entity import Entity, ExtraAspectsType
 
-_DEFAULT_ACTOR_URN = "urn:li:corpuser:__ingestion"
+logger = logging.getLogger(__name__)
 
-
-class SemanticFieldType(SemanticFieldTypeClass):
-    pass
-
-
-class ERModelRelationshipCardinality(ERModelRelationshipCardinalityClass):
-    pass
-
-
-@dataclass
-class AiContextInput:
-    """Input container for the first-class ``aiContext`` aspect.
-
-    The aspect is only emitted when at least one field carries content; an
-    all-empty ``AiContextInput`` produces no aspect.
-    """
-
-    synonyms: Optional[List[str]] = None
-    instructions: Optional[str] = None
-    examples: Optional[List[str]] = None
-    custom_instructions: Optional[str] = None
-
-
-@dataclass
-class DialectExpressionInput:
-    """A single (dialect, expression) pair for a metric or field expression."""
-
-    expression: str
-    dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL
-
-
-MetricExpressionInputType: TypeAlias = Union[
-    str,
-    DialectExpressionInput,
-    List[DialectExpressionInput],
-    MetricExpressionClass,
+__all__ = [
+    "AiContextInput",
+    "DialectExpressionInput",
+    "MetricExpressionInputType",
+    "SemanticFieldInput",
+    "SemanticModel",
+    "SemanticModelDataset",
+    "SemanticModelDatasetInputType",
+    "SemanticModelRelationshipInput",
 ]
 
 
@@ -132,52 +110,6 @@ class SemanticFieldInput:
     ai_context: Optional[AiContextInput] = None
 
 
-def _build_ai_context(ai: Optional[AiContextInput]) -> Optional[AiContextClass]:
-    if ai is None or not (
-        ai.synonyms or ai.instructions or ai.examples or ai.custom_instructions
-    ):
-        return None
-    return AiContextClass(
-        synonyms=list(ai.synonyms) if ai.synonyms else None,
-        instructions=ai.instructions,
-        examples=list(ai.examples) if ai.examples else None,
-        customInstructions=ai.custom_instructions,
-    )
-
-
-def _build_metric_expression(
-    expression: MetricExpressionInputType,
-    *,
-    default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
-) -> MetricExpressionClass:
-    if isinstance(expression, MetricExpressionClass):
-        return expression
-    if isinstance(expression, DialectExpressionInput):
-        dialects = [
-            DialectExpressionClass(
-                dialect=expression.dialect, expression=expression.expression
-            )
-        ]
-    elif isinstance(expression, str):
-        dialects = [
-            DialectExpressionClass(dialect=default_dialect, expression=expression)
-        ]
-    elif isinstance(expression, list):
-        dialects = [
-            DialectExpressionClass(dialect=item.dialect, expression=item.expression)
-            for item in expression
-        ]
-    else:  # pragma: no cover - defensive
-        raise TypeError(f"Unsupported expression input type: {type(expression)!r}")
-    return MetricExpressionClass(dialects=dialects)
-
-
-def _make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
-    if ts is None:
-        return None
-    return AuditStampClass(time=make_ts_millis(ts), actor=_DEFAULT_ACTOR_URN)
-
-
 SemanticModelDatasetInputType: TypeAlias = Union[
     str, DatasetUrn, "SemanticModelDataset"
 ]
@@ -217,9 +149,15 @@ class SemanticModel(
     ``semanticModelInfo.datasets`` (Contains), and each logical dataset's own
     ``upstreamLineage``. Do not populate ``metricUpstreams`` for
     semantic-model-backed metrics.
+
+    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
+    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    semanticModel/metric model (operator's responsibility — no automatic
+    check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
+    preflight helper.
     """
 
-    __slots__ = ()
+    __slots__ = ("_attached_logical_datasets",)
 
     @classmethod
     def get_urn_type(cls) -> Type[SemanticModelUrn]:
@@ -254,6 +192,7 @@ class SemanticModel(
         self._set_platform_instance(urn.platform, platform_instance)
         # Status is part of the producer contract for this entity.
         self._set_aspect(StatusClass(removed=False))
+        self._attached_logical_datasets: List["SemanticModelDataset"] = []
         self._ensure_model_props()
 
         if name is not None:
@@ -334,7 +273,7 @@ class SemanticModel(
         return parse_ts_millis(stamp.time)
 
     def set_created(self, created: datetime) -> None:
-        self._ensure_model_props().created = _make_audit_stamp(created)
+        self._ensure_model_props().created = make_audit_stamp(created)
 
     @property
     def last_modified(self) -> Optional[datetime]:
@@ -344,7 +283,7 @@ class SemanticModel(
         return parse_ts_millis(stamp.time)
 
     def set_last_modified(self, last_modified: datetime) -> None:
-        self._ensure_model_props().lastModified = _make_audit_stamp(last_modified)
+        self._ensure_model_props().lastModified = make_audit_stamp(last_modified)
 
     @property
     def native_definition(self) -> Optional[str]:
@@ -371,6 +310,7 @@ class SemanticModel(
         if isinstance(dataset, SemanticModelDataset):
             ds_urn = str(dataset.urn)
             dataset._set_semantic_model_back_ref(self.urn)
+            self._attached_logical_datasets.append(dataset)
         else:
             ds_urn = str(dataset)
         props = self._ensure_model_props()
@@ -381,6 +321,7 @@ class SemanticModel(
 
     def set_datasets(self, datasets: Sequence[SemanticModelDatasetInputType]) -> None:
         self._ensure_model_props().datasets = []
+        self._attached_logical_datasets = []
         for dataset in datasets:
             self.add_dataset(dataset)
 
@@ -394,12 +335,14 @@ class SemanticModel(
         self._ensure_model_props().relationships = [
             self._build_relationship(rel) for rel in relationships
         ]
+        self._validate_relationship_aliases()
 
     def add_relationship(self, relationship: SemanticModelRelationshipInput) -> None:
         props = self._ensure_model_props()
         if props.relationships is None:
             props.relationships = []
         props.relationships.append(self._build_relationship(relationship))
+        self._validate_relationship_aliases()
 
     @staticmethod
     def _build_relationship(
@@ -412,15 +355,42 @@ class SemanticModel(
             to=rel.to_alias,
             toColumns=list(rel.to_columns),
             cardinality=rel.cardinality,
-            aiContext=_build_ai_context(rel.ai_context),
+            aiContext=build_ai_context(rel.ai_context),
         )
+
+    def _attached_dataset_aliases(self) -> Set[str]:
+        return {ds.alias for ds in self._attached_logical_datasets}
+
+    def _validate_relationship_aliases(self) -> None:
+        """Best-effort warn when a relationship alias has no matching attached
+        dataset. Datasets are often attached after relationships, so this only
+        flags aliases that are still unmatched at the time it runs; it never
+        raises.
+        """
+        rels = self._ensure_model_props().relationships
+        if not rels:
+            return
+        known = self._attached_dataset_aliases()
+        if not known:
+            return
+        for rel in rels:
+            for alias in (rel.from_, rel.to):
+                if alias and alias not in known:
+                    logger.warning(
+                        "SemanticModel %s: relationship alias %r does not match "
+                        "any attached dataset alias (known: %s). Join path may "
+                        "be broken.",
+                        str(self.urn),
+                        alias,
+                        sorted(known),
+                    )
 
     @property
     def ai_context(self) -> Optional[AiContextClass]:
         return self._get_aspect(AiContextClass)
 
     def set_ai_context(self, ai_context: AiContextInput) -> None:
-        built = _build_ai_context(ai_context)
+        built = build_ai_context(ai_context)
         if built is None:
             # Don't emit an empty aiContext; drop any previously set one.
             self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore
@@ -440,6 +410,19 @@ class SemanticModelDataset(Dataset):
 
     The dataset ``name`` should encode ``<sm_path>.<sm_id>.<view_name>`` so
     logical datasets stay unique across semantic models.
+
+    Per-field ``semanticFieldAnnotation`` and field-level ``aiContext`` are
+    **create-only**: they are not preserved on a read-modify-write cycle. A
+    graph read returns a :class:`SemanticModelDataset` but its
+    ``_semantic_field_annotations`` is empty, so re-emitting the result drops
+    every field-anchored annotation. Re-attach fields via the ``schema``
+    constructor kwarg to preserve them.
+
+    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
+    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    semanticModel/metric model (operator's responsibility — no automatic
+    check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
+    preflight helper.
     """
 
     __slots__ = ("_semantic_field_annotations",)
@@ -456,7 +439,7 @@ class SemanticModelDataset(Dataset):
         env: str = DEFAULT_ENV,
         description: Optional[str] = None,
         view_definition: Optional[str] = None,
-        upstreams: Optional[object] = None,
+        upstreams: Optional[UpstreamLineageInputType] = None,
         owners: Optional[OwnersInputType] = None,
         links: Optional[LinksInputType] = None,
         tags: Optional[TagsInputType] = None,
@@ -465,9 +448,9 @@ class SemanticModelDataset(Dataset):
         structured_properties: Optional[StructuredPropertyInputType] = None,
         extra_aspects: ExtraAspectsType = None,
     ):
-        # Build SchemaFieldClass list + per-field annotation/aiContext records
-        # before delegating to Dataset so the platform is known for type
-        # resolution.
+        # Initialize the per-field annotation store before delegating to
+        # Dataset so _set_semantic_schema can populate it.
+        self._semantic_field_annotations: Dict[str, _FieldAnnotation] = {}
         super().__init__(
             platform=platform,
             name=name,
@@ -476,7 +459,7 @@ class SemanticModelDataset(Dataset):
             subtype=DatasetSubTypes.SEMANTIC_MODEL_DATASET,
             description=description,
             view_definition=view_definition,
-            upstreams=upstreams,  # type: ignore[arg-type]
+            upstreams=upstreams,
             owners=owners,
             links=links,
             tags=tags,
@@ -485,28 +468,33 @@ class SemanticModelDataset(Dataset):
             structured_properties=structured_properties,
             extra_aspects=extra_aspects,
         )
-        self._semantic_field_annotations: Dict[str, _FieldAnnotation] = {}
-        self._set_semantic_model_back_ref(semantic_model)
-        self._set_alias(alias)
+        self._set_semantic_model_properties(semantic_model=semantic_model, alias=alias)
         self._set_semantic_schema(schema, alias=alias)
 
-    def _set_semantic_model_back_ref(
-        self, semantic_model: Union[str, SemanticModelUrn]
+    def _set_semantic_model_properties(
+        self,
+        *,
+        semantic_model: Union[str, SemanticModelUrn],
+        alias: str,
     ) -> None:
         existing = self._get_aspect(SemanticModelPropertiesClass)
         if existing is None:
             self._set_aspect(
                 SemanticModelPropertiesClass(
-                    alias="", semanticModel=str(semantic_model)
+                    alias=alias, semanticModel=str(semantic_model)
                 )
             )
         else:
+            existing.alias = alias
             existing.semanticModel = str(semantic_model)
 
-    def _set_alias(self, alias: str) -> None:
+    def _set_semantic_model_back_ref(
+        self, semantic_model: Union[str, SemanticModelUrn]
+    ) -> None:
+        """Reconcile the back-reference to the owning model, preserving alias."""
         props = self._get_aspect(SemanticModelPropertiesClass)
         assert props is not None
-        props.alias = alias
+        props.semanticModel = str(semantic_model)
 
     @property
     def alias(self) -> str:
@@ -520,12 +508,18 @@ class SemanticModelDataset(Dataset):
         platform_name = self.urn.get_data_platform_urn().platform_name
         schema_fields: List[SchemaFieldClass] = []
         for spec in schema:
+            if spec.field_path in self._semantic_field_annotations:
+                raise SdkUsageError(
+                    f"Duplicate field_path {spec.field_path!r} in "
+                    f"SemanticModelDataset {str(self.urn)}; each field must be "
+                    f"unique."
+                )
             schema_fields.append(
                 self._build_schema_field(spec, platform_name=platform_name)
             )
             self._semantic_field_annotations[spec.field_path] = _FieldAnnotation(
                 annotation=self._build_field_annotation(spec, alias=alias),
-                ai_context=_build_ai_context(spec.ai_context),
+                ai_context=build_ai_context(spec.ai_context),
             )
         # Use the private schema setter so the schema is recorded exactly as
         # we built it (with per-field tags/isPartOfKey preserved).
@@ -545,7 +539,10 @@ class SemanticModelDataset(Dataset):
         field_type = resolved if resolved is not None else NullTypeClass()
         global_tags = None
         if spec.tags is not None:
-            parsed = [TagAssociationClass(tag=str(tag)) for tag in spec.tags]
+            parsed = [
+                SemanticModelDataset._parse_tag_association_class(tag)
+                for tag in spec.tags
+            ]
             global_tags = GlobalTagsClass(tags=parsed)
         return SchemaFieldClass(
             fieldPath=spec.field_path,
@@ -564,11 +561,11 @@ class SemanticModelDataset(Dataset):
         # expression is REQUIRED on the annotation; synthesize a trivial
         # qualified reference when the caller gives none.
         if spec.expression is None:
-            expression: MetricExpressionClass = _build_metric_expression(
+            expression: MetricExpressionClass = build_metric_expression(
                 f"{alias}.{spec.field_path}"
             )
         else:
-            expression = _build_metric_expression(spec.expression)
+            expression = build_metric_expression(spec.expression)
         dimension: Optional[DimensionClass] = None
         if spec.semantic_type == SemanticFieldTypeClass.DIMENSION:
             dimension = DimensionClass(isTime=spec.is_time_dimension)
@@ -578,6 +575,18 @@ class SemanticModelDataset(Dataset):
             aggregationFunction=spec.aggregation_function,
             dimension=dimension,
         )
+
+    @classmethod
+    def _new_from_graph(cls, urn: Urn, current_aspects: object) -> Self:  # type: ignore[override]
+        assert isinstance(urn, DatasetUrn)
+        # Bypass __init__ (which requires semantic_model/alias/schema) and
+        # construct via the Entity base. _init_from_graph resets _aspects = {}
+        # before repopulating from the graph. Field annotations are
+        # create-only: a read-constructed instance has none.
+        entity = cls.__new__(cls)
+        Entity.__init__(entity, urn)  # type: ignore[arg-type]
+        entity._semantic_field_annotations = {}
+        return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
 
     def as_mcps(
         self,

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -150,8 +150,7 @@ class SemanticModel(
     ``upstreamLineage``. Do not populate ``metricUpstreams`` for
     semantic-model-backed metrics.
 
-    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
-    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    Server compatibility: requires a server build that includes the
     semanticModel/metric model (operator's responsibility — no automatic
     check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
     preflight helper.
@@ -478,8 +477,7 @@ class SemanticModelDataset(Dataset):
     fresh ``SemanticModelDataset`` and re-attach its fields via the ``schema``
     constructor kwarg rather than read-modify-writing the fetched ``Dataset``.
 
-    Server compatibility: requires a DataHub Cloud server >= v2.1.0 with the
-    Metrics feature enabled, or a self-hosted/OSS GMS build that includes the
+    Server compatibility: requires a server build that includes the
     semanticModel/metric model (operator's responsibility — no automatic
     check). See :func:`datahub.sdk.require_metrics_support` for an opt-in
     preflight helper.

--- a/metadata-ingestion/src/datahub/sdk/semantic_model.py
+++ b/metadata-ingestion/src/datahub/sdk/semantic_model.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List, Optional, Sequence, Type, Union
+
+from typing_extensions import Self, TypeAlias
+
+from datahub.emitter.mce_builder import DEFAULT_ENV, make_ts_millis, parse_ts_millis
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
+from datahub.metadata.schema_classes import (
+    AiContextClass,
+    AuditStampClass,
+    ChangeTypeClass,
+    DialectClass,
+    DialectExpressionClass,
+    DimensionClass,
+    ERModelRelationshipCardinalityClass,
+    GlobalTagsClass,
+    MetricExpressionClass,
+    SchemaFieldClass,
+    SemanticFieldAnnotationClass,
+    SemanticFieldTypeClass,
+    SemanticModelInfoClass,
+    SemanticModelPropertiesClass,
+    SemanticModelRelationshipClass,
+    StatusClass,
+    TagAssociationClass,
+)
+from datahub.metadata.urns import (
+    DatasetUrn,
+    SchemaFieldUrn,
+    SemanticModelUrn,
+    Urn,
+)
+from datahub.sdk._shared import (
+    DomainInputType,
+    HasDomain,
+    HasInstitutionalMemory,
+    HasOwnership,
+    HasPlatformInstance,
+    HasStructuredProperties,
+    HasTags,
+    HasTerms,
+    LinksInputType,
+    OwnersInputType,
+    StructuredPropertyInputType,
+    TagsInputType,
+    TermsInputType,
+)
+from datahub.sdk.dataset import Dataset
+from datahub.sdk.entity import Entity, ExtraAspectsType
+
+_DEFAULT_ACTOR_URN = "urn:li:corpuser:__ingestion"
+
+
+class SemanticFieldType(SemanticFieldTypeClass):
+    pass
+
+
+class ERModelRelationshipCardinality(ERModelRelationshipCardinalityClass):
+    pass
+
+
+@dataclass
+class AiContextInput:
+    """Input container for the first-class ``aiContext`` aspect.
+
+    The aspect is only emitted when at least one field carries content; an
+    all-empty ``AiContextInput`` produces no aspect.
+    """
+
+    synonyms: Optional[List[str]] = None
+    instructions: Optional[str] = None
+    examples: Optional[List[str]] = None
+    custom_instructions: Optional[str] = None
+
+
+@dataclass
+class DialectExpressionInput:
+    """A single (dialect, expression) pair for a metric or field expression."""
+
+    expression: str
+    dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL
+
+
+MetricExpressionInputType: TypeAlias = Union[
+    str,
+    DialectExpressionInput,
+    List[DialectExpressionInput],
+    MetricExpressionClass,
+]
+
+
+@dataclass
+class SemanticModelRelationshipInput:
+    """A join path between two logical datasets in a semantic model.
+
+    ``from_alias``/``to_alias`` must match the ``alias`` of the corresponding
+    logical datasets' ``semanticModelProperties``.
+    """
+
+    from_alias: str
+    from_columns: List[str]
+    to_alias: str
+    to_columns: List[str]
+    name: Optional[str] = None
+    cardinality: Optional[ERModelRelationshipCardinalityClass] = None
+    ai_context: Optional[AiContextInput] = None
+
+
+@dataclass
+class SemanticFieldInput:
+    """A schema field plus its semantic annotation and optional AI context.
+
+    ``expression`` is required on the emitted ``semanticFieldAnnotation``; when
+    omitted it is auto-synthesized as ``f"{alias}.{field_path}"`` so the field
+    references its own logical dataset by alias.
+    """
+
+    field_path: str
+    type: str
+    semantic_type: Union[str, SemanticFieldTypeClass]
+    description: Optional[str] = None
+    nullable: bool = True
+    is_part_of_key: bool = False
+    tags: Optional[TagsInputType] = None
+    expression: Optional[MetricExpressionInputType] = None
+    aggregation_function: Optional[str] = None
+    is_time_dimension: bool = False
+    ai_context: Optional[AiContextInput] = None
+
+
+def _ai_context_is_empty(ai: Optional[AiContextInput]) -> bool:
+    if ai is None:
+        return True
+    return not (ai.synonyms or ai.instructions or ai.examples or ai.custom_instructions)
+
+
+def _build_ai_context(ai: Optional[AiContextInput]) -> Optional[AiContextClass]:
+    if _ai_context_is_empty(ai):
+        return None
+    return AiContextClass(
+        synonyms=list(ai.synonyms) if ai.synonyms else None,  # type: ignore[union-attr]
+        instructions=ai.instructions,
+        examples=list(ai.examples) if ai.examples else None,  # type: ignore[union-attr]
+        customInstructions=ai.custom_instructions,
+    )
+
+
+def _build_metric_expression(
+    expression: MetricExpressionInputType,
+    *,
+    default_dialect: Union[str, DialectClass] = DialectClass.ANSI_SQL,
+) -> MetricExpressionClass:
+    if isinstance(expression, MetricExpressionClass):
+        return expression
+    if isinstance(expression, DialectExpressionInput):
+        dialects = [
+            DialectExpressionClass(
+                dialect=expression.dialect, expression=expression.expression
+            )
+        ]
+    elif isinstance(expression, str):
+        dialects = [
+            DialectExpressionClass(dialect=default_dialect, expression=expression)
+        ]
+    elif isinstance(expression, list):
+        dialects = [
+            DialectExpressionClass(dialect=item.dialect, expression=item.expression)
+            for item in expression
+        ]
+    else:  # pragma: no cover - defensive
+        raise TypeError(f"Unsupported expression input type: {type(expression)!r}")
+    return MetricExpressionClass(dialects=dialects)
+
+
+def _make_audit_stamp(ts: Optional[datetime]) -> Optional[AuditStampClass]:
+    if ts is None:
+        return None
+    return AuditStampClass(time=make_ts_millis(ts), actor=_DEFAULT_ACTOR_URN)
+
+
+SemanticModelDatasetInputType: TypeAlias = Union[
+    str, DatasetUrn, "SemanticModelDataset"
+]
+
+
+@dataclass
+class _FieldAnnotation:
+    """Internal pairing of a field's annotation aspect with its AI context."""
+
+    annotation: SemanticFieldAnnotationClass
+    ai_context: Optional[AiContextClass] = None
+
+
+class SemanticModel(
+    HasPlatformInstance,
+    HasOwnership,
+    HasInstitutionalMemory,
+    HasTags,
+    HasTerms,
+    HasDomain,
+    HasStructuredProperties,
+    Entity,
+):
+    """A semantic model: a logical grouping of datasets with dimensional context.
+
+    The semantic model is the bridge between raw datasets and the business
+    metrics calculated over them. Each logical dataset it exposes is its own
+    ``dataset`` entity (subtype ``Semantic Model Dataset``) carrying a
+    ``semanticModelProperties`` back-reference; metrics point back at the model
+    via ``metricInfo.semanticModel`` (the ``ModeledBy`` lineage edge).
+
+    The canonical lineage chain is::
+
+        Metric -> SemanticModel -> Logical Dataset -> Physical Dataset
+
+    expressed entirely by ``metricInfo.semanticModel`` (ModeledBy),
+    ``semanticModelInfo.datasets`` (Contains), and each logical dataset's own
+    ``upstreamLineage``. Do not populate ``metricUpstreams`` for
+    semantic-model-backed metrics.
+    """
+
+    __slots__ = ()
+
+    @classmethod
+    def get_urn_type(cls) -> Type[SemanticModelUrn]:
+        return SemanticModelUrn
+
+    def __init__(
+        self,
+        *,
+        platform: str,
+        path: str,
+        id: str,
+        platform_instance: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        created: Optional[datetime] = None,
+        last_modified: Optional[datetime] = None,
+        native_definition: Optional[str] = None,
+        datasets: Optional[Sequence[SemanticModelDatasetInputType]] = None,
+        relationships: Optional[Sequence[SemanticModelRelationshipInput]] = None,
+        ai_context: Optional[AiContextInput] = None,
+        owners: Optional[OwnersInputType] = None,
+        links: Optional[LinksInputType] = None,
+        tags: Optional[TagsInputType] = None,
+        terms: Optional[TermsInputType] = None,
+        domain: Optional[DomainInputType] = None,
+        structured_properties: Optional[StructuredPropertyInputType] = None,
+        extra_aspects: ExtraAspectsType = None,
+    ):
+        urn = SemanticModelUrn(platform=platform, path=path, id=id)
+        super().__init__(urn)
+        self._set_extra_aspects(extra_aspects)
+        self._set_platform_instance(urn.platform, platform_instance)
+        # Status is part of the producer contract for this entity.
+        self._set_aspect(StatusClass(removed=False))
+        self._ensure_model_props()
+
+        if name is not None:
+            self.set_name(name)
+        if description is not None:
+            self.set_description(description)
+        if created is not None:
+            self.set_created(created)
+        if last_modified is not None:
+            self.set_last_modified(last_modified)
+        if native_definition is not None:
+            self.set_native_definition(native_definition)
+        if relationships is not None:
+            self.set_relationships(relationships)
+        if ai_context is not None:
+            self.set_ai_context(ai_context)
+        if owners is not None:
+            self.set_owners(owners)
+        if links is not None:
+            self.set_links(links)
+        if tags is not None:
+            self.set_tags(tags)
+        if terms is not None:
+            self.set_terms(terms)
+        if domain is not None:
+            self.set_domain(domain)
+        if structured_properties is not None:
+            for key, value in structured_properties.items():
+                self.set_structured_property(property_urn=key, values=value)
+        # datasets last so add_dataset can reconcile back-refs against the
+        # already-populated alias on each SemanticModelDataset.
+        if datasets is not None:
+            for dataset in datasets:
+                self.add_dataset(dataset)
+
+    @classmethod
+    def _new_from_graph(cls, urn: Urn, current_aspects: object) -> Self:  # type: ignore[override]
+        assert isinstance(urn, SemanticModelUrn)
+        entity = cls(
+            platform=urn.platform,
+            path=urn.path,
+            id=urn.id,
+        )
+        return entity._init_from_graph(current_aspects)  # type: ignore[arg-type]
+
+    @property
+    def urn(self) -> SemanticModelUrn:
+        return self._urn  # type: ignore
+
+    def _ensure_model_props(self) -> SemanticModelInfoClass:
+        props = self._get_aspect(SemanticModelInfoClass)
+        if props is None:
+            # name is required on the aspect; default to the URN id so the
+            # entity is always constructible without an explicit name.
+            props = SemanticModelInfoClass(name=self.urn.id)
+            self._set_aspect(props)
+        return props
+
+    @property
+    def name(self) -> str:
+        return self._ensure_model_props().name
+
+    def set_name(self, name: str) -> None:
+        self._ensure_model_props().name = name
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._ensure_model_props().description
+
+    def set_description(self, description: str) -> None:
+        self._ensure_model_props().description = description
+
+    @property
+    def created(self) -> Optional[datetime]:
+        stamp = self._ensure_model_props().created
+        if stamp is None or stamp.time == 0:
+            return None
+        return parse_ts_millis(stamp.time)
+
+    def set_created(self, created: datetime) -> None:
+        self._ensure_model_props().created = _make_audit_stamp(created)
+
+    @property
+    def last_modified(self) -> Optional[datetime]:
+        stamp = self._ensure_model_props().lastModified
+        if stamp is None or stamp.time == 0:
+            return None
+        return parse_ts_millis(stamp.time)
+
+    def set_last_modified(self, last_modified: datetime) -> None:
+        self._ensure_model_props().lastModified = _make_audit_stamp(last_modified)
+
+    @property
+    def native_definition(self) -> Optional[str]:
+        return self._ensure_model_props().nativeDefinition
+
+    def set_native_definition(self, native_definition: str) -> None:
+        self._ensure_model_props().nativeDefinition = native_definition
+
+    @property
+    def datasets(self) -> List[str]:
+        props = self._ensure_model_props()
+        return list(props.datasets) if props.datasets else []
+
+    def add_dataset(self, dataset: SemanticModelDatasetInputType) -> None:
+        """Attach a logical dataset to this model.
+
+        If ``dataset`` is a :class:`SemanticModelDataset`, its
+        ``semanticModelProperties.semanticModel`` back-reference is reconciled
+        to this model's URN (so the caller does not have to set it twice) and
+        its alias is left as the source of truth for relationship join paths.
+
+        Insertion order is preserved across re-emits.
+        """
+        if isinstance(dataset, SemanticModelDataset):
+            ds_urn = str(dataset.urn)
+            dataset._set_semantic_model_back_ref(self.urn)
+        else:
+            ds_urn = str(dataset)
+        props = self._ensure_model_props()
+        if props.datasets is None:
+            props.datasets = []
+        if ds_urn not in props.datasets:
+            props.datasets.append(ds_urn)
+
+    def set_datasets(self, datasets: Sequence[SemanticModelDatasetInputType]) -> None:
+        self._ensure_model_props().datasets = []
+        for dataset in datasets:
+            self.add_dataset(dataset)
+
+    @property
+    def relationships(self) -> Optional[List[SemanticModelRelationshipClass]]:
+        return self._ensure_model_props().relationships
+
+    def set_relationships(
+        self, relationships: Sequence[SemanticModelRelationshipInput]
+    ) -> None:
+        self._ensure_model_props().relationships = [
+            self._build_relationship(rel) for rel in relationships
+        ]
+
+    def add_relationship(self, relationship: SemanticModelRelationshipInput) -> None:
+        props = self._ensure_model_props()
+        if props.relationships is None:
+            props.relationships = []
+        props.relationships.append(self._build_relationship(relationship))
+
+    @staticmethod
+    def _build_relationship(
+        rel: SemanticModelRelationshipInput,
+    ) -> SemanticModelRelationshipClass:
+        return SemanticModelRelationshipClass(
+            name=rel.name,
+            from_=rel.from_alias,
+            fromColumns=list(rel.from_columns),
+            to=rel.to_alias,
+            toColumns=list(rel.to_columns),
+            cardinality=rel.cardinality,
+            aiContext=_build_ai_context(rel.ai_context),
+        )
+
+    @property
+    def ai_context(self) -> Optional[AiContextClass]:
+        return self._get_aspect(AiContextClass)
+
+    def set_ai_context(self, ai_context: AiContextInput) -> None:
+        built = _build_ai_context(ai_context)
+        if built is None:
+            # Don't emit an empty aiContext; drop any previously set one.
+            self._aspects.pop(AiContextClass.ASPECT_NAME, None)  # type: ignore[union-attr]
+            return
+        self._set_aspect(built)
+
+
+class SemanticModelDataset(Dataset):
+    """A logical dataset exposed by a :class:`SemanticModel`.
+
+    This is a standard :class:`Dataset` carrying the ``Semantic Model Dataset``
+    subtype and a ``semanticModelProperties`` back-reference to its owning
+    semantic model. Per-field semantic metadata (``semanticFieldAnnotation``)
+    and per-field AI hints (``aiContext``) are layered on each field's
+    ``schemaField`` URN and emitted on serialization alongside the
+    dataset-anchored aspects.
+
+    The dataset ``name`` should encode ``<sm_path>.<sm_id>.<view_name>`` so
+    logical datasets stay unique across semantic models.
+    """
+
+    __slots__ = ("_semantic_field_annotations",)
+
+    def __init__(
+        self,
+        *,
+        platform: str,
+        name: str,
+        semantic_model: Union[str, SemanticModelUrn],
+        alias: str,
+        schema: Sequence[SemanticFieldInput],
+        platform_instance: Optional[str] = None,
+        env: str = DEFAULT_ENV,
+        description: Optional[str] = None,
+        view_definition: Optional[str] = None,
+        upstreams: Optional[object] = None,
+        owners: Optional[OwnersInputType] = None,
+        links: Optional[LinksInputType] = None,
+        tags: Optional[TagsInputType] = None,
+        terms: Optional[TermsInputType] = None,
+        domain: Optional[DomainInputType] = None,
+        structured_properties: Optional[StructuredPropertyInputType] = None,
+        extra_aspects: ExtraAspectsType = None,
+    ):
+        # Build SchemaFieldClass list + per-field annotation/aiContext records
+        # before delegating to Dataset so the platform is known for type
+        # resolution.
+        super().__init__(
+            platform=platform,
+            name=name,
+            platform_instance=platform_instance,
+            env=env,
+            subtype=DatasetSubTypes.SEMANTIC_MODEL_DATASET,
+            description=description,
+            view_definition=view_definition,
+            upstreams=upstreams,  # type: ignore[arg-type]
+            owners=owners,
+            links=links,
+            tags=tags,
+            terms=terms,
+            domain=domain,
+            structured_properties=structured_properties,
+            extra_aspects=extra_aspects,
+        )
+        self._semantic_field_annotations: Dict[str, _FieldAnnotation] = {}
+        self._set_semantic_model_back_ref(semantic_model)
+        self._set_alias(alias)
+        self._set_semantic_schema(schema, alias=alias)
+
+    def _set_semantic_model_back_ref(
+        self, semantic_model: Union[str, SemanticModelUrn]
+    ) -> None:
+        existing = self._get_aspect(SemanticModelPropertiesClass)
+        if existing is None:
+            self._set_aspect(
+                SemanticModelPropertiesClass(
+                    alias="", semanticModel=str(semantic_model)
+                )
+            )
+        else:
+            existing.semanticModel = str(semantic_model)
+
+    def _set_alias(self, alias: str) -> None:
+        props = self._get_aspect(SemanticModelPropertiesClass)
+        assert props is not None
+        props.alias = alias
+
+    @property
+    def alias(self) -> str:
+        props = self._get_aspect(SemanticModelPropertiesClass)
+        assert props is not None
+        return props.alias
+
+    def _set_semantic_schema(
+        self, schema: Sequence[SemanticFieldInput], *, alias: str
+    ) -> None:
+        platform_name = self.urn.get_data_platform_urn().platform_name
+        schema_fields: List[SchemaFieldClass] = []
+        for spec in schema:
+            schema_fields.append(
+                self._build_schema_field(spec, platform_name=platform_name)
+            )
+            self._semantic_field_annotations[spec.field_path] = _FieldAnnotation(
+                annotation=self._build_field_annotation(spec, alias=alias),
+                ai_context=_build_ai_context(spec.ai_context),
+            )
+        # Use the private schema setter so the schema is recorded exactly as
+        # we built it (with per-field tags/isPartOfKey preserved).
+        self._set_schema(schema_fields)
+
+    @staticmethod
+    def _build_schema_field(
+        spec: SemanticFieldInput, *, platform_name: str
+    ) -> SchemaFieldClass:
+        from datahub.ingestion.source.sql.sql_types import resolve_sql_type
+        from datahub.metadata.schema_classes import (
+            NullTypeClass,
+            SchemaFieldDataTypeClass,
+        )
+
+        resolved = resolve_sql_type(spec.type, platform=platform_name)
+        field_type = resolved if resolved is not None else NullTypeClass()
+        global_tags = None
+        if spec.tags is not None:
+            parsed = [TagAssociationClass(tag=str(tag)) for tag in spec.tags]
+            global_tags = GlobalTagsClass(tags=parsed)
+        return SchemaFieldClass(
+            fieldPath=spec.field_path,
+            type=SchemaFieldDataTypeClass(field_type),
+            nativeDataType=spec.type,
+            description=spec.description,
+            nullable=spec.nullable,
+            isPartOfKey=spec.is_part_of_key,
+            globalTags=global_tags,
+        )
+
+    @staticmethod
+    def _build_field_annotation(
+        spec: SemanticFieldInput, *, alias: str
+    ) -> SemanticFieldAnnotationClass:
+        # expression is REQUIRED on the annotation; synthesize a trivial
+        # qualified reference when the caller gives none.
+        if spec.expression is None:
+            expression: MetricExpressionClass = _build_metric_expression(
+                f"{alias}.{spec.field_path}"
+            )
+        else:
+            expression = _build_metric_expression(spec.expression)
+        dimension: Optional[DimensionClass] = None
+        if spec.semantic_type == SemanticFieldTypeClass.DIMENSION:
+            dimension = DimensionClass(isTime=spec.is_time_dimension)
+        return SemanticFieldAnnotationClass(
+            type=spec.semantic_type,
+            expression=expression,
+            aggregationFunction=spec.aggregation_function,
+            dimension=dimension,
+        )
+
+    def as_mcps(
+        self,
+        change_type: Union[str, ChangeTypeClass] = ChangeTypeClass.UPSERT,
+    ) -> List[MetadataChangeProposalWrapper]:  # type: ignore[override]
+        mcps = super().as_mcps(change_type=change_type)
+        # Emit schemaField-anchored semanticFieldAnnotation + aiContext MCPs.
+        ds_urn = str(self.urn)
+        for field_path, field_ann in self._semantic_field_annotations.items():
+            field_urn = SchemaFieldUrn(ds_urn, field_path).urn()
+            mcps.append(
+                MetadataChangeProposalWrapper(
+                    entityUrn=field_urn, aspect=field_ann.annotation
+                )
+            )
+            if field_ann.ai_context is not None:
+                mcps.append(
+                    MetadataChangeProposalWrapper(
+                        entityUrn=field_urn, aspect=field_ann.ai_context
+                    )
+                )
+        return mcps

--- a/metadata-ingestion/src/datahub/utilities/server_config_util.py
+++ b/metadata-ingestion/src/datahub/utilities/server_config_util.py
@@ -35,7 +35,10 @@ class ServiceFeature(Enum):
     PATCH_CAPABLE = "patch_capable"
     CLI_TELEMETRY = "cli_telemetry"
     DATAHUB_CLOUD = "datahub_cloud"
-    SEMANTIC_MODELS = "semantic_models"
+    # Server can accept semanticModel/metric entities (and their structured-property
+    # entityTypes). Version-gated on managed servers; OSS is recipe-driven, so no
+    # "core" requirement is defined (supports_feature returns False for core).
+    SEMANTIC_MODEL_ENTITIES = "semantic_model_entities"
     # Add more features as needed
 
 
@@ -44,12 +47,8 @@ _REQUIRED_VERSION_OPENAPI_TRACING = {
     "core": (1, 0, 1, 0),
 }
 
-# semanticModel/metric/logical-dataset entities. Core (OSS) is not version-gated
-# yet — (0, 0, 0, 0) means any core version passes; the operator is responsible
-# for running a build that includes the model.
-_REQUIRED_VERSION_SEMANTIC_MODELS = {
+_REQUIRED_VERSION_SEMANTIC_MODEL_ENTITIES = {
     "cloud": (2, 1, 0, 0),
-    "core": (0, 0, 0, 0),
 }
 
 
@@ -258,7 +257,7 @@ class RestServiceConfig:
         feature_requirements = {
             ServiceFeature.OPEN_API_SDK: _REQUIRED_VERSION_OPENAPI_TRACING,
             ServiceFeature.API_TRACING: _REQUIRED_VERSION_OPENAPI_TRACING,
-            ServiceFeature.SEMANTIC_MODELS: _REQUIRED_VERSION_SEMANTIC_MODELS,
+            ServiceFeature.SEMANTIC_MODEL_ENTITIES: _REQUIRED_VERSION_SEMANTIC_MODEL_ENTITIES,
             # Additional features can be defined here
         }
 

--- a/metadata-ingestion/src/datahub/utilities/server_config_util.py
+++ b/metadata-ingestion/src/datahub/utilities/server_config_util.py
@@ -35,12 +35,21 @@ class ServiceFeature(Enum):
     PATCH_CAPABLE = "patch_capable"
     CLI_TELEMETRY = "cli_telemetry"
     DATAHUB_CLOUD = "datahub_cloud"
+    SEMANTIC_MODELS = "semantic_models"
     # Add more features as needed
 
 
 _REQUIRED_VERSION_OPENAPI_TRACING = {
     "cloud": (0, 3, 11, 0),
     "core": (1, 0, 1, 0),
+}
+
+# semanticModel/metric/logical-dataset entities. Core (OSS) is not version-gated
+# yet — (0, 0, 0, 0) means any core version passes; the operator is responsible
+# for running a build that includes the model.
+_REQUIRED_VERSION_SEMANTIC_MODELS = {
+    "cloud": (2, 1, 0, 0),
+    "core": (0, 0, 0, 0),
 }
 
 
@@ -249,6 +258,7 @@ class RestServiceConfig:
         feature_requirements = {
             ServiceFeature.OPEN_API_SDK: _REQUIRED_VERSION_OPENAPI_TRACING,
             ServiceFeature.API_TRACING: _REQUIRED_VERSION_OPENAPI_TRACING,
+            ServiceFeature.SEMANTIC_MODELS: _REQUIRED_VERSION_SEMANTIC_MODELS,
             # Additional features can be defined here
         }
 

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -341,6 +341,7 @@ def test_clear_hydrated_ai_context_emits_empty_overwrite() -> None:
     emitted = {mcp.aspectName: mcp.aspect for mcp in hydrated.as_mcps()}
     assert "aiContext" in emitted  # overwrite emitted, not dropped
     cleared = emitted["aiContext"]
+    assert isinstance(cleared, AiContextClass)
     assert cleared.synonyms is None
     assert cleared.instructions is None
     assert cleared.examples is None

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -1,0 +1,235 @@
+"""Unit tests for the Metric SDK.
+
+These tests assert the producer contract for the ``metric`` entity: URN
+pattern, ``metricInfo`` shape (with optional expression and semantic-model
+back-ref), the always-emitted ``metricRelationships`` (so ``hasParentMetric``
+indexes as false), aiContext-only-when-non-empty, and the no-``metricUpstreams``
+rule for semantic-model-backed metrics.
+"""
+
+from datetime import datetime, timezone
+
+from datahub.metadata.schema_classes import (
+    AiContextClass,
+    DerivedMetricInputClass,
+    DialectClass,
+    MetricExpressionClass,
+    MetricInfoClass,
+    MetricRelationshipsClass,
+    StatusClass,
+)
+from datahub.metadata.urns import DataPlatformUrn, MetricUrn
+from datahub.sdk.metric import Metric
+from datahub.sdk.semantic_model import (
+    AiContextInput,
+    DialectExpressionInput,
+)
+
+
+def _aspects_by_name(entity) -> dict:
+    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps()}
+
+
+def test_metric_urn_and_core_aspects() -> None:
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model=model_urn,
+        name="Total Revenue",
+        description="Sum of order amounts.",
+    )
+    assert metric.urn == MetricUrn(
+        "urn:li:dataPlatform:snowflake", "analytics", "total_revenue"
+    )
+    assert str(metric.urn) == (
+        "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,total_revenue)"
+    )
+    aspects = _aspects_by_name(metric)
+    assert "status" in aspects
+    assert isinstance(aspects["status"], StatusClass)
+    assert aspects["status"].removed is False
+    info = aspects["metricInfo"]
+    assert isinstance(info, MetricInfoClass)
+    assert info.name == "Total Revenue"
+    assert info.description == "Sum of order amounts."
+    assert info.semanticModel == model_urn
+    # No expression provided -> omitted (never fabricated).
+    assert info.expression is None
+    # metricRelationships always emitted, even with empty derivedFrom.
+    assert "metricRelationships" in aspects
+    rels = aspects["metricRelationships"]
+    assert isinstance(rels, MetricRelationshipsClass)
+    assert rels.derivedFrom == []
+    assert rels.parentMetric is None
+    # No metricUpstreams for semantic-model-backed metrics.
+    assert "upstreamLineage" not in aspects
+    # No aiContext when none provided.
+    assert "aiContext" not in aspects
+
+
+def test_metric_name_defaults_to_id() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+    )
+    assert metric.name == "total_revenue"
+
+
+def test_metric_expression_with_dialect() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        expression=DialectExpressionInput(
+            expression="SUM(ORDERS.amount)", dialect=DialectClass.SNOWFLAKE
+        ),
+    )
+    expr = metric.expression
+    assert isinstance(expr, MetricExpressionClass)
+    assert expr.dialects[0].dialect == DialectClass.SNOWFLAKE
+    assert expr.dialects[0].expression == "SUM(ORDERS.amount)"
+
+
+def test_metric_expression_bare_string_defaults_to_ansi_sql() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        expression="2 * total_revenue",
+    )
+    expr = metric.expression
+    assert expr is not None
+    assert expr.dialects[0].dialect == DialectClass.ANSI_SQL
+    assert expr.dialects[0].expression == "2 * total_revenue"
+
+
+def test_metric_expression_omitted_when_absent() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+    )
+    assert metric.expression is None
+    info = _aspects_by_name(metric)["metricInfo"]
+    assert info.expression is None
+
+
+def test_metric_relationships_always_emitted() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+    )
+    rels = _aspects_by_name(metric)["metricRelationships"]
+    assert isinstance(rels, MetricRelationshipsClass)
+    assert rels.derivedFrom == []
+    assert rels.parentMetric is None
+
+
+def test_metric_derived_from_records_destination_urns() -> None:
+    parent_urn = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,total_revenue)"
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="double_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        derived_from=[parent_urn],
+    )
+    rels = _aspects_by_name(metric)["metricRelationships"]
+    assert len(rels.derivedFrom) == 1
+    assert isinstance(rels.derivedFrom[0], DerivedMetricInputClass)
+    assert rels.derivedFrom[0].destinationUrn == parent_urn
+    assert rels.parentMetric is None
+
+
+def test_metric_add_derived_from_dedupes() -> None:
+    parent_urn = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,total_revenue)"
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="double_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        derived_from=[parent_urn],
+    )
+    metric.add_derived_from(parent_urn)  # duplicate -> no-op
+    metric.add_derived_from(
+        "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,other_metric)"
+    )
+    assert [d.destinationUrn for d in metric.derived_from] == [
+        parent_urn,
+        "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,other_metric)",
+    ]
+
+
+def test_metric_ai_context_only_emitted_when_non_empty() -> None:
+    # Empty aiContext -> no aspect.
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        ai_context=AiContextInput(),
+    )
+    assert "aiContext" not in _aspects_by_name(metric)
+    assert metric.ai_context is None
+
+    # Non-empty aiContext -> aspect emitted.
+    metric2 = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        ai_context=AiContextInput(synonyms=["revenue"]),
+    )
+    ai = metric2.ai_context
+    assert isinstance(ai, AiContextClass)
+    assert ai.synonyms == ["revenue"]
+
+
+def test_metric_created_last_modified_roundtrip() -> None:
+    ts = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        created=ts,
+        last_modified=ts,
+    )
+    assert metric.created == ts
+    assert metric.last_modified == ts
+
+
+def test_metric_semantic_model_back_ref() -> None:
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model=model_urn,
+    )
+    assert metric.semantic_model == model_urn
+    info = _aspects_by_name(metric)["metricInfo"]
+    assert info.semanticModel == model_urn
+
+
+def test_metric_platform() -> None:
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+    )
+    assert metric.platform == DataPlatformUrn("urn:li:dataPlatform:snowflake")

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -235,3 +235,43 @@ def test_metric_platform() -> None:
         semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
     )
     assert metric.platform == DataPlatformUrn("urn:li:dataPlatform:snowflake")
+
+
+def test_derived_from_mutators_preserve_sibling_relationship_fields() -> None:
+    # Read-modify-write must not clobber parentMetric/relatedMetrics when only
+    # derivedFrom changes.
+    from datahub.metadata.schema_classes import EdgeClass
+
+    parent = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,base_revenue)"
+    related = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,related_revenue)"
+    existing = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,seed_revenue)"
+    new = "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,extra_revenue)"
+
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+    )
+    # Simulate a graph-hydrated aspect carrying server-set sibling fields.
+    metric._set_aspect(
+        MetricRelationshipsClass(
+            parentMetric=parent,
+            relatedMetrics=[EdgeClass(destinationUrn=related)],
+            derivedFrom=[DerivedMetricInputClass(destinationUrn=existing)],
+        )
+    )
+
+    metric.add_derived_from(new)
+    rels = metric._get_aspect(MetricRelationshipsClass)
+    assert rels is not None
+    assert rels.parentMetric == parent
+    assert [e.destinationUrn for e in rels.relatedMetrics] == [related]
+    assert {d.destinationUrn for d in rels.derivedFrom} == {existing, new}
+
+    metric.set_derived_from([new])
+    rels = metric._get_aspect(MetricRelationshipsClass)
+    assert rels is not None
+    assert rels.parentMetric == parent
+    assert [e.destinationUrn for e in rels.relatedMetrics] == [related]
+    assert [d.destinationUrn for d in rels.derivedFrom] == [new]

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -68,7 +68,7 @@ def test_metric_urn_and_core_aspects() -> None:
     assert rels.derivedFrom == []
     assert rels.parentMetric is None
     # No metricUpstreams for semantic-model-backed metrics.
-    assert "upstreamLineage" not in aspects
+    assert "metricUpstreams" not in aspects
     # No aiContext when none provided.
     assert "aiContext" not in aspects
 

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -8,6 +8,7 @@ rule for semantic-model-backed metrics.
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 from datahub.metadata.schema_classes import (
     AiContextClass,
@@ -19,6 +20,7 @@ from datahub.metadata.schema_classes import (
     StatusClass,
 )
 from datahub.metadata.urns import DataPlatformUrn, MetricUrn
+from datahub.sdk.entity import Entity
 from datahub.sdk.metric import Metric
 from datahub.sdk.semantic_model import (
     AiContextInput,
@@ -26,8 +28,8 @@ from datahub.sdk.semantic_model import (
 )
 
 
-def _aspects_by_name(entity) -> dict:
-    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps()}
+def _aspects_by_name(entity: Entity) -> dict[str, Any]:
+    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps() if mcp.aspectName}
 
 
 def test_metric_urn_and_core_aspects() -> None:

--- a/metadata-ingestion/tests/unit/sdk/test_metric.py
+++ b/metadata-ingestion/tests/unit/sdk/test_metric.py
@@ -10,6 +10,8 @@ rule for semantic-model-backed metrics.
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
 from datahub.metadata.schema_classes import (
     AiContextClass,
     DerivedMetricInputClass,
@@ -275,3 +277,71 @@ def test_derived_from_mutators_preserve_sibling_relationship_fields() -> None:
     assert rels.parentMetric == parent
     assert [e.destinationUrn for e in rels.relatedMetrics] == [related]
     assert [d.destinationUrn for d in rels.derivedFrom] == [new]
+
+
+_SM = "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+
+
+def test_derived_from_scalar_string_is_single_edge() -> None:
+    # A bare URN string must be one edge, not one edge per character.
+    from datahub.sdk import require_metrics_support  # noqa: F401  (import sanity)
+
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="revenue",
+        semantic_model=_SM,
+        derived_from="urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,base)",
+    )
+    edges = metric.derived_from
+    assert len(edges) == 1
+    assert (
+        edges[0].destinationUrn
+        == "urn:li:metric:(urn:li:dataPlatform:snowflake,analytics,base)"
+    )
+
+
+def test_semantic_model_reference_rejects_blank_and_malformed() -> None:
+    from datahub.errors import SdkUsageError
+
+    for bad in ("", "   ", "urn:li:placeholder"):
+        with pytest.raises(SdkUsageError):
+            Metric(
+                platform="snowflake",
+                path="analytics",
+                id="revenue",
+                semantic_model=bad,
+            )
+
+
+def test_set_semantic_model_rejects_blank() -> None:
+    from datahub.errors import SdkUsageError
+
+    metric = Metric(
+        platform="snowflake", path="analytics", id="revenue", semantic_model=_SM
+    )
+    with pytest.raises(SdkUsageError):
+        metric.set_semantic_model("")
+
+
+def test_clear_hydrated_ai_context_emits_empty_overwrite() -> None:
+    # Clearing an aiContext that was read from the graph must emit an empty
+    # aspect to overwrite the server value, not silently drop it.
+    metric = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="revenue",
+        semantic_model=_SM,
+        ai_context=AiContextInput(synonyms=["rev"]),
+    )
+    hydrated = Metric._new_from_graph(metric.urn, dict(metric._aspects))
+    assert hydrated.ai_context is not None
+
+    hydrated.set_ai_context(AiContextInput())  # clear
+    emitted = {mcp.aspectName: mcp.aspect for mcp in hydrated.as_mcps()}
+    assert "aiContext" in emitted  # overwrite emitted, not dropped
+    cleared = emitted["aiContext"]
+    assert cleared.synonyms is None
+    assert cleared.instructions is None
+    assert cleared.examples is None
+    assert cleared.customInstructions is None

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -116,7 +116,7 @@ def test_semantic_model_add_dataset_records_urn_and_back_ref() -> None:
     ds = SemanticModelDataset(
         platform="snowflake",
         name="analytics.orders_model.orders_ds",
-        semantic_model="urn:li:placeholder",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,placeholder)",
         alias="ORDERS",
         schema=[
             SemanticFieldInput(
@@ -1088,3 +1088,147 @@ def test_require_metrics_support_accepts_client() -> None:
     client = DataHubClient(graph=graph)
     with pytest.raises(SdkUsageError):
         require_metrics_support(client)
+
+
+def _ds(alias: str, name: str, cols: list) -> SemanticModelDataset:
+    return SemanticModelDataset(
+        platform="snowflake",
+        name=name,
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias=alias,
+        schema=[
+            SemanticFieldInput(
+                field_path=c, type="int", semantic_type=SemanticFieldTypeClass.DIMENSION
+            )
+            for c in cols
+        ],
+    )
+
+
+def _model_with(
+    datasets: list, relationship: SemanticModelRelationshipInput
+) -> SemanticModel:
+    return SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        datasets=datasets,
+        relationships=[relationship],
+    )
+
+
+def test_datasets_scalar_string_is_single_dataset() -> None:
+    # A bare dataset URN string must be one dataset, not one per character.
+    urn = "urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.orders_model.orders_ds,PROD)"
+    model = SemanticModel(
+        platform="snowflake", path="analytics", id="orders_model", datasets=urn
+    )
+    assert model.datasets == [urn]
+
+
+def test_semantic_model_dataset_rejects_blank_semantic_model() -> None:
+    from datahub.errors import SdkUsageError
+
+    with pytest.raises(SdkUsageError):
+        SemanticModelDataset(
+            platform="snowflake",
+            name="analytics.orders_model.orders_ds",
+            semantic_model="",
+            alias="ORDERS",
+            schema=[
+                SemanticFieldInput(
+                    field_path="order_id",
+                    type="int",
+                    semantic_type=SemanticFieldTypeClass.DIMENSION,
+                )
+            ],
+        )
+
+
+def test_relationship_blank_alias_raises_at_emit() -> None:
+    from datahub.errors import SdkUsageError
+
+    orders = _ds("ORDERS", "analytics.orders_model.orders_ds", ["customer_id"])
+    model = _model_with(
+        [orders],
+        SemanticModelRelationshipInput(
+            from_alias="",
+            from_columns=["customer_id"],
+            to_alias="ORDERS",
+            to_columns=["customer_id"],
+        ),
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_relationship_unequal_column_counts_raises_at_emit() -> None:
+    from datahub.errors import SdkUsageError
+
+    orders = _ds(
+        "ORDERS", "analytics.orders_model.orders_ds", ["customer_id", "region_id"]
+    )
+    customers = _ds("CUSTOMERS", "analytics.orders_model.customers_ds", ["customer_id"])
+    model = _model_with(
+        [orders, customers],
+        SemanticModelRelationshipInput(
+            from_alias="ORDERS",
+            from_columns=["customer_id", "region_id"],
+            to_alias="CUSTOMERS",
+            to_columns=["customer_id"],
+        ),
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_relationship_empty_columns_raises_at_emit() -> None:
+    from datahub.errors import SdkUsageError
+
+    orders = _ds("ORDERS", "analytics.orders_model.orders_ds", ["customer_id"])
+    customers = _ds("CUSTOMERS", "analytics.orders_model.customers_ds", ["customer_id"])
+    model = _model_with(
+        [orders, customers],
+        SemanticModelRelationshipInput(
+            from_alias="ORDERS",
+            from_columns=[],
+            to_alias="CUSTOMERS",
+            to_columns=[],
+        ),
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_relationship_duplicate_alias_distinct_datasets_raises_at_emit() -> None:
+    from datahub.errors import SdkUsageError
+
+    ds1 = _ds("DUP", "analytics.orders_model.a_ds", ["customer_id"])
+    ds2 = _ds("DUP", "analytics.orders_model.b_ds", ["customer_id"])
+    model = _model_with(
+        [ds1, ds2],
+        SemanticModelRelationshipInput(
+            from_alias="DUP",
+            from_columns=["customer_id"],
+            to_alias="DUP",
+            to_columns=["customer_id"],
+        ),
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_semantic_model_clear_hydrated_ai_context_emits_empty_overwrite() -> None:
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        ai_context=AiContextInput(synonyms=["orders"]),
+    )
+    hydrated = SemanticModel._new_from_graph(model.urn, dict(model._aspects))
+    assert hydrated.ai_context is not None
+
+    hydrated.set_ai_context(AiContextInput())  # clear
+    emitted = {mcp.aspectName: mcp.aspect for mcp in hydrated.as_mcps()}
+    assert "aiContext" in emitted
+    assert emitted["aiContext"].synonyms is None

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -8,6 +8,7 @@ the required-expression fallback, and aiContext-only-when-non-empty.
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.schema_classes import (
@@ -27,6 +28,7 @@ from datahub.metadata.urns import (
     SchemaFieldUrn,
     SemanticModelUrn,
 )
+from datahub.sdk.entity import Entity
 from datahub.sdk.semantic_model import (
     AiContextInput,
     DialectExpressionInput,
@@ -37,14 +39,15 @@ from datahub.sdk.semantic_model import (
 )
 
 
-def _aspects_by_name(entity) -> dict:
-    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps()}
+def _aspects_by_name(entity: Entity) -> dict[str, Any]:
+    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps() if mcp.aspectName}
 
 
-def _mcps_by_urn(entity) -> dict:
-    out: dict = {}
+def _mcps_by_urn(entity: Entity) -> dict[str, list[Any]]:
+    out: dict[str, list[Any]] = {}
     for mcp in entity.as_mcps():
-        out.setdefault(mcp.entityUrn, []).append(mcp.aspect)
+        if mcp.entityUrn:
+            out.setdefault(mcp.entityUrn, []).append(mcp.aspect)
     return out
 
 

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -778,47 +778,27 @@ def test_governance_kwargs_land_in_aspects(builder: Callable[[], Entity]) -> Non
         assert name in aspects, f"{name} missing from {type(entity).__name__}"
 
 
-def test_require_metrics_support_saas_below_min_raises() -> None:
+def test_require_metrics_support_unsupported_raises() -> None:
     from unittest.mock import MagicMock
-
-    from datahub.sdk import require_metrics_support
-
-    graph = MagicMock()
-    graph.server_config.is_datahub_cloud = True
-    graph.server_config.is_version_at_least.return_value = False
-    graph.server_config.service_version = "2.0.0"
 
     from datahub.errors import SdkUsageError
+    from datahub.sdk import require_metrics_support
 
-    try:
+    graph = MagicMock()
+    graph.server_config.supports_feature.return_value = False
+    graph.server_config.service_version = "2.0.0"
+    with pytest.raises(SdkUsageError):
         require_metrics_support(graph)
-    except SdkUsageError as e:
-        assert "v2.0.0" in str(e)
-        assert "2.1.0" in str(e)
-    else:
-        raise AssertionError("expected SdkUsageError for old SaaS server")
 
 
-def test_require_metrics_support_saas_at_or_above_min_ok() -> None:
+def test_require_metrics_support_supported_is_noop() -> None:
     from unittest.mock import MagicMock
 
     from datahub.sdk import require_metrics_support
 
     graph = MagicMock()
-    graph.server_config.is_datahub_cloud = True
-    graph.server_config.is_version_at_least.return_value = True
-    graph.server_config.service_version = "2.1.0"
+    graph.server_config.supports_feature.return_value = True
     require_metrics_support(graph)  # should not raise
-
-
-def test_require_metrics_support_oss_is_noop() -> None:
-    from unittest.mock import MagicMock
-
-    from datahub.sdk import require_metrics_support
-
-    graph = MagicMock()
-    graph.server_config.is_datahub_cloud = False
-    require_metrics_support(graph)  # should not raise, no version probe
 
 
 def test_require_metrics_support_no_server_config_fail_open() -> None:
@@ -831,15 +811,14 @@ def test_require_metrics_support_no_server_config_fail_open() -> None:
 
 
 def test_require_metrics_support_non_semver_fails_open() -> None:
-    # Non-semver Cloud builds (dev/snapshot/sha) make is_version_at_least raise
-    # ValueError; the preflight helper must fail open, not leak a parse error.
+    # A non-semver build makes supports_feature raise ValueError; the preflight
+    # helper must fail open, not leak a parse error.
     from unittest.mock import MagicMock
 
     from datahub.sdk import require_metrics_support
 
     graph = MagicMock()
-    graph.server_config.is_datahub_cloud = True
-    graph.server_config.is_version_at_least.side_effect = ValueError(
+    graph.server_config.supports_feature.side_effect = ValueError(
         "Invalid version format: dev-snapshot"
     )
     require_metrics_support(graph)  # should not raise
@@ -1104,8 +1083,7 @@ def test_require_metrics_support_accepts_client() -> None:
     from datahub.sdk import DataHubClient, require_metrics_support
 
     graph = MagicMock()
-    graph.server_config.is_datahub_cloud = True
-    graph.server_config.is_version_at_least.return_value = False
+    graph.server_config.supports_feature.return_value = False
     graph.server_config.service_version = "1.0.0"
     client = DataHubClient(graph=graph)
     with pytest.raises(SdkUsageError):

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -1,0 +1,601 @@
+"""Unit tests for the SemanticModel + SemanticModelDataset SDK.
+
+These tests assert the producer contract for the ``semanticModel`` entity and
+its logical ``dataset`` entities: URN patterns, aspect shapes, the
+``Semantic Model Dataset`` subtype, the ``semanticModelProperties`` back-ref,
+the schemaField-anchored ``semanticFieldAnnotation`` + ``aiContext`` MCPs,
+the required-expression fallback, and aiContext-only-when-non-empty.
+"""
+
+from datetime import datetime, timezone
+
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
+from datahub.metadata.schema_classes import (
+    AiContextClass,
+    DialectClass,
+    ERModelRelationshipCardinalityClass,
+    MetricRelationshipsClass,
+    SemanticFieldTypeClass,
+    SemanticModelInfoClass,
+    SemanticModelPropertiesClass,
+    StatusClass,
+    SubTypesClass,
+)
+from datahub.metadata.urns import (
+    DataPlatformUrn,
+    DatasetUrn,
+    SchemaFieldUrn,
+    SemanticModelUrn,
+)
+from datahub.sdk.semantic_model import (
+    AiContextInput,
+    DialectExpressionInput,
+    SemanticFieldInput,
+    SemanticModel,
+    SemanticModelDataset,
+    SemanticModelRelationshipInput,
+)
+
+
+def _aspects_by_name(entity) -> dict:
+    return {mcp.aspectName: mcp.aspect for mcp in entity.as_mcps()}
+
+
+def _mcps_by_urn(entity) -> dict:
+    out: dict = {}
+    for mcp in entity.as_mcps():
+        out.setdefault(mcp.entityUrn, []).append(mcp.aspect)
+    return out
+
+
+def test_semantic_model_urn_and_core_aspects() -> None:
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        name="Orders Model",
+        description="Orders semantic model",
+    )
+    assert model.urn == SemanticModelUrn(
+        "urn:li:dataPlatform:snowflake", "analytics", "orders_model"
+    )
+    assert str(model.urn) == (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+    aspects = _aspects_by_name(model)
+    assert "status" in aspects
+    assert isinstance(aspects["status"], StatusClass)
+    assert aspects["status"].removed is False
+    assert "semanticModelInfo" in aspects
+    info = aspects["semanticModelInfo"]
+    assert isinstance(info, SemanticModelInfoClass)
+    assert info.name == "Orders Model"
+    assert info.description == "Orders semantic model"
+    assert info.datasets == []
+    assert info.relationships is None
+    # No aiContext when none provided.
+    assert "aiContext" not in aspects
+
+
+def test_semantic_model_name_defaults_to_id() -> None:
+    model = SemanticModel(platform="snowflake", path="analytics", id="orders_model")
+    assert model.name == "orders_model"
+
+
+def test_semantic_model_created_last_modified_roundtrip() -> None:
+    ts = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        created=ts,
+        last_modified=ts,
+    )
+    assert model.created == ts
+    assert model.last_modified == ts
+
+
+def test_semantic_model_native_definition() -> None:
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        native_definition="CREATE SEMANTIC VIEW ...",
+    )
+    assert model.native_definition == "CREATE SEMANTIC VIEW ..."
+
+
+def test_semantic_model_add_dataset_records_urn_and_back_ref() -> None:
+    model = SemanticModel(platform="snowflake", path="analytics", id="orders_model")
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:placeholder",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    model.add_dataset(ds)
+    assert model.datasets == [str(ds.urn)]
+    # Back-ref must be reconciled to the model's URN.
+    props = ds._get_aspect(SemanticModelPropertiesClass)
+    assert props is not None
+    assert props.semanticModel == str(model.urn)
+    assert props.alias == "ORDERS"
+    assert ds.alias == "ORDERS"
+
+
+def test_semantic_model_add_dataset_accepts_urn_string() -> None:
+    model = SemanticModel(platform="snowflake", path="analytics", id="orders_model")
+    model.add_dataset(
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.orders_model.orders_ds,PROD)"
+    )
+    assert model.datasets == [
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.orders_model.orders_ds,PROD)"
+    ]
+
+
+def test_semantic_model_datasets_preserve_insertion_order() -> None:
+    model = SemanticModel(platform="snowflake", path="analytics", id="orders_model")
+    ds1 = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model=model.urn,
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    ds2 = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.customers_ds",
+        semantic_model=model.urn,
+        alias="CUSTOMERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    model.set_datasets([ds1, ds2])
+    assert model.datasets == [str(ds1.urn), str(ds2.urn)]
+
+
+def test_semantic_model_relationships() -> None:
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="CUSTOMERS",
+                to_columns=["id"],
+                name="orders_to_customers",
+                cardinality=ERModelRelationshipCardinalityClass.N_ONE,
+            )
+        ],
+    )
+    rels = model.relationships
+    assert rels is not None and len(rels) == 1
+    rel = rels[0]
+    assert rel.name == "orders_to_customers"
+    assert rel.from_ == "ORDERS"
+    assert rel.fromColumns == ["customer_id"]
+    assert rel.to == "CUSTOMERS"
+    assert rel.toColumns == ["id"]
+    assert rel.cardinality == ERModelRelationshipCardinalityClass.N_ONE
+
+
+def test_semantic_model_ai_context_only_emitted_when_non_empty() -> None:
+    # Empty aiContext -> no aspect.
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        ai_context=AiContextInput(),
+    )
+    assert "aiContext" not in _aspects_by_name(model)
+    assert model.ai_context is None
+
+    # Non-empty aiContext -> aspect emitted with all four fields.
+    model2 = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        ai_context=AiContextInput(
+            synonyms=["orders model"],
+            instructions="Use for revenue analysis.",
+            examples=["SELECT * FROM orders"],
+            custom_instructions="Always filter by date.",
+        ),
+    )
+    ai = model2.ai_context
+    assert isinstance(ai, AiContextClass)
+    assert ai.synonyms == ["orders model"]
+    assert ai.instructions == "Use for revenue analysis."
+    assert ai.examples == ["SELECT * FROM orders"]
+    assert ai.customInstructions == "Always filter by date."
+
+
+def test_semantic_model_platform() -> None:
+    model = SemanticModel(platform="snowflake", path="analytics", id="orders_model")
+    assert model.platform == DataPlatformUrn("urn:li:dataPlatform:snowflake")
+
+
+def test_logical_dataset_urn_and_subtype() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    assert ds.urn == DatasetUrn(
+        "urn:li:dataPlatform:snowflake", "analytics.orders_model.orders_ds", "PROD"
+    )
+    assert ds.subtype == DatasetSubTypes.SEMANTIC_MODEL_DATASET
+    aspects = _aspects_by_name(ds)
+    assert isinstance(aspects["subTypes"], SubTypesClass)
+    assert aspects["subTypes"].typeNames == [DatasetSubTypes.SEMANTIC_MODEL_DATASET]
+
+
+def test_logical_dataset_semantic_model_properties_back_ref() -> None:
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model=model_urn,
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    props = ds._get_aspect(SemanticModelPropertiesClass)
+    assert props is not None
+    assert props.alias == "ORDERS"
+    assert props.semanticModel == model_urn
+
+
+def test_logical_dataset_emits_schemafield_anchored_annotations() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_part_of_key=True,
+            ),
+            SemanticFieldInput(
+                field_path="amount",
+                type="float",
+                semantic_type=SemanticFieldTypeClass.MEASURE,
+                aggregation_function="SUM",
+            ),
+        ],
+    )
+    by_urn = _mcps_by_urn(ds)
+    ds_urn = str(ds.urn)
+    # Dataset-anchored aspects.
+    assert "schemaMetadata" in [a.ASPECT_NAME for a in by_urn[ds_urn]]
+    # Each field has a schemaField-anchored semanticFieldAnnotation.
+    for field_path in ("order_id", "amount"):
+        field_urn = SchemaFieldUrn(ds_urn, field_path).urn()
+        anns = by_urn.get(field_urn, [])
+        assert any(a.ASPECT_NAME == "semanticFieldAnnotation" for a in anns), (
+            f"missing annotation for {field_path}"
+        )
+    # No aiContext MCPs when none of the fields carry ai_context.
+    assert all(a.ASPECT_NAME != "aiContext" for anns in by_urn.values() for a in anns)
+
+
+def test_logical_dataset_annotation_required_expression_fallback() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                # No expression -> must auto-synthesize "ORDERS.order_id".
+            )
+        ],
+    )
+    by_urn = _mcps_by_urn(ds)
+    field_urn = SchemaFieldUrn(str(ds.urn), "order_id").urn()
+    ann = next(
+        a for a in by_urn[field_urn] if a.ASPECT_NAME == "semanticFieldAnnotation"
+    )
+    assert ann.expression is not None
+    assert ann.expression.dialects[0].expression == "ORDERS.order_id"
+    assert ann.type == SemanticFieldTypeClass.DIMENSION
+    assert ann.dimension is not None
+    assert ann.dimension.isTime is False
+
+
+def test_logical_dataset_annotation_explicit_expression_preserved() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="amount",
+                type="float",
+                semantic_type=SemanticFieldTypeClass.MEASURE,
+                expression=DialectExpressionInput(
+                    expression="SUM(amount)", dialect=DialectClass.SNOWFLAKE
+                ),
+                aggregation_function="SUM",
+            )
+        ],
+    )
+    by_urn = _mcps_by_urn(ds)
+    field_urn = SchemaFieldUrn(str(ds.urn), "amount").urn()
+    ann = next(
+        a for a in by_urn[field_urn] if a.ASPECT_NAME == "semanticFieldAnnotation"
+    )
+    assert ann.expression.dialects[0].expression == "SUM(amount)"
+    assert ann.expression.dialects[0].dialect == DialectClass.SNOWFLAKE
+    assert ann.aggregationFunction == "SUM"
+    assert ann.dimension is None  # only set for DIMENSION
+
+
+def test_logical_dataset_time_dimension() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_ts",
+                type="timestamp",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_time_dimension=True,
+            )
+        ],
+    )
+    by_urn = _mcps_by_urn(ds)
+    ann = next(
+        a
+        for a in by_urn[SchemaFieldUrn(str(ds.urn), "order_ts").urn()]
+        if a.ASPECT_NAME == "semanticFieldAnnotation"
+    )
+    assert ann.dimension is not None
+    assert ann.dimension.isTime is True
+
+
+def test_logical_dataset_field_ai_context_only_when_non_empty() -> None:
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="amount",
+                type="float",
+                semantic_type=SemanticFieldTypeClass.MEASURE,
+                ai_context=AiContextInput(synonyms=["revenue"]),
+            ),
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                # No ai_context -> no aiContext MCP for this field.
+            ),
+        ],
+    )
+    by_urn = _mcps_by_urn(ds)
+    amount_urn = SchemaFieldUrn(str(ds.urn), "amount").urn()
+    order_id_urn = SchemaFieldUrn(str(ds.urn), "order_id").urn()
+    assert any(a.ASPECT_NAME == "aiContext" for a in by_urn[amount_urn])
+    assert not any(a.ASPECT_NAME == "aiContext" for a in by_urn[order_id_urn])
+
+
+def test_end_to_end_semantic_model_with_metrics() -> None:
+    """Build a small model with two logical datasets, a relationship, and two
+    metrics (one derived from the other), then assert the full aspect set and
+    the lineage wiring (Metric -> SemanticModel -> Logical Dataset -> Physical).
+    """
+    model_urn_str = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+
+    orders_ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model=model_urn_str,
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_part_of_key=True,
+            ),
+            SemanticFieldInput(
+                field_path="order_ts",
+                type="timestamp",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_time_dimension=True,
+            ),
+            SemanticFieldInput(
+                field_path="amount",
+                type="float",
+                semantic_type=SemanticFieldTypeClass.MEASURE,
+                expression=DialectExpressionInput(
+                    expression="SUM(amount)", dialect=DialectClass.SNOWFLAKE
+                ),
+                aggregation_function="SUM",
+            ),
+        ],
+        upstreams=["urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.orders,PROD)"],
+    )
+    customers_ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.customers_ds",
+        semantic_model=model_urn_str,
+        alias="CUSTOMERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                is_part_of_key=True,
+            ),
+            SemanticFieldInput(
+                field_path="customer_name",
+                type="varchar",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            ),
+        ],
+        upstreams=["urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.customers,PROD)"],
+    )
+
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        name="Orders Model",
+        description="Orders semantic model",
+        datasets=[orders_ds, customers_ds],
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="CUSTOMERS",
+                to_columns=["customer_id"],
+                cardinality=ERModelRelationshipCardinalityClass.N_ONE,
+            )
+        ],
+    )
+
+    from datahub.sdk.metric import Metric
+
+    total_revenue = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="total_revenue",
+        semantic_model=str(model.urn),
+        name="Total Revenue",
+        expression=DialectExpressionInput(
+            expression="SUM(ORDERS.amount)", dialect=DialectClass.SNOWFLAKE
+        ),
+        ai_context=AiContextInput(synonyms=["revenue"]),
+    )
+    double_revenue = Metric(
+        platform="snowflake",
+        path="analytics",
+        id="double_revenue",
+        semantic_model=str(model.urn),
+        name="Double Revenue",
+        expression="2 * total_revenue",
+        derived_from=[total_revenue.urn],
+    )
+
+    # --- Semantic model aspects ---
+    model_aspects = _aspects_by_name(model)
+    assert isinstance(model_aspects["status"], StatusClass)
+    info = model_aspects["semanticModelInfo"]
+    assert info.datasets == [str(orders_ds.urn), str(customers_ds.urn)]
+    assert info.relationships is not None and len(info.relationships) == 1
+    assert info.relationships[0].from_ == "ORDERS"
+    assert info.relationships[0].to == "CUSTOMERS"
+
+    # --- Logical dataset aspects ---
+    for ds in (orders_ds, customers_ds):
+        ds_aspects = _aspects_by_name(ds)
+        assert ds_aspects["subTypes"].typeNames == [
+            DatasetSubTypes.SEMANTIC_MODEL_DATASET
+        ]
+        props = ds_aspects["semanticModelProperties"]
+        assert props.semanticModel == str(model.urn)
+        assert "schemaMetadata" in ds_aspects
+        assert "upstreamLineage" in ds_aspects
+        # No metricUpstreams on logical datasets.
+        assert "metricUpstreams" not in ds_aspects
+
+    # Field-anchored annotations exist for every field.
+    orders_by_urn = _mcps_by_urn(orders_ds)
+    for field_path in ("order_id", "order_ts", "amount"):
+        field_urn = SchemaFieldUrn(str(orders_ds.urn), field_path).urn()
+        assert any(
+            a.ASPECT_NAME == "semanticFieldAnnotation" for a in orders_by_urn[field_urn]
+        )
+
+    # --- Metric aspects ---
+    tr_aspects = _aspects_by_name(total_revenue)
+    assert tr_aspects["metricInfo"].semanticModel == str(model.urn)
+    assert tr_aspects["metricInfo"].expression is not None
+    assert tr_aspects["metricInfo"].expression.dialects[0].dialect == (
+        DialectClass.SNOWFLAKE
+    )
+    assert isinstance(tr_aspects["aiContext"], AiContextClass)
+    assert tr_aspects["aiContext"].synonyms == ["revenue"]
+    assert isinstance(tr_aspects["metricRelationships"], MetricRelationshipsClass)
+    assert tr_aspects["metricRelationships"].derivedFrom == []
+    # No metricUpstreams for semantic-model-backed metrics.
+    assert "upstreamLineage" not in tr_aspects
+
+    dr_aspects = _aspects_by_name(double_revenue)
+    assert dr_aspects["metricInfo"].expression.dialects[0].dialect == (
+        DialectClass.ANSI_SQL
+    )
+    assert [
+        d.destinationUrn for d in dr_aspects["metricRelationships"].derivedFrom
+    ] == [str(total_revenue.urn)]
+    # No aiContext when none provided.
+    assert "aiContext" not in dr_aspects
+
+    # --- Lineage chain wiring ---
+    # Metric -> SemanticModel (ModeledBy) via metricInfo.semanticModel.
+    assert total_revenue.semantic_model == str(model.urn)
+    assert double_revenue.semantic_model == str(model.urn)
+    # SemanticModel -> Logical Datasets (Contains) via semanticModelInfo.datasets.
+    assert str(orders_ds.urn) in model.datasets
+    assert str(customers_ds.urn) in model.datasets
+    # Logical Dataset -> Physical (upstreamLineage).
+    assert orders_ds.upstreams is not None
+    assert customers_ds.upstreams is not None
+    assert (
+        orders_ds.upstreams.upstreams[0].dataset
+        == "urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.orders,PROD)"
+    )
+    assert (
+        customers_ds.upstreams.upstreams[0].dataset
+        == "urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.customers,PROD)"
+    )

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -11,8 +11,6 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 import pytest
-
-from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.schema_classes import (
     AiContextClass,
     DialectClass,
@@ -30,6 +28,8 @@ from datahub.metadata.urns import (
     SchemaFieldUrn,
     SemanticModelUrn,
 )
+
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.sdk.entity import Entity
 from datahub.sdk.metric import Metric
 from datahub.sdk.semantic_model import (
@@ -644,7 +644,7 @@ def test_logical_dataset_tag_validation_runs() -> None:
     """
     from datahub.utilities.urns.error import InvalidUrnError
 
-    try:
+    with pytest.raises(InvalidUrnError):
         SemanticModelDataset(
             platform="snowflake",
             name="analytics.orders_model.orders_ds",
@@ -659,10 +659,6 @@ def test_logical_dataset_tag_validation_runs() -> None:
                 )
             ],
         )
-    except (InvalidUrnError, AssertionError):
-        pass
-    else:
-        raise AssertionError("expected error for bare tag name 'PII'")
 
 
 def test_relationship_alias_mismatch_warns(caplog: Any) -> None:
@@ -827,3 +823,158 @@ def test_require_metrics_support_no_server_config_fail_open() -> None:
         pass
 
     require_metrics_support(_BareGraph())  # should not raise
+
+
+def test_require_metrics_support_non_semver_fails_open() -> None:
+    # Non-semver Cloud builds (dev/snapshot/sha) make is_version_at_least raise
+    # ValueError; the preflight helper must fail open, not leak a parse error.
+    from unittest.mock import MagicMock
+
+    from datahub.sdk import require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.is_datahub_cloud = True
+    graph.server_config.is_version_at_least.side_effect = ValueError(
+        "Invalid version format: dev-snapshot"
+    )
+    require_metrics_support(graph)  # should not raise
+
+
+def test_entity_classes_dataset_not_overwritten() -> None:
+    # Regression: SemanticModelDataset is a Dataset subtype sharing the
+    # "dataset" entity type. It must NOT be registered in ENTITY_CLASSES, or it
+    # would overwrite Dataset and every dataset URN would hydrate as a
+    # SemanticModelDataset on read-back.
+    from datahub.sdk._all_entities import ENTITY_CLASSES
+    from datahub.sdk.dataset import Dataset
+
+    assert ENTITY_CLASSES["dataset"] is Dataset
+    assert ENTITY_CLASSES[SemanticModel.get_urn_type().ENTITY_TYPE] is SemanticModel
+    assert ENTITY_CLASSES[Metric.get_urn_type().ENTITY_TYPE] is Metric
+
+
+def test_metric_requires_semantic_model() -> None:
+    # The whole feature hinges on metrics being semantic-model-backed;
+    # constructing one without a semantic_model must be rejected.
+    with pytest.raises(TypeError):
+        Metric(platform="snowflake", path="analytics", id="revenue")  # type: ignore[call-arg]
+
+
+def test_field_expression_empty_rejected() -> None:
+    from datahub.errors import SdkUsageError
+
+    with pytest.raises(SdkUsageError):
+        SemanticModelDataset(
+            platform="snowflake",
+            name="analytics.orders_model.orders_ds",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            alias="ORDERS",
+            schema=[
+                SemanticFieldInput(
+                    field_path="amount",
+                    type="double",
+                    semantic_type=SemanticFieldTypeClass.DIMENSION,
+                    expression="   ",
+                )
+            ],
+        )
+
+
+def test_metric_expression_empty_rejected() -> None:
+    from datahub.errors import SdkUsageError
+
+    with pytest.raises(SdkUsageError):
+        Metric(
+            platform="snowflake",
+            path="analytics",
+            id="revenue",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            expression="",
+        )
+
+
+def test_relationship_alias_mismatch_raises_at_emit() -> None:
+    # With full alias coverage (every dataset attached as a SemanticModelDataset),
+    # a mistyped relationship alias must be caught at emit time, not silently
+    # shipped to the server.
+    from datahub.errors import SdkUsageError
+
+    orders_ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        datasets=[orders_ds],
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="TYPO_CUSTOMERS",
+                to_columns=["customer_id"],
+            )
+        ],
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_graph_read_drops_field_annotations_warns(caplog: Any) -> None:
+    # Field annotations are create-only. A graph read-back that carries schema
+    # fields but no annotations must warn, so a later re-emit dropping them is
+    # traceable.
+    import logging
+
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    with caplog.at_level(logging.WARNING, logger="datahub.sdk.semantic_model"):
+        read_back = SemanticModelDataset._new_from_graph(ds.urn, dict(ds._aspects))
+    assert not read_back._semantic_field_annotations
+    assert any("create-only" in r.message for r in caplog.records)
+
+
+def test_field_annotation_mcps_inherit_change_type() -> None:
+    # schemaField-anchored aspects must follow the requested change_type, not
+    # silently default to UPSERT (e.g. EntityClient.create requests CREATE).
+    from datahub.metadata.schema_classes import ChangeTypeClass
+
+    ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+                ai_context=AiContextInput(synonyms=["oid"]),
+            )
+        ],
+    )
+    mcps = ds.as_mcps(change_type=ChangeTypeClass.CREATE)
+    field_mcps = [m for m in mcps if m.entityUrn and "schemaField" in m.entityUrn]
+    assert field_mcps  # both semanticFieldAnnotation and aiContext are anchored here
+    assert all(m.changeType == ChangeTypeClass.CREATE for m in field_mcps)

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -10,6 +10,8 @@ the required-expression fallback, and aiContext-only-when-non-empty.
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.schema_classes import (
     AiContextClass,
@@ -29,6 +31,7 @@ from datahub.metadata.urns import (
     SemanticModelUrn,
 )
 from datahub.sdk.entity import Entity
+from datahub.sdk.metric import Metric
 from datahub.sdk.semantic_model import (
     AiContextInput,
     DialectExpressionInput,
@@ -507,8 +510,6 @@ def test_end_to_end_semantic_model_with_metrics() -> None:
         ],
     )
 
-    from datahub.sdk.metric import Metric
-
     total_revenue = Metric(
         platform="snowflake",
         path="analytics",
@@ -549,8 +550,9 @@ def test_end_to_end_semantic_model_with_metrics() -> None:
         assert props.semanticModel == str(model.urn)
         assert "schemaMetadata" in ds_aspects
         assert "upstreamLineage" in ds_aspects
-        # No metricUpstreams on logical datasets.
-        assert "metricUpstreams" not in ds_aspects
+        # A dataset never carries metricUpstreams; assert the logical dataset's
+        # actual back-ref is present instead.
+        assert ds_aspects["semanticModelProperties"].semanticModel == str(model.urn)
 
     # Field-anchored annotations exist for every field.
     orders_by_urn = _mcps_by_urn(orders_ds)
@@ -572,7 +574,7 @@ def test_end_to_end_semantic_model_with_metrics() -> None:
     assert isinstance(tr_aspects["metricRelationships"], MetricRelationshipsClass)
     assert tr_aspects["metricRelationships"].derivedFrom == []
     # No metricUpstreams for semantic-model-backed metrics.
-    assert "upstreamLineage" not in tr_aspects
+    assert "metricUpstreams" not in tr_aspects
 
     dr_aspects = _aspects_by_name(double_revenue)
     assert dr_aspects["metricInfo"].expression.dialects[0].dialect == (
@@ -602,3 +604,226 @@ def test_end_to_end_semantic_model_with_metrics() -> None:
         customers_ds.upstreams.upstreams[0].dataset
         == "urn:li:dataset:(urn:li:dataPlatform:snowflake,raw.customers,PROD)"
     )
+
+
+def test_logical_dataset_duplicate_field_path_raises() -> None:
+    """Two SemanticFieldInput specs with the same field_path must raise rather
+    than silently dropping one of the per-field annotations.
+    """
+    from datahub.errors import SdkUsageError
+
+    try:
+        SemanticModelDataset(
+            platform="snowflake",
+            name="analytics.orders_model.orders_ds",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            alias="ORDERS",
+            schema=[
+                SemanticFieldInput(
+                    field_path="order_id",
+                    type="int",
+                    semantic_type=SemanticFieldTypeClass.DIMENSION,
+                ),
+                SemanticFieldInput(
+                    field_path="order_id",
+                    type="int",
+                    semantic_type=SemanticFieldTypeClass.DIMENSION,
+                ),
+            ],
+        )
+    except SdkUsageError as e:
+        assert "order_id" in str(e)
+    else:
+        raise AssertionError("expected SdkUsageError for duplicate field_path")
+
+
+def test_logical_dataset_tag_validation_runs() -> None:
+    """SemanticFieldInput(tags=[...]) must route through the canonical tag
+    parser so a bare tag name (not a URN) is rejected rather than silently
+    emitting an invalid tag URN.
+    """
+    from datahub.utilities.urns.error import InvalidUrnError
+
+    try:
+        SemanticModelDataset(
+            platform="snowflake",
+            name="analytics.orders_model.orders_ds",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            alias="ORDERS",
+            schema=[
+                SemanticFieldInput(
+                    field_path="order_id",
+                    type="int",
+                    semantic_type=SemanticFieldTypeClass.DIMENSION,
+                    tags=["PII"],
+                )
+            ],
+        )
+    except (InvalidUrnError, AssertionError):
+        pass
+    else:
+        raise AssertionError("expected error for bare tag name 'PII'")
+
+
+def test_relationship_alias_mismatch_warns(caplog: Any) -> None:
+    """A relationship alias with no matching attached dataset should emit a
+    warning (best-effort, never raise).
+    """
+    import logging
+
+    model_urn_str = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)"
+    )
+    orders_ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model=model_urn_str,
+        alias="ORDERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        datasets=[orders_ds],
+    )
+    with caplog.at_level(logging.WARNING, logger="datahub.sdk.semantic_model"):
+        model.set_relationships(
+            [
+                SemanticModelRelationshipInput(
+                    from_alias="ORDERS",
+                    from_columns=["customer_id"],
+                    to_alias="TYPO_CUSTOMERS",
+                    to_columns=["customer_id"],
+                )
+            ]
+        )
+    assert any("TYPO_CUSTOMERS" in r.message for r in caplog.records)
+
+
+def _build_governance_kwargs():
+    return dict(
+        owners=["urn:li:corpuser:datahub"],
+        links=["https://example.com/docs"],
+        tags=["urn:li:tag:PII"],
+        terms=["urn:li:glossaryTerm:Revenue.abc"],
+        domain="urn:li:domain:Analytics",
+        structured_properties={"urn:li:structuredProperty:team": ["data"]},
+    )
+
+
+def _governance_aspect_names():
+    return {
+        "institutionalMemory",
+        "ownership",
+        "globalTags",
+        "glossaryTerms",
+        "domains",
+        "structuredProperties",
+    }
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        pytest.param(
+            lambda: SemanticModel(
+                platform="snowflake",
+                path="analytics",
+                id="orders_model",
+                **_build_governance_kwargs(),
+            ),
+            id="SemanticModel",
+        ),
+        pytest.param(
+            lambda: Metric(
+                platform="snowflake",
+                path="analytics",
+                id="total_revenue",
+                semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+                **_build_governance_kwargs(),
+            ),
+            id="Metric",
+        ),
+        pytest.param(
+            lambda: SemanticModelDataset(
+                platform="snowflake",
+                name="analytics.orders_model.orders_ds",
+                semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+                alias="ORDERS",
+                schema=[
+                    SemanticFieldInput(
+                        field_path="order_id",
+                        type="int",
+                        semantic_type=SemanticFieldTypeClass.DIMENSION,
+                    )
+                ],
+                **_build_governance_kwargs(),
+            ),
+            id="SemanticModelDataset",
+        ),
+    ],
+)
+def test_governance_kwargs_land_in_aspects(builder) -> None:
+    entity = builder()
+    aspects = _aspects_by_name(entity)
+    for name in _governance_aspect_names():
+        assert name in aspects, f"{name} missing from {type(entity).__name__}"
+
+
+def test_require_metrics_support_saas_below_min_raises() -> None:
+    from unittest.mock import MagicMock
+
+    from datahub.sdk import require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.is_datahub_cloud = True
+    graph.server_config.is_version_at_least.return_value = False
+    graph.server_config.service_version = "2.0.0"
+
+    from datahub.errors import SdkUsageError
+
+    try:
+        require_metrics_support(graph)
+    except SdkUsageError as e:
+        assert "v2.0.0" in str(e)
+        assert "2.1.0" in str(e)
+    else:
+        raise AssertionError("expected SdkUsageError for old SaaS server")
+
+
+def test_require_metrics_support_saas_at_or_above_min_ok() -> None:
+    from unittest.mock import MagicMock
+
+    from datahub.sdk import require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.is_datahub_cloud = True
+    graph.server_config.is_version_at_least.return_value = True
+    graph.server_config.service_version = "2.1.0"
+    require_metrics_support(graph)  # should not raise
+
+
+def test_require_metrics_support_oss_is_noop() -> None:
+    from unittest.mock import MagicMock
+
+    from datahub.sdk import require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.is_datahub_cloud = False
+    require_metrics_support(graph)  # should not raise, no version probe
+
+
+def test_require_metrics_support_no_server_config_fail_open() -> None:
+    from datahub.sdk import require_metrics_support
+
+    class _BareGraph:
+        pass
+
+    require_metrics_support(_BareGraph())  # should not raise

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 import pytest
+
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.schema_classes import (
     AiContextClass,
     DialectClass,
@@ -28,8 +30,6 @@ from datahub.metadata.urns import (
     SchemaFieldUrn,
     SemanticModelUrn,
 )
-
-from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.sdk.entity import Entity
 from datahub.sdk.metric import Metric
 from datahub.sdk.semantic_model import (

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -1231,4 +1231,6 @@ def test_semantic_model_clear_hydrated_ai_context_emits_empty_overwrite() -> Non
     hydrated.set_ai_context(AiContextInput())  # clear
     emitted = {mcp.aspectName: mcp.aspect for mcp in hydrated.as_mcps()}
     assert "aiContext" in emitted
-    assert emitted["aiContext"].synonyms is None
+    cleared = emitted["aiContext"]
+    assert isinstance(cleared, AiContextClass)
+    assert cleared.synonyms is None

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -8,7 +8,7 @@ the required-expression fallback, and aiContext-only-when-non-empty.
 """
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
@@ -770,7 +770,7 @@ def _governance_aspect_names():
         ),
     ],
 )
-def test_governance_kwargs_land_in_aspects(builder) -> None:
+def test_governance_kwargs_land_in_aspects(builder: Callable[[], Entity]) -> None:
     entity = builder()
     aspects = _aspects_by_name(entity)
     for name in _governance_aspect_names():

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -454,6 +454,11 @@ def test_end_to_end_semantic_model_with_metrics() -> None:
                 is_part_of_key=True,
             ),
             SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            ),
+            SemanticFieldInput(
                 field_path="order_ts",
                 type="timestamp",
                 semantic_type=SemanticFieldTypeClass.DIMENSION,
@@ -930,31 +935,6 @@ def test_relationship_alias_mismatch_raises_at_emit() -> None:
         model.as_mcps()
 
 
-def test_graph_read_drops_field_annotations_warns(caplog: Any) -> None:
-    # Field annotations are create-only. A graph read-back that carries schema
-    # fields but no annotations must warn, so a later re-emit dropping them is
-    # traceable.
-    import logging
-
-    ds = SemanticModelDataset(
-        platform="snowflake",
-        name="analytics.orders_model.orders_ds",
-        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
-        alias="ORDERS",
-        schema=[
-            SemanticFieldInput(
-                field_path="order_id",
-                type="int",
-                semantic_type=SemanticFieldTypeClass.DIMENSION,
-            )
-        ],
-    )
-    with caplog.at_level(logging.WARNING, logger="datahub.sdk.semantic_model"):
-        read_back = SemanticModelDataset._new_from_graph(ds.urn, dict(ds._aspects))
-    assert not read_back._semantic_field_annotations
-    assert any("create-only" in r.message for r in caplog.records)
-
-
 def test_field_annotation_mcps_inherit_change_type() -> None:
     # schemaField-anchored aspects must follow the requested change_type, not
     # silently default to UPSERT (e.g. EntityClient.create requests CREATE).
@@ -978,3 +958,155 @@ def test_field_annotation_mcps_inherit_change_type() -> None:
     field_mcps = [m for m in mcps if m.entityUrn and "schemaField" in m.entityUrn]
     assert field_mcps  # both semanticFieldAnnotation and aiContext are anchored here
     assert all(m.changeType == ChangeTypeClass.CREATE for m in field_mcps)
+
+
+def _orders_ds(schema: list) -> SemanticModelDataset:
+    return SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.orders_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="ORDERS",
+        schema=schema,
+    )
+
+
+def test_relationship_no_datasets_raises_at_emit() -> None:
+    # Relationships with zero datasets attached can't resolve any alias; the
+    # strict emit-time check must catch this instead of returning early.
+    from datahub.errors import SdkUsageError
+
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="CUSTOMERS",
+                to_columns=["customer_id"],
+            )
+        ],
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_relationship_duplicate_dataset_does_not_defeat_coverage() -> None:
+    # A duplicated attachment must not make full-coverage detection fail and
+    # downgrade a real alias mismatch to a warning.
+    from datahub.errors import SdkUsageError
+
+    orders_ds = _orders_ds(
+        [
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ]
+    )
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        datasets=[orders_ds, orders_ds],  # duplicate on purpose
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],
+                to_alias="TYPO_CUSTOMERS",
+                to_columns=["customer_id"],
+            )
+        ],
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_relationship_missing_join_column_raises_at_emit() -> None:
+    # Aliases match, but the join column is absent from the dataset schema.
+    from datahub.errors import SdkUsageError
+
+    orders_ds = _orders_ds(
+        [
+            SemanticFieldInput(
+                field_path="order_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ]
+    )
+    customers_ds = SemanticModelDataset(
+        platform="snowflake",
+        name="analytics.orders_model.customers_ds",
+        semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+        alias="CUSTOMERS",
+        schema=[
+            SemanticFieldInput(
+                field_path="customer_id",
+                type="int",
+                semantic_type=SemanticFieldTypeClass.DIMENSION,
+            )
+        ],
+    )
+    model = SemanticModel(
+        platform="snowflake",
+        path="analytics",
+        id="orders_model",
+        datasets=[orders_ds, customers_ds],
+        relationships=[
+            SemanticModelRelationshipInput(
+                from_alias="ORDERS",
+                from_columns=["customer_id"],  # not in ORDERS schema
+                to_alias="CUSTOMERS",
+                to_columns=["customer_id"],
+            )
+        ],
+    )
+    with pytest.raises(SdkUsageError):
+        model.as_mcps()
+
+
+def test_metric_expression_empty_list_rejected() -> None:
+    from datahub.errors import SdkUsageError
+
+    with pytest.raises(SdkUsageError):
+        Metric(
+            platform="snowflake",
+            path="analytics",
+            id="revenue",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            expression=[],
+        )
+
+
+def test_metric_expression_prebuilt_empty_dialects_rejected() -> None:
+    from datahub.errors import SdkUsageError
+    from datahub.metadata.schema_classes import MetricExpressionClass
+
+    with pytest.raises(SdkUsageError):
+        Metric(
+            platform="snowflake",
+            path="analytics",
+            id="revenue",
+            semantic_model="urn:li:semanticModel:(urn:li:dataPlatform:snowflake,analytics,orders_model)",
+            expression=MetricExpressionClass(dialects=[]),
+        )
+
+
+def test_require_metrics_support_accepts_client() -> None:
+    # require_metrics_support unwraps DataHubClient._graph (the client keeps its
+    # graph private), so passing the client works as the docs show.
+    from unittest.mock import MagicMock
+
+    from datahub.errors import SdkUsageError
+    from datahub.sdk import DataHubClient, require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.is_datahub_cloud = True
+    graph.server_config.is_version_at_least.return_value = False
+    graph.server_config.service_version = "1.0.0"
+    client = DataHubClient(graph=graph)
+    with pytest.raises(SdkUsageError):
+        require_metrics_support(client)

--- a/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
+++ b/metadata-ingestion/tests/unit/sdk/test_semantic_model.py
@@ -778,7 +778,7 @@ def test_governance_kwargs_land_in_aspects(builder: Callable[[], Entity]) -> Non
         assert name in aspects, f"{name} missing from {type(entity).__name__}"
 
 
-def test_require_metrics_support_unsupported_raises() -> None:
+def test_require_metrics_support_cloud_below_min_raises() -> None:
     from unittest.mock import MagicMock
 
     from datahub.errors import SdkUsageError
@@ -786,9 +786,23 @@ def test_require_metrics_support_unsupported_raises() -> None:
 
     graph = MagicMock()
     graph.server_config.supports_feature.return_value = False
+    graph.server_config.is_datahub_cloud = True
     graph.server_config.service_version = "2.0.0"
     with pytest.raises(SdkUsageError):
         require_metrics_support(graph)
+
+
+def test_require_metrics_support_oss_fails_open() -> None:
+    # OSS reports SEMANTIC_MODEL_ENTITIES unsupported (no core requirement); the
+    # SDK must not block OSS emits — it's operator/recipe-driven there.
+    from unittest.mock import MagicMock
+
+    from datahub.sdk import require_metrics_support
+
+    graph = MagicMock()
+    graph.server_config.supports_feature.return_value = False
+    graph.server_config.is_datahub_cloud = False
+    require_metrics_support(graph)  # should not raise
 
 
 def test_require_metrics_support_supported_is_noop() -> None:
@@ -1084,6 +1098,7 @@ def test_require_metrics_support_accepts_client() -> None:
 
     graph = MagicMock()
     graph.server_config.supports_feature.return_value = False
+    graph.server_config.is_datahub_cloud = True
     graph.server_config.service_version = "1.0.0"
     client = DataHubClient(graph=graph)
     with pytest.raises(SdkUsageError):

--- a/metadata-ingestion/tests/unit/utilities/test_server_config_util.py
+++ b/metadata-ingestion/tests/unit/utilities/test_server_config_util.py
@@ -297,8 +297,9 @@ def test_supports_feature_required_versions(sample_config):
         mock_version_check.assert_called_with(1, 0, 1, 0)
 
 
-def test_supports_feature_semantic_models_versions(sample_config):
-    """SEMANTIC_MODELS gates cloud on 2.1.0 and leaves core ungated (0.0.0)."""
+def test_supports_feature_semantic_model_entities_versions(sample_config):
+    """SEMANTIC_MODEL_ENTITIES gates cloud on 2.1.0; core has no requirement so
+    it is unsupported (recipe-driven for OSS)."""
     with patch.object(
         RestServiceConfig, "is_version_at_least", return_value=True
     ) as mock_version_check:
@@ -307,7 +308,7 @@ def test_supports_feature_semantic_models_versions(sample_config):
             cloud_config["datahub"] = {}
         cloud_config["datahub"]["serverEnv"] = "cloud"
         config = RestServiceConfig(raw_config=cloud_config)
-        assert config.supports_feature(ServiceFeature.SEMANTIC_MODELS) is True
+        assert config.supports_feature(ServiceFeature.SEMANTIC_MODEL_ENTITIES) is True
         mock_version_check.assert_called_with(2, 1, 0, 0)
 
         mock_version_check.reset_mock()
@@ -317,8 +318,9 @@ def test_supports_feature_semantic_models_versions(sample_config):
             core_config["datahub"] = {}
         core_config["datahub"]["serverEnv"] = "core"
         config = RestServiceConfig(raw_config=core_config)
-        assert config.supports_feature(ServiceFeature.SEMANTIC_MODELS) is True
-        mock_version_check.assert_called_with(0, 0, 0, 0)
+        # No "core" requirement -> unsupported, and no version check is made.
+        assert config.supports_feature(ServiceFeature.SEMANTIC_MODEL_ENTITIES) is False
+        mock_version_check.assert_not_called()
 
 
 def test_datahub_cloud_feature(sample_config):

--- a/metadata-ingestion/tests/unit/utilities/test_server_config_util.py
+++ b/metadata-ingestion/tests/unit/utilities/test_server_config_util.py
@@ -297,6 +297,30 @@ def test_supports_feature_required_versions(sample_config):
         mock_version_check.assert_called_with(1, 0, 1, 0)
 
 
+def test_supports_feature_semantic_models_versions(sample_config):
+    """SEMANTIC_MODELS gates cloud on 2.1.0 and leaves core ungated (0.0.0)."""
+    with patch.object(
+        RestServiceConfig, "is_version_at_least", return_value=True
+    ) as mock_version_check:
+        cloud_config = sample_config.copy()
+        if "datahub" not in cloud_config:
+            cloud_config["datahub"] = {}
+        cloud_config["datahub"]["serverEnv"] = "cloud"
+        config = RestServiceConfig(raw_config=cloud_config)
+        assert config.supports_feature(ServiceFeature.SEMANTIC_MODELS) is True
+        mock_version_check.assert_called_with(2, 1, 0, 0)
+
+        mock_version_check.reset_mock()
+
+        core_config = sample_config.copy()
+        if "datahub" not in core_config:
+            core_config["datahub"] = {}
+        core_config["datahub"]["serverEnv"] = "core"
+        config = RestServiceConfig(raw_config=core_config)
+        assert config.supports_feature(ServiceFeature.SEMANTIC_MODELS) is True
+        mock_version_check.assert_called_with(0, 0, 0, 0)
+
+
 def test_datahub_cloud_feature(sample_config):
     """Test the DATAHUB_CLOUD feature detection."""
     # Test with cloud environment


### PR DESCRIPTION
Lifts the semantic-model modeling that already exists inside the Snowflake connector into the source-agnostic `datahub.sdk.*` package so any producer can emit `semanticModel`, `metric`, and their logical-`dataset` entities the same way `Dataset`, `Chart`, `MLModel` etc. are emitted today.

New builders:
- `datahub.sdk.semantic_model.SemanticModel` — emits `Status`, `SemanticModelInfo` (with `datasets` preserving insertion order and optional `relationships`), and a model-level `AiContext` only when non-empty. Reuses the standard `Has*` governance mixins.
- `datahub.sdk.semantic_model.SemanticModelDataset` — a `Dataset` subclass that emits the `Semantic Model Dataset` subtype, a `SemanticModelProperties(alias, semanticModel)` back-ref, a `SchemaMetadata`, an `UpstreamLineage` to the physical datasets, and — the tricky part — `schemaField`-anchored `semanticFieldAnnotation` and `aiContext` MCPs on serialization. The required `semanticFieldAnnotation.expression` is auto-synthesized as `f"{alias}.{field_path}"` when the caller omits it.
- `datahub.sdk.metric.Metric` — emits `Status`, `MetricInfo` (with `semanticModel` back-ref and optional `expression`; the expression is never fabricated when omitted), `MetricRelationships` (always emitted, even with empty `derivedFrom`, so `hasParentMetric` indexes as false), and an `AiContext` only when non-empty.

The lineage chain `Metric -> SemanticModel -> Logical Dataset -> Physical Dataset` is wired automatically via `metricInfo.semanticModel`, `semanticModelInfo.datasets`, and the logical dataset's own `upstreamLineage`. The SDK does NOT populate `metricUpstreams` for semantic-model-backed metrics.

Logical-dataset API choice: a dedicated `SemanticModelDataset` builder that subclasses `Dataset` and reuses its machinery, rather than overloading `Dataset` with `semantic_model=`/`alias=`/per-field annotation kwargs. This keeps the field-anchored emission logic (which is specific to the semantic-model contract) encapsulated in one place, while still letting callers use any standard `Dataset` governance mixin on logical datasets. Intended to be consumed by connectors in a later refactor.

Includes:
- Exports from `sdk/__init__.py` and registration in `_all_entities.py`.
- Unit tests (`tests/unit/sdk/test_semantic_model.py`, `test_metric.py`) covering URNs, core aspects, audit-stamp round-tripping, expression fallback, aiContext gating, and an end-to-end test building a small model with two logical datasets, a relationship, and two derived metrics.
- An example (`examples/library/semantic_model_create.py`) emitting the full graph to a JSON file.
- Docs: a tutorial (`docs/api/tutorials/semantic-models.md`) and sphinx `entities.rst` entries, with the tutorial wired into `sidebars.js`.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Introduces **high-level Python SDK v2 builders** so any producer can emit `semanticModel`, logical `dataset` (Semantic Model Dataset subtype), and `metric` entities with the same patterns as existing SDK entities.
> 
> **`SemanticModel`** emits status, `SemanticModelInfo` (datasets in insertion order, optional relationships), and model-level `aiContext` only when non-empty. **`SemanticModelDataset`** subclasses `Dataset`, sets subtype and `semanticModelProperties`, optional physical `upstreamLineage`, and on `as_mcps()` adds **schemaField-anchored** `semanticFieldAnnotation` (default expression `alias.field_path`) and field `aiContext` when provided. **`Metric`** requires a semantic-model back-ref, always emits `metricRelationships` (empty `derivedFrom` when none), optional `metricInfo.expression` (never auto-filled), and does **not** emit `metricUpstreams` for model-backed metrics.
> 
> Shared **`_semantic_shared`** covers expression/AI-context building, URN validation, scalar-vs-list normalization for URNs, and opt-in **`require_metrics_support`** (Cloud version gate via new `ServiceFeature.SEMANTIC_MODEL_ENTITIES`; OSS/offline fail open). **`SemanticModel`/`Metric`** register in `_all_entities`; **`SemanticModelDataset` is excluded** so dataset hydration stays `Dataset`. **`EntityClient.get`** gains overloads for semantic model and metric URNs.
> 
> Also adds library example + JSON MCP dump, API tutorial/sidebar/Sphinx entries, broad unit tests (emit contract, relationship validation at emit, governance mixins), and widens **`Dataset.upstreams`** to `UpstreamLineageInputType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc0ae69d2404839f56ef24ea7414f95eb72dc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


