### PR TITLE
feat(api): support structured fields on custom assertions

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolver.java
@@ -3,16 +3,27 @@ package com.linkedin.datahub.graphql.resolvers.assertion;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
+import com.linkedin.assertion.AssertionStdAggregation;
+import com.linkedin.assertion.AssertionStdOperator;
+import com.linkedin.assertion.AssertionStdParameter;
+import com.linkedin.assertion.AssertionStdParameterType;
+import com.linkedin.assertion.AssertionStdParameters;
 import com.linkedin.assertion.CustomAssertionInfo;
+import com.linkedin.assertion.DatasetAssertionScope;
 import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.SetMode;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.Assertion;
+import com.linkedin.datahub.graphql.generated.AssertionStdParameterInput;
+import com.linkedin.datahub.graphql.generated.AssertionStdParametersInput;
 import com.linkedin.datahub.graphql.generated.PlatformInput;
+import com.linkedin.datahub.graphql.generated.StringMapEntryInput;
 import com.linkedin.datahub.graphql.generated.UpsertCustomAssertionInput;
 import com.linkedin.datahub.graphql.types.assertion.AssertionMapper;
 import com.linkedin.metadata.key.DataPlatformKey;
@@ -21,9 +32,11 @@ import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.SchemaFieldUtils;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -102,15 +115,80 @@ public class UpsertCustomAssertionResolver implements DataFetcher<CompletableFut
     customAssertionInfo.setEntity(entityUrn);
     customAssertionInfo.setLogic(input.getLogic(), SetMode.IGNORE_NULL);
 
