### PR TITLE
fix(documents): reveal and focus open document in sidebar on deep link

### DIFF
--- a/datahub-web-react/src/app/document/hooks/useLoadDocumentTree.ts
+++ b/datahub-web-react/src/app/document/hooks/useLoadDocumentTree.ts
@@ -197,9 +197,9 @@ export function useLoadDocumentTree() {
 
     // Load more children for a parent (subsequent pages)
     const loadMoreChildren = useCallback(
-        async (parentUrn: string) => {
+        async (parentUrn: string): Promise<DocumentTreeNode[]> => {
             const state = childPaginationRef.current.get(parentUrn);
-            if (!state || state.offset >= state.total) return;
+            if (!state || state.offset >= state.total) return [];
 
             try {
                 const result = await searchDocumentsQuery({
@@ -228,8 +228,10 @@ export function useLoadDocumentTree() {
                     total: state.total,
                 });
                 setChildPaginationVersion((v) => v + 1);
+                return nodes;
             } catch (error) {
                 console.error('Failed to load more children:', error);
+                return [];
             }
         },
         [searchDocumentsQuery, checkForChildren, appendNodeChildren, viewUrn],

--- a/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
+++ b/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
@@ -6,7 +6,7 @@ interface NodeLoaders {
     /** Loads (and returns) the first page of a node's children. */
     loadChildren: (parentUrn: string | null) => Promise<DocumentTreeNode[]>;
     /** Loads the next page of an already-expanded node's children. */
-    loadMoreChildren: (parentUrn: string) => Promise<void>;
+    loadMoreChildren: (parentUrn: string) => Promise<DocumentTreeNode[] | void>;
 }
 
 interface NodeChildrenLoading {

--- a/datahub-web-react/src/app/document/hooks/useRevealDocumentInTree.ts
+++ b/datahub-web-react/src/app/document/hooks/useRevealDocumentInTree.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
+
+import { DocumentTreeNode, useDocumentTree } from '@app/document/DocumentTreeContext';
+import { useDocumentNavigation } from '@app/document/hooks/useDocumentNavigation';
+import { revealDocumentInTree } from '@app/document/utils/documentTreeReveal';
+
+import { useGetDocumentQuery } from '@graphql/document.generated';
+
+interface RevealLoaders {
+    loadChildren: (parentUrn: string) => Promise<DocumentTreeNode[]>;
+    loadMoreChildren: (parentUrn: string) => Promise<DocumentTreeNode[]>;
+    hasMoreChildren: (parentUrn: string) => boolean;
+    /** True while the first page of roots is still loading — reveal waits for this. */
+    rootsLoading: boolean;
+}
+
+/**
+ * When the open document changes via URL (deep link / in-app navigation), expand and
+ * load its ancestor path in the sidebar tree so the selected row can mount and scroll
+ * into view. No-op while roots are still initializing or when there is no document URN.
+ */
+export function useRevealDocumentInTree({
+    loadChildren,
+    loadMoreChildren,
+    hasMoreChildren,
+    rootsLoading,
+}: RevealLoaders): void {
+    const { getCurrentDocumentUrn } = useDocumentNavigation();
+    const documentUrn = getCurrentDocumentUrn();
+    const { getNode, expandNode, addNode } = useDocumentTree();
+
+    const getNodeRef = useRef(getNode);
+    getNodeRef.current = getNode;
+    const expandNodeRef = useRef(expandNode);
+    expandNodeRef.current = expandNode;
+    const addNodeRef = useRef(addNode);
+    addNodeRef.current = addNode;
+    const loadChildrenRef = useRef(loadChildren);
+    loadChildrenRef.current = loadChildren;
+    const loadMoreChildrenRef = useRef(loadMoreChildren);
+    loadMoreChildrenRef.current = loadMoreChildren;
+    const hasMoreChildrenRef = useRef(hasMoreChildren);
+    hasMoreChildrenRef.current = hasMoreChildren;
+
+    // Prefer the profile's cached getDocument (same query + includeParentDocuments).
+    const { data, loading: documentLoading } = useGetDocumentQuery({
+        variables: { urn: documentUrn || '', includeParentDocuments: true },
+        skip: !documentUrn || rootsLoading,
+        fetchPolicy: 'cache-first',
+    });
+
+    useEffect(() => {
+        if (!documentUrn || rootsLoading || documentLoading || !data?.document) {
+            return undefined;
+        }
+
+        // Only reveal when this response is for the currently open document.
+        if (data.document.urn !== documentUrn) {
+            return undefined;
+        }
+
+        let cancelled = false;
+
+        const run = async () => {
+            const parents = (data.document?.parentDocuments?.documents || []).map((parent) => ({
+                urn: parent.urn,
+                title: parent.info?.title,
+            }));
+
+            try {
+                await revealDocumentInTree({
+                    documentUrn,
+                    documentTitle: data.document?.info?.title,
+                    parentDocuments: parents,
+                    getNode: (urn) => getNodeRef.current(urn),
+                    expandNode: (urn) => expandNodeRef.current(urn),
+                    ensureNode: (node) => {
+                        if (!getNodeRef.current(node.urn)) {
+                            flushSync(() => {
+                                addNodeRef.current(node);
+                            });
+                        }
+                    },
+                    loadChildren: (parentUrn) => loadChildrenRef.current(parentUrn),
+                    loadMoreChildren: (parentUrn) => loadMoreChildrenRef.current(parentUrn),
+                    hasMoreChildren: (parentUrn) => hasMoreChildrenRef.current(parentUrn),
+                });
+            } catch (error) {
+                if (!cancelled) {
+                    console.error('Failed to reveal document in sidebar tree:', error);
+                }
+            }
+        };
+
+        run();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [documentUrn, rootsLoading, documentLoading, data]);
+}

--- a/datahub-web-react/src/app/document/hooks/useRevealDocumentInTree.ts
+++ b/datahub-web-react/src/app/document/hooks/useRevealDocumentInTree.ts
@@ -13,6 +13,8 @@ interface RevealLoaders {
     hasMoreChildren: (parentUrn: string) => boolean;
     /** True while the first page of roots is still loading — reveal waits for this. */
     rootsLoading: boolean;
+    /** When true, skip reveal entirely (e.g. picker / multi-select mode). */
+    skip?: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ export function useRevealDocumentInTree({
     loadMoreChildren,
     hasMoreChildren,
     rootsLoading,
+    skip = false,
 }: RevealLoaders): void {
     const { getCurrentDocumentUrn } = useDocumentNavigation();
     const documentUrn = getCurrentDocumentUrn();
@@ -46,12 +49,12 @@ export function useRevealDocumentInTree({
     // Prefer the profile's cached getDocument (same query + includeParentDocuments).
     const { data, loading: documentLoading } = useGetDocumentQuery({
         variables: { urn: documentUrn || '', includeParentDocuments: true },
-        skip: !documentUrn || rootsLoading,
+        skip: skip || !documentUrn || rootsLoading,
         fetchPolicy: 'cache-first',
     });
 
     useEffect(() => {
-        if (!documentUrn || rootsLoading || documentLoading || !data?.document) {
+        if (skip || !documentUrn || rootsLoading || documentLoading || !data?.document) {
             return undefined;
         }
 
@@ -98,5 +101,5 @@ export function useRevealDocumentInTree({
         return () => {
             cancelled = true;
         };
-    }, [documentUrn, rootsLoading, documentLoading, data]);
+    }, [skip, documentUrn, rootsLoading, documentLoading, data]);
 }

--- a/datahub-web-react/src/app/document/utils/__tests__/documentTreeReveal.test.ts
+++ b/datahub-web-react/src/app/document/utils/__tests__/documentTreeReveal.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+import { revealDocumentInTree } from '@app/document/utils/documentTreeReveal';
+
+function makeNode(overrides: Partial<DocumentTreeNode> = {}): DocumentTreeNode {
+    return { urn: 'urn:li:document:test', title: 'Test', parentUrn: null, hasChildren: false, ...overrides };
+}
+
+describe('revealDocumentInTree', () => {
+    it('ensures a root document is present without loading children', async () => {
+        const nodes = new Map<string, DocumentTreeNode>();
+        const ensureNode = vi.fn((node: DocumentTreeNode) => {
+            nodes.set(node.urn, node);
+        });
+        const expandNode = vi.fn();
+        const loadChildren = vi.fn().mockResolvedValue([]);
+        const loadMoreChildren = vi.fn().mockResolvedValue([]);
+
+        await revealDocumentInTree({
+            documentUrn: 'urn:li:document:root',
+            documentTitle: 'Root Doc',
+            parentDocuments: [],
+            getNode: (urn) => nodes.get(urn),
+            expandNode,
+            ensureNode,
+            loadChildren,
+            loadMoreChildren,
+            hasMoreChildren: () => false,
+        });
+
+        expect(ensureNode).toHaveBeenCalledWith(
+            expect.objectContaining({ urn: 'urn:li:document:root', parentUrn: null, title: 'Root Doc' }),
+        );
+        expect(expandNode).not.toHaveBeenCalled();
+        expect(loadChildren).not.toHaveBeenCalled();
+    });
+
+    it('expands ancestors root-first and loads children along the path', async () => {
+        const nodes = new Map<string, DocumentTreeNode>();
+        const expanded = new Set<string>();
+        const childPages = new Map<string, DocumentTreeNode[][]>([
+            [
+                'urn:li:document:a',
+                [[makeNode({ urn: 'urn:li:document:b', title: 'B', parentUrn: 'urn:li:document:a' })]],
+            ],
+            [
+                'urn:li:document:b',
+                [[makeNode({ urn: 'urn:li:document:c', title: 'C', parentUrn: 'urn:li:document:b' })]],
+            ],
+        ]);
+
+        const ensureNode = vi.fn((node: DocumentTreeNode) => {
+            nodes.set(node.urn, node);
+        });
+        const expandNode = vi.fn((urn: string) => {
+            expanded.add(urn);
+        });
+        const loadChildren = vi.fn(async (parentUrn: string) => {
+            const pages = childPages.get(parentUrn) || [[]];
+            const first = pages[0] || [];
+            first.forEach((n) => nodes.set(n.urn, n));
+            return first;
+        });
+        const loadMoreChildren = vi.fn().mockResolvedValue([]);
+
+        await revealDocumentInTree({
+            documentUrn: 'urn:li:document:c',
+            documentTitle: 'C',
+            // API order: direct parent first
+            parentDocuments: [
+                { urn: 'urn:li:document:b', title: 'B' },
+                { urn: 'urn:li:document:a', title: 'A' },
+            ],
+            getNode: (urn) => nodes.get(urn),
+            expandNode,
+            ensureNode,
+            loadChildren,
+            loadMoreChildren,
+            hasMoreChildren: () => false,
+        });
+
+        expect(expandNode.mock.calls.map((c) => c[0])).toEqual(['urn:li:document:a', 'urn:li:document:b']);
+        expect(loadChildren.mock.calls.map((c) => c[0])).toEqual(['urn:li:document:a', 'urn:li:document:b']);
+        expect(nodes.get('urn:li:document:c')?.parentUrn).toBe('urn:li:document:b');
+    });
+
+    it('pages through children until the next path node appears', async () => {
+        const nodes = new Map<string, DocumentTreeNode>();
+        const ensureNode = vi.fn((node: DocumentTreeNode) => {
+            nodes.set(node.urn, node);
+        });
+        const expandNode = vi.fn();
+        const page1 = [makeNode({ urn: 'urn:li:document:other', parentUrn: 'urn:li:document:a' })];
+        const page2 = [makeNode({ urn: 'urn:li:document:target', title: 'Target', parentUrn: 'urn:li:document:a' })];
+        let page = 0;
+
+        const loadChildren = vi.fn(async () => {
+            page = 1;
+            page1.forEach((n) => nodes.set(n.urn, n));
+            return page1;
+        });
+        const loadMoreChildren = vi.fn(async () => {
+            page = 2;
+            page2.forEach((n) => nodes.set(n.urn, n));
+            return page2;
+        });
+
+        await revealDocumentInTree({
+            documentUrn: 'urn:li:document:target',
+            documentTitle: 'Target',
+            parentDocuments: [{ urn: 'urn:li:document:a', title: 'A' }],
+            getNode: (urn) => nodes.get(urn),
+            expandNode,
+            ensureNode,
+            loadChildren,
+            loadMoreChildren,
+            hasMoreChildren: () => page < 2,
+        });
+
+        expect(loadChildren).toHaveBeenCalledTimes(1);
+        expect(loadMoreChildren).toHaveBeenCalledTimes(1);
+        expect(nodes.has('urn:li:document:target')).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/document/utils/__tests__/documentTreeReveal.test.ts
+++ b/datahub-web-react/src/app/document/utils/__tests__/documentTreeReveal.test.ts
@@ -122,4 +122,51 @@ describe('revealDocumentInTree', () => {
         expect(loadMoreChildren).toHaveBeenCalledTimes(1);
         expect(nodes.has('urn:li:document:target')).toBe(true);
     });
+
+    it('pages through multiple child pages when the target is far down the list', async () => {
+        const nodes = new Map<string, DocumentTreeNode>();
+        const ensureNode = vi.fn((node: DocumentTreeNode) => {
+            nodes.set(node.urn, node);
+        });
+        const expandNode = vi.fn();
+        // Simulate ~50 siblings (page size 25): target lands on page 3.
+        const pages = [
+            Array.from({ length: 25 }, (_, i) =>
+                makeNode({ urn: `urn:li:document:p1-${i}`, parentUrn: 'urn:li:document:a' }),
+            ),
+            Array.from({ length: 25 }, (_, i) =>
+                makeNode({ urn: `urn:li:document:p2-${i}`, parentUrn: 'urn:li:document:a' }),
+            ),
+            [makeNode({ urn: 'urn:li:document:target', title: 'Target', parentUrn: 'urn:li:document:a' })],
+        ];
+        let loadedPages = 0;
+
+        const loadChildren = vi.fn(async () => {
+            loadedPages = 1;
+            pages[0].forEach((n) => nodes.set(n.urn, n));
+            return pages[0];
+        });
+        const loadMoreChildren = vi.fn(async () => {
+            const next = pages[loadedPages];
+            loadedPages += 1;
+            next.forEach((n) => nodes.set(n.urn, n));
+            return next;
+        });
+
+        await revealDocumentInTree({
+            documentUrn: 'urn:li:document:target',
+            documentTitle: 'Target',
+            parentDocuments: [{ urn: 'urn:li:document:a', title: 'A' }],
+            getNode: (urn) => nodes.get(urn),
+            expandNode,
+            ensureNode,
+            loadChildren,
+            loadMoreChildren,
+            hasMoreChildren: () => loadedPages < pages.length,
+        });
+
+        expect(loadChildren).toHaveBeenCalledTimes(1);
+        expect(loadMoreChildren).toHaveBeenCalledTimes(2);
+        expect(nodes.has('urn:li:document:target')).toBe(true);
+    });
 });

--- a/datahub-web-react/src/app/document/utils/documentTreeReveal.ts
+++ b/datahub-web-react/src/app/document/utils/documentTreeReveal.ts
@@ -1,0 +1,101 @@
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+
+/**
+ * Minimal parent-document shape from `getDocument` / search (`parentDocuments.documents`).
+ * API order is direct-parent first; callers reverse to walk root → leaf.
+ */
+export interface DocumentParentRef {
+    urn: string;
+    title?: string | null;
+}
+
+export interface RevealDocumentInTreeArgs {
+    documentUrn: string;
+    documentTitle?: string | null;
+    /** Parent chain in API order: [direct parent, grandparent, ...]. */
+    parentDocuments: DocumentParentRef[];
+    getNode: (urn: string) => DocumentTreeNode | undefined;
+    expandNode: (urn: string) => void;
+    /** Synchronously commit the node into tree state before subsequent loads. */
+    ensureNode: (node: DocumentTreeNode) => void;
+    loadChildren: (parentUrn: string) => Promise<DocumentTreeNode[]>;
+    loadMoreChildren: (parentUrn: string) => Promise<DocumentTreeNode[]>;
+    hasMoreChildren: (parentUrn: string) => boolean;
+}
+
+function untitledTitle(title?: string | null): string {
+    return title?.trim() ? title : 'Untitled';
+}
+
+/**
+ * Expand and lazy-load every ancestor so `documentUrn` is mounted in the sidebar tree.
+ *
+ * Deep links only open the profile; nested rows are not fetched until parents expand.
+ * This walks the parent chain root-first, expands each folder, loads children (paging
+ * until the next path node appears), and injects stubs when a node is missing from
+ * the currently loaded window (e.g. root beyond the first page).
+ */
+export async function revealDocumentInTree({
+    documentUrn,
+    documentTitle,
+    parentDocuments,
+    getNode,
+    expandNode,
+    ensureNode,
+    loadChildren,
+    loadMoreChildren,
+    hasMoreChildren,
+}: RevealDocumentInTreeArgs): Promise<void> {
+    const ancestors = [...parentDocuments].reverse();
+
+    if (ancestors.length === 0) {
+        ensureNode({
+            urn: documentUrn,
+            title: untitledTitle(documentTitle),
+            parentUrn: null,
+            hasChildren: getNode(documentUrn)?.hasChildren ?? false,
+        });
+        return;
+    }
+
+    for (let i = 0; i < ancestors.length; i++) {
+        const ancestor = ancestors[i];
+        const parentUrn = i === 0 ? null : ancestors[i - 1].urn;
+        const nextUrn = i < ancestors.length - 1 ? ancestors[i + 1].urn : documentUrn;
+
+        ensureNode({
+            urn: ancestor.urn,
+            title: untitledTitle(ancestor.title),
+            parentUrn,
+            hasChildren: true,
+        });
+
+        expandNode(ancestor.urn);
+
+        // eslint-disable-next-line no-await-in-loop
+        let children = await loadChildren(ancestor.urn);
+
+        while (!children.some((child) => child.urn === nextUrn) && hasMoreChildren(ancestor.urn)) {
+            // eslint-disable-next-line no-await-in-loop
+            const more = await loadMoreChildren(ancestor.urn);
+            children = children.concat(more);
+        }
+
+        if (!getNode(nextUrn) && nextUrn !== documentUrn) {
+            ensureNode({
+                urn: nextUrn,
+                title: untitledTitle(ancestors[i + 1]?.title),
+                parentUrn: ancestor.urn,
+                hasChildren: true,
+            });
+        }
+    }
+
+    const directParentUrn = ancestors[ancestors.length - 1].urn;
+    ensureNode({
+        urn: documentUrn,
+        title: untitledTitle(documentTitle),
+        parentUrn: directParentUrn,
+        hasChildren: getNode(documentUrn)?.hasChildren ?? false,
+    });
+}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -6,6 +6,7 @@ import { useDocumentTree } from '@app/document/DocumentTreeContext';
 import { useDocumentNavigation } from '@app/document/hooks/useDocumentNavigation';
 import { useLoadDocumentTree } from '@app/document/hooks/useLoadDocumentTree';
 import { useNodeChildrenLoading } from '@app/document/hooks/useNodeChildrenLoading';
+import { useRevealDocumentInTree } from '@app/document/hooks/useRevealDocumentInTree';
 import { useSectionExpansion } from '@app/document/hooks/useSectionExpansion';
 import {
     DocumentTreeFilterSelection,
@@ -91,6 +92,16 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
     });
     const { getCurrentDocumentUrn, handleDocumentClick } = useDocumentNavigation(onSelectDocument);
 
+    // Deep-link / URL navigation: expand + load the ancestor path so the selected
+    // row mounts. Skip in picker/selection mode (move dialog, etc.).
+    const isNavigationMode = !onSelectDocument && !multiSelect;
+    useRevealDocumentInTree({
+        loadChildren,
+        loadMoreChildren,
+        hasMoreChildren,
+        rootsLoading: loading || !isNavigationMode,
+    });
+
     // Section-scoped expand-all / collapse-all (per DataHub + per-platform group).
     const { isSectionExpanded, isSectionExpanding, toggleSectionExpandAll } = useSectionExpansion(loadChildren);
     const expandAllLabel = t('context.tree.expandAll');
@@ -123,6 +134,37 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
             return next;
         });
     }, []);
+
+    // Keep the section that owns the open document expanded (native vs platform).
+    useEffect(() => {
+        if (!isNavigationMode) return;
+        const currentUrn = getCurrentDocumentUrn();
+        if (!currentUrn) return;
+
+        let cursor: string | null = currentUrn;
+        let rootUrn = currentUrn;
+        while (cursor) {
+            const node = getNode(cursor);
+            if (!node) break;
+            rootUrn = node.urn;
+            cursor = node.parentUrn;
+        }
+
+        const rootNode = getNode(rootUrn);
+        if (!rootNode) return;
+
+        if (rootNode.isExternal && rootNode.platform?.urn) {
+            const platformUrn = rootNode.platform.urn;
+            setCollapsedPlatformUrns((prev) => {
+                if (!prev.has(platformUrn)) return prev;
+                const next = new Set(prev);
+                next.delete(platformUrn);
+                return next;
+            });
+        } else {
+            setIsNativeExpanded(true);
+        }
+    }, [isNavigationMode, getCurrentDocumentUrn, getNode, expandedUrns]);
 
     const renderTreeNode = useCallback(
         (urn: string, level: number): React.ReactNode => {

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
@@ -99,7 +99,8 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
         loadChildren,
         loadMoreChildren,
         hasMoreChildren,
-        rootsLoading: loading || !isNavigationMode,
+        rootsLoading: loading,
+        skip: !isNavigationMode,
     });
 
     // Section-scoped expand-all / collapse-all (per DataHub + per-platform group).

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
@@ -1,7 +1,7 @@
 import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled, { useTheme } from 'styled-components';
 
@@ -208,6 +208,14 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
     const theme = useTheme();
     const [isHovered, setIsHovered] = useState(false);
     const [forceShowActions, setForceShowActions] = useState(false);
+    const rowRef = useRef<HTMLDivElement>(null);
+
+    // Deep links / URL navigation mount the selected row after ancestors expand —
+    // bring it into the sidebar scrollport once it becomes selected.
+    useEffect(() => {
+        if (!isSelected || multiSelect) return;
+        rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, [isSelected, multiSelect, urn]);
 
     const handleExpandClick = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -289,6 +297,7 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
 
     return (
         <TreeItemContainer
+            ref={rowRef}
             className="tree-item-container"
             data-testid={`document-tree-item-${urn}`}
             $isSelected={isSelected}


### PR DESCRIPTION
When a document is opened via URL, expand and load its ancestor path in the sidebar tree and scroll the selected row into view.


https://github.com/user-attachments/assets/bbca77cd-d96b-44d1-8064-4655995debb0



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
