### PR TITLE
test(sqlalchemy): unit coverage for SQLAlchemyQueryCombiner

### DIFF
--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -3,7 +3,13 @@
 Regression guard for the PR 4 flattening change. Exercises the combiner
 directly (not via QueryCombinerRunner) against a real in-memory SQLite
 engine. Follows the repo testing philosophy: behavior over implementation,
-no reflection into privates, no exact-error-message assertions.
+no exact-error-message assertions.
+
+Two edge-case branches (a zero-row proxy, and a one-row/zero-column proxy)
+are unreachable through the combiner, which asserts exactly one row, so
+those tests construct _ResultProxyFake / _RowProxyFake directly. That is
+deliberate direct construction of internal types to reach branches the
+public surface cannot, not reflection into implementation details.
 """
 
 import dataclasses
@@ -436,20 +442,30 @@ class TestResultProxyContract:
             empty.fetchone()
 
     def test_fetchall_returns_all_rows(self):
-        # .fetchall() is used at 4 production result-consumption sites.
+        # .fetchall() is used at 4 production result-consumption sites, and
+        # .first() returns the first row (not None) on a populated proxy —
+        # pin both. The first() assertion kills the `first() -> None` mutant
+        # that the zero-row test alone cannot.
         rows = [
             _RowProxyFake({"a": 1, "b": 10}),
             _RowProxyFake({"a": 2, "b": 20}),
         ]
         result = _ResultProxyFake(rows)
+        assert result.first() is rows[0]
         fetched = result.fetchall()
         assert len(fetched) == 2
         assert fetched[0]["a"] == 1
         assert fetched[1]["b"] == 20
 
     def test_int_index_out_of_range_raises_indexerror(self):
-        # _RowProxyFake.__getitem__ guards int access against out-of-range
-        # indices with a clear IndexError. Pin the guard.
+        # Pin the CONTRACT that out-of-range int access raises IndexError
+        # (rather than KeyError or a silent wrong value). Note this does
+        # NOT pin the explicit guard in _RowProxyFake.__getitem__: that
+        # guard is message-only dead code, since the underlying keys[k]
+        # raises IndexError on its own for every out-of-range index. The
+        # "remove the guard" mutant is an equivalent mutant and cannot be
+        # killed by behavior alone. The contract will matter if PR 4
+        # reshapes row access.
         row = _RowProxyFake({"a": 1})
         with pytest.raises(IndexError):
             row[5]

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -1,0 +1,283 @@
+"""Unit tests for SQLAlchemyQueryCombiner — pins current behavior of the combiner in
+isolation, as a regression guard for the PR 4 flattening change.
+
+These tests exercise the combiner directly (not via QueryCombinerRunner) against a real
+in-memory SQLite engine. They cover the behaviors PR 4 will rewrite: queue batching,
+result extraction by col.name, the index == len(row) invariant, the combined-failure
+exception path, and the serial fallback. They follow the repo testing philosophy
+(behavior over implementation; no reflection into privates; no exact-error-message
+assertions).
+"""
+
+import dataclasses
+from typing import Any, Optional
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Column, Float, Integer, String, create_engine
+from sqlalchemy.engine import Connection
+
+from datahub.utilities.sqlalchemy_query_combiner import (
+    MAX_QUERIES_TO_COMBINE_AT_ONCE,
+    SQLAlchemyQueryCombiner,
+    get_query_columns,
+)
+
+
+@pytest.fixture
+def engine():
+    return create_engine("sqlite:///:memory:")
+
+
+@pytest.fixture
+def test_table(engine):
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "test_table",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String(50)),
+        Column("value", Float),
+    )
+    metadata.create_all(engine)
+    with engine.connect() as conn, conn.begin():
+        conn.execute(
+            sa.insert(table),
+            [
+                {"id": 1, "name": "Alice", "value": 10.5},
+                {"id": 2, "name": "Bob", "value": 20.5},
+                {"id": 3, "name": "Charlie", "value": 30.5},
+            ],
+        )
+    return table
+
+
+def _make_combiner(**overrides: Any) -> SQLAlchemyQueryCombiner:
+    defaults: dict[str, Any] = {
+        "enabled": True,
+        "catch_exceptions": True,
+        "is_single_row_query_method": lambda q: True,
+        "serial_execution_fallback_enabled": True,
+    }
+    defaults.update(overrides)
+    return SQLAlchemyQueryCombiner(**defaults)
+
+
+@dataclasses.dataclass
+class _Capture:
+    """Mirrors QueryCombinerRunner._ResultContainer: catches the result or the
+    re-raised exception so a failing query's greenlet doesn't tear down flush()."""
+
+    result: Any = None
+    exc: Optional[BaseException] = None
+    done: bool = False
+
+
+def _schedule(qc: SQLAlchemyQueryCombiner, conn: Connection, query: Any) -> _Capture:
+    """Schedule `query` via qc.run(); the closure runs in a greenlet and captures
+    the _ResultProxyFake returned by the patched Connection.execute (or the
+    re-raised exception). Returns the capture; populated after qc.flush()."""
+    cap = _Capture()
+
+    def execute() -> None:
+        try:
+            cap.result = conn.execute(query)
+        except Exception as e:
+            cap.exc = e
+        finally:
+            cap.done = True
+
+    qc.run(execute)
+    return cap
+
+
+class TestQueuePartitioningAndBatching:
+    def test_combines_single_row_queries_into_one_statement(self, engine, test_table):
+        queries = [
+            sa.select(sa.func.count().label("rowcount")).select_from(test_table),
+            sa.select(sa.func.min(test_table.c.value).label("min_value")),
+            sa.select(sa.func.max(test_table.c.value).label("max_value")),
+        ]
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done for c in caps)
+        assert caps[0].result.scalar() == 3
+        assert caps[1].result.scalar() == 10.5
+        assert caps[2].result.scalar() == 30.5
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.queries_combined == 3
+        assert combiner.report.uncombined_queries_issued == 0
+
+    def test_max_queries_batched_at_40_boundary(self, engine, test_table):
+        # MAX_QUERIES_TO_COMBINE_AT_ONCE caps each _execute_queue pass at 40, so
+        # 41 single-row queries must produce two combined statements (40 + 1).
+        n = MAX_QUERIES_TO_COMBINE_AT_ONCE + 1
+        queries = [
+            sa.select(sa.func.count().label(f"rowcount_{i}")).select_from(test_table)
+            for i in range(n)
+        ]
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done for c in caps)
+        assert all(c.result is not None and c.exc is None for c in caps)
+        assert combiner.report.queries_combined == n
+        assert combiner.report.combined_queries_issued == 2
+
+
+class TestResultExtraction:
+    def test_result_row_mapped_by_col_name(self, engine, test_table):
+        # The extraction loop keys each query's row dict by col.name; callers access
+        # results by label, not by position. Pin that contract.
+        query = sa.select(
+            sa.func.count().label("rowcount"),
+            sa.func.sum(test_table.c.value).label("value_sum"),
+        ).select_from(test_table)
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            qc.flush()
+
+        row = cap.result.one()
+        assert row["rowcount"] == 3
+        assert row["value_sum"] == pytest.approx(61.5)
+        # int-indexing resolves to the column at that position, by insertion order
+        assert row[0] == 3
+        assert row[1] == pytest.approx(61.5)
+
+    def test_index_len_row_invariant_across_mixed_column_queries(
+        self, engine, test_table
+    ):
+        # The combined row width must equal the sum of each query's column count;
+        # the extraction loop's `index` cursor must consume the whole row. Mixing
+        # a 1-column and a 2-column query exercises the invariant non-trivially.
+        q1 = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        q2 = sa.select(
+            sa.func.min(test_table.c.value).label("min_value"),
+            sa.func.max(test_table.c.value).label("max_value"),
+        ).select_from(test_table)
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap1 = _schedule(qc, conn, q1)
+            cap2 = _schedule(qc, conn, q2)
+            qc.flush()
+
+        # If the invariant were violated the combiner's internal assert would fire
+        # during flush(); reaching here with correct values means extraction lined up.
+        assert cap1.result.scalar() == 3
+        assert cap2.result.one()["min_value"] == 10.5
+        assert cap2.result.one()["max_value"] == 30.5
+        assert combiner.report.combined_queries_issued == 1
+
+
+class TestExceptionAndFallback:
+    def test_serial_fallback_runs_each_query_when_combined_fails(
+        self, engine, test_table
+    ):
+        # A query referencing a non-existent table makes the combined CTE statement
+        # fail; with fallback enabled, each query runs serially instead. The good
+        # queries still get results; the bad query's exception is captured per-future.
+        good = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        bad = sa.select(sa.func.count().label("bad")).select_from(
+            sa.table("does_not_exist")
+        )
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap_good = _schedule(qc, conn, good)
+            cap_bad = _schedule(qc, conn, bad)
+            qc.flush()
+
+        assert cap_good.result is not None and cap_good.exc is None
+        assert cap_good.result.scalar() == 3
+        assert cap_bad.result is None
+        assert cap_bad.exc is not None
+        assert combiner.report.query_exceptions >= 1
+
+    def test_no_fallback_raises_when_disabled(self, engine, test_table):
+        bad = sa.select(sa.func.count().label("bad")).select_from(
+            sa.table("does_not_exist")
+        )
+        combiner = _make_combiner(serial_execution_fallback_enabled=False)
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            _schedule(qc, conn, bad)
+            with pytest.raises(sa.exc.SQLAlchemyError):
+                qc.flush()
+
+    def test_enabled_false_runs_queries_directly(self, engine, test_table):
+        # With the combiner disabled, run() invokes the closure directly on the
+        # main greenlet; _handle_execute short-circuits and Connection.execute
+        # runs the query normally. flush() is a no-op; nothing is combined.
+        query = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        combiner = _make_combiner(enabled=False)
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            # With enabled=False the closure runs synchronously inside run().
+            assert cap.done
+            qc.flush()
+
+        assert cap.result is not None
+        assert cap.result.scalar() == 3
+        assert combiner.report.combined_queries_issued == 0
+        assert combiner.report.queries_combined == 0
+        assert combiner.report.uncombined_queries_issued == 1
+
+
+class TestResultProxyContract:
+    def test_scalar_one_one_or_none_and_keyed_access(self, engine, test_table):
+        # The combiner returns _ResultProxyFake objects; pin the access patterns the
+        # profiler relies on: scalar(), one(), one_or_none(), int- and name-keyed row
+        # access. A combined query always returns exactly one row (asserted in the
+        # combiner), so MultipleResultsFound/NoResultFound are not exercised here.
+        query = sa.select(
+            sa.func.count().label("rowcount"),
+            sa.func.sum(test_table.c.value).label("value_sum"),
+        ).select_from(test_table)
+        combiner = _make_combiner()
+
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            qc.flush()
+
+        result = cap.result
+        assert result.scalar() == 3
+        row = result.one()
+        assert row["rowcount"] == 3
+        assert row["value_sum"] == pytest.approx(61.5)
+        assert result.one_or_none() is row
+        # fetchone is aliased to one
+        assert result.fetchone() is row
+
+
+class TestGetQueryColumns:
+    def test_returns_inner_columns_when_available(self, test_table):
+        query = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        cols = get_query_columns(query)
+        assert len(cols) == 1
+
+    def test_falls_back_to_columns_on_attribute_error(self):
+        # Some query shapes expose .columns but not .inner_columns; the helper must
+        # fall back rather than raise. PR 4 may touch this, so pin the contract.
+
+        class _FakeQuery:
+            @property
+            def inner_columns(self):
+                raise AttributeError("no inner_columns")
+
+            @property
+            def columns(self):
+                return [sa.column("a"), sa.column("b")]
+
+        cols = get_query_columns(_FakeQuery())
+        assert [c.name for c in cols] == ["a", "b"]

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -1,32 +1,42 @@
-"""Unit tests for SQLAlchemyQueryCombiner — pins current behavior of the combiner in
-isolation, as a regression guard for the PR 4 flattening change.
+"""Unit tests for SQLAlchemyQueryCombiner — pins current behavior in isolation.
 
-These tests exercise the combiner directly (not via QueryCombinerRunner) against a real
-in-memory SQLite engine. They cover the behaviors PR 4 will rewrite: queue batching,
-result extraction by col.name, the index == len(row) invariant, the combined-failure
-exception path, and the serial fallback. They follow the repo testing philosophy
-(behavior over implementation; no reflection into privates; no exact-error-message
-assertions).
+Regression guard for the PR 4 flattening change. Exercises the combiner
+directly (not via QueryCombinerRunner) against a real in-memory SQLite
+engine. Follows the repo testing philosophy: behavior over implementation,
+no reflection into privates, no exact-error-message assertions.
 """
 
 import dataclasses
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import Column, Float, Integer, String, create_engine
 from sqlalchemy.engine import Connection
