### PR TITLE
docs: document required customType for CUSTOM incidents

### DIFF
--- a/docs/api/tutorials/incidents.md
+++ b/docs/api/tutorials/incidents.md
@@ -54,6 +54,24 @@ Where supported Incident Types include
 - `DATA_SCHEMA`
 - `CUSTOM`
 
+When using `CUSTOM`, you must also provide `customType`. It is a free-text label naming
+your incident category, and it is required: omitting it fails with
+`customType is required: Failed to create incident.`
+
+```graphql
+mutation raiseCustomIncident {
+  raiseIncident(
+    input: {
+      resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:snowflake,public.prod.purchases,PROD)"
+      type: CUSTOM
+      customType: "ML_LEAKAGE"
+      title: "Feature built from post-decision data"
+      description: "days_since_last_payment reads payment events recorded after loan origination."
+    }
+  )
+}
+```
+
 If you see the following response, a unique identifier for the new incident will be returned.
 
 ```json


### PR DESCRIPTION
The incidents guide lists `CUSTOM` as a supported incident type, but does not mention `customType`, which is required whenever you use it.

Following the guide as written fails:

```graphql
mutation {
  raiseIncident(input: {
    resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:duckdb,example,PROD)"
    type: CUSTOM
    title: "Example"
    description: "Example"
  })
}
```

```json
{"errors":[{"message":"java.lang.RuntimeException: customType is required: Failed to create incident."}]}
```

Adding `customType` succeeds and returns the incident URN. Verified against DataHub Core v1.5.0.6.

This adds a short note and a worked example directly after the incident type list, so the required field is visible at the point where someone picks `CUSTOM`.
