### PR TITLE
test(profiling): MySQL SQLAlchemy profiler integration suite (PR 5)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ge_profiling_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_profiling_config.py
@@ -7,7 +7,12 @@ import pydantic
 from pydantic import field_validator, model_validator
 from pydantic.fields import Field
 
-from datahub.configuration.common import AllowDenyPattern, ConfigModel, SupportedSources
+from datahub.configuration.common import (
+    AllowDenyPattern,
+    ConfigModel,
+    HiddenFromDocs,
+    SupportedSources,
+)
 from datahub.configuration.validate_field_removal import pydantic_removed_field
 from datahub.ingestion.source_config.operation_config import OperationConfig
 from datahub.utilities.str_enum import StrEnum
@@ -16,6 +21,7 @@ _PROFILING_FLAGS_TO_REPORT = {
     "turn_off_expensive_profiling_metrics",
     "profile_table_level_only",
     "query_combiner_enabled",
+    "query_combiner_flatten_enabled",
     # all include_field_ flags are reported.
 }
 
@@ -185,6 +191,31 @@ class GEProfilingConfig(GEProfilingBaseConfig):
     query_combiner_enabled: bool = Field(
         default=True,
         description="*This feature is still experimental and can be disabled if it causes issues.* Reduces the total number of queries issued and speeds up profiling by dynamically combining SQL queries where possible.",
+    )
+
+    # When enabled, the combiner flattens same-shape aggregate queries (no
+    # WHERE/GROUP BY/ORDER BY/LIMIT/DISTINCT, same FROM) into a single flat
+    # SELECT per FROM group, instead of one CTE per query. Each CTE in the
+    # legacy path is an independent aggregate over the same table, so the DB
+    # scans the table once per CTE; flattening collapses those into one scan.
+    # COUNT(DISTINCT) futures are capped at max_distinct_per_statement per
+    # flat statement to avoid coexisting distinct-value trees (server memory).
+    # Off by default — flip in a separate follow-up PR after validation.
+    query_combiner_flatten_enabled: bool = Field(
+        default=False,
+        description="*Experimental.* Flattens same-shape aggregate queries into one flat SELECT per FROM group to reduce full table scans on row stores (e.g. MySQL). Off by default. Cheap aggregates (COUNT/MIN/MAX/AVG/STDDEV) coexist freely; COUNT(DISTINCT) is capped per statement to bound server memory.",
+    )
+
+    # Hidden option - starting cap on COUNT(DISTINCT) futures per flat statement.
+    # Exposed so the right value can be measured without a release
+    # cycle. The module default lives at DEFAULT_MAX_DISTINCT_PER_STATEMENT in
+    # datahub.utilities.sqlalchemy_query_combiner (kept here as a literal so
+    # this config module does not import sqlalchemy/greenlet at module scope —
+    # kafka, cassandra, and excel configs import this module and none of those
+    # extras ship sqlalchemy).
+    max_distinct_per_statement: HiddenFromDocs[pydantic.PositiveInt] = Field(
+        default=5,
+        description="",
     )
 
     # Hidden option - used for debugging purposes.

--- a/metadata-ingestion/src/datahub/ingestion/source/sqlalchemy_profiler/sqlalchemy_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sqlalchemy_profiler/sqlalchemy_profiler.py
@@ -1058,6 +1058,8 @@ class SQLAlchemyProfiler:
                 catch_exceptions=self.config.catch_exceptions,
                 is_single_row_query_method=_is_single_row_query_method,
                 serial_execution_fallback_enabled=True,
+                flatten_enabled=self.config.query_combiner_flatten_enabled,
+                max_distinct_per_statement=self.config.max_distinct_per_statement,
             ).activate() as query_combiner,
         ):
             # Submit the profiling requests to the thread pool executor.

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -13,6 +13,10 @@ import greenlet
 import sqlalchemy
 import sqlalchemy.engine
 import sqlalchemy.sql
+import sqlalchemy.sql.elements
+import sqlalchemy.sql.functions
+import sqlalchemy.sql.operators
+import sqlalchemy.sql.visitors
 from packaging import version
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
@@ -29,6 +33,40 @@ IS_SQLALCHEMY_1_4 = version.parse(SQLALCHEMY_VERSION) >= version.parse("1.4.0")
 
 
 MAX_QUERIES_TO_COMBINE_AT_ONCE = 40
+
+# Cap on the number of COUNT(DISTINCT) futures that may coexist in a single
+# flattened statement. Each COUNT(DISTINCT) materializes a distinct-value tree
+# on the server; letting all of them coexist trades a scan problem for a memory
+# problem. Cheap aggregates (COUNT/MIN/MAX/AVG/STDDEV) coexist
+# freely; distinct-heavy futures are split into chunks of at most this many.
+# Starting value, not yet measured. Overridable via a hidden config
+# knob (see SQLAlchemyQueryCombiner.max_distinct_per_statement).
+DEFAULT_MAX_DISTINCT_PER_STATEMENT = 5
+
+# Aggregates the flatten path may emit. Every emitted column must be one of
+# these (or a Label wrapping one); a clause-free non-aggregate like
+# `SELECT v FROM t` would otherwise pass the clause gate and group with
+# real aggregates, emitting `SELECT count(*), v FROM t` — one row on
+# SQLite/MySQL, silently dropping the non-aggregate's rows. upper(v) is a
+# FunctionElement but returns N rows, so the check is on the function name,
+# not the type. Exotic per-platform aggregates (approx_distinct, uniq,
+# approx_percentile, approx_quantiles, median) are intentionally omitted —
+# they fall to the CTE path, which is correct-but-slower and consistent
+# with fail-closed. MySQL-motivated; flag is off by default.
+_FLATTENABLE_AGGREGATES = frozenset(
+    {"count", "min", "max", "avg", "sum", "stddev", "stddev_samp", "std"}
+)
+
+
+def _chunked(seq: List[Any], n: int) -> Iterator[List[Any]]:
+    # Yield successive n-sized chunks. Makes the ceil(len(seq) / n) claim in
+    # _execute_flat_group self-evident. Reject n < 1 by raising so a
+    # misconfigured cap re-routes through the flat-group except's CTE path
+    # instead of yielding nothing and leaving distinct-heavy futures undone.
+    if n < 1:
+        raise ValueError(f"chunk size must be >= 1, got {n}")
+    for i in range(0, len(seq), n):
+        yield seq[i : i + n]
 
 
 # We need to make sure that only one query combiner attempts to patch
@@ -138,6 +176,24 @@ class SQLAlchemyQueryCombinerReport(Report):
     combined_queries_issued: int = 0
     queries_combined: int = 0
 
+    # Flat statements *attempted* under the flatten path. Counts attempts, not
+    # successes: the counter increments before execution (consistent with
+    # combined_queries_issued), so a flat statement that fails still counts.
+    # Read scans_avoided for the success signal — it increments only after
+    # extraction succeeds. Distinct from combined_queries_issued, which counts
+    # both the legacy CTE path and the flat path so existing assertions stay
+    # green when the flag is off.
+    flat_queries_issued: int = 0
+
+    # Estimated table scans avoided by flattening. Each flat statement
+    # collapses N queued aggregates over one table into one scan, so this
+    # counter reads as `sum(len(members) - 1) per flat statement`. Read it
+    # alongside combined_queries_issued: flattening trades round trips for
+    # scans, so combined_queries_issued rises (2 -> 9 in the mixed batch) while
+    # scans fall (~80 -> 9). Without this counter the rise in
+    # combined_queries_issued reads as a regression on a round-trip dashboard.
+    scans_avoided: int = 0
+
     query_exceptions: int = 0
 
 
@@ -153,6 +209,17 @@ class SQLAlchemyQueryCombiner:
     catch_exceptions: bool
     is_single_row_query_method: Callable[[Any], bool]
     serial_execution_fallback_enabled: bool
+    # When True, _execute_queue partitions the pending queue by FROM signature
+    # and emits one flat SELECT per group (with COUNT(DISTINCT) capped at
+    # max_distinct_per_statement per statement) instead of one CTE per query.
+    # Default False — off for everyone.
+    flatten_enabled: bool = False
+    # Cap on the number of COUNT(DISTINCT) futures that may coexist in one
+    # flat statement, to bound server-side memory. Module-level
+    # DEFAULT_MAX_DISTINCT_PER_STATEMENT is the starting value (5); a hidden
+    # config knob threads an override through so the right value can be
+    # measured without a release cycle.
+    max_distinct_per_statement: int = DEFAULT_MAX_DISTINCT_PER_STATEMENT
 
     # The Python GIL ensures that modifications to the report's counters
     # are safe.
@@ -321,74 +388,374 @@ class SQLAlchemyQueryCombiner:
         )
 
         if pending_queue:
-            queue_item = next(iter(pending_queue.values()))
+            if self.flatten_enabled:
+                self._execute_queue_flattened(pending_queue)
+            else:
+                self._execute_cte_combine(pending_queue)
 
-            # Actually combine these queries together. We do this by (1) putting
-            # each query into its own CTE, (2) selecting all the columns we need
-            # and (3) extracting the results once the query finishes.
+    def _execute_cte_combine(self, pending_queue: Dict[str, _QueryFuture]) -> None:
+        # The legacy combine path: one CTE per queued query, all appended into
+        # one SELECT. Each CTE is an independent aggregate over the same
+        # table, so the DB scans the table once per CTE. Preserved unchanged
+        # for the flag-off path and as the fallback for queries the flatten
+        # path cannot handle (those with WHERE/GROUP BY/ORDER BY/LIMIT).
+        queue_item = next(iter(pending_queue.values()))
 
-            ctes = {
-                k: query_future.query.cte(k)
-                for k, query_future in pending_queue.items()
-            }
+        # Actually combine these queries together. We do this by (1) putting
+        # each query into its own CTE, (2) selecting all the columns we need
+        # and (3) extracting the results once the query finishes.
 