-    if (input.getFieldPath() != null) {
+    List<String> fieldPaths = input.getFieldPaths();
+    if (fieldPaths != null && !fieldPaths.isEmpty()) {
+      UrnArray fieldUrns = new UrnArray();
+      for (String fieldPath : fieldPaths) {
+        if (fieldPath == null || fieldPath.isBlank()) {
+          throw new IllegalArgumentException(
+              "Failed to upsert Custom Assertion. fieldPaths must not contain blank entries;"
+                  + " omit fieldPaths for dataset-level assertions.");
+        }
+        fieldUrns.add(SchemaFieldUtils.generateSchemaFieldUrn(entityUrn, fieldPath));
+      }
+      customAssertionInfo.setFields(fieldUrns);
+      // Keep singular field populated for backward compatibility
+      customAssertionInfo.setField(fieldUrns.get(0));
+    } else if (input.getFieldPath() != null) {
       if (input.getFieldPath().isBlank()) {
         throw new IllegalArgumentException(
             "Failed to upsert Custom Assertion. fieldPath must not be blank when provided;"
                 + " omit fieldPath for dataset-level assertions.");
       }
-      customAssertionInfo.setField(
-          SchemaFieldUtils.generateSchemaFieldUrn(entityUrn, input.getFieldPath()));
+      Urn fieldUrn = SchemaFieldUtils.generateSchemaFieldUrn(entityUrn, input.getFieldPath());
+      customAssertionInfo.setField(fieldUrn);
+      customAssertionInfo.setFields(new UrnArray(fieldUrn));
+    }
+
+    if (input.getScope() != null) {
+      customAssertionInfo.setScope(DatasetAssertionScope.valueOf(input.getScope().name()));
+    }
+    if (input.getAggregation() != null) {
+      customAssertionInfo.setAggregation(
+          AssertionStdAggregation.valueOf(input.getAggregation().name()));
+    }
+    if (input.getOperator() != null) {
+      customAssertionInfo.setOperator(AssertionStdOperator.valueOf(input.getOperator().name()));
+    }
+    if (input.getParameters() != null) {
+      customAssertionInfo.setParameters(mapParameters(input.getParameters()));
+    }
+    customAssertionInfo.setNativeType(input.getNativeType(), SetMode.IGNORE_NULL);
+    if (input.getNativeParameters() != null && !input.getNativeParameters().isEmpty()) {
+      customAssertionInfo.setNativeParameters(mapNativeParameters(input.getNativeParameters()));
     }
     return customAssertionInfo;
+  }
+
+  @Nullable
+  private AssertionStdParameters mapParameters(
+      @Nonnull AssertionStdParametersInput parametersInput) {
+    AssertionStdParameters parameters = new AssertionStdParameters();
+    if (parametersInput.getValue() != null) {
+      parameters.setValue(mapParameter(parametersInput.getValue()));
+    }
+    if (parametersInput.getMinValue() != null) {
+      parameters.setMinValue(mapParameter(parametersInput.getMinValue()));
+    }
+    if (parametersInput.getMaxValue() != null) {
+      parameters.setMaxValue(mapParameter(parametersInput.getMaxValue()));
+    }
+    return parameters;
+  }
+
+  private AssertionStdParameter mapParameter(@Nonnull AssertionStdParameterInput parameterInput) {
+    return new AssertionStdParameter()
+        .setType(AssertionStdParameterType.valueOf(parameterInput.getType().name()))
+        .setValue(parameterInput.getValue());
+  }
+
+  private StringMap mapNativeParameters(@Nonnull List<StringMapEntryInput> entries) {
+    StringMap map = new StringMap();
+    for (StringMapEntryInput entry : entries) {
+      if (entry.getKey() != null && entry.getValue() != null) {
+        map.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return map;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
@@ -42,6 +42,7 @@ import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAsp
 import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
 import com.linkedin.datahub.graphql.types.dataset.mappers.SchemaFieldMapper;
 import com.linkedin.datahub.graphql.types.dataset.mappers.SchemaMetadataMapper;
+import com.linkedin.datahub.graphql.types.mappers.PdlEnumMapper;
 import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
@@ -49,7 +50,9 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.utils.AssertionUtils;
 import com.linkedin.schema.SchemaField;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -359,8 +362,53 @@ public class AssertionMapper {
     CustomAssertionInfo result = new CustomAssertionInfo();
     result.setType(gmsCustomAssertionInfo.getType());
     result.setEntityUrn(gmsCustomAssertionInfo.getEntity().toString());
+
+    // Merge field (deprecated) and fields into a single array for backward compatibility
+    List<SchemaFieldRef> allFields = new ArrayList<>();
+    if (gmsCustomAssertionInfo.hasFields()) {
+      allFields.addAll(
+          gmsCustomAssertionInfo.getFields().stream()
+              .map(AssertionMapper::mapDatasetSchemaField)
+              .collect(Collectors.toList()));
+    }
     if (gmsCustomAssertionInfo.hasField()) {
-      result.setField(AssertionMapper.mapDatasetSchemaField(gmsCustomAssertionInfo.getField()));
+      SchemaFieldRef legacyField = mapDatasetSchemaField(gmsCustomAssertionInfo.getField());
+      if (allFields.stream().noneMatch(f -> f.getUrn().equals(legacyField.getUrn()))) {
+        allFields.add(legacyField);
+      }
+      result.setField(legacyField);
+    } else if (!allFields.isEmpty()) {
+      // Populate singular field from first of fields for older clients
+      result.setField(allFields.get(0));
+    }
+    result.setFields(allFields);
+
+    if (gmsCustomAssertionInfo.hasScope()) {
+      result.setScope(
+          PdlEnumMapper.mapDefaultNull(
+              DatasetAssertionScope.class, gmsCustomAssertionInfo.getScope()));
+    }
+    if (gmsCustomAssertionInfo.hasAggregation()) {
+      result.setAggregation(
+          PdlEnumMapper.mapDefaultNull(
+              AssertionStdAggregation.class, gmsCustomAssertionInfo.getAggregation()));
+    }
+    if (gmsCustomAssertionInfo.hasOperator()) {
+      result.setOperator(
+          PdlEnumMapper.mapDefaultNull(
+              AssertionStdOperator.class, gmsCustomAssertionInfo.getOperator()));
+    }
+    if (gmsCustomAssertionInfo.hasParameters()) {
+      result.setParameters(mapParameters(gmsCustomAssertionInfo.getParameters()));
+    }
+    if (gmsCustomAssertionInfo.hasNativeType()) {
+      result.setNativeType(gmsCustomAssertionInfo.getNativeType());
+    }
+    if (gmsCustomAssertionInfo.hasNativeParameters()) {
+      result.setNativeParameters(
+          StringMapMapper.map(context, gmsCustomAssertionInfo.getNativeParameters()));
+    } else {
+      result.setNativeParameters(Collections.emptyList());
     }
     if (gmsCustomAssertionInfo.hasLogic()) {
       result.setLogic(gmsCustomAssertionInfo.getLogic());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
@@ -305,7 +305,7 @@ public class AssertionMapper {
   private static AssertionStdParameter mapParameter(
       final com.linkedin.assertion.AssertionStdParameter param) {
     final AssertionStdParameter result = new AssertionStdParameter();
-    result.setType(AssertionStdParameterType.valueOf(param.getType().name()));
+    result.setType(PdlEnumMapper.mapDefaultNull(AssertionStdParameterType.class, param.getType()));
     result.setValue(param.getValue());
     return result;
   }

--- a/datahub-graphql-core/src/main/resources/assertions.graphql
+++ b/datahub-graphql-core/src/main/resources/assertions.graphql
@@ -1,6 +1,11 @@
 extend type Mutation {
   """
-  Upsert a Custom Assertion
+  Upsert a Custom Assertion.
+
+  Updates fully replace assertionInfo / customAssertion (same contract as
+  native freshness / volume / field / SQL / schema assertion monitor upserts).
+  Callers must resend any fields they want to keep; omitted optional fields
+  are cleared.
   """
   upsertCustomAssertion(
     """

--- a/datahub-graphql-core/src/main/resources/assertions.graphql
+++ b/datahub-graphql-core/src/main/resources/assertions.graphql
@@ -53,8 +53,16 @@ input UpsertCustomAssertionInput {
   Optional dataset column name targeted by this assertion.
   When set, DataHub builds a schemaField URN from entityUrn + fieldPath.
   Omit for dataset-level assertions. Do not pass a full schemaField URN — use the bare column name.
+  Deprecated: Use fieldPaths instead for multi-column support.
   """
   fieldPath: String
+
+  """
+  Optional dataset column names targeted by this assertion.
+  Use this for assertions involving multiple columns. As with fieldPath, provide bare
+  column names — DataHub builds the schemaField URNs from entityUrn + each path.
+  """
+  fieldPaths: [String!]
 
   """
   The external Platform associated with the assertion.
@@ -71,6 +79,71 @@ input UpsertCustomAssertionInput {
   Logic comprising a raw, unstructured assertion. for example - custom SQL query for the assertion.
   """
   logic: String
+
+  """
+  Scope of the assertion (column, rows, schema, etc.). Optional structured metadata for display.
+  """
+  scope: DatasetAssertionScope
+
+  """
+  Standardized assertion aggregation / metric.
+  """
+  aggregation: AssertionStdAggregation
+
+  """
+  Standardized assertion operator.
+  """
+  operator: AssertionStdOperator
+
+  """
+  Standard parameters required for the assertion.
+  """
+  parameters: AssertionStdParametersInput
+
+  """
+  Native assertion type (platform-specific), e.g. Great Expectations expectation name.
+  """
+  nativeType: String
+
+  """
+  Native parameters required for the assertion.
+  """
+  nativeParameters: [StringMapEntryInput!]
+}
+
+"""
+Input for AssertionStdParameters.
+"""
+input AssertionStdParametersInput {
+  """
+  The value parameter of an assertion
+  """
+  value: AssertionStdParameterInput
+
+  """
+  The maxValue parameter of an assertion
+  """
+  maxValue: AssertionStdParameterInput
+
+  """
+  The minValue parameter of an assertion
+  """
+  minValue: AssertionStdParameterInput
+}
+
+"""
+Input for a single AssertionStdParameter.
+"""
+input AssertionStdParameterInput {
+  """
+  The parameter value
+  """
+  value: String!
+
+  """
+  The type of the parameter
+  """
+  type: AssertionStdParameterType!
 }
 
 """
@@ -1070,8 +1143,45 @@ type CustomAssertionInfo {
 
   """
   The field serving as input to the assertion, if any.
+  Deprecated: Prefer fields for multi-column support. Still populated when a single field is set.
   """
   field: SchemaFieldRef
+
+  """
+  The fields serving as input to the assertion, if any.
+  Merges deprecated singular field and fields for backward compatibility.
+  """
+  fields: [SchemaFieldRef!]
+
+  """
+  Scope of the assertion (column, rows, schema, etc.).
+  """
+  scope: DatasetAssertionScope
+
+  """
+  Standardized assertion aggregation / metric.
+  """
+  aggregation: AssertionStdAggregation
+
+  """
+  Standardized assertion operator.
+  """
+  operator: AssertionStdOperator
+
+  """
+  Standard parameters required for the assertion.
+  """
+  parameters: AssertionStdParameters
+
+  """
+  Native assertion type (platform-specific).
+  """
+  nativeType: String
+
+  """
+  Native parameters required for the assertion.
+  """
+  nativeParameters: [StringMapEntry!]
 
   """
   Logic comprising a raw, unstructured assertion.

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolverTest.java
@@ -8,16 +8,27 @@ import com.google.common.collect.ImmutableMap;
 import com.linkedin.assertion.AssertionInfo;
 import com.linkedin.assertion.AssertionSource;
 import com.linkedin.assertion.AssertionSourceType;
+import com.linkedin.assertion.AssertionStdAggregation;
+import com.linkedin.assertion.AssertionStdOperator;
+import com.linkedin.assertion.AssertionStdParameter;
+import com.linkedin.assertion.AssertionStdParameterType;
+import com.linkedin.assertion.AssertionStdParameters;
 import com.linkedin.assertion.AssertionType;
 import com.linkedin.assertion.CustomAssertionInfo;
+import com.linkedin.assertion.DatasetAssertionScope;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.url.Url;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Assertion;
+import com.linkedin.datahub.graphql.generated.AssertionStdParameterInput;
+import com.linkedin.datahub.graphql.generated.AssertionStdParametersInput;
 import com.linkedin.datahub.graphql.generated.PlatformInput;
+import com.linkedin.datahub.graphql.generated.StringMapEntryInput;
 import com.linkedin.datahub.graphql.generated.UpsertCustomAssertionInput;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
@@ -27,7 +38,9 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.service.AssertionService;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.List;
 import java.util.concurrent.CompletionException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -55,44 +68,85 @@ public class UpsertCustomAssertionResolverTest {
   private static final String customAssertionLogic = "custom script of assertion";
 
   private static final UpsertCustomAssertionInput TEST_INPUT =
-      new UpsertCustomAssertionInput(
-          TEST_DATASET_URN.toString(),
-          customAssertionType,
-          customAssertionDescription,
-          "field1",
-          new PlatformInput(null, "DQplatform"),
-          customAssertionUrl,
-          customAssertionLogic);
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_DATASET_URN.toString())
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPath("field1")
+          .setPlatform(new PlatformInput(null, "DQplatform"))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .build();
 
   private static final UpsertCustomAssertionInput TEST_INPUT_MISSING_PLATFORM =
-      new UpsertCustomAssertionInput(
-          TEST_DATASET_URN.toString(),
-          customAssertionType,
-          customAssertionDescription,
-          "field1",
-          new PlatformInput(null, null),
-          customAssertionUrl,
-          customAssertionLogic);
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_DATASET_URN.toString())
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPath("field1")
+          .setPlatform(new PlatformInput(null, null))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .build();
 
   private static final UpsertCustomAssertionInput TEST_INPUT_BLANK_FIELD_PATH =
-      new UpsertCustomAssertionInput(
-          TEST_DATASET_URN.toString(),
-          customAssertionType,
-          customAssertionDescription,
-          "   ",
-          new PlatformInput(null, "DQplatform"),
-          customAssertionUrl,
-          customAssertionLogic);
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_DATASET_URN.toString())
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPath("   ")
+          .setPlatform(new PlatformInput(null, "DQplatform"))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .build();
+
+  private static final UpsertCustomAssertionInput TEST_INPUT_BLANK_FIELD_PATHS_ENTRY =
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_DATASET_URN.toString())
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPaths(List.of("field1", "   "))
+          .setPlatform(new PlatformInput(null, "DQplatform"))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .build();
 
   private static final UpsertCustomAssertionInput TEST_INPUT_INVALID_ENTITY_URN =
-      new UpsertCustomAssertionInput(
-          TEST_INVALID_DATASET_URN,
-          customAssertionType,
-          customAssertionDescription,
-          "field1",
-          new PlatformInput(null, "DQplatform"),
-          customAssertionUrl,
-          customAssertionLogic);
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_INVALID_DATASET_URN)
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPath("field1")
+          .setPlatform(new PlatformInput(null, "DQplatform"))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .build();
+
+  private static final UpsertCustomAssertionInput TEST_INPUT_STRUCTURED =
+      UpsertCustomAssertionInput.builder()
+          .setEntityUrn(TEST_DATASET_URN.toString())
+          .setType(customAssertionType)
+          .setDescription(customAssertionDescription)
+          .setFieldPaths(List.of("field1"))
+          .setPlatform(new PlatformInput(null, "DQplatform"))
+          .setExternalUrl(customAssertionUrl)
+          .setLogic(customAssertionLogic)
+          .setScope(com.linkedin.datahub.graphql.generated.DatasetAssertionScope.DATASET_COLUMN)
+          .setAggregation(com.linkedin.datahub.graphql.generated.AssertionStdAggregation.IDENTITY)
+          .setOperator(com.linkedin.datahub.graphql.generated.AssertionStdOperator.NOT_NULL)
+          .setParameters(
+              AssertionStdParametersInput.builder()
+                  .setValue(
+                      AssertionStdParameterInput.builder()
+                          .setType(
+                              com.linkedin.datahub.graphql.generated.AssertionStdParameterType
+                                  .NUMBER)
+                          .setValue("1")
+                          .build())
+                  .build())
+          .setNativeType("not_null")
+          .setNativeParameters(List.of(new StringMapEntryInput("column_name", "field1")))
+          .build();
 
   private static final AssertionInfo TEST_ASSERTION_INFO =
       new AssertionInfo()
@@ -111,6 +165,7 @@ public class UpsertCustomAssertionResolverTest {
                   .setEntity(TEST_DATASET_URN)
                   .setType(customAssertionType)
                   .setField(TEST_FIELD_URN)
+                  .setFields(new UrnArray(TEST_FIELD_URN))
                   .setLogic(customAssertionLogic));
 
   private static final DataPlatformInstance TEST_DATA_PLATFORM_INSTANCE =
@@ -212,6 +267,72 @@ public class UpsertCustomAssertionResolverTest {
   }
 
   @Test
+  public void testGetSuccessCreateAssertionWithStructuredFields() throws Exception {
+    AssertionService mockedService = Mockito.mock(AssertionService.class);
+    UpsertCustomAssertionResolver resolver = new UpsertCustomAssertionResolver(mockedService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(null);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT_STRUCTURED);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Mockito.when(mockedService.generateAssertionUrn()).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(
+            mockedService.getAssertionEntityResponse(
+                any(OperationContext.class), Mockito.eq(TEST_ASSERTION_URN)))
+        .thenReturn(
+            new EntityResponse()
+                .setAspects(
+                    new EnvelopedAspectMap(
+                        ImmutableMap.of(
+                            Constants.ASSERTION_INFO_ASPECT_NAME,
+                            new EnvelopedAspect().setValue(new Aspect(TEST_ASSERTION_INFO.data())),
+                            Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+                            new EnvelopedAspect()
+                                .setValue(new Aspect(TEST_DATA_PLATFORM_INSTANCE.data())))))
+                .setEntityName(Constants.ASSERTION_ENTITY_NAME)
+                .setUrn(TEST_ASSERTION_URN));
+
+    Assertion assertion = resolver.get(mockEnv).get();
+    assertNotNull(assertion);
+    assertEquals(assertion.getUrn(), TEST_ASSERTION_URN.toString());
+
+    ArgumentCaptor<CustomAssertionInfo> customAssertionCaptor =
+        ArgumentCaptor.forClass(CustomAssertionInfo.class);
+    Mockito.verify(mockedService, Mockito.times(1))
+        .upsertCustomAssertion(
+            any(OperationContext.class),
+            Mockito.eq(TEST_ASSERTION_URN),
+            Mockito.eq(TEST_DATASET_URN),
+            Mockito.eq(customAssertionDescription),
+            Mockito.eq(customAssertionUrl),
+            Mockito.eq(TEST_DATA_PLATFORM_INSTANCE),
+            customAssertionCaptor.capture());
+
+    CustomAssertionInfo customAssertion = customAssertionCaptor.getValue();
+    assertEquals(customAssertion.getType(), customAssertionType);
+    assertEquals(customAssertion.getEntity(), TEST_DATASET_URN);
+    assertEquals(customAssertion.getField(), TEST_FIELD_URN);
+    assertEquals(customAssertion.getFields(), new UrnArray(TEST_FIELD_URN));
+    assertEquals(customAssertion.getLogic(), customAssertionLogic);
+    assertEquals(customAssertion.getScope(), DatasetAssertionScope.DATASET_COLUMN);
+    assertEquals(customAssertion.getAggregation(), AssertionStdAggregation.IDENTITY);
+    assertEquals(customAssertion.getOperator(), AssertionStdOperator.NOT_NULL);
+    assertEquals(customAssertion.getNativeType(), "not_null");
+    assertEquals(
+        customAssertion.getParameters(),
+        new AssertionStdParameters()
+            .setValue(
+                new AssertionStdParameter()
+                    .setType(AssertionStdParameterType.NUMBER)
+                    .setValue("1")));
+    StringMap expectedNativeParameters = new StringMap();
+    expectedNativeParameters.put("column_name", "field1");
+    assertEquals(customAssertion.getNativeParameters(), expectedNativeParameters);
+  }
+
+  @Test
   public void testGetUpdateAssertionUnauthorized() throws Exception {
     // Update resolver
     AssertionService mockedService = Mockito.mock(AssertionService.class);
@@ -285,6 +406,33 @@ public class UpsertCustomAssertionResolverTest {
     CompletionException e =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
     assert e.getMessage().contains("fieldPath must not be blank when provided");
+
+    Mockito.verify(mockedService, Mockito.times(0))
+        .upsertCustomAssertion(
+            any(OperationContext.class),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any());
+  }
+
+  @Test
+  public void testGetUpsertAssertionBlankFieldPathsEntryFailure() throws Exception {
+    AssertionService mockedService = Mockito.mock(AssertionService.class);
+    UpsertCustomAssertionResolver resolver = new UpsertCustomAssertionResolver(mockedService);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input")))
+        .thenReturn(TEST_INPUT_BLANK_FIELD_PATHS_ENTRY);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    CompletionException e =
+        expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    assert e.getMessage().contains("fieldPaths must not contain blank entries");
 
     Mockito.verify(mockedService, Mockito.times(0))
         .upsertCustomAssertion(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapperTest.java
@@ -27,6 +27,7 @@ import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.url.Url;
 import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.StringMap;
@@ -234,6 +235,21 @@ public class AssertionMapperTest {
     if (input.hasField()) {
       Assert.assertEquals(output.getField().getPath(), input.getField().getEntityKey().get(1));
     }
+    if (input.hasFields()) {
+      Assert.assertEquals(output.getFields().size(), input.getFields().size());
+    }
+    if (input.hasScope()) {
+      Assert.assertEquals(output.getScope().toString(), input.getScope().toString());
+    }
+    if (input.hasAggregation()) {
+      Assert.assertEquals(output.getAggregation().toString(), input.getAggregation().toString());
+    }
+    if (input.hasOperator()) {
+      Assert.assertEquals(output.getOperator().toString(), input.getOperator().toString());
+    }
+    if (input.hasNativeType()) {
+      Assert.assertEquals(output.getNativeType(), input.getNativeType());
+    }
   }
 
   private void verifyCronSchedule(
@@ -386,9 +402,18 @@ public class AssertionMapperTest {
     customAssertionInfo.setType("Custom Type 1");
     customAssertionInfo.setEntity(
         UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,name,PROD)"));
-    customAssertionInfo.setField(
+    Urn fieldUrn =
         UrnUtils.getUrn(
-            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,name,PROD),field)"));
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,name,PROD),field)");
+    customAssertionInfo.setField(fieldUrn);
+    customAssertionInfo.setFields(new UrnArray(fieldUrn));
+    customAssertionInfo.setScope(DatasetAssertionScope.DATASET_COLUMN);
+    customAssertionInfo.setAggregation(AssertionStdAggregation.IDENTITY);
+    customAssertionInfo.setOperator(AssertionStdOperator.GREATER_THAN);
+    customAssertionInfo.setParameters(createAssertionStdParameters());
+    customAssertionInfo.setNativeType("native_type");
+    customAssertionInfo.setNativeParameters(
+        new StringMap(Collections.singletonMap("key", "value")));
     customAssertionInfo.setLogic("custom logic");
     info.setCustomAssertion(customAssertionInfo);
     info.setSource(new AssertionSource().setType(AssertionSourceType.EXTERNAL));

--- a/docs/api/tutorials/assertions.md
+++ b/docs/api/tutorials/assertions.md
@@ -1246,6 +1246,41 @@ query dataset {
             }
             logic
           }
+          customAssertion {
+            type
+            entityUrn
+            field {
+              urn
+              path
+            }
+            fields {
+              urn
+              path
+            }
+            scope
+            aggregation
+            operator
+            parameters {
+              value {
+                value
+                type
+              }
+              minValue {
+                value
+                type
+              }
+              maxValue {
+                value
+                type
+              }
+            }
+            nativeType
+            nativeParameters {
+              key
+              value
+            }
+            logic
+          }
           freshnessAssertion {
             type
             entityUrn
@@ -1474,6 +1509,41 @@ query getAssertion {
         fields {
           urn
           path
+        }
+        nativeType
+        nativeParameters {
+          key
+          value
+        }
+        logic
+      }
+      customAssertion {
+        type
+        entityUrn
+        field {
+          urn
+          path
+        }
+        fields {
+          urn
+          path
+        }
+        scope
+        aggregation
+        operator
+        parameters {
+          value {
+            value
+            type
+          }
+          minValue {
+            value
+            type
+          }
+          maxValue {
+            value
+            type
+          }
         }
         nativeType
         nativeParameters {

--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -6,6 +6,10 @@ import TabItem from '@theme/TabItem';
 This guide specifically covers how to create and report results for custom assertions in DataHub.
 Custom Assertions are those not natively run or directly modeled by DataHub, and managed by a 3rd party framework or tool.
 
+**CUSTOM is the only supported assertion type for external / self-reported checks** (dbt, Great Expectations, partner tools, SDK integrations).
+Do not emit native typed models (`FIELD`, `VOLUME`, `FRESHNESS`, `DATA_SCHEMA`, `SQL`) for externally managed assertions — those are intended for assertions DataHub evaluates / schedules natively.
+The legacy `DATASET` / `DatasetAssertionInfo` shape is deprecated; new writers should use `CUSTOM` with optional structured fields on `CustomAssertionInfo` (scope, operator, aggregation, parameters, fields, nativeType).
+
 To create _native_ assertions using the API (e.g. for DataHub to manage), please refer to the [Assertions API](./assertions.md).
 
 This guide may be used as reference for partners seeking to integrate their own monitoring tools with DataHub.
@@ -39,9 +43,13 @@ You may create custom assertions using the following APIs for a Dataset in DataH
 
 Optional:
 
-- `fieldPath` — **optional** bare column name for field-level assertions (for example `profile_id`).
-  DataHub builds the schemaField URN for you. Omit it for dataset-level assertions.
-  Do **not** pass a full `urn:li:schemaField:(...)` string here.
+- `fieldPaths` — bare column names for field-level assertions (for example `["profile_id"]`).
+  DataHub builds the schemaField URNs for you. Omit for dataset-level assertions.
+  Do **not** pass full `urn:li:schemaField:(...)` strings here.
+- `fieldPath` — single-column form of `fieldPaths`, kept for backward compatibility.
+  Prefer `fieldPaths`; when both are set, `fieldPaths` wins.
+- `scope`, `aggregation`, `operator`, `parameters`, `nativeType`, `nativeParameters` — optional
+  structured display fields (migrated from the legacy `DatasetAssertionInfo` shape)
 - `logic` — optional raw query / expression rendered in the UI
 - `externalUrl` — optional link back to your monitoring tool
 - `urn` (mutation argument) — optional stable assertion id; otherwise DataHub generates one
@@ -116,8 +124,13 @@ mutation upsertCustomAssertion {
       platform: {
         urn: "urn:li:dataPlatform:great-expectations" # OR you can provide name: "My Custom Platform" if you do not have an URN for the platform.
       }
-      fieldPath: "field_foo" # Optional: bare column name for a field-level assertion
+      fieldPaths: ["field_foo"] # Optional: bare column names for a field-level assertion. Prefer this over singular fieldPath.
       externalUrl: "https://my-monitoring-tool.com/result-for-this-assertion" # Optional: if you want to provide a link to the monitoring tool
+      # Optional structured display fields (migrated from legacy DatasetAssertionInfo):
+      scope: DATASET_COLUMN
+      operator: NOT_NULL
+      aggregation: IDENTITY
+      nativeType: "expect_column_values_to_not_be_null"
       # Optional: If you want to provide a custom SQL query for the assertion. This will be rendered as a query in the UI.
       # logic: "SELECT * FROM X WHERE Y"
     }
@@ -133,12 +146,12 @@ Note that you can either provide a unique `urn` for the assertion, which will be
 
 or a random urn will be created and returned for you. This id should be stable over time and unique for each assertion.
 
-The upsert API will return the unique identifier (URN) for the the assertion if you were successful:
+The upsert API will return the unique identifier (URN) for the assertion if you were successful:
 
 ```json
 {
   "data": {
-    "upsertExternalAssertion": {
+    "upsertCustomAssertion": {
       "urn": "urn:li:assertion:your-new-assertion-id"
     }
   },
@@ -150,10 +163,16 @@ The upsert API will return the unique identifier (URN) for the the assertion if 
 
 <TabItem value="python" label="Python">
 
-To upsert an assertion in Python, simply use the `upsert_external_assertion` method on the DataHub Client object.
+To upsert an assertion in Python, use `DataHubGraph.upsert_custom_assertion` or the V2 SDK helper
+`client.assertions.sync_custom_assertion` (recommended for partners). Report run results with
+`report_assertion_result` / `client.assertions.report_assertion_result`.
 
 ```python
 {{ inline /metadata-ingestion/examples/library/upsert_custom_assertion.py show_path_as_comment }}
+```
+
+```python
+{{ inline /metadata-ingestion/examples/library/sync_custom_assertion.py show_path_as_comment }}
 ```
 
 </TabItem>

--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -160,23 +160,22 @@ The upsert API will return the unique identifier (URN) for the assertion if you 
 ```
 
 </TabItem>
-
 <TabItem value="python" label="Python">
 
-To upsert an assertion in Python, use `DataHubGraph.upsert_custom_assertion` or the V2 SDK helper
-`client.assertions.sync_custom_assertion` (recommended for partners). Report run results with
-`report_assertion_result` / `client.assertions.report_assertion_result`.
-
-```python
-{{ inline /metadata-ingestion/examples/library/upsert_custom_assertion.py show_path_as_comment }}
-```
+To create or update a custom assertion in Python, use `client.assertions.sync_custom_assertion`.
+This wraps the same `upsertCustomAssertion` GraphQL mutation.
 
 ```python
 {{ inline /metadata-ingestion/examples/library/sync_custom_assertion.py show_path_as_comment }}
 ```
 
-</TabItem>
+Lower-level `DataHubGraph.upsert_custom_assertion` is also available if you are not using the V2 SDK:
 
+```python
+{{ inline /metadata-ingestion/examples/library/upsert_custom_assertion.py show_path_as_comment }}
+```
+
+</TabItem>
 </Tabs>
 
 ## Report Results For Custom Assertions
@@ -190,8 +189,7 @@ displayed as passing or failing in the DataHub UI.
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
 
-To report results for a custom, use the `reportAssertionResult` GraphQL Mutation. This mutation both allows you to
-create and update a given assertion.
+To report results for a custom assertion, use the `reportAssertionResult` GraphQL Mutation.
 
 ```graphql
 mutation reportAssertionResult {
@@ -241,17 +239,16 @@ The full list of supported error types include:
 If the result is `true`, the result was successfully reported.
 
 </TabItem>
-
 <TabItem value="python" label="Python">
 
-To report an assertion result in Python, simply use the `report_assertion_result` method on the DataHub Client object.
+To report an assertion result in Python, use `client.assertions.report_assertion_result`
+(or `DataHubGraph.report_assertion_result`).
 
 ```python
 {{ inline /metadata-ingestion/examples/library/report_assertion_result.py show_path_as_comment }}
 ```
 
 </TabItem>
-
 </Tabs>
 
 ## Retrieve Results For Custom Assertions
@@ -296,16 +293,45 @@ query dataset {
         }
         info {
           type # Will be CUSTOM
-          customType # Will be your custom type.
           description
+          externalUrl
           lastUpdated {
             time
             actor
           }
           customAssertion {
+            type # Your custom category (e.g. "dbt", "greatExpectations")
             entityUrn
-            fieldPath
-            externalUrl
+            field {
+              urn
+              path
+            }
+            fields {
+              urn
+              path
+            }
+            scope
+            aggregation
+            operator
+            parameters {
+              value {
+                value
+                type
+              }
+              minValue {
+                value
+                type
+              }
+              maxValue {
+                value
+                type
+              }
+            }
+            nativeType
+            nativeParameters {
+              key
+              value
+            }
             logic
           }
           source {
@@ -349,16 +375,45 @@ query getAssertion {
     }
     info {
       type # Will be CUSTOM
-      customType # Will be your custom type.
       description
+      externalUrl
       lastUpdated {
         time
         actor
       }
       customAssertion {
+        type # Your custom category (e.g. "dbt", "greatExpectations")
         entityUrn
-        fieldPath
-        externalUrl
+        field {
+          urn
+          path
+        }
+        fields {
+          urn
+          path
+        }
+        scope
+        aggregation
+        operator
+        parameters {
+          value {
+            value
+            type
+          }
+          minValue {
+            value
+            type
+          }
+          maxValue {
+            value
+            type
+          }
+        }
+        nativeType
+        nativeParameters {
+          key
+          value
+        }
         logic
       }
       source {

--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -31,6 +31,14 @@ The actor making API calls must have the `Edit Assertions` and `Edit Monitors` p
 
 You may create custom assertions using the following APIs for a Dataset in DataHub.
 
+### Upsert semantics (full replace)
+
+`upsertCustomAssertion` creates or **fully replaces** the assertion's `assertionInfo` /
+`customAssertion` on each call — the same contract as DataHub Cloud's native assertion
+monitor upserts (`upsertDatasetFreshnessAssertionMonitor`, volume / field / SQL / schema).
+When updating an existing assertion (pass `urn`), resend every field you want to keep;
+omitted optional fields are cleared.
+
 ### Required and optional fields
 
 `upsertCustomAssertion` requires:
@@ -111,7 +119,8 @@ graph.report_assertion_result(
 <TabItem value="graphql" label="GraphQL" default>
 
 To create a new assertion, use the `upsertCustomAssertion` GraphQL Mutation. This mutation both allows you to
-create and update a given assertion.
+create and update a given assertion. Updates fully replace `assertionInfo` / `customAssertion` — resend
+fields you want to keep (see [Upsert semantics](#upsert-semantics-full-replace)).
 
 ```graphql
 mutation upsertCustomAssertion {

--- a/metadata-ingestion/examples/library/data_quality_mcpw_rest.py
+++ b/metadata-ingestion/examples/library/data_quality_mcpw_rest.py
@@ -10,13 +10,15 @@ from datahub.metadata.com.linkedin.pegasus2avro.assertion import (
     AssertionResultType,
     AssertionRunEvent,
     AssertionRunStatus,
+    AssertionSource,
+    AssertionSourceType,
     AssertionStdAggregation,
     AssertionStdOperator,
     AssertionStdParameter,
     AssertionStdParameters,
     AssertionStdParameterType,
     AssertionType,
-    DatasetAssertionInfo,
+    CustomAssertionInfo,
     DatasetAssertionScope,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
@@ -61,16 +63,19 @@ dataset_mcp = MetadataChangeProposalWrapper(
 # Emit Dataset entity properties aspect! (Skip if dataset is already present)
 emitter.emit_mcp(dataset_mcp)
 
-# Construct an assertion object.
+field = fldUrn("bazTable", "col1")
+# Construct a CUSTOM assertion with structured display fields (external self-reporting).
 assertion_maxVal = AssertionInfo(
-    type=AssertionType.DATASET,
-    datasetAssertion=DatasetAssertionInfo(
+    type=AssertionType.CUSTOM,
+    customAssertion=CustomAssertionInfo(
+        type="greatExpectations",
+        entity=datasetUrn("bazTable"),
         scope=DatasetAssertionScope.DATASET_COLUMN,
         operator=AssertionStdOperator.BETWEEN,
         nativeType="expect_column_max_to_be_between",
         aggregation=AssertionStdAggregation.MAX,
-        fields=[fldUrn("bazTable", "col1")],
-        dataset=datasetUrn("bazTable"),
+        field=field,
+        fields=[field],
         nativeParameters={"max_value": "99", "min_value": "89"},
         parameters=AssertionStdParameters(
             minValue=AssertionStdParameter(
@@ -81,6 +86,7 @@ assertion_maxVal = AssertionInfo(
             ),
         ),
     ),
+    source=AssertionSource(type=AssertionSourceType.EXTERNAL),
     customProperties={"suite_name": "demo_suite"},
 )
 
@@ -98,67 +104,28 @@ assertion_dataPlatformInstance = DataPlatformInstance(
     platform=builder.make_data_platform_urn("great-expectations")
 )
 
-# Construct a MetadataChangeProposalWrapper object for assertion platform
-assertion_dataPlatformInstance_mcp = MetadataChangeProposalWrapper(
+# Construct a MetadataChangeProposalWrapper object for assertion dataPlatformInstance
+assertionDataPlatform_mcp = MetadataChangeProposalWrapper(
     entityUrn=assertionUrn(assertion_maxVal),
     aspect=assertion_dataPlatformInstance,
 )
-# Emit Assertion entity platform aspect!
-emitter.emit(assertion_dataPlatformInstance_mcp)
 
+# Emit Assertion entity dataPlatformInstance aspect!
+emitter.emit_mcp(assertionDataPlatform_mcp)
 
-# Construct batch assertion result object for partition 1 batch
-assertionResult_maxVal_batch_partition1 = AssertionRunEvent(
+# Construct an assertionResult object.
+assertionResult_maxVal = AssertionRunEvent(
     timestampMillis=int(time.time() * 1000),
     assertionUrn=assertionUrn(assertion_maxVal),
     asserteeUrn=datasetUrn("bazTable"),
-    partitionSpec=PartitionSpec(partition=json.dumps([{"country": "IN"}])),
-    runId="uuid1",
+    runId=str(int(time.time() * 1000)),
     status=AssertionRunStatus.COMPLETE,
+    partitionSpec=PartitionSpec(partition="FULL_TABLE_SNAPSHOT"),
     result=AssertionResult(
         type=AssertionResultType.SUCCESS,
-        externalUrl="http://example.com/uuid1",
         actualAggValue=90,
+        nativeResults={"result": json.dumps({"element_count": 90})},
     ),
 )
 
-emitAssertionResult(
-    assertionResult_maxVal_batch_partition1,
-)
-
-# Construct batch assertion result object for partition 2 batch
-assertionResult_maxVal_batch_partition2 = AssertionRunEvent(
-    timestampMillis=int(time.time() * 1000),
-    assertionUrn=assertionUrn(assertion_maxVal),
-    asserteeUrn=datasetUrn("bazTable"),
-    partitionSpec=PartitionSpec(partition=json.dumps([{"country": "US"}])),
-    runId="uuid1",
-    status=AssertionRunStatus.COMPLETE,
-    result=AssertionResult(
-        type=AssertionResultType.FAILURE,
-        externalUrl="http://example.com/uuid1",
-        actualAggValue=101,
-    ),
-)
-
-emitAssertionResult(
-    assertionResult_maxVal_batch_partition2,
-)
-
-# Construct batch assertion result object for full table batch.
-assertionResult_maxVal_batch_fulltable = AssertionRunEvent(
-    timestampMillis=int(time.time() * 1000),
-    assertionUrn=assertionUrn(assertion_maxVal),
-    asserteeUrn=datasetUrn("bazTable"),
-    runId="uuid1",
-    status=AssertionRunStatus.COMPLETE,
-    result=AssertionResult(
-        type=AssertionResultType.SUCCESS,
-        externalUrl="http://example.com/uuid1",
-        actualAggValue=93,
-    ),
-)
-
-emitAssertionResult(
-    assertionResult_maxVal_batch_fulltable,
-)
+emitAssertionResult(assertionResult_maxVal)

--- a/metadata-ingestion/examples/library/sync_custom_assertion.py
+++ b/metadata-ingestion/examples/library/sync_custom_assertion.py
@@ -1,0 +1,35 @@
+import logging
+import time
+
+from datahub.sdk import DataHubClient
+
+log = logging.getLogger(__name__)
+
+client = DataHubClient.from_env()
+
+assertion_urn = "urn:li:assertion:my-unique-assertion-id"
+entity_urn = "urn:li:dataset:(urn:li:dataPlatform:hive,example.table,PROD)"
+
+# Sync a CUSTOM assertion with structured display fields (external / self-reported).
+res = client.assertions.sync_custom_assertion(
+    urn=assertion_urn,
+    entity_urn=entity_urn,
+    type="My Custom Category",
+    description="Column profileId must not be null",
+    platform_urn="urn:li:dataPlatform:great-expectations",
+    field_paths=["profileId"],
+    scope="DATASET_COLUMN",
+    aggregation="IDENTITY",
+    operator="NOT_NULL",
+    native_type="expect_column_values_to_not_be_null",
+    external_url="https://my-monitoring-tool.com/result-for-this-assertion",
+)
+
+# Report a run result so the assertion appears as passing/failing in the UI.
+client.assertions.report_assertion_result(
+    urn=assertion_urn,
+    timestamp_millis=int(time.time() * 1000),
+    type="SUCCESS",
+)
+
+log.info("Synced custom assertion %s: %s", assertion_urn, res)

--- a/metadata-ingestion/examples/library/upsert_custom_assertion.py
+++ b/metadata-ingestion/examples/library/upsert_custom_assertion.py
@@ -12,14 +12,18 @@ graph = DataHubGraph(
 
 new_assertion_urn = "urn:li:assertion:my-unique-assertion-id"
 
-# Upsert the assertion
+# Upsert the assertion (lower-level GraphQL helper; prefer client.assertions.sync_custom_assertion).
 res = graph.upsert_custom_assertion(
     urn=new_assertion_urn,  # If the assertion already exists, provide the URN
     entity_urn="<urn of entity being monitored>",
     type="My Custom Category",  # This categorizes your assertion in DataHub
     description="The description of my external assertion for my dataset",
     platform_urn="urn:li:dataPlatform:great-expectations",  # OR you can provide 'platformName="My Custom Platform"'
-    field_path="field_foo",  # Optional: if you want to associate it with a specific field
+    field_paths=["field_foo"],  # Optional: columns associated with the assertion
+    scope="DATASET_COLUMN",
+    aggregation="IDENTITY",
+    operator="NOT_NULL",
+    native_type="expect_column_values_to_not_be_null",
     external_url="https://my-monitoring-tool.com/result-for-this-assertion",  # Optional: link to monitoring tool
     logic="SELECT * FROM X WHERE Y",  # Optional: custom SQL for the assertion, rendered in the UI
 )

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -2046,8 +2046,15 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         platform_name: Optional[str] = None,
         platform_urn: Optional[str] = None,
         field_path: Optional[str] = None,
+        field_paths: Optional[List[str]] = None,
         external_url: Optional[str] = None,
         logic: Optional[str] = None,
+        scope: Optional[str] = None,
+        aggregation: Optional[str] = None,
+        operator: Optional[str] = None,
+        parameters: Optional[Dict] = None,
+        native_type: Optional[str] = None,
+        native_parameters: Optional[List[Dict[str, str]]] = None,
     ) -> Dict:
         graph_query: str = """
             mutation upsertCustomAssertion(
@@ -2056,22 +2063,36 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 $type: String!,
                 $description: String!,
                 $fieldPath: String,
+                $fieldPaths: [String!],
                 $platformName: String,
                 $platformUrn: String,
                 $externalUrl: String,
-                $logic: String
+                $logic: String,
+                $scope: DatasetAssertionScope,
+                $aggregation: AssertionStdAggregation,
+                $operator: AssertionStdOperator,
+                $parameters: AssertionStdParametersInput,
+                $nativeType: String,
+                $nativeParameters: [StringMapEntryInput!]
             ) {
                 upsertCustomAssertion(urn: $assertionUrn, input: {
                     entityUrn: $entityUrn
                     type: $type
                     description: $description
                     fieldPath: $fieldPath
+                    fieldPaths: $fieldPaths
                     platform: {
                         urn: $platformUrn
                         name: $platformName
                     }
                     externalUrl: $externalUrl
                     logic: $logic
+                    scope: $scope
+                    aggregation: $aggregation
+                    operator: $operator
+                    parameters: $parameters
+                    nativeType: $nativeType
+                    nativeParameters: $nativeParameters
                 }) {
                         urn
                 }
@@ -2084,10 +2105,17 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "type": type,
             "description": description,
             "fieldPath": field_path,
+            "fieldPaths": field_paths,
             "platformName": platform_name,
             "platformUrn": platform_urn,
             "externalUrl": external_url,
             "logic": logic,
+            "scope": scope,
+            "aggregation": aggregation,
+            "operator": operator,
+            "parameters": parameters,
+            "nativeType": native_type,
+            "nativeParameters": native_parameters,
         }
 
         res = self.execute_graphql(

--- a/metadata-ingestion/src/datahub/sdk/assertion_client.py
+++ b/metadata-ingestion/src/datahub/sdk/assertion_client.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Literal, NoReturn, Optional
+
+from datahub.errors import SdkUsageError
+
+if TYPE_CHECKING:
+    from datahub.sdk.main_client import DataHubClient
+
+
+class AssertionClient:
+    """Client for externally managed (CUSTOM) assertions.
+
+    Use this for third-party / self-reported data quality checks. Do not use
+    native typed assertion models (FIELD, VOLUME, FRESHNESS, DATA_SCHEMA, SQL)
+    for external self-reporting — those are for assertions DataHub evaluates
+    or schedules natively.
+    """
+
+    def __init__(self, client: DataHubClient):
+        self._client = client
+        self._graph = client._graph
+
+    def __getattr__(self, name: str) -> NoReturn:
+        # This client stands in for the Cloud AssertionsClient when
+        # acryl-datahub-cloud is absent, so anything it does not implement is a
+        # Cloud-only API. Point at the install rather than an AttributeError.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        raise SdkUsageError(
+            "AssertionsClient is not installed, please install it with "
+            f"`pip install acryl-datahub-cloud` to use {name}. Without it, only "
+            "sync_custom_assertion and report_assertion_result are available."
+        )
+
+    def sync_custom_assertion(
+        self,
+        *,
+        entity_urn: str,
+        type: str,
+        description: str,
+        platform_name: Optional[str] = None,
+        platform_urn: Optional[str] = None,
+        urn: Optional[str] = None,
+        field_path: Optional[str] = None,
+        field_paths: Optional[List[str]] = None,
+        external_url: Optional[str] = None,
+        logic: Optional[str] = None,
+        scope: Optional[str] = None,
+        aggregation: Optional[str] = None,
+        operator: Optional[str] = None,
+        parameters: Optional[Dict] = None,
+        native_type: Optional[str] = None,
+        native_parameters: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict:
+        """Create or update a CUSTOM assertion with optional structured fields.
+
+        Args:
+            entity_urn: Dataset URN the assertion monitors.
+            type: UI category for the assertion (appears as customType).
+            description: Human-readable description.
+            platform_name: Data platform name when platform_urn is not known.
+            platform_urn: Data platform URN (preferred over platform_name).
+            urn: Optional stable assertion URN. Preserves run history across syncs.
+            field_path: Optional single column path (compat). Prefer field_paths.
+            field_paths: Optional list of column paths for multi-column checks.
+            external_url: Link to the external monitoring tool.
+            logic: Optional native logic / SQL string.
+            scope: Optional DatasetAssertionScope value (e.g. DATASET_COLUMN).
+            aggregation: Optional AssertionStdAggregation value.
+            operator: Optional AssertionStdOperator value.
+            parameters: Optional AssertionStdParametersInput-shaped dict.
+            native_type: Platform-specific assertion type string.
+            native_parameters: Optional list of {key, value} maps.
+
+        Returns:
+            GraphQL response containing the assertion urn.
+        """
+        return self._graph.upsert_custom_assertion(
+            urn=urn,
+            entity_urn=entity_urn,
+            type=type,
+            description=description,
+            platform_name=platform_name,
+            platform_urn=platform_urn,
+            field_path=field_path,
+            field_paths=field_paths,
+            external_url=external_url,
+            logic=logic,
+            scope=scope,
+            aggregation=aggregation,
+            operator=operator,
+            parameters=parameters,
+            native_type=native_type,
+            native_parameters=native_parameters,
+        )
+
+    def report_assertion_result(
+        self,
+        urn: str,
+        timestamp_millis: int,
+        type: Literal["SUCCESS", "FAILURE", "ERROR", "INIT"],
+        properties: Optional[List[Dict[str, str]]] = None,
+        external_url: Optional[str] = None,
+        error_type: Optional[str] = None,
+        error_message: Optional[str] = None,
+        severity: Optional[Literal["LOW", "MEDIUM", "HIGH"]] = None,
+    ) -> bool:
+        """Report a run result for an assertion."""
+        return self._graph.report_assertion_result(
+            urn=urn,
+            timestamp_millis=timestamp_millis,
+            type=type,
+            properties=properties,
+            external_url=external_url,
+            error_type=error_type,
+            error_message=error_message,
+            severity=severity,
+        )

--- a/metadata-ingestion/src/datahub/sdk/main_client.py
+++ b/metadata-ingestion/src/datahub/sdk/main_client.py
@@ -128,17 +128,18 @@ class DataHubClient:
         return LineageClient(self)
 
     @property
-    def assertions(self):  # type: ignore[report-untyped-call]  # Not available due to circular import issues
+    def assertions(self):
         try:
-            from acryl_datahub_cloud.sdk import AssertionsClient
-        except ImportError as e:
-            if "acryl_datahub_cloud" in str(e):
-                raise SdkUsageError(
-                    "AssertionsClient is not installed, please install it with `pip install acryl-datahub-cloud`"
-                ) from e
-            else:
-                raise e
-        return AssertionsClient(self)
+            from acryl_datahub_cloud.sdk import (  # type: ignore[import-not-found]
+                AssertionsClient,
+            )
+
+            return AssertionsClient(self)
+        except ImportError:
+            # Fallback: CUSTOM / external assertion sync + result reporting only.
+            from datahub.sdk.assertion_client import AssertionClient
+
+            return AssertionClient(self)
 
     @property
     def subscriptions(self):  # type: ignore[report-untyped-call]  # Not available due to circular import issues

--- a/metadata-ingestion/src/datahub/sdk/main_client.py
+++ b/metadata-ingestion/src/datahub/sdk/main_client.py
@@ -135,8 +135,11 @@ class DataHubClient:
             )
 
             return AssertionsClient(self)
-        except ImportError:
-            # Fallback: CUSTOM / external assertion sync + result reporting only.
+        except ImportError as e:
+            # Fallback only when the cloud package is missing. Re-raise other
+            # ImportErrors (broken deps inside an installed cloud package).
+            if "acryl_datahub_cloud" not in str(e):
+                raise
             from datahub.sdk.assertion_client import AssertionClient
 
             return AssertionClient(self)

--- a/metadata-ingestion/tests/unit/sdk_v2/test_assertions_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_assertions_client.py
@@ -29,3 +29,18 @@ def test_use_assertions_client_fails_if_not_installed(
         match="AssertionsClient is not installed, please install it with `pip install acryl-datahub-cloud`",
     ):
         client.assertions.get_assertions(urn="urn:li:assertion:123")
+
+
+def test_sync_custom_assertion_works_without_cloud_sdk(
+    client: DataHubClient, mock_graph: Mock
+) -> None:
+    client.assertions.sync_custom_assertion(
+        entity_urn="urn:li:dataset:(urn:li:dataPlatform:hive,example.table,PROD)",
+        type="My Custom Category",
+        description="Column profileId must not be null",
+        field_paths=["profileId"],
+        scope="DATASET_COLUMN",
+        operator="NOT_NULL",
+    )
+
+    assert mock_graph.upsert_custom_assertion.call_count == 1


### PR DESCRIPTION
## Summary
- Extend `upsertCustomAssertion` GraphQL input and `CustomAssertionInfo` read type with structured fields
- Wire resolver + `AssertionMapper` round-trips
- Add `AssertionClient.sync_custom_assertion` / `report_assertion_result` and extend `DataHubGraph.upsert_custom_assertion`
- Update custom assertions API docs and library examples

## Test plan
- [ ] `UpsertCustomAssertionResolverTest` (incl. structured fields)
- [ ] `AssertionMapperTest` for structured CUSTOM
- [ ] Python lint / SDK import smoke

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Extends **custom assertion** GraphQL and Python APIs so externally managed checks can carry the same structured metadata as the legacy `DatasetAssertionInfo` shape (scope, operator, aggregation, parameters, `nativeType` / `nativeParameters`) while staying on assertion type **CUSTOM**.
> 
> **`upsertCustomAssertion`** gains `fieldPaths` for multi-column targets (with `fieldPath` kept in sync for older clients), validation for blank paths, and mapping of the new optional fields into `CustomAssertionInfo`. **`AssertionMapper`** merges singular `field` and `fields` on read and exposes the structured fields on `CustomAssertionInfo`. Schema/docs call out **full-replace** upsert semantics: omitted optional fields are cleared on update.
> 
> Python adds **`client.assertions.sync_custom_assertion`** / **`report_assertion_result`** via a core **`AssertionClient`** when `acryl-datahub-cloud` is not installed, and extends **`DataHubGraph.upsert_custom_assertion`** with the new GraphQL variables. Tutorials and library examples shift from `DATASET` / `DatasetAssertionInfo` to **CUSTOM** with structured fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb654f233e2c9081ae0047734d383cda0279ed6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->