### PR TITLE
fix(ingest): casing key error for dbt/trino type lookup

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
@@ -243,12 +243,16 @@ def resolve_postgres_modified_type(type_string: str) -> Any:
 
 
 def resolve_trino_modified_type(type_string: str) -> Any:
+    # Trino types are conventionally lowercase, but dbt catalogs (e.g. types
+    # rendered from a CAST(... AS DECIMAL(38,2)) in the compiled SQL) may
+    # surface them uppercase, so normalize before lookup.
+    type_string = type_string.lower()
     # for cases like timestamp(3), decimal(10,0), row(...)
     match = re.match(r"([a-zA-Z]+)\(.+\)", type_string)
     if match:
         modified_type_base: str = match.group(1)
-        return TRINO_SQL_TYPES_MAP[modified_type_base]
-    return TRINO_SQL_TYPES_MAP[type_string]
+        return TRINO_SQL_TYPES_MAP.get(modified_type_base)
+    return TRINO_SQL_TYPES_MAP.get(type_string)
 
 
 def resolve_athena_modified_type(type_string: str) -> Any:

--- a/metadata-ingestion/tests/unit/test_sql_types.py
+++ b/metadata-ingestion/tests/unit/test_sql_types.py
@@ -44,6 +44,8 @@ from datahub.metadata.schema_classes import (
         ("row(x bigint, y double)", "row"),
         ("array(row(x bigint, y double))", "array"),
         ("map(varchar, varchar)", "map"),
+        ("DECIMAL(38, 2)", "decimal"),
+        ("VARCHAR(20)", "varchar"),
     ],
 )
 def test_resolve_trino_modified_type(data_type, expected_data_type):


### PR DESCRIPTION
Fixed a KeyError: 'DECIMAL' crash in dbt-over-Trino ingestion caused by `resolve_trino_modified_type()` doing a case-sensitive lookup against a lowercase-only type map. This broke on uppercase catalog types like DECIMAL(38, 2). Normalized the input to lowercase and switched from dict indexing to .get() (matching the Snowflake's resolver pattern) so any future unmapped Trino type degrades to a per-column warning instead of aborting the whole ingestion run. Added test for a couple of types in UPPER case

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