-            combined_cols = itertools.chain(
-                *[
-                    [
-                        col  # .label(self._generate_sql_safe_identifier())
-                        for col in get_query_columns(cte)
-                    ]
-                    for _, cte in ctes.items()
+        ctes = {
+            k: query_future.query.cte(k) for k, query_future in pending_queue.items()
+        }
+
+        combined_cols = itertools.chain(
+            *[
+                [
+                    col  # .label(self._generate_sql_safe_identifier())
+                    for col in get_query_columns(cte)
                 ]
+                for _, cte in ctes.items()
+            ]
+        )
+        combined_query = sqlalchemy.select(combined_cols)
+        for cte in ctes.values():
+            combined_query.append_from(cte)
+
+        query_id = SQLAlchemyQueryCombiner._generate_query_id()
+        self.report.combined_queries_issued += 1
+        logger.info(
+            f"[{query_id}] Executing combined query ({len(pending_queue)} queries combined)"
+        )
+        logger.debug(f"[{query_id}] SQL: {str(combined_query)}")
+        with PerfTimer() as timer:
+            sa_res = _sa_execute_underlying_method(queue_item.conn, combined_query)
+
+        logger.info(
+            f"[{query_id}] Combined query executed in {timer.elapsed_seconds():.3f}s"
+        )
+
+        # Fetch the results and ensure that exactly one row is returned.
+        results = sa_res.fetchall()
+        assert len(results) == 1
+        row = results[0]
+
+        # Extract the results into a result for each query.
+        index = 0
+        for _, query_future in pending_queue.items():
+            query = query_future.query
+            if IS_SQLALCHEMY_1_4:
+                # On 1.4, it prints a warning if we don't call subquery.
+                query = query.subquery()  # type: ignore
+            cols = query.columns
+
+            data = {}
+            for col in cols:
+                data[col.name] = row[index]
+                index += 1
+
+            res = _ResultProxyFake([_RowProxyFake(data)])
+
+            query_future.res = res
+            query_future.done = True
+
+        # Verify that we consumed all the columns.
+        assert index == len(row)
+
+    # -- flatten path -------------------------------------------------------
+
+    @staticmethod
+    def _is_flattenable(query: Any) -> bool:
+        # Fail-closed allowlist. Rather than enumerating clauses to reject
+        # (a denylist silently misses OFFSET, HAVING, FOR UPDATE,
+        # prefix_with("DISTINCT"), suffix_with, with_hint, and fetch() — all
+        # of which render extra SQL), rebuild the minimal
+        # `SELECT <cols> FROM <froms>` and require it to render identically.
+        # Anything carrying additional state renders differently and falls
+        # through to the CTE path, so a SQLAlchemy clause we have never
+        # heard of is safe by default. HAVING is the reason this must fail
+        # closed: the flat path would drop the clause and fabricate a row
+        # that must not exist (verified).
+        #
+        # The subquery().columns access guards a query with duplicate
+        # explicit .label() names makes .columns raise InvalidRequestError.
+        # The CTE path hits the same raise and recovers via serial fallback;
+        # route there rather than demoting a whole flat batch inside
+        # _execute_flat_select.
+        #
+        # Cost: two str() compiles plus one subquery build per queued query
+        # per flush pass. Cheap against a table scan, not free. Both sides
+        # use the default dialect, so the str() comparison is sound.
+        try:
+            rebuilt = sqlalchemy.select(get_query_columns(query))
+            for f in query.froms:
+                rebuilt.append_from(f)
+            if str(query) != str(rebuilt):
+                return False
+            # Aggregate allowlist on the select list. A clause-free non-
+            # aggregate (`SELECT v FROM t`) passes the clause gate above;
+            # grouped with real aggregates it would emit
+            # `SELECT count(*), v FROM t` and return one row on
+            # SQLite/MySQL, silently dropping the non-aggregate's rows.
+            # upper(v) is a FunctionElement but returns N rows, so the
+            # check is on the function name, not the type. See
+            # _FLATTENABLE_AGGREGATES for the rationale.
+            for col in get_query_columns(query):
+                elem = (
+                    col.element
+                    if isinstance(col, sqlalchemy.sql.elements.Label)
+                    else col
+                )
+                if not (
+                    isinstance(elem, sqlalchemy.sql.functions.FunctionElement)
+                    and elem.name in _FLATTENABLE_AGGREGATES
+                ):
+                    return False
+            # Parity between emit-side columns (get_query_columns) and
+            # subquery().columns (name-side). A bare sa.text() column gives
+            # emit=1, names=0 and would trip the assert in _execute_flat_select
+            # after the plan loop starts; reject here so the invariant stays
+            # local and that assert stays unreachable. Same reasoning as the
+            # duplicate .label() check below.
+            if len(get_query_columns(query)) != len(query.subquery().columns):
+                return False
+            # Accessing .columns on the subquery raises InvalidRequestError
+            # when the query has duplicate explicit .label() names; that
+            # routes the query to the CTE path (which recovers via serial
+            # fallback) instead of demoting a whole flat batch.
+            _ = query.subquery().columns
+            return True
+        except Exception as e:
+            logger.debug("_is_flattenable rejected query", exc_info=e)
+            return False
+
+    @staticmethod
+    def _flatten_signature(fut: "_QueryFuture") -> Tuple[Tuple[Any, ...], Any]:
+        # Group key: the FROM clause objects (by identity) plus the connection
+        # the future executes on. This function owns the whole key so the next
+        # reader cannot fix one half and forget the other.
+        #
+        # Both halves are hashable with identity semantics. From-clause elements
+        # (Table, Subquery, Join) have stable hash and compare unequal across
+        # distinct objects that share a name (verified). sqlalchemy.engine.Connection
+        # is likewise hashable and dict-keyable, so fut.conn groups by identity
+        # directly — no id(). id() is only unique among live objects, a latent
+        # hazard for a future reader who caches or defers the key, so neither
+        # half uses it. Same-name-different-object tables therefore land in
+        # separate groups instead of one self-cross-join (FROM t, t) the server
+        # would reject.
+        #
+        # The froms are nested (not splatted) so the two element kinds do not
+        # mix in one flat tuple. The connection is folded in because
+        # _execute_flat_select runs the whole group on members[0].conn; mixing
+        # connections in one group would run some futures on the wrong one.
+        return (tuple(fut.query.froms), fut.conn)
+
+    @staticmethod
+    def _has_count_distinct(query: Any) -> bool:
+        # True if any column expression in the query contains a
+        # count(distinct(...)) sub-expression. COUNT(DISTINCT) has three
+        # spellings in SQLAlchemy, all of which must trip the cap:
+        #   sa.func.count(sa.func.distinct(c))  -> FunctionElement name "distinct"
+        #   sa.func.count(sa.distinct(c))       -> UnaryExpression, operator distinct_op
+        #   sa.func.count(c.distinct())         -> UnaryExpression, operator distinct_op
+        # Matching only the first silently bypasses max_distinct_per_statement
+        # for the other two — the server-memory failure mode the cap exists to
+        # prevent. SELECT-level DISTINCT is excluded by _is_flattenable.
+        for col in get_query_columns(query):
+            for elem in sqlalchemy.sql.visitors.iterate(col):
+                if (
+                    isinstance(elem, sqlalchemy.sql.functions.FunctionElement)
+                    and elem.name == "distinct"
+                ):
+                    return True
+                if (
+                    isinstance(elem, sqlalchemy.sql.elements.UnaryExpression)
+                    and elem.operator is sqlalchemy.sql.operators.distinct_op
+                ):
+                    return True
+        return False
+
+    def _execute_queue_flattened(self, pending_queue: Dict[str, _QueryFuture]) -> None:
+        # Partition the capped pending queue into flatten groups (by FROM
+        # signature) plus an unmatched subset.
+        groups: Dict[Any, List[Tuple[str, _QueryFuture]]] = collections.defaultdict(
+            list
+        )
+        unmatched: Dict[str, _QueryFuture] = {}
+        for k, fut in pending_queue.items():
+            if self._is_flattenable(fut.query):
+                groups[self._flatten_signature(fut)].append((k, fut))
+            else:
+                unmatched[k] = fut
+
+        # Each sub-unit is independently recoverable. A failing unit does not
+        # cancel the others: a single bad query must not zero out the
+        # scan-reduction benefit of the whole batch. Flat groups run first so
+        # the common case is not hostage to an exceptional unmatched query.
+        # On failure, increment query_exceptions and try a gentler landing
+        # (re-route the unit's untouched futures through the CTE path); if
+        # that also fails, run THAT UNIT's futures serially via the scoped
+        # _execute_futures_serially — NOT the global _execute_queue_fallback,
+        # which operates on the whole queue and would demote out-of-window
+        # futures that were never attempted and would flatten on the next
+        # pass (measured: one failing group demoted all 50 queued futures,
+        # scans_avoided 4 -> 0). Every failed unit's futures are resolved
+        # here, so no trailing guard is needed — flush()'s greenlet loop
+        # cannot spin on futures parked in _handle_execute's done-loop.
+        for members in groups.values():
+            try:
+                self._execute_flat_group(members)
+            except Exception as e:
+                if not self.serial_execution_fallback_enabled:
+                    raise
+                self.report.query_exceptions += 1
+                logger.warning(
+                    "Failed to execute flat group; will attempt CTE re-route."
+                )
+                logger.debug("Failed to execute flat group", exc_info=e)
+                group_queue = {k: fut for k, fut in members if not fut.done}
+                if group_queue:
+                    try:
+                        self._execute_cte_combine(group_queue)
+                    except Exception as e2:
+                        logger.debug(
+                            "Flat-group CTE re-route also failed; "
+                            "running this group's futures serially",
+                            exc_info=e2,
+                        )
+                        self._execute_futures_serially(
+                            [fut for _, fut in members if not fut.done]
+                        )
+
+        if unmatched:
+            try:
+                self._execute_cte_combine(unmatched)
+            except Exception as e:
+                if not self.serial_execution_fallback_enabled:
+                    raise
+                self.report.query_exceptions += 1
+                logger.warning(
+                    "Failed to execute unmatched CTE combine; "
+                    "will fallback its futures."
+                )
+                logger.debug("Failed to execute unmatched CTE combine", exc_info=e)
+                self._execute_futures_serially(
+                    [fut for fut in unmatched.values() if not fut.done]
+                )
+
+    def _execute_flat_group(self, members: List[Tuple[str, _QueryFuture]]) -> None:
+        # Split a flatten group into cheap and distinct-heavy aggregates and
+        # emit one flat SELECT for the cheap ones plus ceil(n / K) flat SELECTs
+        # for the distinct-heavy ones, each carrying at most K distinct trees.
+        cheap: List[Tuple[str, _QueryFuture]] = []
+        distinct_heavy: List[Tuple[str, _QueryFuture]] = []
+        for k, fut in members:
+            if self._has_count_distinct(fut.query):
+                distinct_heavy.append((k, fut))
+            else:
+                cheap.append((k, fut))
+
+        if cheap:
+            self._execute_flat_select(cheap)
+        for chunk in _chunked(distinct_heavy, self.max_distinct_per_statement):
+            self._execute_flat_select(chunk)
+
+    def _execute_flat_select(self, members: List[Tuple[str, _QueryFuture]]) -> None:
+        # Build one flat SELECT with unique generated labels, execute it, and
+        # map results back to each future BY POSITION (not by name — labels can
+        # collide for anonymous or duplicate-named aggregates). Each future's
+        # result dict is keyed by the names from query.subquery().columns,
+        # matching the CTE path's keying exactly so a flag flip does not
+        # change result keys. _is_flattenable has already guaranteed
+        # subquery().columns does not raise for these queries.
+        labeled_cols: List[Any] = []
+        # plan: (future, [original col.name from subquery().columns, ...])
+        plan: List[Tuple[_QueryFuture, List[str]]] = []
+        for _, fut in members:
+            emit_cols = get_query_columns(fut.query)
+            # Names come from subquery().columns (the same source the CTE path
+            # uses), which anon-labels duplicates so keys stay distinct within
+            # a future. Emission columns still come from get_query_columns so
+            # emission order and count are unchanged.
+            name_cols = fut.query.subquery().columns
+            assert len(emit_cols) == len(name_cols), (
+                "emit/name column count mismatch — _is_flattenable should have "
+                "excluded this query"
             )
-            combined_query = sqlalchemy.select(combined_cols)
-            for cte in ctes.values():
-                combined_query.append_from(cte)
+            names: List[str] = []
+            for col in emit_cols:
+                uid = self._generate_sql_safe_identifier()
+                labeled_cols.append(col.label(uid))
+            for col in name_cols:
+                names.append(col.name)
+            plan.append((fut, names))
 
-            query_id = SQLAlchemyQueryCombiner._generate_query_id()
-            self.report.combined_queries_issued += 1
-            logger.info(
-                f"[{query_id}] Executing combined query ({len(pending_queue)} queries combined)"
-            )
-            logger.debug(f"[{query_id}] SQL: {str(combined_query)}")
-            with PerfTimer() as timer:
-                sa_res = _sa_execute_underlying_method(queue_item.conn, combined_query)
+        # All members share the same FROM by signature; use one representative
+        # so we append exactly one table and avoid a cross-join.
+        rep_froms = members[0][1].query.froms
+        combined_query = sqlalchemy.select(labeled_cols)
+        for f in rep_froms:
+            combined_query.append_from(f)
 
-            logger.info(
-                f"[{query_id}] Combined query executed in {timer.elapsed_seconds():.3f}s"
-            )
+        query_id = SQLAlchemyQueryCombiner._generate_query_id()
+        self.report.combined_queries_issued += 1
+        self.report.flat_queries_issued += 1
+        logger.info(
+            f"[{query_id}] Executing flat query ({len(members)} queries flattened)"
+        )
+        logger.debug(f"[{query_id}] SQL: {str(combined_query)}")
+        with PerfTimer() as timer:
+            sa_res = _sa_execute_underlying_method(members[0][1].conn, combined_query)
 
-            # Fetch the results and ensure that exactly one row is returned.
-            results = sa_res.fetchall()
-            assert len(results) == 1
-            row = results[0]
+        logger.info(
+            f"[{query_id}] Flat query executed in {timer.elapsed_seconds():.3f}s"
+        )
 
-            # Extract the results into a result for each query.
-            index = 0
-            for _, query_future in pending_queue.items():
-                query = query_future.query
-                if IS_SQLALCHEMY_1_4:
-                    # On 1.4, it prints a warning if we don't call subquery.
-                    query = query.subquery()  # type: ignore
-                cols = query.columns
+        results = sa_res.fetchall()
+        assert len(results) == 1
+        row = results[0]
 
-                data = {}
-                for col in cols:
-                    data[col.name] = row[index]
-                    index += 1
+        index = 0
+        for fut, names in plan:
+            data = {}
+            for name in names:
+                data[name] = row[index]
+                index += 1
+            fut.res = _ResultProxyFake([_RowProxyFake(data)])
 
-                res = _ResultProxyFake([_RowProxyFake(data)])
+        # Verify that we consumed all the columns before marking futures
+        # done — a failing assert would otherwise leave wrong-but-done
+        # futures that the `if not fut.done` re-route filter then skips.
+        assert index == len(row)
+        for fut, _ in plan:
+            fut.done = True
 
-                query_future.res = res
-                query_future.done = True
+        # N queued aggregates collapsed into one scan over the same table.
+        self.report.scans_avoided += len(members) - 1
 
-            # Verify that we consumed all the columns.
-            assert index == len(row)
-
-    def _execute_queue_fallback(self, main_greenlet: greenlet.greenlet) -> None:
-        full_queue = self._get_queue(main_greenlet)
-
-        for _, query_future in full_queue.items():
+    def _execute_futures_serially(self, futures: List["_QueryFuture"]) -> None:
+        # Serial fallback scoped to a specific list of futures. Extracted from
+        # _execute_queue_fallback so the flatten path can recover a failed unit
+        # WITHOUT demoting out-of-window futures: _execute_queue_fallback
+        # operates on the whole queue (it is called by flush() when the entire
+        # _execute_queue raises), but a failed unit in _execute_queue_flattened
+        # must only resolve its own futures — the rest of the batch should
+        # still flatten on the next pass.
+        #
+        # The skip-done guard below is load-bearing for _execute_queue_fallback's
+        # whole-queue call: `del queue[query_id]` (in _handle_execute) only
+        # runs when the parked greenlet resumes, which happens in flush()'s
+        # `for let in list(pool): let.switch()` loop AFTER _execute_queue. So
+        # the queue legitimately holds done futures during execution —
+        # _execute_cte_combine sets every future done before its post-loop
+        # assert can fire, then hands the fallback an all-done queue. Without
+        # this guard those futures are re-executed serially (correct results,
+        # N wasted round trips, inflated uncombined_queries_issued). The
+        # flatten path's callers pre-filter (`group_queue = {... if not
+        # fut.done}`), so for them the guard is a no-op — do not delete it as
+        # redundant; it exists for the whole-queue caller.
+        for query_future in futures:
             if query_future.done:
                 continue
 
@@ -423,6 +790,13 @@ class SQLAlchemyQueryCombiner:
                     )
                 finally:
                     query_future.done = True
+
+    def _execute_queue_fallback(self, main_greenlet: greenlet.greenlet) -> None:
+        # flush() calls this when the entire _execute_queue raises; it falls
+        # back the whole queue. Per-unit recovery in the flatten path uses the
+        # scoped _execute_futures_serially directly.
+        full_queue = self._get_queue(main_greenlet)
+        self._execute_futures_serially(list(full_queue.values()))
 
     def flush(self) -> None:
         """Executes until the queue and pool are empty."""

--- a/metadata-ingestion/tests/integration/mysql/test_mysql.py
+++ b/metadata-ingestion/tests/integration/mysql/test_mysql.py
@@ -1,4 +1,3 @@
-import subprocess
 from datetime import datetime, timezone
 
 import pytest
@@ -8,7 +7,7 @@ from datahub.ingestion.source.sql.mysql import MySQLSource
 from datahub.testing import mce_helpers
 from tests.test_helpers import mysql_usage_helpers, test_connection_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
-from tests.test_helpers.docker_helpers import wait_for_port
+from tests.test_helpers.docker_helpers import is_mysql_up, wait_for_port
 
 FROZEN_TIME = "2020-04-14 07:00:00"
 FROZEN_TIME_DT = datetime.fromisoformat(FROZEN_TIME).replace(tzinfo=timezone.utc)
@@ -19,17 +18,6 @@ MYSQL_USAGE_PORT = 53308
 @pytest.fixture(scope="module")
 def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/mysql"
-
-
-def is_mysql_up(container_name: str, port: int) -> bool:
-    """A cheap way to figure out if mysql is responsive on a container"""
-
-    cmd = f"docker logs {container_name} 2>&1 | grep '/usr/sbin/mysqld: ready for connections.' | grep {port}"
-    ret = subprocess.run(
-        cmd,
-        shell=True,
-    )
-    return ret.returncode == 0
 
 
 @pytest.fixture(scope="module")

--- a/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  mysql:
+    image: mysql:8
+    container_name: testmysql_profiler
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+    ports:
+      - "53310:3306"
+    volumes:
+      - ./setup:/docker-entrypoint-initdb.d

--- a/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/setup/setup.sql
+++ b/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/setup/setup.sql
@@ -1,0 +1,92 @@
+-- Test data for the MySQL SQLAlchemy profiler integration tests.
+-- All tables have known values for exact validation. Mirrors the Postgres
+-- sqlalchemy_profiler suite with MySQL-adapted types (BOOLEAN -> TINYINT(1),
+-- TIMESTAMP -> DATETIME). test_distinct_heavy is new: it carries enough
+-- COUNT(DISTINCT) aggregates (7 columns) to exercise the
+-- MAX_DISTINCT_PER_STATEMENT cap splitting in the flatten path.
+
+CREATE DATABASE IF NOT EXISTS testdb;
+USE testdb;
+
+-- Values: [1, 2, 3, 4, 5, NULL, NULL]
+-- Expected: row_count=7, non_null=5, null=2, min=1, max=5, mean=3.0, stdev~1.5811
+CREATE TABLE test_exact_numeric (
+    id INT PRIMARY KEY,
+    value_col INT
+);
+
+INSERT INTO test_exact_numeric (id, value_col) VALUES
+    (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, NULL), (7, NULL);
+
+-- Table with various data types
+CREATE TABLE test_mixed_types (
+    id INT PRIMARY KEY,
+    int_col INT,
+    float_col FLOAT,
+    decimal_col DECIMAL(10,2),
+    varchar_col VARCHAR(100),
+    text_col TEXT,
+    date_col DATE,
+    timestamp_col DATETIME,
+    bool_col TINYINT(1)
+);
+
+INSERT INTO test_mixed_types (
+    id, int_col, float_col, decimal_col, varchar_col, text_col,
+    date_col, timestamp_col, bool_col
+) VALUES
+    (1, 100, 10.5, 99.99, 'test1', 'text1', '2024-01-01', '2024-01-01 10:00:00', 1),
+    (2, 200, 20.5, 199.99, 'test2', 'text2', '2024-01-02', '2024-01-02 11:00:00', 0),
+    (3, 300, 30.5, 299.99, 'test3', 'text3', '2024-01-03', '2024-01-03 12:00:00', 1),
+    (4, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+-- Edge case: Empty table
+CREATE TABLE test_empty (
+    id INT PRIMARY KEY,
+    value_col INT
+);
+
+-- Edge case: Single row
+CREATE TABLE test_single_row (
+    id INT PRIMARY KEY,
+    value_col INT
+);
+
+INSERT INTO test_single_row (id, value_col) VALUES (1, 42);
+
+-- Edge case: All NULLs
+CREATE TABLE test_all_nulls (
+    id INT PRIMARY KEY,
+    value_col INT
+);
+
+INSERT INTO test_all_nulls (id, value_col) VALUES
+    (1, NULL), (2, NULL), (3, NULL);
+
+-- Distinct-heavy table for the flatten off/on decisive test.
+-- 8 columns (id + col_a..col_g), so 8 COUNT(DISTINCT) aggregates; with
+-- include_field_distinct_count enabled and MAX_DISTINCT_PER_STATEMENT=5 that
+-- splits into 2 distinct-chunk flat statements, so the off/on comparison
+-- exercises the cap splitting path, not just cheap aggregates.
+CREATE TABLE test_distinct_heavy (
+    id INT PRIMARY KEY,
+    col_a INT,
+    col_b INT,
+    col_c INT,
+    col_d INT,
+    col_e INT,
+    col_f INT,
+    col_g INT
+);
+
+INSERT INTO test_distinct_heavy (id, col_a, col_b, col_c, col_d, col_e, col_f, col_g) VALUES
+    (1,  1,  2,  3,  4,  5,  6,  7),
+    (2,  2,  3,  4,  5,  6,  7,  8),
+    (3,  3,  4,  5,  6,  7,  8,  9),
+    (4,  4,  5,  6,  7,  8,  9, 10),
+    (5,  5,  6,  7,  8,  9, 10, 11),
+    (6,  6,  7,  8,  9, 10, 11, 12),
+    (7,  7,  8,  9, 10, 11, 12, 13),
+    (8,  8,  9, 10, 11, 12, 13, 14),
+    (9,  9, 10, 11, 12, 13, 14, 15),
+    (10, 10, 11, 12, 13, 14, 15, 16);

--- a/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/test_mysql_profiler.py
+++ b/metadata-ingestion/tests/integration/sqlalchemy_profiler/mysql/test_mysql_profiler.py
@@ -1,0 +1,339 @@
+"""Integration tests for the SQLAlchemy profiler with MySQL.
+
+The decisive test runs the same table with query_combiner_flatten_enabled off
+and on and asserts identical profile output (flattening changes SQL text, not
+results), AND asserts the flat path actually executed via the combiner report
+counters. Mirrors the Postgres sqlalchemy_profiler suite. No default flip: the
+flag stays False; the flip is a separate follow-up PR.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import pytest
+import time_machine
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sql.mysql import MySQLSource
+from datahub.metadata.schema_classes import (
+    DatasetFieldProfileClass,
+    DatasetProfileClass,
+)
+from tests.test_helpers.docker_helpers import is_mysql_up, wait_for_port
+
+FROZEN_TIME = "2024-01-01 12:00:00"
+MYSQL_PORT = 53310
+
+
+@pytest.fixture(scope="module")
+def test_resources_dir(pytestconfig):
+    return pytestconfig.rootpath / "tests/integration/sqlalchemy_profiler/mysql"
+
+
+@pytest.fixture(scope="module")
+def mysql_runner(docker_compose_runner, test_resources_dir):
+    with docker_compose_runner(
+        test_resources_dir / "docker-compose.yml", "mysql"
+    ) as docker_services:
+        wait_for_port(
+            docker_services,
+            "testmysql_profiler",
+            3306,
+            timeout=120,
+            checker=lambda: is_mysql_up("testmysql_profiler", 3306),
+        )
+        yield docker_services
+
+
+def _make_source(flatten_enabled: bool) -> MySQLSource:
+    from datahub.ingestion.source.sql.mysql import MySQLConfig
+
+    config_dict = {
+        "username": "root",
+        "password": "example",
+        "host_port": f"localhost:{MYSQL_PORT}",
+        "database": "testdb",
+        "profiling": {
+            "enabled": True,
+            "method": "sqlalchemy",
+            "include_field_null_count": True,
+            "include_field_distinct_count": True,
+            "include_field_min_value": True,
+            "include_field_max_value": True,
+            "include_field_mean_value": True,
+            "include_field_median_value": True,
+            "include_field_stddev_value": True,
+            "include_field_quantiles": True,
+            "include_field_histogram": True,
+            "include_field_distinct_value_frequencies": True,
+            "include_field_sample_values": True,
+            "query_combiner_flatten_enabled": flatten_enabled,
+        },
+    }
+    config = MySQLConfig.model_validate(config_dict)
+    ctx = PipelineContext(run_id="test-mysql-profiler")
+    return MySQLSource(config, ctx)
+
+
+@pytest.fixture
+def mysql_source(request):
+    # Yield-teardown fixture (deliberate deviation from the Postgres suite, whose
+    # postgres_source fixture returns the source with no close() -- leaking the
+    # engine). Closing here makes a failing assert exception-safe. This does NOT
+    # fully solve the leak: get_profile_for_table calls list(source.get_inspectors()),
+    # and get_inspectors creates a fresh engine per database that source.close() does
+    # not dispose. That is shared source behavior (the Postgres suite has the same
+    # shape); don't try to fix it here.
+    #
+    # request.param (set via indirect parametrize) is the flatten_enabled bool.
+    source = _make_source(request.param)
+    yield source
+    source.close()
+
+
+@dataclass
+class ProfilerRequest:
+    """Simple request class for the profiler (mirrors the Postgres suite)."""
+
+    pretty_name: str
+    batch_kwargs: dict
+
+
+def get_profile_for_table(
+    source: MySQLSource,
+    schema: str,
+    table: str,
+    max_workers: int = 1,
+) -> Optional[DatasetProfileClass]:
+    """Profile a single table (max_workers clamps to 1 for a 1-element list)."""
+    inspectors = list(source.get_inspectors())
+    if not inspectors:
+        return None
+    inspector = inspectors[0]
+    profiler = source.get_profiler_instance(inspector)
+    request = ProfilerRequest(
+        pretty_name=f"{schema}.{table}",
+        batch_kwargs={"schema": schema, "table": table},
+    )
+    profiles = list(profiler.generate_profiles([request], max_workers=max_workers))  # type: ignore[arg-type,list-item]
+    if profiles:
+        return profiles[0][1]
+    return None
+
+
+def get_profiles_for_tables(
+    source: MySQLSource,
+    schema: str,
+    tables: list,
+    max_workers: int,
+) -> Dict[str, Optional[DatasetProfileClass]]:
+    """Fan-out: one ProfilerRequest per table in a single generate_profiles() call.
+
+    sqlalchemy_profiler clamps max_workers to min(max_workers, len(requests)), so
+    only a multi-table call exercises real concurrency -- this is the first
+    integration coverage of the combiner's per-thread/per-greenlet bookkeeping.
+    Returns a dict keyed by table name.
+    """
+    inspectors = list(source.get_inspectors())
+    assert inspectors
+    inspector = inspectors[0]
+    profiler = source.get_profiler_instance(inspector)
+    requests = [
+        ProfilerRequest(
+            pretty_name=f"{schema}.{t}",
+            batch_kwargs={"schema": schema, "table": t},
+        )
+        for t in tables
+    ]
+    profiles = list(profiler.generate_profiles(requests, max_workers=max_workers))  # type: ignore[arg-type,list-item]
+    return {req.pretty_name.split(".", 1)[1]: profile for req, profile in profiles}
+
+
+def _field_profile(
+    profile: DatasetProfileClass, field_path: str
+) -> Optional[DatasetFieldProfileClass]:
+    assert profile.fieldProfiles is not None
+    return next(
+        (fp for fp in profile.fieldProfiles if fp.fieldPath == field_path), None
+    )
+
+
+def _profile_deterministic_dict(profile: DatasetProfileClass) -> Dict[str, Any]:
+    """Project a DatasetProfileClass onto a deterministic, comparable dict.
+
+    Built on to_obj() so new fields added to DatasetProfile are covered by
+    default rather than silently dropped by an allowlist. timestampMillis is the
+    only intentionally-dropped field (set from wall-clock time at aspect
+    construction). sampleValues order is not guaranteed across execution paths,
+    so sort it. partitionSpec is deterministic (FULL_TABLE_SNAPSHOT).
+    """
+    obj: Dict[str, Any] = dict(profile.to_obj())
+    obj.pop("timestampMillis", None)
+    for fp in obj.get("fieldProfiles") or []:
+        if fp.get("sampleValues") is not None:
+            fp["sampleValues"] = sorted(fp["sampleValues"])
+    return obj
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize("mysql_source", [False, True], indirect=True)
+def test_basic_statistics_exact_values(mysql_runner, mysql_source):
+    """Sanity: correct values under both flag states (the 'stays green' guard)."""
+    profile = get_profile_for_table(mysql_source, "testdb", "test_exact_numeric")
+    assert profile is not None
+    assert profile.rowCount == 7
+    value_col = _field_profile(profile, "value_col")
+    assert value_col is not None
+    assert value_col.nullCount == 2
+    assert value_col.min == "1"
+    assert value_col.max == "5"
+    assert value_col.mean is not None
+    assert float(value_col.mean) == pytest.approx(3.0, rel=1e-6)
+    # MySQL's bare STDDEV() is population stddev, but adapter.get_column_stdev
+    # emits stddev_samp, so ~1.5811 holds.
+    assert value_col.stdev is not None
+    assert float(value_col.stdev) == pytest.approx(1.5811, rel=1e-3)
+    assert value_col.uniqueCount == 5
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize("mysql_source", [False, True], indirect=True)
+def test_edge_case_empty_table(mysql_runner, mysql_source):
+    profile = get_profile_for_table(mysql_source, "testdb", "test_empty")
+    assert profile is not None
+    assert profile.rowCount == 0
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize("mysql_source", [False, True], indirect=True)
+def test_edge_case_single_row(mysql_runner, mysql_source):
+    profile = get_profile_for_table(mysql_source, "testdb", "test_single_row")
+    assert profile is not None
+    assert profile.rowCount == 1
+    value_col = _field_profile(profile, "value_col")
+    assert value_col is not None
+    assert value_col.min == "42"
+    assert value_col.max == "42"
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize("mysql_source", [False, True], indirect=True)
+def test_edge_case_all_nulls(mysql_runner, mysql_source):
+    profile = get_profile_for_table(mysql_source, "testdb", "test_all_nulls")
+    assert profile is not None
+    assert profile.rowCount == 3
+    value_col = _field_profile(profile, "value_col")
+    assert value_col is not None
+    assert value_col.nullCount == 3
+    assert value_col.min is None
+    assert value_col.max is None
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "table,numeric_col",
+    [("test_distinct_heavy", "col_a"), ("test_mixed_types", "int_col")],
+)
+def test_flatten_off_vs_on_identical_profile(mysql_runner, table, numeric_col):
+    """Decisive: identical profile output with the flatten flag off vs on.
+
+    test_distinct_heavy has 8 columns (id + col_a..col_g), so 8 COUNT(DISTINCT)
+    aggregates; at cap=5 that splits into 2 distinct-chunk flat statements.
+    test_mixed_types covers FLOAT/DECIMAL/DATE/TEXT/DATETIME/BOOL -- the types
+    where a flat SELECT's coercion could plausibly differ from the CTE path.
+    """
+    off_source = _make_source(False)
+    on_source = _make_source(True)
+    try:
+        off = get_profile_for_table(off_source, "testdb", table)
+        on = get_profile_for_table(on_source, "testdb", table)
+        assert off is not None and on is not None
+
+        # T2: full to_obj() comparison, normalized for nondeterminism.
+        assert _profile_deterministic_dict(off) == _profile_deterministic_dict(on)
+
+        # T3: "identical AND non-trivial" -- the fields MySQL actually populates
+        # must be populated, so the equality above is not just None == None.
+        # median IS populated on MySQL: adapters/mysql.py:47 returns None from
+        # get_median_expr, but base_adapter.get_column_median falls back to a
+        # Python OFFSET/LIMIT query (base_adapter.py:498-511).
+        numeric = _field_profile(on, numeric_col)
+        assert numeric is not None
+        assert numeric.uniqueCount is not None
+        assert numeric.min is not None and numeric.max is not None
+        assert numeric.mean is not None and numeric.stdev is not None
+        assert numeric.median is not None
+
+        # T3: document the real capability gap. quantiles are unsupported
+        # (base_adapter.get_quantiles_expr defaults to None; mysql.py does not
+        # override; no fallback). Asserting quantiles IS None makes the test
+        # trip if native quantile support is ever added.
+        assert numeric.quantiles is None
+
+        # distinctValueFrequencies is None for a different reason than "high
+        # cardinality": convert_to_cardinality (profiling/common.py:40-41) tests
+        # pct_unique == 1.0 -> Cardinality.UNIQUE BEFORE the cardinality buckets
+        # that gate frequency computation. Both fixture columns have every
+        # non-null value distinct (col_a: 10 distinct / 10 non-null; int_col:
+        # 3 distinct / 3 non-null), so they resolve to Cardinality.UNIQUE,
+        # which is outside the allowed set {ONE, TWO, VERY_FEW, FEW} for which
+        # frequencies are computed.
+        # NOTE: this depends on every non-null value in the column being
+        # distinct. Add a duplicate to either fixture column and pct_unique
+        # drops below 1.0; with unique_count < 20 the column lands in VERY_FEW,
+        # frequencies ARE computed, and this assertion fails with no obvious
+        # link to the setup.sql edit.
+        assert numeric.distinctValueFrequencies is None
+
+        # B2: assert the flat path actually executed. Without this the equality
+        # holds trivially if the flag failed to plumb through or _is_flattenable
+        # rejected every query. Counters are wired end-to-end: SQLSourceReport.
+        # query_combiner is the same report object the SQLAlchemyProfiler uses.
+        off_report = off_source.report.query_combiner
+        on_report = on_source.report.query_combiner
+        assert off_report is not None, "combiner report missing -- plumbing regression"
+        assert on_report is not None, "combiner report missing -- plumbing regression"
+        assert off_report.flat_queries_issued == 0
+        assert on_report.flat_queries_issued >= 2
+        assert on_report.scans_avoided > 0
+    finally:
+        off_source.close()
+        on_source.close()
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.integration
+@pytest.mark.parametrize("mysql_source", [True], indirect=True)
+def test_concurrent_profiles_complete(mysql_runner, mysql_source):
+    """Concurrency correctness: profile all six tables in one generate_profiles()
+    call with max_workers=6 so the combiner's per-thread/per-greenlet bookkeeping
+    gets real integration coverage (every existing profiler suite runs
+    single-threaded). flatten_enabled=True so the flat path runs under
+    concurrency. Asserts every profile comes back (no None) with correct rowCount.
+    """
+    tables = [
+        "test_exact_numeric",
+        "test_mixed_types",
+        "test_empty",
+        "test_single_row",
+        "test_all_nulls",
+        "test_distinct_heavy",
+    ]
+    expected = {
+        "test_exact_numeric": 7,
+        "test_mixed_types": 4,
+        "test_empty": 0,
+        "test_single_row": 1,
+        "test_all_nulls": 3,
+        "test_distinct_heavy": 10,
+    }
+    profiles = get_profiles_for_tables(mysql_source, "testdb", tables, max_workers=6)
+    for table in tables:
+        profile = profiles[table]
+        assert profile is not None, f"missing profile for {table}"
+        assert profile.rowCount == expected[table], table

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -47,3 +47,20 @@ def cleanup_image(image_name: str) -> None:
         shell=True,
         check=True,
     )
+
+
+def is_mysql_up(container_name: str, port: int) -> bool:
+    """A cheap way to figure out if mysql is responsive on a container.
+
+    Shared by the MySQL ingest suite (tests/integration/mysql) and the MySQL
+    SQLAlchemy-profiler suite (tests/integration/sqlalchemy_profiler/mysql).
+    ``capture_output=True`` keeps the docker-logs dump out of the test
+    output; ``shell=True`` is retained because the command is a literal
+    pipeline with no interpolated user input (the port is an int).
+    """
+    cmd = (
+        f"docker logs {container_name} 2>&1 | "
+        "grep '/usr/sbin/mysqld: ready for connections.' | grep " + str(port)
+    )
+    ret = subprocess.run(cmd, shell=True, capture_output=True)
+    return ret.returncode == 0

--- a/metadata-ingestion/tests/unit/test_ge_profiling_config.py
+++ b/metadata-ingestion/tests/unit/test_ge_profiling_config.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 from datahub.configuration.common import ConfigurationWarning
@@ -106,3 +110,63 @@ def test_profiling_isolation_level_json_schema_has_default():
     # Field(default=None) emits that key; default_factory does not.
     schema = GEProfilingConfig.model_json_schema()
     assert "default" in schema["properties"]["profiling_isolation_level"]
+
+
+def test_max_distinct_per_statement_default_matches_combiner_constant() -> None:
+    # Drift guard: the config's literal default must stay in lockstep with
+    # the combiner's module-level constant. The config inlines the literal
+    # (it cannot import the combiner — kafka/cassandra/excel configs import
+    # this module and none of those extras ship sqlalchemy). This test fires
+    # if either side changes without the other.
+    from datahub.utilities.sqlalchemy_query_combiner import (
+        DEFAULT_MAX_DISTINCT_PER_STATEMENT,
+    )
+
+    config = GEProfilingConfig()
+    assert config.max_distinct_per_statement == DEFAULT_MAX_DISTINCT_PER_STATEMENT
+
+
+def test_ge_profiling_and_kafka_config_import_without_sqlalchemy_or_greenlet() -> None:
+    # kafka, cassandra, and excel configs import ge_profiling_config at module
+    # scope, and none of those extras ship sqlalchemy. Importing either module
+    # must not pull sqlalchemy or greenlet at module scope. Running in a
+    # subprocess gives a cold interpreter — what a `pip install
+    # acryl-datahub[kafka]` user actually hits — and avoids mutating this
+    # process's sys.modules, which previously left a stale duplicate of
+    # kafka_config reachable by attribute traversal and broke order-dependent
+    # tests that patched it.
+    script = textwrap.dedent(
+        """
+        import sys
+
+
+        class _BlockFinder:
+            def find_spec(self, name, path, target=None):
+                if name.split(".")[0] in ("sqlalchemy", "greenlet"):
+                    raise ImportError(
+                        f"import of {name!r} is blocked for this test"
+                    )
+                return None
+
+
+        sys.meta_path.insert(0, _BlockFinder())
+
+        import datahub.ingestion.source.ge_profiling_config  # noqa: F401
+        import datahub.ingestion.source.kafka.kafka_config  # noqa: F401
+
+        for blocked in ("sqlalchemy", "greenlet"):
+            assert blocked not in sys.modules, (
+                f"{blocked} was imported at module scope"
+            )
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"subprocess exited {result.returncode}\n"
+        f"stdout: {result.stdout.decode()}\n"
+        f"stderr: {result.stderr.decode()}"
+    )

--- a/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/tests/unit/utilities/test_sqlalchemy_query_combiner.py
@@ -16,6 +16,9 @@ from sqlalchemy.engine import Connection
 from datahub.utilities.sqlalchemy_query_combiner import (
     MAX_QUERIES_TO_COMBINE_AT_ONCE,
     SQLAlchemyQueryCombiner,
+    _QueryFuture,
+    _ResultProxyFake,
+    _RowProxyFake,
     get_query_columns,
 )
 
@@ -381,6 +384,62 @@ class TestExceptionAndFallback:
         assert combiner.report.uncombined_queries_issued == 2
         assert combiner.report.total_queries == 2
 
+    def test_serial_fallback_skips_already_done_futures(self, engine, test_table):
+        # The skip-done contract is load-bearing for two callers: flush()'s
+        # _execute_queue_fallback runs over the WHOLE queue, which legitimately
+        # holds done futures (del queue[query_id] only runs when the parked
+        # greenlet resumes, after _execute_queue). _execute_cte_combine sets
+        # every future done before its post-loop assert can fire, so a failed
+        # CTE pass hands the fallback an all-done queue. Without this guard
+        # those futures are re-executed serially — correct results, N wasted
+        # round trips, and an inflated uncombined_queries_issued.
+        #
+        # Call _execute_futures_serially directly with a mix of already-done
+        # and un-done futures. The done ones must be skipped (their sentinel
+        # result untouched); only the un-done ones count toward
+        # uncombined_queries_issued and get a real result.
+        combiner = _make_combiner()
+        with engine.connect() as conn:
+            done_query = sa.select(sa.func.count().label("done")).select_from(
+                test_table
+            )
+            undone_query = sa.select(sa.func.count().label("rowcount")).select_from(
+                test_table
+            )
+
+            # Two futures already done, carrying a sentinel result that
+            # re-execution would overwrite.
+            done_fut_a = _QueryFuture(conn, done_query, (), {})
+            done_fut_a.done = True
+            done_fut_a.res = _ResultProxyFake(
+                [_RowProxyFake({"sentinel": "a-untouched"})]
+            )
+            done_fut_b = _QueryFuture(conn, done_query, (), {})
+            done_fut_b.done = True
+            done_fut_b.res = _ResultProxyFake(
+                [_RowProxyFake({"sentinel": "b-untouched"})]
+            )
+
+            # Two futures not yet done — these should be executed.
+            undone_fut_a = _QueryFuture(conn, undone_query, (), {})
+            undone_fut_b = _QueryFuture(conn, undone_query, (), {})
+
+            combiner._execute_futures_serially(
+                [done_fut_a, undone_fut_a, done_fut_b, undone_fut_b]
+            )
+
+        # Only the two un-done futures counted.
+        assert combiner.report.uncombined_queries_issued == 2
+        # Done futures were skipped: sentinel results untouched, still done.
+        assert done_fut_a.res.fetchone()["sentinel"] == "a-untouched"
+        assert done_fut_b.res.fetchone()["sentinel"] == "b-untouched"
+        assert done_fut_a.done and done_fut_b.done
+        # Un-done futures were executed: real result, now done.
+        assert undone_fut_a.done and undone_fut_b.done
+        assert undone_fut_a.res is not None and undone_fut_b.res is not None
+        assert undone_fut_a.res.scalar() == 3
+        assert undone_fut_b.res.scalar() == 3
+
     def test_no_fallback_raises_when_disabled(self, engine, test_table):
         bad = sa.select(sa.func.count().label("bad")).select_from(
             sa.table("does_not_exist")
@@ -443,3 +502,643 @@ class TestGetQueryColumns:
         assert len(cte_cols) == 2
         # .columns yields anon labels (embed an object id), not 'count':
         assert all(c.name != "count" for c in cte_cols)
+
+
+class TestFlattenPath:
+    """The flatten path partitions by FROM signature and emits one flat
+    SELECT per group (COUNT(DISTINCT) capped at MAX_DISTINCT_PER_STATEMENT),
+    instead of one CTE per query. Flag off by default; these tests opt in via
+    _make_combiner(flatten_enabled=True).
+    """
+
+    def test_flat_path_combines_same_from_queries_into_one_statement(
+        self, engine, test_table
+    ):
+        # Three cheap aggregates on the same table, no clauses. The flatten
+        # path emits ONE flat SELECT (not one CTE per query).
+        queries = [
+            sa.select(sa.func.count().label("rowcount")).select_from(test_table),
+            sa.select(sa.func.min(test_table.c.value).label("minv")).select_from(
+                test_table
+            ),
+            sa.select(sa.func.max(test_table.c.value).label("maxv")).select_from(
+                test_table
+            ),
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done and c.exc is None for c in caps)
+        assert caps[0].result.scalar() == 3
+        assert caps[1].result.scalar() == 10.5
+        assert caps[2].result.scalar() == 30.5
+        assert combiner.report.flat_queries_issued == 1
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.queries_combined == 3
+        assert combiner.report.uncombined_queries_issued == 0
+        assert combiner.report.scans_avoided == 2  # 3 queued - 1 scan
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 3
+
+    def test_flat_path_unique_labels_for_anonymous_columns(self, engine, test_table):
+        # Two unlabeled COUNT() queries. The flat SELECT must assign unique
+        # generated labels and map results back by POSITION, so both futures
+        # get the right value despite the colliding inner-column name. This
+        # kills the "key by col.name" mutant (which would overwrite on the
+        # collision and return one wrong value).
+        queries = [
+            sa.select(sa.func.count()).select_from(test_table),
+            sa.select(sa.func.count(sa.column("id"))).select_from(test_table),
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert caps[0].result.scalar() == 3
+        assert caps[1].result.scalar() == 3
+        assert combiner.report.flat_queries_issued == 1
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+
+    def test_flat_path_index_invariant_mixed_width(self, engine, test_table):
+        # A 1-column and a 2-column query in one flat group: the position
+        # cursor must consume the whole row (index == len(row)).
+        q1 = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        q2 = sa.select(
+            sa.func.min(test_table.c.value).label("minv"),
+            sa.func.max(test_table.c.value).label("maxv"),
+        ).select_from(test_table)
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap1 = _schedule(qc, conn, q1)
+            cap2 = _schedule(qc, conn, q2)
+            qc.flush()
+
+        assert cap1.result.scalar() == 3
+        row2 = cap2.result.one()
+        assert row2["minv"] == 10.5
+        assert row2["maxv"] == 30.5
+        assert combiner.report.flat_queries_issued == 1
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+
+    def test_count_distinct_cap_splits_into_multiple_statements(
+        self, engine, test_table
+    ):
+        # 7 COUNT(DISTINCT) aggregates with MAX_DISTINCT_PER_STATEMENT = 5 must
+        # split into ceil(7/5) = 2 flat statements, each carrying at most 5
+        # distinct trees. This bounds server memory by capping distinct-value
+        # trees per statement.
+        queries = [
+            sa.select(
+                sa.func.count(sa.func.distinct(test_table.c.id)).label(f"uc{i}")
+            ).select_from(test_table)
+            for i in range(7)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done and c.exc is None for c in caps)
+        assert all(c.result.scalar() == 3 for c in caps)
+        assert combiner.report.flat_queries_issued == 2
+        assert combiner.report.scans_avoided == 5  # (5-1) + (2-1)
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 7
+
+    def test_cheap_and_distinct_heavy_split_into_separate_statements(
+        self, engine, test_table
+    ):
+        # 3 cheap + 7 distinct-heavy on the same table: 1 cheap flat SELECT +
+        # 2 distinct flat SELECTs (ceil(7/5)) = 3 flat statements total. The
+        # cheap and distinct aggregates never coexist in one statement.
+        cheap = [
+            sa.select(sa.func.count().label("rowcount")).select_from(test_table),
+            sa.select(sa.func.min(test_table.c.value).label("minv")).select_from(
+                test_table
+            ),
+            sa.select(sa.func.max(test_table.c.value).label("maxv")).select_from(
+                test_table
+            ),
+        ]
+        distinct = [
+            sa.select(
+                sa.func.count(sa.func.distinct(test_table.c.id)).label(f"uc{i}")
+            ).select_from(test_table)
+            for i in range(7)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in cheap + distinct]
+            qc.flush()
+
+        assert all(c.done and c.exc is None for c in caps)
+        assert combiner.report.flat_queries_issued == 3
+        assert combiner.report.scans_avoided == 7  # (3-1) + (5-1) + (2-1)
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 10
+
+    def test_unmatched_shape_falls_through_to_cte_path(self, engine, test_table):
+        # A query with a WHERE clause is not flattenable (conservative
+        # signature) and falls through to the legacy CTE path. The flat
+        # counter does not increment; the CTE combine handles both futures.
+        flat_query = sa.select(sa.func.count().label("rowcount")).select_from(
+            test_table
+        )
+        where_query = (
+            sa.select(sa.func.count().label("filtered"))
+            .select_from(test_table)
+            .where(test_table.c.id > 1)
+        )
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap_flat = _schedule(qc, conn, flat_query)
+            cap_where = _schedule(qc, conn, where_query)
+            qc.flush()
+
+        assert cap_flat.result.scalar() == 3
+        assert cap_where.result.scalar() == 2
+        # The cheap query forms a 1-member flat group (1 flat SELECT); the
+        # WHERE query is unmatched and runs through the CTE path (1 CTE
+        # combine). A 1-member flat group saves no scans, so scans_avoided
+        # is 0 — the only success signal that distinguishes "flat path ran
+        # and produced nothing" from "flat path never ran".
+        assert combiner.report.flat_queries_issued == 1
+        assert combiner.report.combined_queries_issued == 2
+        assert combiner.report.scans_avoided == 0
+        assert combiner.report.query_exceptions == 0
+        assert combiner.report.total_queries == 2
+
+    def test_flatten_disabled_uses_cte_path(self, engine, test_table):
+        # Flag off: today's CTE path. flat_queries_issued never increments.
+        queries = [
+            sa.select(sa.func.count().label("rowcount")).select_from(test_table),
+            sa.select(sa.func.min(test_table.c.value).label("minv")).select_from(
+                test_table
+            ),
+        ]
+        combiner = _make_combiner(flatten_enabled=False)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert caps[0].result.scalar() == 3
+        assert caps[1].result.scalar() == 10.5
+        assert combiner.report.flat_queries_issued == 0
+        assert combiner.report.combined_queries_issued == 1
+        assert combiner.report.queries_combined == 2
+        assert combiner.report.total_queries == 2
+
+    @pytest.mark.parametrize("flatten_enabled", [False, True])
+    def test_duplicate_unlabeled_names_within_one_future(
+        self, engine, test_table, flatten_enabled
+    ):
+        # Item 1: two unlabeled COUNT() columns in ONE query share the inner
+        # column name "count". Keying the result dict by col.name would
+        # collapse them to one entry and lose a column with no signal. The
+        # flat path sources names from subquery().columns (which anon-labels
+        # duplicates), so both columns survive. Both flag states must agree
+        # on len(row) == 2 and on the values.
+        q = sa.select(
+            sa.func.count(test_table.c.id), sa.func.count(test_table.c.value)
+        ).select_from(test_table)
+        combiner = _make_combiner(flatten_enabled=flatten_enabled)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, q)
+            qc.flush()
+
+        assert cap.done and cap.exc is None
+        row = cap.result.one()
+        assert len(row) == 2
+        assert row[0] == 3
+        assert row[1] == 3
+
+    @pytest.mark.parametrize("flatten_enabled", [False, True])
+    def test_duplicate_explicit_labels_route_away_from_flat_path(
+        self, engine, test_table, flatten_enabled
+    ):
+        # Item 1 guard: duplicate explicit .label() names make
+        # subquery().columns raise InvalidRequestError. _is_flattenable must
+        # exclude this query from the flat path (route to CTE/serial) rather
+        # than raising inside _execute_flat_select and demoting a whole batch.
+        # Under flatten=True the flat counter must NOT increment for this
+        # query; under both flags the values must be correct (the CTE path
+        # hits the same raise and recovers via serial fallback).
+        q = sa.select(
+            sa.func.min(test_table.c.value).label("v"),
+            sa.func.max(test_table.c.value).label("v"),
+        ).select_from(test_table)
+        combiner = _make_combiner(flatten_enabled=flatten_enabled)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, q)
+            qc.flush()
+
+        assert cap.done and cap.exc is None
+        row = cap.result.one()
+        assert row[0] == 10.5
+        assert row[1] == 30.5
+        # The flat path must not have issued a statement for this query.
+        assert combiner.report.flat_queries_issued == 0
+
+    @pytest.mark.parametrize(
+        "distinct_fn",
+        [
+            lambda c: sa.func.count(sa.func.distinct(c)),
+            lambda c: sa.func.count(sa.distinct(c)),
+            lambda c: sa.func.count(c.distinct()),
+        ],
+        ids=["func.distinct", "sa.distinct", "col.distinct()"],
+    )
+    def test_count_distinct_cap_covers_all_three_spellings(
+        self, engine, test_table, distinct_fn
+    ):
+        # Item 2: COUNT(DISTINCT) has three SQLAlchemy spellings. The cap
+        # must catch all three — a silent bypass trades a scan problem for a
+        # server-memory problem. 7 aggregates with cap 5 -> 2 flat statements
+        # for every spelling.
+        queries = [
+            sa.select(distinct_fn(test_table.c.id).label(f"uc{i}")).select_from(
+                test_table
+            )
+            for i in range(7)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done and c.exc is None for c in caps)
+        assert all(c.result.scalar() == 3 for c in caps)
+        assert combiner.report.flat_queries_issued == 2
+        assert combiner.report.query_exceptions == 0
+
+    def test_is_flattenable_rejects_every_clause_family(self, engine, test_table):
+        # Item 3: the allowlist must reject every clause that renders extra
+        # SQL. HAVING is a data-correctness break (the flat path would drop
+        # it and fabricate a row); the rest are missed optimizations that
+        # would silently change semantics. Asserted directly against the
+        # static helper because that is the contract being pinned.
+        t = test_table
+        non_flattenable = {
+            "where": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .where(t.c.id > 1),
+            "group_by": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .group_by(t.c.id),
+            "order_by": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .order_by(t.c.id),
+            "limit": sa.select(sa.func.count().label("c")).select_from(t).limit(1),
+            "offset": sa.select(sa.func.count().label("c")).select_from(t).offset(1),
+            "distinct": sa.select(sa.func.count().label("c")).select_from(t).distinct(),
+            "having": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .having(sa.func.count() > 100),
+            "for_update": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .with_for_update(),
+            "prefix_distinct": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .prefix_with("DISTINCT"),
+            "suffix_for_share": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .suffix_with("FOR SHARE"),
+            "fetch": sa.select(sa.func.count().label("c")).select_from(t).fetch(1),
+            "with_hint": sa.select(sa.func.count().label("c"))
+            .select_from(t)
+            .with_hint(t, "USE INDEX (PRIMARY)"),
+        }
+        for label, q in non_flattenable.items():
+            assert not SQLAlchemyQueryCombiner._is_flattenable(q), (
+                f"_is_flattenable should reject {label!r}"
+            )
+
+        # And the plain shapes that ARE flattenable.
+        flattenable = {
+            "plain single": sa.select(sa.func.count().label("c")).select_from(t),
+            "plain multi": sa.select(
+                sa.func.count(t.c.id), sa.func.count(t.c.value)
+            ).select_from(t),
+            "anon count": sa.select(sa.func.count()).select_from(t),
+            "count distinct": sa.select(
+                sa.func.count(sa.func.distinct(t.c.id)).label("uc")
+            ).select_from(t),
+        }
+        for label, q in flattenable.items():
+            assert SQLAlchemyQueryCombiner._is_flattenable(q), (
+                f"_is_flattenable should accept {label!r}"
+            )
+
+    @pytest.mark.parametrize("flatten_enabled", [False, True])
+    def test_having_query_returns_zero_rows_under_both_flags(
+        self, engine, test_table, flatten_enabled
+    ):
+        # Item 3 data-correctness probe: HAVING count(*) > 100 over a 3-row
+        # table must return zero rows. Under flatten=False the CTE combine
+        # fails and serial fallback returns []; under flatten=True the
+        # allowlist routes HAVING to the unmatched CTE path (which also
+        # fails) and the serial fallback returns []. Both flags must agree
+        # on [] — a fabricated row would be a silent data-correctness break.
+        q = (
+            sa.select(sa.func.count().label("c"))
+            .select_from(test_table)
+            .having(sa.func.count() > 100)
+        )
+        combiner = _make_combiner(flatten_enabled=flatten_enabled)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap = _schedule(qc, conn, q)
+            qc.flush()
+
+        assert cap.done and cap.exc is None
+        assert cap.result.fetchall() == []
+
+    def test_bad_unflattenable_query_does_not_zero_out_flat_path(
+        self, engine, test_table
+    ):
+        # Item 4: one failing unflattenable query (WHERE on a missing table)
+        # plus five good flattenable ones. The bad query must not cancel the
+        # flat path for the good ones — flat_queries_issued > 0 and all good
+        # futures resolve. Under the old code the bad query's CTE combine
+        # failure escaped before any flat group ran, silently cancelling the
+        # whole optimization.
+        missing = sa.Table("does_not_exist", sa.MetaData(), Column("x", Integer))
+        bad = (
+            sa.select(sa.func.count().label("c"))
+            .select_from(missing)
+            .where(missing.c.x > 1)
+        )
+        good = [
+            sa.select(sa.func.count().label(f"c{i}")).select_from(test_table)
+            for i in range(5)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in [bad] + good]
+            qc.flush()
+
+        assert caps[0].exc is not None  # the bad query fails
+        assert all(c.done and c.exc is None for c in caps[1:])  # all 5 good resolve
+        assert all(c.result.scalar() == 3 for c in caps[1:])
+        # flat_queries_issued counts ATTEMPTS, not successes (it increments
+        # before execution). The load-bearing assertion is scans_avoided: it
+        # increments only after extraction succeeds, so it is positive iff the
+        # flat path actually delivered the scan reduction. Do not prune the
+        # scans_avoided assertion as redundant with flat_queries_issued.
+        assert combiner.report.flat_queries_issued > 0
+        assert combiner.report.scans_avoided == 4  # 5 good - 1
+
+    def test_failing_unit_does_not_demote_out_of_window_futures(
+        self, engine, test_table
+    ):
+        # Item 4 (round 2): the scoped fallback must operate on the FAILED
+        # UNIT's futures only, not the whole queue. The pending queue is
+        # islice'd to MAX_QUERIES_TO_COMBINE_AT_ONCE in _execute_queue, so
+        # futures beyond the cap were never attempted and must flatten on
+        # the next pass — a global fallback (the old code) would demote them
+        # to serial, zeroing scans_avoided. Here one bad query (referencing a
+        # nonexistent column on the same table, so it shares the FROM group
+        # with the good ones) poisons its whole in-window group, but the
+        # out-of-window good futures still flatten.
+        bad = sa.select(
+            sa.func.count(sa.column("no_such_col")).label("bad")
+        ).select_from(test_table)
+        good_count = MAX_QUERIES_TO_COMBINE_AT_ONCE + 10
+        good = [
+            sa.select(sa.func.count().label(f"c{i}")).select_from(test_table)
+            for i in range(good_count)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in [bad] + good]
+            qc.flush()
+
+        assert caps[0].exc is not None  # the bad query fails
+        assert all(c.done and c.exc is None for c in caps[1:])  # all good resolve
+        assert all(c.result.scalar() == 3 for c in caps[1:])
+        # The failed in-window group (bad + 39 good = MAX_QUERIES_TO_COMBINE_AT_ONCE)
+        # goes serial; the out-of-window good futures flatten on the next pass.
+        # uncombined is the FAILED GROUP's size, not the whole queue (which
+        # would be MAX_QUERIES_TO_COMBINE_AT_ONCE + good_count + 1).
+        assert (
+            combiner.report.uncombined_queries_issued == MAX_QUERIES_TO_COMBINE_AT_ONCE
+        )
+        # The out-of-window good futures collapsed into one scan.
+        assert (
+            combiner.report.scans_avoided == good_count - MAX_QUERIES_TO_COMBINE_AT_ONCE
+        )
+
+    def test_failing_flat_group_does_not_cancel_other_groups(self, engine, test_table):
+        # Item 4 (two flat groups): the first flat group fails (references a
+        # missing table); the second must still issue a flat statement and
+        # resolve its futures. Each sub-unit is independently recoverable.
+        missing = sa.Table("does_not_exist", sa.MetaData(), Column("x", Integer))
+        group_a = [
+            sa.select(sa.func.count().label(f"a{i}")).select_from(missing)
+            for i in range(2)
+        ]
+        group_b = [
+            sa.select(sa.func.count().label(f"b{i}")).select_from(test_table)
+            for i in range(3)
+        ]
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in group_a + group_b]
+            qc.flush()
+
+        # group_a futures fail (missing table); group_b futures all resolve.
+        assert all(c.exc is not None for c in caps[:2])
+        assert all(c.done and c.exc is None for c in caps[2:])
+        assert all(c.result.scalar() == 3 for c in caps[2:])
+        # group_a's flat select was attempted (counter increments before
+        # execution) and group_b's succeeded: 2 flat attempts. group_a's
+        # CTE re-route also ran: 3 combined total. scans_avoided counts only
+        # group_b's success (3-1 = 2); group_a's flat and CTE both failed.
+        assert combiner.report.flat_queries_issued == 2
+        assert combiner.report.combined_queries_issued == 3
+        assert combiner.report.scans_avoided == 2
+        assert combiner.report.query_exceptions == 1
+
+    def test_same_name_different_object_tables_not_grouped(self, engine):
+        # Item 5: two distinct Table objects that share the name "t" (built
+        # against separate MetaData, as several adapters do) must NOT group
+        # into one flat statement — that would produce a self-cross-join
+        # (FROM t, t) the server rejects. Keying the signature on from
+        # objects (by identity) keeps them in separate groups. Both futures
+        # resolve and the flat counter reflects two statements, not one.
+        #
+        # SQLite in-memory shares one physical DB across MetaData, so both
+        # inserts land in the same physical "t" table (2 rows) — that is fine:
+        # the test asserts grouping (flat_queries_issued == 2), not distinct
+        # per-table data.
+        md1 = sa.MetaData()
+        t1 = sa.Table("t", md1, Column("id", Integer))
+        md2 = sa.MetaData()
+        t2 = sa.Table("t", md2, Column("id", Integer))
+        md1.create_all(engine)
+        md2.create_all(engine)
+        with engine.connect() as conn, conn.begin():
+            conn.execute(sa.insert(t1).values(id=1))
+            conn.execute(sa.insert(t2).values(id=2))
+
+        q1 = sa.select(sa.func.count().label("c1")).select_from(t1)
+        q2 = sa.select(sa.func.count().label("c2")).select_from(t2)
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap1 = _schedule(qc, conn, q1)
+            cap2 = _schedule(qc, conn, q2)
+            qc.flush()
+
+        assert cap1.done and cap1.exc is None
+        assert cap2.done and cap2.exc is None
+        assert cap1.result.scalar() == 2
+        assert cap2.result.scalar() == 2
+        # Two separate groups (keyed on from-object identity) -> two flat
+        # statements, not one cross-joined statement.
+        assert combiner.report.flat_queries_issued == 2
+        assert combiner.report.query_exceptions == 0
+
+    @pytest.mark.timeout(30)
+    def test_negative_max_distinct_per_statement_does_not_hang(
+        self, engine, test_table
+    ):
+        # A cap < 1 makes _chunked yield nothing, leaving distinct-heavy
+        # futures un-done and flush() spinning on parked greenlets. _chunked
+        # rejects n < 1 by raising, which lands in the flat-group except and
+        # re-routes through the CTE path, so every future gets a result.
+        queries = [
+            sa.select(
+                sa.func.count(sa.func.distinct(test_table.c.id)).label(f"uc{i}")
+            ).select_from(test_table)
+            for i in range(3)
+        ]
+        combiner = _make_combiner(flatten_enabled=True, max_distinct_per_statement=-1)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done for c in caps)
+        assert all(c.exc is None for c in caps)
+        assert all(c.result.scalar() == 3 for c in caps)
+        # The cap raised before _execute_flat_select ran, so no flat statement
+        # succeeded and scans_avoided stays 0; the CTE re-route resolves the
+        # futures.
+        assert combiner.report.flat_queries_issued == 0
+        assert combiner.report.scans_avoided == 0
+        assert combiner.report.query_exceptions == 1
+
+    def test_no_fallback_raises_when_disabled_under_flatten(self, engine, test_table):
+        # serial_execution_fallback_enabled=False must propagate a failed
+        # flat group out of _execute_queue_flattened so flush()'s raise path
+        # handles it. The flatten recovery must not swallow the exception
+        # and leave futures un-done (the livelock). Same contract as the CTE
+        # path.
+        bad = sa.select(
+            sa.func.count(sa.column("no_such_col")).label("bad")
+        ).select_from(test_table)
+        combiner = _make_combiner(
+            flatten_enabled=True, serial_execution_fallback_enabled=False
+        )
+        with engine.connect() as conn, combiner.activate() as qc:
+            _schedule(qc, conn, bad)
+            with pytest.raises(sa.exc.SQLAlchemyError):
+                qc.flush()
+
+    def test_max_distinct_per_statement_knob_splits_distinct_heavy(
+        self, engine, test_table
+    ):
+        # The cap knob is wired through to _chunked. K=3 with 7 distinct-heavy
+        # aggregates splits into ceil(7/3) = 3 flat statements. A mutant that
+        # ignores self.max_distinct_per_statement and uses the module default
+        # (5) would split into 2 and fail this.
+        queries = [
+            sa.select(
+                sa.func.count(sa.func.distinct(test_table.c.id)).label(f"uc{i}")
+            ).select_from(test_table)
+            for i in range(7)
+        ]
+        combiner = _make_combiner(flatten_enabled=True, max_distinct_per_statement=3)
+        with engine.connect() as conn, combiner.activate() as qc:
+            caps = [_schedule(qc, conn, q) for q in queries]
+            qc.flush()
+
+        assert all(c.done and c.exc is None for c in caps)
+        assert all(c.result.scalar() == 3 for c in caps)
+        assert combiner.report.flat_queries_issued == 3
+        assert combiner.report.scans_avoided == 4  # (3-1) + (3-1) + (1-1)
+        assert combiner.report.query_exceptions == 0
+
+    def test_two_connections_same_from_not_grouped(self, engine, test_table):
+        # The flatten signature keys on (froms, conn). Two futures over the
+        # same FROM on different connections must land in separate groups,
+        # emitting two flat statements. A FROM-only-key mutant would group
+        # them and emit one.
+        q = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        combiner = _make_combiner(flatten_enabled=True)
+        with (
+            engine.connect() as conn1,
+            engine.connect() as conn2,
+            combiner.activate() as qc,
+        ):
+            cap1 = _schedule(qc, conn1, q)
+            cap2 = _schedule(qc, conn2, q)
+            qc.flush()
+
+        assert cap1.done and cap1.exc is None
+        assert cap2.done and cap2.exc is None
+        assert cap1.result.scalar() == 3
+        assert cap2.result.scalar() == 3
+        assert combiner.report.flat_queries_issued == 2
+        assert combiner.report.scans_avoided == 0  # each group has 1 member
+        assert combiner.report.query_exceptions == 0
+
+    def test_non_aggregate_column_rejected_by_allowlist(self, engine, test_table):
+        # _is_flattenable checks clauses, not the select list. A clause-
+        # free non-aggregate like `SELECT v FROM t` passes the clause gate;
+        # grouped with a real aggregate it would emit
+        # `SELECT count(*), v FROM t` and return one row on SQLite/MySQL,
+        # silently dropping the non-aggregate's rows. The aggregate
+        # allowlist rejects it so the query routes to the CTE path, whose
+        # cross-join returns N rows and `assert len(results) == 1` catches.
+        non_agg = sa.select(test_table.c.name).select_from(test_table)
+        assert not SQLAlchemyQueryCombiner._is_flattenable(non_agg)
+
+        # And a mixed batch under flatten=True keeps every row of the
+        # non-aggregate: it falls through to the CTE path, which (with one
+        # aggregate) returns one row per future via serial fallback.
+        agg = sa.select(sa.func.count().label("rowcount")).select_from(test_table)
+        combiner = _make_combiner(flatten_enabled=True)
+        with engine.connect() as conn, combiner.activate() as qc:
+            cap_agg = _schedule(qc, conn, agg)
+            cap_non = _schedule(qc, conn, non_agg)
+            qc.flush()
+
+        # The aggregate resolves normally.
+        assert cap_agg.done and cap_agg.exc is None
+        assert cap_agg.result.scalar() == 3
+        # The non-aggregate returns all 3 rows, not one fabricated row.
+        assert cap_non.done and cap_non.exc is None
+        rows = cap_non.result.fetchall()
+        assert len(rows) == 3
+        assert {r["name"] for r in rows} == {"Alice", "Bob", "Charlie"}
+        # The aggregate's 1-member flat group issued one flat statement; the
+        # non-aggregate routed to the unmatched CTE path, which failed (3
+        # rows) and serial-fell-back. No flat statement carried the
+        # non-aggregate.
+        assert combiner.report.flat_queries_issued == 1
+        assert combiner.report.scans_avoided == 0  # 1-member flat group
+        assert combiner.report.query_exceptions == 1  # the unmatched CTE fail
+        assert combiner.report.uncombined_queries_issued == 1  # non-agg serial
+
+    def test_text_clause_column_rejected_by_parity(self, engine, test_table):
+        # A bare sa.text() column gives emit-side columns (get_query_columns)
+        # of length 1 but subquery().columns of length 0, which would trip
+        # `assert len(emit_cols) == len(name_cols)` inside _execute_flat_select
+        # after the plan loop starts. The parity check rejects the query up
+        # front so the assert stays unreachable.
+        text_query = sa.select(sa.text("name")).select_from(test_table)
+        assert not SQLAlchemyQueryCombiner._is_flattenable(text_query)


