### PR TITLE
fix(structuredProperty): skip wrong urn values while mapping string values

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapper.java
@@ -88,7 +88,20 @@ public class StructuredPropertiesMapper {
       List<Entity> entities) {
     try {
       final Urn urnValue = Urn.createFromString(stringValue);
-      entities.add(UrnToEntityMapper.map(context, urnValue));
+      // UrnToEntityMapper returns null for entity types it does not know how to map. A string value
+      // that merely parses as a URN (e.g. free text on a non-urn property, or a URN of an unmapped
+      // entity type) must not contribute a null entity, otherwise downstream resolution of
+      // valueEntities NPEs on the null element.
+      final Entity mappedEntity = UrnToEntityMapper.map(context, urnValue);
+      if (mappedEntity != null) {
+        entities.add(mappedEntity);
+      } else {
+        log.warn(
+            "Skipping value entity for structured property value '{}': entity type '{}' is not"
+                + " mapped by UrnToEntityMapper",
+            stringValue,
+            urnValue.getEntityType());
+      }
     } catch (Exception e) {
       log.debug("String value is not an urn for this structured property entry");
     }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapperTest.java
@@ -1,0 +1,62 @@
+package com.linkedin.datahub.graphql.types.structuredproperty;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PrimitivePropertyValueArray;
+import com.linkedin.structured.StructuredProperties;
+import com.linkedin.structured.StructuredPropertyValueAssignment;
+import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
+import org.testng.annotations.Test;
+
+public class StructuredPropertiesMapperTest {
+
+  private static final Urn PROPERTY_URN = UrnUtils.getUrn("urn:li:structuredProperty:test");
+  private static final Urn ENTITY_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
+
+  private static StructuredProperties propertiesWithValue(String value) {
+    StructuredPropertyValueAssignment assignment = new StructuredPropertyValueAssignment();
+    assignment.setPropertyUrn(PROPERTY_URN);
+    assignment.setValues(new PrimitivePropertyValueArray(PrimitivePropertyValue.create(value)));
+    StructuredProperties properties = new StructuredProperties();
+    properties.setProperties(new StructuredPropertyValueAssignmentArray(assignment));
+    return properties;
+  }
+
+  @Test
+  public void testMappedUrnValueProducesValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(
+            null, propertiesWithValue("urn:li:domain:marketing"), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 1);
+    assertEquals(
+        mapped.getProperties().get(0).getValueEntities().get(0).getType(), EntityType.DOMAIN);
+  }
+
+  // A value that parses as a URN of an entity type UrnToEntityMapper cannot map (here a valid but
+  // unmapped entity type, e.g. free text on a non-urn property) must not add a null value entity —
+  // otherwise valueEntities resolution NPEs on the null element.
+  @Test
+  public void testUnmappedUrnValueDoesNotProduceValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(
+            null, propertiesWithValue("urn:li:dataHubUpgrade:foo"), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 0);
+    assertEquals(mapped.getProperties().get(0).getValues().size(), 1);
+  }
+
+  @Test
+  public void testNonUrnStringValueProducesNoValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(null, propertiesWithValue("just some text"), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 0);
+    assertEquals(mapped.getProperties().get(0).getValues().size(), 1);
+  }
+}


### PR DESCRIPTION
UrnToEntityMapper returns null for entity types it does not know how to map, so a string value that merely parses as a URN (free text on a non-urn property, or a URN of an unmapped entity type) added a null element to valueEntities and made downstream resolution NPE. Skip those values and log a warning instead.

Backport of SaaS-fix - https://github.com/acryldata/datahub-fork/pull/10990
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
