### PR TITLE
feat(sql-parsing): opt-in multiprocessing core for SqlParsingAggregator

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -1,0 +1,417 @@
+import concurrent.futures
+import multiprocessing
+import pathlib
+import threading
+import time
+from concurrent.futures import Future, ProcessPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, Optional, Set, Tuple, Union
+
+from datahub.emitter.mce_builder import DEFAULT_ENV
+from datahub.ingestion.api.closeable import Closeable
+from datahub.ingestion.graph.config import DatahubClientConfig
+from datahub.sql_parsing.schema_resolver import (
+    SchemaResolver,
+    SchemaResolverInterface,
+)
+from datahub.sql_parsing.sqlglot_lineage import SqlParsingResult, sqlglot_lineage
+from datahub.sql_parsing.sqlglot_utils import try_format_query
+
+
+class ParallelParserUnavailable(Exception):
+    """Raised when the parallel parser process pool cannot be created.
+
+    The caller is expected to catch this and fall back to serial parsing.
+    """
+
+
+# Allowed types for ParseTask/ParseOutcome correlation keys.  The key crosses
+# the process boundary (pickle), so only simple, unconditionally-picklable
+# types are permitted.
+TaskKey = Optional[Union[str, int, Tuple[Union[str, int], ...]]]
+
+
+def _validate_task_key(key: Any) -> None:
+    """Raise TypeError if *key* is not a valid task key (None, str, int, or a
+    tuple whose elements are all str or int)."""
+    if key is None:
+        return
+    if isinstance(key, (str, int)):
+        return
+    if isinstance(key, tuple):
+        if not all(isinstance(el, (str, int)) for el in key):
+            raise TypeError(
+                f"ParseTask/ParseOutcome.key tuple elements must all be str or int "
+                f"(got {[type(el).__name__ for el in key if not isinstance(el, (str, int))]})"
+            )
+        return
+    raise TypeError(
+        f"ParseTask/ParseOutcome.key must be None, str, int, or tuple of str/int "
+        f"(got {type(key).__name__}); it must be picklable to cross the worker "
+        f"process boundary."
+    )
+
+
+@dataclass(frozen=True)
+class ParseTask:
+    """A single query to parse. ``key`` is an opaque correlation id the caller
+    uses to match the resulting :class:`ParseOutcome` back to its source, since
+    results are returned out of order."""
+
+    key: TaskKey
+    query: str
+    default_db: Optional[str]
+    default_schema: Optional[str]
+    override_dialect: Optional[str] = None
+    generate_column_lineage: bool = True
+
+    def __post_init__(self) -> None:
+        # ``key`` is shipped across the process boundary, so a non-picklable key
+        # would only surface later as an opaque broken pool. Restrict it to the
+        # simple picklable types the correlation-id use actually needs, and fail
+        # loudly at construction instead.
+        _validate_task_key(self.key)
+
+
+@dataclass(frozen=True)
+class ParseOutcome:
+    """The result of parsing a single :class:`ParseTask`.
+
+    There are three possible states:
+
+    * ``result`` is non-None, ``error`` is None — the worker ran to completion
+      and produced a result (even if ``result.debug_info`` records a normal
+      parse failure, the worker itself succeeded).
+    * ``result`` is None, ``error`` is non-None — the worker itself raised or
+      its process died; the caller decides how to handle it.
+    * ``result`` is None, ``error`` is None — the worker ran but produced
+      nothing (e.g. an empty outcome). This is treated as a failure:
+      :attr:`failed` returns True and :attr:`ok` returns False.
+
+    ``result`` and ``error`` are never both set. ``formatted_query`` is only
+    meaningful on a successful outcome (``error`` is None); it is always None
+    when ``error`` is set.
+
+    ``parse_seconds`` is the wall-clock time the worker spent in
+    ``sqlglot_lineage`` (the parse metric). It lets the main process account for
+    parse time that would otherwise be invisible to the main-thread
+    ``sql_parsing_timer`` (which only sees inline temp parsing on the parallel
+    path). It is 0.0 when the worker did not run to a result (``error`` set).
+
+    Callers should test :attr:`failed` (or :attr:`ok`) rather than
+    re-checking the individual fields by hand.
+    """
+
+    key: TaskKey
+    result: Optional[SqlParsingResult]
+    error: Optional[str]
+    # The query formatted in-worker (byte-identical to try_format_query on the
+    # main thread). Populated only when the worker was told to format; left None
+    # when formatting is disabled or the format step raised, in which case the
+    # main thread formats as it does on the serial path.
+    formatted_query: Optional[str] = None
+    # Wall-clock seconds the worker spent in sqlglot_lineage. Always 0.0 on an
+    # error outcome (the parse never completed).
+    parse_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.result is not None and self.error is not None:
+            raise ValueError("ParseOutcome cannot have both a result and an error set.")
+        if self.error is not None and self.formatted_query is not None:
+            raise ValueError("formatted_query must be None when error is set.")
+        if self.error is not None and self.parse_seconds != 0.0:
+            raise ValueError("parse_seconds must be 0.0 when error is set.")
+        if self.parse_seconds < 0:
+            raise ValueError("parse_seconds must be non-negative.")
+        _validate_task_key(self.key)
+
+    @property
+    def failed(self) -> bool:
+        """True if the worker did not produce a usable result.
+
+        This covers two distinct sub-cases:
+        * ``error`` is set — the worker raised or its process died.
+        * ``result`` is None and ``error`` is also None — the worker ran but
+          produced nothing.
+
+        Normal parse failures captured inside ``result.debug_info`` are NOT
+        failures at this level — the worker ran to completion, so ``failed``
+        is False."""
+        return self.error is not None or self.result is None
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+
+
+# ---------------------------------------------------------------------------
+# Worker side. These are module-level so the spawn start method can pickle them.
+# ---------------------------------------------------------------------------
+
+# Populated once per worker process by _worker_init, then reused for every task
+# that worker handles. Process-local, so no cross-process sharing concerns.
+_WORKER_RESOLVER: Optional[SchemaResolverInterface] = None
+# The platform and format toggle are also process-local, set once per worker so
+# _worker_parse can format the query in-worker (moving that serial-bottleneck
+# work off the main thread).
+_WORKER_PLATFORM: Optional[str] = None
+_WORKER_FORMAT_QUERIES: bool = False
+
+
+def _worker_init(
+    snapshot_path: pathlib.Path,
+    platform: str,
+    platform_instance: Optional[str],
+    env: str,
+    graph_config: Optional[DatahubClientConfig],
+    format_queries: bool,
+) -> None:
+    global _WORKER_RESOLVER, _WORKER_PLATFORM, _WORKER_FORMAT_QUERIES
+    _WORKER_PLATFORM = platform
+    _WORKER_FORMAT_QUERIES = format_queries
+    if graph_config is not None:
+        # Rebuild a live graph client inside the worker from the picklable config
+        # so cache-miss lazy hydration works in-worker exactly like the serial
+        # path. The live DataHubGraph object itself is not safely picklable, so it
+        # is constructed here rather than passed across the process boundary.
+        #
+        # Use for_worker: a two-tier resolver reads the bulk of schemas from the
+        # shared read-only snapshot but keeps graph-hydrated results (and None-miss
+        # dedup) in a small writable overlay. load_readonly's cache is read-only,
+        # so its writes are no-ops and graph-hydrated lineage would be lost.
+        # Import DataHubGraph here (not at module level) for two reasons: it is a
+        # heavyweight client that should not be loaded in every worker process when
+        # graph_config is None, and the live client object is not safely picklable
+        # so it must be constructed inside the worker rather than passed across the
+        # process boundary.
+        from datahub.ingestion.graph.client import DataHubGraph
+
+        resolver = SchemaResolver.for_worker(
+            snapshot_path,
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+            graph=DataHubGraph(graph_config),
+        )
+    else:
+        # No graph → no hydration, no writes: the lowest-memory read-only path.
+        resolver = SchemaResolver.load_readonly(
+            snapshot_path,
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+        )
+    _WORKER_RESOLVER = resolver
+
+
+def _worker_parse(task: ParseTask) -> ParseOutcome:
+    assert _WORKER_RESOLVER is not None, "worker resolver not initialized"
+    try:
+        # Time only the sqlglot_lineage call (the parse metric), mirroring what
+        # the main-thread sql_parsing_timer wraps on the serial path. Uses a
+        # monotonic clock so it is unaffected by wall-clock adjustments.
+        _parse_start = time.perf_counter()
+        result = sqlglot_lineage(
+            task.query,
+            schema_resolver=_WORKER_RESOLVER,
+            default_db=task.default_db,
+            default_schema=task.default_schema,
+            override_dialect=task.override_dialect,
+            generate_column_lineage=task.generate_column_lineage,
+        )
+        parse_seconds = time.perf_counter() - _parse_start
+        # Format in-worker so the (otherwise serial) formatting work is spread
+        # across the pool. try_format_query is pure and deterministic in
+        # (query, platform), so this is byte-identical to formatting on the main
+        # thread. A formatting failure must not fail the parse — fall back to
+        # None and let the main thread format as it does on the serial path.
+        formatted_query: Optional[str] = None
+        if _WORKER_FORMAT_QUERIES:
+            assert _WORKER_PLATFORM is not None
+            try:
+                formatted_query = try_format_query(task.query, _WORKER_PLATFORM)
+            except Exception:
+                # Defensive catch: try_format_query has raises=False today and
+                # won't propagate, but this guards against a future contract
+                # change. On failure the main thread reformats — no data loss.
+                formatted_query = None
+        # Normal parse failures are already captured inside result.debug_info,
+        # so they are returned as a result, not an error.
+        return ParseOutcome(
+            key=task.key,
+            result=result,
+            error=None,
+            formatted_query=formatted_query,
+            parse_seconds=parse_seconds,
+        )
+    except Exception as e:
+        # A worker-side exception becomes an error outcome rather than killing
+        # the pool.
+        return ParseOutcome(key=task.key, result=None, error=repr(e))
+
+
+# ---------------------------------------------------------------------------
+# Parent side.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParallelSqlParser(Closeable):
+    """Parses SQL across worker processes to sidestep the GIL for pure-Python
+    sqlglot work.
+
+    The pool is created eagerly at construction so that a
+    :class:`ParallelParserUnavailable` failure is raised deterministically here
+    (where the caller already handles it) rather than on a racing first parse
+    from a worker thread. Each worker opens the schema snapshot read-only (and,
+    if ``graph_config`` is provided, rebuilds a live graph client for cache-miss
+    hydration). Results are yielded unordered; the caller correlates them via
+    :attr:`ParseTask.key`.
+    """
+
+    num_workers: int
+    snapshot_path: pathlib.Path
+    platform: str
+    platform_instance: Optional[str]
+    env: str = DEFAULT_ENV
+    # repr=False so DatahubClientConfig.token (a plain str) can never leak via a
+    # repr() of this dataclass, matching _executor/_closed/pool_broke below.
+    graph_config: Optional[DatahubClientConfig] = field(default=None, repr=False)
+    max_pending: Optional[int] = None
+    # Constructor-only: threaded to workers via initargs at pool creation.
+    # Mutating format_queries after construction has no effect on the pool.
+    format_queries: bool = False
+
+    _executor: Optional[ProcessPoolExecutor] = field(
+        default=None, init=False, repr=False
+    )
+    _closed: bool = field(default=False, init=False, repr=False)
+    pool_broke: threading.Event = field(
+        default_factory=threading.Event, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        try:
+            # Spawn avoids inheriting the parent's threading.Lock / SQLite fds;
+            # fork-with-threads can deadlock. (macOS already defaults to spawn.)
+            mp_context = multiprocessing.get_context("spawn")
+            self._executor = ProcessPoolExecutor(
+                max_workers=self.num_workers,
+                mp_context=mp_context,
+                initializer=_worker_init,
+                initargs=(
+                    self.snapshot_path,
+                    self.platform,
+                    self.platform_instance,
+                    self.env,
+                    self.graph_config,
+                    self.format_queries,
+                ),
+            )
+        except Exception as e:
+            raise ParallelParserUnavailable(
+                f"Failed to create parallel SQL parser process pool: {e!r}"
+            ) from e
+
+    def _ensure_executor(self) -> ProcessPoolExecutor:
+        # The pool is created eagerly in __post_init__; a None executor here means
+        # the parser was already closed, which is a caller bug on the parse path.
+        # This is NOT ParallelParserUnavailable (reserved for genuine
+        # pool-creation failure): the aggregator's serial-fallback catches that
+        # exception, and swallowing a use-after-close there would hide the bug.
+        if self._executor is None:
+            raise RuntimeError("ParallelSqlParser has been closed")
+        return self._executor
+
+    def map_unordered(self, tasks: Iterable[ParseTask]) -> Iterator[ParseOutcome]:
+        """Parse each task in a worker process, yielding outcomes as they complete
+        (unordered). Pending futures are bounded (default ``2*num_workers``) so we
+        don't accumulate results in memory faster than the caller consumes them.
+
+        The bounded drain mirrors
+        :class:`datahub.utilities.backpressure_aware_executor.BackpressureAwareExecutor`.
+        It is inlined here (rather than reusing that helper) because we must map
+        each future back to its task ``key`` to synthesize a
+        ``ParseOutcome(error=...)`` if a worker process dies at the executor layer
+        — information the helper's future-only return type does not expose.
+        """
+        executor = self._ensure_executor()
+
+        max_pending = self.max_pending
+        if max_pending is None:
+            max_pending = 2 * self.num_workers
+        assert max_pending >= self.num_workers
+
+        future_to_key: Dict[Future, Any] = {}
+        pending: Set[Future] = set()
+
+        def drain(future: Future) -> ParseOutcome:
+            key = future_to_key.pop(future)
+            try:
+                return future.result()
+            except Exception as e:
+                # Any executor-layer failure at result time (BrokenProcessPool,
+                # or a worker process that died before returning a ParseOutcome)
+                # is an infra failure, NOT a parse failure: trip pool_broke so
+                # the caller falls the rest of the run back to serial, and
+                # surface it as an error outcome instead of propagating.
+                self.pool_broke.set()
+                return ParseOutcome(key=key, result=None, error=repr(e))
+
+        for task in tasks:
+            if len(pending) >= max_pending:
+                done, _ = concurrent.futures.wait(
+                    pending, return_when=concurrent.futures.FIRST_COMPLETED
+                )
+                for future in done:
+                    pending.remove(future)
+                    yield drain(future)
+
+            try:
+                submitted = executor.submit(_worker_parse, task)
+            except Exception as e:
+                # submit() can raise BrokenProcessPool immediately if the pool is
+                # already broken. That is an infra failure, not a parse failure:
+                # trip pool_broke and yield an error outcome so the query is not
+                # silently dropped (the exception must never escape here).
+                self.pool_broke.set()
+                yield ParseOutcome(key=task.key, result=None, error=repr(e))
+                continue
+            future_to_key[submitted] = task.key
+            pending.add(submitted)
+
+        for future in concurrent.futures.as_completed(pending):
+            yield drain(future)
+
+    def parse_one(self, task: ParseTask) -> ParseOutcome:
+        """Parse a single task in a worker process and block until its outcome.
+
+        Unlike :meth:`map_unordered`, this submits exactly one task and waits for
+        it, so the caller can drive its own per-task ordering (e.g. a
+        PartitionExecutor) rather than relying on the unordered stream. A dead
+        worker process is surfaced as a :class:`ParseOutcome` with ``error`` set,
+        mirroring the drain behavior of :meth:`map_unordered`.
+        """
+        executor = self._ensure_executor()
+        try:
+            # submit() and result() are wrapped together so that ANY
+            # executor-layer failure — a BrokenProcessPool raised immediately by
+            # submit() when the pool is already broken, or a worker death
+            # surfaced at result() — is treated as an infra failure. These are
+            # NOT parse failures: trip pool_broke so the caller falls back to
+            # serial, and return an error outcome. No executor exception may
+            # escape this method (a raise here would be miscounted upstream as an
+            # ordinary parse failure and the query silently dropped).
+            future = executor.submit(_worker_parse, task)
+            return future.result()
+        except Exception as e:
+            self.pool_broke.set()
+            return ParseOutcome(key=task.key, result=None, error=repr(e))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -1,11 +1,10 @@
-import concurrent.futures
 import multiprocessing
 import pathlib
 import threading
 import time
-from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, Iterator, Optional, Set, Tuple, Union
+from typing import Optional
 
 from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.closeable import Closeable
@@ -25,52 +24,15 @@ class ParallelParserUnavailable(Exception):
     """
 
 
-# Allowed types for ParseTask/ParseOutcome correlation keys.  The key crosses
-# the process boundary (pickle), so only simple, unconditionally-picklable
-# types are permitted.
-TaskKey = Optional[Union[str, int, Tuple[Union[str, int], ...]]]
-
-
-def _validate_task_key(key: Any) -> None:
-    """Raise TypeError if *key* is not a valid task key (None, str, int, or a
-    tuple whose elements are all str or int)."""
-    if key is None:
-        return
-    if isinstance(key, (str, int)):
-        return
-    if isinstance(key, tuple):
-        if not all(isinstance(el, (str, int)) for el in key):
-            raise TypeError(
-                f"ParseTask/ParseOutcome.key tuple elements must all be str or int "
-                f"(got {[type(el).__name__ for el in key if not isinstance(el, (str, int))]})"
-            )
-        return
-    raise TypeError(
-        f"ParseTask/ParseOutcome.key must be None, str, int, or tuple of str/int "
-        f"(got {type(key).__name__}); it must be picklable to cross the worker "
-        f"process boundary."
-    )
-
-
 @dataclass(frozen=True)
 class ParseTask:
-    """A single query to parse. ``key`` is an opaque correlation id the caller
-    uses to match the resulting :class:`ParseOutcome` back to its source, since
-    results are returned out of order."""
+    """A single query to parse in a worker process."""
 
-    key: TaskKey
     query: str
     default_db: Optional[str]
     default_schema: Optional[str]
     override_dialect: Optional[str] = None
     generate_column_lineage: bool = True
-
-    def __post_init__(self) -> None:
-        # ``key`` is shipped across the process boundary, so a non-picklable key
-        # would only surface later as an opaque broken pool. Restrict it to the
-        # simple picklable types the correlation-id use actually needs, and fail
-        # loudly at construction instead.
-        _validate_task_key(self.key)
 
 
 @dataclass(frozen=True)
@@ -102,7 +64,6 @@ class ParseOutcome:
     re-checking the individual fields by hand.
     """
 
-    key: TaskKey
     result: Optional[SqlParsingResult]
     error: Optional[str]
     # The query formatted in-worker (byte-identical to try_format_query on the
@@ -123,7 +84,6 @@ class ParseOutcome:
             raise ValueError("parse_seconds must be 0.0 when error is set.")
         if self.parse_seconds < 0:
             raise ValueError("parse_seconds must be non-negative.")
-        _validate_task_key(self.key)
 
     @property
     def failed(self) -> bool:
@@ -238,7 +198,6 @@ def _worker_parse(task: ParseTask) -> ParseOutcome:
         # Normal parse failures are already captured inside result.debug_info,
         # so they are returned as a result, not an error.
         return ParseOutcome(
-            key=task.key,
             result=result,
             error=None,
             formatted_query=formatted_query,
@@ -247,7 +206,7 @@ def _worker_parse(task: ParseTask) -> ParseOutcome:
     except Exception as e:
         # A worker-side exception becomes an error outcome rather than killing
         # the pool.
-        return ParseOutcome(key=task.key, result=None, error=repr(e))
+        return ParseOutcome(result=None, error=repr(e))
 
 
 # ---------------------------------------------------------------------------
@@ -277,7 +236,6 @@ class ParallelSqlParser(Closeable):
     # repr=False so DatahubClientConfig.token (a plain str) can never leak via a
     # repr() of this dataclass, matching _executor/_closed/pool_broke below.
     graph_config: Optional[DatahubClientConfig] = field(default=None, repr=False)
-    max_pending: Optional[int] = None
     # Constructor-only: threaded to workers via initargs at pool creation.
     # Mutating format_queries after construction has no effect on the pool.
     format_queries: bool = False
@@ -323,74 +281,13 @@ class ParallelSqlParser(Closeable):
             raise RuntimeError("ParallelSqlParser has been closed")
         return self._executor
 
-    def map_unordered(self, tasks: Iterable[ParseTask]) -> Iterator[ParseOutcome]:
-        """Parse each task in a worker process, yielding outcomes as they complete
-        (unordered). Pending futures are bounded (default ``2*num_workers``) so we
-        don't accumulate results in memory faster than the caller consumes them.
-
-        The bounded drain mirrors
-        :class:`datahub.utilities.backpressure_aware_executor.BackpressureAwareExecutor`.
-        It is inlined here (rather than reusing that helper) because we must map
-        each future back to its task ``key`` to synthesize a
-        ``ParseOutcome(error=...)`` if a worker process dies at the executor layer
-        — information the helper's future-only return type does not expose.
-        """
-        executor = self._ensure_executor()
-
-        max_pending = self.max_pending
-        if max_pending is None:
-            max_pending = 2 * self.num_workers
-        assert max_pending >= self.num_workers
-
-        future_to_key: Dict[Future, Any] = {}
-        pending: Set[Future] = set()
-
-        def drain(future: Future) -> ParseOutcome:
-            key = future_to_key.pop(future)
-            try:
-                return future.result()
-            except Exception as e:
-                # Any executor-layer failure at result time (BrokenProcessPool,
-                # or a worker process that died before returning a ParseOutcome)
-                # is an infra failure, NOT a parse failure: trip pool_broke so
-                # the caller falls the rest of the run back to serial, and
-                # surface it as an error outcome instead of propagating.
-                self.pool_broke.set()
-                return ParseOutcome(key=key, result=None, error=repr(e))
-
-        for task in tasks:
-            if len(pending) >= max_pending:
-                done, _ = concurrent.futures.wait(
-                    pending, return_when=concurrent.futures.FIRST_COMPLETED
-                )
-                for future in done:
-                    pending.remove(future)
-                    yield drain(future)
-
-            try:
-                submitted = executor.submit(_worker_parse, task)
-            except Exception as e:
-                # submit() can raise BrokenProcessPool immediately if the pool is
-                # already broken. That is an infra failure, not a parse failure:
-                # trip pool_broke and yield an error outcome so the query is not
-                # silently dropped (the exception must never escape here).
-                self.pool_broke.set()
-                yield ParseOutcome(key=task.key, result=None, error=repr(e))
-                continue
-            future_to_key[submitted] = task.key
-            pending.add(submitted)
-
-        for future in concurrent.futures.as_completed(pending):
-            yield drain(future)
-
     def parse_one(self, task: ParseTask) -> ParseOutcome:
         """Parse a single task in a worker process and block until its outcome.
 
-        Unlike :meth:`map_unordered`, this submits exactly one task and waits for
-        it, so the caller can drive its own per-task ordering (e.g. a
-        PartitionExecutor) rather than relying on the unordered stream. A dead
-        worker process is surfaced as a :class:`ParseOutcome` with ``error`` set,
-        mirroring the drain behavior of :meth:`map_unordered`.
+        Submits exactly one task and waits for it, so the caller drives its own
+        per-task ordering (e.g. a PartitionExecutor). A dead worker process is
+        surfaced as a :class:`ParseOutcome` with ``error`` set rather than
+        propagating an executor exception.
         """
         executor = self._ensure_executor()
         try:
@@ -406,7 +303,7 @@ class ParallelSqlParser(Closeable):
             return future.result()
         except Exception as e:
             self.pool_broke.set()
-            return ParseOutcome(key=task.key, result=None, error=repr(e))
+            return ParseOutcome(result=None, error=repr(e))
 
     def close(self) -> None:
         if self._closed:

--- a/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/parallel_sql_parser.py
@@ -3,6 +3,7 @@ import pathlib
 import threading
 import time
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -14,7 +15,7 @@ from datahub.sql_parsing.schema_resolver import (
     SchemaResolverInterface,
 )
 from datahub.sql_parsing.sqlglot_lineage import SqlParsingResult, sqlglot_lineage
-from datahub.sql_parsing.sqlglot_utils import try_format_query
+from datahub.sql_parsing.sqlglot_utils import DialectOrStr, try_format_query
 
 
 class ParallelParserUnavailable(Exception):
@@ -31,7 +32,11 @@ class ParseTask:
     query: str
     default_db: Optional[str]
     default_schema: Optional[str]
-    override_dialect: Optional[str] = None
+    # Passed through unchanged (not stringified) so a sqlglot.Dialect round-trips
+    # exactly as it does on the serial path, where get_dialect() accepts either
+    # form. Must be picklable to cross to the worker (str always is; a Dialect
+    # object is what the serial path already holds).
+    override_dialect: Optional[DialectOrStr] = None
     generate_column_lineage: bool = True
 
 
@@ -285,24 +290,27 @@ class ParallelSqlParser(Closeable):
         """Parse a single task in a worker process and block until its outcome.
 
         Submits exactly one task and waits for it, so the caller drives its own
-        per-task ordering (e.g. a PartitionExecutor). A dead worker process is
+        per-task ordering (e.g. a PartitionExecutor). An executor-layer failure is
         surfaced as a :class:`ParseOutcome` with ``error`` set rather than
-        propagating an executor exception.
+        propagating (a raise would be miscounted upstream as an ordinary parse
+        failure and the query silently dropped). Only a genuine
+        :class:`BrokenProcessPool` trips the sticky ``pool_broke`` flag; a
+        per-query executor error (e.g. a result that fails to unpickle) is
+        reported as an error outcome WITHOUT disabling the pool for the rest of
+        the run — the caller reparses that one query inline.
         """
         executor = self._ensure_executor()
         try:
-            # submit() and result() are wrapped together so that ANY
-            # executor-layer failure — a BrokenProcessPool raised immediately by
-            # submit() when the pool is already broken, or a worker death
-            # surfaced at result() — is treated as an infra failure. These are
-            # NOT parse failures: trip pool_broke so the caller falls back to
-            # serial, and return an error outcome. No executor exception may
-            # escape this method (a raise here would be miscounted upstream as an
-            # ordinary parse failure and the query silently dropped).
             future = executor.submit(_worker_parse, task)
             return future.result()
-        except Exception as e:
+        except BrokenProcessPool as e:
+            # The pool itself is unusable — trip the sticky flag so the caller
+            # falls the REST of the run back to serial.
             self.pool_broke.set()
+            return ParseOutcome(result=None, error=repr(e))
+        except Exception as e:
+            # A per-query executor-layer failure: surface it (the caller reparses
+            # this query inline) but leave the pool usable for other queries.
             return ParseOutcome(result=None, error=repr(e))
 
     def close(self) -> None:

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import shutil
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, Tuple, Union
 
 from requests.models import HTTPError
 from typing_extensions import TypedDict
@@ -30,6 +30,14 @@ logger = logging.getLogger(__name__)
 
 # A lightweight table schema: column -> type mapping.
 SchemaInfo = Dict[str, str]
+
+
+class _CacheAbsent:
+    """Sentinel returned by the two-tier cache lookup when a URN has NO entry in
+    either tier. Distinct from a cached ``None`` (a remembered miss)."""
+
+
+_CACHE_ABSENT = _CacheAbsent()
 
 
 @dataclass
@@ -221,15 +229,16 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             urns_to_try.append(urn_mixed)
 
         for candidate_urn in urns_to_try:
-            if self._cache_contains(candidate_urn):
-                schema_info = self._cache_get(candidate_urn)
-                if schema_info is not None:
-                    self._track_cache_hit()
-                    return candidate_urn, schema_info
+            cached = self._cache_peek(candidate_urn)
+            if not isinstance(cached, _CacheAbsent) and cached is not None:
+                self._track_cache_hit()
+                return candidate_urn, cached
 
         if self.graph:
             # Skip URNs already in cache (None entries included) to avoid repeated API calls.
-            urns_to_fetch = [u for u in urns_to_try if not self._cache_contains(u)]
+            urns_to_fetch = [
+                u for u in urns_to_try if isinstance(self._cache_peek(u), _CacheAbsent)
+            ]
 
             if urns_to_fetch:
                 try:
@@ -274,10 +283,10 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
                         self._save_to_cache(fetch_urn, None)
 
             for candidate_urn in urns_to_try:
-                schema_info = self._cache_get(candidate_urn)
-                if schema_info is not None:
+                cached = self._cache_peek(candidate_urn)
+                if not isinstance(cached, _CacheAbsent) and cached is not None:
                     self._track_cache_hit()
-                    return candidate_urn, schema_info
+                    return candidate_urn, cached
 
         logger.debug(
             f"Schema resolution failed for table {table}. Tried URNs: "
@@ -320,32 +329,36 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         if self.report is not None:
             self.report.num_schema_cache_misses += 1
 
-    def _cache_contains(self, urn: str) -> bool:
-        """Whether *urn* has an entry (including a cached None) in either tier.
-
-        Reads consult the writable primary cache first, then the optional
-        read-only fallback snapshot. Writes only ever touch the primary cache.
-        """
-        if urn in self._schema_cache:
-            return True
-        if self._readonly_fallback is not None and urn in self._readonly_fallback:
-            return True
-        return False
+    def _cache_peek(self, urn: str) -> "Union[Optional[SchemaInfo], _CacheAbsent]":
+        """Single two-tier lookup: consult the writable primary cache first, then
+        the optional read-only fallback snapshot. Returns the stored value (which
+        may be ``None`` for a remembered miss) or the :data:`_CACHE_ABSENT`
+        sentinel when the URN has no entry in either tier. Collapsing the old
+        ``_cache_contains`` + ``_cache_get`` pair into one call halves the SQLite
+        membership work on the resolver hot path. Writes only ever touch the
+        primary cache."""
+        try:
+            return self._schema_cache[urn]
+        except KeyError:
+            pass
+        if self._readonly_fallback is not None:
+            try:
+                return self._readonly_fallback[urn]
+            except KeyError:
+                pass
+        return _CACHE_ABSENT
 
     def _cache_get(self, urn: str) -> Optional[SchemaInfo]:
-        """Read *urn*'s schema from the primary cache, falling back to the
-        read-only snapshot. Returns None if absent or cached as a miss — callers
-        that must distinguish absence from a cached miss should use
-        :meth:`_cache_contains`."""
-        if urn in self._schema_cache:
-            return self._schema_cache[urn]
-        if self._readonly_fallback is not None and urn in self._readonly_fallback:
-            return self._readonly_fallback[urn]
-        return None
+        """Read *urn*'s schema, or None if absent OR cached as a miss. Callers
+        needing to distinguish absence from a cached miss use
+        :meth:`_cache_peek`."""
+        value = self._cache_peek(urn)
+        return None if isinstance(value, _CacheAbsent) else value
 
     def _resolve_schema_info(self, urn: str) -> Optional[SchemaInfo]:
-        if self._cache_contains(urn):
-            return self._cache_get(urn)
+        cached = self._cache_peek(urn)
+        if not isinstance(cached, _CacheAbsent):
+            return cached
 
         # TODO: For bigquery partitioned tables, add the pseudo-column _PARTITIONTIME
         # or _PARTITIONDATE where appropriate.

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import logging
 import pathlib
+import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Set, Tuple
 
@@ -72,6 +73,43 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         _cache_filename: Optional[pathlib.Path] = None,
         report: Optional[SchemaResolverReport] = None,
     ):
+        # Init cache, potentially restoring from a previous run.
+        shared_conn = None
+        if _cache_filename:
+            shared_conn = ConnectionWrapper(filename=_cache_filename)
+        schema_cache: FileBackedDict[Optional[SchemaInfo]] = FileBackedDict(
+            shared_connection=shared_conn,
+            extra_columns={"is_missing": lambda v: v is None},
+        )
+
+        self._init_components(
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+            graph=graph,
+            schema_cache=schema_cache,
+            readonly_fallback=None,
+            report=report,
+        )
+
+    def _init_components(
+        self,
+        *,
+        platform: str,
+        platform_instance: Optional[str],
+        env: str,
+        graph: Optional["DataHubGraph"],
+        schema_cache: "FileBackedDict[Optional[SchemaInfo]]",
+        readonly_fallback: "Optional[FileBackedDict[Optional[SchemaInfo]]]",
+        report: Optional[SchemaResolverReport],
+        owned_connections: "Optional[List[ConnectionWrapper]]" = None,
+    ) -> None:
+        """Single place every construction path (``__init__``, ``load_readonly``,
+        ``for_worker``) wires up the resolver's attributes.
+
+        Centralized so a new attribute is added once here instead of silently
+        missing from the factory methods that bypass ``__init__``.
+        """
         # Also supports platform with an urn prefix.
         self._platform = DataPlatformUrn(platform).platform_name
         self.platform_instance = platform_instance
@@ -80,14 +118,23 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         self.graph = graph
         self.report = report
 
-        # Init cache, potentially restoring from a previous run.
-        shared_conn = None
-        if _cache_filename:
-            shared_conn = ConnectionWrapper(filename=_cache_filename)
-        self._schema_cache: FileBackedDict[Optional[SchemaInfo]] = FileBackedDict(
-            shared_connection=shared_conn,
-            extra_columns={"is_missing": lambda v: v is None},
+        # Optional read-only fallback cache consulted on a primary-cache miss.
+        # Used by worker resolvers (see for_worker) to read the bulk of schemas
+        # from a shared read-only snapshot while keeping graph-hydrated results and
+        # None-miss dedup in the writable primary cache. None → single-tier behavior.
+        self._readonly_fallback: Optional[FileBackedDict[Optional[SchemaInfo]]] = (
+            readonly_fallback
         )
+
+        self._schema_cache: FileBackedDict[Optional[SchemaInfo]] = schema_cache
+
+        # ConnectionWrapper(s) this resolver owns and must close explicitly.
+        # A read-only ConnectionWrapper handed to a FileBackedDict as its
+        # shared_connection is NOT closed by FileBackedDict.close() (shared
+        # connections are considered externally owned), so without tracking it
+        # here the underlying SQLite handle would leak until GC. See load_readonly
+        # / for_worker, which register their read-only conn here.
+        self._owned_connections: List[ConnectionWrapper] = owned_connections or []
 
     @property
     def platform(self) -> str:
@@ -174,15 +221,15 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             urns_to_try.append(urn_mixed)
 
         for candidate_urn in urns_to_try:
-            if candidate_urn in self._schema_cache:
-                schema_info = self._schema_cache[candidate_urn]
+            if self._cache_contains(candidate_urn):
+                schema_info = self._cache_get(candidate_urn)
                 if schema_info is not None:
                     self._track_cache_hit()
                     return candidate_urn, schema_info
 
         if self.graph:
             # Skip URNs already in cache (None entries included) to avoid repeated API calls.
-            urns_to_fetch = [u for u in urns_to_try if u not in self._schema_cache]
+            urns_to_fetch = [u for u in urns_to_try if not self._cache_contains(u)]
 
             if urns_to_fetch:
                 try:
@@ -227,7 +274,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
                         self._save_to_cache(fetch_urn, None)
 
             for candidate_urn in urns_to_try:
-                schema_info = self._schema_cache.get(candidate_urn)
+                schema_info = self._cache_get(candidate_urn)
                 if schema_info is not None:
                     self._track_cache_hit()
                     return candidate_urn, schema_info
@@ -261,7 +308,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         return self.platform not in PLATFORMS_WITH_CASE_SENSITIVE_TABLES
 
     def has_urn(self, urn: str) -> bool:
-        return self._schema_cache.get(urn) is not None
+        return self._cache_get(urn) is not None
 
     def _track_cache_hit(self) -> None:
         """Track a cache hit if reporting is enabled."""
@@ -273,9 +320,32 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         if self.report is not None:
             self.report.num_schema_cache_misses += 1
 
-    def _resolve_schema_info(self, urn: str) -> Optional[SchemaInfo]:
+    def _cache_contains(self, urn: str) -> bool:
+        """Whether *urn* has an entry (including a cached None) in either tier.
+
+        Reads consult the writable primary cache first, then the optional
+        read-only fallback snapshot. Writes only ever touch the primary cache.
+        """
+        if urn in self._schema_cache:
+            return True
+        if self._readonly_fallback is not None and urn in self._readonly_fallback:
+            return True
+        return False
+
+    def _cache_get(self, urn: str) -> Optional[SchemaInfo]:
+        """Read *urn*'s schema from the primary cache, falling back to the
+        read-only snapshot. Returns None if absent or cached as a miss — callers
+        that must distinguish absence from a cached miss should use
+        :meth:`_cache_contains`."""
         if urn in self._schema_cache:
             return self._schema_cache[urn]
+        if self._readonly_fallback is not None and urn in self._readonly_fallback:
+            return self._readonly_fallback[urn]
+        return None
+
+    def _resolve_schema_info(self, urn: str) -> Optional[SchemaInfo]:
+        if self._cache_contains(urn):
+            return self._cache_get(urn)
 
         # TODO: For bigquery partitioned tables, add the pseudo-column _PARTITIONTIME
         # or _PARTITIONDATE where appropriate.
@@ -333,6 +403,11 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         )
 
     def _save_to_cache(self, urn: str, schema_info: Optional[SchemaInfo]) -> None:
+        # Read-only resolvers have no graph and no persistent store to update;
+        # writing to the in-memory cache would only dirty it and trigger a write
+        # attempt (→ sqlite3.OperationalError) when the cache is flushed at close.
+        if self._schema_cache.read_only:
+            return
         self._schema_cache[urn] = schema_info
 
     def _fetch_schema_info(
@@ -358,8 +433,116 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
             if "." not in get_simple_field_path_from_v2_field_path(field["fieldPath"])
         }
 
+    def snapshot_to(self, path: pathlib.Path) -> None:
+        """Flush all in-memory cache entries to SQLite then copy the DB file to *path*.
+
+        The resulting file is a self-contained SQLite database that worker processes
+        can open read-only with ``immutable=1``, avoiding all locking overhead.
+
+        The source connection must be quiescent (no concurrent writers) when this is
+        called: we flush with ``synchronous=OFF`` so the OS page cache may not have
+        been synced to disk; copying mid-write could produce a corrupt snapshot.
+        """
+        self._schema_cache.flush()
+        shutil.copyfile(self._schema_cache.filename, path)
+
+    @classmethod
+    def load_readonly(
+        cls,
+        path: pathlib.Path,
+        *,
+        platform: str,
+        platform_instance: Optional[str] = None,
+        env: str = DEFAULT_ENV,
+    ) -> "SchemaResolver":
+        """Open a snapshot created by :meth:`snapshot_to` as a read-only resolver.
+
+        The returned resolver has ``graph=None`` so it never makes network calls.
+        Multiple processes may open the same snapshot file simultaneously via
+        ``immutable=1``, which bypasses SQLite locking entirely and allows the OS
+        to share the page cache across processes.
+        """
+        ro_conn = ConnectionWrapper(filename=path, read_only=True)
+        # Bypass __init__ — inject the read-only connection without triggering the
+        # normal writable-setup path — but route all attribute wiring through the
+        # shared _init_components so no field is silently dropped.
+        resolver = cls.__new__(cls)
+        resolver._init_components(
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+            graph=None,
+            schema_cache=FileBackedDict(
+                shared_connection=ro_conn,
+                extra_columns={"is_missing": lambda v: v is None},
+            ),
+            readonly_fallback=None,
+            report=None,
+            # The read-only ConnectionWrapper is shared into the FileBackedDict,
+            # which won't close it — register it so close() does.
+            owned_connections=[ro_conn],
+        )
+        return resolver
+
+    @classmethod
+    def for_worker(
+        cls,
+        snapshot_path: pathlib.Path,
+        *,
+        platform: str,
+        platform_instance: Optional[str] = None,
+        env: str = DEFAULT_ENV,
+        graph: Optional["DataHubGraph"] = None,
+    ) -> "SchemaResolver":
+        """Build a two-tier resolver for a parallel-parsing worker process.
+
+        The bulk of schemas are read from the shared read-only *snapshot_path*
+        (opened ``immutable=1`` so the OS page cache is shared across workers,
+        keeping memory low). A small **writable** in-memory primary cache sits in
+        front of it to hold graph-hydrated results and None-miss dedup, so a
+        worker with a ``graph`` attached does not silently drop lineage — unlike
+        :meth:`load_readonly`, whose cache is read-only and cannot absorb fetches.
+
+        Use :meth:`load_readonly` instead when there is no graph: it avoids the
+        extra writable cache entirely (lowest memory, no writes).
+        """
+        ro_conn = ConnectionWrapper(filename=snapshot_path, read_only=True)
+        # Bypass __init__ so we can wire a writable primary cache in front of a
+        # read-only fallback, but route attribute wiring through the shared
+        # _init_components so no field is silently dropped.
+        resolver = cls.__new__(cls)
+        resolver._init_components(
+            platform=platform,
+            platform_instance=platform_instance,
+            env=env,
+            graph=graph,
+            # Fresh writable in-memory cache (temp file) so _save_to_cache works.
+            schema_cache=FileBackedDict(
+                extra_columns={"is_missing": lambda v: v is None},
+            ),
+            readonly_fallback=FileBackedDict(
+                shared_connection=ro_conn,
+                extra_columns={"is_missing": lambda v: v is None},
+            ),
+            report=None,
+            # The read-only ConnectionWrapper is shared into the fallback
+            # FileBackedDict, which won't close it — register it so close() does.
+            owned_connections=[ro_conn],
+        )
+        return resolver
+
     def close(self) -> None:
+        # Close the FileBackedDicts first (flushes the writable primary and, for
+        # non-shared connections, closes their underlying wrapper), then close any
+        # ConnectionWrapper we own directly. ConnectionWrapper.close() is
+        # idempotent, so closing a wrapper already torn down by its FileBackedDict
+        # is safe (no double-close error).
+        if self._readonly_fallback is not None:
+            self._readonly_fallback.close()
         self._schema_cache.close()
+        for conn in self._owned_connections:
+            conn.close()
+        self._owned_connections = []
 
 
 class _SchemaResolverWithExtras(SchemaResolverInterface):

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -455,6 +455,9 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         The source connection must be quiescent (no concurrent writers) when this is
         called: we flush with ``synchronous=OFF`` so the OS page cache may not have
         been synced to disk; copying mid-write could produce a corrupt snapshot.
+        The aggregator satisfies this by snapshotting at parallel-scope entry,
+        before any worker or PartitionExecutor thread starts — it must never be
+        called from inside an active scope.
         """
         self._schema_cache.flush()
         shutil.copyfile(self._schema_cache.filename, path)
@@ -572,7 +575,13 @@ class _SchemaResolverWithExtras(SchemaResolverInterface):
         return self._base_resolver.platform
 
     def includes_temp_tables(self) -> bool:
-        return True
+        # Only claims temp tables when some have actually been registered
+        # (add_temp_tables populates _extra_schemas). The previous unconditional
+        # True marked every session-less query as temp-bearing, which (a) tagged
+        # its QueryMetadata.used_temp_tables even with no temps and (b) forced the
+        # parallel path to route every session-less query inline — defeating
+        # parallelism for connectors that never set a session id.
+        return bool(self._extra_schemas)
 
     def resolve_table(self, table: _TableName) -> Tuple[str, Optional[SchemaInfo]]:
         urn = self._base_resolver.get_urn_for_table(

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -6,13 +6,29 @@ import json
 import logging
 import pathlib
 import tempfile
+import threading
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Callable, Dict, Iterable, List, Optional, Set, Union, cast
+from typing import (
+    Callable,
+    ContextManager,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+
+from pydantic import Field, model_validator
 
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
+from datahub.configuration import ConfigModel
 from datahub.configuration.env_vars import (
     get_report_info_sample_size,
     get_sql_agg_query_log,
@@ -36,6 +52,11 @@ from datahub.metadata.urns import (
     Urn,
 )
 from datahub.sql_parsing.fingerprint_utils import generate_hash
+from datahub.sql_parsing.parallel_sql_parser import (
+    ParallelParserUnavailable,
+    ParallelSqlParser,
+    ParseTask,
+)
 from datahub.sql_parsing.schema_resolver import (
     SchemaResolver,
     SchemaResolverInterface,
@@ -74,6 +95,7 @@ from datahub.utilities.file_backed_collections import (
 from datahub.utilities.groupby import groupby_unsorted
 from datahub.utilities.lossy_collections import LossyDict, LossyList
 from datahub.utilities.ordered_set import OrderedSet
+from datahub.utilities.partition_executor import PartitionExecutor
 from datahub.utilities.perf_timer import PerfTimer
 
 logger = logging.getLogger(__name__)
@@ -94,6 +116,45 @@ _DEFAULT_QUERY_LOG_SETTING = QueryLogSetting[
 ]
 MAX_UPSTREAM_TABLES_COUNT = 300
 MAX_FINEGRAINEDLINEAGE_COUNT = 2000
+
+
+class SqlParsingParallelismConfig(ConfigModel):
+    """Mixin that adds parallel SQL-parsing fields to any connector config.
+
+    Inherit from (or embed in) a connector's config class to expose these two
+    fields to users.  Pass them straight through to ``SqlParsingAggregator``.
+    """
+
+    use_parallel_sql_parsing: bool = Field(
+        default=False,
+        description=(
+            "Parse SQL queries across multiple processes to speed up lineage/usage "
+            "extraction. Off by default. When enabled, sql_parsing_workers MUST be "
+            "set explicitly — auto-detection is not available."
+        ),
+    )
+    sql_parsing_workers: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=512,
+        description=(
+            "Number of worker processes for parallel SQL parsing. "
+            "Required when use_parallel_sql_parsing is enabled; "
+            "ignored (and may be None) when parallel parsing is disabled. "
+            "Capped at 512 to prevent accidental process-pool oversubscription."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _require_workers_when_parallel_enabled(self) -> "SqlParsingParallelismConfig":
+        if self.use_parallel_sql_parsing and self.sql_parsing_workers is None:
+            raise ValueError(
+                "sql_parsing_workers must be set (>=1) when use_parallel_sql_parsing "
+                "is enabled. Auto-detection via os.cpu_count() is unsafe on "
+                "virtualized/containerized hosts where the reported CPU count reflects "
+                "the underlying node rather than the cgroup limit."
+            )
+        return self
 
 
 @dataclasses.dataclass
@@ -302,6 +363,11 @@ class SqlAggregatorReport(Report):
     # Observed queries.
     num_observed_queries: int = 0
     num_observed_queries_failed: int = 0
+    # Observed queries whose parallel dispatch OR inline recovery hit an
+    # infra/executor failure (a dead pool, a raised inline reparse), NOT a parse
+    # failure. Kept separate so infra degradation is visible to an operator and
+    # does not inflate the parse-failure bucket.
+    num_observed_queries_infra_failed: int = 0
     num_observed_queries_column_timeout: int = 0
     num_observed_queries_column_failed: int = 0
     observed_query_parse_failures: LossyList[str] = dataclasses.field(
@@ -330,7 +396,29 @@ class SqlAggregatorReport(Report):
     sql_formatting_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
     sql_parsing_cache_stats: Optional[dict] = dataclasses.field(default=None)
     parse_statement_cache_stats: Optional[dict] = dataclasses.field(default=None)
+    # Main-process only: on the parallel path formatting runs in workers, so
+    # this cache reflects near-zero hits when parallel parsing is active.
     format_query_cache_stats: Optional[dict] = dataclasses.field(default=None)
+
+    # Preparsed queries.
+    num_preparsed_queries_failed: int = 0
+    preparsed_query_parse_failures: LossyList[str] = dataclasses.field(
+        default_factory=LossyList
+    )
+
+    # Parallel SQL parsing (multiprocessing). Off unless use_parallel_sql_parsing.
+    sql_parsing_parallel_enabled: bool = False
+    sql_parsing_parallelism: Optional[int] = None
+    sql_parsing_fell_back_to_serial: bool = False
+    sql_parsing_fell_back_to_serial_reason: Optional[str] = None
+    num_queries_parsed_in_parallel: int = 0
+    sql_parsing_pool_broke: bool = False
+    # Wall-clock seconds workers spent in sqlglot_lineage, summed across all
+    # worker parses. On the parallel path the main-process sql_parsing_timer only
+    # captures inline temp parsing, so it under-reports; this makes the
+    # off-main-thread parse cost visible. (Wall-time summed over parallel workers
+    # can exceed elapsed real time — it is a throughput/cost metric, not latency.)
+    parallel_sql_parsing_time_seconds: float = 0.0
 
     # Other lineage loading metrics.
     num_known_query_lineage: int = 0
@@ -418,10 +506,13 @@ class SqlParsingAggregator(Closeable):
         is_allowed_table: Optional[Callable[[str], bool]] = None,
         format_queries: bool = True,
         query_log: QueryLogSetting = _DEFAULT_QUERY_LOG_SETTING,
+        use_parallel_sql_parsing: bool = False,
+        sql_parsing_workers: Optional[int] = None,
     ) -> None:
         self.platform = DataPlatformUrn(platform)
         self.platform_instance = platform_instance
         self.env = env
+        self._graph = graph
 
         self.generate_lineage = generate_lineage
         self.generate_queries = generate_queries
@@ -601,11 +692,130 @@ class SqlParsingAggregator(Closeable):
         self._tool_meta_extractor = ToolMetaExtractor.create(graph)
         self.report.tool_meta_report = self._tool_meta_extractor.report
 
+        # Parallel SQL parsing. The process pool and thread-based partition
+        # executor are NOT built here — they are created lazily on entering
+        # parallel_sql_parsing_scope(). When disabled, everything runs inline
+        # exactly as before.
+        self._use_parallel_sql_parsing = use_parallel_sql_parsing
+        self._workers: Optional[int] = None
+        if use_parallel_sql_parsing:
+            # Config validation guarantees sql_parsing_workers is set whenever
+            # parallel parsing is enabled (see SqlParsingParallelismConfig).
+            assert sql_parsing_workers is not None
+            self._workers = sql_parsing_workers
+            logger.info(
+                "Parallel SQL parsing requested with %d worker(s).", self._workers
+            )
+        self._parallel_parser: Optional[ParallelSqlParser] = None
+        self._partition_executor: Optional[PartitionExecutor] = None
+        self._parallel_active: bool = False
+        # Serializes the cheap classify/apply steps that mutate shared aggregator
+        # state (temp maps, query map, lineage map) while cross-session parse work
+        # runs concurrently on worker processes.
+        self._apply_lock = threading.Lock()
+
+    def _maybe_apply_lock(self) -> ContextManager[object]:
+        """Return the apply-lock when parallel parsing is active, else a no-op.
+
+        On the parallel path every side effect on shared aggregator state
+        (report counters, the query log, shared ``PerfTimer``s) must be
+        serialized because tasks run on concurrent PartitionExecutor threads.
+        On the serial path there is only one thread, so acquiring a lock would
+        be pure overhead and could subtly change behavior — return a
+        ``nullcontext`` so the serial path is byte-for-byte unchanged.
+        """
+        if self._parallel_active:
+            return self._apply_lock
+        return contextlib.nullcontext()
+
+    @contextlib.contextmanager
+    def parallel_sql_parsing_scope(self) -> Iterator[None]:
+        """Explicit query-processing boundary for parallel SQL parsing.
+
+        Connectors wrap their query loop in ``with aggregator.parallel_sql_parsing_scope():``.
+        Schema extraction must happen BEFORE entering so the snapshot handed to the
+        workers is complete; anything still missing is graph-hydrated in-worker.
+
+        When the feature is off this is a no-op and every query runs inline exactly
+        as it does today.
+        """
+        workers = self._workers
+        if not self._use_parallel_sql_parsing or workers is None:
+            yield
+            return
+
+        with tempfile.TemporaryDirectory() as _tmp_dir:
+            snapshot_path = pathlib.Path(_tmp_dir) / "schema_snapshot.db"
+            self._schema_resolver.snapshot_to(snapshot_path)
+
+            try:
+                self._parallel_parser = ParallelSqlParser(
+                    num_workers=workers,
+                    snapshot_path=snapshot_path,
+                    platform=self.platform.platform_name,
+                    platform_instance=self.platform_instance,
+                    env=self.env,
+                    graph_config=(self._graph.config if self._graph else None),
+                    format_queries=self.format_queries,
+                )
+            except ParallelParserUnavailable as e:
+                logger.warning(
+                    "Parallel SQL parser unavailable (%s); running scope serially.", e
+                )
+                self._populate_parallel_report(workers=None, active=False)
+                self.report.sql_parsing_fell_back_to_serial_reason = str(e)
+                yield
+                return
+
+            # A few tasks per worker in flight bounds memory while keeping workers busy.
+            self._partition_executor = PartitionExecutor(
+                max_workers=workers,
+                max_pending=4 * workers,
+            )
+            self._parallel_active = True
+            self._populate_parallel_report(workers=workers, active=True)
+
+            try:
+                yield
+            finally:
+                self._teardown_parallel()
+
+    def _populate_parallel_report(
+        self, *, workers: Optional[int], active: bool
+    ) -> None:
+        self.report.sql_parsing_parallel_enabled = active
+        self.report.sql_parsing_parallelism = workers if active else None
+        self.report.sql_parsing_fell_back_to_serial = (
+            not active and self._use_parallel_sql_parsing
+        )
+
     def close(self) -> None:
+        # Defensively tear down the parallel machinery in case a connector never
+        # exited the scope (or bypassed it). Never leak worker processes.
+        self._teardown_parallel()
+
         # Compute stats once before closing connections
         self.report.compute_stats()
         self._closed = True
         self._exit_stack.close()
+
+    def _teardown_parallel(self) -> None:
+        if self._partition_executor is not None:
+            try:
+                self._partition_executor.flush()
+                self._partition_executor.close()
+            finally:
+                self._partition_executor = None
+        if self._parallel_parser is not None:
+            if self._parallel_parser.pool_broke.is_set():
+                self.report.sql_parsing_pool_broke = True
+                logger.warning(
+                    "Parallel SQL parser worker pool died; some queries "
+                    "may have been skipped."
+                )
+            self._parallel_parser.close()
+            self._parallel_parser = None
+        self._parallel_active = False
 
     @property
     def _need_schemas(self) -> bool:
@@ -693,14 +903,39 @@ class SqlParsingAggregator(Closeable):
         """
         This assumes that queries come in order of increasing timestamps.
         """
+        if isinstance(item, (ObservedQuery, PreparsedQuery)):
+            # These flow through the per-session partition executor when parallel
+            # parsing is active; the routing lives in their own add_* methods.
+            if isinstance(item, PreparsedQuery):
+                self.add_preparsed_query(item)
+            else:
+                self.add_observed_query(item)
+            return
+
+        # Rarer items (renames, swaps, known lineage) mutate shared state and are
+        # infrequent in the query loop. To keep them correct relative to the
+        # in-flight parallel applies, drain all pending work first, then process
+        # inline under the apply lock so nothing races with them.
+        if self._parallel_active and self._partition_executor is not None:
+            self._partition_executor.flush()
+            with self._apply_lock:
+                self._add_rare_item(item)
+        else:
+            self._add_rare_item(item)
+
+    def _add_rare_item(
+        self,
+        item: Union[
+            KnownQueryLineageInfo,
+            KnownLineageMapping,
+            TableRename,
+            TableSwap,
+        ],
+    ) -> None:
         if isinstance(item, KnownQueryLineageInfo):
             self.add_known_query_lineage(item)
         elif isinstance(item, KnownLineageMapping):
             self.add_known_lineage_mapping(item.upstream_urn, item.downstream_urn)
-        elif isinstance(item, PreparsedQuery):
-            self.add_preparsed_query(item)
-        elif isinstance(item, ObservedQuery):
-            self.add_observed_query(item)
         elif isinstance(item, TableRename):
             self.add_table_rename(item)
         elif isinstance(item, TableSwap):
@@ -877,6 +1112,22 @@ class SqlParsingAggregator(Closeable):
         """
         self.report.num_observed_queries += 1
 
+        if self._parallel_active and self._partition_executor is not None:
+            # Route to the per-session partition executor. The task itself does
+            # classify -> parse -> apply on a worker thread. The PE guarantees at
+            # most one task per session runs at a time and submits the next
+            # same-session task only after this one's future completes, so a temp
+            # producer is always applied before its consumer is classified.
+            session_id = observed.session_id or _MISSING_SESSION_ID
+            self._partition_executor.submit(
+                session_id,
+                self._process_observed_task,
+                observed,
+                is_known_temp_table,
+                require_out_table_schema,
+            )
+            return
+
         # All queries with no session ID are assumed to be part of the same session.
         session_id = observed.session_id or _MISSING_SESSION_ID
 
@@ -910,6 +1161,25 @@ class SqlParsingAggregator(Closeable):
             if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
                 self.report.num_observed_queries_column_timeout += 1
 
+        self._apply_observed_parse_result(
+            observed,
+            session_id,
+            session_has_temp_tables,
+            parsed,
+            is_known_temp_table,
+            require_out_table_schema,
+        )
+
+    def _apply_observed_parse_result(
+        self,
+        observed: ObservedQuery,
+        session_id: str,
+        session_has_temp_tables: bool,
+        parsed: SqlParsingResult,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+        preformatted_query: Optional[str] = None,
+    ) -> None:
         query_fingerprint = observed.query_hash or parsed.query_fingerprint
 
         # Register the first output table (standard single-query behavior).
@@ -940,7 +1210,265 @@ class SqlParsingAggregator(Closeable):
             require_out_table_schema=require_out_table_schema,
             session_has_temp_tables=session_has_temp_tables,
             _is_internal=True,
+            preformatted_query=preformatted_query,
         )
+
+    def _pool_is_broken(self) -> bool:
+        """True once the worker pool has died (or failed to initialize). Sticky:
+        the underlying ``threading.Event`` is never cleared for the life of the
+        parser, so once observed here every subsequent observed query is routed
+        through the inline serial path instead of a dead pool."""
+        return (
+            self._parallel_parser is not None
+            and self._parallel_parser.pool_broke.is_set()
+        )
+
+    def _reparse_observed_inline(
+        self,
+        observed: ObservedQuery,
+        session_id: str,
+        session_has_temp: bool,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+        schema_resolver: SchemaResolverInterface,
+    ) -> None:
+        """Parse *observed* on the main process (this PartitionExecutor thread)
+        and apply it — the same code the serial path runs. Used for temp-session
+        queries (whose in-memory schemas can't cross the process boundary) and,
+        critically, to recover a query whose worker parse hit an infra failure so
+        it is never silently dropped.
+
+        ``_run_sql_parser`` acquires ``_maybe_apply_lock`` internally, so it MUST
+        be called WITHOUT holding ``_apply_lock`` (mirroring the serial-path temp
+        branch) to avoid a self-deadlock; the parse-quality accounting and apply
+        below re-take the lock.
+        """
+        parsed = self._run_sql_parser(
+            observed.query,
+            default_db=observed.default_db,
+            default_schema=observed.default_schema,
+            schema_resolver=schema_resolver,
+            session_id=session_id,
+            timestamp=observed.timestamp,
+            user=observed.user,
+            override_dialect=observed.override_dialect,
+        )
+        with self._apply_lock:
+            if parsed.debug_info.error:
+                self.report.observed_query_parse_failures.append(
+                    f"{parsed.debug_info.error} on query: {observed.query[:100]}"
+                )
+            if parsed.debug_info.table_error:
+                self.report.num_observed_queries_failed += 1
+                return
+            elif parsed.debug_info.column_error:
+                self.report.num_observed_queries_column_failed += 1
+                if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
+                    self.report.num_observed_queries_column_timeout += 1
+
+            self._apply_observed_parse_result(
+                observed,
+                session_id,
+                session_has_temp,
+                parsed,
+                is_known_temp_table,
+                require_out_table_schema,
+                preformatted_query=None,
+            )
+
+    def _process_observed_task(
+        self,
+        observed: ObservedQuery,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+    ) -> None:
+        """Runs on a PartitionExecutor thread: classify -> parse -> apply.
+
+        Failures are recorded to the report exactly as the serial path would; we
+        never let an exception vanish into the (unused) future.
+        """
+        session_id = observed.session_id or _MISSING_SESSION_ID
+        # On the parallel path the worker pre-formats the query; the inline
+        # temp-table branch below does not, so it stays None and the main thread
+        # formats as on the serial path.
+        preformatted_query: Optional[str] = None
+
+        def _reparse_inline_or_record_infra() -> None:
+            # Inline recovery is our last line of defense against dropping a
+            # query. If it ITSELF raises, that is an infra failure (e.g. the pool
+            # degraded further), NOT a parse failure — record it under the infra
+            # bucket and warn (an operator needs to see pool degradation) rather
+            # than silently inflating num_observed_queries_failed via the outer
+            # except.
+            try:
+                self._reparse_observed_inline(
+                    observed,
+                    session_id,
+                    session_has_temp,
+                    is_known_temp_table,
+                    require_out_table_schema,
+                    schema_resolver,
+                )
+            except Exception as inline_exc:
+                with self._apply_lock:
+                    self.report.num_observed_queries_infra_failed += 1
+                    self.report.observed_query_parse_failures.append(
+                        f"inline reparse infra failure: {inline_exc!r} on query: "
+                        f"{observed.query[:100]}"
+                    )
+                logger.warning(
+                    "Inline reparse of observed query failed (infra)",
+                    exc_info=inline_exc,
+                )
+
+        try:
+            # Reading the session temp state touches shared maps, so hold the lock.
+            with self._apply_lock:
+                with self.report.make_schema_resolver_timer:
+                    schema_resolver: SchemaResolverInterface = (
+                        self._make_schema_resolver_for_session(session_id)
+                    )
+                    session_has_temp = schema_resolver.includes_temp_tables()
+
+            # Route to the inline serial parser when (a) the session carries
+            # in-memory temp schemas that can't be shipped to a worker, or (b) the
+            # pool is already known to be broken — no point dispatching to a dead
+            # pool, and it preserves the no-loss guarantee.
+            if session_has_temp or self._pool_is_broken():
+                _reparse_inline_or_record_infra()
+                return
+
+            assert self._parallel_parser is not None
+            outcome = self._parallel_parser.parse_one(
+                ParseTask(
+                    key=None,
+                    query=observed.query,
+                    default_db=observed.default_db,
+                    default_schema=observed.default_schema,
+                    override_dialect=(
+                        str(observed.override_dialect)
+                        if observed.override_dialect is not None
+                        else None
+                    ),
+                )
+            )
+            if outcome.error is not None:
+                # Infra failure: the worker process died / the pool broke, so the
+                # query was NOT actually parsed. Do NOT count it as a parse
+                # failure (that would inflate num_observed_queries_failed and
+                # silently drop lineage). Reparse it inline on the main process so
+                # no query is lost, and pool_broke (set by parse_one) makes every
+                # subsequent query take the inline branch above.
+                _reparse_inline_or_record_infra()
+                return
+            if outcome.failed:
+                # Not an infra error (error is None) but no result — the worker
+                # ran and genuinely produced nothing. This matches a serial parse
+                # failure: count + skip.
+                with self._apply_lock:
+                    self.report.num_observed_queries_failed += 1
+                    self.report.observed_query_parse_failures.append(
+                        f"empty parse outcome on query: {observed.query[:100]}"
+                    )
+                return
+            # outcome.failed is False here, so result is guaranteed non-None;
+            # assert narrows the Optional for the type checker.
+            assert outcome.result is not None
+            parsed = outcome.result
+            preformatted_query = outcome.formatted_query
+            # _account_parsed_query takes the apply-lock internally.
+            self._account_parsed_query(
+                observed.query,
+                default_db=observed.default_db,
+                default_schema=observed.default_schema,
+                session_id=session_id,
+                timestamp=observed.timestamp,
+                user=observed.user,
+                parsed=parsed,
+            )
+            with self._apply_lock:
+                self.report.num_queries_parsed_in_parallel += 1
+                # Surface the off-main-thread parse cost that sql_parsing_timer
+                # cannot see (it only wraps inline parsing on this path).
+                self.report.parallel_sql_parsing_time_seconds += outcome.parse_seconds
+
+            # Recording parse-quality counters mutates shared report state
+            # (counters + LossyList) from a worker thread, so serialize it.
+            with self._apply_lock:
+                if parsed.debug_info.error:
+                    self.report.observed_query_parse_failures.append(
+                        f"{parsed.debug_info.error} on query: {observed.query[:100]}"
+                    )
+                if parsed.debug_info.table_error:
+                    self.report.num_observed_queries_failed += 1
+                    return
+                elif parsed.debug_info.column_error:
+                    self.report.num_observed_queries_column_failed += 1
+                    if isinstance(
+                        parsed.debug_info.column_error, CooperativeTimeoutError
+                    ):
+                        self.report.num_observed_queries_column_timeout += 1
+
+            with self._apply_lock:
+                self._apply_observed_parse_result(
+                    observed,
+                    session_id,
+                    session_has_temp,
+                    parsed,
+                    is_known_temp_table,
+                    require_out_table_schema,
+                    preformatted_query=preformatted_query,
+                )
+        except Exception as e:
+            # Serialize the failure bookkeeping — this runs on a worker thread and
+            # mutates shared report state (counter + LossyList).
+            with self._apply_lock:
+                self.report.num_observed_queries_failed += 1
+                self.report.observed_query_parse_failures.append(
+                    f"{e!r} on query: {observed.query[:100]}"
+                )
+            logger.debug("Parallel observed-query task failed", exc_info=e)
+
+    def _account_parsed_query(
+        self,
+        query: str,
+        *,
+        default_db: Optional[str],
+        default_schema: Optional[str],
+        session_id: str,
+        timestamp: Optional[datetime],
+        user: Optional[Union[CorpUserUrn, CorpGroupUrn]],
+        parsed: SqlParsingResult,
+    ) -> None:
+        """Update the same report counters / query log that ``_run_sql_parser``
+        would, for a result produced by a worker process (which cannot mutate the
+        parent's report or query log). Keeps parallel and serial book-keeping
+        identical.
+
+        Runs on a PartitionExecutor thread on the parallel path, so both the
+        ``num_sql_parsed`` increment and the ``_logged_queries.append`` (neither
+        of which is thread-safe: the increment is a non-atomic read-modify-write
+        and ``FileBackedList.append`` mutates a shared length/cache and may write
+        to SQLite) are serialized under the apply-lock."""
+        with self._maybe_apply_lock():
+            self.report.num_sql_parsed += 1
+
+            if self.query_log == QueryLogSetting.STORE_ALL or (
+                self.query_log == QueryLogSetting.STORE_FAILED
+                and parsed.debug_info.error
+            ):
+                self._logged_queries.append(
+                    LoggedQuery(
+                        query=query,
+                        session_id=(
+                            session_id if session_id != _MISSING_SESSION_ID else None
+                        ),
+                        timestamp=timestamp,
+                        user=user.urn() if user else None,
+                        default_db=default_db,
+                        default_schema=default_schema,
+                    )
+                )
 
     def add_preparsed_query(
         self,
@@ -949,6 +1477,79 @@ class SqlParsingAggregator(Closeable):
         require_out_table_schema: bool = False,
         session_has_temp_tables: bool = True,
         _is_internal: bool = False,
+        _skip_parallel_routing: bool = False,
+        preformatted_query: Optional[str] = None,
+    ) -> None:
+        # preformatted_query is only valid on the internal observed-query apply
+        # path (_apply_observed_parse_result sets _is_internal=True). An external
+        # caller passing it has no effect on the serial path and its value would
+        # be silently dropped on the parallel-routing branch, so reject it eagerly.
+        if preformatted_query is not None and not _is_internal:
+            raise ValueError(
+                "preformatted_query is only valid on internal observed-query apply "
+                "(_is_internal=True). External callers must not pass it."
+            )
+        # When parallel parsing is active, an externally-added PreparsedQuery is
+        # routed through the partition executor keyed by session, so it stays
+        # FIFO-ordered relative to the observed queries in the same session. The
+        # internal call from _apply_observed_parse_result sets _is_internal (it
+        # already runs under the apply-lock inside a task), so it is never
+        # re-routed. Rare-item internal calls set _skip_parallel_routing.
+        if (
+            self._parallel_active
+            and self._partition_executor is not None
+            and not _is_internal
+            and not _skip_parallel_routing
+        ):
+            self._partition_executor.submit(
+                parsed.session_id or _MISSING_SESSION_ID,
+                self._process_preparsed_task,
+                parsed,
+                is_known_temp_table,
+                require_out_table_schema,
+            )
+            return
+
+        self._add_preparsed_query_impl(
+            parsed,
+            is_known_temp_table=is_known_temp_table,
+            require_out_table_schema=require_out_table_schema,
+            session_has_temp_tables=session_has_temp_tables,
+            _is_internal=_is_internal,
+            preformatted_query=preformatted_query,
+        )
+
+    def _process_preparsed_task(
+        self,
+        parsed: PreparsedQuery,
+        is_known_temp_table: bool,
+        require_out_table_schema: bool,
+    ) -> None:
+        try:
+            with self._apply_lock:
+                self._add_preparsed_query_impl(
+                    parsed,
+                    is_known_temp_table=is_known_temp_table,
+                    require_out_table_schema=require_out_table_schema,
+                    session_has_temp_tables=True,
+                    _is_internal=False,
+                )
+        except Exception as e:
+            with self._apply_lock:
+                self.report.num_preparsed_queries_failed += 1
+                self.report.preparsed_query_parse_failures.append(
+                    f"{e!r} on query: {parsed.query_text[:100]}"
+                )
+            logger.debug("Parallel preparsed-query task failed", exc_info=e)
+
+    def _add_preparsed_query_impl(
+        self,
+        parsed: PreparsedQuery,
+        is_known_temp_table: bool = False,
+        require_out_table_schema: bool = False,
+        session_has_temp_tables: bool = True,
+        _is_internal: bool = False,
+        preformatted_query: Optional[str] = None,
     ) -> None:
         # Adding tool specific metadata extraction here allows it
         # to work for both ObservedQuery and PreparsedQuery as
@@ -970,8 +1571,15 @@ class SqlParsingAggregator(Closeable):
                 platform=self.platform.platform_name,
             )
 