### PR DESCRIPTION
## Summary

Validates PR 4's flatten path end-to-end on MySQL. Stacked on PR 4 (#18707); review/merge after PR 4. This PR is **test-only** — no source changes.

- **Decisive test** (`test_flatten_off_vs_on_identical_profile`): runs the same table with `query_combiner_flatten_enabled` off and on and asserts identical profile output — flattening changes SQL text, not results — **and** asserts the flat path actually executed via the `SQLAlchemyQueryCombiner` report counters (`flat_queries_issued`, `scans_avoided`), so a plumbing regression that silently skipped flattening would fail the test rather than pass trivially. Exercises the `COUNT(DISTINCT)` cap splitting via `test_distinct_heavy` (8 columns → 8 `COUNT(DISTINCT)` aggregates → 2 distinct-chunk flat statements at cap=5) and covers mixed types (`test_mixed_types`: FLOAT/DECIMAL/DATE/TEXT/DATETIME/BOOL) where a flat SELECT's coercion could plausibly differ from the CTE path.
- **New MySQL SQLAlchemy-profiler integration suite** mirroring the Postgres `sqlalchemy_profiler` suite: dedicated `docker-compose.yml` (mysql:8, port 53310, container `testmysql_profiler`), deterministic `setup.sql`, direct `MySQLSource` + `generate_profiles()` → `DatasetProfileClass` assertions (no golden-file churn). Edge cases (empty/single-row/all-nulls) parametrized on the flag so both states must agree.
- **Concurrency-correctness test** (`test_concurrent_profiles_complete`): profiles all six tables in one `generate_profiles()` call with `max_workers=6` — the first integration coverage of the combiner's per-thread/per-greenlet bookkeeping, since every existing profiler suite runs single-threaded (`max_workers` clamps to `min(max_workers, len(requests))`, so single-table calls can't fan out). It is a correctness test (every profile comes back, `rowCount` correct), not a benchmark.
- **Helper hoist**: `is_mysql_up` moved from `tests/integration/mysql/test_mysql.py` into `tests/test_helpers/docker_helpers.py` so the ingestion suite and this profiler suite share one definition.

