### PR TITLE
perf(roles): batch actor existence checks and role membership writes

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/role/RoleService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/role/RoleService.java
@@ -11,7 +11,9 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,14 @@ import lombok.extern.slf4j.Slf4j;
 public class RoleService {
   private final EntityClient _entityClient;
 
+  /**
+   * Assigns (or with a null role, clears) the role membership of every given actor.
+   *
+   * <p>Actors are resolved and ingested as a batch: one existence query for all of them and one
+   * ingest for all of them, rather than a pair of round trips per actor. Actors that are malformed
+   * or do not exist are skipped with a warning, as are individual failures when the batch has to be
+   * retried actor by actor.
+   */
   public void batchAssignRoleToActors(
       @Nonnull OperationContext opContext,
       @Nonnull final List<String> actors,
@@ -31,43 +41,78 @@ public class RoleService {
       throw new RuntimeException(
           String.format("Role %s does not exist. Skipping batch role assignment", roleUrn));
     }
-    actors.forEach(
-        actor -> {
-          try {
-            assignRoleToActor(opContext, actor, roleUrn);
-          } catch (Exception e) {
-            log.warn(
-                String.format(
-                    "Failed to assign role %s to actor %s. Skipping actor assignment",
-                    roleUrn, actor),
-                e);
-          }
-        });
-  }
 
-  private void assignRoleToActor(
-      @Nonnull OperationContext opContext, @Nonnull final String actor, @Nullable final Urn roleUrn)
-      throws URISyntaxException, RemoteInvocationException {
-    final Urn actorUrn = Urn.createFromString(actor);
-    if (!_entityClient.exists(opContext, actorUrn)) {
-      log.warn(
-          String.format(
-              "Failed to assign role %s to actor %s, actor does not exist. Skipping actor assignment",
-              roleUrn, actor));
+    final List<Urn> actorUrns = new ArrayList<>(actors.size());
+    for (final String actor : actors) {
+      try {
+        actorUrns.add(Urn.createFromString(actor));
+      } catch (URISyntaxException e) {
+        log.warn(
+            String.format(
+                "Failed to assign role %s to actor %s, actor urn is malformed. Skipping actor assignment",
+                roleUrn, actor),
+            e);
+      }
+    }
+    if (actorUrns.isEmpty()) {
       return;
     }
 
-    final RoleMembership roleMembership = new RoleMembership();
-    if (roleUrn == null) {
-      roleMembership.setRoles(new UrnArray());
-    } else {
-      roleMembership.setRoles(new UrnArray(roleUrn));
+    // Resolving existence in one query keeps this at a single round trip regardless of actor count.
+    // The check itself cannot be dropped: ingesting a RoleMembership for an actor that does not
+    // exist would materialize that entity via its default key aspect, inventing a user.
+    final Set<Urn> existingActorUrns = _entityClient.filterExistingUrns(opContext, actorUrns);
+
+    final List<MetadataChangeProposal> proposals = new ArrayList<>(actorUrns.size());
+    for (final Urn actorUrn : actorUrns) {
+      if (!existingActorUrns.contains(actorUrn)) {
+        log.warn(
+            String.format(
+                "Failed to assign role %s to actor %s, actor does not exist. Skipping actor assignment",
+                roleUrn, actorUrn));
+        continue;
+      }
+      proposals.add(buildRoleMembershipProposal(actorUrn, roleUrn));
+    }
+    if (proposals.isEmpty()) {
+      return;
     }
 
-    // Ingest new RoleMembership aspect
-    final MetadataChangeProposal proposal =
-        buildSynchronousMetadataChangeProposal(
-            actorUrn, ROLE_MEMBERSHIP_ASPECT_NAME, roleMembership);
-    _entityClient.ingestProposal(opContext, proposal, false);
+    try {
+      _entityClient.batchIngestProposals(opContext, proposals, false);
+    } catch (Exception e) {
+      log.warn(
+          String.format(
+              "Failed to assign role %s to %s actors as one batch, retrying them individually",
+              roleUrn, proposals.size()),
+          e);
+      // Retrying per actor preserves the original behaviour that one bad actor does not prevent the
+      // rest from being assigned. Re-ingesting is safe because these are idempotent upserts.
+      proposals.forEach(proposal -> ingestRoleMembership(opContext, proposal, roleUrn));
+    }
+  }
+
+  @Nonnull
+  private static MetadataChangeProposal buildRoleMembershipProposal(
+      @Nonnull final Urn actorUrn, @Nullable final Urn roleUrn) {
+    final RoleMembership roleMembership = new RoleMembership();
+    roleMembership.setRoles(roleUrn == null ? new UrnArray() : new UrnArray(roleUrn));
+    return buildSynchronousMetadataChangeProposal(
+        actorUrn, ROLE_MEMBERSHIP_ASPECT_NAME, roleMembership);
+  }
+
+  private void ingestRoleMembership(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final MetadataChangeProposal proposal,
+      @Nullable final Urn roleUrn) {
+    try {
+      _entityClient.ingestProposal(opContext, proposal, false);
+    } catch (Exception e) {
+      log.warn(
+          String.format(
+              "Failed to assign role %s to actor %s. Skipping actor assignment",
+              roleUrn, proposal.getEntityUrn()),
+          e);
+    }
   }
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/RoleServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/RoleServiceTest.java
@@ -4,17 +4,21 @@ import static com.linkedin.metadata.Constants.APP_SOURCE;
 import static com.linkedin.metadata.Constants.UI_SOURCE;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
 import com.datahub.authorization.role.RoleService;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -27,6 +31,8 @@ public class RoleServiceTest {
   private static final Authentication SYSTEM_AUTHENTICATION =
       new Authentication(new Actor(ActorType.USER, DATAHUB_SYSTEM_CLIENT_ID), "");
   private Urn roleUrn;
+  private Urn firstActorUrn;
+  private Urn secondActorUrn;
   private EntityClient _entityClient;
   private RoleService _roleService;
   private OperationContext opContext =
@@ -35,6 +41,8 @@ public class RoleServiceTest {
   @BeforeMethod
   public void setupTest() throws Exception {
     roleUrn = Urn.createFromString(ROLE_URN_STRING);
+    firstActorUrn = Urn.createFromString(FIRST_ACTOR_URN_STRING);
+    secondActorUrn = Urn.createFromString(SECOND_ACTOR_URN_STRING);
     _entityClient = mock(EntityClient.class);
     when(_entityClient.exists(any(), eq(roleUrn))).thenReturn(true);
 
@@ -43,52 +51,114 @@ public class RoleServiceTest {
 
   @Test
   public void testBatchAssignRoleNoActorExists() throws Exception {
-    when(_entityClient.exists(
-            any(OperationContext.class), eq(Urn.createFromString(FIRST_ACTOR_URN_STRING))))
-        .thenReturn(false);
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of());
 
     _roleService.batchAssignRoleToActors(
         opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING), roleUrn);
+
+    // Nothing was assignable, so no ingest should have been attempted at all.
+    verify(_entityClient, never()).batchIngestProposals(any(), anyCollection(), anyBoolean());
     verify(_entityClient, never()).ingestProposal(any(OperationContext.class), any(), eq(false));
   }
 
   @Test
   public void testBatchAssignRoleSomeActorExists() throws Exception {
-    when(_entityClient.exists(
-            any(OperationContext.class), eq(Urn.createFromString(FIRST_ACTOR_URN_STRING))))
-        .thenReturn(true);
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of(firstActorUrn));
 
     _roleService.batchAssignRoleToActors(
         opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING, SECOND_ACTOR_URN_STRING), roleUrn);
-    ArgumentCaptor<MetadataChangeProposal> proposalCaptor =
-        ArgumentCaptor.forClass(MetadataChangeProposal.class);
-    verify(_entityClient, times(1))
-        .ingestProposal(any(OperationContext.class), proposalCaptor.capture(), eq(false));
-    assertEquals(
-        UI_SOURCE, proposalCaptor.getValue().getSystemMetadata().getProperties().get(APP_SOURCE));
+
+    // Only the existing actor is assigned, and the UI source marker is preserved.
+    final Collection<MetadataChangeProposal> proposals = captureBatch();
+    assertEquals(1, proposals.size());
+    final MetadataChangeProposal proposal = proposals.iterator().next();
+    assertEquals(firstActorUrn, proposal.getEntityUrn());
+    assertEquals(UI_SOURCE, proposal.getSystemMetadata().getProperties().get(APP_SOURCE));
   }
 
   @Test
   public void testBatchAssignRoleAllActorsExist() throws Exception {
-    when(_entityClient.exists(
-            any(OperationContext.class), eq(Urn.createFromString(FIRST_ACTOR_URN_STRING))))
-        .thenReturn(true);
-    when(_entityClient.exists(
-            any(OperationContext.class), eq(Urn.createFromString(SECOND_ACTOR_URN_STRING))))
-        .thenReturn(true);
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of(firstActorUrn, secondActorUrn));
 
     _roleService.batchAssignRoleToActors(
         opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING, SECOND_ACTOR_URN_STRING), roleUrn);
-    verify(_entityClient, times(2)).ingestProposal(any(OperationContext.class), any(), eq(false));
+
+    // Both actors go out in a single request, and existence is resolved in a single query.
+    assertEquals(2, captureBatch().size());
+    verify(_entityClient, times(1))
+        .filterExistingUrns(any(OperationContext.class), anyCollection());
+    verify(_entityClient, never()).ingestProposal(any(OperationContext.class), any(), eq(false));
   }
 
   @Test
   public void testAssignNullRoleToActorAllActorsExist() throws Exception {
-    when(_entityClient.exists(
-            any(OperationContext.class), eq(Urn.createFromString(FIRST_ACTOR_URN_STRING))))
-        .thenReturn(true);
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of(firstActorUrn));
 
     _roleService.batchAssignRoleToActors(opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING), null);
