### PR TITLE
fix(graphql): expose dbt compiled SQL (formattedLogic) in VersionedDatasetMapper

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -300,7 +300,9 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
     graphqlProperties.setMaterialized(properties.isMaterialized());
     graphqlProperties.setLanguage(properties.getViewLanguage());
     graphqlProperties.setLogic(properties.getViewLogic());
-    graphqlProperties.setFormattedLogic(properties.getFormattedViewLogic());
+    if (properties.hasFormattedViewLogic()) {
+      graphqlProperties.setFormattedLogic(properties.getFormattedViewLogic());
+    }
     dataset.setViewProperties(graphqlProperties);
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapper.java
@@ -186,6 +186,10 @@ public class VersionedDatasetMapper implements ModelMapper<EntityResponse, Versi
     graphqlProperties.setMaterialized(properties.isMaterialized());
     graphqlProperties.setLanguage(properties.getViewLanguage());
     graphqlProperties.setLogic(properties.getViewLogic());
+    // Keep parity with DatasetMapper so dbt compiled SQL (formattedViewLogic) is exposed.
+    if (properties.hasFormattedViewLogic()) {
+      graphqlProperties.setFormattedLogic(properties.getFormattedViewLogic());
+    }
     dataset.setViewProperties(graphqlProperties);
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapperTest.java
@@ -284,4 +284,57 @@ public class DatasetMapperTest {
         actual.getSemanticModelProperties().getSemanticModel().getUrn(),
         semanticModelUrn.toString());
   }
