### PR TITLE
fix(cli/migrate): derive incoming-relationship types from the entity registry

### DIFF
--- a/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
+++ b/metadata-ingestion/docs/dev_guides/ingestion_migrations.md
@@ -14,7 +14,7 @@ Use one when a connector change means metadata **already in DataHub** must be tr
 - The set of applied migration ids is stored in a **ledger** that rides the stateful-ingestion checkpoint, keyed per pipeline. So migrations **require stateful ingestion** to be enabled.
 - Before ingestion, a pre-ingestion hook computes the **pending** migrations (declared but not in the ledger) and, when enabled, runs them in id order, recording each id as it succeeds.
 
-Because the ledger is per pipeline, a migration can re-trigger when a *different* pipeline ingests the same data, and the ledger read is eventually consistent (so two runs of the *same* pipeline in quick succession could both apply). **Migrations must therefore be idempotent** — re-running one must be a no-op. A migration that selects its targets with a filter that matches nothing after the first apply (e.g. "datasets whose URN is not already lowercase") satisfies this naturally.
+Because the ledger is per pipeline, a migration can re-trigger when a _different_ pipeline ingests the same data, and the ledger read is eventually consistent (so two runs of the _same_ pipeline in quick succession could both apply). **Migrations must therefore be idempotent** — re-running one must be a no-op. A migration that selects its targets with a filter that matches nothing after the first apply (e.g. "datasets whose URN is not already lowercase") satisfies this naturally.
 
 ## Declaring a migration
 
@@ -67,6 +67,14 @@ def _lowercase_urns(self, graph, report, dry_run):
 
 For aspect-shape changes, fetch the affected aspects and re-emit them in the new shape from within `run`.
 
+#### Incoming references and the entity registry
+
+Renaming a URN also has to repoint everything that references it. Entities migrated together in the same run are handled from an in-memory old→new map, but references held by _other_ entities are found through the relationship index, which has to be queried with an explicit list of relationship types.
+
+That list is read from the live entity registry at `/openapi/v1/registry/models/aspect/specifications` — every relationship whose `@Relationship` annotation can target the entity type being migrated (a relationship with no `entityTypes` is unconstrained and always qualifies). A relationship added to the metadata model is therefore covered automatically.
+
+That endpoint requires `MANAGE_SYSTEM_OPERATIONS_PRIVILEGE`, which an ingestion token typically does not have. When it can't be read, the migration logs a warning and falls back to a built-in list of lineage relationship types; it still runs, but references held through other relationship types are left pointing at the old URN. Grant the privilege to the ingestion token, or run `datahub migrate transform` as an admin, if full coverage matters for your migration.
+
 ## Ordering and version gating
 
 **Ordering** is by **id**. Pending migrations run sorted by their `id`, each recorded on success — so the id is the ordering key, not the position in the list. Use a **timestamp prefix** (`20260722-...`, optionally `20260722T1530-...`) so migrations run chronologically and a global fix (see below) interleaves correctly with a connector's own. If one migration depends on another, give it a later timestamp. Ids are permanent — never reorder or reuse them.
@@ -112,10 +120,10 @@ source:
     stateful_ingestion:
       enabled: true
       migrations:
-        enabled: true        # apply pending migrations before ingestion
-        dry_run: false       # log what would run without mutating
-        fail_on_pending: false  # if true, abort when a migration is pending but disabled
-        force: false         # re-run every migration even if the ledger/version gate would skip it
+        enabled: true # apply pending migrations before ingestion
+        dry_run: false # log what would run without mutating
+        fail_on_pending: false # if true, abort when a migration is pending but disabled
+        force: false # re-run every migration even if the ledger/version gate would skip it
 ```
 
 When migrations are pending but `enabled` is false, the run logs a warning listing the pending ids (and fails if `fail_on_pending` is set), so operators know a migration is waiting.

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -253,7 +253,9 @@ def _migrate_single_entity(
     # entities reference the migrated URN; we then rewrite that reference
     # wherever it appears, across all of the referencing entity's aspects.
     seen_targets = set()
-    for relationship in migration_utils.get_incoming_relationships(src_entity_urn):
+    for relationship in migration_utils.get_incoming_relationships(
+        graph, src_entity_urn
+    ):
         target_urn = relationship.urn
         if target_urn in seen_targets:
             continue
@@ -532,7 +534,7 @@ def _process_container_relationships(
     client = get_default_graph(ClientMode.CLI)
     rewrite_urn = migration_utils.make_self_urn_rewriter(src_urn, dst_urn)
     seen_targets = set()
-    for relationship in migration_utils.get_incoming_relationships(urn=src_urn):
+    for relationship in migration_utils.get_incoming_relationships(client, src_urn):
         target_urn: str = relationship.urn
         if target_urn in container_id_map:
             target_urn = container_id_map[target_urn]

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -117,6 +117,26 @@ SYSTEM_MANAGED_ASPECTS = {
 
 _SCHEMA_FIELD_PREFIX = "urn:li:schemaField:"
 
+# Entity-registry endpoint exposing every aspect's @Relationship annotations.
+_ASPECT_SPECS_PATH = "/openapi/v1/registry/models/aspect/specifications"
+# Read every aspect spec in one request — see get_incoming_relationship_types.
+_ASPECT_SPECS_PAGE_SIZE = 10000
+
+# Used only when the entity registry can't be read (see
+# get_incoming_relationship_types). Historically the hardcoded list.
+_FALLBACK_RELATIONSHIP_TYPES = [
+    "Consumes",
+    "DerivedFrom",
+    "DownstreamOf",
+    "ForeignKeyToDataset",
+    "IsPartOf",
+    "Produces",
+]
+
+# Relationship types are fixed for the lifetime of a run; keyed by (server, entity
+# type) so a process talking to two instances doesn't cross them.
+_RELATIONSHIP_TYPE_CACHE: Dict[Tuple[str, str], List[str]] = {}
+
 
 def get_migratable_aspect_names(entity_type: str) -> List[str]:
     """Non-timeseries, user-migratable aspects for an entity type.
@@ -286,18 +306,77 @@ def clone_aspect(
                 log.debug(f"did not find aspect {a} in response, continuing...")
 
 
-def get_incoming_relationships(urn: str) -> Iterable[RelatedEntity]:
-    client = get_default_graph(ClientMode.CLI)
-    yield from client.get_related_entities(
+def get_incoming_relationship_types(graph: DataHubGraph, entity_type: str) -> List[str]:
+    """Relationship names in the live entity registry that can point at ``entity_type``.
+
+    The relationships endpoint requires an explicit ``relationshipTypes`` filter —
+    there is no "every incoming edge" query — so the migration has to name every
+    relationship a referrer could use. Deriving that from the registry keeps it in
+    step with :func:`get_migratable_aspect_names`: a relationship added to the model
+    is picked up without touching this file, where a hand-maintained list would
+    silently leave those referrers pointing at the migrated-away URN.
+
+    A relationship with no ``entityTypes`` on its ``@Relationship`` annotation is
+    unconstrained and may point at anything, so it always matches.
+
+    Falls back to :data:`_FALLBACK_RELATIONSHIP_TYPES` when the registry is
+    unreachable — most importantly for connector migrations, which run under an
+    ingestion token that usually lacks MANAGE_SYSTEM_OPERATIONS_PRIVILEGE.
+    """
+    cache_key = (graph.config.server, entity_type)
+    cached = _RELATIONSHIP_TYPE_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        response = graph._get_generic(
+            f"{graph.config.server}{_ASPECT_SPECS_PATH}",
+            # A single unpaginated read: PaginatedResponse raises once start goes
+            # past the end, so walking pages costs a guess at the total.
+            params={"start": 0, "count": _ASPECT_SPECS_PAGE_SIZE},
+        )
+        names = _extract_relationship_types(response, entity_type)
+        if not names:
+            raise ValueError(f"registry reported no relationships for {entity_type}")
+    except Exception as e:
+        log.warning(
+            f"Could not read relationship types from the entity registry at "
+            f"{graph.config.server} ({e}). Falling back to the built-in list "
+            f"{_FALLBACK_RELATIONSHIP_TYPES} — references to migrated URNs held by "
+            f"other relationship types will not be repointed. The registry endpoint "
+            f"requires MANAGE_SYSTEM_OPERATIONS_PRIVILEGE."
+        )
+        names = list(_FALLBACK_RELATIONSHIP_TYPES)
+
+    _RELATIONSHIP_TYPE_CACHE[cache_key] = names
+    return names
+
+
+def _extract_relationship_types(response: Dict, entity_type: str) -> List[str]:
+    """Pull relationship names targeting ``entity_type`` out of an aspect-specs response."""
+    names = set()
+    for aspect_spec in response.get("elements", []):
+        for field_spec in (aspect_spec.get("relationshipFieldSpec") or {}).values():
+            annotation = (field_spec.get("annotations") or {}).get(
+                "relationshipAnnotation"
+            ) or {}
+            name = annotation.get("name")
+            if not name:
+                continue
+            destinations = annotation.get("validDestinationTypes") or []
+            if not destinations or entity_type in destinations:
+                names.add(name)
+    return sorted(names)
+
+
+def get_incoming_relationships(
+    graph: DataHubGraph, urn: str
+) -> Iterable[RelatedEntity]:
+    yield from graph.get_related_entities(
         entity_urn=urn,
-        relationship_types=[
-            "DownstreamOf",
-            "Consumes",
-            "Produces",
-            "ForeignKeyToDataset",
-            "DerivedFrom",
-            "IsPartOf",
-        ],
+        relationship_types=get_incoming_relationship_types(
+            graph, guess_entity_type(urn)
+        ),
         direction=RelationshipDirection.INCOMING,
     )
 

--- a/metadata-ingestion/tests/unit/cli/test_migration_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_utils.py
@@ -1,6 +1,6 @@
 """Tests for datahub.cli.migration_utils — relationship-to-aspect mapping and URN rewriting."""
 
-from typing import Dict
+from typing import Dict, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,7 +10,11 @@ from datahub.cli.migrate import (
     MigrationReport,
 )
 from datahub.cli.migration_utils import (
+    _FALLBACK_RELATIONSHIP_TYPES,
+    _RELATIONSHIP_TYPE_CACHE,
     ConflictStrategy,
+    get_incoming_relationship_types,
+    get_incoming_relationships,
     make_batch_urn_rewriter,
     make_i2i_chart_urn,
     make_i2i_dashboard_urn,
@@ -27,6 +31,7 @@ from datahub.cli.migration_utils import (
     replace_instance_prefix,
     should_overwrite_non_additive,
 )
+from datahub.ingestion.graph.openapi import RelationshipDirection
 from datahub.metadata.schema_classes import (
     AuditStampClass,
     DatasetPropertiesClass,
@@ -558,3 +563,111 @@ class TestBatchUrnRewriter:
         assert aspect.fineGrainedLineages[0].downstreams == [
             make_schema_field_urn(self.A_NEW, "order_id")
         ]
+
+
+def _aspect_specs_response(*relationships: Dict) -> Dict:
+    """An aspect-specifications payload carrying the given @Relationship annotations."""
+    return {
+        "elements": [
+            {
+                "relationshipFieldSpec": {
+                    f"/field{i}": {"annotations": {"relationshipAnnotation": rel}}
+                }
+            }
+            for i, rel in enumerate(relationships)
+        ]
+    }
+
+
+class TestGetIncomingRelationshipTypes:
+    def setup_method(self):
+        _RELATIONSHIP_TYPE_CACHE.clear()
+
+    def _graph(self, response: Union[Dict, Exception]) -> MagicMock:
+        graph = MagicMock()
+        graph.config.server = "http://localhost:8080"
+        if isinstance(response, Exception):
+            graph._get_generic.side_effect = response
+        else:
+            graph._get_generic.return_value = response
+        return graph
+
+    def test_selects_relationships_targeting_the_entity_type(self):
+        graph = self._graph(
+            _aspect_specs_response(
+                {"name": "DownstreamOf", "validDestinationTypes": ["dataset"]},
+                {"name": "OwnedBy", "validDestinationTypes": ["corpuser", "corpGroup"]},
+                {"name": "Consumes", "validDestinationTypes": ["dataset", "dataJob"]},
+            )
+        )
+
+        assert get_incoming_relationship_types(graph, "dataset") == [
+            "Consumes",
+            "DownstreamOf",
+        ]
+
+    def test_unconstrained_relationship_always_matches(self):
+        """No entityTypes on @Relationship means it may point at anything."""
+        graph = self._graph(
+            _aspect_specs_response(
+                {"name": "AssociatedWith", "validDestinationTypes": []},
+                {"name": "OwnedBy", "validDestinationTypes": ["corpuser"]},
+            )
+        )
+
+        assert get_incoming_relationship_types(graph, "dataset") == ["AssociatedWith"]
+
+    def test_falls_back_when_registry_unauthorized(self):
+        """Ingestion tokens lack MANAGE_SYSTEM_OPERATIONS_PRIVILEGE — don't hard-fail."""
+        graph = self._graph(Exception("403 Forbidden"))
+
+        assert (
+            get_incoming_relationship_types(graph, "dataset")
+            == _FALLBACK_RELATIONSHIP_TYPES
+        )
+
+    def test_falls_back_when_registry_returns_nothing(self):
+        graph = self._graph({"elements": []})
+
+        assert (
+            get_incoming_relationship_types(graph, "dataset")
+            == _FALLBACK_RELATIONSHIP_TYPES
+        )
+
+    def test_result_is_cached_per_server_and_entity_type(self):
+        graph = self._graph(
+            _aspect_specs_response(
+                {"name": "DownstreamOf", "validDestinationTypes": ["dataset"]}
+            )
+        )
+
+        get_incoming_relationship_types(graph, "dataset")
+        get_incoming_relationship_types(graph, "dataset")
+        assert graph._get_generic.call_count == 1
+
+        get_incoming_relationship_types(graph, "chart")
+        assert graph._get_generic.call_count == 2
+
+
+class TestGetIncomingRelationships:
+    def setup_method(self):
+        _RELATIONSHIP_TYPE_CACHE.clear()
+
+    def test_queries_registry_derived_types_for_the_urn_entity_type(self):
+        graph = MagicMock()
+        graph.config.server = "http://localhost:8080"
+        graph._get_generic.return_value = _aspect_specs_response(
+            {"name": "DownstreamOf", "validDestinationTypes": ["dataset"]},
+            {"name": "OwnedBy", "validDestinationTypes": ["corpuser"]},
+        )
+        graph.get_related_entities.return_value = iter([])
+
+        list(
+            get_incoming_relationships(
+                graph, "urn:li:dataset:(urn:li:dataPlatform:mysql,db.t,PROD)"
+            )
+        )
+
+        _, kwargs = graph.get_related_entities.call_args
+        assert kwargs["relationship_types"] == ["DownstreamOf"]
+        assert kwargs["direction"] == RelationshipDirection.INCOMING


### PR DESCRIPTION
Stacked on #18551 (which is on #18550 → #18544). Review the last commit only.

## Problem

When `migrate transform` renames a URN, it repoints references in three passes: the entity's own aspects, siblings migrated in the same batch, and **incoming references from unrelated entities**. That third pass finds referrers through the relationship index — and it was querying a hardcoded list of six relationship types:

```python
relationship_types=["DownstreamOf", "Consumes", "Produces",
                    "ForeignKeyToDataset", "DerivedFrom", "IsPartOf"]
