### PR TITLE
fix(cli): align semantic view migration with first-class SemanticModel datasets

### DIFF
--- a/metadata-ingestion/src/datahub/cli/snowflake_semantic_view_migration.py
+++ b/metadata-ingestion/src/datahub/cli/snowflake_semantic_view_migration.py
@@ -57,7 +57,7 @@ SNOWFLAKE_PLATFORM = "snowflake"
 SEMANTIC_VIEW_SUBTYPE = DatasetSubTypes.SEMANTIC_VIEW
 
 # Connector-synthesized column classification tags on legacy schemaMetadata.
-# Not customer tags — remodeled as SemanticField.type / metric entities.
+# Not customer tags — remodeled as semanticFieldAnnotation.type / metric entities.
 # Lowercase variants have no connector-enum equivalent (SemanticViewColumnSubtype
 # is uppercase-only), so those stay as literals.
 _SYNTHETIC_SUBTYPE_TAG_URNS: Set[str] = {
@@ -446,27 +446,30 @@ def collect_dataset_field_governance(
 def _semantic_model_field_path(
     column_name: str, convert_urns_to_lowercase: bool
 ) -> str:
-    # Matches SnowflakeSemanticModelMapper SemanticField fieldPath construction
+    # Matches SnowflakeSemanticModelMapper semantic field fieldPath construction
     # (identifier of the uppercased column name).
     return snowflake_identifier(column_name.upper(), convert_urns_to_lowercase)
+
+
+def _schema_metadata_fields(
+    graph: DataHubGraph, dataset_urn: str
+) -> List[SchemaFieldClass]:
+    schema_metadata = graph.get_aspects_for_entity(
+        entity_urn=dataset_urn,
+        aspects=["schemaMetadata"],
+        aspect_types=[SchemaMetadataClass],
+    ).get("schemaMetadata")
+    if not isinstance(schema_metadata, SchemaMetadataClass):
+        return []
+    return list(schema_metadata.fields or [])
 
 
 def _dataset_schema_field_paths(
     graph: DataHubGraph, dataset_urn: str
 ) -> Dict[str, str]:
     """Map casefolded simple column name -> schemaMetadata fieldPath."""
-    schema_metadata = graph.get_aspects_for_entity(
-        entity_urn=dataset_urn,
-        aspects=["schemaMetadata"],
-        aspect_types=[SchemaMetadataClass],
-    ).get("schemaMetadata")
     paths: Dict[str, str] = {}
-    if (
-        not isinstance(schema_metadata, SchemaMetadataClass)
-        or not schema_metadata.fields
-    ):
-        return paths
-    for schema_field in schema_metadata.fields:
+    for schema_field in _schema_metadata_fields(graph, dataset_urn):
         simple = _simple_column_name(schema_field.fieldPath)
         paths[simple.casefold()] = schema_field.fieldPath
     return paths
@@ -580,7 +583,12 @@ def collect_semantic_model_field_governance(
     semantic_model_urn: str,
     convert_urns_to_lowercase: bool,
 ) -> List[FieldGovernance]:
-    """Gather column tags/terms from metric entities and schemaField URNs under the model."""
+    """Gather column tags/terms from metric entities and schemaField URNs under the model.
+
+    Columns are enumerated from the ``schemaMetadata`` of each dataset listed in
+    ``semanticModelInfo.datasets`` — the model aspect holds dataset URNs, and the
+    structural field list lives on those datasets.
+    """
     by_column: Dict[str, FieldGovernance] = {}
 
     for related in graph.get_related_entities(
@@ -616,12 +624,9 @@ def collect_semantic_model_field_governance(
         aspects=["semanticModelInfo"],
         aspect_types=[SemanticModelInfoClass],
     ).get("semanticModelInfo")
-    if isinstance(model_info, SemanticModelInfoClass) and model_info.datasets:
-        for model_dataset in model_info.datasets:
-            for semantic_field in model_dataset.fields or []:
-                schema_field = semantic_field.schemaField
-                if schema_field is None:
-                    continue
+    if isinstance(model_info, SemanticModelInfoClass):
+        for model_dataset_urn in model_info.datasets:
+            for schema_field in _schema_metadata_fields(graph, model_dataset_urn):
                 column_name = _simple_column_name(schema_field.fieldPath)
                 field_urn = make_schema_field_urn(
                     semantic_model_urn,
@@ -635,7 +640,7 @@ def collect_semantic_model_field_governance(
                 tags = aspects.get("globalTags")
                 terms = aspects.get("glossaryTerms")
                 # Prefer schemaField entity aspects (migration/UI); fall back to
-                # tags embedded on the SemanticField from Snowflake ingest.
+                # what Snowflake ingest wrote onto the model dataset's schema.
                 if tags is None and schema_field.globalTags is not None:
                     tags = _strip_synthetic_subtype_tags(schema_field.globalTags)
                 if terms is None:

--- a/metadata-ingestion/tests/unit/cli/test_snowflake_semantic_view_migration.py
+++ b/metadata-ingestion/tests/unit/cli/test_snowflake_semantic_view_migration.py
@@ -39,16 +39,15 @@ from datahub.emitter.mce_builder import make_tag_urn
 from datahub.ingestion.graph.filters import RemovedStatusFilter
 from datahub.ingestion.graph.openapi import RelatedEntity
 from datahub.metadata.schema_classes import (
-    DialectClass,
-    DialectExpressionClass,
+    AuditStampClass,
     DocumentationAssociationClass,
     DocumentationClass,
     EditableDatasetPropertiesClass,
     EditableSchemaFieldInfoClass,
     EditableSchemaMetadataClass,
     GlobalTagsClass,
-    MetricExpressionClass,
-    ModelDatasetClass,
+    GlossaryTermAssociationClass,
+    GlossaryTermsClass,
     OtherSchemaClass,
     OwnerClass,
     OwnershipClass,
@@ -56,8 +55,6 @@ from datahub.metadata.schema_classes import (
     SchemaFieldClass,
     SchemaFieldDataTypeClass,
     SchemaMetadataClass,
-    SemanticFieldClass,
-    SemanticFieldTypeClass,
     SemanticModelInfoClass,
     StringTypeClass,
     SubTypesClass,
@@ -68,6 +65,7 @@ from datahub.metadata.schema_classes import (
 _DB = "TEST_DB"
 _SCHEMA = "PUBLIC"
 _VIEW = "Sales_Analytics"
+_AUDIT_STAMP = AuditStampClass(time=0, actor="urn:li:corpuser:datahub")
 
 
 def _identity(
@@ -307,6 +305,7 @@ def _schema_field(
     field_path: str,
     tags: Optional[list] = None,
     json_props: Optional[str] = None,
+    terms: Optional[list] = None,
 ) -> SchemaFieldClass:
     return SchemaFieldClass(
         fieldPath=field_path,
@@ -317,37 +316,32 @@ def _schema_field(
             if tags
             else None
         ),
+        glossaryTerms=(
+            GlossaryTermsClass(
+                terms=[GlossaryTermAssociationClass(urn=t) for t in terms],
+                auditStamp=_AUDIT_STAMP,
+            )
+            if terms
+            else None
+        ),
         jsonProps=json_props,
     )
 
 
-def _semantic_model_info(*field_paths: str) -> SemanticModelInfoClass:
-    fields = [
-        SemanticFieldClass(
-            schemaField=_schema_field(path),
-            type=SemanticFieldTypeClass.DIMENSION,
-            expression=MetricExpressionClass(
-                dialects=[
-                    DialectExpressionClass(
-                        dialect=DialectClass.SNOWFLAKE, expression=path.upper()
-                    )
-                ]
-            ),
-        )
-        for path in field_paths
-    ]
-    return SemanticModelInfoClass(
-        name="sales_analytics",
-        datasets=[
-            ModelDatasetClass(
-                name="sales_analytics",
-                source=(
-                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
-                    "test_db.public.sales_analytics,PROD)"
-                ),
-                fields=fields,
-            )
-        ],
+def _semantic_model_info(*dataset_urns: str) -> SemanticModelInfoClass:
+    # semanticModelInfo carries dataset URNs only; the column list lives on each
+    # of those datasets' schemaMetadata.
+    return SemanticModelInfoClass(name="sales_analytics", datasets=list(dataset_urns))
+
+
+def _schema_metadata(*fields: SchemaFieldClass) -> SchemaMetadataClass:
+    return SchemaMetadataClass(
+        schemaName="sales_analytics",
+        platform="urn:li:dataPlatform:snowflake",
+        version=0,
+        hash="",
+        platformSchema=OtherSchemaClass(rawSchema=""),
+        fields=list(fields),
     )
 
 
@@ -1206,6 +1200,12 @@ class TestSchemaFieldIsMetric:
 class TestMigrateSemanticModelFieldGovernance:
     SM = "urn:li:semanticModel:(urn:li:dataPlatform:snowflake,test_db.public,sales_analytics)"
     DST = "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.public.sales_analytics,PROD)"
+    # A dataset listed in semanticModelInfo.datasets, distinct from the legacy
+    # dataset the governance is migrated onto.
+    MODEL_DATASET = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+        "test_db.public.sales_analytics_model,PROD)"
+    )
     METRIC = (
         "urn:li:metric:(urn:li:dataPlatform:snowflake,"
         "test_db.public.sales_analytics,total_revenue)"
@@ -1227,17 +1227,7 @@ class TestMigrateSemanticModelFieldGovernance:
                 ),
             ]
         )
-        schema = SchemaMetadataClass(
-            schemaName="sales_analytics",
-            platform="urn:li:dataPlatform:snowflake",
-            version=0,
-            hash="",
-            platformSchema=OtherSchemaClass(rawSchema=""),
-            fields=[
-                _schema_field("OrderId"),
-                _schema_field("OtherCol"),
-            ],
-        )
+        schema = _schema_metadata(_schema_field("OrderId"), _schema_field("OtherCol"))
 
         def get_aspects(entity_urn, aspects, aspect_types):
             out: Dict[str, Optional[_Aspect]] = {}
@@ -1246,8 +1236,10 @@ class TestMigrateSemanticModelFieldGovernance:
                     out[name] = existing_editable
                 elif name == "schemaMetadata" and entity_urn == self.DST:
                     out[name] = schema
+                elif name == "schemaMetadata" and entity_urn == self.MODEL_DATASET:
+                    out[name] = _schema_metadata(_schema_field("OrderId"))
                 elif name == "semanticModelInfo" and entity_urn == self.SM:
-                    out[name] = _semantic_model_info("OrderId")
+                    out[name] = _semantic_model_info(self.MODEL_DATASET)
                 elif name == "globalTags" and entity_urn.startswith(
                     "urn:li:schemaField:"
                 ):
@@ -1319,6 +1311,46 @@ class TestMigrateSemanticModelFieldGovernance:
         metric_tags = fields[0].global_tags
         assert metric_tags is not None
         assert [t.tag for t in metric_tags.tags] == [make_tag_urn("finance")]
+
+    def test_collect_falls_back_to_model_dataset_schema_tags(self):
+        """No schemaField aspects: read the model dataset's schemaMetadata instead."""
+        model_schema = _schema_metadata(
+            _schema_field(
+                "TOTAL_AMOUNT",
+                tags=[make_tag_urn("pii"), make_tag_urn("dimension")],
+                terms=["urn:li:glossaryTerm:Revenue"],
+            )
+        )
+
+        def get_aspects(entity_urn, aspects, aspect_types):
+            out: Dict[str, Optional[_Aspect]] = {}
+            for name in aspects:
+                if name == "semanticModelInfo" and entity_urn == self.SM:
+                    out[name] = _semantic_model_info(self.MODEL_DATASET)
+                elif name == "schemaMetadata" and entity_urn == self.MODEL_DATASET:
+                    out[name] = model_schema
+                else:
+                    out[name] = None
+            return out
+
+        graph = MagicMock()
+        graph.get_aspects_for_entity.side_effect = get_aspects
+        graph.get_related_entities.return_value = []
+
+        fields = collect_semantic_model_field_governance(
+            graph, self.SM, convert_urns_to_lowercase=False
+        )
+
+        assert len(fields) == 1
+        assert fields[0].column_name == "TOTAL_AMOUNT"
+        assert fields[0].is_metric is False
+        tags = fields[0].global_tags
+        assert tags is not None
+        # Synthetic subtype tag dropped, customer tag kept.
+        assert [t.tag for t in tags.tags] == [make_tag_urn("pii")]
+        terms = fields[0].glossary_terms
+        assert terms is not None
+        assert [t.urn for t in terms.terms] == ["urn:li:glossaryTerm:Revenue"]
 
     def test_sm_to_dataset_folds_documentation_into_editable_description(self):
         doc = DocumentationClass(


### PR DESCRIPTION
## Summary

`master` is currently red on `python-lint` and `metadata-ingestion` `testQuick`.

[#18662](https://github.com/datahub-project/datahub/pull/18662) made SemanticModel datasets/fields first-class: `semanticModelInfo.datasets` is now `array[Urn]`, and the nested `ModelDataset` / `SemanticField` records were removed (field-level semantics moved to a per-`schemaField` `semanticFieldAnnotation` aspect). The Snowflake semantic view migration CLI added in [#18509](https://github.com/datahub-project/datahub/pull/18509) was written against the old nested shape and merged after that refactor, so the generated classes it imports no longer exist:

```
ImportError: cannot import name 'ModelDatasetClass' from 'datahub.metadata.schema_classes'
```

This PR adapts the CLI and its tests to the current model. No metadata model changes.

## What changed

- `collect_semantic_model_field_governance` now enumerates the model's columns from the `schemaMetadata` of each dataset URN listed in `semanticModelInfo.datasets`, instead of walking `ModelDataset.fields[].schemaField`.
- Extracted `_schema_metadata_fields()` so that lookup is shared with the existing `_dataset_schema_field_paths()`.
- Governance is still read from — and written to — `schemaField` URNs parented to the `semanticModel`, so the dataset ↔ semanticModel round-trip is unchanged.
- Tests: fixture builds `semanticModelInfo` with dataset URNs, with the column list supplied via the model dataset's `schemaMetadata`. Added a case covering the fallback that reads tags/terms off the model dataset's schema (synthetic DIMENSION/FACT/METRIC tags still stripped).

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added/updated
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes documented (n/a)