### PR TITLE
fix(structured-properties): match search on displayed name, not just displayName

### DIFF
--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsTable.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsTable.tsx
@@ -18,7 +18,7 @@ import {
     PropDescription,
     PropName,
 } from '@app/govern/structuredProperties/styledComponents';
-import { getDisplayName } from '@app/govern/structuredProperties/utils';
+import { getDisplayName, getFilteredSortedStructuredProperties } from '@app/govern/structuredProperties/utils';
 import ActorPill from '@app/sharedV2/owners/ActorPill';
 import { AlignmentOptions } from '@src/alchemy-components/theme/config';
 import analytics, { EventType } from '@src/app/analytics';
@@ -76,16 +76,8 @@ const StructuredPropsTable = ({
 
     const structuredProperties = (searchQuery && (searchResults as StructuredPropertyEntity[])) || [];
 
-    // Filter the search results on just displayName based on the search query
-    const filteredProperties = structuredProperties
-        .filter((prop: StructuredPropertyEntity) =>
-            prop.definition?.displayName?.toLowerCase().includes(searchQuery.toLowerCase()),
-        )
-        .sort(
-            (propA, propB) =>
-                ((propB as StructuredPropertyEntity).definition.created?.time || 0) -
-                ((propA as StructuredPropertyEntity).definition.created?.time || 0),
-        );
+    // Filter on the displayed name (displayName, falling back to qualifiedName) and sort by newest first.
+    const filteredProperties = getFilteredSortedStructuredProperties(structuredProperties, searchQuery);
 
     const [deleteStructuredProperty] = useDeleteStructuredPropertyMutation();
 

--- a/datahub-web-react/src/app/govern/structuredProperties/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { getNewAllowedPlatforms, matchesAllowedPlatforms } from '@app/govern/structuredProperties/utils';
+import {
+    getFilteredSortedStructuredProperties,
+    getNewAllowedPlatforms,
+    matchesAllowedPlatforms,
+} from '@app/govern/structuredProperties/utils';
 import { StructuredPropertyEntity } from '@src/types.generated';
 
 function makePlatform(urn: string) {
@@ -74,5 +78,41 @@ describe('getNewAllowedPlatforms', () => {
             allowedPlatforms: ['urn:li:dataPlatform:bigquery', 'urn:li:dataPlatform:snowflake'],
         });
         expect(result).toEqual(['urn:li:dataPlatform:bigquery', 'urn:li:dataPlatform:snowflake']);
+    });
+});
+
+function makeSp(opts: { displayName?: string; qualifiedName?: string; time?: number }): StructuredPropertyEntity {
+    return {
+        urn: `urn:li:structuredProperty:${opts.qualifiedName ?? opts.displayName ?? 'x'}`,
+        type: 'STRUCTURED_PROPERTY' as any,
+        definition: {
+            displayName: opts.displayName,
+            qualifiedName: opts.qualifiedName ?? '',
+            created: opts.time !== undefined ? { time: opts.time } : undefined,
+        },
+    } as any;
+}
+
+describe('getFilteredSortedStructuredProperties', () => {
+    it('matches on displayName, case-insensitively', () => {
+        const props = [makeSp({ displayName: 'Data Quality Score' })];
+        expect(getFilteredSortedStructuredProperties(props, 'quality')).toHaveLength(1);
+    });
+
+    it('falls back to qualifiedName when displayName is missing', () => {
+        const props = [makeSp({ qualifiedName: 'io.acryl.privacy.enumProperty14' })];
+        expect(getFilteredSortedStructuredProperties(props, 'enumProperty14')).toHaveLength(1);
+    });
+
+    it('excludes properties whose displayed name does not contain the query', () => {
+        const props = [makeSp({ displayName: 'Certification Status' })];
+        expect(getFilteredSortedStructuredProperties(props, 'quality')).toHaveLength(0);
+    });
+
+    it('sorts matches by creation time, newest first', () => {
+        const older = makeSp({ displayName: 'test one', time: 1 });
+        const newer = makeSp({ displayName: 'test two', time: 2 });
+        const result = getFilteredSortedStructuredProperties([older, newer], 'test');
+        expect(result.map((p) => p.definition.created?.time)).toEqual([2, 1]);
     });
 });

--- a/datahub-web-react/src/app/govern/structuredProperties/utils.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/utils.ts
@@ -210,6 +210,16 @@ export function getDisplayName(structuredProperty: StructuredPropertyEntity) {
     return structuredProperty.definition.displayName || structuredProperty.definition.qualifiedName;
 }
 
+export function getFilteredSortedStructuredProperties(
+    properties: StructuredPropertyEntity[],
+    searchQuery: string,
+): StructuredPropertyEntity[] {
+    const query = searchQuery.toLowerCase();
+    return properties
+        .filter((property) => getDisplayName(property).toLowerCase().includes(query))
+        .sort((propA, propB) => (propB.definition.created?.time || 0) - (propA.definition.created?.time || 0));
+}
+
 export const getValueType = (valueUrn: string, cardinality: PropertyCardinality) => {
     return valueTypes.find((valueType) => valueType.urn === valueUrn && valueType.cardinality === cardinality)?.value;
 };


### PR DESCRIPTION
### Summary

The Structured Properties management page (**Govern → Structured Properties**) filters the search box only on `definition.displayName`. Structured properties that have no `displayName` — their name in the table comes from `qualifiedName` — can't be found: the row is visible in the list, but typing that name returns **"No search results!"**.

Each row is rendered with `getDisplayName()` (`displayName || qualifiedName`), but the filter used `displayName` alone, so what you see and what you can search disagreed.

### Changes

- Filter on `getDisplayName()`, so search matches the same name the row shows (display name, falling back to qualified name).
- Extract the filter + sort into a pure `getFilteredSortedStructuredProperties` helper in `utils.ts`.
- Unit-test the helper: displayName match, qualifiedName fallback, exclusion, newest-first sort.

Frontend only — no API or schema changes.