+
+  @Test
+  public void testDatasetMapperViewPropertiesWithFormattedLogic() {
+    final com.linkedin.dataset.ViewProperties input = new com.linkedin.dataset.ViewProperties();
+    input.setMaterialized(true);
+    input.setViewLanguage("SQL");
+    input.setViewLogic("select * from {{ ref('upstream') }}");
+    input.setFormattedViewLogic("select * from warehouse.schema.upstream");
+
+    final Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.VIEW_PROPERTIES_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect().setValue(new Aspect(input.data())));
+    final EntityResponse response =
+        new EntityResponse()
+            .setEntityName(Constants.DATASET_ENTITY_NAME)
+            .setUrn(TEST_DATASET_URN)
+            .setAspects(new EnvelopedAspectMap(aspects));
+
+    final Dataset actual = DatasetMapper.map(null, response);
+
+    Assert.assertNotNull(actual.getViewProperties());
+    Assert.assertTrue(actual.getViewProperties().getMaterialized());
+    Assert.assertEquals(actual.getViewProperties().getLanguage(), "SQL");
+    Assert.assertEquals(
+        actual.getViewProperties().getLogic(), "select * from {{ ref('upstream') }}");
+    Assert.assertEquals(
+        actual.getViewProperties().getFormattedLogic(), "select * from warehouse.schema.upstream");
+  }
+
+  @Test
+  public void testDatasetMapperViewPropertiesWithoutFormattedLogic() {
+    final com.linkedin.dataset.ViewProperties input = new com.linkedin.dataset.ViewProperties();
+    input.setMaterialized(false);
+    input.setViewLanguage("SQL");
+    input.setViewLogic("select 1");
+
+    final Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.VIEW_PROPERTIES_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect().setValue(new Aspect(input.data())));
+    final EntityResponse response =
+        new EntityResponse()
+            .setEntityName(Constants.DATASET_ENTITY_NAME)
+            .setUrn(TEST_DATASET_URN)
+            .setAspects(new EnvelopedAspectMap(aspects));
+
+    final Dataset actual = DatasetMapper.map(null, response);
+
+    Assert.assertNotNull(actual.getViewProperties());
+    Assert.assertEquals(actual.getViewProperties().getLogic(), "select 1");
+    Assert.assertNull(actual.getViewProperties().getFormattedLogic());
+  }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataset/mappers/VersionedDatasetMapperTest.java
@@ -1,0 +1,71 @@
+package com.linkedin.datahub.graphql.types.dataset.mappers;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.VersionedDataset;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VersionedDatasetMapperTest {
+
+  private static final Urn TEST_DATASET_URN =
+      Urn.createFromTuple(Constants.DATASET_ENTITY_NAME, "test");
+
+  @Test
+  public void testVersionedDatasetMapperViewPropertiesWithFormattedLogic() {
+    final com.linkedin.dataset.ViewProperties input = new com.linkedin.dataset.ViewProperties();
+    input.setMaterialized(true);
+    input.setViewLanguage("SQL");
+    input.setViewLogic("select * from {{ ref('upstream') }}");
+    input.setFormattedViewLogic("select * from warehouse.schema.upstream");
+
+    final Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.VIEW_PROPERTIES_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect().setValue(new Aspect(input.data())));
+    final EntityResponse response =
+        new EntityResponse()
+            .setEntityName(Constants.DATASET_ENTITY_NAME)
+            .setUrn(TEST_DATASET_URN)
+            .setAspects(new EnvelopedAspectMap(aspects));
+
+    final VersionedDataset actual = VersionedDatasetMapper.map(null, response);
+
+    Assert.assertNotNull(actual.getViewProperties());
+    Assert.assertTrue(actual.getViewProperties().getMaterialized());
+    Assert.assertEquals(actual.getViewProperties().getLanguage(), "SQL");
+    Assert.assertEquals(
+        actual.getViewProperties().getLogic(), "select * from {{ ref('upstream') }}");
+    Assert.assertEquals(
+        actual.getViewProperties().getFormattedLogic(), "select * from warehouse.schema.upstream");
+  }
+
+  @Test
+  public void testVersionedDatasetMapperViewPropertiesWithoutFormattedLogic() {
+    final com.linkedin.dataset.ViewProperties input = new com.linkedin.dataset.ViewProperties();
+    input.setMaterialized(false);
+    input.setViewLanguage("SQL");
+    input.setViewLogic("select 1");
+
+    final Map<String, com.linkedin.entity.EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        Constants.VIEW_PROPERTIES_ASPECT_NAME,
+        new com.linkedin.entity.EnvelopedAspect().setValue(new Aspect(input.data())));
+    final EntityResponse response =
+        new EntityResponse()
+            .setEntityName(Constants.DATASET_ENTITY_NAME)
+            .setUrn(TEST_DATASET_URN)
+            .setAspects(new EnvelopedAspectMap(aspects));
+
+    final VersionedDataset actual = VersionedDatasetMapper.map(null, response);
+
+    Assert.assertNotNull(actual.getViewProperties());
+    Assert.assertEquals(actual.getViewProperties().getLogic(), "select 1");
+    Assert.assertNull(actual.getViewProperties().getFormattedLogic());
+  }
+}

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -116,6 +116,71 @@ def create_base_dbt_config() -> Dict:
     )
 
 
+def _make_sql_model_node(
+    *,
+    compiled_code: Optional[str] = "select 1 as id",
+) -> DBTNode:
+    return DBTNode(
+        database="test_db",
+        schema="test_schema",
+        name="my_model",
+        alias=None,
+        comment="",
+        description="",
+        language="sql",
+        raw_code="select 1 as id",
+        dbt_adapter="postgres",
+        dbt_name="model.package.my_model",
+        dbt_file_path="models/my_model.sql",
+        dbt_package_name="package",
+        node_type="model",
+        max_loaded_at=None,
+        materialization="table",
+        catalog_type=None,
+        missing_from_catalog=False,
+        owner=None,
+        compiled_code=compiled_code,
+    )
+
+
+def test_create_view_properties_includes_compiled_code() -> None:
+    source = create_mocked_dbt_source()
+    aspect = source._create_view_properties_aspect(_make_sql_model_node())
+
+    assert aspect is not None
+    assert aspect.viewLogic == "select 1 as id"
+    assert aspect.formattedViewLogic is not None
+    assert "select" in aspect.formattedViewLogic.lower()
+    assert aspect.materialized is True
+
+
+def test_create_view_properties_skips_compiled_code_when_missing() -> None:
+    source = create_mocked_dbt_source()
+    aspect = source._create_view_properties_aspect(
+        _make_sql_model_node(compiled_code=None)
+    )
+
+    assert aspect is not None
+    assert aspect.viewLogic == "select 1 as id"
+    assert aspect.formattedViewLogic is None
+
+
+def test_create_view_properties_respects_include_compiled_code_false() -> None:
+    ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-source")
+    config = DBTCoreConfig(
+        **{
+            **create_base_dbt_config(),
+            "include_compiled_code": False,
+        }
+    )
+    source = DBTCoreSource(config, ctx)
+    aspect = source._create_view_properties_aspect(_make_sql_model_node())
+
+    assert aspect is not None
+    assert aspect.viewLogic == "select 1 as id"
+    assert aspect.formattedViewLogic is None
+
+
 def test_dbt_source_patching_no_new():
     source = create_mocked_dbt_source()
 


