### PR TITLE
fix(validation): clarify CustomAssertionInfo URN validation error messages

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidator.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -66,21 +67,37 @@ public class UrnAnnotationValidator extends AspectPayloadValidator {
                       .map(
                           validationEntry -> {
                             UrnValidationAnnotation annotation = validationEntry.getAnnotation();
+                            String urnStr = validationEntry.getUrn();
+                            String fieldPath = validationEntry.getFieldPath();
+
+                            final Urn urn;
+                            try {
+                              urn = UrnUtils.requireUrn(urnStr);
+                            } catch (IllegalArgumentException ex) {
+                              return Map.entry(
+                                  itemEntry.getKey(),
+                                  AspectValidationException.forItem(
+                                      itemEntry.getKey(),
+                                      formatInvalidUrnMessage(
+                                          fieldPath, urnStr, annotation.getEntityTypes())));
+                            }
 
                             if (annotation.isStrict()) {
                               try {
                                 UrnValidationUtil.validateUrn(
                                     retrieverContext.getAspectRetriever().getEntityRegistry(),
-                                    UrnUtils.getUrn(validationEntry.getUrn()),
+                                    urn,
                                     true);
                               } catch (RuntimeException ex) {
                                 return Map.entry(
                                     itemEntry.getKey(),
                                     AspectValidationException.forItem(
-                                        itemEntry.getKey(), ex.getMessage()));
+                                        itemEntry.getKey(),
+                                        String.format(
+                                            "Invalid URN at path %s: %s",
+                                            fieldPath, ex.getMessage())));
                               }
                             }
-                            Urn urn = UrnUtils.getUrn(validationEntry.getUrn());
                             if (annotation.getEntityTypes() != null
                                 && !annotation.getEntityTypes().isEmpty()) {
                               if (annotation.getEntityTypes().stream()
@@ -90,11 +107,8 @@ public class UrnAnnotationValidator extends AspectPayloadValidator {
                                     itemEntry.getKey(),
                                     AspectValidationException.forItem(
                                         itemEntry.getKey(),
-                                        String.format(
-                                            "Invalid entity type urn validation failure (Required: %s). Path: %s Urn: %s",
-                                            validationEntry.getAnnotation().getEntityTypes(),
-                                            validationEntry.getFieldPath(),
-                                            urn)));
+                                        formatEntityTypeMismatchMessage(
+                                            fieldPath, urn, annotation.getEntityTypes())));
                               }
                             }
                             return null;