-    verify(_entityClient, times(1)).ingestProposal(any(OperationContext.class), any(), eq(false));
+
+    final Collection<MetadataChangeProposal> proposals = captureBatch();
+    assertEquals(1, proposals.size());
+    // A null role clears membership rather than assigning one.
+    assertTrue(
+        proposals
+            .iterator()
+            .next()
+            .getAspect()
+            .getValue()
+            .asString(StandardCharsets.UTF_8)
+            .contains("\"roles\":[]"));
+  }
+
+  @Test
+  public void testBatchAssignRoleFallsBackToIndividualIngestOnBatchFailure() throws Exception {
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of(firstActorUrn, secondActorUrn));
+    when(_entityClient.batchIngestProposals(any(), anyCollection(), eq(false)))
+        .thenThrow(new RuntimeException("batch failed"));
+    // The first actor is retried successfully, the second keeps failing and is skipped.
+    when(_entityClient.ingestProposal(any(OperationContext.class), any(), eq(false)))
+        .thenReturn(FIRST_ACTOR_URN_STRING)
+        .thenThrow(new RuntimeException("individual failure"));
+
+    _roleService.batchAssignRoleToActors(
+        opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING, SECOND_ACTOR_URN_STRING), roleUrn);
+
+    // A failed batch must not abandon the assignments, and one bad actor must not stop the other.
+    verify(_entityClient, times(2)).ingestProposal(any(OperationContext.class), any(), eq(false));
+  }
+
+  @Test
+  public void testBatchAssignRoleSkipsMalformedActorUrn() throws Exception {
+    when(_entityClient.filterExistingUrns(any(OperationContext.class), anyCollection()))
+        .thenReturn(ImmutableSet.of(firstActorUrn));
+
+    _roleService.batchAssignRoleToActors(
+        opContext, ImmutableList.of(FIRST_ACTOR_URN_STRING, "not a urn"), roleUrn);
+
+    // The malformed entry is dropped before the existence query rather than failing the request.
+    final Collection<MetadataChangeProposal> proposals = captureBatch();
+    assertEquals(1, proposals.size());
+    assertEquals(firstActorUrn, proposals.iterator().next().getEntityUrn());
+  }
+
+  @Test
+  public void testBatchAssignRoleNoActorsMakesNoCalls() throws Exception {
+    _roleService.batchAssignRoleToActors(opContext, ImmutableList.of(), roleUrn);
+
+    verify(_entityClient, never()).filterExistingUrns(any(OperationContext.class), anyCollection());
+    verify(_entityClient, never()).batchIngestProposals(any(), anyCollection(), anyBoolean());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Collection<MetadataChangeProposal> captureBatch() throws Exception {
+    final ArgumentCaptor<Collection<MetadataChangeProposal>> captor =
+        ArgumentCaptor.forClass(Collection.class);
+    verify(_entityClient, times(1))
+        .batchIngestProposals(any(OperationContext.class), captor.capture(), eq(false));
+    return captor.getValue();
   }
 }