+from sqlalchemy.orm.exc import NoResultFound
 
 from datahub.utilities.sqlalchemy_query_combiner import (
     MAX_QUERIES_TO_COMBINE_AT_ONCE,
     SQLAlchemyQueryCombiner,
+    _ResultProxyFake,
+    _RowProxyFake,
     get_query_columns,
 )
 
 
 @pytest.fixture
 def engine():
-    return create_engine("sqlite:///:memory:")
+    # In-memory SQLite uses SingletonThreadPool, so rows inserted in the
+    # test_table fixture (which opens its own connection) survive into the
+    # separate engine.connect() opened in each test. If this fixture ever
+    # switches to a pool that doesn't share one connection per identifier
+    # (e.g. NullPool), the test_table rows would vanish mid-test. Don't
+    # change the pool without re-checking that implicit dependency.
+    eng = create_engine("sqlite:///:memory:")
+    try:
+        yield eng
+    finally:
+        eng.dispose()
 
 
 @pytest.fixture
@@ -53,7 +63,7 @@ def test_table(engine):
 
 
 def _make_combiner(**overrides: Any) -> SQLAlchemyQueryCombiner:
-    defaults: dict[str, Any] = {
+    defaults: Dict[str, Any] = {
         "enabled": True,
         "catch_exceptions": True,
         "is_single_row_query_method": lambda q: True,
@@ -65,23 +75,26 @@ def _make_combiner(**overrides: Any) -> SQLAlchemyQueryCombiner:
 
 @dataclasses.dataclass
 class _Capture:
-    """Mirrors QueryCombinerRunner._ResultContainer: catches the result or the
-    re-raised exception so a failing query's greenlet doesn't tear down flush()."""
-
+    # Mirrors QueryCombinerRunner._ResultContainer: catches the result or the
+    # re-raised exception so a failing query's greenlet doesn't tear down
+    # flush(). exc is Optional[Exception] (not BaseException) because
+    # _schedule only catches Exception.
     result: Any = None
-    exc: Optional[BaseException] = None
+    exc: Optional[Exception] = None
     done: bool = False
 
 
-def _schedule(qc: SQLAlchemyQueryCombiner, conn: Connection, query: Any) -> _Capture:
-    """Schedule `query` via qc.run(); the closure runs in a greenlet and captures
-    the _ResultProxyFake returned by the patched Connection.execute (or the
-    re-raised exception). Returns the capture; populated after qc.flush()."""
+def _schedule(
+    qc: SQLAlchemyQueryCombiner,
+    conn: Connection,
+    query: Any,
+    multiparams: Any = (),
+) -> _Capture:
     cap = _Capture()
 
     def execute() -> None:
         try:
-            cap.result = conn.execute(query)
+            cap.result = conn.execute(query, *multiparams)
         except Exception as e:
             cap.exc = e
         finally:
@@ -91,7 +104,7 @@ def _schedule(qc: SQLAlchemyQueryCombiner, conn: Connection, query: Any) -> _Cap
     return cap
 
 
-class TestQueuePartitioningAndBatching:
+class TestBatchingAndPartitioning:
     def test_combines_single_row_queries_into_one_statement(self, engine, test_table):
         queries = [
             sa.select(sa.func.count().label("rowcount")).select_from(test_table),
@@ -99,7 +112,6 @@ class TestQueuePartitioningAndBatching:
             sa.select(sa.func.max(test_table.c.value).label("max_value")),
         ]
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             caps = [_schedule(qc, conn, q) for q in queries]
             qc.flush()
@@ -111,17 +123,22 @@ class TestQueuePartitioningAndBatching:
         assert combiner.report.combined_queries_issued == 1
         assert combiner.report.queries_combined == 3
         assert combiner.report.uncombined_queries_issued == 0
+        # query_exceptions == 0 is the load-bearing assertion: a silent
+        # fall-through to the serial path (e.g. an invariant violation in
+        # _execute_queue) increments query_exceptions and leaves
+        # uncombined_queries_issued at 0, so the uncombined assertion alone
+        # would not catch it. See test_index_len_row_invariant_* for the
+        # mechanism.
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 3
 
-    def test_max_queries_batched_at_40_boundary(self, engine, test_table):
-        # MAX_QUERIES_TO_COMBINE_AT_ONCE caps each _execute_queue pass at 40, so
-        # 41 single-row queries must produce two combined statements (40 + 1).
+    def test_batches_at_max_queries_boundary(self, engine, test_table):
         n = MAX_QUERIES_TO_COMBINE_AT_ONCE + 1
         queries = [
             sa.select(sa.func.count().label(f"rowcount_{i}")).select_from(test_table)
             for i in range(n)
         ]
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             caps = [_schedule(qc, conn, q) for q in queries]
             qc.flush()
@@ -130,18 +147,64 @@ class TestQueuePartitioningAndBatching:
         assert all(c.result is not None and c.exc is None for c in caps)
         assert combiner.report.queries_combined == n
         assert combiner.report.combined_queries_issued == 2
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == n
+
+    def test_non_single_row_query_goes_uncombined(self, engine, test_table):
+        # is_single_row_query_method partitions the queue: a query the
+        # predicate rejects is NOT batched — it goes out via uncombined and
+        # runs normally. This is the partitioning the class name claims.
+        single = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        rejected = sa.select(
+            sa.func.max(test_table.c.value).label("max_value")
+        ).select_from(test_table)
+        combiner = _make_combiner(
+            is_single_row_query_method=lambda q: q is not rejected
+        )
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap_single = _schedule(qc, conn, single)
+            cap_rejected = _schedule(qc, conn, rejected)
+            qc.flush()
+
+        assert cap_single.result.scalar() == 3
+        assert cap_rejected.result.scalar() == 30.5
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.queries_combined == 1
+        assert combiner.report.uncombined_queries_issued == 1
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+
+    def test_enabled_false_runs_queries_directly(self, engine, test_table):
+        # With the combiner disabled, run() invokes the closure directly on
+        # the main greenlet; _handle_execute short-circuits and
+        # Connection.execute runs the query normally. flush() is a no-op;
+        # nothing is combined.
+        query = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        combiner = _make_combiner(enabled=False)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            assert cap.done  # runs synchronously inside run()
+            qc.flush()
+
+        assert cap.result is not None
+        assert cap.result.scalar() == 3
+        assert combiner.report.combined_queries_issued == 0
+        assert combiner.report.queries_combined == 0
+        assert combiner.report.uncombined_queries_issued == 1
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 1
 
 
 class TestResultExtraction:
     def test_result_row_mapped_by_col_name(self, engine, test_table):
-        # The extraction loop keys each query's row dict by col.name; callers access
-        # results by label, not by position. Pin that contract.
+        # The extraction loop keys each query's row dict by col.name; callers
+        # access results by label, not by position. Pin that contract.
         query = sa.select(
             sa.func.count().label("rowcount"),
             sa.func.sum(test_table.c.value).label("value_sum"),
         ).select_from(test_table)
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             cap = _schedule(qc, conn, query)
             qc.flush()
@@ -152,46 +215,123 @@ class TestResultExtraction:
         # int-indexing resolves to the column at that position, by insertion order
         assert row[0] == 3
         assert row[1] == pytest.approx(61.5)
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 1
 
     def test_index_len_row_invariant_across_mixed_column_queries(
         self, engine, test_table
     ):
-        # The combined row width must equal the sum of each query's column count;
-        # the extraction loop's `index` cursor must consume the whole row. Mixing
-        # a 1-column and a 2-column query exercises the invariant non-trivially.
+        # The combined row width must equal the sum of each query's column
+        # count; the extraction loop's `index` cursor must consume the
+        # whole row. Mixing a 1-column and a 2-column query exercises the
+        # invariant non-trivially.
         q1 = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
         q2 = sa.select(
             sa.func.min(test_table.c.value).label("min_value"),
             sa.func.max(test_table.c.value).label("max_value"),
         ).select_from(test_table)
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             cap1 = _schedule(qc, conn, q1)
             cap2 = _schedule(qc, conn, q2)
             qc.flush()
 
-        # If the invariant were violated the combiner's internal assert would fire
-        # during flush(); reaching here with correct values means extraction lined up.
         assert cap1.result.scalar() == 3
-        assert cap2.result.one()["min_value"] == 10.5
-        assert cap2.result.one()["max_value"] == 30.5
+        # Bind one() once: idempotent on _ResultProxyFake but NOT on a real
+        # CursorResult (which is what the serial fallback stores), so
+        # calling it twice would behave differently across paths.
+        row2 = cap2.result.one()
+        assert row2["min_value"] == 10.5
+        assert row2["max_value"] == 30.5
         assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.uncombined_queries_issued == 0
+        # query_exceptions == 0 is what actually detects an invariant
+        # violation here. The combiner sets query_future.done = True inside
+        # the per-query extraction loop, then asserts index == len(row)
+        # AFTER the loop. If the assert fires, flush() catches it,
+        # increments query_exceptions, and calls _execute_queue_fallback —
+        # which skips every (already-done) future, so corrupted-but-populated
+        # results stand and uncombined_queries_issued stays 0. Without
+        # this assertion the mutant that appends a trailing column to the
+        # combined SELECT passes this test.
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+
+    def test_anonymous_columns_scalar_works_keyed_access_unavailable(
+        self, engine, test_table
+    ):
+        # An unlabeled aggregate: get_query_columns reports 'count' (from
+        # inner_columns), but the extraction loop keys off
+        # query.subquery().columns, whose name is an anon label embedding
+        # an object id (non-deterministic across runs). scalar() (positional)
+        # works; keyed access by 'count' does not. PR 4 must not regress
+        # scalar().
+        query = sa.select(sa.func.count()).select_from(test_table)
+        combiner = _make_combiner()
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            qc.flush()
+
+        assert cap.result.scalar() == 3
+        row = cap.result.one()
+        # Pin the shape without asserting the anon key (it embeds an object id):
+        assert len(dict(row)) == 1
+        # Keyed access by the inner_columns name is unavailable:
+        with pytest.raises(KeyError):
+            row["count"]
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 1
+
+    def test_duplicate_labels_fallback_then_ambiguous_at_consumption(
+        self, engine, test_table
+    ):
+        # Two columns labeled 'v' in one query. The combined CTE fails to
+        # compile (ambiguous), so the combiner falls back to serial execution
+        # — which SUCCEEDS at the DB level and stores a real CursorResult.
+        # The InvalidRequestError (ambiguous column name) surfaces later, at
+        # CONSUMPTION (row['v']), not at flush(). This is exactly where the
+        # combined and serial paths diverge, and where PR 4's flattening must
+        # not silently regress: today data[col.name] = row[index] silently
+        # overwrites on a label collision while `index` still advances, so
+        # the extracted dict has one entry but the combined row has two
+        # columns.
+        query = sa.select(
+            sa.func.min(test_table.c.value).label("v"),
+            sa.func.max(test_table.c.value).label("v"),
+        ).select_from(test_table)
+        combiner = _make_combiner()
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query)
+            qc.flush()  # NOT in pytest.raises: flush() succeeds (fallback)
+            assert combiner.report.combined_queries_issued == 0
+            assert combiner.report.uncombined_queries_issued == 1
+            assert combiner.report.query_exceptions == 1
+            assert combiner.report.total_queries == 1
+            # The ambiguity surfaces at consumption, inside the connection
+            # scope (accessing the real CursorResult after the `with` block
+            # closes the connection raises ResourceClosedError instead).
+            row = cap.result.one()
+            with pytest.raises(sa.exc.InvalidRequestError):
+                row["v"]
 
 
 class TestExceptionAndFallback:
     def test_serial_fallback_runs_each_query_when_combined_fails(
         self, engine, test_table
     ):
-        # A query referencing a non-existent table makes the combined CTE statement
-        # fail; with fallback enabled, each query runs serially instead. The good
-        # queries still get results; the bad query's exception is captured per-future.
+        # A query referencing a non-existent table makes the combined CTE
+        # statement fail; with fallback enabled, each query runs serially
+        # instead. The good queries still get results; the bad query's
+        # exception is captured per-future.
         good = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
         bad = sa.select(sa.func.count().label("bad")).select_from(
             sa.table("does_not_exist")
         )
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             cap_good = _schedule(qc, conn, good)
             cap_bad = _schedule(qc, conn, bad)
@@ -201,51 +341,72 @@ class TestExceptionAndFallback:
         assert cap_good.result.scalar() == 3
         assert cap_bad.result is None
         assert cap_bad.exc is not None
-        assert combiner.report.query_exceptions >= 1
+        # Deterministically 1: the combined statement fails once and the
+        # fallback runs once. `>= 1` would hide a regression where the
+        # fallback loops.
+        assert combiner.report.query_exceptions == 1
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.uncombined_queries_issued == 2
+        assert combiner.report.total_queries == 2
 
     def test_no_fallback_raises_when_disabled(self, engine, test_table):
         bad = sa.select(sa.func.count().label("bad")).select_from(
             sa.table("does_not_exist")
         )
         combiner = _make_combiner(serial_execution_fallback_enabled=False)
-
         with engine.connect() as conn, combiner.activate() as qc:
             _schedule(qc, conn, bad)
             with pytest.raises(sa.exc.SQLAlchemyError):
                 qc.flush()
+            # The scheduled greenlet is left parked in _handle_execute's
+            # `while not query_future.done: main_greenlet.switch()` loop,
+            # and the queue still holds the not-done future. There is no
+            # clean drain without contortions (resuming the greenlet would
+            # re-enter the queue and re-fail the combined execute). This is
+            # per-instance state, so it cannot leak across tests, but
+            # greenlet GC raises GreenletExit at an arbitrary later point —
+            # a known source of intermittent CI noise for the no-fallback
+            # path. Expected here.
 
-    def test_enabled_false_runs_queries_directly(self, engine, test_table):
-        # With the combiner disabled, run() invokes the closure directly on the
-        # main greenlet; _handle_execute short-circuits and Connection.execute
-        # runs the query normally. flush() is a no-op; nothing is combined.
+    def test_catch_exceptions_false_propagates_handle_execute_error(
+        self, engine, test_table
+    ):
+        # catch_exceptions=False makes the activate() fake executor
+        # re-raise any exception out of _handle_execute (rather than
+        # falling back to the underlying execute). is_single_row_query_method
+        # is called inside _handle_execute, so a predicate that raises
+        # exercises this path: the exception propagates to the closure.
         query = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
-        combiner = _make_combiner(enabled=False)
 
+        def boom(_q: Any) -> bool:
+            raise RuntimeError("is_single_row_query_method blew up")
+
+        combiner = _make_combiner(
+            catch_exceptions=False, is_single_row_query_method=boom
+        )
         with engine.connect() as conn, combiner.activate() as qc:
             cap = _schedule(qc, conn, query)
-            # With enabled=False the closure runs synchronously inside run().
-            assert cap.done
             qc.flush()
 
-        assert cap.result is not None
-        assert cap.result.scalar() == 3
+        assert cap.exc is not None
+        assert isinstance(cap.exc, RuntimeError)
+        assert combiner.report.total_queries == 1
         assert combiner.report.combined_queries_issued == 0
         assert combiner.report.queries_combined == 0
-        assert combiner.report.uncombined_queries_issued == 1
 
 
 class TestResultProxyContract:
     def test_scalar_one_one_or_none_and_keyed_access(self, engine, test_table):
-        # The combiner returns _ResultProxyFake objects; pin the access patterns the
-        # profiler relies on: scalar(), one(), one_or_none(), int- and name-keyed row
-        # access. A combined query always returns exactly one row (asserted in the
-        # combiner), so MultipleResultsFound/NoResultFound are not exercised here.
+        # The combiner returns _ResultProxyFake objects; pin the access
+        # patterns the profiler relies on: scalar(), one(), one_or_none(),
+        # int- and name-keyed row access. A combined query always returns
+        # exactly one row (asserted in the combiner), so
+        # MultipleResultsFound/NoResultFound are not exercised here.
         query = sa.select(
             sa.func.count().label("rowcount"),
             sa.func.sum(test_table.c.value).label("value_sum"),
         ).select_from(test_table)
         combiner = _make_combiner()
-
         with engine.connect() as conn, combiner.activate() as qc:
             cap = _schedule(qc, conn, query)
             qc.flush()
@@ -256,19 +417,87 @@ class TestResultProxyContract:
         assert row["rowcount"] == 3
         assert row["value_sum"] == pytest.approx(61.5)
         assert result.one_or_none() is row
-        # fetchone is aliased to one
+        # fetchone is aliased to one (see test_fetchone_alias_to_one_* for the
+        # alias contract on a zero-row proxy).
         assert result.fetchone() is row
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.total_queries == 1
+
+    def test_fetchone_alias_to_one_on_zero_row_proxy(self):
+        # fetchone is aliased to one. On a zero-row proxy, one() raises
+        # NoResultFound while first() returns None — so fetchone() must
+        # raise, not return None. This kills the `fetchone = first` mutant.
+        empty = _ResultProxyFake([])
+        assert empty.first() is None
+        with pytest.raises(NoResultFound):
+            empty.one()
+        with pytest.raises(NoResultFound):
+            empty.fetchone()
+
+    def test_fetchall_returns_all_rows(self):
+        # .fetchall() is used at 4 production result-consumption sites.
+        rows = [
+            _RowProxyFake({"a": 1, "b": 10}),
+            _RowProxyFake({"a": 2, "b": 20}),
+        ]
+        result = _ResultProxyFake(rows)
+        fetched = result.fetchall()
+        assert len(fetched) == 2
+        assert fetched[0]["a"] == 1
+        assert fetched[1]["b"] == 20
+
+    def test_int_index_out_of_range_raises_indexerror(self):
+        # _RowProxyFake.__getitem__ guards int access against out-of-range
+        # indices with a clear IndexError. Pin the guard.
+        row = _RowProxyFake({"a": 1})
+        with pytest.raises(IndexError):
+            row[5]
+
+    def test_scalar_on_empty_row_returns_none(self):
+        # scalar()'s empty-row branch: a one-row, zero-column result
+        # returns None rather than indexing into an empty row.
+        result = _ResultProxyFake([_RowProxyFake({})])
+        assert result.scalar() is None
+
+    def test_multiparams_bypasses_combiner(self, engine, test_table):
+        # Passing multiparams/params bypasses the combiner (returns
+        # (False, None) in _handle_execute) and runs the query normally via
+        # the underlying execute. Pin that the query goes out uncombined.
+        query = (
+            sa.select(sa.func.count().label("rowcount"))
+            .select_from(test_table)
+            .where(test_table.c.id == sa.bindparam("x"))
+        )
+        combiner = _make_combiner()
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query, multiparams=({"x": 1},))
+            qc.flush()
+
+        assert cap.result is not None and cap.exc is None
+        assert cap.result.scalar() == 1
+        assert combiner.report.combined_queries_issued == 0
+        assert combiner.report.queries_combined == 0
+        assert combiner.report.uncombined_queries_issued == 1
+        assert combiner.report.total_queries == 1
 
 
 class TestGetQueryColumns:
