### PR TITLE
fix(ci): update OBS assignee in PR-to-Linear routing

### DIFF
--- a/.github/workflows/pr-to-linear-routing-test.yml
+++ b/.github/workflows/pr-to-linear-routing-test.yml
@@ -42,7 +42,7 @@ env:
       {
         "key": "OBS",
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
-        "assignee_id": "2bd2434a-cf1e-47a4-8243-0e77ed19faf7",
+        "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
         "description": "Data Quality and Assertions. Any PR touching the Assertions codebase belongs to this team."
       }
     ]

--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -36,7 +36,7 @@ env:
       {
         "key": "OBS",
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
-        "assignee_id": "2bd2434a-cf1e-47a4-8243-0e77ed19faf7",
+        "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
         "description": "Data Quality and Assertions. Any PR touching the Assertions codebase belongs to this team."
       }
     ]


### PR DESCRIPTION
## Summary

Updates the `OBS` team's `assignee_id` in the `LINEAR_TEAM_CONFIG` of both `pr-to-linear.yml` and `pr-to-linear-routing-test.yml`.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)