### PR DESCRIPTION
## Summary

* `VersionedDatasetMapper` was missing the `setFormattedLogic()` call that `DatasetMapper` already had, so the dbt compiled SQL (`ViewProperties.formattedViewLogic`) was not exposed via the `formattedLogic` GraphQL field on versioned dataset profiles. The UI's Source/Compiled toggle (`canShowFormatted = !!formattedLogic`) therefore never rendered for those entities.
* Both mappers now guard the call with `hasFormattedViewLogic()` so the field is only set when the aspect carries it.
* Added unit tests for both `DatasetMapper` and `VersionedDatasetMapper` covering the with/without `formattedViewLogic` cases.
* Added dbt ingestion contract tests in `test_dbt_source.py` locking `_create_view_properties_aspect` behavior for `include_compiled_code` and missing `compiled_code`.

## Context

[CUS-8840](https://linear.app/acryl-data/issue/CUS-8840/compiled-dbt-sql-not-visible-in-datahub-ui-for-admin-users-despite): Compiled dbt SQL not visible in DataHub UI. Investigation showed GMS had `viewProperties.logic` (raw Jinja) but `formattedLogic` was null. The UI only renders the Source/Compiled toggle when `formattedLogic` is non-null. The primary cause for the reported customer case was missing `compiled_code` in the manifest at ingest time, but `VersionedDatasetMapper` also had a parity gap with `DatasetMapper` that this PR closes.

## Test plan

- [X] `./gradlew :datahub-graphql-core:test --tests '*DatasetMapperTest' --tests '*VersionedDatasetMapperTest'` — 11 passing
- [X] `./gradlew :datahub-graphql-core:spotlessJavaCheck` — clean
- [X] `./gradlew :metadata-ingestion:lintFix` — clean
- [X] `pytest tests/unit/dbt/test_dbt_source.py -k create_view_properties` — 3 passing
- [X] Local e2e: ingested two dbt fixtures (with/without `compiled_code`) into local GMS; GraphQL returns `formattedLogic: SET` for the compiled case and `formattedLogic: null` for the missing case — UI View Definition tab shows Source/Compiled toggle only for the former

---

> \[!NOTE\]<br>**Overview**<br>Fixes missing **compiled dbt SQL** on versioned dataset GraphQL profiles by aligning `VersionedDatasetMapper` with `DatasetMapper`: both now set `formattedLogic` only when `ViewProperties` has `formattedViewLogic`, so the UI Source/Compiled toggle can appear when ingest stored compiled SQL.
>
> `DatasetMapper` no longer unconditionally maps `formattedLogic`; it uses the same `hasFormattedViewLogic()` guard. Unit tests cover with/without formatted logic for both mappers, and dbt ingestion tests lock `_create_view_properties_aspect` behavior for `include_compiled_code` and absent `compiled_code`.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit f2e37dececae9b1f21c7d6447f8582fc44d9d761. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).