### PR TITLE
fix(security): bump lz4-java to 1.11.1 for CVE-2026-59949

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,8 @@ buildscript {
   ext.hadoopShadedGuavaVersion = '1.5.0'
   ext.kafkaVersion = '8.1.0'
   // at.yawk.lz4 fork (CVE-2025-12183); single version for externalDependency.lz4Java + resolutionStrategy
-  ext.lz4JavaVersion = '1.11.0'
+  // CVE-2026-59949: fixed in 1.11.1+
+  ext.lz4JavaVersion = '1.11.1'
   // Hazelcast shades Jackson 2.x/3.x inside hazelcast-*.jar (v5.7.0: jackson-databind 2.21.2, 3.1.2).
   // CVE-2026-54512/54513 require jackson-databind 2.21.4+ / 3.1.4+; ext.jacksonVersion does not replace
   // shaded copies — bump when Hazelcast publishes a fix (https://github.com/hazelcast/hazelcast/issues/26597).

--- a/datahub-frontend/gradle.lockfile
+++ b/datahub-frontend/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 cglib:cglib:3.3.0=testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/datahub-graphql-core/gradle.lockfile
+++ b/datahub-graphql-core/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/datahub-upgrade/gradle.lockfile
+++ b/datahub-upgrade/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/ingestion-scheduler/gradle.lockfile
+++ b/ingestion-scheduler/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-dao-impl/kafka-producer/gradle.lockfile
+++ b/metadata-dao-impl/kafka-producer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-integration/java/acryl-spark-lineage/gradle.lockfile
+++ b/metadata-integration/java/acryl-spark-lineage/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.clearspring.analytics:stream:2.9.6=compileClasspath,provided,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-integration/java/datahub-client/gradle.lockfile
+++ b/metadata-integration/java/datahub-client/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-integration/java/datahub-schematron/cli/gradle.lockfile
+++ b/metadata-integration/java/datahub-schematron/cli/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-io/gradle.lockfile
+++ b/metadata-io/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testFixturesCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testFixturesCompileClasspath,testRestClient

--- a/metadata-jobs/common/gradle.lockfile
+++ b/metadata-jobs/common/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-jobs/mae-consumer-job/gradle.lockfile
+++ b/metadata-jobs/mae-consumer-job/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-jobs/mae-consumer/gradle.lockfile
+++ b/metadata-jobs/mae-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-jobs/mce-consumer-job/gradle.lockfile
+++ b/metadata-jobs/mce-consumer-job/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/metadata-jobs/mce-consumer/gradle.lockfile
+++ b/metadata-jobs/mce-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-jobs/pe-consumer/gradle.lockfile
+++ b/metadata-jobs/pe-consumer/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataTemplate,dataTemplateCompile,pegasusPlugin,restClient,restClientCompile,runtimeClasspath,testCompileClasspath,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-service/auth-filter/gradle.lockfile
+++ b/metadata-service/auth-filter/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/auth-impl/gradle.lockfile
+++ b/metadata-service/auth-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/auth-servlet-impl/gradle.lockfile
+++ b/metadata-service/auth-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/events-service/gradle.lockfile
+++ b/metadata-service/events-service/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=runtimeClasspath,testRuntimeClasspath
 com.beust:jcommander:1.82=testCompileClasspath,testRuntimeClasspath

--- a/metadata-service/factories/gradle.lockfile
+++ b/metadata-service/factories/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/graphql-servlet-impl/gradle.lockfile
+++ b/metadata-service/graphql-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/iceberg-catalog/gradle.lockfile
+++ b/metadata-service/iceberg-catalog/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/openapi-analytics-servlet/gradle.lockfile
+++ b/metadata-service/openapi-analytics-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/openapi-entity-servlet/gradle.lockfile
+++ b/metadata-service/openapi-entity-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/openapi-servlet/gradle.lockfile
+++ b/metadata-service/openapi-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/restli-servlet-impl/gradle.lockfile
+++ b/metadata-service/restli-servlet-impl/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,dataModel,dataTemplate,dataTemplateCompile,integTestCompileClasspath,integTestRuntimeClasspath,modelValidation,pegasusPlugin,restClient,restClientCompile,restModelResolverPath,runtimeClasspath,testCompileClasspath,testDataModel,testDataTemplate,testRestClient,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,integTestCompileClasspath,integTestRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=integTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=integTestRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,integTestCompileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient
 ch.qos.logback:logback-classic:1.5.32=integTestRuntimeClasspath,modelValidation,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,integTestCompileClasspath,pegasusPlugin,restClient,restClientCompile,testCompileClasspath,testRestClient

--- a/metadata-service/schema-registry-servlet/gradle.lockfile
+++ b/metadata-service/schema-registry-servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/services/gradle.lockfile
+++ b/metadata-service/services/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath

--- a/metadata-service/servlet/gradle.lockfile
+++ b/metadata-service/servlet/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.3.15=compileClasspath,testCompileClasspath
 ch.qos.logback:logback-classic:1.5.32=runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.3.15=compileClasspath,testCompileClasspath

--- a/metadata-service/war/gradle.lockfile
+++ b/metadata-service/war/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 aopalliance:aopalliance:1.0=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-at.yawk.lz4:lz4-java:1.11.0=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.1=productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 ch.qos.logback:logback-classic:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.5.32=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 co.elastic.clients:elasticsearch-java:8.17.4=compileClasspath,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
Bumps `at.yawk.lz4:lz4-java` from 1.11.0 to 1.11.1 to address [CVE-2026-59949](https://avd.aquasec.com/nvd/cve-2026-59949).

### Changes

- `ext.lz4JavaVersion` 1.11.0 → 1.11.1 in `build.gradle`, with a comment recording the fix version
- Regenerated Gradle lockfiles with `./gradlew resolveAndLockAll --write-locks`

A single pin is sufficient here: `ext.lz4JavaVersion` feeds `externalDependency.lz4Java`, the `org.lz4` → `at.yawk` fork `resolutionStrategy`, and the capability resolution, so every module that resolves lz4-java picks up the new version.

The lockfile diff was checked to confirm `at.yawk.lz4:lz4-java` is the only coordinate that changed across all 30 affected lockfiles — nothing else moved.

### Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated (if applicable) — n/a, dependency version bump only
- [x] Docs added/updated (if applicable) — n/a
- [x] Breaking changes documented in `docs/how/updating-datahub.md` — n/a, patch-level bump with no API change