```

A referrer linked by any other relationship type is never visited, so its pointer keeps referencing the migrated-away URN. `rewrite_incoming_references` would have fixed it — the entity just never gets discovered. The list is also a maintenance trap: adding a relationship to the metadata model silently widens the gap.

The relationships endpoint (`/openapi/relationships/v1/`) requires an explicit `relationshipTypes` filter, so there is no "give me every incoming edge" query. The list has to be enumerated — but it can be enumerated from the model instead of by hand.

## Change

Derive it from the live entity registry via `GET /openapi/v1/registry/models/aspect/specifications`. `AspectSpecDto.relationshipFieldSpec` exposes each aspect's `@Relationship` annotations, including `name` and `validDestinationTypes`, so the allowlist becomes *every relationship that can target the entity type being migrated*.

This puts referrer discovery on the same registry footing as `get_migratable_aspect_names` (#18544), so the two halves of the migration no longer drift apart: a relationship added to the model is picked up without touching this file.

Details:

- An empty `validDestinationTypes` means the `@Relationship` had no `entityTypes` and is unconstrained, so it always matches. Skipping those would reintroduce the same class of gap.
- Cached per `(server, entity_type)` — it's fixed for the run, and keyed by server so a process talking to two instances doesn't cross them.
- Single unpaginated read: `PaginatedResponse.fromMap` throws once `start` goes past the end, so paging would cost a guess at the total.
- `get_incoming_relationships` now takes the caller's `DataHubGraph` instead of building its own via `get_default_graph`.

## The privilege caveat

`EntityRegistryController` requires `MANAGE_SYSTEM_OPERATIONS_PRIVILEGE`. That's fine for `datahub migrate transform` run by an admin, but a Layer 2 connector migration runs under an ingestion token that usually doesn't have it.

So an unreadable registry logs a warning naming the reason and falls back to the previous six types, rather than aborting the migration. Coverage degrades to what it is on master today and the operator is told why; silently narrowing back to six would be the worst outcome. Documented in the dev guide, including how to get full coverage.

The strict alternative — hard-fail when the registry is unreachable — is more correct but makes ingestion-time migrations depend on an admin-only endpoint. Happy to switch if that's preferred.

## Testing

- Six new unit tests in `test_migration_utils.py`: destination-type selection, unconstrained relationships, both fallback paths (403 and empty registry), caching, and that `get_incoming_relationships` queries the derived types for the URN's entity type.
- `pytest tests/unit/cli/test_migration_utils.py` — 46 passed.
- `pytest tests/unit/cli tests/unit/stateful_ingestion/test_ingestion_migration.py` — the only failures are 14 pre-existing ones in `test_ingest_cli.py::TestSetupRecording`, which fail identically on the base branch.
- `ruff` clean; `mypy` clean on the changed files (two pre-existing `fineGrainedLineages` index errors in the test file are unrelated).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [x] Docs updated (`metadata-ingestion/docs/dev_guides/ingestion_migrations.md`)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)