### PR TITLE
feat(ingest): add output_port flag to DataProductPatchBuilder.add_asset

### DIFF
--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/DataProductPropertiesTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/DataProductPropertiesTemplateTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.metadata.aspect.patch.template;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.dataproduct.DataProductAssociation;
+import com.linkedin.dataproduct.DataProductAssociationArray;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.metadata.aspect.patch.template.dataproduct.DataProductPropertiesTemplate;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DataProductPropertiesTemplateTest {
+
+  private static final DataProductPropertiesTemplate TEMPLATE = new DataProductPropertiesTemplate();
+  private static final String DATASET_A =
+      "urn:li:dataset:(urn:li:dataPlatform:postgres,appdb.public.orders,PROD)";
+  private static final String DATASET_B =
+      "urn:li:dataset:(urn:li:dataPlatform:postgres,appdb.public.order_events,PROD)";
+
+  /** The patch DataProductPatchBuilder.add_asset(urn, output_port=True) emits. */
+  private static JsonPatch addOutputPort(String assetUrn) {
+    return Json.createPatch(
+        Json.createArrayBuilder()
+            .add(
+                Json.createObjectBuilder()
+                    .add("op", "add")
+                    .add("path", "/assets/" + assetUrn)
+                    .add(
+                        "value",
+                        Json.createObjectBuilder()
+                            .add("destinationUrn", assetUrn)
+                            .add("outputPort", true)))
+            .build());
+  }
+
+  private static DataProductAssociation assetOf(DataProductProperties props, String assetUrn) {
+    Assert.assertNotNull(props.getAssets());
+    return props.getAssets().stream()
+        .filter(asset -> assetUrn.equals(asset.getDestinationUrn().toString()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("asset not found: " + assetUrn));
+  }
+
+  @Test
+  public void testAddAssetAsOutputPort() throws Exception {
+    DataProductProperties initial = TEMPLATE.getDefault();
+
+    DataProductProperties result = TEMPLATE.applyPatch(initial, addOutputPort(DATASET_A));
+
+    Assert.assertTrue(assetOf(result, DATASET_A).isOutputPort());
+  }
+
+  @Test
+  public void testOutputPortPatchPromotesExistingAssetAndLeavesOthersAlone() throws Exception {
+    // A product curated in DataHub: one plain asset, one that a contract also covers.
+    DataProductProperties initial = new DataProductProperties();
+    initial.setAssets(
+        new DataProductAssociationArray(
+            new DataProductAssociation().setDestinationUrn(UrnUtils.getUrn(DATASET_A)),
+            new DataProductAssociation().setDestinationUrn(UrnUtils.getUrn(DATASET_B))));
+
+    DataProductProperties result = TEMPLATE.applyPatch(initial, addOutputPort(DATASET_A));
+
+    Assert.assertEquals(result.getAssets().size(), 2);
+    Assert.assertTrue(assetOf(result, DATASET_A).isOutputPort(), "patched asset is an output port");
+    Assert.assertFalse(assetOf(result, DATASET_B).isOutputPort(), "other asset is untouched");
+  }
+}

--- a/metadata-ingestion/src/datahub/specific/dataproduct.py
+++ b/metadata-ingestion/src/datahub/specific/dataproduct.py
@@ -75,12 +75,16 @@ class DataProductPatchBuilder(
         )
         return self
 
-    def add_asset(self, asset_urn: str) -> "DataProductPatchBuilder":
+    def add_asset(
+        self, asset_urn: str, output_port: bool = False
+    ) -> "DataProductPatchBuilder":
         self._add_patch(
             DataProductProperties.ASPECT_NAME,
             "add",
             path=("assets", asset_urn),
-            value=DataProductAssociation(destinationUrn=asset_urn),
+            value=DataProductAssociation(
+                destinationUrn=asset_urn, outputPort=output_port
+            ),
         )
         return self
 


### PR DESCRIPTION
## Summary

`DataProductAssociation` carries an `outputPort` boolean — surfaced in the UI as a data product's **Output Ports** and by the lineage "output ports only" filter — but `DataProductPatchBuilder.add_asset` had no way to set it. Only the declarative `DataProduct` YAML / SDK path could mark an asset as an output port; anything building the patch programmatically was stuck writing `outputPort: false`.

This adds an `output_port` keyword to `add_asset` (default `False`, so every existing caller is unchanged) that writes the flag into the additive `assets` patch.

```python
DataProductPatchBuilder(product_urn).add_asset(dataset_urn, output_port=True)
```

## Why

Split out of the ODCS output-ports work (#18631) as a standalone, connector-agnostic change to a shared patch builder used by the Snowflake Marketplace source, transformers, and the SDK.

## Testing

Adds `DataProductPropertiesTemplateTest` covering the GMS-side patch template:
- an asset added with `outputPort: true` round-trips through the array-merge template
- promoting one existing asset to an output port leaves the `outputPort` state of the product's other assets untouched

`./gradlew :entity-registry:test` passes; `add_asset` callers already exercised by the ingestion suite are unaffected.