### PR DESCRIPTION
`RoleService.batchAssignRoleToActors` looped over actors calling `assignRoleToActor`, which did one `exists()` query and one `ingestProposal` per actor. Each `ingestProposal` wraps its single proposal in a `List` and delegates to `batchIngestProposals`, so every actor also got its own `AspectsBatch` and its own `ingestAspectsToLocalDB` transaction.

Assigning a role to N users cost **2N + 1** round trips. It is now **3**, flat in N:

| | before | after |
| --- | --- | --- |
| role existence check | 1 | 1 |
| actor existence checks | **N** | **1** (`filterExistingUrns`) |
| ingest transactions | **N** | **1** (`batchIngestProposals`) |

`EntityClient` already exposed `filterExistingUrns(opContext, Collection<Urn>)`, batched in both implementations (`JavaEntityClient` delegates to `entityService.exists(urns, true)`; `RestliEntityClient` sends a single action request), so no client API change was needed.

## The existence check is batched, not removed

This is the part worth reviewing closely. A sibling change to `BatchGetStepStatesResolver` (#18713) deletes a per-id `exists` probe outright because it was redundant there. Here it is **load bearing** and had to be kept: ingesting a `RoleMembership` aspect for an actor that does not exist would materialize that entity through its default key aspect, so a typo in the assign dialog would invent a user.

To confirm the substitution is behaviour-preserving rather than assuming it: `EntityClient.exists(opContext, urn)` resolves to `entityService.exists(opContext, urn, true)` and `filterExistingUrns(opContext, urns)` resolves to `entityService.exists(opContext, urns, true)` — both land on `exists(urns, null, includeSoftDelete=true, forUpdate=false)`. Identical predicate, including soft-delete handling.

## Behaviour preserved

- Malformed actor urns are still skipped with a warning. They are now filtered out before the existence query, so a bad entry cannot poison the batch.
- Actors that do not exist are still skipped with a warning.
- A null role still clears membership rather than assigning one.
- Proposals still carry the UI source system metadata that `buildSynchronousMetadataChangeProposal` stamps. Despite its name that helper only sets system metadata; the synchronous behaviour comes from `async=false` on the ingest call, which is unchanged.
- The old code caught failures per actor specifically so one bad actor could not block the others. A failed batch is therefore retried actor by actor, preserving that. Re-ingesting is safe because these are idempotent upserts.

`AcceptRoleResolver` (the other production caller) passes a single-element list; the signature is unchanged and it is unaffected.

## Testing

`./gradlew :metadata-service:auth-impl:test` — 373 passing.
`./gradlew :datahub-graphql-core:test` — 1825 passing (covers `BatchAssignRoleResolverTest` and `AcceptRoleResolverTest`, both of which mock `RoleService`).

The four existing `RoleServiceTest` cases stubbed the per-actor `exists` call that no longer happens, so they are rewritten against `filterExistingUrns` plus a captor on the batch. Three cases were added: the batch-failure fallback to individual ingest, a malformed actor urn, and an empty actor list making no client calls at all.

## Measurements

Measured locally against a running GMS with OpenTelemetry export enabled, 15 actors per request, 10 repetitions per scenario. Span counts come from Jaeger traces correlated by a caller-supplied `traceparent`; statement counts from the MySQL general log filtered to the seeded bench actors. Both builds differ only in `RoleService`; each was measured on a freshly restarted, warmed GMS.

| Scenario | Metric | Before | After | |
| --- | --- | --- | --- | --- |
| assign to 15 existing actors | latency median | 155.1 ms | **72.9 ms** | 2.1x |
| | latency p95 | 212.2 ms | **92.1 ms** | 2.3x |
| | MySQL stmts/req | 90.0 | **20.0** | 4.5x |
| | — SELECTs | 75.0 | **5.0** | 15x |
| | DB commits | 30 | **2** | 15x |
| | retention passes | 15 | **1** | 15x |
| reassign same 15 actors | latency median | 69.2 ms | **37.1 ms** | 1.9x |
| | latency p95 | 190.5 ms | **74.2 ms** | 2.6x |
| | DB commits | 30 | **2** | 15x |
| 15 absent actors (no writes) | MySQL stmts/req | 15.0 | **1.0** | 15x |
| | SQL spans | 21 | **7** | 3.0x |
| clear role (null) | latency median | 72.4 ms | **36.2 ms** | 2.0x |
| | DB commits | 30 | **2** | 15x |

The clearest single indicator is **urns per SQL statement**: the existence check went from at most 1 urn per statement to all 15 in one, and 30 commits (two per actor) collapsed to 2.

Structural counters were byte-identical across a repeat run while latency varied by ~8 ms, so the gaps are well outside noise. One ES search appeared in a single scenario across 10 requests (0.1/req) — background traffic, not caused by this path; neither build performs any search here.

## Functional verification

14 assertions run against both builds through the GraphQL API, **all identical**: role assigned to every existing actor, reassignment overwriting, null role clearing membership, malformed urn skipped without failing the request, mixed existing/absent assigning only the real actors, empty actor list, and a nonexistent role still rejected.

Three of those specifically pin the reason the existence check was kept rather than dropped — assigning a role to actors that do not exist leaves them **still absent**, with **no role membership aspect**, on both builds. That is the phantom-user regression this change had to avoid, and it is verified rather than argued.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Links to related issues — n/a. Related PR: #18713 (same batching pattern, different module)
- [ ] Docs — n/a, no user-facing surface or schema change
- [ ] Updating DataHub entry — n/a, no breaking change; observable behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