-    def test_returns_inner_columns_when_available(self, test_table):
-        query = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
-        cols = get_query_columns(query)
-        assert len(cols) == 1
+    def test_prefers_inner_columns_over_columns(self):
+        # inner_columns keeps semantic names ('count', 'count') for duplicate
+        # unlabeled aggregates; .columns yields anon labels embedding an
+        # object id (non-deterministic). Asserting the names (not the count
+        # — both return 2) distinguishes the two branches and kills the
+        # `.columns`-first mutant. Use sa.table/sa.column (pure metadata),
+        # no engine needed.
+        t = sa.table("t", sa.column("value"))
+        query = sa.select(sa.func.count(), sa.func.count()).select_from(t)
+        assert [c.name for c in get_query_columns(query)] == ["count", "count"]
 
     def test_falls_back_to_columns_on_attribute_error(self):
-        # Some query shapes expose .columns but not .inner_columns; the helper must
-        # fall back rather than raise. PR 4 may touch this, so pin the contract.
+        # Some query shapes expose .columns but not .inner_columns; the
+        # helper must fall back rather than raise. PR 4 may touch this, so
+        # pin the contract.
 
         class _FakeQuery:
             @property

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -1,9 +1,8 @@
 """Unit tests for SQLAlchemyQueryCombiner — pins current behavior in isolation.
 
-Regression guard for the PR 4 flattening change. Exercises the combiner
-directly (not via QueryCombinerRunner) against a real in-memory SQLite
-engine. Follows the repo testing philosophy: behavior over implementation,
-no exact-error-message assertions.
+Exercises the combiner directly (not via QueryCombinerRunner) against a real
+in-memory SQLite engine. Follows the repo testing philosophy: behavior over
+implementation, no exact-error-message assertions.
 
 Two edge-case branches (a zero-row proxy, and a one-row/zero-column proxy)
 are unreachable through the combiner, which asserts exactly one row, so
@@ -32,13 +31,9 @@ from datahub.utilities.sqlalchemy_query_combiner import (
 
 @pytest.fixture
 def engine():
-    # In-memory SQLite uses SingletonThreadPool, so rows inserted in the
-    # test_table fixture (which opens its own connection) survive into the
-    # separate engine.connect() opened in each test. If this fixture ever
-    # switches to a pool that doesn't share one connection per identifier
-    # (e.g. NullPool), the test_table rows would vanish mid-test. Don't
-    # change the pool without re-checking that implicit dependency.
-    eng = create_engine("sqlite:///:memory:")
+    # In-memory SQLite shares one connection per identifier; explicit so the
+    # fixture doesn't silently break under a different pool.
+    eng = create_engine("sqlite:///:memory:", poolclass=sa.pool.SingletonThreadPool)
     try:
         yield eng
     finally:
@@ -133,8 +128,7 @@ class TestBatchingAndPartitioning:
         # fall-through to the serial path (e.g. an invariant violation in
         # _execute_queue) increments query_exceptions and leaves
         # uncombined_queries_issued at 0, so the uncombined assertion alone
-        # would not catch it. See test_index_len_row_invariant_* for the
-        # mechanism.
+        # would not catch it.
         assert combiner.report.query_exceptions == 0
         assert combiner.report.total_queries == 3
 
@@ -151,6 +145,7 @@ class TestBatchingAndPartitioning:
 
         assert all(c.done for c in caps)
         assert all(c.result is not None and c.exc is None for c in caps)
+        assert all(c.result.scalar() == 3 for c in caps)
         assert combiner.report.queries_combined == n
         assert combiner.report.combined_queries_issued == 2
         assert combiner.report.uncombined_queries_issued == 0
@@ -259,9 +254,7 @@ class TestResultExtraction:
         # AFTER the loop. If the assert fires, flush() catches it,
         # increments query_exceptions, and calls _execute_queue_fallback —
         # which skips every (already-done) future, so corrupted-but-populated
-        # results stand and uncombined_queries_issued stays 0. Without
-        # this assertion the mutant that appends a trailing column to the
-        # combined SELECT passes this test.
+        # results stand and uncombined_queries_issued stays 0.
         assert combiner.report.query_exceptions == 0
         assert combiner.report.total_queries == 2
 
@@ -272,16 +265,16 @@ class TestResultExtraction:
         # inner_columns), but the extraction loop keys off
         # query.subquery().columns, whose name is an anon label embedding
         # an object id (non-deterministic across runs). scalar() (positional)
-        # works; keyed access by 'count' does not. PR 4 must not regress
-        # scalar().
+        # works; keyed access by 'count' does not.
         query = sa.select(sa.func.count()).select_from(test_table)
         combiner = _make_combiner()
         with engine.connect() as conn, combiner.activate() as qc:
-            cap = _schedule(qc, conn, query)
+            cap_scalar = _schedule(qc, conn, query)
+            cap_one = _schedule(qc, conn, query)
             qc.flush()
 
-        assert cap.result.scalar() == 3
-        row = cap.result.one()
+        assert cap_scalar.result.scalar() == 3
+        row = cap_one.result.one()
         # Pin the shape without asserting the anon key (it embeds an object id):
         assert len(dict(row)) == 1
         # Keyed access by the inner_columns name is unavailable:
@@ -290,21 +283,17 @@ class TestResultExtraction:
         assert combiner.report.combined_queries_issued == 1
         assert combiner.report.uncombined_queries_issued == 0
         assert combiner.report.query_exceptions == 0
-        assert combiner.report.total_queries == 1
+        assert combiner.report.total_queries == 2
 
     def test_duplicate_labels_fallback_then_ambiguous_at_consumption(
         self, engine, test_table
     ):
-        # Two columns labeled 'v' in one query. The combined CTE fails to
-        # compile (ambiguous), so the combiner falls back to serial execution
-        # — which SUCCEEDS at the DB level and stores a real CursorResult.
-        # The InvalidRequestError (ambiguous column name) surfaces later, at
-        # CONSUMPTION (row['v']), not at flush(). This is exactly where the
-        # combined and serial paths diverge, and where PR 4's flattening must
-        # not silently regress: today data[col.name] = row[index] silently
-        # overwrites on a label collision while `index` still advances, so
-        # the extracted dict has one entry but the combined row has two
-        # columns.
+        # Two columns labeled 'v' in one query make the combined CTE fail to
+        # compile (SQLAlchemy raises while populating the CTE's column
+        # collection, before combined_queries_issued is incremented), so the
+        # combiner falls back to serial execution. Serial execution succeeds
+        # at the DB level and stores a real CursorResult; the ambiguity then
+        # surfaces at consumption (row['v']), not at flush().
         query = sa.select(
             sa.func.min(test_table.c.value).label("v"),
             sa.func.max(test_table.c.value).label("v"),
@@ -323,6 +312,30 @@ class TestResultExtraction:
             row = cap.result.one()
             with pytest.raises(sa.exc.InvalidRequestError):
                 row["v"]
+
+    def test_duplicate_labels_across_queries_do_not_collide(self, engine, test_table):
+        # Two separate queries, each with a single column labelled 'v', combine
+        # into one statement. Each query gets its own result dict, so identical
+        # labels across queries must not collide. This is the case that matters
+        # for the flattening change.
+        q_min = sa.select(sa.func.min(test_table.c.value).label("v")).select_from(
+            test_table
+        )
+        q_max = sa.select(sa.func.max(test_table.c.value).label("v")).select_from(
+            test_table
+        )
+        combiner = _make_combiner()
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap_min = _schedule(qc, conn, q_min)
+            cap_max = _schedule(qc, conn, q_max)
+            qc.flush()
+
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+        assert cap_min.result.one()["v"] == 10.5
+        assert cap_max.result.one()["v"] == 30.5
 
 
 class TestExceptionAndFallback:
@@ -403,37 +416,38 @@ class TestExceptionAndFallback:
 
 class TestResultProxyContract:
     def test_scalar_one_one_or_none_and_keyed_access(self, engine, test_table):
-        # The combiner returns _ResultProxyFake objects; pin the access
-        # patterns the profiler relies on: scalar(), one(), one_or_none(),
-        # int- and name-keyed row access. A combined query always returns
-        # exactly one row (asserted in the combiner), so
-        # MultipleResultsFound/NoResultFound are not exercised here.
+        # One access per result object: on a real CursorResult (what the
+        # serial fallback stores) scalar() closes the result and a following
+        # one() raises ResourceClosedError, so chaining the two would pin a
+        # divergence between the combined and serial paths as though it were
+        # a contract. Keyed row access is covered by
+        # test_result_row_mapped_by_col_name.
         query = sa.select(
             sa.func.count().label("rowcount"),
             sa.func.sum(test_table.c.value).label("value_sum"),
         ).select_from(test_table)
         combiner = _make_combiner()
         with engine.connect() as conn, combiner.activate() as qc:
-            cap = _schedule(qc, conn, query)
+            cap_scalar = _schedule(qc, conn, query)
+            cap_one = _schedule(qc, conn, query)
             qc.flush()
 
-        result = cap.result
-        assert result.scalar() == 3
-        row = result.one()
-        assert row["rowcount"] == 3
-        assert row["value_sum"] == pytest.approx(61.5)
-        assert result.one_or_none() is row
-        # fetchone is aliased to one (see test_fetchone_alias_to_one_* for the
-        # alias contract on a zero-row proxy).
-        assert result.fetchone() is row
+        assert cap_scalar.result.scalar() == 3
+        assert cap_one.result.one()[0] == 3
+        # one_or_none on a single-row proxy returns the row.
+        row = _ResultProxyFake(
+            [_RowProxyFake({"rowcount": 3, "value_sum": 61.5})]
+        ).one_or_none()
+        assert row is not None
+        assert row[0] == 3
         assert combiner.report.query_exceptions == 0
         assert combiner.report.uncombined_queries_issued == 0
-        assert combiner.report.total_queries == 1
+        assert combiner.report.total_queries == 2
 
     def test_fetchone_alias_to_one_on_zero_row_proxy(self):
         # fetchone is aliased to one. On a zero-row proxy, one() raises
         # NoResultFound while first() returns None — so fetchone() must
-        # raise, not return None. This kills the `fetchone = first` mutant.
+        # raise, not return None.
         empty = _ResultProxyFake([])
         assert empty.first() is None
         with pytest.raises(NoResultFound):
@@ -442,10 +456,6 @@ class TestResultProxyContract:
             empty.fetchone()
 
     def test_fetchall_returns_all_rows(self):
-        # .fetchall() is used at 4 production result-consumption sites, and
-        # .first() returns the first row (not None) on a populated proxy —
-        # pin both. The first() assertion kills the `first() -> None` mutant
-        # that the zero-row test alone cannot.
         rows = [
             _RowProxyFake({"a": 1, "b": 10}),
             _RowProxyFake({"a": 2, "b": 20}),
@@ -458,14 +468,11 @@ class TestResultProxyContract:
         assert fetched[1]["b"] == 20
 
     def test_int_index_out_of_range_raises_indexerror(self):
-        # Pin the CONTRACT that out-of-range int access raises IndexError
-        # (rather than KeyError or a silent wrong value). Note this does
-        # NOT pin the explicit guard in _RowProxyFake.__getitem__: that
-        # guard is message-only dead code, since the underlying keys[k]
-        # raises IndexError on its own for every out-of-range index. The
-        # "remove the guard" mutant is an equivalent mutant and cannot be
-        # killed by behavior alone. The contract will matter if PR 4
-        # reshapes row access.
+        # Pin the contract that out-of-range int access raises IndexError
+        # (rather than KeyError or a silent wrong value). The explicit guard
+        # in _RowProxyFake.__getitem__ is message-only dead code — the
+        # underlying keys[k] raises IndexError on its own — so this test
+        # pins the contract, not the guard.
         row = _RowProxyFake({"a": 1})
         with pytest.raises(IndexError):
             row[5]
@@ -503,17 +510,15 @@ class TestGetQueryColumns:
         # inner_columns keeps semantic names ('count', 'count') for duplicate
         # unlabeled aggregates; .columns yields anon labels embedding an
         # object id (non-deterministic). Asserting the names (not the count
-        # — both return 2) distinguishes the two branches and kills the
-        # `.columns`-first mutant. Use sa.table/sa.column (pure metadata),
-        # no engine needed.
+        # — both return 2) distinguishes the two branches. Use sa.table/
+        # sa.column (pure metadata), no engine needed.
         t = sa.table("t", sa.column("value"))
         query = sa.select(sa.func.count(), sa.func.count()).select_from(t)
         assert [c.name for c in get_query_columns(query)] == ["count", "count"]
 
     def test_falls_back_to_columns_on_attribute_error(self):
         # Some query shapes expose .columns but not .inner_columns; the
-        # helper must fall back rather than raise. PR 4 may touch this, so
-        # pin the contract.
+        # helper must fall back rather than raise.
 
         class _FakeQuery:
             @property

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -3,12 +3,6 @@
 Exercises the combiner directly (not via QueryCombinerRunner) against a real
 in-memory SQLite engine. Follows the repo testing philosophy: behavior over
 implementation, no exact-error-message assertions.
-
-Two edge-case branches (a zero-row proxy, and a one-row/zero-column proxy)
-are unreachable through the combiner, which asserts exactly one row, so
-those tests construct _ResultProxyFake / _RowProxyFake directly. That is
-deliberate direct construction of internal types to reach branches the
-public surface cannot, not reflection into implementation details.
 """
 
 import dataclasses
