### PR TITLE
fix(search): apply ignore_above as an in-place mapping update instead of forcing a reindex

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/BuildIndices.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/BuildIndices.java
@@ -72,6 +72,25 @@ public class BuildIndices implements BlockingSystemUpgrade {
                 .getBuildIndices()
                 .isIncrementalReindexEnabled();
 
+    // Mapping reconciliation is driven exclusively by BuildIndicesIncrementalStep, which is only
+    // constructed on the incremental path. Asking for it without incremental reindexing enabled
+    // is a no-op, and silently so — the operator would see a clean upgrade and conclude the
+    // historical documents had been rebuilt.
+    if (!_incrementalReindexEnabled
+        && configurationProvider.getElasticSearch().getBuildIndices() != null
+        && configurationProvider
+            .getElasticSearch()
+            .getBuildIndices()
+            .isReconcileInPlaceMappingUpdates()) {
+      log.warn(
+          "ELASTICSEARCH_BUILD_INDICES_RECONCILE_IN_PLACE_MAPPING_UPDATES=true has no effect"
+              + " because incremental reindexing is disabled"
+              + " (ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED / ZDU_STAGE_20 = false)."
+              + " In-place mapping parameter updates will still be applied to the live index, but"
+              + " existing documents will NOT be rebuilt under the new mapping. Enable incremental"
+              + " reindexing on the same run, or reconcile the affected indices separately.");
+    }
+
     _steps =
         buildSteps(
             _indexedServices,
@@ -131,7 +150,12 @@ public class BuildIndices implements BlockingSystemUpgrade {
       // aliases
       steps.add(
           new BuildIndicesIncrementalStep(
-              opContext, indexedServices, _structuredProperties, entityService, upgradeVersion));
+              opContext,
+              indexedServices,
+              _structuredProperties,
+              entityService,
+              upgradeVersion,
+              configurationProvider.getElasticSearch().getBuildIndices()));
     } else {
       // Legacy path: block writes, reindex in-place, swap aliases, unblock writes
       steps.add(

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -7,8 +7,8 @@ import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
-import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
 import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.upgrade.DataHubUpgradeResultConditionalPersist;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
@@ -21,7 +21,9 @@ import com.linkedin.upgrade.DataHubUpgradeResult;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -52,6 +54,7 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
   private final EntityService<?> entityService;
   private final String upgradeVersion;
   private final Urn upgradeIdUrn;
+  private final BuildIndicesConfiguration buildIndicesConfig;
 
   /**
    * @param upgradeVersion version string (e.g. "{gitVersion}-{revision}") used to scope upgrade
@@ -62,13 +65,15 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
       List<ElasticSearchIndexed> indexedServices,
       Set<Pair<Urn, StructuredPropertyDefinition>> structuredProperties,
       EntityService<?> entityService,
-      String upgradeVersion) {
+      String upgradeVersion,
+      BuildIndicesConfiguration buildIndicesConfig) {
     this.opContext = opContext;
     this.indexedServices = indexedServices;
     this.structuredProperties = structuredProperties;
     this.entityService = entityService;
     this.upgradeVersion = upgradeVersion;
     this.upgradeIdUrn = BootstrapStep.getUpgradeUrn(UPGRADE_ID_PREFIX + "_" + upgradeVersion);
+    this.buildIndicesConfig = buildIndicesConfig;
   }
 
   @Override
@@ -85,12 +90,36 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
   public Function<UpgradeContext, UpgradeStepResult> executable() {
     return (context) -> {
       try {
+        List<ReindexConfig> allConfigs =
+            getAllReindexConfigs(context.opContext(), indexedServices, structuredProperties);
         List<ReindexConfig> configsNeedingReindex =
-            IndexUtils.getIndicesNeedingReindexOrBuild(
-                context.opContext(), indexedServices, structuredProperties);
+            allConfigs.stream()
+                .filter(config -> !config.exists() || config.requiresReindex())
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        if (buildIndicesConfig.isReconcileInPlaceMappingUpdates()) {
+          Set<String> selectedNames =
+              configsNeedingReindex.stream()
+                  .map(ReindexConfig::name)
+                  .collect(Collectors.toCollection(HashSet::new));
+          List<ReindexConfig> reconciliationConfigs =
+              allConfigs.stream()
+                  .filter(ReindexConfig::requiresMappingReconciliation)
+                  .filter(config -> selectedNames.add(config.name()))
+                  .collect(Collectors.toList());
+          configsNeedingReindex.addAll(reconciliationConfigs);
+          if (!reconciliationConfigs.isEmpty()) {
+            log.info(
+                "Reconciling {} in-place mapping update(s) through incremental reindex: {}",
+                reconciliationConfigs.size(),
+                reconciliationConfigs.stream()
+                    .map(ReindexConfig::name)
+                    .collect(Collectors.toList()));
+          }
+        }
+
         if (configsNeedingReindex.isEmpty()) {
           log.info("No indices require incremental reindex");
-          return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.SUCCEEDED);
         }
 
         // Load any previously persisted state for resumption
@@ -315,10 +344,14 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
         // Also handle indices that don't need reindex but need mapping/settings updates, note that
         // while we call the
         // get again it avoids reprocessing so has minimal cost.
+        Set<String> incrementallyBuiltIndices =
+            configsNeedingReindex.stream()
+                .map(ReindexConfig::name)
+                .collect(Collectors.toCollection(HashSet::new));
         List<ReindexConfig> configsNoReindex =
-            getAllReindexConfigs(context.opContext(), indexedServices, structuredProperties)
-                .stream()
+            allConfigs.stream()
                 .filter(c -> !c.requiresReindex())
+                .filter(c -> !incrementallyBuiltIndices.contains(c.name()))
                 .filter(c -> c.requiresApplyMappings() || c.requiresApplySettings())
                 .collect(Collectors.toList());
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -21,6 +21,7 @@ import com.linkedin.datahub.upgrade.Upgrade;
 import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.IngestResult;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
@@ -61,6 +62,7 @@ public class BuildIndicesIncrementalStepTest {
 
   private OperationContext opContext;
   private BuildIndicesIncrementalStep step;
+  private BuildIndicesConfiguration buildIndicesConfig;
 
   @BeforeMethod
   public void setup() throws Exception {
@@ -85,9 +87,19 @@ public class BuildIndicesIncrementalStepTest {
         .thenReturn(true);
     when(indexBuilder.indexExists(any(OperationContext.class), anyString())).thenReturn(true);
 
-    step =
-        new BuildIndicesIncrementalStep(
-            opContext, List.of(indexedService), Set.of(), entityService, UPGRADE_VERSION);
+    buildIndicesConfig =
+        BuildIndicesConfiguration.builder().reconcileInPlaceMappingUpdates(false).build();
+    step = createStep();
+  }
+
+  private BuildIndicesIncrementalStep createStep() {
+    return new BuildIndicesIncrementalStep(
+        opContext,
+        List.of(indexedService),
+        Set.of(),
+        entityService,
+        UPGRADE_VERSION,
+        buildIndicesConfig);
   }
 
   @Test
@@ -105,6 +117,55 @@ public class BuildIndicesIncrementalStepTest {
     assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
     verify(indexBuilder, never())
         .buildIndexIncremental(any(OperationContext.class), any(), anyString());
+  }
+
+  @Test
+  public void testAppliesInPlaceMappingUpdateWithoutReconciliation() throws Throwable {
+    ReindexConfig inPlaceConfig = mockReindexConfig(INDEX_NAME, false);
+    when(inPlaceConfig.requiresMappingReconciliation()).thenReturn(true);
+    when(inPlaceConfig.requiresApplyMappings()).thenReturn(true);
+    when(indexedService.buildReindexConfigs(any(), any())).thenReturn(List.of(inPlaceConfig));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    verify(indexBuilder).buildIndex(any(OperationContext.class), eq(inPlaceConfig));
+    verify(indexBuilder, never())
+        .buildIndexIncremental(any(OperationContext.class), any(), anyString());
+  }
+
+  @Test
+  public void testReconcilesInPlaceMappingUpdateWhenEnabled() throws Throwable {
+    buildIndicesConfig.setReconcileInPlaceMappingUpdates(true);
+    step = createStep();
+
+    ReindexConfig inPlaceConfig = mockReindexConfig(INDEX_NAME, false);
+    when(inPlaceConfig.requiresMappingReconciliation()).thenReturn(true);
+    when(inPlaceConfig.requiresApplyMappings()).thenReturn(true);
+    when(indexedService.buildReindexConfigs(any(), any())).thenReturn(List.of(inPlaceConfig));
+
+    IncrementalReindexResult incrementalResult =
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), eq(inPlaceConfig), eq(UPGRADE_VERSION)))
+        .thenReturn(incrementalResult);
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            eq("task1")))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 100L)));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    verify(indexBuilder)
+        .buildIndexIncremental(any(OperationContext.class), eq(inPlaceConfig), eq(UPGRADE_VERSION));
+    verify(indexBuilder, never()).buildIndex(any(OperationContext.class), eq(inPlaceConfig));
   }
 
   @Test
@@ -514,6 +575,7 @@ public class BuildIndicesIncrementalStepTest {
     when(config.exists()).thenReturn(true);
     when(config.isSettingsReindex()).thenReturn(false);
     when(config.isPureMappingsAddition()).thenReturn(false);
+    when(config.requiresMappingReconciliation()).thenReturn(false);
     when(config.requiresApplyMappings()).thenReturn(false);
     when(config.requiresApplySettings()).thenReturn(false);
     when(config.requiresDataBackfill()).thenReturn(requiresReindex);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -7,6 +7,7 @@ import static com.linkedin.metadata.models.StructuredPropertyUtils.toElasticsear
 import static com.linkedin.metadata.models.annotation.SearchableAnnotation.OBJECT_FIELD_TYPES;
 import static com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder.*;
 import static com.linkedin.metadata.search.utils.ESUtils.ALIAS_FIELD_TYPE;
+import static com.linkedin.metadata.search.utils.ESUtils.IGNORE_ABOVE;
 import static com.linkedin.metadata.search.utils.ESUtils.PATH;
 import static com.linkedin.metadata.search.utils.ESUtils.PROPERTIES;
 import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
@@ -396,7 +397,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
   private static Map<String, Object> getMappingsForKeywordWithIgnoreAbove(int keywordMaxLength) {
     Map<String, Object> mappingForField = getMappingsForKeyword();
     // ignore_above is character-based; convert configured byte limit to a byte-safe char threshold
-    mappingForField.put("ignore_above", ESUtils.keywordIgnoreAboveForMaxBytes(keywordMaxLength));
+    mappingForField.put(IGNORE_ABOVE, ESUtils.keywordIgnoreAboveForMaxBytes(keywordMaxLength));
     return mappingForField;
   }
 
@@ -414,7 +415,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
     Map<String, Object> mappingForField = new HashMap<>();
     mappingForField.put(TYPE, ESUtils.KEYWORD_FIELD_TYPE);
     mappingForField.put(NORMALIZER, KEYWORD_NORMALIZER);
-    mappingForField.put("ignore_above", ESUtils.KEYWORD_MAXLENGTH);
+    mappingForField.put(IGNORE_ABOVE, ESUtils.KEYWORD_MAXLENGTH);
     Map<String, Object> subFields = new HashMap<>();
     if (fieldType == FieldType.TEXT_PARTIAL || fieldType == FieldType.WORD_GRAM) {
       subFields.put(
@@ -440,8 +441,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
             ANALYZER, TEXT_ANALYZER,
             SEARCH_ANALYZER, TEXT_SEARCH_ANALYZER,
             SEARCH_QUOTE_ANALYZER, CUSTOM_QUOTE_ANALYZER));
-    subFields.put(
-        KEYWORD, ImmutableMap.of(TYPE, KEYWORD, "ignore_above", ESUtils.KEYWORD_MAXLENGTH));
+    subFields.put(KEYWORD, ImmutableMap.of(TYPE, KEYWORD, IGNORE_ABOVE, ESUtils.KEYWORD_MAXLENGTH));
     mappingForField.put(FIELDS, subFields);
     return mappingForField;
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.search.utils.ESUtils.BOOLEAN_FIELD_TYPE;
 import static com.linkedin.metadata.search.utils.ESUtils.DATE_FIELD_TYPE;
 import static com.linkedin.metadata.search.utils.ESUtils.DOUBLE_FIELD_TYPE;
 import static com.linkedin.metadata.search.utils.ESUtils.FLOAT_FIELD_TYPE;
+import static com.linkedin.metadata.search.utils.ESUtils.IGNORE_ABOVE;
 import static com.linkedin.metadata.search.utils.ESUtils.INTEGER_FIELD_TYPE;
 import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_FIELD_TYPE;
 import static com.linkedin.metadata.search.utils.ESUtils.KEYWORD_MAXLENGTH;
@@ -149,7 +150,7 @@ public class FieldTypeMapper {
   public static Map<String, Object> getMappingsForKeywordWithIgnoreAbove() {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
-    mapping.put("ignore_above", KEYWORD_MAXLENGTH);
+    mapping.put(IGNORE_ABOVE, KEYWORD_MAXLENGTH);
     return mapping;
   }
 
@@ -161,7 +162,7 @@ public class FieldTypeMapper {
   public static Map<String, Object> getMappingsForKeywordWithIgnoreAbove(int keywordMaxBytes) {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
-    mapping.put("ignore_above", keywordIgnoreAboveForMaxBytes(keywordMaxBytes));
+    mapping.put(IGNORE_ABOVE, keywordIgnoreAboveForMaxBytes(keywordMaxBytes));
     return mapping;
   }
 
@@ -174,7 +175,7 @@ public class FieldTypeMapper {
   public static Map<String, Object> getMappingsForUrn() {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
-    mapping.put("ignore_above", 255);
+    mapping.put(IGNORE_ABOVE, 255);
     return mapping;
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -735,13 +735,29 @@ public class ESIndexBuilder {
   public void applyMappings(
       @Nonnull OperationContext opContext, ReindexConfig indexState, boolean suppressError)
       throws IOException {
-    if (indexState.isPureMappingsAddition() || indexState.isPureStructuredPropertyAddition()) {
+    if (indexState.isPureMappingsAddition()
+        || indexState.isPureStructuredPropertyAddition()
+        || indexState.isInPlaceMappingParameterUpdate()) {
       log.info("Updating index {} mappings in place.", indexState.name());
       PutMappingRequest request =
           new PutMappingRequest(indexState.name()).source(indexState.targetMappings());
       searchClient.putIndexMapping(opContext, request, requestOptionsLong);
       log.info("Updated index {} with new mappings", indexState.name());
     } else {
+      // Reached when the mappings differ but put-mapping cannot express the diff: not a pure
+      // field addition, not a pure structured-property addition, and not confined to an
+      // in-place updatable parameter. buildIndex passes suppressError=true, so without this
+      // warning the upgrade step reports success while the index mapping is silently left
+      // untouched — the operator sees no reindex and no change.
+      log.warn(
+          "Index: {} - Mapping changes were NOT applied: put-mapping cannot express this diff,"
+              + " so a reindex is required to pick them up."
+              + " requiresReindex={}, enableIndexMappingsReindex={}."
+              + " If reindexing is disabled, enable ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX"
+              + " or the new mappings will keep being ignored.",
+          indexState.name(),
+          indexState.requiresReindex(),
+          indexState.enableIndexMappingsReindex());
       if (!suppressError) {
         log.error(
             "Attempted to apply invalid mappings. Current: {} Target: {}",

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ReindexConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search.elasticsearch.indexbuilder;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.search.utils.ESUtils.IGNORE_ABOVE;
 import static com.linkedin.metadata.search.utils.ESUtils.PROPERTIES;
 import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
@@ -53,6 +54,17 @@ public class ReindexConfig {
       Stream.concat(SETTINGS_DYNAMIC.stream(), SETTINGS_STATIC.stream())
           .collect(Collectors.toList());
 
+  /**
+   * Mapping parameters that Elasticsearch/OpenSearch accept on an <i>existing</i> field via {@code
+   * PUT /<index>/_mapping}. A modified field whose changed leaf keys are all in this set can be
+   * applied live instead of forcing a reindex.
+   *
+   * <p>{@code ignore_above} sits on the keyword surface of TEXT / TEXT_PARTIAL / WORD_GRAM, which
+   * exist on nearly every index — so classifying a change to it as reindex-requiring makes {@code
+   * system-update} attempt to rebuild the whole fleet at once.
+   */
+  public static final Set<String> IN_PLACE_UPDATABLE_MAPPING_PARAMETERS = Set.of(IGNORE_ABOVE);
+
   private final String name;
   private final boolean exists;
   private final Settings currentSettings;
@@ -70,6 +82,25 @@ public class ReindexConfig {
   private boolean requiresApplySettings;
   private boolean requiresApplyMappings;
   private final boolean isPureMappingsAddition;
+
+  /**
+   * True when the mapping diff modifies existing fields but every modification is confined to an
+   * in-place updatable mapping parameter (see {@link #IN_PLACE_UPDATABLE_MAPPING_PARAMETERS}). Such
+   * a diff is applied with a single {@code PutMappingRequest} — no reindex and no backfill. New
+   * fields may be present alongside, since adding fields is already an in-place operation.
+   *
+   * <p>Removals are excluded: dropping {@code ignore_above} makes writes <i>stricter</i> and would
+   * reintroduce immense-term rejections on indices that currently carry the guard.
+   */
+  private final boolean isInPlaceMappingParameterUpdate;
+
+  /**
+   * True when existing documents should eventually be rebuilt under an in-place mapping parameter
+   * update. Applying the mapping live only changes how subsequent writes are indexed, so a
+   * controlled incremental rebuild is required for consistent historical search behavior.
+   */
+  private final boolean requiresMappingReconciliation;
+
   private final boolean isSettingsReindex;
   private final boolean hasNewStructuredProperty;
   private final boolean isPureStructuredPropertyAddition;
@@ -137,6 +168,14 @@ public class ReindexConfig {
     }
 
     private ReindexConfigBuilder isPureMappingsAddition(boolean ignored) {
+      return this;
+    }
+
+    private ReindexConfigBuilder isInPlaceMappingParameterUpdate(boolean ignored) {
+      return this;
+    }
+
+    private ReindexConfigBuilder requiresMappingReconciliation(boolean ignored) {
       return this;
     }
 
@@ -280,6 +319,13 @@ public class ReindexConfig {
             super.requiresApplyMappings
                 && mappingsDiff.entriesDiffering().isEmpty()
                 && !mappingsDiff.entriesOnlyOnRight().isEmpty();
+        Set<String> inPlaceApplyableFields =
+            inPlaceApplyableDifferingFields(mappingsDiff.entriesDiffering());
+        super.isInPlaceMappingParameterUpdate =
+            super.requiresApplyMappings
+                && !inPlaceApplyableFields.isEmpty()
+                && inPlaceApplyableFields.equals(mappingsDiff.entriesDiffering().keySet());
+        super.requiresMappingReconciliation = super.isInPlaceMappingParameterUpdate;
         // Compute SP diffs independently of mappingsDiff because calculateMapDifference
         // strips dynamic fields (including structuredProperties) from the comparison.
         Pair<Long, Long> spDiffCount =
@@ -331,9 +377,12 @@ public class ReindexConfig {
             mappingsDiff.entriesOnlyOnRight().keySet().stream()
                 .filter(key -> !STRUCTURED_PROPERTY_MAPPING_FIELD.equals(key))
                 .collect(Collectors.toSet());
+        // In-place parameter updates are excluded: they change how subsequent writes are indexed,
+        // not what any document stores, so there is nothing to backfill.
         Set<String> modifiedNonStructuredPropertyFields =
             mappingsDiff.entriesDiffering().keySet().stream()
                 .filter(key -> !STRUCTURED_PROPERTY_MAPPING_FIELD.equals(key))
+                .filter(key -> !inPlaceApplyableFields.contains(key))
                 .collect(Collectors.toSet());
         super.requiresDataBackfill =
             !newNonStructuredPropertyFields.isEmpty()
@@ -344,9 +393,16 @@ public class ReindexConfig {
               "Index: {} - New fields have been added to index. Adding: {}",
               super.name,
               mappingsDiff.entriesOnlyOnRight());
+        } else if (super.requiresApplyMappings && super.isInPlaceMappingParameterUpdate) {
+          log.info(
+              "Index: {} - Mapping parameter change applyable in place, no reindex required."
+                  + " Fields: {} Adding: {}",
+              super.name,
+              inPlaceApplyableFields,
+              mappingsDiff.entriesOnlyOnRight().keySet());
         } else if (super.requiresApplyMappings) {
           log.info(
-              "Index: {} - There's diff between new mappings (left) and old mappings (right): {}",
+              "Index: {} - There's diff between old mappings (left) and new mappings (right): {}",
               super.name,
               mappingsDiff.entriesDiffering());
         }
@@ -356,7 +412,9 @@ public class ReindexConfig {
         super.isSettingsReindex = isSettingsReindexRequired();
 
         /* Determine reindexing required - some settings and mappings do not require reindex, analysis always does */
-        if (super.requiresApplyMappings && !super.isPureMappingsAddition) {
+        if (super.requiresApplyMappings
+            && !super.isPureMappingsAddition
+            && !super.isInPlaceMappingParameterUpdate) {
           if (super.enableIndexMappingsReindex) {
             super.requiresReindex = true;
           } else {
@@ -440,6 +498,70 @@ public class ReindexConfig {
       } else {
         return getOrDefault(item, path.subList(1, path.size()));
       }
+    }
+
+    /**
+     * Subset of the modified top-level fields whose changes Elasticsearch/OpenSearch can apply to
+     * the live index via {@code PUT /<index>/_mapping}.
+     *
+     * @param entriesDiffering modified fields, keyed by top-level field name under {@code
+     *     properties}
+     * @return names of the fields that need no reindex
+     */
+    private static Set<String> inPlaceApplyableDifferingFields(
+        Map<String, MapDifference.ValueDifference<Object>> entriesDiffering) {
+      return entriesDiffering.entrySet().stream()
+          .filter(
+              entry ->
+                  isInPlaceApplyableMappingDiff(
+                      entry.getValue().leftValue(), entry.getValue().rightValue()))
+          .map(Map.Entry::getKey)
+          .collect(Collectors.toSet());
+    }
+
+    /**
+     * Whether every leaf difference between a field's current and target mapping is the addition or
+     * modification of an in-place updatable parameter.
+     *
+     * <p>Deliberately conservative — anything else keeps the existing reindex behaviour:
+     *
+     * <ul>
+     *   <li>a key present only in {@code current} is a <b>removal</b>. Removing {@code
+     *       ignore_above} makes writes stricter, so it must not be applied silently in place.
+     *   <li>an added key that is not an in-place updatable parameter is a structural change (a new
+     *       sub-field, a {@code copy_to}, an analyzer), which put-mapping cannot retrofit onto
+     *       already-indexed documents.
+     *   <li>a modified scalar that is not an in-place updatable parameter (notably {@code type})
+     *       cannot be changed on an existing field at all.
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    private static boolean isInPlaceApplyableMappingDiff(
+        @Nullable Object current, @Nullable Object target) {
+      if (!(current instanceof Map) || !(target instanceof Map)) {
+        return false;
+      }
+
+      MapDifference<String, Object> diff =
+          Maps.difference((Map<String, Object>) current, (Map<String, Object>) target);
+
+      if (!diff.entriesOnlyOnLeft().isEmpty()) {
+        return false;
+      }
+      if (!IN_PLACE_UPDATABLE_MAPPING_PARAMETERS.containsAll(diff.entriesOnlyOnRight().keySet())) {
+        return false;
+      }
+
+      return diff.entriesDiffering().entrySet().stream()
+          .allMatch(
+              entry -> {
+                Object leftValue = entry.getValue().leftValue();
+                Object rightValue = entry.getValue().rightValue();
+                if (leftValue instanceof Map && rightValue instanceof Map) {
+                  return isInPlaceApplyableMappingDiff(leftValue, rightValue);
+                }
+                return IN_PLACE_UPDATABLE_MAPPING_PARAMETERS.contains(entry.getKey());
+              });
     }
 
     /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -151,6 +151,9 @@ public class ESUtils {
    */
   public static final int KEYWORD_MAXLENGTH = 32766;
 
+  /** Mapping parameter name for the keyword length guard described above. */
+  public static final String IGNORE_ABOVE = "ignore_above";
+
   /** Byte-safe {@code ignore_above} (characters) for a configured keyword max length in bytes. */
   public static int keywordIgnoreAboveForMaxBytes(int keywordMaxBytes) {
     int maxBytes = keywordMaxBytes > 0 ? keywordMaxBytes : KEYWORD_MAXLENGTH;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -909,6 +909,33 @@ public class ESIndexBuilderTest {
   }
 
   @Test
+  void testApplyMappings_WithInPlaceMappingParameterUpdate() throws IOException {
+    ReindexConfig indexState = mock(ReindexConfig.class);
+    when(indexState.name()).thenReturn(TEST_INDEX_NAME);
+    when(indexState.isPureMappingsAddition()).thenReturn(false);
+    when(indexState.isPureStructuredPropertyAddition()).thenReturn(false);
+    when(indexState.isInPlaceMappingParameterUpdate()).thenReturn(true);
+    when(indexState.currentMappings()).thenReturn(createTestMappings());
+    when(indexState.targetMappings()).thenReturn(createTestMappings());
+
+    AcknowledgedResponse putMappingResponse = mock(AcknowledgedResponse.class);
+    when(putMappingResponse.isAcknowledged()).thenReturn(true);
+    when(searchClient.putIndexMapping(
+            any(OperationFingerprint.class),
+            any(PutMappingRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(putMappingResponse);
+
+    indexBuilder.applyMappings(opContext, indexState, false);
+
+    verify(searchClient)
+        .putIndexMapping(
+            any(OperationFingerprint.class),
+            any(PutMappingRequest.class),
+            any(RequestOptions.class));
+  }
+
+  @Test
   void testBuildIndex_HandlesOpenSearchStatusException() throws IOException {
     // Setup
     ReindexConfig indexState = mock(ReindexConfig.class);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ReindexConfigTest.java
@@ -23,6 +23,7 @@ public class ReindexConfigTest {
   private static final String TEST_INDEX_NAME = "test_index";
   private static final String PROPERTIES_KEY = "properties";
   private static final String TYPE_KEY = "type";
+  private static final String IGNORE_ABOVE_KEY = "ignore_above";
 
   private static SearchClientShim<?> es8SettingsComparisonShim() {
     SearchClientShim<?> shim = mock(SearchClientShim.class);
@@ -1945,5 +1946,164 @@ public class ReindexConfigTest {
 
     // Assert - Structured properties differences should be ignored (since they're dynamic)
     Assert.assertFalse(config.requiresApplyMappings());
+  }
+
+  /**
+   * TEXT-shaped field mapping: a keyword parent with a `.keyword` sub-field, both carrying the same
+   * {@code ignore_above} guard. {@code ignoreAbove} of null omits the guard entirely.
+   */
+  private static Map<String, Object> textFieldMapping(Integer ignoreAbove) {
+    Map<String, Object> keywordSubField = new HashMap<>();
+    keywordSubField.put(TYPE_KEY, "keyword");
+    Map<String, Object> mapping = new HashMap<>();
+    mapping.put(TYPE_KEY, "keyword");
+    mapping.put("normalizer", "keyword_normalizer");
+    if (ignoreAbove != null) {
+      mapping.put(IGNORE_ABOVE_KEY, ignoreAbove);
+      keywordSubField.put(IGNORE_ABOVE_KEY, ignoreAbove);
+    }
+    mapping.put("fields", ImmutableMap.of("keyword", keywordSubField));
+    return mapping;
+  }
+
+  private static Map<String, Object> mappingsWithFields(Map<String, Object> fields) {
+    Map<String, Object> mappings = new HashMap<>();
+    mappings.put(PROPERTIES_KEY, new HashMap<>(fields));
+    return mappings;
+  }
+
+  private static ReindexConfig buildMappingDiffConfig(
+      Map<String, Object> currentMappings, Map<String, Object> targetMappings) {
+    return ReindexConfig.builder()
+        .name(TEST_INDEX_NAME)
+        .exists(true)
+        .currentMappings(currentMappings)
+        .targetMappings(targetMappings)
+        .currentSettings(Settings.EMPTY)
+        .targetSettings(new HashMap<>())
+        .enableIndexMappingsReindex(true)
+        .build();
+  }
+
+  @DataProvider(name = "inPlaceIgnoreAboveChanges")
+  public Object[][] inPlaceIgnoreAboveChanges() {
+    return new Object[][] {
+      {"raise", 8191, 32766},
+      {"lower", 32766, 8191},
+      {"add where absent", null, 8191},
+    };
+  }
+
+  @Test(dataProvider = "inPlaceIgnoreAboveChanges")
+  void testIgnoreAboveChangeAppliedInPlace(String label, Integer current, Integer target) {
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(current))),
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(target))));
+
+    Assert.assertTrue(config.requiresApplyMappings(), label);
+    Assert.assertTrue(config.isInPlaceMappingParameterUpdate(), label);
+    Assert.assertTrue(config.requiresMappingReconciliation(), label);
+    Assert.assertFalse(config.requiresReindex(), label);
+    Assert.assertFalse(config.requiresDataBackfill(), label);
+  }
+
+  @Test
+  void testIgnoreAboveRemovalStillRequiresReindex() {
+    // Removing the guard makes writes stricter — oversized values would be rejected outright.
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(8191))),
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(null))));
+
+    Assert.assertTrue(config.requiresApplyMappings());
+    Assert.assertFalse(config.isInPlaceMappingParameterUpdate());
+    Assert.assertFalse(config.requiresMappingReconciliation());
+    Assert.assertTrue(config.requiresReindex());
+  }
+
+  @Test
+  void testIgnoreAboveChangeOnSubFieldOnlyAppliedInPlace() {
+    Map<String, Object> current = textFieldMapping(8191);
+    Map<String, Object> target = textFieldMapping(8191);
+    target.put("fields", ImmutableMap.of("keyword", ImmutableMap.of(TYPE_KEY, "keyword")));
+
+    // Removal on the sub-field is still a removal.
+    ReindexConfig removal =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", current)),
+            mappingsWithFields(ImmutableMap.of("description", target)));
+    Assert.assertFalse(removal.isInPlaceMappingParameterUpdate());
+    Assert.assertTrue(removal.requiresReindex());
+
+    // A value change confined to the sub-field is applyable.
+    Map<String, Object> subFieldChanged = textFieldMapping(8191);
+    subFieldChanged.put(
+        "fields",
+        ImmutableMap.of("keyword", ImmutableMap.of(TYPE_KEY, "keyword", IGNORE_ABOVE_KEY, 32766)));
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(8191))),
+            mappingsWithFields(ImmutableMap.of("description", subFieldChanged)));
+    Assert.assertTrue(config.isInPlaceMappingParameterUpdate());
+    Assert.assertFalse(config.requiresReindex());
+  }
+
+  @Test
+  void testIgnoreAboveChangeAlongsideNewFieldNeedsBackfillButNoReindex() {
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(8191))),
+            mappingsWithFields(
+                ImmutableMap.of(
+                    "description",
+                    textFieldMapping(32766),
+                    "newField",
+                    ImmutableMap.of(TYPE_KEY, "keyword"))));
+
+    Assert.assertTrue(config.isInPlaceMappingParameterUpdate());
+    Assert.assertFalse(config.requiresReindex());
+    // The added field still needs a backfill — _reindex/put-mapping can't populate it.
+    Assert.assertTrue(config.requiresDataBackfill());
+  }
+
+  @Test
+  void testIgnoreAboveChangeWithOtherModificationRequiresReindex() {
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(
+                ImmutableMap.of(
+                    "description",
+                    textFieldMapping(8191),
+                    "otherField",
+                    ImmutableMap.of(TYPE_KEY, "text"))),
+            mappingsWithFields(
+                ImmutableMap.of(
+                    "description",
+                    textFieldMapping(32766),
+                    "otherField",
+                    ImmutableMap.of(TYPE_KEY, "keyword"))));
+
+    Assert.assertFalse(config.isInPlaceMappingParameterUpdate());
+    Assert.assertTrue(config.requiresReindex());
+    Assert.assertTrue(config.requiresDataBackfill());
+  }
+
+  @Test
+  void testPureAdditionIsNotClassifiedAsInPlaceParameterUpdate() {
+    ReindexConfig config =
+        buildMappingDiffConfig(
+            mappingsWithFields(ImmutableMap.of("description", textFieldMapping(8191))),
+            mappingsWithFields(
+                ImmutableMap.of(
+                    "description",
+                    textFieldMapping(8191),
+                    "newField",
+                    ImmutableMap.of(TYPE_KEY, "keyword"))));
+
+    Assert.assertTrue(config.isPureMappingsAddition());
+    Assert.assertFalse(config.isInPlaceMappingParameterUpdate());
+    Assert.assertFalse(config.requiresMappingReconciliation());
+    Assert.assertFalse(config.requiresReindex());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -645,6 +645,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "elasticsearch.buildIndices.reindexBatchSize",
           "elasticsearch.buildIndices.reindexMaxSlices",
           "elasticsearch.buildIndices.reindexNoProgressRetryMinutes",
+          "elasticsearch.buildIndices.reconcileInPlaceMappingUpdates",
           "elasticsearch.buildIndices.clusterHealthCheckIntervalSeconds",
           "elasticsearch.buildIndices.clusterHeapThresholdPercent",
           "elasticsearch.buildIndices.enableIndexThrottling",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
@@ -271,6 +271,15 @@ public class BuildIndicesConfiguration {
   private boolean incrementalReindexEnabled;
 
   /**
+   * When true, mapping parameters applied live are also reconciled through the incremental
+   * alias-rebuild path so historical documents are indexed under the new mapping. This is opt-in
+   * because a broad mapping change can rebuild many indices; incremental reindexing must also be
+   * enabled. Enable it on the system-update run that first applies the mapping change because the
+   * reconciliation need can no longer be inferred after the live mapping matches.
+   */
+  @Builder.Default private boolean reconcileInPlaceMappingUpdates = false;
+
+  /**
    * Seconds between polls when checking if a timeseries catch-up reindex task is still running via
    * the listTasks API. Default 5 seconds.
    */

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -888,6 +888,7 @@ elasticsearch:
     rethrottleExecutorPoolSize: ${ELASTICSEARCH_BUILD_INDICES_RETHROTTLE_EXECUTOR_POOL_SIZE:8} # Thread pool size for concurrent rethrottle operations
     minimumReplicasForPromotion: ${ELASTICSEARCH_BUILD_INDICES_MINIMUM_REPLICAS_FOR_PROMOTION:1} # Minimum replicas to restore before promotion
     incrementalReindexEnabled: ${ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED:${ZDU_STAGE_20:false}} # non-blocking incremental reindex with dual-write
+    reconcileInPlaceMappingUpdates: ${ELASTICSEARCH_BUILD_INDICES_RECONCILE_IN_PLACE_MAPPING_UPDATES:false} # opt-in incremental rebuild when first applying live mapping parameter updates
     rollbackDualWriteEnabled: ${ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED:${ZDU_STAGE_20:false}} # dual-write to old backing index for rollback safety during incremental reindex
     catchUpSqlPageSize: ${ELASTICSEARCH_BUILD_INDICES_CATCH_UP_SQL_PAGE_SIZE:50} # SQL page size for incremental reindex catch-up MCL emission
     catchUpFlushInterval: ${ELASTICSEARCH_BUILD_INDICES_CATCH_UP_FLUSH_INTERVAL:500} # rows between producer flush and checkpoint during catch-up


### PR DESCRIPTION
## Problem

`ReindexConfig` classifies any changed mapping **value** as reindex-requiring. Because `ignore_above` modifies an _existing_ field rather than adding a new one, it lands in `entriesDiffering()`, fails the `isPureMappingsAddition` test, and forces `requiresReindex = true`.

`ignore_above` sits on the keyword surface of `TEXT` / `TEXT_PARTIAL` / `WORD_GRAM`, which exist on **nearly every index**. So changing it at all makes `system-update` attempt to rebuild the entire fleet in one pass.

This is not theoretical. On a large deployment it produced 62 indices needing reindex (including one with ~8.4M docs), saturated the search cluster to 98% JVM / 98% CPU, tripped the parent circuit breaker, and then exhausted the cluster's shard ceiling from orphaned `_next` indices.

Reverting the emitted value doesn't fix it either: a fleet can be split across several `ignore_above` states (e.g. `8191`, `32766`, and absent), so **no single emitted value avoids a reindex** everywhere. Emitting nothing strips the guard and makes oversized values unwritable.

## ES/OpenSearch supports this in place

`ignore_above` is one of the handful of updatable mapping parameters. Verified against a live OpenSearch domain via `PUT /<index>/_mapping` — no reindex, no downtime:

| Operation                                            | Result               |
| ---------------------------------------------------- | -------------------- |
| **add** `ignore_above` to an existing keyword field  | `acknowledged: true` |
| **change** `8191` → `32766`                          | `acknowledged: true` |
| **remove** it                                        | `acknowledged: true` |

Mapping changes govern only **subsequent** writes; existing documents are untouched. Adding or raising the guard is therefore strictly safe — it only makes writes more permissive.

## The change

DataHub already has the in-place path; it was gated too narrowly. `ESIndexBuilder` skips the reindex and calls `applyMappings(...)` when `!requiresReindex()`, but `applyMappings` only proceeds for `isPureMappingsAddition() || isPureStructuredPropertyAddition()` and otherwise silently no-ops.

This adds a third in-place applyable category — `isInPlaceMappingParameterUpdate`: a modified field whose changed leaf keys are all in `IN_PLACE_UPDATABLE_MAPPING_PARAMETERS` (currently just `ignore_above`). Then:

- `requiresReindex` stays `false` → no fleet-wide rebuild
- the `applyMappings` gate widens to include it → `PutMappingRequest` applies the new value live
- `requiresDataBackfill` drops for those fields, since no stored value changes

New fields may be present alongside — adding fields is already an in-place operation — and those still set `requiresDataBackfill`.

### Removals are excluded

Since **removal** makes writes stricter, "target has no `ignore_above` where current has one" is still classified reindex-requiring. Otherwise we'd silently reintroduce immense-term write rejections on the indices that currently carry a guard.

The classifier is conservative in the same direction throughout. Anything other than an add/change of an in-place updatable parameter keeps today's reindex behaviour:

- a key present only in _current_ is a removal
- an added key that is not an in-place updatable parameter is a structural change (a new sub-field, a `copy_to`, an analyzer) that put-mapping can't retrofit onto indexed documents
- a modified scalar that is not one — notably `type` — can't be changed on an existing field at all

Structured-property removal and type-mismatch detection are unaffected: those flags are computed independently and their reindex branch still fires.

### Optional reconciliation

Applying the mapping live governs only subsequent writes, so historical documents keep whatever indexing they got under the old mapping. `requiresMappingReconciliation` exposes that, and the new opt-in `reconcileInPlaceMappingUpdates` (`ELASTICSEARCH_BUILD_INDICES_RECONCILE_IN_PLACE_MAPPING_UPDATES`, default `false`) routes the affected indices through the incremental alias-rebuild path so those documents are rebuilt under the new mapping.

It is opt-in because a broad mapping change can rebuild many indices, and it must be enabled on the same `system-update` run that first applies the mapping change — once the live mapping matches, the reconciliation need can no longer be inferred. It also requires incremental reindexing (`ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED` / `ZDU_STAGE_20`); `BuildIndices` now warns if it's requested without it rather than silently doing nothing.

### Drive-by

- `ReindexConfig` logged the mapping diff with the left/right labels reversed — the call is `Maps.difference(currentMappings, targetMappings)`, so left is _current_. The reversed message actively misled triage of the incident above.
- `applyMappings` now warns when put-mapping cannot express the diff. `buildIndex` passes `suppressError=true`, so previously the upgrade step reported success while the index mapping was silently left untouched.
- Hoisted the `"ignore_above"` literal into `ESUtils.IGNORE_ABOVE` and used it in the two mappings builders.

## Testing

`ReindexConfigTest` — new cases for raise / lower / add-where-absent (all in-place, no reindex, no backfill), removal (still reindexes), sub-field-only change, in-place change alongside a new field (no reindex but backfill required), in-place change alongside a real type change (reindexes), and that a pure addition is not misclassified as a parameter update.

`ESIndexBuilderTest` — `applyMappings` issues a `PutMappingRequest` when only `isInPlaceMappingParameterUpdate` is set.

`BuildIndicesIncrementalStepTest` — an in-place mapping update is applied without an incremental rebuild by default, and routed through `buildIndexIncremental` when reconciliation is enabled.

```
./gradlew :metadata-io:test \
  --tests "com.linkedin.metadata.search.indexbuilder.ReindexConfigTest" \
  --tests "com.linkedin.metadata.search.indexbuilder.ESIndexBuilderTest" \
  --tests "com.linkedin.metadata.system_info.collectors.PropertiesCollectorConfigurationTest" \
  -x generateGitPropertiesGlobal

./gradlew :datahub-upgrade:test \
  --tests "com.linkedin.datahub.upgrade.system.elasticsearch.steps.BuildIndicesIncrementalStepTest" \
  -x generateGitPropertiesGlobal
```

All passing (129 + 16, plus 298 in the v2/v3 mappings-builder suites for the constant hoist).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Links to related issues — n/a
- [x] Tests added/updated
- [ ] Docs added/updated — n/a, internal reindex-classification behaviour
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` — n/a, strictly reduces reindexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