-        # Format the query.
-        formatted_query = self._maybe_format_query(parsed.query_text)
+        # Format the query. On the parallel path the worker already computed the
+        # formatted query (byte-identical to _maybe_format_query, using the same
+        # try_format_query helper), so reuse it and skip re-formatting on the main
+        # thread. When it is None (serial path, preparsed fast-path, views), format
+        # here as before.
+        if preformatted_query is not None:
+            formatted_query = preformatted_query
+        else:
+            formatted_query = self._maybe_format_query(parsed.query_text)
 
         # Register the query's usage.
         if not self._usage_aggregator:
@@ -1098,7 +1706,8 @@ class SqlParsingAggregator(Closeable):
                 ),
                 session_id=table_rename.session_id,
                 timestamp=table_rename.timestamp,
-            )
+            ),
+            _skip_parallel_routing=True,
         )
 
     def add_table_swap(self, table_swap: TableSwap) -> None:
@@ -1137,7 +1746,8 @@ class SqlParsingAggregator(Closeable):
                     ),
                     session_id=table_swap.session_id,
                     timestamp=table_swap.timestamp,
-                )
+                ),
+                _skip_parallel_routing=True,
             )
 
         if not self.is_temp_table(table_swap.urn1):
@@ -1153,7 +1763,8 @@ class SqlParsingAggregator(Closeable):
                     ),
                     session_id=table_swap.session_id,
                     timestamp=table_swap.timestamp,
