### PR TITLE
fix(api): clarify custom assertion and CUSTOM incident write-back DX

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolver.java
@@ -103,6 +103,11 @@ public class UpsertCustomAssertionResolver implements DataFetcher<CompletableFut
     customAssertionInfo.setLogic(input.getLogic(), SetMode.IGNORE_NULL);
 
     if (input.getFieldPath() != null) {
+      if (input.getFieldPath().isBlank()) {
+        throw new IllegalArgumentException(
+            "Failed to upsert Custom Assertion. fieldPath must not be blank when provided;"
+                + " omit fieldPath for dataset-level assertions.");
+      }
       customAssertionInfo.setField(
           SchemaFieldUtils.generateSchemaFieldUrn(entityUrn, input.getFieldPath()));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolver.java
@@ -114,8 +114,9 @@ public class RaiseIncidentResolver implements DataFetcher<CompletableFuture<Stri
                 .name())); // Assumption Alert: This assumes that GMS incident type === GraphQL
     // incident type.
     if (IncidentType.CUSTOM.name().equals(input.getType().name())
-        && input.getCustomType() == null) {
-      throw new URISyntaxException("Failed to create incident.", "customType is required");
+        && (input.getCustomType() == null || input.getCustomType().isBlank())) {
+      throw new IllegalArgumentException(
+          "Failed to raise incident: customType is required when type is CUSTOM");
     }
     result.setCustomType(input.getCustomType(), SetMode.IGNORE_NULL);
     result.setTitle(input.getTitle(), SetMode.IGNORE_NULL);

