### PR TITLE
fix(cli): use UTF-8 for quickstart secrets

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -185,7 +185,7 @@ def _resolve_token_service_secrets() -> None:
 
     persisted: Dict[str, str] = {}
     if secrets_file.exists():
-        for line in secrets_file.read_text().splitlines():
+        for line in secrets_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:
                 key, _, value = line.partition("=")
@@ -211,7 +211,8 @@ def _resolve_token_service_secrets() -> None:
         secrets_file.write_text(
             f"# Auto-generated local dev secrets — do not commit\n"
             f"DATAHUB_TOKEN_SERVICE_SIGNING_KEY={signing_key}\n"
-            f"DATAHUB_TOKEN_SERVICE_SALT={salt}\n"
+            f"DATAHUB_TOKEN_SERVICE_SALT={salt}\n",
+            encoding="utf-8",
         )
         logger.debug(
             f"Generated token service secrets saved to {secrets_file} for reuse across restarts"

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -184,9 +184,7 @@ def test_get_github_file_url_custom_base():
     custom_base = "https://github.com/my-fork/datahub/my-branch"
     with patch.dict("os.environ", {"DOCKER_COMPOSE_BASE": custom_base}):
         result = get_github_file_url("v2.0.0")
-        expected = (
-            f"{custom_base}/docker/quickstart/docker-compose.quickstart-profile.yml"
-        )
+        expected = f"{custom_base}/docker/quickstart/docker-compose.quickstart-profile.yml"
         assert result == expected
 
 
@@ -222,18 +220,12 @@ def test_check_upgrade_and_show_instructions_upgrade_not_supported():
     """Test _check_upgrade_and_show_instructions when check_upgrade_supported returns False"""
     # Mock the dependencies
     mock_status = MagicMock()
-    mock_status.is_ok.return_value = (
-        True  # Status is OK, so migration instructions will be shown
-    )
+    mock_status.is_ok.return_value = True  # Status is OK, so migration instructions will be shown
 
     with (
-        patch(
-            "datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status
-        ),
+        patch("datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status),
         patch("datahub.cli.docker_cli.check_upgrade_supported", return_value=False),
-        patch(
-            "datahub.cli.docker_cli.show_migration_instructions"
-        ) as mock_show_migration,
+        patch("datahub.cli.docker_cli.show_migration_instructions") as mock_show_migration,
     ):
         # Call the function
         result = _check_upgrade_and_show_instructions([])
@@ -249,14 +241,10 @@ def test_check_upgrade_and_show_instructions_upgrade_not_supported_repair():
     """Test _check_upgrade_and_show_instructions when check_upgrade_supported returns False and status is not OK"""
     # Mock the dependencies
     mock_status = MagicMock()
-    mock_status.is_ok.return_value = (
-        False  # Status is not OK, so repair instructions will be shown
-    )
+    mock_status.is_ok.return_value = False  # Status is not OK, so repair instructions will be shown
 
     with (
-        patch(
-            "datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status
-        ),
+        patch("datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status),
         patch("datahub.cli.docker_cli.check_upgrade_supported", return_value=False),
         patch("datahub.cli.docker_cli.show_repair_instructions") as mock_show_repair,
     ):

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -377,9 +377,45 @@ def test_resolve_secrets_generates_and_persists(tmp_path: Path) -> None:
         assert len(os.environ["DATAHUB_TOKEN_SERVICE_SIGNING_KEY"]) > 0
         assert len(os.environ["DATAHUB_TOKEN_SERVICE_SALT"]) > 0
         assert secrets_file.exists()
-        content = secrets_file.read_text()
+        content = secrets_file.read_text(encoding="utf-8")
         assert "DATAHUB_TOKEN_SERVICE_SIGNING_KEY=" in content
         assert "DATAHUB_TOKEN_SERVICE_SALT=" in content
+
+
+def test_resolve_secrets_uses_utf8_on_non_utf8_locale(tmp_path: Path) -> None:
+    """The Unicode comment is portable when the system default encoding is not UTF-8."""
+    original_read_text = Path.read_text
+    original_write_text = Path.write_text
+
+    def read_text_with_cp949_default(path: Path, *args, **kwargs):
+        kwargs.setdefault("encoding", "cp949")
+        return original_read_text(path, *args, **kwargs)
+
+    def write_text_with_cp949_default(path: Path, data: str, *args, **kwargs):
+        kwargs.setdefault("encoding", "cp949")
+        return original_write_text(path, data, *args, **kwargs)
+
+    secrets_file = tmp_path / "quickstart" / ".local-secrets.env"
+    with (
+        patch("datahub.cli.docker_cli.DATAHUB_ROOT_FOLDER", str(tmp_path)),
+        patch.object(Path, "read_text", new=read_text_with_cp949_default),
+        patch.object(Path, "write_text", new=write_text_with_cp949_default),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        os.environ.pop("DATAHUB_TOKEN_SERVICE_SIGNING_KEY", None)
+        os.environ.pop("DATAHUB_TOKEN_SERVICE_SALT", None)
+        _resolve_token_service_secrets()
+        generated_key = os.environ["DATAHUB_TOKEN_SERVICE_SIGNING_KEY"]
+        generated_salt = os.environ["DATAHUB_TOKEN_SERVICE_SALT"]
+
+        os.environ.pop("DATAHUB_TOKEN_SERVICE_SIGNING_KEY", None)
+        os.environ.pop("DATAHUB_TOKEN_SERVICE_SALT", None)
+        _resolve_token_service_secrets()
+
+        assert os.environ["DATAHUB_TOKEN_SERVICE_SIGNING_KEY"] == generated_key
+        assert os.environ["DATAHUB_TOKEN_SERVICE_SALT"] == generated_salt
+
+    assert "— do not commit" in secrets_file.read_text(encoding="utf-8")
 
 
 def test_resolve_secrets_env_vars_take_priority(tmp_path: Path) -> None:

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import click
@@ -387,11 +388,11 @@ def test_resolve_secrets_uses_utf8_on_non_utf8_locale(tmp_path: Path) -> None:
     original_read_text = Path.read_text
     original_write_text = Path.write_text
 
-    def read_text_with_cp949_default(path: Path, *args, **kwargs):
+    def read_text_with_cp949_default(path: Path, *args: Any, **kwargs: Any) -> str:
         kwargs.setdefault("encoding", "cp949")
         return original_read_text(path, *args, **kwargs)
 
-    def write_text_with_cp949_default(path: Path, data: str, *args, **kwargs):
+    def write_text_with_cp949_default(path: Path, data: str, *args: Any, **kwargs: Any) -> int:
         kwargs.setdefault("encoding", "cp949")
         return original_write_text(path, data, *args, **kwargs)
 

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -184,7 +184,9 @@ def test_get_github_file_url_custom_base():
     custom_base = "https://github.com/my-fork/datahub/my-branch"
     with patch.dict("os.environ", {"DOCKER_COMPOSE_BASE": custom_base}):
         result = get_github_file_url("v2.0.0")
-        expected = f"{custom_base}/docker/quickstart/docker-compose.quickstart-profile.yml"
+        expected = (
+            f"{custom_base}/docker/quickstart/docker-compose.quickstart-profile.yml"
+        )
         assert result == expected
 
 
@@ -220,12 +222,18 @@ def test_check_upgrade_and_show_instructions_upgrade_not_supported():
     """Test _check_upgrade_and_show_instructions when check_upgrade_supported returns False"""
     # Mock the dependencies
     mock_status = MagicMock()
-    mock_status.is_ok.return_value = True  # Status is OK, so migration instructions will be shown
+    mock_status.is_ok.return_value = (
+        True  # Status is OK, so migration instructions will be shown
+    )
 
     with (
-        patch("datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status),
+        patch(
+            "datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status
+        ),
         patch("datahub.cli.docker_cli.check_upgrade_supported", return_value=False),
-        patch("datahub.cli.docker_cli.show_migration_instructions") as mock_show_migration,
+        patch(
+            "datahub.cli.docker_cli.show_migration_instructions"
+        ) as mock_show_migration,
     ):
         # Call the function
         result = _check_upgrade_and_show_instructions([])
@@ -241,10 +249,14 @@ def test_check_upgrade_and_show_instructions_upgrade_not_supported_repair():
     """Test _check_upgrade_and_show_instructions when check_upgrade_supported returns False and status is not OK"""
     # Mock the dependencies
     mock_status = MagicMock()
-    mock_status.is_ok.return_value = False  # Status is not OK, so repair instructions will be shown
+    mock_status.is_ok.return_value = (
+        False  # Status is not OK, so repair instructions will be shown
+    )
 
     with (
-        patch("datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status),
+        patch(
+            "datahub.cli.docker_cli.check_docker_quickstart", return_value=mock_status
+        ),
         patch("datahub.cli.docker_cli.check_upgrade_supported", return_value=False),
         patch("datahub.cli.docker_cli.show_repair_instructions") as mock_show_repair,
     ):
@@ -380,7 +392,9 @@ def test_resolve_secrets_uses_utf8_on_non_utf8_locale(tmp_path: Path) -> None:
         kwargs.setdefault("encoding", "cp949")
         return original_read_text(path, *args, **kwargs)
 
-    def write_text_with_cp949_default(path: Path, data: str, *args: Any, **kwargs: Any) -> int:
+    def write_text_with_cp949_default(
+        path: Path, data: str, *args: Any, **kwargs: Any
+    ) -> int:
         kwargs.setdefault("encoding", "cp949")
         return original_write_text(path, data, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

- read and write `.local-secrets.env` explicitly as UTF-8
- add a regression test that simulates a CP949 system default
- verify that generated secrets can be persisted and read on the next quickstart

## Root cause

`_resolve_token_service_secrets` writes a Unicode em dash to the generated comment while relying
on the platform-default encoding. On Windows installations whose default encoding is CP949, the
first quickstart raises `UnicodeEncodeError`. A UTF-8 file could also fail on the next run because
the read path relied on the same platform default.

## Impact

This makes `datahub docker quickstart` portable across Windows and other non-UTF-8 locales without
requiring users to set `PYTHONUTF8=1`.

## Validation

- focused Docker CLI test module: 22 passed
- regression covers both generation and a second read under a simulated CP949 default
- Python compilation and `git diff --check` pass
