### PR TITLE
feat(): Adding tag support to Glossary Terms

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermType.java
@@ -62,7 +62,8 @@ public class GlossaryTermType
           FORMS_ASPECT_NAME,
           APPLICATION_MEMBERSHIP_ASPECT_NAME,
           DISPLAY_PROPERTIES_ASPECT_NAME,
-          ASSET_SETTINGS_ASPECT_NAME);
+          ASSET_SETTINGS_ASPECT_NAME,
+          GLOBAL_TAGS_ASPECT_NAME);
 
   private final EntityClient _entityClient;
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryTermMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryTermMapper.java
@@ -7,6 +7,7 @@ import com.linkedin.application.Applications;
 import com.linkedin.common.Deprecation;
 import com.linkedin.common.DisplayProperties;
 import com.linkedin.common.Forms;
+import com.linkedin.common.GlobalTags;
 import com.linkedin.common.InstitutionalMemory;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
@@ -29,6 +30,7 @@ import com.linkedin.datahub.graphql.types.form.FormsMapper;
 import com.linkedin.datahub.graphql.types.glossary.GlossaryTermUtils;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertiesMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.datahub.graphql.util.EntityResponseUtils;
 import com.linkedin.domain.Domains;
 import com.linkedin.entity.EntityResponse;
@@ -89,6 +91,11 @@ public class GlossaryTermMapper implements ModelMapper<EntityResponse, GlossaryT
         (glossaryTerm, dataMap) ->
             glossaryTerm.setOwnership(
                 OwnershipMapper.map(context, new Ownership(dataMap), entityUrn)));
