### PR TITLE
fix(permissions): add debouncing to searches in policy builder and lists

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/SearchBar/SearchBar.tsx
+++ b/datahub-web-react/src/alchemy-components/components/SearchBar/SearchBar.tsx
@@ -1,7 +1,8 @@
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
 import { InputProps, InputRef } from 'antd';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'react-use';
 
 import { StyledSearchBar } from '@components/components/SearchBar/components';
 import { SearchBarProps } from '@components/components/SearchBar/types';
@@ -13,6 +14,7 @@ export const searchBarDefaults: SearchBarProps = {
     width: '100%',
     height: '40px',
     allowClear: true,
+    debounceDelay: 0,
 };
 
 export const SearchBar = forwardRef<InputRef, SearchBarProps & Omit<InputProps, 'onChange'>>(
@@ -23,6 +25,7 @@ export const SearchBar = forwardRef<InputRef, SearchBarProps & Omit<InputProps, 
             width = searchBarDefaults.width,
             height = searchBarDefaults.height,
             allowClear = searchBarDefaults.allowClear,
+            debounceDelay = searchBarDefaults.debounceDelay,
             clearIcon,
             forceUncontrolled = false,
             onCompositionStart,
@@ -34,13 +37,52 @@ export const SearchBar = forwardRef<InputRef, SearchBarProps & Omit<InputProps, 
     ) => {
         const { t } = useTranslation('alchemy');
         const resolvedPlaceholder = placeholder ?? t('search.placeholder');
+
+        // Local state to track the input value for immediate UI updates
+        const [localValue, setLocalValue] = useState(value || '');
+
+        // Update local value when controlled value prop changes
+        useEffect(() => {
+            if (!forceUncontrolled && value !== undefined) {
+                setLocalValue(value);
+            }
+        }, [value, forceUncontrolled]);
+
+        // Call onChange with debouncing when debounceDelay is set
+        useDebounce(
+            () => {
+                if (onChange && debounceDelay !== undefined && debounceDelay > 0) {
+                    // Create a synthetic event-like object for the onChange signature
+                    const syntheticEvent = {
+                        target: { value: localValue },
+                    } as React.ChangeEvent<HTMLInputElement>;
+                    onChange(localValue, syntheticEvent);
+                }
+            },
+            debounceDelay,
+            [localValue],
+        );
+
+        // Handle immediate onChange when debounceDelay is 0
+        const handleChange = useCallback(
+            (e: React.ChangeEvent<HTMLInputElement>) => {
+                const newValue = e.target.value;
+                setLocalValue(newValue);
+
+                if (debounceDelay === 0) {
+                    onChange?.(newValue, e);
+                }
+            },
+            [onChange, debounceDelay],
+        );
+
         // Override value handling when forceUncontrolled is true
-        const inputValue = forceUncontrolled ? undefined : value;
+        const inputValue = forceUncontrolled ? undefined : localValue;
 
         return (
             <StyledSearchBar
                 placeholder={resolvedPlaceholder}
-                onChange={(e) => onChange?.(e.target.value, e)}
+                onChange={handleChange}
                 value={inputValue}
                 prefix={<Icon icon={MagnifyingGlass} />}
                 allowClear={clearIcon ? allowClear && { clearIcon } : allowClear}

--- a/datahub-web-react/src/alchemy-components/components/SearchBar/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/SearchBar/types.ts
@@ -13,4 +13,5 @@ export interface SearchBarProps {
     forceUncontrolled?: boolean;
     onCompositionStart?: React.CompositionEventHandler<HTMLInputElement>;
     onCompositionEnd?: React.CompositionEventHandler<HTMLInputElement>;
+    debounceDelay?: number; // Set to 0 to avoid debouncing
 }

--- a/datahub-web-react/src/app/permissions/policy/GlossarySelector.tsx
+++ b/datahub-web-react/src/app/permissions/policy/GlossarySelector.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/macro';
 import GlossaryBrowser from '@app/glossaryV2/GlossaryBrowser/GlossaryBrowser';
 import { createCriterionValueWithEntity, getFieldValues, setFieldValues } from '@app/permissions/policy/policyUtils';
 import ClickOutside from '@app/shared/ClickOutside';
+import useDebouncedCallback from '@app/shared/hooks/useDebouncedCallback';
 import { BrowserWrapper } from '@app/shared/tags/BrowserWrapper';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -106,9 +107,7 @@ export default function GlossarySelector({ resources, setResources }: Props) {
         });
     };
 