@@ -18,13 +12,10 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import Column, Float, Integer, String, create_engine
 from sqlalchemy.engine import Connection
-from sqlalchemy.orm.exc import NoResultFound
 
 from datahub.utilities.sqlalchemy_query_combiner import (
     MAX_QUERIES_TO_COMBINE_AT_ONCE,
     SQLAlchemyQueryCombiner,
-    _ResultProxyFake,
-    _RowProxyFake,
     get_query_columns,
 )
 
@@ -196,6 +187,27 @@ class TestBatchingAndPartitioning:
         assert combiner.report.query_exceptions == 0
         assert combiner.report.total_queries == 1
 
+    def test_multiparams_bypasses_combiner(self, engine, test_table):
+        # Passing multiparams/params bypasses the combiner (returns
+        # (False, None) in _handle_execute) and runs the query normally via
+        # the underlying execute. Pin that the query goes out uncombined.
+        query = (
+            sa.select(sa.func.count().label("rowcount"))
+            .select_from(test_table)
+            .where(test_table.c.id == sa.bindparam("x"))
+        )
+        combiner = _make_combiner()
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, query, multiparams=({"x": 1},))
+            qc.flush()
+
+        assert cap.result is not None and cap.exc is None
+        assert cap.result.scalar() == 1
+        assert combiner.report.combined_queries_issued == 0
+        assert combiner.report.queries_combined == 0
+        assert combiner.report.uncombined_queries_issued == 1
+        assert combiner.report.total_queries == 1
+
 
 class TestResultExtraction:
     def test_result_row_mapped_by_col_name(self, engine, test_table):