-                )
+                ),
+                _skip_parallel_routing=True,
             )
 
     def _make_schema_resolver_for_session(
@@ -1242,29 +1853,40 @@ class SqlParsingAggregator(Closeable):
         user: Optional[Union[CorpUserUrn, CorpGroupUrn]] = None,
         override_dialect: Optional[DialectOrStr] = None,
     ) -> SqlParsingResult:
-        with self.report.sql_parsing_timer:
-            parsed = sqlglot_lineage(
-                query,
-                schema_resolver=schema_resolver,
-                default_db=default_db,
-                default_schema=default_schema,
-                override_dialect=override_dialect,
-            )
-        self.report.num_sql_parsed += 1
+        # On the parallel path this runs on a PartitionExecutor thread (the
+        # temp-session inline-parse case). The shared ``sql_parsing_timer`` is a
+        # non-reentrant ``PerfTimer`` and ``_logged_queries.append`` /
+        # ``num_sql_parsed`` are not thread-safe, so serialize the whole body
+        # under the apply-lock. Temp sessions are the minority and are inherently
+        # serial per session, so this adds no meaningful contention. On the serial
+        # path ``_maybe_apply_lock`` is a nullcontext, leaving behavior unchanged.
+        with self._maybe_apply_lock():
+            with self.report.sql_parsing_timer:
+                parsed = sqlglot_lineage(
+                    query,
+                    schema_resolver=schema_resolver,
+                    default_db=default_db,
+                    default_schema=default_schema,
+                    override_dialect=override_dialect,
+                )
+            self.report.num_sql_parsed += 1
 
-        # Conditionally log the query.
-        if self.query_log == QueryLogSetting.STORE_ALL or (
-            self.query_log == QueryLogSetting.STORE_FAILED and parsed.debug_info.error
-        ):
-            query_log_entry = LoggedQuery(
-                query=query,
-                session_id=session_id if session_id != _MISSING_SESSION_ID else None,
-                timestamp=timestamp,
-                user=user.urn() if user else None,
-                default_db=default_db,
-                default_schema=default_schema,
-            )
-            self._logged_queries.append(query_log_entry)
+            # Conditionally log the query.
+            if self.query_log == QueryLogSetting.STORE_ALL or (
+                self.query_log == QueryLogSetting.STORE_FAILED
+                and parsed.debug_info.error
+            ):
+                query_log_entry = LoggedQuery(
+                    query=query,
+                    session_id=(
+                        session_id if session_id != _MISSING_SESSION_ID else None
+                    ),
+                    timestamp=timestamp,
+                    user=user.urn() if user else None,
+                    default_db=default_db,
+                    default_schema=default_schema,
+                )
+                self._logged_queries.append(query_log_entry)
 
         # Also add some extra logging.
         if parsed.debug_info.error:
@@ -1276,6 +1898,25 @@ class SqlParsingAggregator(Closeable):
 
         return parsed
 
+    @staticmethod
+    def _merge_sort_key(query: QueryMetadata) -> Tuple[str, str, str]:
+        """Stable, arrival-order-independent, TOTAL tie-break key for merging two
+        QueryMetadata records with equal (or both-None) timestamps.
+
+        The key is a tuple compared lexicographically:
+        (formatted query string or query id, session id, actor). The extra
+        session/actor components make the ordering total: two cross-session
+        records with equal timestamp AND identical formatted text would produce
+        equal single-string keys, leaving actor/session selection to fall back to
+        arrival order. Extending the key guarantees a stable winner regardless of
+        which record arrived first.
+        """
+        return (
+            query.formatted_query_string or query.query_id,
+            query.session_id or "",
+            str(query.actor) if query.actor is not None else "",
+        )
+
     def _add_to_query_map(
         self, new: QueryMetadata, merge_lineage: bool = False
     ) -> None:
@@ -1284,11 +1925,57 @@ class SqlParsingAggregator(Closeable):
         if query_fingerprint in self._query_map:
             current = self._query_map.for_mutation(query_fingerprint)
 
-            # This assumes that queries come in order of increasing timestamps,
-            # so the current query is more authoritative than the previous one.
-            current.formatted_query_string = new.formatted_query_string
-            current.latest_timestamp = new.latest_timestamp or current.latest_timestamp
-            current.actor = new.actor or current.actor
+            # Compute a single deterministic winner so every representative field
+            # (formatted_query_string, query_type, actor, session_id, ...) comes
+            # from the same record regardless of merge order. This is required for
+            # serial-vs-parallel
+            # equivalence: in the parallel path sessions may be applied out of
+            # global-timestamp order, so a plain last-writer-wins overwrite would make
+            # the stored text/actor non-deterministic run-to-run.
+            #
+            # The winner is the record with the later timestamp. When timestamps are
+            # equal (or both None) we fall back to a stable, arrival-order-independent
+            # tie-break: the record whose sort key (formatted query string, then
+            # session id, then actor) compares lexicographically greater.
+            #
+            # Compare NORMALIZED epoch-millis, never the raw datetimes:
+            # latest_timestamp is documented to accept both naive and UTC-aware
+            # datetimes, and Python raises TypeError when > compares a naive with
+            # an aware datetime (this can happen even on the serial path for a
+            # duplicate fingerprint with mixed timestamp forms). make_ts_millis
+            # normalizes both to ints, exactly as the lineage sort already does.
+            new_ms = make_ts_millis(new.latest_timestamp)
+            cur_ms = make_ts_millis(current.latest_timestamp)
+            _new_ts_wins = new_ms is not None and (cur_ms is None or new_ms > cur_ms)
+            _timestamps_tied = new_ms == cur_ms  # includes the both-None case
+            new_wins = _new_ts_wins or (
+                _timestamps_tied
+                and self._merge_sort_key(new) > self._merge_sort_key(current)
+            )
+            winner, loser = (new, current) if new_wins else (current, new)
+
+            # Representative fields all come from the winner. Actor and session_id
+            # additionally coalesce so a winner with a None value never drops a
+            # known value from the loser (this restores the original
+            # ``new.actor or current.actor`` behaviour and fixes the serial-path
+            # regression where a trailing actor-less duplicate wiped the actor).
+            current.formatted_query_string = winner.formatted_query_string
+            current.query_type = winner.query_type
+            current.actor = winner.actor or loser.actor
+
+            # Keep the timestamp of the later instant so merge order does not
+            # matter. Selection is driven by the NORMALIZED millis (mixed
+            # naive/aware datetimes are safe to order this way), but we STORE the
+            # actual winning datetime object, not the millis. In serial mode
+            # timestamps arrive in ascending order, so this is equivalent to the
+            # previous last-writer-wins behaviour; in the parallel path sessions
+            # may be applied out of global-timestamp order, making this necessary
+            # for serial-vs-parallel equivalence.
+            if new_ms is None:
+                pass  # keep current
+            elif cur_ms is None or new_ms > cur_ms:
+                current.latest_timestamp = new.latest_timestamp
+            # else: current already holds the later (or equal) instant — keep it.
 
             if current.used_temp_tables and not new.used_temp_tables:
                 # If we see the same query again, but in a different session,
@@ -1296,20 +1983,25 @@ class SqlParsingAggregator(Closeable):
                 # but did in the older one. If that happens, we treat the older session's
                 # lineage as more authoritative. This isn't technically correct, but it's
                 # better than using the newer session's lineage, which is likely incorrect.
+                # Preserve the older (current) session_id here: don't let the
+                # non-authoritative newer session override which lineage wins.
                 self.report.queries_with_non_authoritative_session.append(
                     query_fingerprint
                 )
                 return
-            current.session_id = new.session_id
+
+            current.session_id = winner.session_id or loser.session_id
 
             if not merge_lineage:
                 # An invariant of the fingerprinting is that if two queries have the
-                # same fingerprint, they must also have the same lineage. We overwrite
-                # here just in case more schemas got registered in the interim.
-                current.upstreams = new.upstreams
-                current.column_lineage = new.column_lineage
-                current.column_usage = new.column_usage
-                current.confidence_score = new.confidence_score
+                # same fingerprint, they must also have the same lineage, so taking
+                # upstreams/column_lineage/column_usage from the winner is
+                # content-identical to the previous overwrite but keeps every
+                # representative field tied to the same deterministic winner.
+                current.upstreams = winner.upstreams
+                current.column_lineage = winner.column_lineage
+                current.column_usage = winner.column_usage
+                current.confidence_score = winner.confidence_score
             else:
                 # In the case of known query lineage, we might get things one at a time.
                 # TODO: We don't yet support merging CLL for a single query.
@@ -1323,6 +2015,11 @@ class SqlParsingAggregator(Closeable):
             self._query_map[query_fingerprint] = new
 
     def gen_metadata(self) -> Iterable[MetadataChangeProposalWrapper]:
+        # A connector may have forgotten to exit the parallel scope. Defensively
+        # drain and tear down so all queued applies land before we generate.
+        if self._parallel_active or self._partition_executor is not None:
+            self._teardown_parallel()
+
         queries_generated: Set[QueryId] = set()
 
         yield from self._gen_lineage_mcps(queries_generated)

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -111,6 +111,9 @@ class QueryLogSetting(enum.Enum):
 
 _DEFAULT_USER_URN = CorpUserUrn("_ingestion")
 _MISSING_SESSION_ID = "__MISSING_SESSION_ID"
+# Sort value for a record with no timestamp: below every real epoch-millis so a
+# timestamped record always outranks an undated one in the merge reduction.
+_MIN_MERGE_TS = -(2**63)
 _DEFAULT_QUERY_LOG_SETTING = QueryLogSetting[
     get_sql_agg_query_log() or QueryLogSetting.DISABLED.name
 ]
@@ -628,6 +631,16 @@ class SqlParsingAggregator(Closeable):
         )
         self._exit_stack.push(self._query_map)
 
+        # Tracks the merge-rank of the record that supplied the stored actor for a
+        # fingerprint, but ONLY for the rare case where that actor came from a record
+        # OTHER than the representative (timestamp) winner (i.e. the winner had
+        # actor=None and an earlier duplicate carried a known actor). In the common
+        # case the actor is the representative's own, recomputable from the stored
+        # record, so nothing is kept here. This lets actor selection stay associative
+        # (see _add_to_query_map) without keeping per-fingerprint state for every
+        # query. In-memory only; keyed by the small set of divergent fingerprints.
+        self._actor_source_rank: Dict[QueryId, Tuple[int, str, str]] = {}
+
         # Map of downstream urn -> { query ids }
         self._lineage_map = FileBackedDict[OrderedSet[QueryId]](
             shared_connection=self._shared_connection, tablename="lineage_map"
@@ -802,16 +815,21 @@ class SqlParsingAggregator(Closeable):
     def _teardown_parallel(self) -> None:
         if self._partition_executor is not None:
             try:
-                self._partition_executor.flush()
+                # close() -> shutdown() -> flush(), so this drains all queued
+                # applies before returning; no separate flush() needed.
                 self._partition_executor.close()
             finally:
                 self._partition_executor = None
         if self._parallel_parser is not None:
             if self._parallel_parser.pool_broke.is_set():
                 self.report.sql_parsing_pool_broke = True
+                # The pool died mid-run, so every query after the break was
+                # reparsed inline on the main process — i.e. the run effectively
+                # fell back to serial. Record that alongside the pool_broke flag.
+                self.report.sql_parsing_fell_back_to_serial = True
                 logger.warning(
-                    "Parallel SQL parser worker pool died; some queries "
-                    "may have been skipped."
+                    "Parallel SQL parser worker pool died; remaining queries "
+                    "were reparsed serially on the main process."
                 )
             self._parallel_parser.close()
             self._parallel_parser = None
@@ -1149,17 +1167,8 @@ class SqlParsingAggregator(Closeable):
             user=observed.user,
             override_dialect=observed.override_dialect,
         )
-        if parsed.debug_info.error:
-            self.report.observed_query_parse_failures.append(
-                f"{parsed.debug_info.error} on query: {observed.query[:100]}"
-            )
-        if parsed.debug_info.table_error:
-            self.report.num_observed_queries_failed += 1
-            return  # we can't do anything with this query
-        elif parsed.debug_info.column_error:
-            self.report.num_observed_queries_column_failed += 1
-            if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
-                self.report.num_observed_queries_column_timeout += 1
+        if not self._record_observed_parse_quality(parsed, observed.query):
+            return  # table-level error: we can't do anything with this query
 
         self._apply_observed_parse_result(
             observed,
@@ -1169,6 +1178,30 @@ class SqlParsingAggregator(Closeable):
             is_known_temp_table,
             require_out_table_schema,
         )
+
+    def _record_observed_parse_quality(
+        self, parsed: SqlParsingResult, query: str
+    ) -> bool:
+        """Record the parse-quality counters for an observed query from a single
+        place, so the serial path, the inline-reparse recovery, and the
+        worker-success path classify failures identically. Returns True if the
+        query is applicable (the caller should proceed to apply) and False on a
+        table-level error (the caller must skip apply).
+
+        Mutates shared report state (counters + LossyList). On the parallel path
+        the caller holds ``_apply_lock``; on the serial path no lock is needed."""
+        if parsed.debug_info.error:
+            self.report.observed_query_parse_failures.append(
+                f"{parsed.debug_info.error} on query: {query[:100]}"
+            )
+        if parsed.debug_info.table_error:
+            self.report.num_observed_queries_failed += 1
+            return False
+        if parsed.debug_info.column_error:
+            self.report.num_observed_queries_column_failed += 1
+            if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
+                self.report.num_observed_queries_column_timeout += 1
+        return True
 
     def _apply_observed_parse_result(
         self,
@@ -1254,18 +1287,8 @@ class SqlParsingAggregator(Closeable):
             override_dialect=observed.override_dialect,
         )
         with self._apply_lock:
-            if parsed.debug_info.error:
-                self.report.observed_query_parse_failures.append(
-                    f"{parsed.debug_info.error} on query: {observed.query[:100]}"
-                )
-            if parsed.debug_info.table_error:
-                self.report.num_observed_queries_failed += 1
+            if not self._record_observed_parse_quality(parsed, observed.query):
                 return