**No default flip.** `query_combiner_flatten_enabled` stays `False`. The flip is a separate follow-up PR so it can be reverted independently.

Closes the integration-coverage gap noted in the design spec (§3.9): MySQL profiling was previously validated only via full-pipeline golden-file ingest, with no direct profiler-suite coverage and no test toggling the flatten flag.

## Test plan

- [x] New MySQL suite: 11 passed (run locally with Docker).
- [x] Postgres `sqlalchemy_profiler` suite: 12 passed (PR 4 did not regress it).
- [x] Existing MySQL ingestion suite: 8 passed (the `is_mysql_up` import change did not regress it).
- [x] `./gradlew :metadata-ingestion:lintFix` then `:lint` — clean (ruff + mypy).
- [ ] CI: integration batches.

## Notes for reviewers

- This PR is **test-only** — no source changes. It cannot affect `testQuick` (integration tests are excluded via `-m 'not integration'`).
- The `SADeprecationWarning`s from the combiner (`append_from`, `Select.froms`) are pre-existing and SQLAlchemy 1.4-specific; PR 3's scaffolding already documented them. They are expected under both flag states.
- **Batch weighting:** the new tests live under `tests/integration/sqlalchemy_profiler/mysql/`, so `_connector_key` (`tests/conftest.py`) groups them with the Postgres `sqlalchemy_profiler` suite (the first directory under `tests/integration` is the group key). The `sqlalchemy_profiler` group now holds two docker suites, and all new test ids weigh `_DEFAULT_TEST_WEIGHT = 1.0` (they are not listed in `tests/integration_test_weights.json`). The group is therefore materially underweighted in the bin-pack scheduler; expect the integration batch for this group to run longer than its declared weight implies. No code change needed here — flagging so the maintainer of the weights file knows to expect it.
- On MySQL the profiler capability gap is `quantiles` and `distinctValueFrequencies` (both `None`); `median` **is** populated — `adapters/mysql.py` returns `None` from `get_median_expr`, but `base_adapter.get_column_median` falls back to a Python OFFSET/LIMIT query. The decisive test asserts the real gap (`quantiles`/`distinctValueFrequencies` are `None`) and asserts `median`/`min`/`max`/`mean`/`stdev`/`uniqueCount` are populated, so the off/on equality is non-trivial rather than `None == None`.

## Stack

- PR 1 (#18690): autocommit for profiling connections
- PR 2 (#18699): MySQL guardrails + concurrency default
- PR 3 (#18703): combiner test scaffolding
- PR 4 (#18707): flatten same-shape aggregates (flagged off)
- **PR 5 (this PR): MySQL profiler integration validation**
- Follow-up: flip `query_combiner_flatten_enabled` default to `True` (separate PR)