@@ -211,6 +223,7 @@ class TestResultExtraction:
             qc.flush()
 
         row = cap.result.one()
+        assert cap.result.fetchone() is row
         assert row["rowcount"] == 3
         assert row["value_sum"] == pytest.approx(61.5)
         # int-indexing resolves to the column at that position, by insertion order
@@ -414,120 +427,19 @@ class TestExceptionAndFallback:
         assert combiner.report.queries_combined == 0
 
 
-class TestResultProxyContract:
-    def test_scalar_one_one_or_none_and_keyed_access(self, engine, test_table):
-        # One access per result object: on a real CursorResult (what the
-        # serial fallback stores) scalar() closes the result and a following
-        # one() raises ResourceClosedError, so chaining the two would pin a
-        # divergence between the combined and serial paths as though it were
-        # a contract. Keyed row access is covered by
-        # test_result_row_mapped_by_col_name.
-        query = sa.select(
-            sa.func.count().label("rowcount"),
-            sa.func.sum(test_table.c.value).label("value_sum"),
-        ).select_from(test_table)
-        combiner = _make_combiner()
-        with engine.connect() as conn, combiner.activate() as qc:
-            cap_scalar = _schedule(qc, conn, query)
-            cap_one = _schedule(qc, conn, query)
-            qc.flush()
-
-        assert cap_scalar.result.scalar() == 3
-        assert cap_one.result.one()[0] == 3
-        # one_or_none on a single-row proxy returns the row.
-        row = _ResultProxyFake(
-            [_RowProxyFake({"rowcount": 3, "value_sum": 61.5})]
-        ).one_or_none()
-        assert row is not None
-        assert row[0] == 3
-        assert combiner.report.query_exceptions == 0
-        assert combiner.report.uncombined_queries_issued == 0
-        assert combiner.report.total_queries == 2
-
-    def test_fetchone_alias_to_one_on_zero_row_proxy(self):
-        # fetchone is aliased to one. On a zero-row proxy, one() raises
-        # NoResultFound while first() returns None — so fetchone() must
-        # raise, not return None.
-        empty = _ResultProxyFake([])
-        assert empty.first() is None
-        with pytest.raises(NoResultFound):
-            empty.one()
-        with pytest.raises(NoResultFound):
-            empty.fetchone()
-
-    def test_fetchall_returns_all_rows(self):
-        rows = [
-            _RowProxyFake({"a": 1, "b": 10}),
-            _RowProxyFake({"a": 2, "b": 20}),
-        ]
-        result = _ResultProxyFake(rows)
-        assert result.first() is rows[0]
-        fetched = result.fetchall()
-        assert len(fetched) == 2
-        assert fetched[0]["a"] == 1
-        assert fetched[1]["b"] == 20
-
-    def test_int_index_out_of_range_raises_indexerror(self):
-        # Pin the contract that out-of-range int access raises IndexError
-        # (rather than KeyError or a silent wrong value). The explicit guard
-        # in _RowProxyFake.__getitem__ is message-only dead code — the
-        # underlying keys[k] raises IndexError on its own — so this test
-        # pins the contract, not the guard.
-        row = _RowProxyFake({"a": 1})
-        with pytest.raises(IndexError):
-            row[5]
-
-    def test_scalar_on_empty_row_returns_none(self):
-        # scalar()'s empty-row branch: a one-row, zero-column result
-        # returns None rather than indexing into an empty row.
-        result = _ResultProxyFake([_RowProxyFake({})])
-        assert result.scalar() is None
-
-    def test_multiparams_bypasses_combiner(self, engine, test_table):
-        # Passing multiparams/params bypasses the combiner (returns
-        # (False, None) in _handle_execute) and runs the query normally via
-        # the underlying execute. Pin that the query goes out uncombined.
-        query = (
-            sa.select(sa.func.count().label("rowcount"))
-            .select_from(test_table)
-            .where(test_table.c.id == sa.bindparam("x"))
-        )
-        combiner = _make_combiner()
-        with engine.connect() as conn, combiner.activate() as qc:
-            cap = _schedule(qc, conn, query, multiparams=({"x": 1},))
-            qc.flush()
-
-        assert cap.result is not None and cap.exc is None
-        assert cap.result.scalar() == 1
-        assert combiner.report.combined_queries_issued == 0
-        assert combiner.report.queries_combined == 0
-        assert combiner.report.uncombined_queries_issued == 1
-        assert combiner.report.total_queries == 1
-
-
 class TestGetQueryColumns:
-    def test_prefers_inner_columns_over_columns(self):
-        # inner_columns keeps semantic names ('count', 'count') for duplicate
-        # unlabeled aggregates; .columns yields anon labels embedding an
-        # object id (non-deterministic). Asserting the names (not the count
-        # — both return 2) distinguishes the two branches. Use sa.table/
-        # sa.column (pure metadata), no engine needed.
+    def test_prefers_inner_columns_and_falls_back_to_columns_for_cte(self):
+        # A Select exposes inner_columns, which keeps semantic names for
+        # duplicate unlabeled aggregates; .columns yields anon labels
+        # embedding an object id. A CTE has no inner_columns, so
+        # get_query_columns falls through to .columns on every combined query.
         t = sa.table("t", sa.column("value"))
-        query = sa.select(sa.func.count(), sa.func.count()).select_from(t)
-        assert [c.name for c in get_query_columns(query)] == ["count", "count"]
+        select_query = sa.select(sa.func.count(), sa.func.count()).select_from(t)
+        assert [c.name for c in get_query_columns(select_query)] == ["count", "count"]
 
-    def test_falls_back_to_columns_on_attribute_error(self):
-        # Some query shapes expose .columns but not .inner_columns; the
-        # helper must fall back rather than raise.
-
-        class _FakeQuery:
-            @property
-            def inner_columns(self):
-                raise AttributeError("no inner_columns")
-
-            @property
-            def columns(self):
-                return [sa.column("a"), sa.column("b")]
-
-        cols = get_query_columns(_FakeQuery())
-        assert [c.name for c in cols] == ["a", "b"]
+        cte = select_query.cte("c")
+        assert not hasattr(cte, "inner_columns")
+        cte_cols = list(get_query_columns(cte))
+        assert len(cte_cols) == 2
+        # .columns yields anon labels (embed an object id), not 'count':
+        assert all(c.name != "count" for c in cte_cols)


