### PR TITLE
docs: add cross-api authorization guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,17 @@ Each Python module has a gradle setup similar to `metadata-ingestion/` (document
 - **Register as Spring beans** in `SpringStandardPluginConfiguration.java`
 - **Follow existing patterns**: See `SystemPolicyValidator.java` and `PolicyFieldTypeValidator.java` as examples
 
+### Authorization Architecture
+
+When adding an entity or API:
+
+- Enforce authorization across GraphQL, OpenAPI, and Rest.li
+- Keep basic entity CRUD permissions alongside any higher-level, entity-specific permissions
+- Use `AuthorizationUtils` for GraphQL and `AuthUtil.isAPIAuthorized*` for REST APIs
+- Put shared aspect rules in an `AbstractAspectAuthorizationValidator`
+- Apply view-based access controls by default; only set `viewUnrestricted: true` for intentionally public entities
+- Add allowed and denied access tests
+
 ## Development Flow
 
 1. **Schema changes** in `metadata-models/` trigger code generation across all languages


### PR DESCRIPTION
## Summary

- add concise agent guidance for authorization across GraphQL, OpenAPI, and Rest.li
- require baseline entity CRUD permissions, view-based access controls, and allowed and denied tests

## Test plan

- [x] Run `./gradlew formatChanged`
- [x] Pass pre-commit documentation and secret checks

## Checklist

- [x] The PR conforms to the Contributing Guideline and title format
- [ ] Related issue linked (not applicable)
- [ ] Tests added or updated (documentation-only change)
- [x] Documentation added or updated
- [ ] Breaking changes documented (not applicable)

Made with [Cursor](https://cursor.com)