-            elif parsed.debug_info.column_error:
-                self.report.num_observed_queries_column_failed += 1
-                if isinstance(parsed.debug_info.column_error, CooperativeTimeoutError):
-                    self.report.num_observed_queries_column_timeout += 1
-
             self._apply_observed_parse_result(
                 observed,
                 session_id,
@@ -1341,7 +1364,6 @@ class SqlParsingAggregator(Closeable):
             assert self._parallel_parser is not None
             outcome = self._parallel_parser.parse_one(
                 ParseTask(
-                    key=None,
                     query=observed.query,
                     default_db=observed.default_db,
                     default_schema=observed.default_schema,
@@ -1386,30 +1408,17 @@ class SqlParsingAggregator(Closeable):
                 user=observed.user,
                 parsed=parsed,
             )
+            # Parse-quality accounting + apply share one lock scope (they all
+            # mutate shared report/aggregator state from a worker thread) and go
+            # through the same helper the serial path uses, so classification and
+            # skip-on-table-error behavior are identical across paths.
             with self._apply_lock:
                 self.report.num_queries_parsed_in_parallel += 1
                 # Surface the off-main-thread parse cost that sql_parsing_timer
                 # cannot see (it only wraps inline parsing on this path).
                 self.report.parallel_sql_parsing_time_seconds += outcome.parse_seconds
-
-            # Recording parse-quality counters mutates shared report state
-            # (counters + LossyList) from a worker thread, so serialize it.
-            with self._apply_lock:
-                if parsed.debug_info.error:
-                    self.report.observed_query_parse_failures.append(
-                        f"{parsed.debug_info.error} on query: {observed.query[:100]}"
-                    )
-                if parsed.debug_info.table_error:
-                    self.report.num_observed_queries_failed += 1
+                if not self._record_observed_parse_quality(parsed, observed.query):
                     return
-                elif parsed.debug_info.column_error:
-                    self.report.num_observed_queries_column_failed += 1
-                    if isinstance(
-                        parsed.debug_info.column_error, CooperativeTimeoutError
-                    ):
-                        self.report.num_observed_queries_column_timeout += 1
-
-            with self._apply_lock:
                 self._apply_observed_parse_result(
                     observed,
                     session_id,
@@ -1420,14 +1429,17 @@ class SqlParsingAggregator(Closeable):
                     preformatted_query=preformatted_query,
                 )
         except Exception as e:
-            # Serialize the failure bookkeeping — this runs on a worker thread and
-            # mutates shared report state (counter + LossyList).
+            # Task-boundary safety net: the PartitionExecutor future is never
+            # observed, so an escaping exception would silently drop the query.
+            # This bucket therefore also catches APPLY/programming errors (not
+            # just parse failures) — log at WARNING so a systematic apply bug is
+            # visible rather than hidden behind an inflated parse-failure count.
             with self._apply_lock:
                 self.report.num_observed_queries_failed += 1
                 self.report.observed_query_parse_failures.append(
                     f"{e!r} on query: {observed.query[:100]}"
                 )
-            logger.debug("Parallel observed-query task failed", exc_info=e)
+            logger.warning("Parallel observed-query task failed", exc_info=e)
 
     def _account_parsed_query(
         self,
@@ -1899,22 +1911,28 @@ class SqlParsingAggregator(Closeable):
         return parsed
 
     @staticmethod
-    def _merge_sort_key(query: QueryMetadata) -> Tuple[str, str, str]:
-        """Stable, arrival-order-independent, TOTAL tie-break key for merging two
-        QueryMetadata records with equal (or both-None) timestamps.
+    def _rep_rank(query: QueryMetadata) -> Tuple[int, str, str]:
+        """Immutable, arrival-order-independent rank used to pick the
+        representative record when several share a fingerprint.
 
-        The key is a tuple compared lexicographically:
-        (formatted query string or query id, session id, actor). The extra
-        session/actor components make the ordering total: two cross-session
-        records with equal timestamp AND identical formatted text would produce
-        equal single-string keys, leaving actor/session selection to fall back to
-        arrival order. Extending the key guarantees a stable winner regardless of
-        which record arrived first.
+        The key is ``(normalized epoch-millis, formatted query string, session
+        id)``. Crucially it does NOT fold in the ACTOR: actor is coalesced onto the
+        stored record (a timestamp winner with actor=None keeps an earlier known
+        actor), so a rank containing actor would change after a merge and make
+        three-way grouping order-dependent — the associativity bug this rewrite
+        fixes. ``session_id`` is safe to include: in the common path the stored
+        session equals the representative's, so the stored record's rank is stable
+        across merges; it only diverges in the rare temp-authority case, where the
+        lineage is fingerprint-invariant anyway. NORMALIZED millis are used, never
+        the raw datetimes: latest_timestamp may be naive OR UTC-aware and Python
+        raises TypeError when ``>`` compares the two forms. A record with no
+        timestamp sorts below every timestamped one.
         """
+        ms = make_ts_millis(query.latest_timestamp)
         return (
-            query.formatted_query_string or query.query_id,
-            query.session_id or "",
-            str(query.actor) if query.actor is not None else "",
+            ms if ms is not None else _MIN_MERGE_TS,
+            query.formatted_query_string,
+            query.session_id,
         )
 
     def _add_to_query_map(
@@ -1922,97 +1940,115 @@ class SqlParsingAggregator(Closeable):
     ) -> None:
         query_fingerprint = new.query_id
 
-        if query_fingerprint in self._query_map:
-            current = self._query_map.for_mutation(query_fingerprint)
+        if query_fingerprint not in self._query_map:
+            self._query_map[query_fingerprint] = new
+            # Seed the divergence tracker only if this record actually has an actor
+            # sourced from itself (the common case needs no entry — see below).
+            self._actor_source_rank.pop(query_fingerprint, None)
+            return
 
-            # Compute a single deterministic winner so every representative field
-            # (formatted_query_string, query_type, actor, session_id, ...) comes
-            # from the same record regardless of merge order. This is required for
-            # serial-vs-parallel
-            # equivalence: in the parallel path sessions may be applied out of
-            # global-timestamp order, so a plain last-writer-wins overwrite would make
-            # the stored text/actor non-deterministic run-to-run.
-            #
-            # The winner is the record with the later timestamp. When timestamps are
-            # equal (or both None) we fall back to a stable, arrival-order-independent
-            # tie-break: the record whose sort key (formatted query string, then
-            # session id, then actor) compares lexicographically greater.
-            #
-            # Compare NORMALIZED epoch-millis, never the raw datetimes:
-            # latest_timestamp is documented to accept both naive and UTC-aware
-            # datetimes, and Python raises TypeError when > compares a naive with
-            # an aware datetime (this can happen even on the serial path for a
-            # duplicate fingerprint with mixed timestamp forms). make_ts_millis
-            # normalizes both to ints, exactly as the lineage sort already does.
-            new_ms = make_ts_millis(new.latest_timestamp)
-            cur_ms = make_ts_millis(current.latest_timestamp)
-            _new_ts_wins = new_ms is not None and (cur_ms is None or new_ms > cur_ms)
-            _timestamps_tied = new_ms == cur_ms  # includes the both-None case
-            new_wins = _new_ts_wins or (
-                _timestamps_tied
-                and self._merge_sort_key(new) > self._merge_sort_key(current)
-            )
-            winner, loser = (new, current) if new_wins else (current, new)
+        current = self._query_map.for_mutation(query_fingerprint)
 
-            # Representative fields all come from the winner. Actor and session_id
-            # additionally coalesce so a winner with a None value never drops a
-            # known value from the loser (this restores the original
-            # ``new.actor or current.actor`` behaviour and fixes the serial-path
-            # regression where a trailing actor-less duplicate wiped the actor).
-            current.formatted_query_string = winner.formatted_query_string
-            current.query_type = winner.query_type
-            current.actor = winner.actor or loser.actor
+        # The merge below is a deterministic reduction: the stored result must be a
+        # pure function of the SET of records sharing this fingerprint, independent
+        # of arrival order OR grouping. Serial ingestion feeds duplicates in
+        # ascending-timestamp order, but the parallel path applies sessions out of
+        # global-timestamp order, so a plain last-writer-wins overwrite would make
+        # the stored text/actor/lineage non-deterministic run-to-run. Each field
+        # below is therefore reduced by an order-independent rule.
+        new_rank = self._rep_rank(new)
+        cur_rank = self._rep_rank(current)
+        rep_is_new = new_rank > cur_rank
+        rep_rank = new_rank if rep_is_new else cur_rank
+        # Capture representative field VALUES before mutating `current` (the winner
+        # may BE `current`, aliased to the stored object we are about to write).
+        rep_formatted = (
+            new.formatted_query_string if rep_is_new else current.formatted_query_string
+        )
+        rep_query_type = new.query_type if rep_is_new else current.query_type
 
-            # Keep the timestamp of the later instant so merge order does not
-            # matter. Selection is driven by the NORMALIZED millis (mixed
-            # naive/aware datetimes are safe to order this way), but we STORE the
-            # actual winning datetime object, not the millis. In serial mode
-            # timestamps arrive in ascending order, so this is equivalent to the
-            # previous last-writer-wins behaviour; in the parallel path sessions
-            # may be applied out of global-timestamp order, making this necessary
-            # for serial-vs-parallel equivalence.
-            if new_ms is None:
-                pass  # keep current
-            elif cur_ms is None or new_ms > cur_ms:
-                current.latest_timestamp = new.latest_timestamp
-            # else: current already holds the later (or equal) instant — keep it.
+        # --- latest_timestamp: keep the maximum instant (order-independent). Store
+        # the actual winning datetime, not the normalized millis used for ranking.
+        new_ms = make_ts_millis(new.latest_timestamp)
+        cur_ms = make_ts_millis(current.latest_timestamp)
+        if new_ms is not None and (cur_ms is None or new_ms > cur_ms):
+            current.latest_timestamp = new.latest_timestamp
 
-            if current.used_temp_tables and not new.used_temp_tables:
-                # If we see the same query again, but in a different session,
-                # it's possible that we didn't capture the temp tables in the newer session,
-                # but did in the older one. If that happens, we treat the older session's
-                # lineage as more authoritative. This isn't technically correct, but it's
-                # better than using the newer session's lineage, which is likely incorrect.
-                # Preserve the older (current) session_id here: don't let the
-                # non-authoritative newer session override which lineage wins.
+        # --- actor: attribute the query to the actor of the highest-ranked record
+        # that HAS one (serial's ``new.actor or current.actor`` in ascending-ts
+        # order = "latest known actor"). Reducing actor by a rank independent of the
+        # representative selection — and remembering the source rank only when it
+        # diverges from the representative — keeps this associative. Feeding a
+        # coalesced actor back into the winner ranking is exactly the bug that made
+        # three-way grouping pick different actors run-to-run.
+        cur_actor_rank = (
+            self._actor_source_rank.get(query_fingerprint, cur_rank)
+            if current.actor is not None
+            else None
+        )
+        new_actor_rank = new_rank if new.actor is not None else None
+        actor_rank: Optional[Tuple[int, str, str]]
+        if new_actor_rank is not None and (
+            cur_actor_rank is None or new_actor_rank > cur_actor_rank
+        ):
+            current.actor = new.actor
+            actor_rank = new_actor_rank
+        else:
+            actor_rank = cur_actor_rank
+            # current.actor unchanged
+        if actor_rank is not None and actor_rank != rep_rank:
+            # Actor came from a non-representative record; remember where so the
+            # next merge ranks it correctly.
+            self._actor_source_rank[query_fingerprint] = actor_rank
+        else:
+            self._actor_source_rank.pop(query_fingerprint, None)
+
+        # --- representative text/type (identical across a fingerprint apart from
+        # literal formatting; take the timestamp winner's, matching serial).
+        current.formatted_query_string = rep_formatted
+        current.query_type = rep_query_type
+
+        # --- lineage authority: a record that used temp tables is authoritative
+        # over one that did not, regardless of arrival order (symmetric: the old
+        # one-directional early-return only preserved temp lineage when the EXISTING
+        # record was the temp one, so reversing the pair silently chose non-temp
+        # lineage). When both or neither used temp tables, the representative
+        # (timestamp) winner wins. Reasoning: for a shared fingerprint the temp
+        # session captured intermediate tables the plain one is missing.
+        if new.used_temp_tables != current.used_temp_tables:
+            lineage_is_new = new.used_temp_tables  # the temp record is authoritative
+            if lineage_is_new != rep_is_new:
+                # Temp authority overrode timestamp order — same signal the serial
+                # path reported for the older-temp-beats-newer case.
                 self.report.queries_with_non_authoritative_session.append(
                     query_fingerprint
                 )
-                return
-
-            current.session_id = winner.session_id or loser.session_id
-
-            if not merge_lineage:
-                # An invariant of the fingerprinting is that if two queries have the
-                # same fingerprint, they must also have the same lineage, so taking
-                # upstreams/column_lineage/column_usage from the winner is
-                # content-identical to the previous overwrite but keeps every
-                # representative field tied to the same deterministic winner.
-                current.upstreams = winner.upstreams
-                current.column_lineage = winner.column_lineage
-                current.column_usage = winner.column_usage
-                current.confidence_score = winner.confidence_score
-            else:
-                # In the case of known query lineage, we might get things one at a time.
-                # TODO: We don't yet support merging CLL for a single query.
-                current.upstreams = list(
-                    OrderedSet(current.upstreams) | OrderedSet(new.upstreams)
-                )
-                current.confidence_score = min(
-                    current.confidence_score, new.confidence_score
-                )
         else:
-            self._query_map[query_fingerprint] = new
+            lineage_is_new = rep_is_new
+
+        if merge_lineage:
+            # Known-query lineage may arrive piecemeal; union upstreams and take the
+            # more conservative confidence. (CLL merging is not yet supported.)
+            current.upstreams = list(
+                OrderedSet(current.upstreams) | OrderedSet(new.upstreams)
+            )
+            current.confidence_score = min(
+                current.confidence_score, new.confidence_score
+            )
+            current.session_id = (
+                new.session_id if lineage_is_new else current.session_id
+            )
+            current.used_temp_tables = (
+                new.used_temp_tables if lineage_is_new else current.used_temp_tables
+            )
+        elif lineage_is_new:
+            current.session_id = new.session_id
+            current.upstreams = new.upstreams
+            current.column_lineage = new.column_lineage
+            current.column_usage = new.column_usage
+            current.confidence_score = new.confidence_score
+            current.used_temp_tables = new.used_temp_tables
+        # else: lineage authority is `current` — leave its lineage fields in place.
 
     def gen_metadata(self) -> Iterable[MetadataChangeProposalWrapper]:
         # A connector may have forgotten to exit the parallel scope. Defensively

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -637,9 +637,11 @@ class SqlParsingAggregator(Closeable):
         # actor=None and an earlier duplicate carried a known actor). In the common
         # case the actor is the representative's own, recomputable from the stored
         # record, so nothing is kept here. This lets actor selection stay associative
-        # (see _add_to_query_map) without keeping per-fingerprint state for every
-        # query. In-memory only; keyed by the small set of divergent fingerprints.
-        self._actor_source_rank: Dict[QueryId, Tuple[int, str, str]] = {}
+        # (see _merge_query_metadata_deterministic) without per-fingerprint state for
+        # every query. Populated only on the opt-in parallel path (the serial merge
+        # never touches it); in-memory, keyed by the small set of divergent
+        # fingerprints, and the rank holds a HASH of the query text, not the text.
+        self._actor_source_rank: Dict[QueryId, Tuple[int, int, str]] = {}
 
         # Map of downstream urn -> { query ids }
         self._lineage_map = FileBackedDict[OrderedSet[QueryId]](
@@ -724,8 +726,12 @@ class SqlParsingAggregator(Closeable):
         self._parallel_active: bool = False
         # Serializes the cheap classify/apply steps that mutate shared aggregator
         # state (temp maps, query map, lineage map) while cross-session parse work
-        # runs concurrently on worker processes.
-        self._apply_lock = threading.Lock()
+        # runs concurrently on worker processes. Reentrant (RLock) so a future
+        # nested `with self._apply_lock` — e.g. an apply helper called from
+        # already-locked code — cannot silently self-deadlock; the correctness of
+        # several call sites currently rests only on a "must not hold the lock"
+        # docstring, and RLock makes that free to get wrong.
+        self._apply_lock = threading.RLock()
 
     def _maybe_apply_lock(self) -> ContextManager[object]:
         """Return the apply-lock when parallel parsing is active, else a no-op.
@@ -798,8 +804,12 @@ class SqlParsingAggregator(Closeable):
     ) -> None:
         self.report.sql_parsing_parallel_enabled = active
         self.report.sql_parsing_parallelism = workers if active else None
+        # Accumulate (never clear): a fallback recorded by an earlier scope entry
+        # or by a mid-run pool break (see _teardown_parallel) must survive a later
+        # scope re-entry, matching the sticky pool_broke flag.
         self.report.sql_parsing_fell_back_to_serial = (
-            not active and self._use_parallel_sql_parsing
+            self.report.sql_parsing_fell_back_to_serial
+            or (not active and self._use_parallel_sql_parsing)
         )
 
     def close(self) -> None:
@@ -813,27 +823,35 @@ class SqlParsingAggregator(Closeable):
         self._exit_stack.close()
 
     def _teardown_parallel(self) -> None:
-        if self._partition_executor is not None:
-            try:
-                # close() -> shutdown() -> flush(), so this drains all queued
-                # applies before returning; no separate flush() needed.
-                self._partition_executor.close()
-            finally:
-                self._partition_executor = None
-        if self._parallel_parser is not None:
-            if self._parallel_parser.pool_broke.is_set():
-                self.report.sql_parsing_pool_broke = True
-                # The pool died mid-run, so every query after the break was
-                # reparsed inline on the main process — i.e. the run effectively
-                # fell back to serial. Record that alongside the pool_broke flag.
-                self.report.sql_parsing_fell_back_to_serial = True
-                logger.warning(
-                    "Parallel SQL parser worker pool died; remaining queries "
-                    "were reparsed serially on the main process."
-                )
-            self._parallel_parser.close()
-            self._parallel_parser = None
-        self._parallel_active = False
+        # The parser owns the worker POOL processes, so it must be closed even if
+        # closing the partition executor raises (its shutdown() has an assert) —
+        # otherwise the workers leak. The outer try/finally guarantees that.
+        try:
+            if self._partition_executor is not None:
+                try:
+                    # close() -> shutdown() -> flush(), so this drains all queued
+                    # applies before returning; no separate flush() needed.
+                    self._partition_executor.close()
+                finally:
+                    self._partition_executor = None
+        finally:
+            if self._parallel_parser is not None:
+                if self._parallel_parser.pool_broke.is_set():
+                    self.report.sql_parsing_pool_broke = True
+                    # The pool died mid-run, so every query after the break was
+                    # reparsed inline on the main process — i.e. the run
+                    # effectively fell back to serial. Record that alongside the
+                    # pool_broke flag.
+                    self.report.sql_parsing_fell_back_to_serial = True
+                    logger.warning(
+                        "Parallel SQL parser worker pool died; remaining queries "
+                        "were reparsed serially on the main process."
+                    )
+                try:
+                    self._parallel_parser.close()
+                finally:
+                    self._parallel_parser = None
+            self._parallel_active = False
 
     @property
     def _need_schemas(self) -> bool:
@@ -934,6 +952,13 @@ class SqlParsingAggregator(Closeable):
         # infrequent in the query loop. To keep them correct relative to the
         # in-flight parallel applies, drain all pending work first, then process
         # inline under the apply lock so nothing races with them.
+        #
+        # NOTE: this drain+lock barrier only guards items routed THROUGH add().
+        # The public per-type methods (add_table_rename, add_known_query_lineage,
+        # ...) are unguarded — calling them directly during an active parallel
+        # scope would race with in-flight applies. Connectors call those only
+        # during extraction, before opening the scope, so this holds today; it is
+        # an unenforced precondition, not a checked invariant.
         if self._parallel_active and self._partition_executor is not None:
             self._partition_executor.flush()
             with self._apply_lock:
@@ -1367,11 +1392,9 @@ class SqlParsingAggregator(Closeable):
                     query=observed.query,
                     default_db=observed.default_db,
                     default_schema=observed.default_schema,
-                    override_dialect=(
-                        str(observed.override_dialect)
-                        if observed.override_dialect is not None
-                        else None
-                    ),
+                    # Pass through unchanged so a sqlglot.Dialect resolves in the
+                    # worker exactly as it would on the serial path.
+                    override_dialect=observed.override_dialect,
                 )
             )
             if outcome.error is not None:
@@ -1519,6 +1542,7 @@ class SqlParsingAggregator(Closeable):
                 parsed,
                 is_known_temp_table,
                 require_out_table_schema,
+                session_has_temp_tables,
             )
             return
 
@@ -1536,6 +1560,7 @@ class SqlParsingAggregator(Closeable):
         parsed: PreparsedQuery,
         is_known_temp_table: bool,
         require_out_table_schema: bool,
+        session_has_temp_tables: bool,
     ) -> None:
         try:
             with self._apply_lock:
@@ -1543,16 +1568,19 @@ class SqlParsingAggregator(Closeable):
                     parsed,
                     is_known_temp_table=is_known_temp_table,
                     require_out_table_schema=require_out_table_schema,
-                    session_has_temp_tables=True,
+                    session_has_temp_tables=session_has_temp_tables,
                     _is_internal=False,
                 )
         except Exception as e:
+            # Task-boundary safety net (the PE future is never observed); may catch
+            # apply/programming errors too, so log at WARNING — matching
+            # _process_observed_task — rather than hiding a systematic bug at debug.
             with self._apply_lock:
                 self.report.num_preparsed_queries_failed += 1
                 self.report.preparsed_query_parse_failures.append(
                     f"{e!r} on query: {parsed.query_text[:100]}"
                 )
-            logger.debug("Parallel preparsed-query task failed", exc_info=e)
+            logger.warning("Parallel preparsed-query task failed", exc_info=e)
 
     def _add_preparsed_query_impl(
         self,
@@ -1911,27 +1939,33 @@ class SqlParsingAggregator(Closeable):
         return parsed
 
     @staticmethod
-    def _rep_rank(query: QueryMetadata) -> Tuple[int, str, str]:
+    def _rep_rank(query: QueryMetadata) -> Tuple[int, int, str]:
         """Immutable, arrival-order-independent rank used to pick the
-        representative record when several share a fingerprint.
+        representative record when several share a fingerprint (parallel path
+        only).
 
-        The key is ``(normalized epoch-millis, formatted query string, session
-        id)``. Crucially it does NOT fold in the ACTOR: actor is coalesced onto the
-        stored record (a timestamp winner with actor=None keeps an earlier known
-        actor), so a rank containing actor would change after a merge and make
-        three-way grouping order-dependent — the associativity bug this rewrite
-        fixes. ``session_id`` is safe to include: in the common path the stored
-        session equals the representative's, so the stored record's rank is stable
-        across merges; it only diverges in the rare temp-authority case, where the
-        lineage is fingerprint-invariant anyway. NORMALIZED millis are used, never
-        the raw datetimes: latest_timestamp may be naive OR UTC-aware and Python
-        raises TypeError when ``>`` compares the two forms. A record with no
-        timestamp sorts below every timestamped one.
+        The key is ``(normalized epoch-millis, hash(formatted query string),
+        session id)``. The query text is reduced to a hash rather than kept
+        verbatim: this rank is stashed in the in-memory ``_actor_source_rank`` map,
+        and ``_query_map`` is file-backed precisely to keep full query text off the
+        heap at scale — a hash preserves the deterministic tie-break at no heap
+        cost. (``hash`` is process-stable, which is all this in-process reduction
+        needs.) The rank crucially does NOT fold in the ACTOR: actor is coalesced
+        onto the stored record (a timestamp winner with actor=None keeps an earlier
+        known actor), so a rank containing actor would change after a merge and
+        make three-way grouping order-dependent — the associativity bug this
+        rewrite fixes. ``session_id`` is safe to include: in the common path the
+        stored session equals the representative's, so the stored record's rank is
+        stable across merges; it only diverges in the rare temp-authority case,
+        where the lineage is fingerprint-invariant anyway. NORMALIZED millis are
+        used, never the raw datetimes: latest_timestamp may be naive OR UTC-aware
+        and Python raises TypeError when ``>`` compares the two forms. A record
+        with no timestamp sorts below every timestamped one.
         """
         ms = make_ts_millis(query.latest_timestamp)
         return (
             ms if ms is not None else _MIN_MERGE_TS,
-            query.formatted_query_string,
+            hash(query.formatted_query_string),
             query.session_id,
         )
 
@@ -1942,13 +1976,70 @@ class SqlParsingAggregator(Closeable):
 
         if query_fingerprint not in self._query_map:
             self._query_map[query_fingerprint] = new
-            # Seed the divergence tracker only if this record actually has an actor
-            # sourced from itself (the common case needs no entry — see below).
             self._actor_source_rank.pop(query_fingerprint, None)
             return
 
         current = self._query_map.for_mutation(query_fingerprint)
 
+        # The deterministic reduction is only needed when parallel parsing is
+        # enabled: it exists to make the stored record independent of the order in
+        # which out-of-order pool completions (and temp-session inline parses) are
+        # applied. The default (non-parallel) path feeds duplicates in ascending-
+        # timestamp order, so the original last-writer-wins merge is correct and is
+        # preserved verbatim — no behavior change, and no per-fingerprint state.
+        if self._use_parallel_sql_parsing:
+            self._merge_query_metadata_deterministic(
+                current, new, query_fingerprint, merge_lineage
+            )
+        else:
+            self._merge_query_metadata_serial(current, new, merge_lineage)
+
+    def _merge_query_metadata_serial(
+        self, current: QueryMetadata, new: QueryMetadata, merge_lineage: bool
+    ) -> None:
+        """Original last-writer-wins merge, preserved verbatim for the default
+        (non-parallel) path. Assumes queries arrive in increasing-timestamp order,
+        so the newer (``new``) record is authoritative."""
+        current.formatted_query_string = new.formatted_query_string
+        current.latest_timestamp = new.latest_timestamp or current.latest_timestamp
+        current.actor = new.actor or current.actor
+
+        if current.used_temp_tables and not new.used_temp_tables:
+            # If we see the same query again, but in a different session, it's
+            # possible that we didn't capture the temp tables in the newer session,
+            # but did in the older one. If that happens, we treat the older
+            # session's lineage as more authoritative. This isn't technically
+            # correct, but it's better than using the newer session's lineage,
+            # which is likely incorrect.
+            self.report.queries_with_non_authoritative_session.append(current.query_id)
+            return
+        current.session_id = new.session_id
+
+        if not merge_lineage:
+            # An invariant of the fingerprinting is that if two queries have the
+            # same fingerprint, they must also have the same lineage. We overwrite
+            # here just in case more schemas got registered in the interim.
+            current.upstreams = new.upstreams
+            current.column_lineage = new.column_lineage
+            current.column_usage = new.column_usage
+            current.confidence_score = new.confidence_score
+        else:
+            # In the case of known query lineage, we might get things one at a time.
+            # TODO: We don't yet support merging CLL for a single query.
+            current.upstreams = list(
+                OrderedSet(current.upstreams) | OrderedSet(new.upstreams)
+            )
+            current.confidence_score = min(
+                current.confidence_score, new.confidence_score
+            )
+
+    def _merge_query_metadata_deterministic(
+        self,
+        current: QueryMetadata,
+        new: QueryMetadata,
+        query_fingerprint: QueryId,
+        merge_lineage: bool,
+    ) -> None:
         # The merge below is a deterministic reduction: the stored result must be a
         # pure function of the SET of records sharing this fingerprint, independent
         # of arrival order OR grouping. Serial ingestion feeds duplicates in
@@ -1987,7 +2078,7 @@ class SqlParsingAggregator(Closeable):
             else None
         )
         new_actor_rank = new_rank if new.actor is not None else None
-        actor_rank: Optional[Tuple[int, str, str]]
+        actor_rank: Optional[Tuple[int, int, str]]
         if new_actor_rank is not None and (
             cur_actor_rank is None or new_actor_rank > cur_actor_rank
         ):

--- a/metadata-ingestion/src/datahub/utilities/backpressure_aware_executor.py
+++ b/metadata-ingestion/src/datahub/utilities/backpressure_aware_executor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import concurrent.futures
-from concurrent.futures import Future, ThreadPoolExecutor
+import contextlib
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from typing import Any, Callable, Iterable, Iterator, Optional, Set, Tuple, TypeVar
 
 _R = TypeVar("_R")
@@ -20,6 +21,7 @@ class BackpressureAwareExecutor:
         args_list: Iterable[Tuple[Any, ...]],
         max_workers: int,
         max_pending: Optional[int] = None,
+        executor: Optional[Executor] = None,
     ) -> Iterator[Future[_R]]:
         """Similar to concurrent.futures.ThreadPoolExecutor#map, except that it won't run ahead of the consumer.
 
@@ -34,6 +36,12 @@ class BackpressureAwareExecutor:
             max_workers: The maximum number of threads to use.
             max_pending: The maximum number of pending results to keep in memory.
                 If not set, it will be set to 2*max_workers.
+            executor: An optional executor to submit work to. When provided, it is
+                used as-is and NOT closed by this method (the caller owns its
+                lifecycle) — this lets callers reuse the bounded-drain logic with a
+                ProcessPoolExecutor or a shared pool. When None (the default), a
+                ThreadPoolExecutor with ``max_workers`` threads is created and
+                closed internally, preserving the original behavior.
 
         Returns:
             An iterable of futures.
@@ -53,7 +61,16 @@ class BackpressureAwareExecutor:
 
         pending_futures: Set[Future] = set()
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # When the caller supplies an executor, it owns the lifecycle — we must not
+        # shut it down. Otherwise, create and own a ThreadPoolExecutor as before.
+        if executor is not None:
+            executor_cm: contextlib.AbstractContextManager[Executor] = (
+                contextlib.nullcontext(executor)
+            )
+        else:
+            executor_cm = ThreadPoolExecutor(max_workers=max_workers)
+
+        with executor_cm as active_executor:
             for args in args_list:
                 # If the pending list is full, wait until one is done.
                 if len(pending_futures) >= max_pending:
@@ -68,7 +85,7 @@ class BackpressureAwareExecutor:
                         yield future
 
                 # Now that there's space in the pending list, enqueue the next task.
-                pending_futures.add(executor.submit(fn, *args))
+                pending_futures.add(active_executor.submit(fn, *args))
 
             # Wait for all the remaining tasks to complete.
             for future in concurrent.futures.as_completed(pending_futures):

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -80,33 +80,60 @@ class ConnectionWrapper:
         Union["FileBackedList", "FileBackedDict", "FileBackedCounter"]
     ]
 
-    def __init__(self, filename: Optional[pathlib.Path] = None):
+    def __init__(
+        self,
+        filename: Optional[pathlib.Path] = None,
+        read_only: bool = False,
+    ):
         self._temp_directory = None
         self._dependent_objects = []
+        self._read_only = read_only
 
-        # Warning: If filename is provided, the file will not be automatically cleaned up.
-        if not filename:
-            self._temp_directory = tempfile.mkdtemp()
-            filename = pathlib.Path(self._temp_directory) / _DEFAULT_FILE_NAME
-        self.filename = filename
+        if read_only:
+            # A read-only connection must target an existing file; a temp dir makes
+            # no sense here.
+            if not filename:
+                raise ValueError("filename is required when read_only=True")
+            self.filename = filename
+        else:
+            # Warning: If filename is provided, the file will not be automatically cleaned up.
+            if not filename:
+                self._temp_directory = tempfile.mkdtemp()
+                filename = pathlib.Path(self._temp_directory) / _DEFAULT_FILE_NAME
+            self.filename = filename
 
         # SQLite connections are technically not supposed to be used from multiple threads.
         # We bypass this restriction by setting `check_same_thread=False`. However, we
         # still need to be careful to avoid concurrent access.
         self.conn_lock = threading.Lock()
-        self.conn = sqlite3.connect(
-            filename, isolation_level=None, check_same_thread=False
-        )
-        self.conn.row_factory = sqlite3.Row
 
-        # These settings are optimized for performance.
-        # See https://www.sqlite.org/pragma.html for more information.
-        # Because we're only using these dbs to offload data from memory, we don't need
-        # to worry about data integrity too much.
-        self.conn.execute('PRAGMA locking_mode = "EXCLUSIVE"')
-        self.conn.execute('PRAGMA synchronous = "OFF"')
-        self.conn.execute('PRAGMA journal_mode = "MEMORY"')
-        self.conn.execute(f"PRAGMA journal_size_limit = {100 * 1024 * 1024}")  # 100MB
+        if read_only:
+            # Open with the URI filename API so we can pass mode=ro&immutable=1.
+            # immutable=1 tells SQLite the file will not change, allowing concurrent
+            # readers with no locking overhead and shared OS page-cache.
+            uri = f"file:{filename}?mode=ro&immutable=1"
+            self.conn = sqlite3.connect(
+                uri, uri=True, isolation_level=None, check_same_thread=False
+            )
+            self.conn.row_factory = sqlite3.Row
+            # Do NOT set locking_mode / synchronous / journal_mode — they are
+            # invalid or meaningless on an immutable read-only connection.
+        else:
+            self.conn = sqlite3.connect(
+                filename, isolation_level=None, check_same_thread=False
+            )
+            self.conn.row_factory = sqlite3.Row
+
+            # These settings are optimized for performance.
+            # See https://www.sqlite.org/pragma.html for more information.
+            # Because we're only using these dbs to offload data from memory, we don't need
+            # to worry about data integrity too much.
+            self.conn.execute('PRAGMA locking_mode = "EXCLUSIVE"')
+            self.conn.execute('PRAGMA synchronous = "OFF"')
+            self.conn.execute('PRAGMA journal_mode = "MEMORY"')
+            self.conn.execute(
+                f"PRAGMA journal_size_limit = {100 * 1024 * 1024}"
+            )  # 100MB
 
     @property
     def allow_table_name_reuse(self) -> bool:
@@ -116,6 +143,10 @@ class ConnectionWrapper:
         # which happens when filename is passed explicitly, then we need to allow table name reuse.
 
         return self._temp_directory is None
+
+    @property
+    def read_only(self) -> bool:
+        return self._read_only
 
     def execute(
         self, sql: str, parameters: Union[Dict[str, Any], Sequence[Any]] = ()
@@ -248,15 +279,18 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
         # Create the table.
         # We could use the built-in sqlite `rowid` column, but that can get changed
         # if a VACUUM is performed and would break our ordering guarantees.
-        if_not_exists = "IF NOT EXISTS" if self._conn.allow_table_name_reuse else ""
-        self._conn.execute(
-            f"""CREATE TABLE {if_not_exists} {self.tablename} (
-                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
-                key TEXT UNIQUE,
-                value BLOB
-                {"".join(f", {column_name} BLOB" for column_name in self.extra_columns)}
-            )"""
-        )
+        # Skip CREATE TABLE entirely when the underlying connection is read-only — the
+        # table already exists in the snapshot file and writes are not permitted.
+        if not self._conn.read_only:
+            if_not_exists = "IF NOT EXISTS" if self._conn.allow_table_name_reuse else ""
+            self._conn.execute(
+                f"""CREATE TABLE {if_not_exists} {self.tablename} (
+                    rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE,
+                    value BLOB
+                    {"".join(f", {column_name} BLOB" for column_name in self.extra_columns)}
+                )"""
+            )
 
         if not self.delay_index_creation:
             self.create_indexes()
@@ -269,6 +303,10 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
 
     def create_indexes(self) -> None:
         if self.indexes_created:
+            return
+        if self._conn.read_only:
+            # Indexes already exist in the snapshot; writes are not allowed.
+            self.indexes_created = True
             return
         # The key column will automatically be indexed, but we need indexes for the extra columns.
         for column_name in self.extra_columns:
@@ -338,6 +376,16 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
                         WHERE key = ?""",
                         (*item[1:], item[0]),
                     )
+
+    @property
+    def filename(self) -> pathlib.Path:
+        """Return the path of the backing SQLite file."""
+        return self._conn.filename
+
+    @property
+    def read_only(self) -> bool:
+        """Return whether the underlying connection is read-only."""
+        return self._conn.read_only
 
     def flush(self) -> None:
         self._prune_cache(len(self._active_object_cache))
@@ -490,7 +538,10 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
     def close(self) -> None:
         if self._conn:
             if self.shared_connection:  # Connection not owned by this object
-                self.flush()  # Ensure everything is written out
+                # Skip flush for read-only connections — writes are forbidden
+                # and there is nothing to persist anyway.
+                if not self._conn.read_only:
+                    self.flush()  # Ensure everything is written out
             else:
                 self._conn.close()
 

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -406,7 +406,16 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
         self._add_to_cache(key, deserialized_result, False)
         return deserialized_result
 
+    def _ensure_writable(self) -> None:
+        # A read-only connection never flushes, so a cached dirty write would be
+        # silently dropped at close. Fail loudly instead of losing data.
+        if self._conn.read_only:
+            raise RuntimeError(
+                f"Cannot mutate read-only FileBackedDict (table {self.tablename})"
+            )
+
     def __setitem__(self, key: str, value: _VT) -> None:
+        self._ensure_writable()
         self._add_to_cache(key, value, True)
 
     def for_mutation(
@@ -438,6 +447,7 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
         return self.for_mutation(key, default=default)
 
     def __delitem__(self, key: str) -> None:
+        self._ensure_writable()
         in_cache = False
         if key in self._active_object_cache:
             del self._active_object_cache[key]
@@ -450,6 +460,7 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
             raise KeyError(key)
 
     def mark_dirty(self, key: str) -> None:
+        self._ensure_writable()
         if key not in self._active_object_cache:
             raise ValueError(
                 f"key {key} not in active object cache, which means any dirty value "

--- a/metadata-ingestion/src/datahub/utilities/partition_executor.py
+++ b/metadata-ingestion/src/datahub/utilities/partition_executor.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import atexit
 import collections
 import functools
@@ -61,6 +59,21 @@ class PartitionExecutor(Closeable):
         # Each pending or executing request will acquire a permit from this semaphore.
         self._semaphore = BoundedSemaphore(max_pending + max_workers)
 
+        # Guards all state transitions on self._pending_by_key so that the
+        # inspect+append+create sequence in submit() and the inspect+pop+delete
+        # sequence in the completion callback are each atomic. Without this,
+        # submit() (caller thread) and the completion callback (worker thread)
+        # race on the same key: the callback can observe an empty deque, then
+        # have submit() append to it before the callback deletes the key --
+        # silently dropping the queued task and leaking its semaphore permit.
+        #
+        # This is an RLock (not a plain Lock) because future.add_done_callback
+        # fires the callback synchronously on the submitting thread when the
+        # future is already complete. In that case the callback re-enters this
+        # lock on the same thread that already holds it, so a plain Lock would
+        # self-deadlock.
+        self._pending_lock = threading.RLock()
+
         # A key existing in this dict means that there is a submitted request for that key.
         # Any entries in the key's value e.g. the deque are requests that are waiting
         # to be submitted once the current request for that key completes.
@@ -85,14 +98,17 @@ class PartitionExecutor(Closeable):
     ) -> None:
         """See concurrent.futures.Executor#submit"""
 
+        # Acquire the permit outside the lock: we must never block on the
+        # semaphore while holding self._pending_lock.
         self._semaphore.acquire()
 
-        if key in self._pending_by_key:
-            self._pending_by_key[key].append((fn, args, kwargs, done_callback))
+        with self._pending_lock:
+            if key in self._pending_by_key:
+                self._pending_by_key[key].append((fn, args, kwargs, done_callback))
 
-        else:
-            self._pending_by_key[key] = collections.deque()
-            self._submit_nowait(key, fn, args, kwargs, done_callback=done_callback)
+            else:
+                self._pending_by_key[key] = collections.deque()
+                self._submit_nowait(key, fn, args, kwargs, done_callback=done_callback)
 
     def _submit_nowait(
         self,
@@ -105,32 +121,37 @@ class PartitionExecutor(Closeable):
         future = self._executor.submit(fn, *args, **kwargs)
 
         def _system_done_callback(future: Future) -> None:
+            # Releasing the semaphore doesn't touch _pending_by_key, so it does
+            # not need the lock. Keep it outside to avoid holding the lock any
+            # longer than necessary.
             self._semaphore.release()
 
-            # If there is another pending request for this key, submit it now.
-            # The key must exist in the map.
-            if self._pending_by_key[key]:
-                fn, args, kwargs, user_done_callback = self._pending_by_key[
-                    key
-                ].popleft()
+            # Guard the inspect+pop+delete transition so it's atomic with
+            # respect to submit()'s inspect+append+create. The key must exist
+            # in the map.
+            with self._pending_lock:
+                if self._pending_by_key[key]:
+                    fn, args, kwargs, user_done_callback = self._pending_by_key[
+                        key
+                    ].popleft()
 
-                try:
-                    self._submit_nowait(key, fn, args, kwargs, user_done_callback)
-                except RuntimeError as e:
-                    if self._executor._shutdown:
-                        # If we're in shutdown mode, then we can't submit any more requests.
-                        # That means we'll need to drop requests on the floor, which is to
-                        # be expected in shutdown mode.
-                        # The only reason we'd normally be in shutdown here is during
-                        # Python exit (e.g. KeyboardInterrupt), so this is reasonable.
-                        logger.debug("Dropping request due to shutdown")
-                    else:
-                        raise e
+                    try:
+                        self._submit_nowait(key, fn, args, kwargs, user_done_callback)
+                    except RuntimeError as e:
+                        if self._executor._shutdown:
+                            # If we're in shutdown mode, then we can't submit any more requests.
+                            # That means we'll need to drop requests on the floor, which is to
+                            # be expected in shutdown mode.
+                            # The only reason we'd normally be in shutdown here is during
+                            # Python exit (e.g. KeyboardInterrupt), so this is reasonable.
+                            logger.debug("Dropping request due to shutdown")
+                        else:
+                            raise e
 
-            else:
-                # If there are no pending requests for this key, mark the key
-                # as no longer in progress.
-                del self._pending_by_key[key]
+                else:
+                    # If there are no pending requests for this key, mark the key
+                    # as no longer in progress.
+                    del self._pending_by_key[key]
 
         if done_callback:
             future.add_done_callback(done_callback)
@@ -145,6 +166,11 @@ class PartitionExecutor(Closeable):
             self._semaphore.acquire()
 
         # Now, wait for all the pending requests to complete.
+        # We don't take self._pending_lock here: having acquired all max_pending
+        # permits above, no new key can be created past submit()'s semaphore
+        # acquire, so _pending_by_key only shrinks from here. len() on a dict is
+        # atomic in CPython, and we re-read it every iteration, so a momentarily
+        # stale read at worst costs one extra sleep interval.
         while len(self._pending_by_key) > 0:
             # TODO: There should be a better way to wait for all executor threads to be idle.
             # One option would be to just shutdown the existing executor and create a new one.
@@ -177,7 +203,7 @@ def _now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-_live_executors: weakref.WeakSet[BatchPartitionExecutor] = weakref.WeakSet()
+_live_executors: 'weakref.WeakSet["BatchPartitionExecutor"]' = weakref.WeakSet()
 
 
 def _shutdown_executors() -> None:

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -1,0 +1,1484 @@
+"""Equivalence tests for per-session-safe parallel SQL parsing in SqlParsingAggregator.
+
+The correctness bar: parallel output MUST be byte-identical to serial output
+(no lineage loss). Each test runs the same scripted stream of queries through a
+serial aggregator (feature off) and a parallel aggregator (feature on, wrapped in
+``parallel_sql_parsing_scope()``), then asserts the emitted MCPs are equal after
+normalizing ordering.
+"""
+
+import concurrent.futures.process
+import json
+from datetime import datetime, timezone
+from typing import List, Optional, Union
+from unittest import mock
+
+import pytest
+import time_machine
+
+import datahub.metadata.schema_classes as models
+from datahub.metadata.urns import CorpGroupUrn, CorpUserUrn, DatasetUrn
+from datahub.sql_parsing.parallel_sql_parser import (
+    ParallelParserUnavailable,
+    ParallelSqlParser,
+    ParseOutcome,
+)
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    ObservedQuery,
+    PreparsedQuery,
+    QueryLogSetting,
+    QueryMetadata,
+    SqlParsingAggregator,
+    TableRename,
+    TableSwap,
+)
+from datahub.sql_parsing.sql_parsing_common import QueryType
+
+_StreamItem = Union[ObservedQuery, PreparsedQuery, TableRename, TableSwap]
+
+# Freeze wall-clock so audit stamps that fall back to datetime.now() (for
+# downstream tables with no explicit timestamp) are identical across the serial
+# and parallel runs being compared.
+FROZEN_TIME = "2024-02-06T01:23:45Z"
+
+
+def _ts(ts: int) -> datetime:
+    return datetime.fromtimestamp(ts, tz=timezone.utc)
+
+
+def _make_aggregator(
+    *,
+    use_parallel: bool,
+    workers: int = 2,
+    query_log: QueryLogSetting = QueryLogSetting.DISABLED,
+) -> SqlParsingAggregator:
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=query_log,
+        use_parallel_sql_parsing=use_parallel,
+        sql_parsing_workers=workers if use_parallel else None,
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.bar").urn(),
+        {"a": "int", "b": "int", "c": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream1").urn(),
+        {"a": "int", "b": "int"},
+    )
+    aggregator._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.upstream2").urn(),
+        {"a": "int", "c": "int"},
+    )
+    return aggregator
+
+
+def _mcp_key(mcp: object) -> tuple:
+    return (
+        str(getattr(mcp, "entityUrn", None)),
+        str(getattr(mcp, "aspectName", None)),
+        str(getattr(mcp, "aspect", None)),
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_serial(items: List[_StreamItem]) -> list:
+    aggregator = _make_aggregator(use_parallel=False)
+    for item in items:
+        aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    aggregator.close()
+    return sorted(mcps, key=_mcp_key)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_parallel(items: List[_StreamItem], workers: int = 2) -> tuple:
+    aggregator = _make_aggregator(use_parallel=True, workers=workers)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    report = aggregator.report
+    aggregator.close()
+    return sorted(mcps, key=_mcp_key), report
+
+
+def _assert_equivalent(items: List[_StreamItem]) -> tuple:
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items)
+    serial_keys = [_mcp_key(m) for m in serial]
+    parallel_keys = [_mcp_key(m) for m in parallel]
+    assert parallel_keys == serial_keys
+    return parallel, report
+
+
+def test_equivalence_no_temp_tables() -> None:
+    """Core no-loss proof: a mix of observed + preparsed queries across sessions,
+    no temp tables. Parallel output must equal serial output."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+        PreparsedQuery(
+            query_id=None,
+            query_text="select a, c from upstream2",
+            upstreams=[DatasetUrn("redshift", "dev.public.upstream2").urn()],
+            downstream=DatasetUrn("redshift", "dev.public.derived").urn(),
+            timestamp=_ts(30),
+            session_id="s1",
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            timestamp=_ts(40),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_equivalence_temp_producer_consumer_single_session() -> None:
+    """A temp-table-creating query followed by a consumer in the same session.
+
+    Mirrors the temp-table shapes in test_sql_aggregator.py. Proves the
+    PartitionExecutor per-session ordering guarantee: the temp producer must be
+    applied before the consumer is classified/parsed, so the consumer resolves
+    the temp table and lineage flows through to bar.
+    """
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create temp table foo as select a, b+c as c from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="session2",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="create table foo_session2 as select * from foo",
+            default_db="dev",
+            default_schema="public",
+            session_id="session2",
+            timestamp=_ts(20),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_equivalence_multiple_sessions_interleaved() -> None:
+    """Queries from multiple sessions (including _MISSING_SESSION) interleaved."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create temp table foo as select a, b+c as c from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionA",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="create table foo as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionB",
+            timestamp=_ts(15),
+        ),
+        # No session_id -> _MISSING_SESSION_ID
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            timestamp=_ts(18),
+        ),
+        ObservedQuery(
+            query="create table foo_a as select * from foo",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionA",
+            timestamp=_ts(20),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, c) select a, c from upstream2",
+            default_db="dev",
+            default_schema="public",
+            timestamp=_ts(25),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="sessionB",
+            timestamp=_ts(30),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_fallback_to_serial_on_pool_creation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ParallelSqlParser construction raises ParallelParserUnavailable the
+    scope silently falls back to serial, produces output identical to a plain
+    serial run, and the report records the fallback."""
+
+    reason = "test: multiprocessing unavailable"
+    monkeypatch.setattr(
+        "datahub.sql_parsing.sql_parsing_aggregator.ParallelSqlParser",
+        lambda **kwargs: (_ for _ in ()).throw(ParallelParserUnavailable(reason)),
+    )
+
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+    ]
+
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items)
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+    assert report.sql_parsing_fell_back_to_serial is True
+    assert report.sql_parsing_fell_back_to_serial_reason == reason
+
+
+def _logged_query_tuples(aggregator: SqlParsingAggregator) -> list:
+    """Snapshot the aggregator's logged queries as comparable tuples, sorted so
+    that concurrent-append ordering does not affect the comparison."""
+    entries = [
+        (
+            lq.query,
+            lq.session_id,
+            lq.timestamp,
+            lq.user,
+            lq.default_db,
+            lq.default_schema,
+        )
+        for lq in aggregator._logged_queries
+    ]
+    return sorted(entries, key=repr)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_with_query_log(items: List[_StreamItem], *, use_parallel: bool) -> tuple:
+    aggregator = _make_aggregator(
+        use_parallel=use_parallel,
+        query_log=QueryLogSetting.STORE_ALL,
+    )
+    if use_parallel:
+        with aggregator.parallel_sql_parsing_scope():
+            for item in items:
+                aggregator.add(item)
+    else:
+        for item in items:
+            aggregator.add(item)
+    mcps = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    logged = _logged_query_tuples(aggregator)
+    report = aggregator.report
+    aggregator.close()
+    return mcps, logged, report
+
+
+def test_equivalence_with_query_logging() -> None:
+    """Covers C1: with STORE_ALL query logging, the parallel path appends to the
+    shared FileBackedList query log from worker threads. Serial and parallel must
+    produce identical MCPs AND an identical set of logged queries (no lost or
+    corrupted log entries)."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, c) select a, c from upstream2",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            timestamp=_ts(25),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s4",
+            timestamp=_ts(40),
+        ),
+    ]
+
+    serial_mcps, serial_logged, serial_report = _run_with_query_log(
+        items, use_parallel=False
+    )
+    parallel_mcps, parallel_logged, parallel_report = _run_with_query_log(
+        items, use_parallel=True
+    )
+
+    assert [_mcp_key(m) for m in parallel_mcps] == [_mcp_key(m) for m in serial_mcps]
+    assert len(parallel_logged) == len(serial_logged)
+    assert parallel_logged == serial_logged
+    assert parallel_report.num_sql_parsed == serial_report.num_sql_parsed
+
+
+def _make_stress_items() -> List[_StreamItem]:
+    """Dozens of sessions, several queries each: a mix of temp producer/consumer
+    sessions and plain non-temp sessions, interleaved by timestamp."""
+    items: List[_StreamItem] = []
+    ts = 0
+    num_temp_sessions = 12
+    num_plain_sessions = 12
+
+    # Interleave: for each "round", emit one query from several sessions.
+    for round_idx in range(3):
+        for s in range(num_plain_sessions):
+            ts += 1
+            # Distinct output table per (session, round) so there are no
+            # cross-session query-fingerprint collisions whose "latest timestamp"
+            # would be apply-order-dependent (that would make even a correct
+            # serial run non-deterministic vs parallel). Lineage still flows from
+            # a shared upstream, exercising the real parse path.
+            upstream = "upstream1" if round_idx % 2 == 0 else "upstream2"
+            cols = "a, b" if round_idx % 2 == 0 else "a, c"
+            items.append(
+                ObservedQuery(
+                    query=(
+                        f"create table out_{s}_{round_idx} as "
+                        f"select {cols} from {upstream}"
+                    ),
+                    default_db="dev",
+                    default_schema="public",
+                    session_id=f"plain_{s}",
+                    timestamp=_ts(ts),
+                )
+            )
+        for s in range(num_temp_sessions):
+            ts += 1
+            if round_idx == 0:
+                # Temp producer.
+                items.append(
+                    ObservedQuery(
+                        query="create temp table foo as select a, b+c as c from bar",
+                        default_db="dev",
+                        default_schema="public",
+                        session_id=f"temp_{s}",
+                        timestamp=_ts(ts),
+                    )
+                )
+            else:
+                # Temp consumer.
+                items.append(
+                    ObservedQuery(
+                        query=f"create table foo_{s}_{round_idx} as select * from foo",
+                        default_db="dev",
+                        default_schema="public",
+                        session_id=f"temp_{s}",
+                        timestamp=_ts(ts),
+                    )
+                )
+    return items
+
+
+@pytest.mark.parametrize("run_idx", range(3))
+def test_high_volume_many_sessions_stress(run_idx: int) -> None:
+    """Covers C2/I1/I2: a higher-volume, many-session interleaved stream with a
+    mix of temp and non-temp sessions and workers>=2. Asserts:
+
+    - serial-vs-parallel MCP equivalence (no lineage loss),
+    - report.num_sql_parsed matches the serial count (no lost/double accounting),
+    - report.num_queries_parsed_in_parallel equals the number of non-temp
+      observed queries that were actually pool-parsed (> 0), proving the
+      observability contract.
+
+    Repeated a few times via parametrization since races are timing-dependent.
+    """
+    items = _make_stress_items()
+
+    serial = _run_serial(items)
+    parallel, report = _run_parallel(items, workers=4)
+
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+
+    serial_report = _make_aggregator(use_parallel=False)
+    for item in items:
+        serial_report.add(item)
+    list(serial_report.gen_metadata())
+    expected_num_sql_parsed = serial_report.report.num_sql_parsed
+    serial_report.close()
+
+    assert report.num_sql_parsed == expected_num_sql_parsed
+
+    # A query is pool-parsed iff its session had no temp tables registered at the
+    # time it was classified. That is every plain_* query, plus the temp
+    # producer (the "create temp table foo" runs before the temp table exists in
+    # its session). The temp *consumers* parse inline because their session then
+    # holds an in-memory temp schema that cannot ship to a worker.
+    num_pool_parsed_expected = sum(
+        1
+        for item in items
+        if isinstance(item, ObservedQuery)
+        and (
+            (item.session_id or "").startswith("plain_")
+            or item.query.strip().lower().startswith("create temp table")
+        )
+    )
+    assert report.num_queries_parsed_in_parallel > 0
+    assert report.num_queries_parsed_in_parallel == num_pool_parsed_expected
+
+
+def test_add_to_query_map_latest_timestamp_is_max_not_last_written() -> None:
+    """_add_to_query_map must keep the maximum timestamp regardless of insertion order.
+
+    When the parallel path applies per-session results, the same query fingerprint
+    may be merged in a non-chronological order across sessions.  Before the fix,
+    ``current.latest_timestamp = new.latest_timestamp or current.latest_timestamp``
+    was last-writer-wins, so a later write with an EARLIER timestamp silently
+    replaced the correct (higher) value — a serial-vs-parallel divergence.
+
+    Regression test: insert LATER timestamp first, then EARLIER; assert the stored
+    value is the LATER one (the maximum).
+    """
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
+
+    fingerprint = "test-fingerprint-order-independence"
+
+    first = QueryMetadata(
+        query_id=fingerprint,
+        formatted_query_string="SELECT 1",
+        session_id="session_a",
+        query_type=QueryType.UNKNOWN,
+        lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+        latest_timestamp=later_ts,
+        actor=None,
+        upstreams=[],
+        column_lineage=[],
+        column_usage={},
+        confidence_score=1.0,
+    )
+    second = QueryMetadata(
+        query_id=fingerprint,
+        formatted_query_string="SELECT 1",
+        session_id="session_b",
+        query_type=QueryType.UNKNOWN,
+        lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+        latest_timestamp=earlier_ts,
+        actor=None,
+        upstreams=[],
+        column_lineage=[],
+        column_usage={},
+        confidence_score=1.0,
+    )
+
+    # Insert later-timestamp first, then earlier-timestamp second.
+    # After the fix the stored value must be the maximum (later_ts).
+    aggregator._add_to_query_map(first)
+    aggregator._add_to_query_map(second)
+
+    stored = aggregator._query_map[fingerprint]
+    assert stored.latest_timestamp == later_ts, (
+        f"Expected the maximum timestamp ({later_ts}), "
+        f"got {stored.latest_timestamp} — last-writer-wins bug is present."
+    )
+
+    aggregator.close()
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_teardown_without_scope_exit_matches_scoped_run() -> None:
+    """A connector that forgets to exit the parallel scope (never runs the
+    ``with`` block's __exit__) must still produce correct output and leak no
+    worker pool: close() defensively tears down via _teardown_parallel (R6)."""
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+    ]
+
+    expected = _run_serial(items)
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    scope = aggregator.parallel_sql_parsing_scope()
+    scope.__enter__()
+    for item in items:
+        aggregator.add(item)
+    # Deliberately do NOT call scope.__exit__ — simulate a forgotten `with` exit.
+    mcps = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+
+    assert [_mcp_key(m) for m in mcps] == [_mcp_key(m) for m in expected]
+
+    # close() must defensively tear down the still-open parallel machinery.
+    aggregator.close()
+    assert aggregator._partition_executor is None
+    assert aggregator._parallel_parser is None
+    assert aggregator._parallel_active is False
+
+
+def test_equivalence_rare_item_interleaved() -> None:
+    """A TableRename (and a TableSwap) interleaved with observed queries in the
+    same session. Exercises the flush-then-apply rare-item path: parallel output
+    must equal serial (R6)."""
+    rename = TableRename(
+        original_urn=DatasetUrn("redshift", "dev.public.bar").urn(),
+        new_urn=DatasetUrn("redshift", "dev.public.bar_renamed").urn(),
+        session_id="s1",
+        timestamp=_ts(15),
+    )
+    swap = TableSwap(
+        urn1=DatasetUrn("redshift", "dev.public.upstream1").urn(),
+        urn2=DatasetUrn("redshift", "dev.public.upstream2").urn(),
+        session_id="s1",
+        timestamp=_ts(25),
+    )
+    items: List[_StreamItem] = [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        rename,
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(20),
+        ),
+        swap,
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(30),
+        ),
+    ]
+    _assert_equivalent(items)
+
+
+def test_feature_off_is_default() -> None:
+    """Feature is off by default and the parallel scope is a no-op."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+    assert aggregator.report.sql_parsing_parallel_enabled is False
+    # The scope must be a no-op when the feature is off.
+    with aggregator.parallel_sql_parsing_scope():
+        aggregator.add_observed_query(
+            ObservedQuery(
+                query="create table foo as select a, b from bar",
+                default_db="dev",
+                default_schema="public",
+            )
+        )
+    mcps = list(aggregator.gen_metadata())
+    aggregator.close()
+    assert len(mcps) > 0
+    assert aggregator.report.sql_parsing_parallel_enabled is False
+
+
+def _query_statement_values(mcps: list) -> List[str]:
+    """Extract every QueryProperties.statement.value (the formatted query text)
+    emitted across the MCPs, sorted for order-independent comparison."""
+    values: List[str] = []
+    for mcp in mcps:
+        aspect = getattr(mcp, "aspect", None)
+        if isinstance(aspect, models.QueryPropertiesClass):
+            values.append(aspect.statement.value)
+    return sorted(values)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_equivalence_formatted_query_text_identical() -> None:
+    """The formatted query text in the emitted query aspects must be byte-identical
+    between serial (formats on main thread) and parallel (formats in worker) with
+    format_queries=True (the default)."""
+    items = _observed_no_temp_items()
+
+    serial = _run_serial(items)
+    parallel, _ = _run_parallel(items)
+
+    serial_values = _query_statement_values(serial)
+    parallel_values = _query_statement_values(parallel)
+
+    assert serial_values, "expected at least one query statement aspect"
+    assert parallel_values == serial_values
+    # Sanity: formatting actually happened (multi-line pretty-print), so this is a
+    # meaningful assertion rather than comparing two unformatted strings.
+    assert any("\n" in value for value in serial_values)
+
+
+def _observed_no_temp_items() -> List[_StreamItem]:
+    return [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+    ]
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_parallel_apply_does_not_reformat_on_main_thread() -> None:
+    """On the parallel (non-temp) path the worker pre-formats the query, so the
+    main-thread _maybe_format_query must NOT be called again for those queries."""
+    items = _observed_no_temp_items()
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    assert aggregator.format_queries is True
+    with mock.patch.object(
+        aggregator,
+        "_maybe_format_query",
+        wraps=aggregator._maybe_format_query,
+    ) as spy:
+        with aggregator.parallel_sql_parsing_scope():
+            for item in items:
+                aggregator.add(item)
+        list(aggregator.gen_metadata())
+    aggregator.close()
+
+    assert spy.call_count == 0
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_serial_apply_still_formats_on_main_thread() -> None:
+    """The serial path must still format on the main thread (behavior unchanged)."""
+    items = _observed_no_temp_items()
+
+    aggregator = _make_aggregator(use_parallel=False)
+    assert aggregator.format_queries is True
+    with mock.patch.object(
+        aggregator,
+        "_maybe_format_query",
+        wraps=aggregator._maybe_format_query,
+    ) as spy:
+        for item in items:
+            aggregator.add(item)
+        list(aggregator.gen_metadata())
+    aggregator.close()
+
+    assert spy.call_count > 0
+
+
+def test_add_to_query_map_actor_tracks_latest_timestamp() -> None:
+    """actor/session_id must follow the record with the later timestamp,
+    regardless of insertion order.
+
+    Same fingerprint added with (later-ts, actorA) then (earlier-ts, actorB)
+    must keep actorA both ways.
+    """
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
+    actor_a = CorpUserUrn("actor_a")
+    actor_b = CorpUserUrn("actor_b")
+
+    fingerprint = "test-actor-order-independence"
+
+    def _make_meta(ts, actor, session):
+        return QueryMetadata(
+            query_id=fingerprint,
+            formatted_query_string="SELECT 1",
+            session_id=session,
+            query_type=QueryType.UNKNOWN,
+            lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+            latest_timestamp=ts,
+            actor=actor,
+            upstreams=[],
+            column_lineage=[],
+            column_usage={},
+            confidence_score=1.0,
+        )
+
+    # Forward order: later first, earlier second
+    aggregator._add_to_query_map(_make_meta(later_ts, actor_a, "session_a"))
+    aggregator._add_to_query_map(_make_meta(earlier_ts, actor_b, "session_b"))
+    stored = aggregator._query_map[fingerprint]
+    assert stored.actor == actor_a, "actor should track the later-timestamp record"
+
+    # Now clear and test reverse order: earlier first, later second
+    del aggregator._query_map[fingerprint]
+    aggregator._add_to_query_map(_make_meta(earlier_ts, actor_b, "session_b"))
+    aggregator._add_to_query_map(_make_meta(later_ts, actor_a, "session_a"))
+    stored = aggregator._query_map[fingerprint]
+    assert stored.actor == actor_a, (
+        "actor should track the later-timestamp record (reversed order)"
+    )
+
+    aggregator.close()
+
+
+def _query_meta(
+    *,
+    fingerprint: str,
+    formatted: str = "SELECT 1",
+    session: str = "s0",
+    ts: Optional[datetime],
+    actor: Optional[Union[CorpUserUrn, CorpGroupUrn]],
+) -> QueryMetadata:
+    return QueryMetadata(
+        query_id=fingerprint,
+        formatted_query_string=formatted,
+        session_id=session,
+        query_type=QueryType.UNKNOWN,
+        lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
+        latest_timestamp=ts,
+        actor=actor,
+        upstreams=[],
+        column_lineage=[],
+        column_usage={},
+        confidence_score=1.0,
+    )
+
+
+def test_add_to_query_map_does_not_drop_known_actor_for_none() -> None:
+    """The later-timestamp record having actor=None must NOT wipe a
+    previously-known actor.
+
+    This is the serial-path regression: queries arrive in ascending-timestamp
+    order, so a trailing actor-less duplicate is always the timestamp winner. If
+    the winner's actor overwrites unconditionally, the known actor is lost and
+    Redshift usage/lineage actors regress to the default ingestion user.
+
+    The merged actor must coalesce (winner.actor or loser.actor), so both
+    insertion orders keep the real actor.
+    """
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
+    later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    real_actor = CorpUserUrn("real_actor")
+    fingerprint = "test-actor-not-dropped"
+
+    # Ascending order (serial): known actor first, actor-less winner second.
+    aggregator._add_to_query_map(
+        _query_meta(fingerprint=fingerprint, ts=earlier_ts, actor=real_actor)
+    )
+    aggregator._add_to_query_map(
+        _query_meta(fingerprint=fingerprint, ts=later_ts, actor=None)
+    )
+    stored = aggregator._query_map[fingerprint]
+    assert stored.actor == real_actor, (
+        "known actor must not be dropped when the timestamp winner has actor=None"
+    )
+
+    # Reversed order: actor-less winner first, known actor second.
+    del aggregator._query_map[fingerprint]
+    aggregator._add_to_query_map(
+        _query_meta(fingerprint=fingerprint, ts=later_ts, actor=None)
+    )
+    aggregator._add_to_query_map(
+        _query_meta(fingerprint=fingerprint, ts=earlier_ts, actor=real_actor)
+    )
+    stored = aggregator._query_map[fingerprint]
+    assert stored.actor == real_actor, (
+        "known actor must not be dropped regardless of insertion order"
+    )
+
+    aggregator.close()
+
+
+def test_add_to_query_map_representative_text_is_order_independent() -> None:
+    """The stored formatted_query_string must deterministically come from the
+    MAX-timestamp record, not the last-written one.
+
+    Query fingerprints generalize literals, so two records with the same
+    fingerprint can carry different formatted text. The stored text must be
+    tied to the timestamp winner so serial and parallel produce byte-identical
+    output regardless of which cross-session task finishes last.
+    """
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
+    later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    fingerprint = "test-representative-text"
+    earlier_text = "SELECT * FROM t WHERE ts = 34"
+    later_text = "SELECT * FROM t WHERE ts = 38"
+
+    def _earlier() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=earlier_text, ts=earlier_ts, actor=None
+        )
+
+    def _later() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=later_text, ts=later_ts, actor=None
+        )
+
+    def _run(order: List[QueryMetadata]) -> str:
+        if fingerprint in aggregator._query_map:
+            del aggregator._query_map[fingerprint]
+        for meta in order:
+            aggregator._add_to_query_map(meta)
+        return aggregator._query_map[fingerprint].formatted_query_string
+
+    # Build fresh metadata per run: the map stores a reference on fresh insert
+    # and merges mutate it in place, so reusing objects across runs would alias.
+    ascending = _run([_earlier(), _later()])
+    descending = _run([_later(), _earlier()])
+
+    assert ascending == later_text, (
+        "stored text must be the max-timestamp record's text (ascending order)"
+    )
+    assert descending == later_text, (
+        "stored text must be the max-timestamp record's text (descending order)"
+    )
+
+    aggregator.close()
+
+
+def test_add_to_query_map_equal_timestamp_tie_break_is_deterministic() -> None:
+    """When timestamps are equal (or both None), the winner is chosen by a
+    stable tie-break (lexicographically-greater formatted text), so the merged
+    result is identical regardless of insertion order."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    same_ts = datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+    fingerprint = "test-tie-break"
+    text_a = "SELECT a FROM t"
+    text_b = "SELECT b FROM t"  # lexicographically greater -> deterministic winner
+
+    def _a() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=text_a, ts=same_ts, actor=None
+        )
+
+    def _b() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=text_b, ts=same_ts, actor=None
+        )
+
+    def _run(order: List[QueryMetadata]) -> str:
+        if fingerprint in aggregator._query_map:
+            del aggregator._query_map[fingerprint]
+        for meta in order:
+            aggregator._add_to_query_map(meta)
+        return aggregator._query_map[fingerprint].formatted_query_string
+
+    forward = _run([_a(), _b()])
+    reverse = _run([_b(), _a()])
+
+    assert forward == reverse, "equal-timestamp merge must be order-independent"
+    assert forward == text_b, (
+        "tie-break winner must be the lexicographically greater text"
+    )
+
+    aggregator.close()
+
+
+# ---------------------------------------------------------------------------
+# Worker / pool infra-failure handling. These protect the no-lineage-loss
+# guarantee: when a worker process dies or the pool cannot be initialized, the
+# aggregator must reparse the affected query inline (serially) rather than
+# silently dropping it, and must fall the rest of the run back to serial.
+# ---------------------------------------------------------------------------
+
+
+def _infra_error_items() -> List[_StreamItem]:
+    """A mix of non-temp observed queries across sessions (no temp tables, so
+    every one would normally go to a worker via parse_one)."""
+    return [
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            timestamp=_ts(20),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, c) select a, c from upstream2",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            timestamp=_ts(30),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            timestamp=_ts(40),
+        ),
+    ]
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_worker_infra_failure_falls_back_to_serial_no_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``parse_one`` returns an infra-failure outcome (worker died /
+    BrokenProcessPool), the aggregator must reparse that query inline and mark
+    the pool broken. Output must be byte-identical to a fully-serial run, and
+    infra failures must NOT inflate ``num_observed_queries_failed``."""
+    items = _infra_error_items()
+    serial = _run_serial(items)
+
+    real_parse_one = ParallelSqlParser.parse_one
+
+    def failing_parse_one(self: ParallelSqlParser, task: object) -> ParseOutcome:
+        # Simulate a dead worker / broken pool on the very first parse and
+        # stay broken thereafter (sticky), exactly like a real pool death.
+        self.pool_broke.set()
+        return ParseOutcome(
+            key=getattr(task, "key", None),
+            result=None,
+            error=repr(
+                concurrent.futures.process.BrokenProcessPool("simulated worker death")
+            ),
+        )
+
+    monkeypatch.setattr(ParallelSqlParser, "parse_one", failing_parse_one)
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    parallel = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    report = aggregator.report
+    aggregator.close()
+
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+    assert report.sql_parsing_pool_broke is True
+    # Infra failures were reparsed inline, not counted as parse failures.
+    assert report.num_observed_queries_failed == 0
+
+    # Sanity: real_parse_one still points at the original (monkeypatch restores).
+    assert real_parse_one is not None
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_pool_init_failure_falls_back_to_serial_no_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pool-init failure surfaces as a BrokenProcessPool raised from the first
+    ``parse_one`` (outside the constructor's ParallelParserUnavailable path).
+    The whole run must fall back to serial with identical output and no drops."""
+    items = _infra_error_items()
+    serial = _run_serial(items)
+
+    def raising_parse_one(self: ParallelSqlParser, task: object) -> ParseOutcome:
+        # Mirror the real parse_one: on BrokenProcessPool it sets pool_broke and
+        # returns an error outcome rather than propagating.
+        self.pool_broke.set()
+        return ParseOutcome(
+            key=getattr(task, "key", None),
+            result=None,
+            error=repr(
+                concurrent.futures.process.BrokenProcessPool("worker init failed")
+            ),
+        )
+
+    monkeypatch.setattr(ParallelSqlParser, "parse_one", raising_parse_one)
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    parallel = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    report = aggregator.report
+    aggregator.close()
+
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+    assert report.sql_parsing_pool_broke is True
+    assert report.num_observed_queries_failed == 0
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_worker_parse_time_metric_populated() -> None:
+    """After a real parallel run, worker parse time must be visible in the
+    dedicated accumulator (it was previously invisible to sql_parsing_timer)."""
+    items = _observed_no_temp_items()
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    list(aggregator.gen_metadata())
+    report = aggregator.report
+    aggregator.close()
+
+    assert report.num_queries_parsed_in_parallel > 0
+    assert report.parallel_sql_parsing_time_seconds > 0.0
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_submit_time_broken_pool_falls_back_to_serial_no_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H1: when the executor's ``submit`` itself raises BrokenProcessPool (the
+    pool is already broken at dispatch time), parse_one must convert it to an
+    error outcome + set pool_broke — NOT let it propagate to
+    _process_observed_task's outer except (which would count it as a parse
+    failure and skip inline recovery). Output must be identical to serial and no
+    query dropped."""
+    from concurrent.futures.process import BrokenProcessPool
+
+    items = _infra_error_items()
+    serial = _run_serial(items)
+
+    real_submit = ParallelSqlParser._ensure_executor
+
+    def _patched_ensure(self: ParallelSqlParser) -> object:
+        executor = real_submit(self)
+        # Patch submit on the live executor exactly once so the first dispatch
+        # hits a submit-time BrokenProcessPool, then stays broken (sticky).
+        if getattr(executor, "_h1_patched", False) is False:
+
+            def _boom_submit(*args: object, **kwargs: object) -> object:
+                raise BrokenProcessPool("boom at submit")
+
+            executor.submit = _boom_submit  # type: ignore[assignment]
+            executor._h1_patched = True  # type: ignore[attr-defined]
+        return executor
+
+    monkeypatch.setattr(ParallelSqlParser, "_ensure_executor", _patched_ensure)
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    parallel = sorted(list(aggregator.gen_metadata()), key=_mcp_key)
+    report = aggregator.report
+    aggregator.close()
+
+    assert [_mcp_key(m) for m in parallel] == [_mcp_key(m) for m in serial]
+    assert report.sql_parsing_pool_broke is True
+    # Submit-time infra failure must be reparsed inline, not counted as a parse
+    # failure, and must not land in the infra-failure bucket either (parse_one
+    # swallowed it into an error outcome, so recovery is clean).
+    assert report.num_observed_queries_failed == 0
+
+
+# ---------------------------------------------------------------------------
+# H2 — mixed naive/aware timestamps must not crash the merge (serial path too)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_parallel", [False, True])
+def test_add_to_query_map_mixed_tz_timestamps_no_crash(use_parallel: bool) -> None:
+    """A duplicate fingerprint whose two records carry a naive datetime and a
+    UTC-aware datetime must merge without a TypeError, in BOTH insertion orders
+    and BOTH serial and parallel modes. The later instant wins deterministically."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+        use_parallel_sql_parsing=use_parallel,
+        sql_parsing_workers=2 if use_parallel else None,
+    )
+
+    # One naive datetime and one UTC-aware datetime for the SAME fingerprint.
+    # Comparing them with raw `>` raises TypeError; make_ts_millis normalizes
+    # both to epoch millis so the merge is safe. They are set years apart so the
+    # ordering (aware-2024 later than naive-2020) is unambiguous regardless of
+    # the machine's local timezone that make_ts_millis uses for the naive value.
+    naive_earlier = datetime(2020, 1, 1, 6, 0, 0)  # naive
+    aware_later = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)  # aware
+    fingerprint = "test-mixed-tz"
+    naive_text = "SELECT naive"
+    aware_text = "SELECT aware"
+
+    def _naive() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=naive_text, ts=naive_earlier, actor=None
+        )
+
+    def _aware() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint, formatted=aware_text, ts=aware_later, actor=None
+        )
+
+    def _run(order: List[QueryMetadata]) -> QueryMetadata:
+        if fingerprint in aggregator._query_map:
+            del aggregator._query_map[fingerprint]
+        for meta in order:
+            aggregator._add_to_query_map(meta)  # must not raise TypeError
+        return aggregator._query_map[fingerprint]
+
+    forward = _run([_naive(), _aware()])
+    reverse = _run([_aware(), _naive()])
+
+    # The later instant (aware 12:00) wins deterministically in both orders.
+    assert forward.formatted_query_string == aware_text
+    assert reverse.formatted_query_string == aware_text
+    assert forward.latest_timestamp == aware_later
+    assert reverse.latest_timestamp == aware_later
+
+    aggregator.close()
+
+
+# ---------------------------------------------------------------------------
+# M1 — tie-break must be TOTAL: equal ts + equal text picks a stable winner
+# ---------------------------------------------------------------------------
+
+
+def test_add_to_query_map_total_tie_break_on_equal_ts_and_text() -> None:
+    """When two cross-session records share the same timestamp AND identical
+    formatted text, actor/session selection must still be deterministic (driven
+    by session_id then actor), not by arrival order."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+
+    same_ts = datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
+    same_text = "SELECT a FROM t"
+    fingerprint = "test-total-tie-break"
+    actor_a = CorpUserUrn("actor_a")
+    actor_b = CorpUserUrn("actor_b")
+
+    def _a() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint,
+            formatted=same_text,
+            session="session_a",
+            ts=same_ts,
+            actor=actor_a,
+        )
+
+    def _b() -> QueryMetadata:
+        return _query_meta(
+            fingerprint=fingerprint,
+            formatted=same_text,
+            session="session_b",
+            ts=same_ts,
+            actor=actor_b,
+        )
+
+    def _run(order: List[QueryMetadata]) -> QueryMetadata:
+        if fingerprint in aggregator._query_map:
+            del aggregator._query_map[fingerprint]
+        for meta in order:
+            aggregator._add_to_query_map(meta)
+        return aggregator._query_map[fingerprint]
+
+    forward = _run([_a(), _b()])
+    reverse = _run([_b(), _a()])
+
+    assert forward.actor == reverse.actor, "actor must be arrival-order independent"
+    assert forward.session_id == reverse.session_id, (
+        "session_id must be arrival-order independent"
+    )
+
+    aggregator.close()
+
+
+# ---------------------------------------------------------------------------
+# W2 — inline-reparse failure counted under the infra bucket, not parse failure
+# ---------------------------------------------------------------------------
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_inline_reparse_failure_counts_as_infra_not_parse_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``_reparse_observed_inline`` itself raises (e.g. the pool degraded and
+    the inline recovery hit an infra error), it must be recorded under the new
+    infra-failure counter, NOT inflate ``num_observed_queries_failed``."""
+    items = _infra_error_items()
+
+    # Force every task down the inline branch by pretending the pool is broken,
+    # then make the inline reparse raise.
+    monkeypatch.setattr(SqlParsingAggregator, "_pool_is_broken", lambda self: True)
+
+    def _boom_inline(
+        self: SqlParsingAggregator, *args: object, **kwargs: object
+    ) -> None:
+        raise RuntimeError("inline reparse infra failure")
+
+    monkeypatch.setattr(SqlParsingAggregator, "_reparse_observed_inline", _boom_inline)
+
+    aggregator = _make_aggregator(use_parallel=True, workers=2)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    list(aggregator.gen_metadata())
+    report = aggregator.report
+    aggregator.close()
+
+    assert report.num_observed_queries_failed == 0
+    assert report.num_observed_queries_infra_failed == len(items)
+
+
+# ---------------------------------------------------------------------------
+# Full serialized-MCP equivalence: a complete-object comparison (not a
+# field-subset). Every emitted MCP is serialized in full via to_obj() and the
+# two runs must be byte-for-byte identical after a deterministic sort.
+# ---------------------------------------------------------------------------
+
+
+def _merge_path_items() -> List[_StreamItem]:
+    """A workload that deliberately exercises the cross-session merge path.
+
+    ``s1`` and ``s2`` emit the SAME query fingerprint (literals are generalized
+    away when the fingerprint is computed) but with DIFFERENT literals and
+    DIFFERENT actors. In the parallel path these two sessions are parsed on
+    different workers and merged back in a non-deterministic order, so this is
+    exactly the shape that would diverge if the merge (max-timestamp winner for
+    text/actor/session) were not deterministic.
+    """
+    actor_a = CorpUserUrn("actor_a")
+    actor_b = CorpUserUrn("actor_b")
+    return [
+        # Duplicate fingerprint across sessions, different literals + actors.
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1 where a = 1",
+            default_db="dev",
+            default_schema="public",
+            session_id="s1",
+            user=actor_a,
+            timestamp=_ts(10),
+        ),
+        ObservedQuery(
+            query="insert into downstream (a, b) select a, b from upstream1 where a = 2",
+            default_db="dev",
+            default_schema="public",
+            session_id="s2",
+            user=actor_b,
+            timestamp=_ts(20),
+        ),
+        # Independent lineage-producing queries in further sessions.
+        ObservedQuery(
+            query="create table foo as select a, b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s3",
+            user=actor_a,
+            timestamp=_ts(30),
+        ),
+        ObservedQuery(
+            query="create table baz as select a, 2*b as b from bar",
+            default_db="dev",
+            default_schema="public",
+            session_id="s4",
+            user=actor_b,
+            timestamp=_ts(40),
+        ),
+        PreparsedQuery(
+            query_id=None,
+            query_text="select a, c from upstream2",
+            upstreams=[DatasetUrn("redshift", "dev.public.upstream2").urn()],
+            downstream=DatasetUrn("redshift", "dev.public.derived").urn(),
+            timestamp=_ts(50),
+            session_id="s3",
+        ),
+    ]
+
+
+def _serialize_mcps_canonical(mcps: list) -> List[str]:
+    """Serialize EACH MCP in full via to_obj(), then sort deterministically.
+
+    ``to_obj()`` renders the complete MetadataChangeProposalWrapper — entity
+    urn, aspect name, and the entire aspect payload — so this is a genuine
+    whole-object comparison, not a hand-picked field subset. Each object is
+    dumped to a canonical JSON string (sort_keys=True) and the list is sorted by
+    that string, giving an order-independent full-fidelity fingerprint of the run.
+    """
+    return sorted(json.dumps(mcp.to_obj(), sort_keys=True, default=str) for mcp in mcps)
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_serial_raw(items: List[_StreamItem]) -> list:
+    aggregator = _make_aggregator(use_parallel=False)
+    for item in items:
+        aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    aggregator.close()
+    return mcps
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def _run_parallel_raw(items: List[_StreamItem], workers: int) -> tuple:
+    aggregator = _make_aggregator(use_parallel=True, workers=workers)
+    with aggregator.parallel_sql_parsing_scope():
+        for item in items:
+            aggregator.add(item)
+    mcps = list(aggregator.gen_metadata())
+    report = aggregator.report
+    aggregator.close()
+    return mcps, report
+
+
+@pytest.mark.parametrize("workers", [2, 3, 4])
+def test_full_serialized_mcp_equivalence_serial_vs_parallel(workers: int) -> None:
+    """The COMPLETE serialized MCP output must be identical between serial and
+    parallel, including the merge of a duplicate fingerprint across sessions with
+    different literals and actors.
+
+    This is stronger than the key/subset comparisons elsewhere in this file: we
+    serialize every MCP in full (to_obj -> canonical JSON) and assert the two
+    fully-serialized, deterministically-sorted lists are EQUAL. No aspect is
+    ignored and no field is cherry-picked. Because timestamp/actor/text merges
+    are deterministic (max-timestamp winner with a stable tie-break), no
+    volatile-field normalization is required.
+    """
+    items = _merge_path_items()
+
+    serial_mcps = _run_serial_raw(items)
+    parallel_mcps, report = _run_parallel_raw(items, workers=workers)
+
+    serial_serialized = _serialize_mcps_canonical(serial_mcps)
+    parallel_serialized = _serialize_mcps_canonical(parallel_mcps)
+
+    # Sanity: the workload actually produced output and exercised the pool.
+    assert serial_serialized, "expected the workload to emit at least one MCP"
+    assert report.num_queries_parsed_in_parallel > 0
+
+    assert parallel_serialized == serial_serialized
+
+
+# ---------------------------------------------------------------------------
+# Config-activation behaviour: the config flag must genuinely drive parallelism
+# end-to-end (activate the pool), not merely round-trip as a Pydantic field.
+# ---------------------------------------------------------------------------
+
+
+def test_config_flag_drives_parallelism_end_to_end() -> None:
+    """``use_parallel_sql_parsing`` must actually activate the worker pool.
+
+    With the flag ON (and a scope entered) the report must show parallelism
+    enabled AND report a positive count of queries parsed in the pool. With the
+    flag OFF, parallelism must be disabled, nothing is pool-parsed, and the
+    serialized output must be identical to the parallel run (equivalence).
+    """
+    items = _observed_no_temp_items()
+
+    # Flag OFF: no pool, nothing parsed in parallel.
+    off = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+        use_parallel_sql_parsing=False,
+    )
+    off._schema_resolver.add_raw_schema_info(
+        DatasetUrn("redshift", "dev.public.bar").urn(),
+        {"a": "int", "b": "int", "c": "int"},
+    )
+    with time_machine.travel(FROZEN_TIME, tick=False):
+        with off.parallel_sql_parsing_scope():
+            for item in items:
+                off.add(item)
+        off_mcps = list(off.gen_metadata())
+    off_report = off.report
+    off.close()
+
+    assert off_report.sql_parsing_parallel_enabled is False
+    assert off_report.num_queries_parsed_in_parallel == 0
+
+    # Flag ON: the pool must genuinely activate.
+    on = _make_aggregator(use_parallel=True, workers=2)
+    with time_machine.travel(FROZEN_TIME, tick=False):
+        with on.parallel_sql_parsing_scope():
+            for item in items:
+                on.add(item)
+        on_mcps = list(on.gen_metadata())
+    on_report = on.report
+    on.close()
+
+    assert on_report.sql_parsing_parallel_enabled is True
+    assert on_report.num_queries_parsed_in_parallel > 0
+
+    # Same output regardless of the flag (the flag changes HOW, not WHAT).
+    assert _serialize_mcps_canonical(on_mcps) == _serialize_mcps_canonical(off_mcps)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -8,6 +8,8 @@ normalizing ordering.
 """
 
 import concurrent.futures.process
+import dataclasses
+import itertools
 import json
 from datetime import datetime, timezone
 from typing import List, Optional, Union
@@ -785,6 +787,8 @@ def _query_meta(
     session: str = "s0",
     ts: Optional[datetime],
     actor: Optional[Union[CorpUserUrn, CorpGroupUrn]],
+    used_temp_tables: bool = False,
+    upstreams: Optional[List[str]] = None,
 ) -> QueryMetadata:
     return QueryMetadata(
         query_id=fingerprint,
@@ -794,11 +798,93 @@ def _query_meta(
         lineage_type=models.DatasetLineageTypeClass.TRANSFORMED,
         latest_timestamp=ts,
         actor=actor,
-        upstreams=[],
+        upstreams=upstreams if upstreams is not None else [],
         column_lineage=[],
         column_usage={},
         confidence_score=1.0,
+        used_temp_tables=used_temp_tables,
     )
+
+
+def _reduce_query_map(metas: List[QueryMetadata]) -> QueryMetadata:
+    """Feed ``metas`` (all sharing one fingerprint) through a fresh aggregator's
+    ``_add_to_query_map`` in the given order and return the stored record."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+        query_log=QueryLogSetting.DISABLED,
+    )
+    for meta in metas:
+        aggregator._add_to_query_map(dataclasses.replace(meta))
+    return aggregator._query_map[metas[0].query_id]
+
+
+def test_add_to_query_map_actor_selection_is_order_and_grouping_independent() -> None:
+    """BLOCKER regression: actor selection must be associative.
+
+    Records share a fingerprint. The timestamp winner (A) has actor=None while
+    two earlier records carry distinct actors. Serial semantics attribute the
+    query to the actor of the latest-timestamp record that HAS an actor (B).
+    A previous coalescing rule (``winner.actor or loser.actor``) fed the
+    synthesized actor back into the winner ranking, so three-way grouping could
+    yield B's actor in one order and C's in another. Every permutation must now
+    resolve to the same actor.
+    """
+    fp = "assoc-actor"
+    actor_b = CorpUserUrn("user_b")
+    actor_c = CorpUserUrn("user_c")
+    ts_a = datetime(2024, 1, 3, tzinfo=timezone.utc)  # latest, no actor
+    ts_b = datetime(2024, 1, 2, tzinfo=timezone.utc)  # middle, actor_b
+    ts_c = datetime(2024, 1, 1, tzinfo=timezone.utc)  # earliest, actor_c
+    a = _query_meta(fingerprint=fp, ts=ts_a, actor=None)
+    b = _query_meta(fingerprint=fp, ts=ts_b, actor=actor_b)
+    c = _query_meta(fingerprint=fp, ts=ts_c, actor=actor_c)
+
+    def _order_key(perm: tuple) -> tuple:
+        return tuple(m.latest_timestamp.day if m.latest_timestamp else 0 for m in perm)
+
+    results = {
+        _order_key(perm): _reduce_query_map(list(perm)).actor
+        for perm in itertools.permutations([a, b, c])
+    }
+    assert set(results.values()) == {actor_b}, (
+        f"actor selection depends on merge order: {results}"
+    )
+
+
+def test_add_to_query_map_temp_lineage_authority_is_commutative() -> None:
+    """BLOCKER regression: temp-table lineage authority must be symmetric.
+
+    When one record used temp tables and the other did not, the temp-derived
+    lineage is authoritative regardless of arrival order (the old one-directional
+    early-return only preserved it when the EXISTING record was the temp one)."""
+    fp = "commute-temp"
+    temp_up = ["urn:li:dataset:(urn:li:dataPlatform:redshift,temp_up,PROD)"]
+    plain_up = ["urn:li:dataset:(urn:li:dataPlatform:redshift,plain_up,PROD)"]
+    older = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    newer = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    # Older temp record vs newer non-temp record: temp lineage wins both orders.
+    temp_older = _query_meta(
+        fingerprint=fp, ts=older, actor=None, used_temp_tables=True, upstreams=temp_up
+    )
+    plain_newer = _query_meta(
+        fingerprint=fp, ts=newer, actor=None, used_temp_tables=False, upstreams=plain_up
+    )
+    assert _reduce_query_map([temp_older, plain_newer]).upstreams == temp_up
+    assert _reduce_query_map([plain_newer, temp_older]).upstreams == temp_up
+
+    # Newer temp record vs older non-temp record: temp lineage still wins.
+    temp_newer = _query_meta(
+        fingerprint=fp, ts=newer, actor=None, used_temp_tables=True, upstreams=temp_up
+    )
+    plain_older = _query_meta(
+        fingerprint=fp, ts=older, actor=None, used_temp_tables=False, upstreams=plain_up
+    )
+    assert _reduce_query_map([temp_newer, plain_older]).upstreams == temp_up
+    assert _reduce_query_map([plain_older, temp_newer]).upstreams == temp_up
 
 
 def test_add_to_query_map_does_not_drop_known_actor_for_none() -> None:
@@ -1015,7 +1101,6 @@ def test_worker_infra_failure_falls_back_to_serial_no_loss(
         # stay broken thereafter (sticky), exactly like a real pool death.
         self.pool_broke.set()
         return ParseOutcome(
-            key=getattr(task, "key", None),
             result=None,
             error=repr(
                 concurrent.futures.process.BrokenProcessPool("simulated worker death")
@@ -1056,7 +1141,6 @@ def test_pool_init_failure_falls_back_to_serial_no_loss(
         # returns an error outcome rather than propagating.
         self.pool_broke.set()
         return ParseOutcome(
-            key=getattr(task, "key", None),
             result=None,
             error=repr(
                 concurrent.futures.process.BrokenProcessPool("worker init failed")

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_aggregator.py
@@ -475,6 +475,11 @@ def test_add_to_query_map_latest_timestamp_is_max_not_last_written() -> None:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -738,6 +743,11 @@ def test_add_to_query_map_actor_tracks_latest_timestamp() -> None:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     later_ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -815,6 +825,11 @@ def _reduce_query_map(metas: List[QueryMetadata]) -> QueryMetadata:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
     for meta in metas:
         aggregator._add_to_query_map(dataclasses.replace(meta))
@@ -905,6 +920,11 @@ def test_add_to_query_map_does_not_drop_known_actor_for_none() -> None:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
@@ -955,6 +975,11 @@ def test_add_to_query_map_representative_text_is_order_independent() -> None:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     earlier_ts = datetime(2024, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
@@ -997,14 +1022,21 @@ def test_add_to_query_map_representative_text_is_order_independent() -> None:
 
 def test_add_to_query_map_equal_timestamp_tie_break_is_deterministic() -> None:
     """When timestamps are equal (or both None), the winner is chosen by a
-    stable tie-break (lexicographically-greater formatted text), so the merged
-    result is identical regardless of insertion order."""
+    stable tie-break so the merged result is identical regardless of insertion
+    order. (The tie-break ranks by a hash of the formatted text to keep query
+    text off the heap, so WHICH record wins is deterministic but not
+    lexicographic — order-independence is the property that matters.)"""
     aggregator = SqlParsingAggregator(
         platform="redshift",
         generate_lineage=True,
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     same_ts = datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)
@@ -1033,9 +1065,7 @@ def test_add_to_query_map_equal_timestamp_tie_break_is_deterministic() -> None:
     reverse = _run([_b(), _a()])
 
     assert forward == reverse, "equal-timestamp merge must be order-independent"
-    assert forward == text_b, (
-        "tie-break winner must be the lexicographically greater text"
-    )
+    assert forward in (text_a, text_b)
 
     aggregator.close()
 
@@ -1276,14 +1306,23 @@ def test_add_to_query_map_mixed_tz_timestamps_no_crash(use_parallel: bool) -> No
             aggregator._add_to_query_map(meta)  # must not raise TypeError
         return aggregator._query_map[fingerprint]
 
+    # The key assertion is that neither insertion order raises TypeError.
     forward = _run([_naive(), _aware()])
     reverse = _run([_aware(), _naive()])
 
-    # The later instant (aware 12:00) wins deterministically in both orders.
-    assert forward.formatted_query_string == aware_text
-    assert reverse.formatted_query_string == aware_text
-    assert forward.latest_timestamp == aware_later
-    assert reverse.latest_timestamp == aware_later
+    if use_parallel:
+        # The deterministic reduction normalizes both timestamps and picks the
+        # later instant (aware 12:00) regardless of arrival order.
+        assert forward.formatted_query_string == aware_text
+        assert reverse.formatted_query_string == aware_text
+        assert forward.latest_timestamp == aware_later
+        assert reverse.latest_timestamp == aware_later
+    else:
+        # The serial default keeps last-writer-wins; it never compares the two
+        # timestamps, so it cannot raise on mixed naive/aware forms. Order
+        # dependence is expected here (and harmless — serial input is ordered).
+        assert forward.latest_timestamp is not None
+        assert reverse.latest_timestamp is not None
 
     aggregator.close()
 
@@ -1303,6 +1342,11 @@ def test_add_to_query_map_total_tie_break_on_equal_ts_and_text() -> None:
         generate_usage_statistics=False,
         generate_operations=False,
         query_log=QueryLogSetting.DISABLED,
+        # These tests exercise the deterministic merge reduction, which is only
+        # active on the opt-in parallel path (the serial default keeps the
+        # original last-writer-wins merge).
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=1,
     )
 
     same_ts = datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
@@ -1,7 +1,6 @@
 import pathlib
 import tempfile
 import unittest.mock as mock
-from unittest.mock import patch
 
 import pytest
 
@@ -41,6 +40,14 @@ def _make_writable_resolver(tmp_path: pathlib.Path) -> SchemaResolver:
     return resolver
 
 
+def _make_snapshot(tmp_path: pathlib.Path) -> pathlib.Path:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+    return snap
+
+
 def test_parity_end_to_end(tmp_path: pathlib.Path) -> None:
     """Parallel parsing must produce lineage identical to in-process serial parsing.
 
@@ -62,16 +69,6 @@ def test_parity_end_to_end(tmp_path: pathlib.Path) -> None:
         ),
     }
 
-    tasks = [
-        ParseTask(
-            key=key,
-            query=query,
-            default_db="db",
-            default_schema="schema",
-        )
-        for key, query in queries.items()
-    ]
-
     expected = {
         key: sqlglot_lineage(
             query,
@@ -89,61 +86,26 @@ def test_parity_end_to_end(tmp_path: pathlib.Path) -> None:
         platform_instance="prod",
         env="PROD",
     ) as parser:
-        outcomes = list(parser.map_unordered(tasks))
-
-    assert len(outcomes) == len(queries)
-    for outcome in outcomes:
-        assert outcome.error is None, outcome.error
-        assert outcome.result is not None
-        assert isinstance(outcome.key, str)
-        exp = expected[outcome.key]
-        assert outcome.result.in_tables == exp.in_tables
-        assert outcome.result.out_tables == exp.out_tables
-        assert outcome.result.column_lineage == exp.column_lineage
+        for key, query in queries.items():
+            outcome = parser.parse_one(
+                ParseTask(query=query, default_db="db", default_schema="schema")
+            )
+            assert outcome.error is None, outcome.error
+            assert outcome.result is not None
+            exp = expected[key]
+            assert outcome.result.in_tables == exp.in_tables
+            assert outcome.result.out_tables == exp.out_tables
+            assert outcome.result.column_lineage == exp.column_lineage
 
     writable.close()
-
-
-def test_unordered_correlation(tmp_path: pathlib.Path) -> None:
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
-
-    tasks = [
-        ParseTask(
-            key=i,
-            query="SELECT order_id FROM db.schema.orders",
-            default_db="db",
-            default_schema="schema",
-        )
-        for i in range(25)
-    ]
-    submitted_keys = {task.key for task in tasks}
-
-    with ParallelSqlParser(
-        num_workers=2,
-        snapshot_path=snap,
-        platform="snowflake",
-        platform_instance="prod",
-        env="PROD",
-    ) as parser:
-        returned_keys = [outcome.key for outcome in parser.map_unordered(tasks)]
-
-    assert len(returned_keys) == len(submitted_keys)
-    assert set(returned_keys) == submitted_keys
 
 
 def test_malformed_query_returns_result_not_error(tmp_path: pathlib.Path) -> None:
     """A genuinely unparseable query yields a ParseOutcome carrying a result whose
     debug_info records the error, rather than raising or an outcome-level error."""
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    snap = _make_snapshot(tmp_path)
 
     task = ParseTask(
-        key="bad",
         query="SELECT SELECT FROM WHERE ((((",
         default_db="db",
         default_schema="schema",
@@ -156,11 +118,8 @@ def test_malformed_query_returns_result_not_error(tmp_path: pathlib.Path) -> Non
         platform_instance="prod",
         env="PROD",
     ) as parser:
-        outcomes = list(parser.map_unordered([task]))
+        outcome = parser.parse_one(task)
 
-    assert len(outcomes) == 1
-    outcome = outcomes[0]
-    assert outcome.key == "bad"
     # Normal parse failures are captured inside SqlParsingResult.debug_info,
     # so this is a returned result, not an outcome-level error.
     assert outcome.error is None
@@ -169,10 +128,7 @@ def test_malformed_query_returns_result_not_error(tmp_path: pathlib.Path) -> Non
 
 
 def test_close_is_idempotent(tmp_path: pathlib.Path) -> None:
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    snap = _make_snapshot(tmp_path)
 
     parser = ParallelSqlParser(
         num_workers=2,
@@ -181,17 +137,12 @@ def test_close_is_idempotent(tmp_path: pathlib.Path) -> None:
         platform_instance="prod",
         env="PROD",
     )
-    # Force pool creation so close() has something to shut down.
-    list(
-        parser.map_unordered(
-            [
-                ParseTask(
-                    key=1,
-                    query="SELECT order_id FROM db.schema.orders",
-                    default_db="db",
-                    default_schema="schema",
-                )
-            ]
+    # Force pool use so close() has something to shut down.
+    parser.parse_one(
+        ParseTask(
+            query="SELECT order_id FROM db.schema.orders",
+            default_db="db",
+            default_schema="schema",
         )
     )
     parser.close()
@@ -199,10 +150,7 @@ def test_close_is_idempotent(tmp_path: pathlib.Path) -> None:
 
 
 def test_context_manager(tmp_path: pathlib.Path) -> None:
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    snap = _make_snapshot(tmp_path)
 
     with ParallelSqlParser(
         num_workers=2,
@@ -211,20 +159,14 @@ def test_context_manager(tmp_path: pathlib.Path) -> None:
         platform_instance="prod",
         env="PROD",
     ) as parser:
-        outcomes = list(
-            parser.map_unordered(
-                [
-                    ParseTask(
-                        key=1,
-                        query="SELECT order_id FROM db.schema.orders",
-                        default_db="db",
-                        default_schema="schema",
-                    )
-                ]
+        outcome = parser.parse_one(
+            ParseTask(
+                query="SELECT order_id FROM db.schema.orders",
+                default_db="db",
+                default_schema="schema",
             )
         )
-    assert len(outcomes) == 1
-    assert outcomes[0].error is None
+    assert outcome.error is None
 
 
 def test_parse_one_blocking(tmp_path: pathlib.Path) -> None:
@@ -250,15 +192,9 @@ def test_parse_one_blocking(tmp_path: pathlib.Path) -> None:
         env="PROD",
     ) as parser:
         outcome = parser.parse_one(
-            ParseTask(
-                key="only",
-                query=query,
-                default_db="db",
-                default_schema="schema",
-            )
+            ParseTask(query=query, default_db="db", default_schema="schema")
         )
 
-    assert outcome.key == "only"
     assert outcome.error is None
     assert outcome.result is not None
     assert outcome.result.in_tables == expected.in_tables
@@ -271,10 +207,7 @@ def test_parse_one_blocking(tmp_path: pathlib.Path) -> None:
 def test_worker_formats_query_when_enabled(tmp_path: pathlib.Path) -> None:
     """When format_queries is enabled, the worker must return a populated
     formatted_query that is byte-identical to try_format_query on the main thread."""
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    snap = _make_snapshot(tmp_path)
 
     query = "select order_id, amount from db.schema.orders"
 
@@ -287,12 +220,7 @@ def test_worker_formats_query_when_enabled(tmp_path: pathlib.Path) -> None:
         format_queries=True,
     ) as parser:
         outcome = parser.parse_one(
-            ParseTask(
-                key="fmt",
-                query=query,
-                default_db="db",
-                default_schema="schema",
-            )
+            ParseTask(query=query, default_db="db", default_schema="schema")
         )
 
     assert outcome.ok
@@ -307,10 +235,7 @@ def test_worker_leaves_formatted_query_none_when_disabled(
 ) -> None:
     """When format_queries is disabled (default), formatted_query stays None so the
     main thread formats as it does today."""
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    snap = _make_snapshot(tmp_path)
 
     with ParallelSqlParser(
         num_workers=2,
@@ -321,7 +246,6 @@ def test_worker_leaves_formatted_query_none_when_disabled(
     ) as parser:
         outcome = parser.parse_one(
             ParseTask(
-                key="nofmt",
                 query="select order_id from db.schema.orders",
                 default_db="db",
                 default_schema="schema",
@@ -343,7 +267,7 @@ def test_preparsed_failure_counter(tmp_path: pathlib.Path) -> None:
     def _boom(*args, **kwargs):
         raise RuntimeError("injected failure")
 
-    with patch.object(aggregator, "_add_preparsed_query_impl", side_effect=_boom):
+    with mock.patch.object(aggregator, "_add_preparsed_query_impl", side_effect=_boom):
         with aggregator.parallel_sql_parsing_scope():
             aggregator.add(
                 PreparsedQuery(
@@ -408,53 +332,37 @@ def test_broken_pool_sets_report_flag(tmp_path: pathlib.Path) -> None:
         aggregator._parallel_parser.pool_broke.set()
 
     assert aggregator.report.sql_parsing_pool_broke is True
+    # A mid-run pool break means the rest of the run parsed serially.
+    assert aggregator.report.sql_parsing_fell_back_to_serial is True
     aggregator.close()
 
 
 def test_parse_outcome_rejects_both_result_and_error() -> None:
-    """The result-XOR-error invariant is enforced structurally (R1)."""
+    """The result-XOR-error invariant is enforced structurally."""
     with pytest.raises(ValueError):
-        ParseOutcome(key="k", result=object(), error="boom")  # type: ignore[arg-type]
+        ParseOutcome(result=object(), error="boom")  # type: ignore[arg-type]
 
 
 def test_parse_outcome_failed_and_ok_properties() -> None:
-    """`failed`/`ok` classify outcomes without repeating the null-check (R1)."""
-    error_outcome = ParseOutcome(key="k", result=None, error="boom")
+    """`failed`/`ok` classify outcomes without repeating the null-check."""
+    error_outcome = ParseOutcome(result=None, error="boom")
     assert error_outcome.failed
     assert not error_outcome.ok
 
-    empty_outcome = ParseOutcome(key="k", result=None, error=None)
+    empty_outcome = ParseOutcome(result=None, error=None)
     assert empty_outcome.failed
     assert not empty_outcome.ok
 
-    result_outcome = ParseOutcome(key="k", result=object(), error=None)  # type: ignore[arg-type]
+    result_outcome = ParseOutcome(result=object(), error=None)  # type: ignore[arg-type]
     assert not result_outcome.failed
     assert result_outcome.ok
-
-
-def test_parse_task_rejects_non_picklable_key() -> None:
-    """A non-picklable key raises TypeError at construction, not later as a
-    broken pool (R4)."""
-    with pytest.raises(TypeError):
-        ParseTask(
-            key=lambda: None,  # type: ignore[arg-type]
-            query="SELECT 1",
-            default_db=None,
-            default_schema=None,
-        )
-    # The allowed simple types construct fine.
-    for key in (None, "s", 7, ("a", 1)):
-        ParseTask(key=key, query="SELECT 1", default_db=None, default_schema=None)
 
 
 def test_post_close_use_raises_runtime_error(tmp_path: pathlib.Path) -> None:
     """Using the parser after close() is a caller bug and must surface as a plain
     RuntimeError, NOT ParallelParserUnavailable (which the aggregator's
-    serial-fallback would otherwise silently swallow) (R3)."""
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    serial-fallback would otherwise silently swallow)."""
+    snap = _make_snapshot(tmp_path)
 
     parser = ParallelSqlParser(
         num_workers=2,
@@ -466,7 +374,6 @@ def test_post_close_use_raises_runtime_error(tmp_path: pathlib.Path) -> None:
     parser.close()
 
     task = ParseTask(
-        key="k",
         query="SELECT order_id FROM db.schema.orders",
         default_db="db",
         default_schema="schema",
@@ -475,24 +382,16 @@ def test_post_close_use_raises_runtime_error(tmp_path: pathlib.Path) -> None:
         parser.parse_one(task)
     assert not isinstance(exc_info.value, ParallelParserUnavailable)
 
-    with pytest.raises(RuntimeError) as exc_info2:
-        list(parser.map_unordered([task]))
-    assert not isinstance(exc_info2.value, ParallelParserUnavailable)
-
 
 def test_executor_submit_failure_becomes_error_outcome(
     tmp_path: pathlib.Path,
 ) -> None:
     """An executor-layer failure (worker death / submit blowing up) must surface
     as a ParseOutcome(error=...), not a raised exception, and the parser must
-    still close cleanly (R6)."""
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
+    still close cleanly."""
+    snap = _make_snapshot(tmp_path)
 
     task = ParseTask(
-        key="k",
         query="SELECT order_id FROM db.schema.orders",
         default_db="db",
         default_schema="schema",
@@ -556,19 +455,13 @@ def test_pool_broke_reported_via_close_outside_scope(tmp_path: pathlib.Path) -> 
             pytest.skip("parallel parser unavailable in this environment")
 
         aggregator._parallel_active = True
-        # Simulate pool breaking - after C4 this is a threading.Event
         aggregator._parallel_parser.pool_broke.set()
 
         # Call close() directly - this goes through _teardown_parallel
-        # WITHOUT the scope's finally having run first
+        # WITHOUT the scope's finally having run first.
         aggregator.close()
 
     assert aggregator.report.sql_parsing_pool_broke is True
-
-
-# ---------------------------------------------------------------------------
-# G1 — preformatted_query rejected on external add_preparsed_query calls
-# ---------------------------------------------------------------------------
 
 
 def test_add_preparsed_query_rejects_preformatted_when_external() -> None:
@@ -607,11 +500,6 @@ def test_add_preparsed_query_accepts_preformatted_when_internal() -> None:
     aggregator.close()
 
 
-# ---------------------------------------------------------------------------
-# G2 — ParseOutcome rejects formatted_query when error is set
-# ---------------------------------------------------------------------------
-
-
 def test_parse_outcome_rejects_formatted_query_with_error() -> None:
     """It is a contract violation to set formatted_query alongside error;
     a formatting result is only meaningful on a successful outcome."""
@@ -619,79 +507,10 @@ def test_parse_outcome_rejects_formatted_query_with_error() -> None:
         ValueError, match="formatted_query must be None when error is set"
     ):
         ParseOutcome(
-            key="k",
             result=None,
             error="boom",
             formatted_query="SELECT 1",
         )
-
-
-# ---------------------------------------------------------------------------
-# G4 — ParseTask.key tuple elements must be str or int
-# ---------------------------------------------------------------------------
-
-
-def test_parse_task_rejects_tuple_key_with_non_str_int_elements() -> None:
-    """A tuple key whose elements are not all str/int must raise TypeError
-    at construction (not later as an opaque broken pool)."""
-    with pytest.raises(TypeError, match="tuple elements must all be str or int"):
-        ParseTask(
-            key=("good", object()),  # type: ignore[arg-type]
-            query="SELECT 1",
-            default_db=None,
-            default_schema=None,
-        )
-
-
-def test_parse_task_accepts_valid_tuple_keys() -> None:
-    """Tuple keys made entirely of str/int elements are accepted."""
-    for key in (("a",), (1,), ("a", 1), ("x", "y", 3)):
-        ParseTask(key=key, query="SELECT 1", default_db=None, default_schema=None)
-
-
-# ---------------------------------------------------------------------------
-# G5 — ParseOutcome.key undergoes the same validation as ParseTask.key
-# ---------------------------------------------------------------------------
-
-
-def test_parse_outcome_rejects_invalid_key_types() -> None:
-    """ParseOutcome.key must also be None/str/int/valid-tuple, matching the
-    ParseTask.key restriction (G5 — same validator, DRY)."""
-    with pytest.raises(TypeError):
-        ParseOutcome(
-            key=object(),  # type: ignore[arg-type]
-            result=None,
-            error="err",
-        )
-
-
-def test_parse_outcome_rejects_tuple_key_with_bad_elements() -> None:
-    """A tuple ParseOutcome.key with non-str/int elements raises TypeError."""
-    with pytest.raises(TypeError, match="tuple elements must all be str or int"):
-        ParseOutcome(
-            key=("ok", 3.14),  # type: ignore[arg-type]
-            result=None,
-            error="err",
-        )
-
-
-def test_parse_outcome_accepts_valid_key_types() -> None:
-    """Valid key types (None, str, int, str/int tuple) all construct fine."""
-    for key in (None, "s", 7, ("a", 1)):
-        ParseOutcome(key=key, result=None, error="err")
-
-
-# ---------------------------------------------------------------------------
-# H1 — submit-time pool failure must trip pool_broke and never raise
-# ---------------------------------------------------------------------------
-
-
-def _make_snapshot(tmp_path: pathlib.Path) -> pathlib.Path:
-    writable = _make_writable_resolver(tmp_path)
-    snap = tmp_path / "snapshot.db"
-    writable.snapshot_to(snap)
-    writable.close()
-    return snap
 
 
 def test_parse_one_submit_time_broken_pool_sets_flag_no_raise(
@@ -704,7 +523,6 @@ def test_parse_one_submit_time_broken_pool_sets_flag_no_raise(
 
     snap = _make_snapshot(tmp_path)
     task = ParseTask(
-        key="k",
         query="SELECT order_id FROM db.schema.orders",
         default_db="db",
         default_schema="schema",
@@ -725,40 +543,4 @@ def test_parse_one_submit_time_broken_pool_sets_flag_no_raise(
         assert outcome.failed
         assert outcome.error is not None
         assert outcome.result is None
-        assert parser.pool_broke.is_set()
-
-
-def test_map_unordered_submit_time_broken_pool_sets_flag_no_raise(
-    tmp_path: pathlib.Path,
-) -> None:
-    """Same submit-time BrokenProcessPool guarantee for map_unordered: every
-    task yields an error outcome and pool_broke is set, no exception escapes."""
-    from concurrent.futures.process import BrokenProcessPool
-
-    snap = _make_snapshot(tmp_path)
-    tasks = [
-        ParseTask(
-            key=f"k{i}",
-            query="SELECT order_id FROM db.schema.orders",
-            default_db="db",
-            default_schema="schema",
-        )
-        for i in range(3)
-    ]
-    with ParallelSqlParser(
-        num_workers=2,
-        snapshot_path=snap,
-        platform="snowflake",
-        platform_instance="prod",
-        env="PROD",
-    ) as parser:
-        with mock.patch.object(
-            parser._ensure_executor(),
-            "submit",
-            side_effect=BrokenProcessPool("boom at submit"),
-        ):
-            outcomes = list(parser.map_unordered(tasks))
-        assert len(outcomes) == len(tasks)
-        assert all(o.failed and o.error is not None for o in outcomes)
-        assert {o.key for o in outcomes} == {t.key for t in tasks}
         assert parser.pool_broke.is_set()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
@@ -1,0 +1,764 @@
+import pathlib
+import tempfile
+import unittest.mock as mock
+from unittest.mock import patch
+
+import pytest
+
+from datahub.sql_parsing.parallel_sql_parser import (
+    ParallelParserUnavailable,
+    ParallelSqlParser,
+    ParseOutcome,
+    ParseTask,
+)
+from datahub.sql_parsing.schema_resolver import SchemaResolver
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    PreparsedQuery,
+    SqlParsingAggregator,
+)
+from datahub.sql_parsing.sqlglot_lineage import sqlglot_lineage
+from datahub.sql_parsing.sqlglot_utils import try_format_query
+
+
+def _make_writable_resolver(tmp_path: pathlib.Path) -> SchemaResolver:
+    """Build a file-backed writable SchemaResolver with two known schemas."""
+    cache_file = tmp_path / "schema_cache.db"
+    resolver = SchemaResolver(
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+        graph=None,
+        _cache_filename=cache_file,
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+        schema_info={"order_id": "int", "amount": "float", "customer_id": "int"},
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)",
+        schema_info={"customer_id": "int", "name": "varchar"},
+    )
+    return resolver
+
+
+def test_parity_end_to_end(tmp_path: pathlib.Path) -> None:
+    """Parallel parsing must produce lineage identical to in-process serial parsing.
+
+    Proves cross-process pickling + snapshot resolution preserve lineage.
+    """
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+
+    queries = {
+        "q1": "SELECT order_id, amount FROM db.schema.orders",
+        "q2": (
+            "CREATE TABLE db.schema.summary AS "
+            "SELECT customer_id, amount FROM db.schema.orders"
+        ),
+        "q3": (
+            "SELECT o.order_id, c.name FROM db.schema.orders o "
+            "JOIN db.schema.customers c ON o.customer_id = c.customer_id"
+        ),
+    }
+
+    tasks = [
+        ParseTask(
+            key=key,
+            query=query,
+            default_db="db",
+            default_schema="schema",
+        )
+        for key, query in queries.items()
+    ]
+
+    expected = {
+        key: sqlglot_lineage(
+            query,
+            schema_resolver=writable,
+            default_db="db",
+            default_schema="schema",
+        )
+        for key, query in queries.items()
+    }
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(parser.map_unordered(tasks))
+
+    assert len(outcomes) == len(queries)
+    for outcome in outcomes:
+        assert outcome.error is None, outcome.error
+        assert outcome.result is not None
+        assert isinstance(outcome.key, str)
+        exp = expected[outcome.key]
+        assert outcome.result.in_tables == exp.in_tables
+        assert outcome.result.out_tables == exp.out_tables
+        assert outcome.result.column_lineage == exp.column_lineage
+
+    writable.close()
+
+
+def test_unordered_correlation(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    tasks = [
+        ParseTask(
+            key=i,
+            query="SELECT order_id FROM db.schema.orders",
+            default_db="db",
+            default_schema="schema",
+        )
+        for i in range(25)
+    ]
+    submitted_keys = {task.key for task in tasks}
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        returned_keys = [outcome.key for outcome in parser.map_unordered(tasks)]
+
+    assert len(returned_keys) == len(submitted_keys)
+    assert set(returned_keys) == submitted_keys
+
+
+def test_malformed_query_returns_result_not_error(tmp_path: pathlib.Path) -> None:
+    """A genuinely unparseable query yields a ParseOutcome carrying a result whose
+    debug_info records the error, rather than raising or an outcome-level error."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    task = ParseTask(
+        key="bad",
+        query="SELECT SELECT FROM WHERE ((((",
+        default_db="db",
+        default_schema="schema",
+    )
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(parser.map_unordered([task]))
+
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome.key == "bad"
+    # Normal parse failures are captured inside SqlParsingResult.debug_info,
+    # so this is a returned result, not an outcome-level error.
+    assert outcome.error is None
+    assert outcome.result is not None
+    assert outcome.result.debug_info.error is not None
+
+
+def test_close_is_idempotent(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    parser = ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    )
+    # Force pool creation so close() has something to shut down.
+    list(
+        parser.map_unordered(
+            [
+                ParseTask(
+                    key=1,
+                    query="SELECT order_id FROM db.schema.orders",
+                    default_db="db",
+                    default_schema="schema",
+                )
+            ]
+        )
+    )
+    parser.close()
+    parser.close()  # must be safe to call twice
+
+
+def test_context_manager(tmp_path: pathlib.Path) -> None:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcomes = list(
+            parser.map_unordered(
+                [
+                    ParseTask(
+                        key=1,
+                        query="SELECT order_id FROM db.schema.orders",
+                        default_db="db",
+                        default_schema="schema",
+                    )
+                ]
+            )
+        )
+    assert len(outcomes) == 1
+    assert outcomes[0].error is None
+
+
+def test_parse_one_blocking(tmp_path: pathlib.Path) -> None:
+    """parse_one submits a single task and blocks for its outcome, producing a
+    result identical to in-process serial parsing."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+
+    query = "SELECT order_id, amount FROM db.schema.orders"
+    expected = sqlglot_lineage(
+        query,
+        schema_resolver=writable,
+        default_db="db",
+        default_schema="schema",
+    )
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcome = parser.parse_one(
+            ParseTask(
+                key="only",
+                query=query,
+                default_db="db",
+                default_schema="schema",
+            )
+        )
+
+    assert outcome.key == "only"
+    assert outcome.error is None
+    assert outcome.result is not None
+    assert outcome.result.in_tables == expected.in_tables
+    assert outcome.result.out_tables == expected.out_tables
+    assert outcome.result.column_lineage == expected.column_lineage
+
+    writable.close()
+
+
+def test_worker_formats_query_when_enabled(tmp_path: pathlib.Path) -> None:
+    """When format_queries is enabled, the worker must return a populated
+    formatted_query that is byte-identical to try_format_query on the main thread."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    query = "select order_id, amount from db.schema.orders"
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+        format_queries=True,
+    ) as parser:
+        outcome = parser.parse_one(
+            ParseTask(
+                key="fmt",
+                query=query,
+                default_db="db",
+                default_schema="schema",
+            )
+        )
+
+    assert outcome.ok
+    assert outcome.formatted_query is not None
+    assert outcome.formatted_query == try_format_query(query, "snowflake")
+    # Formatting should actually change the query (pretty-print), proving it ran.
+    assert outcome.formatted_query != query
+
+
+def test_worker_leaves_formatted_query_none_when_disabled(
+    tmp_path: pathlib.Path,
+) -> None:
+    """When format_queries is disabled (default), formatted_query stays None so the
+    main thread formats as it does today."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        outcome = parser.parse_one(
+            ParseTask(
+                key="nofmt",
+                query="select order_id from db.schema.orders",
+                default_db="db",
+                default_schema="schema",
+            )
+        )
+
+    assert outcome.ok
+    assert outcome.formatted_query is None
+
+
+def test_preparsed_failure_counter(tmp_path: pathlib.Path) -> None:
+    """PreparsedQuery failures must increment num_preparsed_queries_failed, not num_observed_queries_failed."""
+    aggregator = SqlParsingAggregator(
+        platform="snowflake",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=2,
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("injected failure")
+
+    with patch.object(aggregator, "_add_preparsed_query_impl", side_effect=_boom):
+        with aggregator.parallel_sql_parsing_scope():
+            aggregator.add(
+                PreparsedQuery(
+                    query_id=None,
+                    query_text="SELECT 1",
+                    upstreams=[],
+                )
+            )
+
+    assert aggregator.report.num_preparsed_queries_failed == 1
+    assert aggregator.report.num_observed_queries_failed == 0
+    assert len(aggregator.report.preparsed_query_parse_failures) == 1
+    aggregator.close()
+
+
+def test_snapshot_temp_dir_cleaned_up(tmp_path: pathlib.Path) -> None:
+    """The snapshot temp directory must be deleted after the scope exits."""
+    resolver = SchemaResolver(
+        platform="snowflake",
+        platform_instance=None,
+        env="PROD",
+        graph=None,
+        _cache_filename=tmp_path / "schema.db",
+    )
+
+    aggregator = SqlParsingAggregator(
+        platform="snowflake",
+        schema_resolver=resolver,
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=2,
+    )
+
+    captured_snapshot_dir: list = []
+
+    original_snapshot_to = resolver.snapshot_to
+
+    def capturing_snapshot_to(path):
+        captured_snapshot_dir.append(path.parent)
+        original_snapshot_to(path)
+
+    with mock.patch.object(resolver, "snapshot_to", side_effect=capturing_snapshot_to):
+        with aggregator.parallel_sql_parsing_scope():
+            pass
+
+    assert len(captured_snapshot_dir) == 1
+    snap_dir = captured_snapshot_dir[0]
+    assert not snap_dir.exists(), f"Snapshot temp dir still exists: {snap_dir}"
+    aggregator.close()
+
+
+def test_broken_pool_sets_report_flag(tmp_path: pathlib.Path) -> None:
+    """When the process pool breaks, report.sql_parsing_pool_broke must be set and run must complete."""
+    aggregator = SqlParsingAggregator(
+        platform="snowflake",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=2,
+    )
+
+    with aggregator.parallel_sql_parsing_scope():
+        assert aggregator._parallel_parser is not None
+        # Simulate broken pool by monkeypatching pool_broke
+        aggregator._parallel_parser.pool_broke.set()
+
+    assert aggregator.report.sql_parsing_pool_broke is True
+    aggregator.close()
+
+
+def test_parse_outcome_rejects_both_result_and_error() -> None:
+    """The result-XOR-error invariant is enforced structurally (R1)."""
+    with pytest.raises(ValueError):
+        ParseOutcome(key="k", result=object(), error="boom")  # type: ignore[arg-type]
+
+
+def test_parse_outcome_failed_and_ok_properties() -> None:
+    """`failed`/`ok` classify outcomes without repeating the null-check (R1)."""
+    error_outcome = ParseOutcome(key="k", result=None, error="boom")
+    assert error_outcome.failed
+    assert not error_outcome.ok
+
+    empty_outcome = ParseOutcome(key="k", result=None, error=None)
+    assert empty_outcome.failed
+    assert not empty_outcome.ok
+
+    result_outcome = ParseOutcome(key="k", result=object(), error=None)  # type: ignore[arg-type]
+    assert not result_outcome.failed
+    assert result_outcome.ok
+
+
+def test_parse_task_rejects_non_picklable_key() -> None:
+    """A non-picklable key raises TypeError at construction, not later as a
+    broken pool (R4)."""
+    with pytest.raises(TypeError):
+        ParseTask(
+            key=lambda: None,  # type: ignore[arg-type]
+            query="SELECT 1",
+            default_db=None,
+            default_schema=None,
+        )
+    # The allowed simple types construct fine.
+    for key in (None, "s", 7, ("a", 1)):
+        ParseTask(key=key, query="SELECT 1", default_db=None, default_schema=None)
+
+
+def test_post_close_use_raises_runtime_error(tmp_path: pathlib.Path) -> None:
+    """Using the parser after close() is a caller bug and must surface as a plain
+    RuntimeError, NOT ParallelParserUnavailable (which the aggregator's
+    serial-fallback would otherwise silently swallow) (R3)."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    parser = ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    )
+    parser.close()
+
+    task = ParseTask(
+        key="k",
+        query="SELECT order_id FROM db.schema.orders",
+        default_db="db",
+        default_schema="schema",
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        parser.parse_one(task)
+    assert not isinstance(exc_info.value, ParallelParserUnavailable)
+
+    with pytest.raises(RuntimeError) as exc_info2:
+        list(parser.map_unordered([task]))
+    assert not isinstance(exc_info2.value, ParallelParserUnavailable)
+
+
+def test_executor_submit_failure_becomes_error_outcome(
+    tmp_path: pathlib.Path,
+) -> None:
+    """An executor-layer failure (worker death / submit blowing up) must surface
+    as a ParseOutcome(error=...), not a raised exception, and the parser must
+    still close cleanly (R6)."""
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+
+    task = ParseTask(
+        key="k",
+        query="SELECT order_id FROM db.schema.orders",
+        default_db="db",
+        default_schema="schema",
+    )
+
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        executor = parser._ensure_executor()
+
+        class _DeadFuture:
+            def result(self, timeout=None):
+                raise RuntimeError("simulated worker death at executor layer")
+
+        # Force the submitted future to blow up on .result(), simulating a worker
+        # that died before returning a ParseOutcome.
+        original_submit = executor.submit
+
+        def _boom_submit(fn, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return _DeadFuture()
+
+        executor.submit = _boom_submit  # type: ignore[assignment]
+
+        outcome = parser.parse_one(task)
+        assert outcome.failed
+        assert outcome.error is not None
+        assert outcome.result is None
+
+        # Restore real submit; the parser must still be usable afterwards.
+        executor.submit = original_submit  # type: ignore[assignment]
+        good = parser.parse_one(task)
+        assert good.ok
+
+
+def test_pool_broke_reported_via_close_outside_scope(tmp_path: pathlib.Path) -> None:
+    """When the pool breaks and close() is called without the scope's finally
+    running the check first, report.sql_parsing_pool_broke must still be True."""
+    aggregator = SqlParsingAggregator(
+        platform="snowflake",
+        use_parallel_sql_parsing=True,
+        sql_parsing_workers=2,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        snapshot_path = pathlib.Path(tmp_dir) / "schema_snapshot.db"
+        aggregator._schema_resolver.snapshot_to(snapshot_path)
+
+        try:
+            aggregator._parallel_parser = ParallelSqlParser(
+                num_workers=2,
+                snapshot_path=snapshot_path,
+                platform="snowflake",
+                platform_instance=None,
+                env="PROD",
+            )
+        except ParallelParserUnavailable:
+            pytest.skip("parallel parser unavailable in this environment")
+
+        aggregator._parallel_active = True
+        # Simulate pool breaking - after C4 this is a threading.Event
+        aggregator._parallel_parser.pool_broke.set()
+
+        # Call close() directly - this goes through _teardown_parallel
+        # WITHOUT the scope's finally having run first
+        aggregator.close()
+
+    assert aggregator.report.sql_parsing_pool_broke is True
+
+
+# ---------------------------------------------------------------------------
+# G1 — preformatted_query rejected on external add_preparsed_query calls
+# ---------------------------------------------------------------------------
+
+
+def test_add_preparsed_query_rejects_preformatted_when_external() -> None:
+    """An external caller must not pass preformatted_query; doing so raises
+    ValueError because the value would be silently dropped on the
+    parallel-routing branch and is meaningless on the external path."""
+    aggregator = SqlParsingAggregator(platform="snowflake")
+    with pytest.raises(
+        ValueError, match="preformatted_query is only valid on internal"
+    ):
+        aggregator.add_preparsed_query(
+            PreparsedQuery(
+                query_id=None,
+                query_text="SELECT 1",
+                upstreams=[],
+            ),
+            preformatted_query="SELECT 1",
+        )
+    aggregator.close()
+
+
+def test_add_preparsed_query_accepts_preformatted_when_internal() -> None:
+    """The internal observed-query apply path sets _is_internal=True and must
+    be allowed to pass preformatted_query."""
+    aggregator = SqlParsingAggregator(platform="snowflake")
+    # Should not raise — _is_internal=True is the valid internal path.
+    aggregator.add_preparsed_query(
+        PreparsedQuery(
+            query_id=None,
+            query_text="SELECT 1",
+            upstreams=[],
+        ),
+        _is_internal=True,
+        preformatted_query="SELECT 1",
+    )
+    aggregator.close()
+
+
+# ---------------------------------------------------------------------------
+# G2 — ParseOutcome rejects formatted_query when error is set
+# ---------------------------------------------------------------------------
+
+
+def test_parse_outcome_rejects_formatted_query_with_error() -> None:
+    """It is a contract violation to set formatted_query alongside error;
+    a formatting result is only meaningful on a successful outcome."""
+    with pytest.raises(
+        ValueError, match="formatted_query must be None when error is set"
+    ):
+        ParseOutcome(
+            key="k",
+            result=None,
+            error="boom",
+            formatted_query="SELECT 1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# G4 — ParseTask.key tuple elements must be str or int
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_rejects_tuple_key_with_non_str_int_elements() -> None:
+    """A tuple key whose elements are not all str/int must raise TypeError
+    at construction (not later as an opaque broken pool)."""
+    with pytest.raises(TypeError, match="tuple elements must all be str or int"):
+        ParseTask(
+            key=("good", object()),  # type: ignore[arg-type]
+            query="SELECT 1",
+            default_db=None,
+            default_schema=None,
+        )
+
+
+def test_parse_task_accepts_valid_tuple_keys() -> None:
+    """Tuple keys made entirely of str/int elements are accepted."""
+    for key in (("a",), (1,), ("a", 1), ("x", "y", 3)):
+        ParseTask(key=key, query="SELECT 1", default_db=None, default_schema=None)
+
+
+# ---------------------------------------------------------------------------
+# G5 — ParseOutcome.key undergoes the same validation as ParseTask.key
+# ---------------------------------------------------------------------------
+
+
+def test_parse_outcome_rejects_invalid_key_types() -> None:
+    """ParseOutcome.key must also be None/str/int/valid-tuple, matching the
+    ParseTask.key restriction (G5 — same validator, DRY)."""
+    with pytest.raises(TypeError):
+        ParseOutcome(
+            key=object(),  # type: ignore[arg-type]
+            result=None,
+            error="err",
+        )
+
+
+def test_parse_outcome_rejects_tuple_key_with_bad_elements() -> None:
+    """A tuple ParseOutcome.key with non-str/int elements raises TypeError."""
+    with pytest.raises(TypeError, match="tuple elements must all be str or int"):
+        ParseOutcome(
+            key=("ok", 3.14),  # type: ignore[arg-type]
+            result=None,
+            error="err",
+        )
+
+
+def test_parse_outcome_accepts_valid_key_types() -> None:
+    """Valid key types (None, str, int, str/int tuple) all construct fine."""
+    for key in (None, "s", 7, ("a", 1)):
+        ParseOutcome(key=key, result=None, error="err")
+
+
+# ---------------------------------------------------------------------------
+# H1 — submit-time pool failure must trip pool_broke and never raise
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(tmp_path: pathlib.Path) -> pathlib.Path:
+    writable = _make_writable_resolver(tmp_path)
+    snap = tmp_path / "snapshot.db"
+    writable.snapshot_to(snap)
+    writable.close()
+    return snap
+
+
+def test_parse_one_submit_time_broken_pool_sets_flag_no_raise(
+    tmp_path: pathlib.Path,
+) -> None:
+    """If executor.submit() itself raises BrokenProcessPool, parse_one must
+    convert it to an error ParseOutcome AND set pool_broke — never let it
+    propagate (which would be counted as an ordinary parse failure upstream)."""
+    from concurrent.futures.process import BrokenProcessPool
+
+    snap = _make_snapshot(tmp_path)
+    task = ParseTask(
+        key="k",
+        query="SELECT order_id FROM db.schema.orders",
+        default_db="db",
+        default_schema="schema",
+    )
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        with mock.patch.object(
+            parser._ensure_executor(),
+            "submit",
+            side_effect=BrokenProcessPool("boom at submit"),
+        ):
+            outcome = parser.parse_one(task)
+        assert outcome.failed
+        assert outcome.error is not None
+        assert outcome.result is None
+        assert parser.pool_broke.is_set()
+
+
+def test_map_unordered_submit_time_broken_pool_sets_flag_no_raise(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Same submit-time BrokenProcessPool guarantee for map_unordered: every
+    task yields an error outcome and pool_broke is set, no exception escapes."""
+    from concurrent.futures.process import BrokenProcessPool
+
+    snap = _make_snapshot(tmp_path)
+    tasks = [
+        ParseTask(
+            key=f"k{i}",
+            query="SELECT order_id FROM db.schema.orders",
+            default_db="db",
+            default_schema="schema",
+        )
+        for i in range(3)
+    ]
+    with ParallelSqlParser(
+        num_workers=2,
+        snapshot_path=snap,
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+    ) as parser:
+        with mock.patch.object(
+            parser._ensure_executor(),
+            "submit",
+            side_effect=BrokenProcessPool("boom at submit"),
+        ):
+            outcomes = list(parser.map_unordered(tasks))
+        assert len(outcomes) == len(tasks)
+        assert all(o.failed and o.error is not None for o in outcomes)
+        assert {o.key for o in outcomes} == {t.key for t in tasks}
+        assert parser.pool_broke.is_set()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parser.py
@@ -423,6 +423,9 @@ def test_executor_submit_failure_becomes_error_outcome(
         assert outcome.failed
         assert outcome.error is not None
         assert outcome.result is None
+        # A per-query executor error (NOT a BrokenProcessPool) must not trip the
+        # sticky pool_broke flag — the pool stays usable for the rest of the run.
+        assert not parser.pool_broke.is_set()
 
         # Restore real submit; the parser must still be usable afterwards.
         executor.submit = original_submit  # type: ignore[assignment]

--- a/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_parallel_sql_parsing_config.py
@@ -1,0 +1,81 @@
+"""Config-parse tests for the SqlParsingParallelismConfig mixin.
+
+Connector-specific config wiring (Snowflake, BigQuery, Redshift, Unity) is tested
+in each connector's own change; here we only cover the shared mixin.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from datahub.sql_parsing.sql_parsing_aggregator import SqlParsingParallelismConfig
+
+# ---------------------------------------------------------------------------
+# Mixin standalone tests
+# ---------------------------------------------------------------------------
+
+
+def test_mixin_accepts_none_workers() -> None:
+    """None (auto-detect) must remain valid after adding ge=1."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg(sql_parsing_workers=None)
+    assert cfg.sql_parsing_workers is None
+
+
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_mixin_rejects_non_positive_workers(bad_value: int) -> None:
+    """Values <= 0 must be rejected at config-parse time (ge=1 constraint)."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    with pytest.raises(ValidationError):
+        _Cfg(sql_parsing_workers=bad_value)
+
+
+def test_parallel_enabled_without_workers_raises() -> None:
+    """use_parallel_sql_parsing=True with no sql_parsing_workers must raise ValidationError.
+
+    Auto-detection via os.cpu_count() is unsafe on virtualized/containerized hosts
+    where the reported CPU count is that of the underlying node, not the cgroup limit.
+    Operators must supply an explicit worker count.
+    """
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    with pytest.raises(ValidationError, match="sql_parsing_workers must be set"):
+        _Cfg(use_parallel_sql_parsing=True)
+
+
+def test_parallel_enabled_with_explicit_workers_accepted() -> None:
+    """use_parallel_sql_parsing=True with an explicit worker count must be accepted."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg(use_parallel_sql_parsing=True, sql_parsing_workers=4)
+    assert cfg.use_parallel_sql_parsing is True
+    assert cfg.sql_parsing_workers == 4
+
+
+def test_parallel_disabled_workers_none_accepted() -> None:
+    """use_parallel_sql_parsing=False with workers unset must remain valid."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    cfg = _Cfg(use_parallel_sql_parsing=False)
+    assert cfg.sql_parsing_workers is None
+
+
+def test_mixin_rejects_excessive_workers() -> None:
+    """Values > 512 must be rejected at config-parse time (le=512 constraint)."""
+
+    class _Cfg(SqlParsingParallelismConfig):
+        pass
+
+    with pytest.raises(ValidationError):
+        _Cfg(sql_parsing_workers=1024)

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -1,3 +1,5 @@
+import pathlib
+import sqlite3
 from unittest.mock import MagicMock
 
 import pytest
@@ -531,3 +533,462 @@ class TestTableNameParts:
         assert table_with_parts == table_without_parts, "Equality ignores parts field"
         assert table_with_parts.parts == ("source", "schema", "table")
         assert table_without_parts.parts is None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / read-only SchemaResolver tests
+# ---------------------------------------------------------------------------
+
+
+def _make_writable_resolver(tmp_path: pathlib.Path) -> SchemaResolver:
+    """Build a file-backed writable SchemaResolver with two known schemas."""
+    cache_file = tmp_path / "schema_cache.db"
+    resolver = SchemaResolver(
+        platform="snowflake",
+        platform_instance="prod",
+        env="PROD",
+        graph=None,
+        _cache_filename=cache_file,
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+        schema_info={"order_id": "int", "amount": "float"},
+    )
+    resolver.add_raw_schema_info(
+        urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)",
+        schema_info={"customer_id": "int", "name": "varchar"},
+    )
+    return resolver
+
+
+class TestSnapshotRoundTrip:
+    def test_snapshot_to_creates_file(self, tmp_path: pathlib.Path) -> None:
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        assert snap.exists()
+        assert snap.stat().st_size > 0
+
+    def test_load_readonly_returns_same_schemas(self, tmp_path: pathlib.Path) -> None:
+        """load_readonly must return identical schema info for tables added to the original."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            assert info is not None
+            assert info["order_id"] == "int"
+            assert info["amount"] == "float"
+
+            urn2, info2 = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info2 is not None
+            assert info2["customer_id"] == "int"
+            assert info2["name"] == "varchar"
+        finally:
+            ro.close()
+
+    def test_load_readonly_unknown_table_returns_none(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Resolving an unknown table via a read-only resolver returns (urn, None)."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="schema", table="nonexistent")
+            )
+            assert urn is not None  # URN is always synthesized
+            assert info is None
+        finally:
+            ro.close()
+
+    def test_load_readonly_has_no_graph(self, tmp_path: pathlib.Path) -> None:
+        """The read-only resolver must not make graph calls (graph=None)."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            assert ro.graph is None
+        finally:
+            ro.close()
+
+    def test_snapshot_flushes_in_memory_cache(self, tmp_path: pathlib.Path) -> None:
+        """snapshot_to must persist entries that are still in the in-memory LRU cache."""
+        cache_file = tmp_path / "schema_cache.db"
+        resolver = SchemaResolver(
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=None,
+            _cache_filename=cache_file,
+        )
+        # Add an entry — it may still be in the LRU cache, not yet written to SQLite.
+        resolver.add_raw_schema_info(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.s.t,PROD)",
+            schema_info={"col": "text"},
+        )
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            urn, info = ro.resolve_table(
+                _TableName(database="db", db_schema="s", table="t")
+            )
+            assert info is not None
+            assert info["col"] == "text"
+        finally:
+            ro.close()
+
+
+class TestForWorkerTwoTier:
+    """Two-tier worker resolver: reads schemas from the read-only snapshot but
+    can hold graph-hydrated results and None-miss dedup in a small writable overlay.
+
+    Regression guard: a worker with a graph attached must NOT silently drop
+    graph-hydrated lineage (the bug: writes were no-ops on the read-only snapshot).
+    """
+
+    def _make_snapshot_with_table_a(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        """Snapshot containing only table A (orders)."""
+        cache_file = tmp_path / "schema_cache.db"
+        writable = SchemaResolver(
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=None,
+            _cache_filename=cache_file,
+        )
+        writable.add_raw_schema_info(
+            urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.orders,PROD)",
+            schema_info={"order_id": "int", "amount": "float"},
+        )
+        snap = tmp_path / "snapshot.db"
+        writable.snapshot_to(snap)
+        writable.close()
+        return snap
+
+    def _graph_returning_table_b(self):
+        """Mock graph whose get_entities returns a real SchemaMetadataClass for
+        table B (customers) only — table A is not in the graph."""
+        urn_b = "urn:li:dataset:(urn:li:dataPlatform:snowflake,prod.db.schema.customers,PROD)"
+        graph = MagicMock(spec=DataHubGraph)
+
+        def get_entities(entity_name, urns, aspects, with_system_metadata):
+            result: dict = {}
+            if urn_b in urns:
+                result[urn_b] = {
+                    "schemaMetadata": (
+                        create_mock_schema(
+                            [("customer_id", "int"), ("name", "varchar")]
+                        ),
+                        {},
+                    )
+                }
+            return result
+
+        graph.get_entities.side_effect = get_entities
+        return graph
+
+    def test_snapshot_hit_and_graph_hydration_parity(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Table A resolves from the snapshot (no graph call needed); table B
+        resolves via graph hydration (NOT None). Proves no lineage loss."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            _, info_a = worker.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            assert info_a is not None
+            assert info_a["order_id"] == "int"
+
+            _, info_b = worker.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info_b is not None, "graph-hydrated schema was silently dropped"
+            assert info_b["customer_id"] == "int"
+        finally:
+            worker.close()
+
+    def test_graph_fetch_deduped_via_overlay(self, tmp_path: pathlib.Path) -> None:
+        """Resolving table B twice fetches from the graph only once; the second
+        call is served from the writable overlay."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            table_b = _TableName(database="db", db_schema="schema", table="customers")
+            _, info1 = worker.resolve_table(table_b)
+            assert info1 is not None
+            first_count = graph.get_entities.call_count
+
+            _, info2 = worker.resolve_table(table_b)
+            assert info2 == info1
+            assert graph.get_entities.call_count == first_count
+        finally:
+            worker.close()
+
+    def test_none_miss_deduped_via_overlay(self, tmp_path: pathlib.Path) -> None:
+        """Table C (in neither snapshot nor graph) returns None and is not re-fetched."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        graph = self._graph_returning_table_b()
+
+        worker = SchemaResolver.for_worker(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+            graph=graph,
+        )
+        try:
+            table_c = _TableName(database="db", db_schema="schema", table="ghost")
+            _, info1 = worker.resolve_table(table_c)
+            assert info1 is None
+            first_count = graph.get_entities.call_count
+
+            _, info2 = worker.resolve_table(table_c)
+            assert info2 is None
+            assert graph.get_entities.call_count == first_count
+        finally:
+            worker.close()
+
+    def test_for_worker_no_graph_close_after_miss_does_not_raise(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """for_worker without a graph: snapshot reads work and close after a miss
+        does not raise (primary overlay is writable in-memory)."""
+        snap = self._make_snapshot_with_table_a(tmp_path)
+        worker = SchemaResolver.for_worker(
+            snap, platform="snowflake", platform_instance="prod", env="PROD", graph=None
+        )
+        _, info_a = worker.resolve_table(
+            _TableName(database="db", db_schema="schema", table="orders")
+        )
+        assert info_a is not None
+        _, info_miss = worker.resolve_table(
+            _TableName(database="db", db_schema="schema", table="nope")
+        )
+        assert info_miss is None
+        worker.close()
+
+
+class TestConcurrentReadonlyResolvers:
+    def test_two_resolvers_same_snapshot(self, tmp_path: pathlib.Path) -> None:
+        """Two independent read-only resolvers on the same snapshot file work without locking errors."""
+        resolver = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        resolver.snapshot_to(snap)
+        resolver.close()
+
+        ro1 = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        ro2 = SchemaResolver.load_readonly(
+            snap,
+            platform="snowflake",
+            platform_instance="prod",
+            env="PROD",
+        )
+        try:
+            # Both open simultaneously — no locking error expected with immutable=1.
+            urn1, info1 = ro1.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            urn2, info2 = ro2.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert info1 is not None
+            assert info2 is not None
+
+            # Cross-check: each resolver can see both tables.
+            _, orders_from_ro2 = ro2.resolve_table(
+                _TableName(database="db", db_schema="schema", table="orders")
+            )
+            _, customers_from_ro1 = ro1.resolve_table(
+                _TableName(database="db", db_schema="schema", table="customers")
+            )
+            assert orders_from_ro2 is not None
+            assert customers_from_ro1 is not None
+        finally:
+            ro1.close()
+            ro2.close()
+
+
+class TestReadOnlyResolverNoWriteOnClose:
+    """Regression test: read-only resolver must not write to SQLite at close/GC time.
+
+    H1 fix verification: FileBackedDict.close() must skip flush() for read-only
+    connections, and _save_to_cache must be a no-op for read-only resolvers so
+    cache-miss paths never dirty the in-memory cache.
+    """
+
+    def test_readonly_resolver_close_after_cache_miss_does_not_raise(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        """Build a writable resolver, snapshot it, open read-only, trigger a miss,
+        then close — no sqlite3.OperationalError should be raised."""
+        snapshot_path = tmp_path / "schema_cache.db"
+
+        # Build a writable resolver and populate it.
+        writable = SchemaResolver(platform="snowflake", env="PROD", graph=None)
+        writable.add_raw_schema_info(
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.known_table,PROD)",
+            {"col_a": "STRING"},
+        )
+        writable.snapshot_to(snapshot_path)
+        writable.close()
+
+        # Open read-only.
+        ro = SchemaResolver.load_readonly(
+            snapshot_path, platform="snowflake", env="PROD"
+        )
+
+        # Trigger a miss on resolve_table (unknown table) — this path calls
+        # _save_to_cache(urn, None) on the writable resolver but must be a no-op here.
+        _, info_table = ro.resolve_table(
+            _TableName(database="db", db_schema="schema", table="unknown_table")
+        )
+        assert info_table is None
+
+        # Trigger a miss on resolve_urn (also calls _resolve_schema_info).
+        _, info_urn = ro.resolve_urn(
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.also_missing,PROD)"
+        )
+        assert info_urn is None
+
+        # close() must NOT raise even though misses may have dirtied the in-memory cache
+        # on the old code path.
+        ro.close()  # This was the crash site before the fix.
+
+    def test_readonly_resolver_del_does_not_raise(self, tmp_path: pathlib.Path) -> None:
+        """Simulates GC path: explicitly calling close() after __del__ chain."""
+        snapshot_path = tmp_path / "schema_cache2.db"
+
+        writable = SchemaResolver(platform="redshift", env="PROD", graph=None)
+        writable.add_raw_schema_info(
+            "urn:li:dataset:(urn:li:dataPlatform:redshift,mydb.public.events,PROD)",
+            {"id": "INT"},
+        )
+        writable.snapshot_to(snapshot_path)
+        writable.close()
+
+        ro = SchemaResolver.load_readonly(
+            snapshot_path, platform="redshift", env="PROD"
+        )
+
+        # Miss path — used to dirty the cache, causing flush() → write → error at close.
+        ro.resolve_table(_TableName(database="mydb", db_schema="public", table="ghost"))
+
+        # Simulate what __del__ → close() does at GC time.
+        ro.close()
+        # Calling close() twice must also be safe (idempotent).
+        ro.close()
+
+
+class TestResolverClosesConnectionWrappers:
+    """L1: close() must explicitly close the underlying ConnectionWrapper(s) for
+    the primary cache AND the read-only fallback, rather than relying on GC."""
+
+    def _make_snapshot(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        writable = _make_writable_resolver(tmp_path)
+        snap = tmp_path / "snapshot.db"
+        writable.snapshot_to(snap)
+        writable.close()
+        return snap
+
+    def test_load_readonly_close_closes_underlying_connection(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        snap = self._make_snapshot(tmp_path)
+        ro = SchemaResolver.load_readonly(snap, platform="snowflake", env="PROD")
+
+        # The primary cache's ConnectionWrapper is the shared read-only conn.
+        conn = ro._schema_cache._conn
+        assert conn is not None
+        ro.close()
+        # SQLite connection must be closed: any query now raises ProgrammingError.
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+        # Double close must be safe.
+        ro.close()
+
+    def test_for_worker_close_closes_readonly_fallback_connection(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        snap = self._make_snapshot(tmp_path)
+        worker = SchemaResolver.for_worker(
+            snap, platform="snowflake", platform_instance="prod", env="PROD", graph=None
+        )
+        assert worker._readonly_fallback is not None
+        ro_conn = worker._readonly_fallback._conn
+        primary_conn = worker._schema_cache._conn
+        assert ro_conn is not None
+        assert primary_conn is not None
+
+        worker.close()
+
+        # Both the read-only fallback connection and the writable primary
+        # connection must be explicitly closed.
+        with pytest.raises(sqlite3.ProgrammingError):
+            ro_conn.execute("SELECT 1")
+        with pytest.raises(sqlite3.ProgrammingError):
+            primary_conn.execute("SELECT 1")
+        # Double close must not raise.
+        worker.close()

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -12,9 +12,26 @@ from datahub.metadata.schema_classes import SchemaFieldClass, SchemaMetadataClas
 from datahub.sql_parsing.schema_resolver import (
     SchemaInfo,
     SchemaResolver,
+    _SchemaResolverWithExtras,
     _TableName,
     match_columns_to_schema,
 )
+
+
+def test_schema_resolver_with_extras_includes_temp_tables_reflects_state() -> None:
+    """includes_temp_tables() must be False until temp tables are registered.
+
+    A hardcoded True marked every session-less query as temp-bearing and forced
+    it onto the inline serial path, defeating parallelism for connectors that
+    never set a session id."""
+    base = SchemaResolver(platform="redshift", env="PROD", graph=None)
+    resolver = _SchemaResolverWithExtras(base_resolver=base, extra_schemas={})
+    assert resolver.includes_temp_tables() is False
+
+    resolver.add_temp_tables(
+        {"urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.tmp,PROD)": None}
+    )
+    assert resolver.includes_temp_tables() is True
 
 
 def create_default_schema_resolver(urn: str) -> SchemaResolver:

--- a/metadata-ingestion/tests/unit/utilities/test_backpressure_aware_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_backpressure_aware_executor.py
@@ -1,4 +1,5 @@
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from datahub.utilities.backpressure_aware_executor import BackpressureAwareExecutor
 from datahub.utilities.perf_timer import PerfTimer
@@ -57,3 +58,28 @@ def test_backpressure_aware_executor_advanced():
         # Validate that the entire process took about 5-10x the task duration.
         # That's because we have 2 workers and 10 tasks.
         assert 5 * task_duration < timer.elapsed_seconds() < 10 * task_duration
+
+
+def test_backpressure_aware_executor_with_provided_executor():
+    """When an executor is passed in, map uses it and does NOT close it."""
+
+    def task(i):
+        return i
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    try:
+        results = {
+            res.result()
+            for res in BackpressureAwareExecutor.map(
+                task,
+                ((i,) for i in range(10)),
+                max_workers=2,
+                executor=executor,
+            )
+        }
+        assert results == set(range(10))
+
+        # The provided executor must remain usable — map must not have shut it down.
+        assert executor.submit(task, 42).result() == 42
+    finally:
+        executor.shutdown(wait=True)

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -431,3 +431,150 @@ def test_file_cleanup():
     assert filename.exists()
     cache.close()
     assert not filename.exists()
+
+
+# ---------------------------------------------------------------------------
+# Read-only ConnectionWrapper and FileBackedDict tests
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_connection_wrapper_opens_immutable(tmp_path: pathlib.Path) -> None:
+    """A read-only ConnectionWrapper opens an existing file and allows SELECTs."""
+    db_path = tmp_path / "test.db"
+
+    # Create a writable DB with some data.
+    with ConnectionWrapper(filename=db_path) as writable:
+        writable.execute("CREATE TABLE items (key TEXT PRIMARY KEY, value INTEGER)")
+        writable.execute("INSERT INTO items VALUES ('a', 1)")
+        writable.execute("INSERT INTO items VALUES ('b', 2)")
+
+    # Open the same file read-only.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        cursor = ro_conn.execute("SELECT value FROM items WHERE key = 'a'")
+        row = cursor.fetchone()
+        assert row[0] == 1
+
+        cursor2 = ro_conn.execute("SELECT COUNT(*) FROM items")
+        assert cursor2.fetchone()[0] == 2
+    finally:
+        ro_conn.close()
+
+
+def test_readonly_connection_skips_writable_pragmas(tmp_path: pathlib.Path) -> None:
+    """Read-only connection should not error on open; writable pragmas are skipped."""
+    db_path = tmp_path / "test.db"
+
+    # Bootstrap a valid SQLite file.
+    with ConnectionWrapper(filename=db_path) as writable:
+        writable.execute("CREATE TABLE t (k TEXT)")
+
+    # Should not raise.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    ro_conn.close()
+
+
+def test_readonly_file_backed_dict_reads(tmp_path: pathlib.Path) -> None:
+    """FileBackedDict on a read-only connection can read existing data."""
+    db_path = tmp_path / "snap.db"
+
+    # Write a writable dict with data.
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[int] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d["x"] = 10
+        d["y"] = 20
+        d.flush()
+
+    # Open read-only and verify reads work.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        ro_dict: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        assert ro_dict["x"] == 10
+        assert ro_dict["y"] == 20
+        assert "x" in ro_dict
+        assert "z" not in ro_dict
+    finally:
+        ro_conn.close()
+
+
+def test_readonly_file_backed_dict_does_not_create_table(
+    tmp_path: pathlib.Path,
+) -> None:
+    """FileBackedDict on a read-only connection must NOT attempt CREATE TABLE."""
+    db_path = tmp_path / "snap.db"
+
+    # Bootstrap a file with the table already present.
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[str] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=str,
+        )
+        d["key"] = "value"
+        d.flush()
+
+    # Open read-only — should succeed without creating a second table.
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        ro_dict: FileBackedDict[str] = FileBackedDict(
+            shared_connection=ro_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=str,
+        )
+        # If CREATE TABLE was attempted on a read-only connection it would have raised.
+        assert ro_dict["key"] == "value"
+    finally:
+        ro_conn.close()
+
+
+def test_two_readonly_connections_same_file(tmp_path: pathlib.Path) -> None:
+    """Two independent read-only connections on the same file work concurrently."""
+    db_path = tmp_path / "shared.db"
+
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[int] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d["a"] = 100
+        d["b"] = 200
+        d.flush()
+
+    ro1 = ConnectionWrapper(filename=db_path, read_only=True)
+    ro2 = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        d1: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro1,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d2: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro2,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+
+        # Both should be readable simultaneously — no locking error.
+        assert d1["a"] == 100
+        assert d2["b"] == 200
+        assert d1["b"] == 200
+        assert d2["a"] == 100
+    finally:
+        ro1.close()
+        ro2.close()

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -507,6 +507,40 @@ def test_readonly_file_backed_dict_reads(tmp_path: pathlib.Path) -> None:
         ro_conn.close()
 
 
+def test_readonly_file_backed_dict_rejects_writes(tmp_path: pathlib.Path) -> None:
+    """Mutating a read-only FileBackedDict must raise, not silently drop the write.
+
+    A read-only connection never flushes, so a cached dirty write would appear to
+    succeed and then vanish at close. Fail loudly instead of losing data."""
+    db_path = tmp_path / "snap.db"
+    with ConnectionWrapper(filename=db_path) as writable_conn:
+        d: FileBackedDict[int] = FileBackedDict(
+            shared_connection=writable_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        d["x"] = 10
+        d.flush()
+
+    ro_conn = ConnectionWrapper(filename=db_path, read_only=True)
+    try:
+        ro_dict: FileBackedDict[int] = FileBackedDict(
+            shared_connection=ro_conn,
+            tablename="data",
+            serializer=str,
+            deserializer=int,
+        )
+        with pytest.raises(RuntimeError):
+            ro_dict["y"] = 20
+        with pytest.raises(RuntimeError):
+            ro_dict.for_mutation("x")
+        with pytest.raises(RuntimeError):
+            del ro_dict["x"]
+    finally:
+        ro_conn.close()
+
+
 def test_readonly_file_backed_dict_does_not_create_table(
     tmp_path: pathlib.Path,
 ) -> None:

--- a/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
@@ -1,5 +1,7 @@
+import collections
 import logging
 import math
+import threading
 import time
 from concurrent.futures import Future
 from datetime import timedelta
@@ -79,6 +81,168 @@ def test_partitioned_executor_bounding():
         # Wait for everything to finish.
         executor.flush()
         assert len(done_tasks) == 16
+
+
+@pytest.mark.timeout(30)
+def test_partitioned_executor_same_key_completion_race():
+    # Deterministically forces interleaving #1: the same-key completion
+    # callback checks its pending deque, sees it empty, and then -- BEFORE it
+    # deletes the key -- a concurrent submit() for the same key appends a new
+    # task to that deque. The callback then deletes the key, silently dropping
+    # the queued task and leaking its semaphore permit.
+    #
+    # We force the exact window by instrumenting the pending deque: when the
+    # callback truthiness-checks the (empty) deque, we let a submit() land its
+    # append, then let the callback proceed to its `del`. Without a lock
+    # guarding these transitions, task2 is lost and its permit leaks; a leaked
+    # permit eventually deadlocks submit(), which the timeout catches.
+    run_counts: dict = {}
+    counts_lock = threading.Lock()
+
+    task1_running = threading.Event()
+    task1_may_finish = threading.Event()
+
+    def counting_task(task_id: str, block: bool = False) -> str:
+        if block:
+            task1_running.set()
+            # Park on the worker thread so task1's completion callback runs
+            # asynchronously (on the worker), not synchronously on the caller.
+            task1_may_finish.wait(timeout=10)
+        with counts_lock:
+            run_counts[task_id] = run_counts.get(task_id, 0) + 1
+        return task_id
+
+    callback_checked_empty = threading.Event()
+    submit_appended = threading.Event()
+    armed = threading.Event()
+
+    class _InstrumentedDeque(collections.deque):
+        def __len__(self):
+            result = super().__len__()
+            # Only trip the wire once, when task1's completion callback (on the
+            # worker thread) observes the empty deque -- the check-then-act
+            # window we want to exploit.
+            if (
+                result == 0
+                and armed.is_set()
+                and not callback_checked_empty.is_set()
+                and threading.current_thread().name != "MainThread"
+            ):
+                callback_checked_empty.set()
+                # Wait for the racing submit() to append before we return, so
+                # the callback then proceeds to `del` a now-non-empty key.
+                submit_appended.wait(timeout=5)
+            return result
+
+    with PartitionExecutor(max_workers=2, max_pending=10) as executor:
+        # Force new deques created by submit()/_submit_nowait to be our
+        # instrumented subclass so the callback's truthiness check is observable.
+        real_deque = collections.deque
+        collections.deque = _InstrumentedDeque  # type: ignore[misc]
+        try:
+            # Submit a blocking task1 for key1; it parks on a worker thread.
+            executor.submit("key1", counting_task, "task1", block=True)
+            assert task1_running.wait(timeout=5)
+
+            # Arm the trip only now, so it fires on task1's async completion
+            # callback rather than on any synchronous fast-path callback.
+            armed.set()
+
+            # Release task1. Its completion callback runs on the worker, sees
+            # the empty deque, and pauses in __len__ at the check-then-act window.
+            task1_may_finish.set()
+
+            assert callback_checked_empty.wait(timeout=5), (
+                "callback never reached the empty-check window"
+            )
+
+            # In the window before the callback's `del`, submit a second
+            # same-key task. Pre-fix this appends to a deque the callback is
+            # about to delete -> task lost + permit leaked.
+            appender = threading.Thread(
+                target=lambda: executor.submit("key1", counting_task, "task2")
+            )
+            appender.start()
+            # Give the append a moment to land inside the window.
+            time.sleep(0.2)
+            submit_appended.set()
+            appender.join(timeout=5)
+        finally:
+            collections.deque = real_deque  # type: ignore[misc]
+
+        executor.flush()
+
+        # Both tasks must have executed exactly once.
+        assert run_counts == {"task1": 1, "task2": 1}, (
+            f"task lost under race: {run_counts}"
+        )
+
+        # Verify no semaphore permit leaked: a leaked permit shrinks capacity
+        # and would eventually deadlock submit()/flush() (caught by timeout).
+        for i in range(30):
+            executor.submit(f"batch{i}", counting_task, f"batch{i}")
+        executor.flush()
+
+        for i in range(30):
+            assert run_counts[f"batch{i}"] == 1
+
+
+@pytest.mark.timeout(60)
+def test_partitioned_executor_concurrent_submit_stress():
+    # Many same-key and cross-key submissions from multiple threads,
+    # interleaved with fast-completing tasks. Every submitted task must run
+    # exactly once and flush() must terminate. Pre-fix, the unguarded
+    # check-then-act on _pending_by_key can lose tasks or raise KeyError;
+    # this is probabilistic, so we run several iterations to make a failure
+    # likely.
+    n_threads = 6
+    per_thread = 100
+    n_keys = 8
+
+    def counting_task(
+        task_id: str, run_counts: dict, counts_lock: threading.Lock
+    ) -> None:
+        with counts_lock:
+            run_counts[task_id] = run_counts.get(task_id, 0) + 1
+
+    def submitter(
+        thread_idx: int,
+        executor: PartitionExecutor,
+        barrier: threading.Barrier,
+        run_counts: dict,
+        counts_lock: threading.Lock,
+    ) -> None:
+        barrier.wait()
+        for j in range(per_thread):
+            key = f"key{(thread_idx + j) % n_keys}"
+            task_id = f"t{thread_idx}-{j}"
+            executor.submit(key, counting_task, task_id, run_counts, counts_lock)
+
+    submitted = {f"t{t}-{j}" for t in range(n_threads) for j in range(per_thread)}
+
+    for _iteration in range(5):
+        run_counts: dict = {}
+        counts_lock = threading.Lock()
+
+        with PartitionExecutor(max_workers=4, max_pending=50) as executor:
+            barrier = threading.Barrier(n_threads)
+            threads = [
+                threading.Thread(
+                    target=submitter,
+                    args=(t, executor, barrier, run_counts, counts_lock),
+                )
+                for t in range(n_threads)
+            ]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join()
+
+            executor.flush()
+
+        assert len(run_counts) == len(submitted)
+        assert all(count == 1 for count in run_counts.values())
+        assert set(run_counts) == submitted
 
 
 @pytest.mark.parametrize("max_workers", [1, 2, 10])


### PR DESCRIPTION
## 📋 Summary
Add the **opt-in multiprocessing core** for `SqlParsingAggregator` so the CPU-bound sqlglot work (parsing **and** query formatting) runs across worker processes. Default **off**. `sql_parsing_workers` is required when enabled (no `os.cpu_count()` inference, so it can't over-spawn on virtualized hosts). Connector wiring lands in separate stacked PRs (#18147 Snowflake, #18148 BigQuery, #18149 Redshift, #18150 Unity).

## 🎯 Motivation
On a large production run, ~1.25M of ~2.45M queries hit the sqlglot path, accounting for **~8.75h of the ~9.4h total** (~25ms/query). The aggregator parsed strictly single-process; sqlglot is pure-Python (GIL-bound), so only worker *processes* help.

## 🔧 Changes
- **`schema_resolver.py` + `file_backed_collections.py`** — read-only `immutable` SQLite snapshot (shared across workers via the OS page cache) + a two-tier `for_worker` resolver (writable overlay + snapshot fallback + per-worker `DataHubGraph`) so per-worker graph hydration is not lost; single `_init_components()` construction path; owned SQLite connections closed deterministically on `close()`.
- **`parallel_sql_parser.py`** — spawn `ProcessPoolExecutor`; workers rebuilt from a picklable `DatahubClientConfig`; workers **parse and format** each query (formatting was the dominant serial term); bounded drain; frozen `ParseTask`/`ParseOutcome` (result-XOR-error). **Any executor-layer failure — at submit *or* result time — trips a sticky `pool_broke` flag and returns an error outcome (never escapes)**; `RuntimeError` on use-after-close; `ParallelParserUnavailable` only for pool-creation failure; `graph_config` kept out of `repr` (token safety).
- **`partition_executor.py`** — `RLock` around all pending-key state transitions so concurrent submit/completion can't lose a same-session task or leak a permit.
- **`sql_parsing_aggregator.py`** — `parallel_sql_parsing_scope()`; **per-session-safe** dispatch via `PartitionExecutor` keyed by `session_id` (a temp producer is always applied before its same-session consumer is parsed); apply-lock serializing all shared-state mutation; worker-preformatted query threaded into apply. **Deterministic, order-independent query-map merge**: timestamps normalized via `make_ts_millis` (handles mixed naive/UTC — fixes a `TypeError` on the default-off path), a total tie-break on equal timestamp+text, and representative fields taken from a single winner while **never dropping a known actor**. **Serial fallback with no lineage loss** on worker/pool failure (infra failures reparse inline and are tracked in a distinct counter, not the parse-failure bucket). Report fields (parallelism, fell-back + reason, pool-broke, parsed-in-parallel, worker parse time); `SqlParsingParallelismConfig` mixin.

## ⚡ Performance
Measured on synthetic high-volume workloads (the smoke-test accounts have ~no query history, so they can't exercise this) — serial vs parallel, output byte-identical:

| workers | speedup (realistic/heavy queries) |
|--------:|:--:|
| 4 | 2.7x |
| 8 | 4.1x |
| 12 | 4.3x |

Roughly **8.75h → ~2h** on the parse phase. Formatting queries in the worker (rather than serially on the main thread) was the key lever: it lifted heavy-query speedup from ~2.6x to ~4.1x at 8 workers.

## ⚠️ Known limitation — current performance bottleneck
Speedup **plateaus around 4–4.5x and does not scale linearly with workers** (8→12 workers only moves 4.1x→4.3x). This is by design, not a bug:

- Parsing + formatting are parallelized across workers, but **aggregation stays on a single main process**: every parsed result is sent back to one process, which updates the **shared** lineage/query/usage ledgers **serially** under one lock. Concurrent writers to the same ledger entry would corrupt lineage, so this serialization is required for the no-loss guarantee.
- A raw parse-only benchmark tops out at ~5.5x on 8 workers for the same reason — funneling results through one process is the ceiling, independent of the aggregator logic. Batching the parse dispatch does **not** help (measured), so IPC is not the bottleneck.
- Consequence: the single-aggregator apply/merge step is now the limiter. Beating ~5x would require **sharded aggregation** (multiple aggregator processes owning disjoint slices of the ledgers, merged at the end) — a substantial follow-up with its own correctness surface, deliberately out of scope here.

**Guidance:** enable only for high-volume, sqlglot-heavy runs (set an explicit `sql_parsing_workers`, ~8 is the sweet spot); small workloads regress due to worker spawn + snapshot overhead, which is why it's default-off.

## 🧪 Testing
Serial-vs-parallel **equivalence** (byte-identical MCPs, incl. formatted query text) across no-temp, temp producer/consumer, interleaved multi-session, query-logging, and high-volume stress. Correctness-hardening coverage added from review: submit-time `BrokenProcessPool` → inline reparse with no loss; mixed naive/UTC timestamp merge (both orders, serial + parallel); equal timestamp+text with differing actor/session → stable winner; known-actor preservation on the default-off path; read-only resolver connection cleanup; PartitionExecutor forced submit/completion race. Full `sql_parsing` + `utilities` suites: **841 passed, 5 skipped**; ruff + mypy clean.

## 📊 Impact
Additive, **default off** → serial path byte-for-byte unchanged. Risk: Low. No migrations, no new dependencies.