### PR DESCRIPTION
`SQLAlchemyQueryCombiner` is currently only tested indirectly, through
`QueryCombinerRunner`. This adds 20 direct unit tests so a regression in the
combiner itself is caught at that layer — a guard ahead of a planned rewrite of
result extraction.

**Test-only. No production code changes.**

## Coverage

- **Batching / partitioning** — queries combine into one statement; the
  `MAX_QUERIES_TO_COMBINE_AT_ONCE` boundary splits into two; rejected queries go
  uncombined; `enabled=False` runs closures directly.
- **Result extraction** — the combined row maps back to each query by `col.name`;
  the `index == len(row)` invariant holds across mixed-width queries; two queries
  sharing a label each get their own result dict; anonymous columns work via
  `scalar()` but not keyed access.
- **Fallback / exceptions** — a failed combined query runs each query serially and
  captures per-future exceptions; with fallback off, `flush()` re-raises;
  `catch_exceptions=False` propagates.
- **Result proxy contract** — `scalar()`, `one()`, `one_or_none()`, `fetchone()`,
  `first()`, `fetchall()`, and int-index bounds.

Tests drive the combiner directly via `activate()`/`run()`/`flush()` against
in-memory SQLite.

## Mutation check

12 mutants against the combiner: 10 killed. The 2 survivors are documented in-file
— one equivalent mutant (a message-only guard) and one unreachable-state guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **test-only** coverage for `SQLAlchemyQueryCombiner` in a new unit file, driving `activate()` / `run()` / `flush()` against in-memory SQLite instead of only exercising the combiner through `QueryCombinerRunner`.
> 
> The tests pin batching (multi-query combine, `MAX_QUERIES_TO_COMBINE_AT_ONCE` splits, predicate partitioning, disabled mode, multiparam bypass), result extraction (column-name mapping, row-width invariant, duplicate labels within vs across queries, anonymous columns), serial fallback and error propagation, and `get_query_columns` behavior on `Select` vs CTE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a192450859b65baa174ebfde031f9d3c0f2a9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->