-    const handleGlossarySearch = (text: string) => {
-        const trimmedText: string = text.trim();
-        setGlossaryInputValue(trimmedText);
+    const searchGlossaryEntitiesDebounced = useDebouncedCallback((trimmedText: string) => {
         searchGlossaryEntities({
             variables: {
                 input: {
@@ -119,6 +118,13 @@ export default function GlossarySelector({ resources, setResources }: Props) {
                 },
             },
         });
+    });
+
+    const handleGlossarySearch = (text: string) => {
+        const trimmedText: string = text.trim();
+        // Kept synchronous: this drives whether the glossary browser or the search dropdown shows.
+        setGlossaryInputValue(trimmedText);
+        searchGlossaryEntitiesDebounced(trimmedText);
     };
 
     const renderSearchResult = (result) => {

--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -34,6 +34,7 @@ import PolicyBuilderModal from '@app/permissions/policy/PolicyBuilderModal';
 import PolicyDetailsModal from '@app/permissions/policy/PolicyDetailsModal';
 import { DEFAULT_PAGE_SIZE, EMPTY_POLICY } from '@app/permissions/policy/policyUtils';
 import { usePolicy } from '@app/permissions/policy/usePolicy';
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
 import { scrollToTop } from '@app/shared/searchUtils';
 import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -467,9 +468,18 @@ export const ManagePolicies = ({ onRegisterCreatePolicy }: ManagePoliciesProps) 
                         placeholder={t('searchPlaceholder')}
                         value={query || ''}
                         onChange={(value) => {
+                            // SearchBar's debounce also fires once on mount with an empty value.
+                            // Normalizing '' to undefined makes that a no-op against the initial
+                            // state instead of a redundant `query: ""` network fetch, and lets
+                            // clearing the box fall back to the cached first page.
+                            const nextQuery = value || undefined;
+                            if (nextQuery === query) {
+                                return;
+                            }
                             setPage(1);
-                            setQuery(value);
+                            setQuery(nextQuery);
                         }}
+                        debounceDelay={DEBOUNCE_SEARCH_MS}
                         width="250px"
                         allowClear
                     />

--- a/datahub-web-react/src/app/permissions/policy/PolicyActorForm.tsx
+++ b/datahub-web-react/src/app/permissions/policy/PolicyActorForm.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import { AvatarType } from '@components/components/AvatarStack/types';
 
+import useDebouncedCallback from '@app/shared/hooks/useDebouncedCallback';
 import ActorPill from '@app/sharedV2/owners/ActorPill';
 import { useOwnershipTypes } from '@app/sharedV2/owners/useOwnershipTypes';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -204,15 +205,16 @@ export default function PolicyActorForm({ policyType, actors, setActors }: Props
         });
     };
 
-    // Invokes the user search API as the user types
-    const handleUserSearch = (text: string) => {
-        return handleSearch(EntityType.CorpUser, text, userSearch);
-    };
+    // Invokes the user search API as the user types. Users and groups get their own debouncer so
+    // typing in one select can't cancel the other's pending search.
+    const handleUserSearch = useDebouncedCallback((text: string) => {
+        handleSearch(EntityType.CorpUser, text, userSearch);
+    });
 
     // Invokes the group search API as the user types
-    const handleGroupSearch = (text: string) => {
-        return handleSearch(EntityType.CorpGroup, text, groupSearch);
-    };
+    const handleGroupSearch = useDebouncedCallback((text: string) => {
+        handleSearch(EntityType.CorpGroup, text, groupSearch);
+    });
 
     // Renders a search result in the select dropdown.
     const renderSearchResult = (result: SearchResult) => {

--- a/datahub-web-react/src/app/permissions/policy/PolicyPrivilegeForm.tsx
+++ b/datahub-web-react/src/app/permissions/policy/PolicyPrivilegeForm.tsx
@@ -22,6 +22,7 @@ import {
 } from '@app/permissions/policy/policyUtils';
 import ClickOutside from '@app/shared/ClickOutside';
 import { ENTER_KEY_CODE } from '@app/shared/constants';
+import useDebouncedCallback from '@app/shared/hooks/useDebouncedCallback';
 import { useIsGlossaryBasedPoliciesEnabled } from '@app/shared/hooks/useIsGlossaryBasedPoliciesEnabled';
 import { useGetRecommendations } from '@app/shared/recommendation';
 import { BrowserWrapper } from '@app/shared/tags/BrowserWrapper';
@@ -332,7 +333,7 @@ export default function PolicyPrivilegeForm({
     };
 
     // Handle resource search, if the resource type has an associated EntityType mapping.
-    const handleResourceSearch = (text: string) => {
+    const handleResourceSearch = useDebouncedCallback((text: string) => {
         const trimmedText: string = text.trim();
         const entityTypes = resourceTypeSelectValue
             .map((resourceType) => mapResourceTypeToEntityType(resourceType, resourcePrivileges))
@@ -347,12 +348,10 @@ export default function PolicyPrivilegeForm({
                 },
             },
         });
-    };
+    });
 
     // Handle domain search, if the domain type has an associated EntityType mapping.
-    const handleDomainSearch = (text: string) => {
-        const trimmedText: string = text.trim();
-        setDomainInputValue(trimmedText);
+    const searchDomainsDebounced = useDebouncedCallback((trimmedText: string) => {
         searchDomains({
             variables: {
                 input: {
@@ -363,11 +362,16 @@ export default function PolicyPrivilegeForm({
                 },
             },
         });
+    });
+
+    const handleDomainSearch = (text: string) => {
+        const trimmedText: string = text.trim();
+        // Kept synchronous: this drives whether the domain navigator or the search dropdown shows.
+        setDomainInputValue(trimmedText);
+        searchDomainsDebounced(trimmedText);
     };
 
-    const handleContainerSearch = (text: string) => {
-        const trimmedText: string = text.trim();
-        setContainerInputValue(trimmedText);
+    const searchContainersDebounced = useDebouncedCallback((trimmedText: string) => {
         searchContainers({
             variables: {
                 input: {
@@ -378,6 +382,13 @@ export default function PolicyPrivilegeForm({
                 },
             },
         });
+    });
+
+    const handleContainerSearch = (text: string) => {
+        const trimmedText: string = text.trim();
+        // Kept synchronous: this drives whether the container navigator or the search dropdown shows.
+        setContainerInputValue(trimmedText);
+        searchContainersDebounced(trimmedText);
     };
 
     const renderSearchResult = (result) => {
@@ -493,7 +504,7 @@ export default function PolicyPrivilegeForm({
     };
 
     const type = EntityType.Tag;
-    const handleSearch = (text: string) => {
+    const handleSearch = useDebouncedCallback((text: string) => {
         if (text.length > 0) {
             tagTermSearch({
                 variables: {
@@ -506,7 +517,7 @@ export default function PolicyPrivilegeForm({
                 },
             });
         }
-    };
+    });
 
     const tagSearchOptions = tagResult?.map((result) => {
         return renderSearchResultTags(result);

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -15,6 +15,7 @@ import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import { ROLES_INTRO_ID } from '@app/onboarding/config/RolesOnboardingConfig';
 import RoleDetailsModal from '@app/permissions/roles/RoleDetailsModal';
 import { getRolePolicies, getRoleUsers } from '@app/permissions/roles/roles.utils';
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
 import { ToastType, showToastMessage } from '@app/sharedV2/toastMessageUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -290,9 +291,18 @@ export const ManageRoles = () => {
                 placeholder={t('searchRolesPlaceholder')}
                 value={query || ''}
                 onChange={(value) => {
+                    // SearchBar's debounce also fires once on mount with an empty value.
+                    // Normalizing '' to undefined makes that a no-op against the initial state
+                    // instead of a redundant `query: ""` network fetch, and lets clearing the box
+                    // fall back to the cached first page.
+                    const nextQuery = value || undefined;
+                    if (nextQuery === query) {
+                        return;
+                    }
                     setPage(1);
-                    setQuery(value);
+                    setQuery(nextQuery);
                 }}
+                debounceDelay={DEBOUNCE_SEARCH_MS}
                 width="300px"
                 allowClear
             />

--- a/datahub-web-react/src/app/shared/hooks/useDebouncedCallback.ts
+++ b/datahub-web-react/src/app/shared/hooks/useDebouncedCallback.ts
@@ -1,0 +1,32 @@
+import { DebouncedFunc, debounce } from 'lodash';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
+
+/**
+ * Debounces `callback` behind a wrapper whose identity is stable for the lifetime of the component.
+ *
+ * The latest `callback` is read from a ref rather than captured by the debounced function. Without
+ * that, passing an inline lambda — the common case for a `Select`'s `onSearch` — would rebuild the
+ * debouncer on every render and discard the pending timer, silently defeating the debounce. Any
+ * pending invocation is cancelled on unmount so a query can't fire against a torn-down component.
+ *
+ * Only debounce the expensive part of a handler. Local state that drives what the user sees while
+ * typing (an input's value, a dropdown's visibility) must stay synchronous.
+ */
+export default function useDebouncedCallback<TArgs extends unknown[]>(
+    callback: (...args: TArgs) => void,
+    delayMs: number = DEBOUNCE_SEARCH_MS,
+): DebouncedFunc<(...args: TArgs) => void> {
+    const callbackRef = useRef(callback);
+
+    useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    const debounced = useMemo(() => debounce((...args: TArgs) => callbackRef.current(...args), delayMs), [delayMs]);
+
+    useEffect(() => () => debounced.cancel(), [debounced]);
+
+    return debounced;
+}

--- a/e2e-test/ui/playwright/pages/settings/policies.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/policies.page.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 import { BaseSettingsPage, type PageOptions } from './base.settings.page';
 import { TOAST_MESSAGES } from './constants';
-import { WAIT_TIMEOUT, SHORT_TIMEOUT } from '../../utils/constants';
+import { WAIT_TIMEOUT, SHORT_TIMEOUT, TIMEOUTS } from '../../utils/constants';
 
 export class PoliciesPage extends BaseSettingsPage {
   private readonly searchInput: Locator;
@@ -89,6 +89,12 @@ export class PoliciesPage extends BaseSettingsPage {
   async searchForPolicy(policyName: string): Promise<void> {
     await this.searchInput.clear();
     await this.searchInput.fill(policyName);
+    // The policies search box is debounced, so the table keeps rendering the previous result set
+    // for a moment after the last keystroke. Callers open a row menu immediately after searching,
+    // and the debounced refetch then unmounts the table rows — silently closing that open menu.
+    // Wait for the debounce to fire and its refetch to finish before handing control back.
+    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    await this.page.waitForLoadState('networkidle');
   }
 
   async openRowMenu(policyName: string): Promise<void> {


### PR DESCRIPTION
This PR includes:
- bringing debounceDelay from SaaS to search bar component
- adding debouncing to searches in policy builder and lists

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