@@ -112,7 +126,7 @@ public class UrnAnnotationValidator extends AspectPayloadValidator {
             .filter(itemEntry -> !nonExistenceFailures.containsKey(itemEntry.getKey()))
             .flatMap(itemEntry -> itemEntry.getValue().stream())
             .filter(validationEntry -> validationEntry.getAnnotation().isExist())
-            .map(entry -> UrnUtils.getUrn(entry.getUrn()))
+            .map(entry -> UrnUtils.requireUrn(entry.getUrn()))
             .collect(Collectors.toSet());
     Map<Urn, Boolean> missingUrns =
         retrieverContext
@@ -132,7 +146,7 @@ public class UrnAnnotationValidator extends AspectPayloadValidator {
                         .map(
                             validationEntry -> {
                               if (missingUrns.containsKey(
-                                  UrnUtils.getUrn(validationEntry.getUrn()))) {
+                                  UrnUtils.requireUrn(validationEntry.getUrn()))) {
                                 return AspectValidationException.forItem(
                                     itemEntry.getKey(),
                                     String.format(
@@ -154,5 +168,37 @@ public class UrnAnnotationValidator extends AspectPayloadValidator {
       @Nonnull Collection<ChangeMCP> changeMCPs,
       @Nonnull RetrieverContext retrieverContext) {
     return Stream.empty();
+  }
+
+  @Nonnull
+  static String formatEntityTypeMismatchMessage(
+      @Nonnull String fieldPath, @Nonnull Urn urn, @Nonnull List<String> expectedEntityTypes) {
+    return String.format(
+        "Invalid URN entity type at path %s: expected one of %s, got %s (%s)",
+        fieldPath, expectedEntityTypes, urn.getEntityType(), urn);
+  }
+
+  @Nonnull
+  static String formatInvalidUrnMessage(
+      @Nonnull String fieldPath,
+      @Nullable String urnStr,
+      @Nullable List<String> expectedEntityTypes) {
+    String expected =
+        (expectedEntityTypes == null || expectedEntityTypes.isEmpty())
+            ? "a valid URN"
+            : formatExpectedUrnDescription(expectedEntityTypes);
+    return String.format(
+        "Invalid URN at path %s: expected %s, got \"%s\"", fieldPath, expected, urnStr);
+  }
+
+  @Nonnull
+  private static String formatExpectedUrnDescription(@Nonnull List<String> expectedEntityTypes) {
+    if (expectedEntityTypes.size() == 1 && "schemaField".equals(expectedEntityTypes.get(0))) {
+      return "a schemaField URN (urn:li:schemaField:(<dataset>,<column>))";
+    }
+    if (expectedEntityTypes.size() == 1) {
+      return "a " + expectedEntityTypes.get(0) + " URN";
+    }
+    return "a valid URN of type(s) " + expectedEntityTypes;
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/AssertionUrnValidationAnnotationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/AssertionUrnValidationAnnotationTest.java
@@ -123,7 +123,7 @@ public class AssertionUrnValidationAnnotationTest {
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type");
     assertTrue(
-        exceptions.get(0).getMessage().contains("Invalid entity type"),
+        exceptions.get(0).getMessage().contains("Invalid URN entity type"),
         "Error should indicate invalid entity type");
   }
 
@@ -159,7 +159,7 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid schemaField entity type");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid URN entity type"));
   }
 
   // ==================== CustomAssertionInfo Tests ====================
@@ -193,7 +193,11 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type on entity field");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN entity type"), message);
+    assertTrue(message.contains("expected one of [dataset]"), message);
+    assertTrue(message.contains("got corpuser"), message);
+    assertTrue(message.contains("/customAssertion/entity"), message);
   }
 
   @Test
@@ -210,7 +214,36 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type on field");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN entity type"), message);
+    assertTrue(message.contains("expected one of [schemaField]"), message);
+    assertTrue(message.contains("got dataset"), message);
+    assertTrue(message.contains("/customAssertion/field"), message);
+  }
+
+  @Test
+  public void testCustomAssertionInfo_BareStringField() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.CUSTOM);
+    CustomAssertionInfo customAssertion = new CustomAssertionInfo();
+    customAssertion.setType("custom-type");
+    customAssertion.setEntity(TEST_DATASET_URN);
+    // Simulate MCP payload with a bare column name instead of a schemaField URN.
+    // RecordTemplate setters require Urn, so mutate the DataMap after construction.
+    assertionInfo.setCustomAssertion(customAssertion);
+    assertionInfo.data().getDataMap("customAssertion").put("field", "segment_denial_rate");
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for bare string field");
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /customAssertion/field"), message);
+    assertTrue(
+        message.contains("expected a schemaField URN (urn:li:schemaField:(<dataset>,<column>))"),
+        message);
+    assertTrue(message.contains("segment_denial_rate"), message);
+    assertFalse(message.contains("Failed to retrieve entity"), message);
   }
 
   // ==================== FreshnessAssertionInfo Tests ====================
@@ -264,7 +297,7 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid URN entity type"));
   }
 
   // ==================== AssertionRunEvent Tests (exist=false, entity type validation only)
@@ -298,7 +331,7 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid assertee entity type");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid URN entity type"));
   }
 
   @Test
@@ -314,7 +347,7 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "Should fail for invalid assertion entity type");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid URN entity type"));
   }
 
   @Test