+    mappingHelper.mapToResult(
+        GLOBAL_TAGS_ASPECT_NAME,
+        (glossaryTerm, dataMap) ->
+            glossaryTerm.setTags(
+                GlobalTagsMapper.map(context, new GlobalTags(dataMap), entityUrn)));
     mappingHelper.mapToResult(context, DOMAINS_ASPECT_NAME, this::mapDomains);
     mappingHelper.mapToResult(
         DEPRECATION_ASPECT_NAME,

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -2586,6 +2586,11 @@ type GlossaryTerm implements Entity {
   deprecation: Deprecation
 
   """
+  Tags associated with the glossary term
+  """
+  tags: GlobalTags
+
+  """
   Edges extending from this entity
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermTypeTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermTypeTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.datahub.graphql.types.glossary;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.GlossaryTerm;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.key.GlossaryTermKey;
+import graphql.execution.DataFetcherResult;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class GlossaryTermTypeTest {
+
+  private static final String TEST_TERM_URN = "urn:li:glossaryTerm:Classification.PII";
+
+  @Test
+  public void testBatchLoadRequestsGlobalTagsAspect() throws Exception {
+    EntityClient client = Mockito.mock(EntityClient.class);
+    Urn termUrn = Urn.createFromString(TEST_TERM_URN);
+
+    GlossaryTermKey key = new GlossaryTermKey().setName("Classification.PII");
+    GlossaryTermInfo info =
+        new GlossaryTermInfo()
+            .setName("PII")
+            .setDefinition("Personally Identifiable Information")
+            .setTermSource("INTERNAL");
+    GlobalTags tags =
+        new GlobalTags()
+            .setTags(
+                new TagAssociationArray(
+                    ImmutableList.of(new TagAssociation().setTag(new TagUrn("sensitive")))));
+
+    Mockito.when(client.batchGetV2(any(), eq(GLOSSARY_TERM_ENTITY_NAME), any(), any()))
+        .thenReturn(
+            ImmutableMap.of(
+                termUrn,
+                new EntityResponse()
+                    .setEntityName(GLOSSARY_TERM_ENTITY_NAME)
+                    .setUrn(termUrn)
+                    .setAspects(
+                        new EnvelopedAspectMap(
+                            ImmutableMap.of(
+                                GLOSSARY_TERM_KEY_ASPECT_NAME,
+                                new EnvelopedAspect().setValue(new Aspect(key.data())),
+                                GLOSSARY_TERM_INFO_ASPECT_NAME,
+                                new EnvelopedAspect().setValue(new Aspect(info.data())),
+                                GLOBAL_TAGS_ASPECT_NAME,
+                                new EnvelopedAspect().setValue(new Aspect(tags.data())))))));
+
+    GlossaryTermType type = new GlossaryTermType(client);
+    QueryContext mockContext = getMockAllowContext();
+
+    List<DataFetcherResult<GlossaryTerm>> result =
+        type.batchLoad(ImmutableList.of(TEST_TERM_URN), mockContext);
+
+    ArgumentCaptor<Set<String>> aspectsCaptor = ArgumentCaptor.forClass(Set.class);
+    Mockito.verify(client)
+        .batchGetV2(
+            any(),
+            eq(GLOSSARY_TERM_ENTITY_NAME),
+            eq(new HashSet<>(ImmutableSet.of(termUrn))),
+            aspectsCaptor.capture());
+    assertTrue(
+        aspectsCaptor.getValue().contains(GLOBAL_TAGS_ASPECT_NAME),
+        "GlossaryTermType must request the globalTags aspect");
+
+    assertEquals(result.size(), 1);
+    GlossaryTerm term = result.get(0).getData();
+    assertEquals(term.getUrn(), TEST_TERM_URN);
+    assertEquals(term.getType(), EntityType.GLOSSARY_TERM);
+    assertNotNull(term.getTags());
+    assertEquals(term.getTags().getTags().size(), 1);
+    assertEquals(term.getTags().getTags().get(0).getTag().getUrn(), "urn:li:tag:sensitive");
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryTermMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryTermMapperTest.java
@@ -1,0 +1,127 @@
+package com.linkedin.datahub.graphql.types.glossary.mappers;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.GlossaryTerm;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.key.GlossaryTermKey;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class GlossaryTermMapperTest {
+
+  private static final String TEST_TERM_URN = "urn:li:glossaryTerm:Classification.PII";
+  private static final String TEST_TERM_ID = "Classification.PII";
+  private static final String TEST_TAG_NAME = "sensitive";
+
+  private Urn glossaryTermUrn;
+  private QueryContext mockQueryContext;
+
+  @BeforeMethod
+  public void setup() throws URISyntaxException {
+    glossaryTermUrn = Urn.createFromString(TEST_TERM_URN);
+    mockQueryContext = mock(QueryContext.class);
+  }
+
+  @Test
+  public void testMapGlossaryTermWithTags() throws Exception {
+    EntityResponse entityResponse = createBasicEntityResponse();
+
+    GlobalTags globalTags = new GlobalTags();
+    globalTags.setTags(
+        new TagAssociationArray(
+            ImmutableList.of(new TagAssociation().setTag(new TagUrn(TEST_TAG_NAME)))));
+    addAspectToResponse(entityResponse, GLOBAL_TAGS_ASPECT_NAME, globalTags);
+
+    try (MockedStatic<AuthorizationUtils> authUtilsMock = mockStatic(AuthorizationUtils.class)) {
+      // GlobalTagsMapper also checks canView on each tag URN.
+      authUtilsMock.when(() -> AuthorizationUtils.canView(any(), any())).thenReturn(true);
+
+      GlossaryTerm result = GlossaryTermMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result);
+      assertEquals(result.getUrn(), TEST_TERM_URN);
+      assertEquals(result.getType(), EntityType.GLOSSARY_TERM);
+      assertNotNull(result.getTags());
+      assertNotNull(result.getTags().getTags());
+      assertEquals(result.getTags().getTags().size(), 1);
+      assertEquals(
+          result.getTags().getTags().get(0).getTag().getUrn(), "urn:li:tag:" + TEST_TAG_NAME);
+    }
+  }
+
+  @Test
+  public void testMapGlossaryTermWithoutTags() {
+    EntityResponse entityResponse = createBasicEntityResponse();
+
+    try (MockedStatic<AuthorizationUtils> authUtilsMock = mockStatic(AuthorizationUtils.class)) {
+      authUtilsMock
+          .when(() -> AuthorizationUtils.canView(any(), eq(glossaryTermUrn)))
+          .thenReturn(true);
+
+      GlossaryTerm result = GlossaryTermMapper.map(mockQueryContext, entityResponse);
+
+      assertNotNull(result);
+      assertEquals(result.getUrn(), TEST_TERM_URN);
+      assertNull(result.getTags());
+    }
+  }
+
+  private EntityResponse createBasicEntityResponse() {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(glossaryTermUrn);
+
+    GlossaryTermKey key = new GlossaryTermKey();
+    key.setName(TEST_TERM_ID);
+
+    EnvelopedAspect keyAspect = new EnvelopedAspect();
+    keyAspect.setValue(new Aspect(key.data()));
+
+    GlossaryTermInfo info = new GlossaryTermInfo();
+    info.setName("PII");
+    info.setDefinition("Personally Identifiable Information");
+    info.setTermSource("INTERNAL");
+
+    EnvelopedAspect infoAspect = new EnvelopedAspect();
+    infoAspect.setValue(new Aspect(info.data()));
+
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(GLOSSARY_TERM_KEY_ASPECT_NAME, keyAspect);
+    aspects.put(GLOSSARY_TERM_INFO_ASPECT_NAME, infoAspect);
+
+    entityResponse.setAspects(new EnvelopedAspectMap(aspects));
+    return entityResponse;
+  }
+
+  private void addAspectToResponse(
+      EntityResponse entityResponse, String aspectName, RecordTemplate aspectData) {
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new Aspect(aspectData.data()));
+    entityResponse.getAspects().put(aspectName, aspect);
+  }
+}

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
@@ -21,6 +21,7 @@ import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profi
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
 import SidebarEntityHeader from '@app/entityV2/shared/containers/profile/sidebar/SidebarEntityHeader';
+import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import StatusSection from '@app/entityV2/shared/containers/profile/sidebar/shared/StatusSection';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
 import { EntityActionItem } from '@app/entityV2/shared/entity/EntityActions';
@@ -120,6 +121,9 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
         },
         {
             component: SidebarApplicationSection,
+        },
+        {
+            component: SidebarTagsSection,
         },
         {
             component: SidebarStructuredProperties,
@@ -253,6 +257,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
             EntityCapabilityType.FORMS,
+            EntityCapabilityType.TAGS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/__tests__/GlossaryTermEntity.test.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/__tests__/GlossaryTermEntity.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { EntityCapabilityType } from '@app/entityV2/Entity';
+import { GlossaryTermEntity } from '@app/entityV2/glossaryTerm/GlossaryTermEntity';
+import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
+
+describe('GlossaryTermEntity tag support', () => {
+    const entity = new GlossaryTermEntity();
+
+    it('declares TAGS as a supported capability', () => {
+        expect(entity.supportedCapabilities().has(EntityCapabilityType.TAGS)).toBe(true);
+    });
+
+    it('includes SidebarTagsSection in the profile sidebar', () => {
+        const sections = entity.getSidebarSections();
+        expect(sections.some((section) => section.component === SidebarTagsSection)).toBe(true);
+    });
+});

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -66,6 +66,9 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
         applications {
             ...entityApplication
         }
+        tags {
+            ...globalTagsFields
+        }
         institutionalMemory {
             ...institutionalMemoryFields
         }

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -955,6 +955,9 @@ fragment searchResultsWithoutSchemaField on Entity {
         domain {
             ...entityDomain
         }
+        tags {
+            ...globalTagsFields
+        }
         structuredProperties {
             properties {
                 ...structuredPropertiesFields

--- a/e2e-test/ui/playwright/pages/glossary.page.ts
+++ b/e2e-test/ui/playwright/pages/glossary.page.ts
@@ -67,6 +67,14 @@ export class GlossaryPage extends BasePage {
   // ── Tabs ──────────────────────────────────────────────────────────────────
   readonly propertiesTab: Locator;
 
+  // ── Sidebar Tags section (entity profile) ─────────────────────────────────
+  readonly tagsSectionContainer: Locator;
+  readonly addTagsButton: Locator;
+  readonly tagTermModalInput: Locator;
+  readonly tagTermInput: Locator;
+  readonly addTagFromModalButton: Locator;
+  readonly tagUnassignConfirmButton: Locator;
+
   private readonly graphqlHelper: GraphQLHelper;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
@@ -128,6 +136,15 @@ export class GlossaryPage extends BasePage {
     this.createGlossaryTermHeading = page.getByRole('heading', { name: 'Create Glossary Term' });
     this.deleteConfirmButton = page.getByRole('button', { name: 'Yes' });
     this.propertiesTab = page.getByRole('tab').filter({ has: page.getByTestId('Properties-entity-tab-header') });
+
+    // eslint-disable-next-line playwright/no-raw-locators -- HTML id set by SidebarTagsSection; no data-testid equivalent
+    this.tagsSectionContainer = page.locator('#entity-profile-tags');
+    this.addTagsButton = this.tagsSectionContainer.getByTestId('add-tags-button');
+    this.tagTermModalInput = page.getByTestId('tag-term-modal-input');
+    // Alchemy SimpleSelect: search input lives in the portaled dropdown; open the trigger first.
+    this.tagTermInput = page.getByTestId('dropdown-search-input');
+    this.addTagFromModalButton = page.getByTestId('add-tag-term-from-modal-btn');
+    this.tagUnassignConfirmButton = page.getByTestId('modal-confirm-button');
   }
 
   // ── Dynamic locator getters ───────────────────────────────────────────────────
@@ -186,6 +203,75 @@ export class GlossaryPage extends BasePage {
     this.logger?.step('navigateToGlossaryTermByUrn', { urn });
     await this.page.goto(`/glossaryTerm/${encodeURIComponent(urn)}`);
     await this.waitForPageLoad();
+  }
+
+  getTagChip(tagName: string): Locator {
+    return this.page.getByTestId(`tag-${tagName}`);
+  }
+
+  getTagOption(tagName: string): Locator {
+    return this.page.getByTestId(`tag-term-option-${tagName}`);
+  }
+
+  getTagRemoveIcon(tagName: string): Locator {
+    return this.getTagChip(tagName).getByTestId('remove-icon');
+  }
+
+  /**
+   * Assign a tag via the glossary term profile sidebar Tags section.
+   *
+   * Multi-select SimpleSelect only commits via the alchemy Checkbox
+   * (`checkbox-base`); the native input is visually hidden. Dismiss the
+   * dropdown by clicking the modal title (Escape closes the whole modal),
+   * then confirm Add.
+   */
+  async assignTag(tagName: string, tagUrn = `urn:li:tag:${tagName}`): Promise<void> {
+    this.logger?.step('assignTag', { tagName, tagUrn });
+    await expect(this.tagsSectionContainer).toBeVisible({ timeout: 30000 });
+    await this.tagsSectionContainer.scrollIntoViewIfNeeded();
+    await expect(this.addTagsButton).toBeVisible();
+    await expect(this.addTagsButton).toBeEnabled();
+    await this.addTagsButton.click();
+
+    const addTagsDialog = this.page.getByRole('dialog').filter({ hasText: 'Add Tags' });
+    await expect(addTagsDialog).toBeVisible();
+    await this.tagTermModalInput.click();
+    await this.tagTermInput.fill(tagName);
+
+    const option = this.page.getByTestId(`option-${tagUrn}`);
+    await expect(option).toBeVisible({ timeout: 15000 });
+    const checkbox = option.getByTestId('checkbox-base');
+    await checkbox.click();
+    await expect(checkbox).toHaveAttribute('data-checked', 'true', { timeout: 10000 });
+    await expect(this.page.getByTestId(`selected-${tagName}`)).toBeVisible({ timeout: 10000 });
+
+    // Dismiss the search dropdown without clearing selection or closing the modal.
+    await addTagsDialog.getByRole('heading', { name: 'Add Tags' }).click();
+
+    await expect(this.addTagFromModalButton).toBeEnabled({ timeout: 10000 });
+    await this.addTagFromModalButton.click();
+
+    await expect(addTagsDialog).toBeHidden({ timeout: 15000 });
+    await this.toast.expectVisible('Added Tags!', { timeout: 15000 });
+  }
+
+  async unassignTag(tagName: string): Promise<void> {
+    this.logger?.step('unassignTag', { tagName });
+    await expect(this.getTagChip(tagName)).toBeVisible({ timeout: 15000 });
+    await this.getTagRemoveIcon(tagName).click();
+    await expect(this.tagUnassignConfirmButton).toBeVisible();
+    await this.tagUnassignConfirmButton.click();
+    await this.toast.expectVisible('Removed Tag!');
+  }
+
+  async expectTagAssigned(tagName: string): Promise<void> {
+    this.logger?.step('expectTagAssigned', { tagName });
+    await expect(this.getTagChip(tagName)).toBeVisible({ timeout: 15000 });
+  }
+
+  async expectTagNotAssigned(tagName: string): Promise<void> {
+    this.logger?.step('expectTagNotAssigned', { tagName });
+    await expect(this.getTagChip(tagName)).toBeHidden({ timeout: 15000 });
   }
 
   async navigateToGlossaryNodeByUrn(urn: string): Promise<void> {

--- a/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/glossary/fixtures/data.json
@@ -340,5 +340,39 @@
         ]
       }
     }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
+        "urn": "urn:li:tag:PlaywrightGlossaryTermProfileTag",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.tag.TagProperties": {
+              "name": "PlaywrightGlossaryTermProfileTag",
+              "description": "Tag used to assign/unassign on a glossary term profile in Playwright"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryTermSnapshot": {
+        "urn": "urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightTaggableTerm",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryTermInfo": {
+              "definition": "Term used to verify tagging on glossary term profile",
+              "name": "PlaywrightTaggableTerm",
+              "parentNode": "urn:li:glossaryNode:PlaywrightGlossaryTermTests",
+              "termSource": "INTERNAL"
+            }
+          }
+        ]
+      }
+    }
   }
 ]

--- a/e2e-test/ui/playwright/tests/glossary/v2-glossary-term-tags.spec.ts
+++ b/e2e-test/ui/playwright/tests/glossary/v2-glossary-term-tags.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Glossary term profile — assign / unassign tags from the sidebar Tags section.
+ *
+ * Prerequisites (seeded via tests/glossary/fixtures/data.json):
+ *   - PlaywrightGlossaryTermTests.PlaywrightTaggableTerm
+ *   - PlaywrightGlossaryTermProfileTag
+ */
+
+import { test } from '../../fixtures/base-test';
+import { GlossaryPage } from '../../pages/glossary.page';
+
+test.use({ featureName: 'glossary' });
+
+const TAGGABLE_TERM_URN = 'urn:li:glossaryTerm:PlaywrightGlossaryTermTests.PlaywrightTaggableTerm';
+const TAG_NAME = 'PlaywrightGlossaryTermProfileTag';
+
+test.describe('glossary term profile tags', () => {
+  // Mutations on a shared seeded term — keep serial to avoid chip-state races.
+  test.describe.configure({ mode: 'serial' });
+
+  let glossaryPage: GlossaryPage;
+
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    glossaryPage = new GlossaryPage(page, logger, logDir);
+    await page.addInitScript(() => {
+      localStorage.setItem('navBarState', '{"state":"COLLAPSED"}');
+    });
+  });
+
+  test('should allow assigning and unassigning a tag on a glossary term', async () => {
+    test.setTimeout(120000);
+
+    await glossaryPage.navigateToGlossaryTermByUrn(TAGGABLE_TERM_URN);
+
+    // Start from a clean sidebar (prior failed runs may have left the tag).
+    if ((await glossaryPage.getTagChip(TAG_NAME).count()) > 0) {
+      await glossaryPage.unassignTag(TAG_NAME);
+      await glossaryPage.expectTagNotAssigned(TAG_NAME);
+    }
+
+    await glossaryPage.assignTag(TAG_NAME);
+    await glossaryPage.expectTagAssigned(TAG_NAME);
+
+    // Reload to confirm the tag persisted via GraphQL, not just client state.
+    await glossaryPage.navigateToGlossaryTermByUrn(TAGGABLE_TERM_URN);
+    await glossaryPage.expectTagAssigned(TAG_NAME);
+
+    await glossaryPage.unassignTag(TAG_NAME);
+    await glossaryPage.expectTagNotAssigned(TAG_NAME);
+
+    await glossaryPage.navigateToGlossaryTermByUrn(TAGGABLE_TERM_URN);
+    await glossaryPage.expectTagNotAssigned(TAG_NAME);
+  });
+});

--- a/metadata-ingestion/src/datahub/sdk/glossary_term.py
+++ b/metadata-ingestion/src/datahub/sdk/glossary_term.py
@@ -12,9 +12,11 @@ from datahub.sdk._shared import (
     HasInstitutionalMemory,
     HasOwnership,
     HasStructuredProperties,
+    HasTags,
     LinksInputType,
     OwnersInputType,
     StructuredPropertyInputType,
+    TagsInputType,
 )
 from datahub.sdk.entity import Entity, ExtraAspectsType
 from datahub.sdk.glossary_node import GlossaryNode, GlossaryNodeUrnOrStr
@@ -27,6 +29,7 @@ class GlossaryTerm(
     HasInstitutionalMemory,
     HasStructuredProperties,
     HasDomain,
+    HasTags,
     Entity,
 ):
     """A business glossary term in DataHub.
@@ -113,6 +116,7 @@ class GlossaryTerm(
         related_terms: Optional[List[GlossaryTermUrnOrStr]] = None,
         owners: Optional[OwnersInputType] = None,
         links: Optional[LinksInputType] = None,
+        tags: Optional[TagsInputType] = None,
         domain: Optional[DomainInputType] = None,
         structured_properties: Optional[StructuredPropertyInputType] = None,
         extra_aspects: ExtraAspectsType = None,
@@ -153,6 +157,7 @@ class GlossaryTerm(
                 terms with no directional semantic.
             owners: Owners of this term.
             links: Documentation or reference links.
+            tags: Tags associated with this term.
             domain: Domain this term belongs to.
             structured_properties: Structured property assignments.
             extra_aspects: Additional raw aspects to attach to the entity.
@@ -188,6 +193,8 @@ class GlossaryTerm(
             self.set_owners(owners)
         if links is not None:
             self.set_links(links)
+        if tags is not None:
+            self.set_tags(tags)
         if domain is not None:
             self.set_domain(domain)
         if structured_properties is not None:

--- a/metadata-ingestion/tests/unit/sdk_v2/test_glossary_term.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_glossary_term.py
@@ -207,6 +207,41 @@ def test_glossary_term_setters() -> None:
     assert term.custom_properties == {"key": "value"}
 
 
+def test_glossary_term_tags() -> None:
+    from datahub.metadata.urns import TagUrn
+
+    def _tag_names(tags):
+        return [str(TagUrn.from_string(tag.tag)) for tag in tags]
+
+    term = GlossaryTerm(
+        id="a1b2c3d4",
+        definition="Tagged term.",
+        tags=[TagUrn("pii"), TagUrn("finance")],
+    )
+    assert term.tags is not None
+    assert _tag_names(term.tags) == [
+        "urn:li:tag:pii",
+        "urn:li:tag:finance",
+    ]
+
+    term.add_tag(TagUrn("sensitive"))
+    term.add_tag(TagUrn("pii"))  # idempotent
+    assert _tag_names(term.tags) == [
+        "urn:li:tag:pii",
+        "urn:li:tag:finance",
+        "urn:li:tag:sensitive",
+    ]
+
+    term.remove_tag(TagUrn("finance"))
+    assert _tag_names(term.tags) == [
+        "urn:li:tag:pii",
+        "urn:li:tag:sensitive",
+    ]
+
+    term.set_tags([TagUrn("classified")])
+    assert _tag_names(term.tags) == ["urn:li:tag:classified"]
+
+
 def test_glossary_term_has_a_and_related() -> None:
     term = GlossaryTerm(id="5e6f7a8b")
 

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/GlossaryTermAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/GlossaryTermAspect.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.metadata.aspect
 
 import com.linkedin.glossary.GlossaryTermInfo
 import com.linkedin.metadata.key.GlossaryTermKey
+import com.linkedin.common.GlobalTags
 import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.BrowsePaths
@@ -10,4 +11,4 @@ import com.linkedin.glossary.GlossaryRelatedTerms
 /**
  * A union of all supported metadata aspects for a CorpUser
  */
-typeref GlossaryTermAspect = union[GlossaryTermKey, GlossaryTermInfo, Ownership, Status, BrowsePaths, GlossaryRelatedTerms]
+typeref GlossaryTermAspect = union[GlossaryTermKey, GlossaryTermInfo, Ownership, Status, BrowsePaths, GlossaryRelatedTerms, GlobalTags]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/GlossaryTermAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/GlossaryTermAspect.pdl
@@ -2,7 +2,6 @@ namespace com.linkedin.metadata.aspect
 
 import com.linkedin.glossary.GlossaryTermInfo
 import com.linkedin.metadata.key.GlossaryTermKey
-import com.linkedin.common.GlobalTags
 import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.BrowsePaths
@@ -11,4 +10,4 @@ import com.linkedin.glossary.GlossaryRelatedTerms
 /**
  * A union of all supported metadata aspects for a CorpUser
  */
-typeref GlossaryTermAspect = union[GlossaryTermKey, GlossaryTermInfo, Ownership, Status, BrowsePaths, GlossaryRelatedTerms, GlobalTags]
+typeref GlossaryTermAspect = union[GlossaryTermKey, GlossaryTermInfo, Ownership, Status, BrowsePaths, GlossaryRelatedTerms]

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -333,6 +333,7 @@ entities:
       - subTypes
       - displayProperties
       - assetSettings
+      - globalTags
   - name: glossaryNode
     category: core
     keyAspect: glossaryNodeKey

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -841,6 +841,7 @@ public class PoliciesConfig {
               EDIT_ENTITY_DEPRECATION_PRIVILEGE,
               EDIT_ENTITY_PRIVILEGE,
               EDIT_ENTITY_PROPERTIES_PRIVILEGE,
+              EDIT_ENTITY_TAGS_PRIVILEGE,
               CREATE_ENTITY_PRIVILEGE,
               EXISTS_ENTITY_PRIVILEGE));
 

--- a/metadata-utils/src/test/java/com/linkedin/metadata/authorization/PoliciesConfigGlossaryTermTagsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/authorization/PoliciesConfigGlossaryTermTagsTest.java
@@ -1,0 +1,17 @@
+package com.linkedin.metadata.authorization;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class PoliciesConfigGlossaryTermTagsTest {
+
+  @Test
+  public void testGlossaryTermPrivilegesIncludeEditTags() {
+    assertTrue(
+        PoliciesConfig.GLOSSARY_TERM_PRIVILEGES
+            .getPrivileges()
+            .contains(PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE),
+        "Glossary terms must allow EDIT_ENTITY_TAGS so users can tag terms");
+  }
+}


### PR DESCRIPTION
Support tagging Glossary Terms, finally!

This allows you to easily organize glossary terms using tags and applying search views for glossary terms as well. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