--- a/datahub-graphql-core/src/main/resources/assertions.graphql
+++ b/datahub-graphql-core/src/main/resources/assertions.graphql
@@ -50,12 +50,15 @@ input UpsertCustomAssertionInput {
   description: String!
 
   """
-  The dataset field targeted by this assertion, if any.
+  Optional dataset column name targeted by this assertion.
+  When set, DataHub builds a schemaField URN from entityUrn + fieldPath.
+  Omit for dataset-level assertions. Do not pass a full schemaField URN — use the bare column name.
   """
   fieldPath: String
 
   """
-  The external Platform associated with the assertion
+  The external Platform associated with the assertion.
+  Required. Provide either PlatformInput.urn or PlatformInput.name (at least one).
   """
   platform: PlatformInput!
 
@@ -129,12 +132,14 @@ Input representing A Data Platform
 """
 input PlatformInput {
   """
-  Urn of platform
+  Urn of platform (for example urn:li:dataPlatform:great-expectations).
+  Provide urn or name — at least one is required.
   """
   urn: String
 
   """
-  Name of platform
+  Name of platform (for example great-expectations). Used when urn is not provided.
+  Provide urn or name — at least one is required.
   """
   name: String
 }

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -332,7 +332,8 @@ input RaiseIncidentInput {
   """
   type: IncidentType!
   """
-  A custom type of incident. Present only if type is 'CUSTOM'
+  A custom type of incident. Required when type is CUSTOM; omit for other incident types.
+  Free-text label naming your incident category (for example ML_LEAKAGE).
   """
   customType: String
   """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/UpsertCustomAssertionResolverTest.java
@@ -74,6 +74,16 @@ public class UpsertCustomAssertionResolverTest {
           customAssertionUrl,
           customAssertionLogic);
 
+  private static final UpsertCustomAssertionInput TEST_INPUT_BLANK_FIELD_PATH =
+      new UpsertCustomAssertionInput(
+          TEST_DATASET_URN.toString(),
+          customAssertionType,
+          customAssertionDescription,
+          "   ",
+          new PlatformInput(null, "DQplatform"),
+          customAssertionUrl,
+          customAssertionLogic);
+
   private static final UpsertCustomAssertionInput TEST_INPUT_INVALID_ENTITY_URN =
       new UpsertCustomAssertionInput(
           TEST_INVALID_DATASET_URN,
@@ -249,6 +259,32 @@ public class UpsertCustomAssertionResolverTest {
     assert e.getMessage()
         .contains(
             "Failed to upsert Custom Assertion. Platform Name or Platform Urn must be specified.");
+
+    Mockito.verify(mockedService, Mockito.times(0))
+        .upsertCustomAssertion(
+            any(OperationContext.class),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any(),
+            Mockito.any());
+  }
+
+  @Test
+  public void testGetUpsertAssertionBlankFieldPathFailure() throws Exception {
+    AssertionService mockedService = Mockito.mock(AssertionService.class);
+    UpsertCustomAssertionResolver resolver = new UpsertCustomAssertionResolver(mockedService);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT_BLANK_FIELD_PATH);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    CompletionException e =
+        expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    assert e.getMessage().contains("fieldPath must not be blank when provided");
 
     Mockito.verify(mockedService, Mockito.times(0))
         .upsertCustomAssertion(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
@@ -132,7 +132,37 @@ public class RaiseIncidentResolverTest {
       Assert.fail("Expected exception was not thrown");
     } catch (ExecutionException e) {
       Assert.assertEquals(
-          "customType is required: Failed to create incident.", e.getCause().getMessage());
+          "Failed to raise incident: customType is required when type is CUSTOM",
+          e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void testCustomTypeBlankRejected() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.CUSTOM);
+    testInput.setCustomType("   ");
+    testInput.setResourceUrn("urn:li:dataset:(test,test,test)");
+    testInput.setTitle("Title");
+    testInput.setDescription("Description");
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+
+    try {
+      resolver.get(mockEnv).get();
+      Assert.fail("Expected exception was not thrown");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(
+          "Failed to raise incident: customType is required when type is CUSTOM",
+          e.getCause().getMessage());
     }
   }
 

--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -27,6 +27,78 @@ The actor making API calls must have the `Edit Assertions` and `Edit Monitors` p
 
 You may create custom assertions using the following APIs for a Dataset in DataHub.
 
+### Required and optional fields
+
+`upsertCustomAssertion` requires:
+
+- `entityUrn` — dataset URN being monitored
+- `type` — free-text category shown in the UI (for example `My Custom Category`)
+- `description` — human-readable assertion description
+- `platform` — **either** `platform.urn` **or** `platform.name` (at least one). An empty `platform: {}` fails with
+  `Failed to upsert Custom Assertion. Platform Name or Platform Urn must be specified.`
+
+Optional:
+
+- `fieldPath` — **optional** bare column name for field-level assertions (for example `profile_id`).
+  DataHub builds the schemaField URN for you. Omit it for dataset-level assertions.
+  Do **not** pass a full `urn:li:schemaField:(...)` string here.
+- `logic` — optional raw query / expression rendered in the UI
+- `externalUrl` — optional link back to your monitoring tool
+- `urn` (mutation argument) — optional stable assertion id; otherwise DataHub generates one
+
+### Minimal field-level write-back (agent example)
+
+Create a field-level custom assertion and report a result in one pass:
+
+```graphql
+mutation writeFieldAssertion {
+  upsertCustomAssertion(
+    urn: "urn:li:assertion:agent-profile-id-not-null"
+    input: {
+      entityUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,example.table,PROD)"
+      type: "Agent Finding"
+      description: "profile_id must not be null"
+      platform: { name: "my-agent" }
+      fieldPath: "profile_id"
+    }
+  ) {
+    urn
+  }
+}
+
+mutation reportFieldAssertionResult {
+  reportAssertionResult(
+    urn: "urn:li:assertion:agent-profile-id-not-null"
+    result: { type: SUCCESS }
+  )
+}
+```
+
+```python
+import time
+
+from datahub.ingestion.graph.client import DataHubGraph, DatahubClientConfig
+
+graph = DataHubGraph(config=DatahubClientConfig(server="http://localhost:8080"))
+
+assertion_urn = "urn:li:assertion:agent-profile-id-not-null"
+entity_urn = "urn:li:dataset:(urn:li:dataPlatform:hive,example.table,PROD)"
+
+graph.upsert_custom_assertion(
+    urn=assertion_urn,
+    entity_urn=entity_urn,
+    type="Agent Finding",
+    description="profile_id must not be null",
+    platform_name="my-agent",
+    field_path="profile_id",
+)
+graph.report_assertion_result(
+    urn=assertion_urn,
+    timestamp_millis=int(time.time() * 1000),
+    type="SUCCESS",
+)
+```
+
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
 
@@ -44,7 +116,7 @@ mutation upsertCustomAssertion {
       platform: {
         urn: "urn:li:dataPlatform:great-expectations" # OR you can provide name: "My Custom Platform" if you do not have an URN for the platform.
       }
-      fieldPath: "field_foo" # Optional: if you want to associated with a specific field,
+      fieldPath: "field_foo" # Optional: bare column name for a field-level assertion
       externalUrl: "https://my-monitoring-tool.com/result-for-this-assertion" # Optional: if you want to provide a link to the monitoring tool
       # Optional: If you want to provide a custom SQL query for the assertion. This will be rendered as a query in the UI.
       # logic: "SELECT * FROM X WHERE Y"

--- a/docs/api/tutorials/incidents.md
+++ b/docs/api/tutorials/incidents.md
@@ -56,8 +56,8 @@ Where supported Incident Types include
 - `CUSTOM`
 
 When using `CUSTOM`, you must also provide `customType`. It is a free-text label naming
-your incident category, and it is required: omitting it fails with
-`customType is required: Failed to create incident.`
+your incident category, and it is required: omitting it (or passing a blank string) fails with
+`Failed to raise incident: customType is required when type is CUSTOM`.
 
 ```graphql
 mutation raiseCustomIncident {


### PR DESCRIPTION
## Summary
- Fix `raiseIncident(type: CUSTOM)` validation: throw a clear `IllegalArgumentException` when `customType` is missing/blank (was a backwards `URISyntaxException` message).
- Clarify GraphQL schema docs for `upsertCustomAssertion`: `platform` needs `urn` **or** `name`; `fieldPath` is **optional** (bare column name).
- Reject blank `fieldPath` with an explicit error instead of building a nonsense schemaField URN.
- Docs: required-fields callout + minimal field-level agent write-back example in `custom-assertions.md`; update the documented CUSTOM incident error string.

Fixes #18746

## Test plan
- [x] `RaiseIncidentResolverTest` (null + blank `customType`)
- [x] `UpsertCustomAssertionResolverTest` (blank `fieldPath`)
- [ ] Manual: `raiseIncident` with `type: CUSTOM` and no `customType` returns the new message
- [ ] Manual: `upsertCustomAssertion` with `platform: {}` still names platform name/urn


Made with [Cursor](https://cursor.com)