@@ -330,7 +363,7 @@ public class AssertionUrnValidationAnnotationTest {
 
     List<AspectValidationException> exceptions = runValidation();
     assertFalse(exceptions.isEmpty(), "DataJob should not be valid as assertee");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid URN entity type"));
   }
 
   // ==================== Helper Methods ====================

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidatorTest.java
@@ -157,35 +157,10 @@ public class UrnAnnotationValidatorTest {
   @Test
   public void testValidateProposedAspects_WithBareStringField() {
     String bareField = "segment_denial_rate";
+    setupSingleUrnField("field", bareField, true, Collections.singletonList("schemaField"));
 
-    DataMap dataMap = new DataMap();
-    dataMap.put("field", bareField);
+    List<AspectValidationException> exceptions = runValidation();
 
-    UrnValidationAnnotation annotation = mock(UrnValidationAnnotation.class);
-    when(annotation.isStrict()).thenReturn(true);
-    when(annotation.getEntityTypes()).thenReturn(Collections.singletonList("schemaField"));
-
-    UrnValidationFieldSpec fieldSpec = mock(UrnValidationFieldSpec.class);
-    when(fieldSpec.getUrnValidationAnnotation()).thenReturn(annotation);
-
-    Map<String, UrnValidationFieldSpec> fieldSpecMap = new HashMap<>();
-    fieldSpecMap.put("/field", fieldSpec);
-    when(mockAspectSpec.getUrnValidationFieldSpecMap()).thenReturn(fieldSpecMap);
-
-    when(mockBatchItem.getAspectSpec()).thenReturn(mockAspectSpec);
-    when(mockBatchItem.getRecordTemplate()).thenReturn(mockRecordTemplate);
-    when(mockRecordTemplate.data()).thenReturn(dataMap);
-
-    when(mockAspectRetriever.entityExists(any(OperationFingerprint.class), any()))
-        .thenReturn(Collections.emptyMap());
-
-    Stream<AspectValidationException> result =
-        validator.validateProposedAspects(
-            OperationFingerprint.EMPTY,
-            Collections.singletonList(mockBatchItem),
-            mockRetrieverContext);
-
-    List<AspectValidationException> exceptions = result.collect(Collectors.toList());
     assertFalse(
         exceptions.isEmpty(), "Validation exception should be thrown for bare string field");
     String message = exceptions.get(0).getMessage();
@@ -195,6 +170,44 @@ public class UrnAnnotationValidatorTest {
         message);
     assertTrue(message.contains(bareField), message);
     assertFalse(message.contains("Failed to retrieve entity"), message);
+  }
+
+  @Test
+  public void testValidateProposedAspects_WithMultipleAllowedEntityTypes() {
+    setupSingleUrnField("entity", "not-a-urn", true, List.of("dataset", "dataJob"));
+
+    List<AspectValidationException> exceptions = runValidation();
+
+    assertFalse(exceptions.isEmpty(), "Validation exception should be thrown for invalid URN");
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /entity"), message);
+    assertTrue(message.contains("[dataset, dataJob]"), message);
+  }
+
+  @Test
+  public void testValidateProposedAspects_WithoutDeclaredEntityTypes() {
+    setupSingleUrnField("entity", "not-a-urn", true, Collections.emptyList());
+
+    List<AspectValidationException> exceptions = runValidation();
+
+    assertFalse(exceptions.isEmpty(), "Validation exception should be thrown for invalid URN");
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /entity"), message);
+    assertTrue(message.contains("expected a valid URN"), message);
+  }
+
+  @Test
+  public void testValidateProposedAspects_WithParseableUrnRejectedByStrictValidation() {
+    // Commas are not permitted in non-tuple URNs, so this parses but fails strict validation.
+    setupSingleUrnField(
+        "urn", "urn:li:corpuser:foo,bar", true, Collections.singletonList("corpuser"));
+
+    List<AspectValidationException> exceptions = runValidation();
+
+    assertFalse(exceptions.isEmpty(), "Validation exception should be thrown for illegal URN");
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /urn"), message);
+    assertTrue(message.contains("comma"), message);
   }
 
   @Test
@@ -340,5 +353,35 @@ public class UrnAnnotationValidatorTest {
     List<AspectValidationException> exceptions = result.collect(Collectors.toList());
     assertFalse(exceptions.isEmpty(), "Validation exception should be thrown for non-existent URN");
     assertTrue(exceptions.get(0).getMessage().contains("Urn does not exist"));
+  }
+
+  private void setupSingleUrnField(
+      String fieldName, String value, boolean strict, List<String> entityTypes) {
+    DataMap dataMap = new DataMap();
+    dataMap.put(fieldName, value);
+
+    UrnValidationAnnotation annotation = mock(UrnValidationAnnotation.class);
+    when(annotation.isStrict()).thenReturn(strict);
+    when(annotation.getEntityTypes()).thenReturn(entityTypes);
+
+    UrnValidationFieldSpec fieldSpec = mock(UrnValidationFieldSpec.class);
+    when(fieldSpec.getUrnValidationAnnotation()).thenReturn(annotation);
+
+    when(mockAspectSpec.getUrnValidationFieldSpecMap())
+        .thenReturn(Map.of("/" + fieldName, fieldSpec));
+    when(mockBatchItem.getAspectSpec()).thenReturn(mockAspectSpec);
+    when(mockBatchItem.getRecordTemplate()).thenReturn(mockRecordTemplate);
+    when(mockRecordTemplate.data()).thenReturn(dataMap);
+    when(mockAspectRetriever.entityExists(any(OperationFingerprint.class), any()))
+        .thenReturn(Collections.emptyMap());
+  }
+
+  private List<AspectValidationException> runValidation() {
+    return validator
+        .validateProposedAspects(
+            OperationFingerprint.EMPTY,
+            Collections.singletonList(mockBatchItem),
+            mockRetrieverContext)
+        .collect(Collectors.toList());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/UrnAnnotationValidatorTest.java
@@ -148,7 +148,53 @@ public class UrnAnnotationValidatorTest {
     // Assert
     List<AspectValidationException> exceptions = result.collect(Collectors.toList());
     assertFalse(exceptions.isEmpty(), "Validation exception should be thrown for invalid URN");
-    assertTrue(exceptions.get(0).getMessage().contains("invalid urn"));
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /urn"), message);
+    assertTrue(message.contains("expected a dataset URN"), message);
+    assertTrue(message.contains(invalidUrn), message);
+  }
+
+  @Test
+  public void testValidateProposedAspects_WithBareStringField() {
+    String bareField = "segment_denial_rate";
+
+    DataMap dataMap = new DataMap();
+    dataMap.put("field", bareField);
+
+    UrnValidationAnnotation annotation = mock(UrnValidationAnnotation.class);
+    when(annotation.isStrict()).thenReturn(true);
+    when(annotation.getEntityTypes()).thenReturn(Collections.singletonList("schemaField"));
+
+    UrnValidationFieldSpec fieldSpec = mock(UrnValidationFieldSpec.class);
+    when(fieldSpec.getUrnValidationAnnotation()).thenReturn(annotation);
+
+    Map<String, UrnValidationFieldSpec> fieldSpecMap = new HashMap<>();
+    fieldSpecMap.put("/field", fieldSpec);
+    when(mockAspectSpec.getUrnValidationFieldSpecMap()).thenReturn(fieldSpecMap);
+
+    when(mockBatchItem.getAspectSpec()).thenReturn(mockAspectSpec);
+    when(mockBatchItem.getRecordTemplate()).thenReturn(mockRecordTemplate);
+    when(mockRecordTemplate.data()).thenReturn(dataMap);
+
+    when(mockAspectRetriever.entityExists(any(OperationFingerprint.class), any()))
+        .thenReturn(Collections.emptyMap());
+
+    Stream<AspectValidationException> result =
+        validator.validateProposedAspects(
+            OperationFingerprint.EMPTY,
+            Collections.singletonList(mockBatchItem),
+            mockRetrieverContext);
+
+    List<AspectValidationException> exceptions = result.collect(Collectors.toList());
+    assertFalse(
+        exceptions.isEmpty(), "Validation exception should be thrown for bare string field");
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN at path /field"), message);
+    assertTrue(
+        message.contains("expected a schemaField URN (urn:li:schemaField:(<dataset>,<column>))"),
+        message);
+    assertTrue(message.contains(bareField), message);
+    assertFalse(message.contains("Failed to retrieve entity"), message);
   }
 
   @Test
@@ -194,7 +240,11 @@ public class UrnAnnotationValidatorTest {
     List<AspectValidationException> exceptions = result.collect(Collectors.toList());
     assertFalse(
         exceptions.isEmpty(), "Validation exception should be thrown for invalid entity type");
-    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+    String message = exceptions.get(0).getMessage();
+    assertTrue(message.contains("Invalid URN entity type at path /urn"), message);
+    assertTrue(message.contains("expected one of [dataset]"), message);
+    assertTrue(message.contains("got corpuser"), message);
+    assertTrue(message.contains(invalidUrn.toString()), message);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Improve `UrnAnnotationValidator` entity-type mismatch messages to include field path, expected types, and actual entity type (e.g. `expected one of [dataset], got mlModel`).
- Replace misleading `Failed to retrieve entity… invalid urn` parse failures with messages that name the expected URN shape (including schemaField format hint) and the invalid value.
- Add/update unit tests covering CustomAssertionInfo wrong entity type and bare-string field cases.

Fixes #18743

## Test plan
- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.aspect.validation.UrnAnnotationValidatorTest' --tests 'com.linkedin.metadata.aspect.validation.AssertionUrnValidationAnnotationTest'`
- [ ] Confirm emitting a CustomAssertionInfo with an MLModel `entity` returns a 422 that names dataset as required
- [ ] Confirm emitting `field` as a bare column name returns a 422 that mentions schemaField URN format


Made with [Cursor](https://cursor.com)