### PR TITLE
fix(entity-service): prevent ingest deadlocks via single-wave lock acquisition and retry backoff

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
@@ -60,11 +60,21 @@ public class DefaultAspectsUtil {
     return !item.getEntitySpec().getKeyAspectName().equals(item.getAspectName());
   }
 
+  /**
+   * Variant that answers entity existence from a caller-provided set instead of querying the
+   * database. Used by the ingest transaction, which has already read (and FOR UPDATE locked) every
+   * key aspect row in its up-front read — issuing another locking exists() query here would
+   * reintroduce the multi-wave lock acquisition that deadlocks against concurrent overlapping
+   * batches.
+   *
+   * @param urnsWithExistingKeyAspects batch urns whose key aspect row exists in the database
+   */
   public static AspectsBatch withAdditionalChanges(
       @Nonnull OperationContext opContext,
       @Nonnull final AspectsBatch inputBatch,
       @Nonnull EntityService<?> entityService,
-      boolean enableBrowseV2) {
+      boolean enableBrowseV2,
+      @Nonnull Set<Urn> urnsWithExistingKeyAspects) {
     /*
      * 1. When deadlock occurs within the transaction the default entity key may need to be removed. This cannot happen
      *    if the batch is fixed with a key aspect prior to the transaction.
@@ -82,30 +92,49 @@ public class DefaultAspectsUtil {
     // Key aspect restored if needed
     result.addAll(
         DefaultAspectsUtil.getAdditionalChanges(
-            opContext, inputBatch.getMCPItems(), entityService, enableBrowseV2));
+            opContext,
+            inputBatch.getMCPItems(),
+            entityService,
+            enableBrowseV2,
+            urnsWithExistingKeyAspects));
     return AspectsBatchImpl.builder()
         .retrieverContext(inputBatch.getRetrieverContext())
         .items(result)
         .build(opContext);
   }
 
+  /** Standalone variant: answers entity existence with a (non-locking) database read. */
   public static List<MCPItem> getAdditionalChanges(
       @Nonnull OperationContext opContext,
       @Nonnull Collection<MCPItem> batch,
       @Nonnull EntityService<?> entityService,
       boolean browsePathV2) {
 
+    Set<Urn> urns =
+        batch.stream()
+            .filter(item -> SUPPORTED_TYPES.contains(item.getChangeType()))
+            .map(BatchItem::getUrn)
+            .collect(Collectors.toSet());
+
+    return getAdditionalChanges(
+        opContext,
+        batch,
+        entityService,
+        browsePathV2,
+        entityService.exists(opContext, urns, true, false));
+  }
+
+  public static List<MCPItem> getAdditionalChanges(
+      @Nonnull OperationContext opContext,
+      @Nonnull Collection<MCPItem> batch,
+      @Nonnull EntityService<?> entityService,
+      boolean browsePathV2,
+      @Nonnull Set<Urn> urnsWithExistingKeyAspects) {
+
     Map<Urn, List<MCPItem>> itemsByUrn =
         batch.stream()
             .filter(item -> SUPPORTED_TYPES.contains(item.getChangeType()))
             .collect(Collectors.groupingBy(BatchItem::getUrn));
-
-    // Non-locking read: the ingest transaction (EntityServiceImpl.ingestAspectsToLocalDB) already
-    // holds FOR UPDATE locks on every key aspect row via its up-front lockLatestRows call. Taking
-    // locks here — a second locking statement — would reintroduce the multi-wave lock acquisition
-    // that deadlocks against concurrent overlapping batches.
-    Set<Urn> urnsWithExistingKeyAspects =
-        entityService.exists(opContext, itemsByUrn.keySet(), true, false);
 
     // create default aspects when key aspect is missing
     return itemsByUrn.entrySet().stream()

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
@@ -100,8 +100,12 @@ public class DefaultAspectsUtil {
             .filter(item -> SUPPORTED_TYPES.contains(item.getChangeType()))
             .collect(Collectors.groupingBy(BatchItem::getUrn));
 
+    // Non-locking read: the ingest transaction (EntityServiceImpl.ingestAspectsToLocalDB) already
+    // holds FOR UPDATE locks on every key aspect row via its up-front lockLatestRows call. Taking
+    // locks here — a second locking statement — would reintroduce the multi-wave lock acquisition
+    // that deadlocks against concurrent overlapping batches.
     Set<Urn> urnsWithExistingKeyAspects =
-        entityService.exists(opContext, itemsByUrn.keySet(), true, true);
+        entityService.exists(opContext, itemsByUrn.keySet(), true, false);
 
     // create default aspects when key aspect is missing
     return itemsByUrn.entrySet().stream()

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
@@ -100,6 +100,24 @@ public interface AspectDao {
       @Nonnull OperationContext opContext, Map<String, Set<String>> urnAspects, boolean forUpdate);
 
   /**
+   * Acquires write locks (e.g. {@code SELECT ... FOR UPDATE}) on the latest-version rows of the
+   * given urn/aspect pairs in a single statement, without reading the aspect payloads. Rows that do
+   * not exist are not locked (there is nothing to lock).
+   *
+   * <p>Intended to be the FIRST locking statement of a write transaction, covering the union of
+   * every row the transaction will later read with {@code forUpdate=true} or modify. Acquiring all
+   * locks in one statement prevents lock-ordering deadlocks between concurrent transactions:
+   * multi-statement (wave) acquisition deadlocks when two transactions' waves overlap crosswise,
+   * whereas a single statement acquires row locks in consistent scan order.
+   *
+   * <p>Implementations without row-level locking transactions may no-op.
+   *
+   * @param urnAspects urn/aspects whose latest-version rows should be locked
+   */
+  default void lockLatestRows(
+      @Nonnull OperationContext opContext, @Nonnull Map<String, Set<String>> urnAspects) {}
+
+  /**
    * Updates the system aspect
    *
    * @param operationContext

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
@@ -90,6 +90,13 @@ public interface AspectDao {
   }
 
   /**
+   * When {@code forUpdate=true}, implementations with row-level locking MUST acquire all row locks
+   * in a single statement: multi-statement (wave) lock acquisition deadlocks when two concurrent
+   * transactions' waves overlap crosswise, whereas a single statement acquires row locks in
+   * consistent scan order. Write transactions should issue ONE locking read covering the union of
+   * every row they will later read with {@code forUpdate=true} or modify, as their first statement
+   * (see {@code EntityServiceImpl#ingestAspectsToLocalDB}).
+   *
    * @param urnAspects urn/aspects to fetch
    * @param forUpdate set to true if the result is used for versioning <a
    *     href="https://ebean.io/docs/query/option#forUpdate">link</a>
@@ -98,24 +105,6 @@ public interface AspectDao {
   @Nonnull
   Map<String, Map<String, SystemAspect>> getLatestAspects(
       @Nonnull OperationContext opContext, Map<String, Set<String>> urnAspects, boolean forUpdate);
-
-  /**
-   * Acquires write locks (e.g. {@code SELECT ... FOR UPDATE}) on the latest-version rows of the
-   * given urn/aspect pairs in a single statement, without reading the aspect payloads. Rows that do
-   * not exist are not locked (there is nothing to lock).
-   *
-   * <p>Intended to be the FIRST locking statement of a write transaction, covering the union of
-   * every row the transaction will later read with {@code forUpdate=true} or modify. Acquiring all
-   * locks in one statement prevents lock-ordering deadlocks between concurrent transactions:
-   * multi-statement (wave) acquisition deadlocks when two transactions' waves overlap crosswise,
-   * whereas a single statement acquires row locks in consistent scan order.
-   *
-   * <p>Implementations without row-level locking transactions may no-op.
-   *
-   * @param urnAspects urn/aspects whose latest-version rows should be locked
-   */
-  default void lockLatestRows(
-      @Nonnull OperationContext opContext, @Nonnull Map<String, Set<String>> urnAspects) {}
 
   /**
    * Updates the system aspect

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1071,6 +1071,26 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
    * @return Details about the new and old version of the aspect
    */
   @Nonnull
+  /**
+   * The urn/aspect rows a batch's ingest transaction locks up front: each item's aspect row plus
+   * each entity's key aspect row (the latter is read by the exists() check in {@link
+   * DefaultAspectsUtil#withAdditionalChanges} and serializes concurrent writers of the same
+   * entity).
+   */
+  private static Map<String, Set<String>> batchLockTargets(@Nonnull final AspectsBatch batch) {
+    final Map<String, Set<String>> targets = new HashMap<>();
+    batch
+        .getUrnAspectsMap()
+        .forEach(
+            (urn, aspects) -> targets.computeIfAbsent(urn, k -> new HashSet<>()).addAll(aspects));
+    for (BatchItem item : batch.getItems()) {
+      targets
+          .computeIfAbsent(item.getUrn().toString(), k -> new HashSet<>())
+          .add(item.getEntitySpec().getKeyAspectName());
+    }
+    return targets;
+  }
+
   private IngestAspectsResult ingestAspectsToLocalDB(
       @Nonnull OperationContext opContext,
       @Nonnull final AspectsBatch inputBatch,
@@ -1098,6 +1118,17 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     .runInTransactionWithRetry(
                         opContext,
                         (txContext) -> {
+                          // Acquire all row locks for this batch in a SINGLE statement before any
+                          // other locking read. Acquiring locks in multiple statements (previously:
+                          // exists() inside withAdditionalChanges, then getLatestAspects below)
+                          // deadlocks when two concurrent batches overlap crosswise — each holds
+                          // rows from its first statement that the other's second statement needs.
+                          // The lock set is the union of every row this transaction reads with
+                          // forUpdate or modifies: each item's aspect row plus each entity's key
+                          // aspect row. Locking the key aspect row also preserves the per-entity
+                          // write mutex previously provided by the locking exists() check.
+                          aspectDao.lockLatestRows(opContext, batchLockTargets(inputBatch));
+
                           // Generate default aspects within the transaction (they are re-calculated
                           // on
                           // retry)

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1072,8 +1072,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
    */
   @Nonnull
   /**
-   * The urn/aspect rows a batch's ingest transaction locks up front: each item's aspect row plus
-   * each entity's key aspect row (the latter is read by the exists() check in {@link
+   * The urn/aspect rows a batch's ingest transaction locks and reads up front: each item's aspect
+   * row plus each entity's key aspect row (the latter answers the entity-existence check in {@link
    * DefaultAspectsUtil#withAdditionalChanges} and serializes concurrent writers of the same
    * entity).
    */
@@ -1089,6 +1089,58 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
           .add(item.getEntitySpec().getKeyAspectName());
     }
     return targets;
+  }
+
+  /** Urns from the batch whose key aspect row exists in the locked up-front read. */
+  private static Set<Urn> urnsWithExistingKeyAspects(
+      @Nonnull final AspectsBatch batch,
+      @Nonnull final Map<String, Map<String, SystemAspect>> lockedAspects) {
+    final Set<Urn> existing = new HashSet<>();
+    for (BatchItem item : batch.getItems()) {
+      if (lockedAspects
+          .getOrDefault(item.getUrn().toString(), Collections.emptyMap())
+          .containsKey(item.getEntitySpec().getKeyAspectName())) {
+        existing.add(item.getUrn());
+      }
+    }
+    return existing;
+  }
+
+  /** Restricts {@code source} to the urn/aspect pairs present in {@code pairs}. */
+  private static Map<String, Map<String, SystemAspect>> filterToPairs(
+      @Nonnull final Map<String, Map<String, SystemAspect>> source,
+      @Nonnull final Map<String, Set<String>> pairs) {
+    final Map<String, Map<String, SystemAspect>> filtered = new HashMap<>();
+    pairs.forEach(
+        (urn, aspects) -> {
+          Map<String, SystemAspect> sourceAspects = source.get(urn);
+          if (sourceAspects != null) {
+            for (String aspect : aspects) {
+              SystemAspect value = sourceAspects.get(aspect);
+              if (value != null) {
+                filtered.computeIfAbsent(urn, k -> new HashMap<>()).put(aspect, value);
+              }
+            }
+          }
+        });
+    return filtered;
+  }
+
+  /** The urn/aspect pairs in {@code pairs} that are not covered by {@code covered}. */
+  private static Map<String, Set<String>> uncoveredPairs(
+      @Nonnull final Map<String, Set<String>> pairs,
+      @Nonnull final Map<String, Set<String>> covered) {
+    final Map<String, Set<String>> uncovered = new HashMap<>();
+    pairs.forEach(
+        (urn, aspects) -> {
+          Set<String> coveredAspects = covered.getOrDefault(urn, Collections.emptySet());
+          for (String aspect : aspects) {
+            if (!coveredAspects.contains(aspect)) {
+              uncovered.computeIfAbsent(urn, k -> new HashSet<>()).add(aspect);
+            }
+          }
+        });
+    return uncovered;
   }
 
   private IngestAspectsResult ingestAspectsToLocalDB(
@@ -1118,40 +1170,55 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     .runInTransactionWithRetry(
                         opContext,
                         (txContext) -> {
-                          // Acquire all row locks for this batch in a SINGLE statement before any
-                          // other locking read. Acquiring locks in multiple statements (previously:
-                          // exists() inside withAdditionalChanges, then getLatestAspects below)
-                          // deadlocks when two concurrent batches overlap crosswise — each holds
-                          // rows from its first statement that the other's second statement needs.
-                          // The lock set is the union of every row this transaction reads with
-                          // forUpdate or modifies: each item's aspect row plus each entity's key
-                          // aspect row. Locking the key aspect row also preserves the per-entity
-                          // write mutex previously provided by the locking exists() check.
-                          aspectDao.lockLatestRows(opContext, batchLockTargets(inputBatch));
+                          // read #1 (also the transaction's lock acquisition)
+                          // READ COMMITTED is used in conjunction with SELECT FOR UPDATE (read
+                          // lock) to ensure that the aspect's version is not modified outside the
+                          // transaction. We rely on the retry mechanism if the row is modified and
+                          // will re-read (require the lock).
+                          //
+                          // All row locks for this batch are acquired in this SINGLE statement,
+                          // before any other locking read. Acquiring locks in multiple statements
+                          // (previously: exists() inside withAdditionalChanges, then a
+                          // getLatestAspects over the batch) deadlocks when two concurrent batches
+                          // overlap crosswise — each holds rows from its first statement that the
+                          // other's second statement needs. The lock set is the union of every row
+                          // this transaction reads with forUpdate or modifies: each item's aspect
+                          // row plus each entity's key aspect row. Locking the key aspect row also
+                          // preserves the per-entity write mutex previously provided by the
+                          // locking exists() check.
+                          final Map<String, Set<String>> lockTargets = batchLockTargets(inputBatch);
+                          final Map<String, Map<String, SystemAspect>> lockedAspects =
+                              aspectDao.getLatestAspects(opContext, lockTargets, true);
 
                           // Generate default aspects within the transaction (they are re-calculated
-                          // on
-                          // retry)
+                          // on retry). Entity existence is answered from the up-front read rather
+                          // than a second (locking) exists() query.
                           AspectsBatch batchWithDefaults =
                               DefaultAspectsUtil.withAdditionalChanges(
-                                  opContext, inputBatch, this, enableBrowseV2);
+                                  opContext,
+                                  inputBatch,
+                                  this,
+                                  enableBrowseV2,
+                                  urnsWithExistingKeyAspects(inputBatch, lockedAspects));
 
                           final Map<String, Set<String>> urnAspects =
                               batchWithDefaults.getUrnAspectsMap();
 
-                          // read #1
-                          // READ COMMITED is used in conjunction with SELECT FOR UPDATE (read lock)
-                          // in
-                          // order
-                          // to ensure that the aspect's version is not modified outside the
-                          // transaction.
-                          // We rely on the retry mechanism if the row is modified and will re-read
-                          // (require the
-                          // lock)
-
-                          // Initial database state from database
+                          // Initial database state: the up-front read restricted to the batch's
+                          // pairs, plus a follow-up read for pairs it did not cover (default
+                          // aspects generated for new entities — normally zero existing rows).
+                          Map<String, Map<String, SystemAspect>> initialAspects =
+                              filterToPairs(lockedAspects, urnAspects);
+                          final Map<String, Set<String>> unreadPairs =
+                              uncoveredPairs(urnAspects, lockTargets);
+                          if (!unreadPairs.isEmpty()) {
+                            initialAspects =
+                                AspectsBatch.merge(
+                                    initialAspects,
+                                    aspectDao.getLatestAspects(opContext, unreadPairs, true));
+                          }
                           final Map<String, Map<String, SystemAspect>> batchAspects =
-                              aspectDao.getLatestAspects(opContext, urnAspects, true);
+                              initialAspects;
                           final Map<String, Map<String, SystemAspect>> updatedLatestAspects;
 
                           // read #2 (potentially)

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/TransactionContext.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/TransactionContext.java
@@ -4,6 +4,7 @@ import io.ebean.DuplicateKeyException;
 import io.ebean.Transaction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
@@ -16,6 +17,8 @@ import org.springframework.lang.Nullable;
 @Accessors(fluent = true)
 public class TransactionContext {
   public static final int DEFAULT_MAX_TRANSACTION_RETRY = 3;
+  public static final long RETRY_BACKOFF_BASE_MS = 50;
+  public static final long RETRY_BACKOFF_MAX_MS = 2000;
 
   public static TransactionContext empty() {
     return empty(DEFAULT_MAX_TRANSACTION_RETRY);
@@ -58,6 +61,38 @@ public class TransactionContext {
 
   public boolean shouldAttemptRetry() {
     return exceptions.size() <= maxRetries;
+  }
+
+  /**
+   * Sleeps with exponential backoff and jitter before the next retry attempt. Immediate lockstep
+   * retries tend to re-collide with the concurrent transaction that caused the failure (e.g. a
+   * deadlock victim retrying while its peer is still mid-transaction); jitter desynchronizes the
+   * contenders so a retry can succeed.
+   */
+  public void backoffBeforeRetry() {
+    long backoffMs = nextBackoffMs(exceptions.size());
+    if (backoffMs > 0) {
+      try {
+        Thread.sleep(backoffMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Backoff for the given number of failed attempts: base * 2^(attempts-1), jittered to 50-150% of
+   * that value, capped at {@link #RETRY_BACKOFF_MAX_MS}. Returns 0 for non-positive attempts.
+   */
+  static long nextBackoffMs(int failedAttempts) {
+    if (failedAttempts <= 0) {
+      return 0;
+    }
+    long exponential =
+        Math.min(
+            RETRY_BACKOFF_MAX_MS, RETRY_BACKOFF_BASE_MS * (1L << Math.min(failedAttempts - 1, 20)));
+    double jitter = 0.5 + ThreadLocalRandom.current().nextDouble();
+    return Math.min(RETRY_BACKOFF_MAX_MS, (long) (exponential * jitter));
   }
 
   public void commitAndContinue() {

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -212,44 +212,15 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
                                     entry.getKey(), aspect, ASPECT_LATEST_VERSION)))
             .collect(Collectors.toSet());
 
-    // Use batchGet to chunk large IN clauses and avoid optimizer memory exhaustion
-    // (range_optimizer_max_mem_size)
-    final List<EbeanAspectV2> results =
-        batchGet(opContext, keys, queryKeysCount, forUpdate && canWrite);
+    // Non-locking reads use batchGet chunking to bound IN-clause size and avoid optimizer memory
+    // exhaustion (range_optimizer_max_mem_size). Locking reads must NOT be chunked: a FOR UPDATE
+    // read split across multiple statements acquires locks in waves, and two concurrent
+    // transactions whose waves overlap crosswise deadlock. All row locks are acquired in a single
+    // statement instead.
+    final boolean locking = forUpdate && canWrite;
+    final int chunkSize = locking ? Math.max(keys.size(), 1) : queryKeysCount;
+    final List<EbeanAspectV2> results = batchGet(opContext, keys, chunkSize, locking);
     return toUrnAspectMap(opContext.getEntityRegistry(), results, opContext);
-  }
-
-  @Override
-  public void lockLatestRows(
-      @Nonnull OperationContext opContext, @Nonnull Map<String, Set<String>> urnAspects) {
-    validateConnection();
-    if (!canWrite || urnAspects.isEmpty()) {
-      return;
-    }
-
-    List<EbeanAspectV2.PrimaryKey> keys =
-        urnAspects.entrySet().stream()
-            .flatMap(
-                entry ->
-                    entry.getValue().stream()
-                        .map(
-                            aspect ->
-                                new EbeanAspectV2.PrimaryKey(
-                                    entry.getKey(), aspect, ASPECT_LATEST_VERSION)))
-            .sorted()
-            .collect(Collectors.toList());
-
-    // Deliberately unchunked (unlike getLatestAspects): splitting the FOR UPDATE across multiple
-    // statements reintroduces the multi-wave lock acquisition this method exists to prevent.
-    // Same unchunked idIn().forUpdate() pattern as getNextVersions. Selecting only the urn column
-    // keeps this a lock-only read without transferring aspect payloads.
-    server
-        .find(EbeanAspectV2.class)
-        .select(EbeanAspectV2.URN_COLUMN)
-        .where()
-        .idIn(keys)
-        .forUpdate()
-        .findList();
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -220,6 +220,39 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
   }
 
   @Override
+  public void lockLatestRows(
+      @Nonnull OperationContext opContext, @Nonnull Map<String, Set<String>> urnAspects) {
+    validateConnection();
+    if (!canWrite || urnAspects.isEmpty()) {
+      return;
+    }
+
+    List<EbeanAspectV2.PrimaryKey> keys =
+        urnAspects.entrySet().stream()
+            .flatMap(
+                entry ->
+                    entry.getValue().stream()
+                        .map(
+                            aspect ->
+                                new EbeanAspectV2.PrimaryKey(
+                                    entry.getKey(), aspect, ASPECT_LATEST_VERSION)))
+            .sorted()
+            .collect(Collectors.toList());
+
+    // Deliberately unchunked (unlike getLatestAspects): splitting the FOR UPDATE across multiple
+    // statements reintroduces the multi-wave lock acquisition this method exists to prevent.
+    // Same unchunked idIn().forUpdate() pattern as getNextVersions. Selecting only the urn column
+    // keeps this a lock-only read without transferring aspect payloads.
+    server
+        .find(EbeanAspectV2.class)
+        .select(EbeanAspectV2.URN_COLUMN)
+        .where()
+        .idIn(keys)
+        .forUpdate()
+        .findList();
+  }
+
+  @Override
   public long countEntities(@Nonnull OperationContext opContext) {
     validateConnection();
     return server
@@ -977,6 +1010,9 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
           metricUtils.increment(MetricRegistry.name(this.getClass(), "txFailed"), 1);
         log.warn("Retryable PersistenceException: {}", exception.getMessage());
         transactionContext.addException(exception);
+        if (transactionContext.shouldAttemptRetry()) {
+          transactionContext.backoffBeforeRetry();
+        }
       }
     } while (transactionContext.shouldAttemptRetry());
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/PostgresTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/PostgresTestUtils.java
@@ -114,7 +114,7 @@ public final class PostgresTestUtils {
   @Nonnull
   public static Database createEbeanDatabase(
       @Nonnull PostgreSQLContainer<?> container, @Nonnull String serverName) {
-    return createEbeanDatabase(container, serverName, false, false);
+    return createEbeanDatabase(container, serverName, false, false, null);
   }
 
   /**
@@ -124,7 +124,34 @@ public final class PostgresTestUtils {
   @Nonnull
   public static Database createEbeanPrimaryDatabase(
       @Nonnull PostgreSQLContainer<?> container, @Nonnull String serverName) {
-    return createEbeanDatabase(container, serverName, true, false);
+    return createEbeanDatabase(container, serverName, true, false, null);
+  }
+
+  /**
+   * Primary Ebean pool confined to its own PostgreSQL schema. Use when a test class runs aspect
+   * DDL: suite classes execute in parallel, and two classes drop/creating {@code
+   * metadata_aspect_v2} in the shared {@code public} schema race each other. The schema is created
+   * if absent; pass {@link #newIntegrationNamespace(String)}'s schema for a unique namespace.
+   */
+  @Nonnull
+  public static Database createEbeanPrimaryDatabase(
+      @Nonnull PostgreSQLContainer<?> container,
+      @Nonnull String serverName,
+      @Nonnull String schema) {
+    createSchemaIfAbsent(container, schema);
+    return createEbeanDatabase(container, serverName, true, false, schema);
+  }
+
+  private static void createSchemaIfAbsent(
+      @Nonnull PostgreSQLContainer<?> container, @Nonnull String schema) {
+    try (java.sql.Connection connection =
+            java.sql.DriverManager.getConnection(
+                container.getJdbcUrl(), container.getUsername(), container.getPassword());
+        java.sql.Statement statement = connection.createStatement()) {
+      statement.execute("CREATE SCHEMA IF NOT EXISTS " + schema);
+    } catch (java.sql.SQLException e) {
+      throw new IllegalStateException("Failed to create test schema " + schema, e);
+    }
   }
 
   /**
@@ -133,7 +160,7 @@ public final class PostgresTestUtils {
   @Nonnull
   public static Database createEbeanReadPoolDatabase(
       @Nonnull PostgreSQLContainer<?> container, @Nonnull String serverName) {
-    return createEbeanDatabase(container, serverName, false, true);
+    return createEbeanDatabase(container, serverName, false, true, null);
   }
 
   @Nonnull
@@ -141,9 +168,14 @@ public final class PostgresTestUtils {
       @Nonnull PostgreSQLContainer<?> container,
       @Nonnull String serverName,
       boolean runAspectDdl,
-      boolean readOnlyPool) {
+      boolean readOnlyPool,
+      @Nullable String schema) {
     DataSourceConfig dsc = new DataSourceConfig();
-    dsc.setUrl(container.getJdbcUrl());
+    String url = container.getJdbcUrl();
+    if (schema != null) {
+      url += (url.contains("?") ? "&" : "?") + "currentSchema=" + schema;
+    }
+    dsc.setUrl(url);
     dsc.setUsername(container.getUsername());
     dsc.setPassword(container.getPassword());
     dsc.setDriver("org.postgresql.Driver");

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -40,6 +40,9 @@ public class EbeanEntityServiceOptimizationTest {
   /*
    Counts for ORM optimization calculations
   */
+  // Up-front single-statement FOR UPDATE lock acquisition (AspectDao.lockLatestRows), the first
+  // statement of every ingest transaction (prevents multi-wave lock-ordering deadlocks)
+  private static final int upfrontLockAcquisition = 1;
   // Default Aspect Generation Step
   // 1. *Key,
   // 2. browsePathsV2 & dataPlatformInstance
@@ -51,7 +54,7 @@ public class EbeanEntityServiceOptimizationTest {
   private static final int defaultAspectsNextVersion = 2;
   // Final default select
   private static final int nonExistingBaseCount =
-      defaultAspectsGeneration + defaultAspectsNextVersion;
+      upfrontLockAcquisition + defaultAspectsGeneration + defaultAspectsNextVersion;
 
   // Existing
   // 1. *Key
@@ -60,7 +63,8 @@ public class EbeanEntityServiceOptimizationTest {
   // 1. dataHubRetentionConfig (if enabled add 1 for read)
   private static final int existingRetention = 0;
   // Final default select existing (no retention)
-  private static final int existingBaseCount = existingDefaultAspectsGeneration + existingRetention;
+  private static final int existingBaseCount =
+      upfrontLockAcquisition + existingDefaultAspectsGeneration + existingRetention;
 
   private final OperationContext opContext =
       TestOperationContexts.systemContextNoSearchAuthorization();

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -38,13 +38,14 @@ import org.testng.annotations.Test;
 
 public class EbeanEntityServiceOptimizationTest {
   /*
-   Counts for ORM optimization calculations
+   Counts for ORM optimization calculations.
+   The transaction's first statement is a single up-front FOR UPDATE read over the batch's aspect
+   rows plus each entity's key aspect row; it replaced the separate locking exists() check
+   (single-wave lock acquisition, prevents lock-ordering deadlocks), so totals match the
+   pre-lock-rework counts: the up-front read is counted where the exists()/key read used to be.
   */
-  // Up-front single-statement FOR UPDATE lock acquisition (AspectDao.lockLatestRows), the first
-  // statement of every ingest transaction (prevents multi-wave lock-ordering deadlocks)
-  private static final int upfrontLockAcquisition = 1;
   // Default Aspect Generation Step
-  // 1. *Key,
+  // 1. up-front locking read (*Key + batch aspects)
   // 2. browsePathsV2 & dataPlatformInstance
   // 3. dataPlatformInfo
   private static final int defaultAspectsGeneration = 3;
@@ -54,17 +55,17 @@ public class EbeanEntityServiceOptimizationTest {
   private static final int defaultAspectsNextVersion = 2;
   // Final default select
   private static final int nonExistingBaseCount =
-      upfrontLockAcquisition + defaultAspectsGeneration + defaultAspectsNextVersion;
+      defaultAspectsGeneration + defaultAspectsNextVersion;
 
   // Existing
-  // 1. *Key
-  private static final int existingDefaultAspectsGeneration = 1;
+  // 0. key-existence check shares the up-front locking read (counted at call sites as the final
+  //    select), so default aspect generation issues no SQL of its own for existing entities
+  private static final int existingDefaultAspectsGeneration = 0;
   // Retention lookup (disabled for test)
   // 1. dataHubRetentionConfig (if enabled add 1 for read)
   private static final int existingRetention = 0;
   // Final default select existing (no retention)
-  private static final int existingBaseCount =
-      upfrontLockAcquisition + existingDefaultAspectsGeneration + existingRetention;
+  private static final int existingBaseCount = existingDefaultAspectsGeneration + existingRetention;
 
   private final OperationContext opContext =
       TestOperationContexts.systemContextNoSearchAuthorization();

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/TransactionContextTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/TransactionContextTest.java
@@ -1,0 +1,42 @@
+package com.linkedin.metadata.entity;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class TransactionContextTest {
+
+  @Test
+  public void testNextBackoffMs_zeroForNoFailures() {
+    assertEquals(TransactionContext.nextBackoffMs(0), 0);
+    assertEquals(TransactionContext.nextBackoffMs(-1), 0);
+  }
+
+  @Test
+  public void testNextBackoffMs_growsExponentiallyWithJitterBounds() {
+    for (int attempt = 1; attempt <= 5; attempt++) {
+      long expectedExponential =
+          Math.min(
+              TransactionContext.RETRY_BACKOFF_MAX_MS,
+              TransactionContext.RETRY_BACKOFF_BASE_MS * (1L << (attempt - 1)));
+      for (int i = 0; i < 100; i++) {
+        long backoff = TransactionContext.nextBackoffMs(attempt);
+        assertTrue(
+            backoff >= expectedExponential / 2,
+            String.format("attempt %d: backoff %d below jitter floor", attempt, backoff));
+        assertTrue(
+            backoff
+                <= Math.min(TransactionContext.RETRY_BACKOFF_MAX_MS, expectedExponential * 3 / 2),
+            String.format("attempt %d: backoff %d above jitter ceiling", attempt, backoff));
+      }
+    }
+  }
+
+  @Test
+  public void testNextBackoffMs_cappedAtMax() {
+    for (int i = 0; i < 100; i++) {
+      assertTrue(TransactionContext.nextBackoffMs(30) <= TransactionContext.RETRY_BACKOFF_MAX_MS);
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
@@ -1,0 +1,278 @@
+package com.linkedin.metadata.entity.ebean;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.metadata.EbeanTestUtils;
+import com.linkedin.metadata.PostgresTestUtils;
+import com.linkedin.metadata.config.EbeanConfiguration;
+import com.linkedin.metadata.entity.EntityAspectIdentifier;
+import com.linkedin.metadata.entity.storage.PrimaryStorageTestUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import io.ebean.Database;
+import io.ebean.Transaction;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Characterizes the PostgreSQL row-lock behavior of {@link EbeanAspectDao#batchGet} with {@code
+ * forUpdate=true}, reproducing the production deadlock seen on the logical-model ingest path
+ * ({@code EntityServiceImpl.ingestAspectsToLocalDB}).
+ *
+ * <p>Findings encoded here:
+ *
+ * <ul>
+ *   <li>Two concurrent <em>single-statement</em> {@code FOR UPDATE} batchGets over overlapping key
+ *       sets do NOT deadlock: PostgreSQL plans the composite-key IN query as a (bitmap) scan that
+ *       locks rows in physical heap order, which is identical for both statements regardless of
+ *       IN-list order. Sorting the IN-list is therefore not a fix on PostgreSQL.
+ *   <li>Deadlocks arise when transactions acquire locks in <em>multiple waves</em> (multiple
+ *       locking statements per transaction), as the ingest path did before {@code
+ *       AspectDao.lockLatestRows}: {@code exists(..., forUpdate=true)} (wave 1) followed by {@code
+ *       getLatestAspects(..., forUpdate=true)} (wave 2). Two transactions whose waves overlap
+ *       crosswise deadlock deterministically — this was the production failure mode behind
+ *       "RetryLimitReached: Failed to add after 3 retries".
+ * </ul>
+ *
+ * <p>The fix: {@code EntityServiceImpl.ingestAspectsToLocalDB} now acquires the batch's full lock
+ * set in one up-front {@code lockLatestRows} statement (see {@link
+ * EntityServiceConcurrentIngestPostgresIT} for the end-to-end regression test). The cross-wave test
+ * below intentionally still demonstrates the deadlock at the DAO level — it documents WHY
+ * single-wave acquisition is required and must keep passing (i.e. keep deadlocking) as long as
+ * PostgreSQL locking semantics are what they are.
+ */
+public class EbeanAspectDaoConcurrentLockPostgresIT {
+
+  private static final String KEY_ASPECT = "schemaFieldKey";
+  private static final int ROWS = 200;
+  private static final int SINGLE_STATEMENT_ITERATIONS = 50;
+
+  private PostgreSQLContainer<?> postgres;
+  private Database database;
+  private EbeanAspectDao aspectDao;
+  private OperationContext opContext;
+
+  /** All seeded key identifiers, in insertion (physical) order. */
+  private List<EntityAspectIdentifier> allKeys;
+
+  @BeforeClass
+  public void init() {
+    postgres = PostgresTestUtils.startPostgres();
+    database =
+        PostgresTestUtils.createEbeanPrimaryDatabase(
+            postgres,
+            PostgresTestUtils.uniqueServerName("lock_wave_it"),
+            PostgresTestUtils.newIntegrationNamespace("lock_wave").getSchema());
+    aspectDao =
+        new EbeanAspectDao(
+            PrimaryStorageTestUtils.ebeanResolver(database),
+            EbeanConfiguration.testDefault,
+            null,
+            List.of(),
+            null);
+    aspectDao.setConnectionValidated(true);
+    opContext = TestOperationContexts.systemContextNoValidate();
+
+    allKeys = new ArrayList<>(ROWS);
+    for (int i = 0; i < ROWS; i++) {
+      String urn =
+          String.format(
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:mainframe,lock_it,PROD),field_%d)",
+              i);
+      EbeanAspectV2 row = new EbeanAspectV2();
+      row.setUrn(urn);
+      row.setAspect(KEY_ASPECT);
+      row.setVersion(0L);
+      row.setMetadata("{}");
+      row.setCreatedBy("urn:li:corpuser:test");
+      row.setCreatedOn(new Timestamp(System.currentTimeMillis()));
+      database.save(row);
+      allKeys.add(new EntityAspectIdentifier(urn, KEY_ASPECT, 0L));
+    }
+    database.sqlUpdate("ANALYZE metadata_aspect_v2").execute();
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    EbeanTestUtils.shutdownDatabase(database);
+  }
+
+  /**
+   * Two concurrent transactions each acquiring all their locks in ONE batchGet statement never
+   * deadlock, even over overlapping key sets: PostgreSQL locks rows in physical scan order, which
+   * is consistent across both statements. This is the invariant a single-wave locking fix relies
+   * on.
+   */
+  @Test(timeOut = 300_000)
+  public void singleStatementForUpdate_overlappingSets_noDeadlock() throws Exception {
+    Set<EntityAspectIdentifier> setA = new HashSet<>(allKeys.subList(0, 150));
+    Set<EntityAspectIdentifier> setB = new HashSet<>(allKeys.subList(50, 200));
+
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    AtomicInteger deadlocks = new AtomicInteger();
+    AtomicInteger unexpectedFailures = new AtomicInteger();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> workerA =
+          executor.submit(() -> singleStatementLoop(setA, barrier, deadlocks, unexpectedFailures));
+      Future<?> workerB =
+          executor.submit(() -> singleStatementLoop(setB, barrier, deadlocks, unexpectedFailures));
+      workerA.get(120, TimeUnit.SECONDS);
+      workerB.get(120, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertEquals(unexpectedFailures.get(), 0, "Non-deadlock failures during concurrent batchGet");
+    assertEquals(
+        deadlocks.get(), 0, "Single-statement FOR UPDATE batchGets must not deadlock each other");
+  }
+
+  /**
+   * Reproduces the production deadlock: each transaction locks rows in TWO waves (two batchGet FOR
+   * UPDATE statements), and the waves overlap crosswise. Transaction A locks rows [0,100) then
+   * wants [100,200); transaction B locks [100,200) then wants [0,100). This mirrors {@code
+   * ingestAspectsToLocalDB}: {@code exists()} locks key-aspect rows, then {@code
+   * getLatestAspects()} locks batch-aspect rows, so two ingests touching overlapping entities
+   * interlock across statements.
+   *
+   * <p>This test asserts the deadlock DOES occur, characterizing the defect. A fix that collapses
+   * lock acquisition into a single wave (or otherwise prevents the interlock) should flip this
+   * assertion to zero deadlocks.
+   */
+  @Test(timeOut = 300_000)
+  public void crossWaveForUpdate_overlappingSets_deadlocks() throws Exception {
+    Set<EntityAspectIdentifier> firstHalf = new HashSet<>(allKeys.subList(0, 100));
+    Set<EntityAspectIdentifier> secondHalf = new HashSet<>(allKeys.subList(100, 200));
+
+    // Both threads hold their wave-1 locks before either starts wave 2.
+    CyclicBarrier midTransactionBarrier = new CyclicBarrier(2);
+    AtomicInteger deadlocks = new AtomicInteger();
+    AtomicInteger commits = new AtomicInteger();
+    AtomicInteger unexpectedFailures = new AtomicInteger();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> workerA =
+          executor.submit(
+              () ->
+                  twoWaveTransaction(
+                      firstHalf,
+                      secondHalf,
+                      midTransactionBarrier,
+                      deadlocks,
+                      commits,
+                      unexpectedFailures));
+      Future<?> workerB =
+          executor.submit(
+              () ->
+                  twoWaveTransaction(
+                      secondHalf,
+                      firstHalf,
+                      midTransactionBarrier,
+                      deadlocks,
+                      commits,
+                      unexpectedFailures));
+      workerA.get(120, TimeUnit.SECONDS);
+      workerB.get(120, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertEquals(unexpectedFailures.get(), 0, "Non-deadlock failures during cross-wave locking");
+    // PostgreSQL picks exactly one victim; the survivor's second wave proceeds and commits.
+    assertEquals(
+        deadlocks.get(),
+        1,
+        "Cross-wave FOR UPDATE lock acquisition should deadlock (production failure mode); "
+            + "if this now reports 0, the locking strategy changed — update this test to assert "
+            + "the fixed behavior");
+    assertEquals(commits.get(), 1, "The non-victim transaction should commit successfully");
+  }
+
+  private void singleStatementLoop(
+      Set<EntityAspectIdentifier> keys,
+      CyclicBarrier barrier,
+      AtomicInteger deadlocks,
+      AtomicInteger unexpectedFailures) {
+    for (int i = 0; i < SINGLE_STATEMENT_ITERATIONS; i++) {
+      try {
+        barrier.await(30, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        return;
+      }
+      try (Transaction transaction = database.beginTransaction()) {
+        forceIndexPlan();
+        aspectDao.batchGet(opContext, keys, true);
+        transaction.commit();
+      } catch (Exception e) {
+        if (isDeadlock(e)) {
+          deadlocks.incrementAndGet();
+        } else {
+          unexpectedFailures.incrementAndGet();
+        }
+      }
+    }
+  }
+
+  private void twoWaveTransaction(
+      Set<EntityAspectIdentifier> waveOne,
+      Set<EntityAspectIdentifier> waveTwo,
+      CyclicBarrier midTransactionBarrier,
+      AtomicInteger deadlocks,
+      AtomicInteger commits,
+      AtomicInteger unexpectedFailures) {
+    try (Transaction transaction = database.beginTransaction()) {
+      forceIndexPlan();
+      aspectDao.batchGet(opContext, waveOne, true);
+      try {
+        midTransactionBarrier.await(30, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        unexpectedFailures.incrementAndGet();
+        return;
+      }
+      aspectDao.batchGet(opContext, waveTwo, true);
+      transaction.commit();
+      commits.incrementAndGet();
+    } catch (Exception e) {
+      if (isDeadlock(e)) {
+        deadlocks.incrementAndGet();
+      } else {
+        unexpectedFailures.incrementAndGet();
+      }
+    }
+  }
+
+  /**
+   * The test table is tiny, so the planner would seq-scan. Production metadata_aspect_v2 is large
+   * and plans these queries as index/bitmap scans; force the comparable plan shape. (Lock order is
+   * physical heap order either way, but keep the plan honest.)
+   */
+  private void forceIndexPlan() {
+    database.sqlUpdate("SET LOCAL enable_seqscan = off").execute();
+  }
+
+  private static boolean isDeadlock(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      String message = cause.getMessage();
+      if (message != null && message.contains("deadlock detected")) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
@@ -28,17 +28,17 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Guards the PostgreSQL locking invariant that single-wave lock acquisition ({@code
- * AspectDao.lockLatestRows}) relies on: two concurrent <em>single-statement</em> {@code FOR UPDATE}
- * batchGets over overlapping key sets cannot deadlock, because PostgreSQL acquires multi-row locks
- * in physical scan order, which is consistent across both statements regardless of IN-list order.
+ * Guards the PostgreSQL locking invariant that the ingest path's single up-front locking read
+ * relies on: two concurrent <em>single-statement</em> {@code FOR UPDATE} reads over overlapping key
+ * sets cannot deadlock, because PostgreSQL acquires multi-row locks in physical scan order, which
+ * is consistent across both statements regardless of IN-list order.
  *
  * <p>Deadlocks arise only when a transaction acquires locks in multiple statements ("waves"), as
- * the ingest path did before {@code lockLatestRows}: {@code exists(..., forUpdate=true)} followed
- * by {@code getLatestAspects(..., forUpdate=true)}. Two transactions whose waves overlap crosswise
- * interlock — the production failure mode behind "RetryLimitReached: Failed to add after 3
- * retries". See {@link EntityServiceConcurrentIngestPostgresIT} for the end-to-end regression test
- * of the fixed ingest path.
+ * the ingest path once did: {@code exists(..., forUpdate=true)} followed by {@code
+ * getLatestAspects(..., forUpdate=true)}. Two transactions whose waves overlap crosswise interlock
+ * — the production failure mode behind "RetryLimitReached: Failed to add after 3 retries". See
+ * {@link EntityServiceConcurrentIngestPostgresIT} for the end-to-end regression test of the fixed
+ * ingest path.
  */
 public class EbeanAspectDaoConcurrentLockPostgresIT {
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoConcurrentLockPostgresIT.java
@@ -28,31 +28,17 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Characterizes the PostgreSQL row-lock behavior of {@link EbeanAspectDao#batchGet} with {@code
- * forUpdate=true}, reproducing the production deadlock seen on the logical-model ingest path
- * ({@code EntityServiceImpl.ingestAspectsToLocalDB}).
+ * Guards the PostgreSQL locking invariant that single-wave lock acquisition ({@code
+ * AspectDao.lockLatestRows}) relies on: two concurrent <em>single-statement</em> {@code FOR UPDATE}
+ * batchGets over overlapping key sets cannot deadlock, because PostgreSQL acquires multi-row locks
+ * in physical scan order, which is consistent across both statements regardless of IN-list order.
  *
- * <p>Findings encoded here:
- *
- * <ul>
- *   <li>Two concurrent <em>single-statement</em> {@code FOR UPDATE} batchGets over overlapping key
- *       sets do NOT deadlock: PostgreSQL plans the composite-key IN query as a (bitmap) scan that
- *       locks rows in physical heap order, which is identical for both statements regardless of
- *       IN-list order. Sorting the IN-list is therefore not a fix on PostgreSQL.
- *   <li>Deadlocks arise when transactions acquire locks in <em>multiple waves</em> (multiple
- *       locking statements per transaction), as the ingest path did before {@code
- *       AspectDao.lockLatestRows}: {@code exists(..., forUpdate=true)} (wave 1) followed by {@code
- *       getLatestAspects(..., forUpdate=true)} (wave 2). Two transactions whose waves overlap
- *       crosswise deadlock deterministically — this was the production failure mode behind
- *       "RetryLimitReached: Failed to add after 3 retries".
- * </ul>
- *
- * <p>The fix: {@code EntityServiceImpl.ingestAspectsToLocalDB} now acquires the batch's full lock
- * set in one up-front {@code lockLatestRows} statement (see {@link
- * EntityServiceConcurrentIngestPostgresIT} for the end-to-end regression test). The cross-wave test
- * below intentionally still demonstrates the deadlock at the DAO level — it documents WHY
- * single-wave acquisition is required and must keep passing (i.e. keep deadlocking) as long as
- * PostgreSQL locking semantics are what they are.
+ * <p>Deadlocks arise only when a transaction acquires locks in multiple statements ("waves"), as
+ * the ingest path did before {@code lockLatestRows}: {@code exists(..., forUpdate=true)} followed
+ * by {@code getLatestAspects(..., forUpdate=true)}. Two transactions whose waves overlap crosswise
+ * interlock — the production failure mode behind "RetryLimitReached: Failed to add after 3
+ * retries". See {@link EntityServiceConcurrentIngestPostgresIT} for the end-to-end regression test
+ * of the fixed ingest path.
  */
 public class EbeanAspectDaoConcurrentLockPostgresIT {
 
@@ -142,68 +128,6 @@ public class EbeanAspectDaoConcurrentLockPostgresIT {
         deadlocks.get(), 0, "Single-statement FOR UPDATE batchGets must not deadlock each other");
   }
 
-  /**
-   * Reproduces the production deadlock: each transaction locks rows in TWO waves (two batchGet FOR
-   * UPDATE statements), and the waves overlap crosswise. Transaction A locks rows [0,100) then
-   * wants [100,200); transaction B locks [100,200) then wants [0,100). This mirrors {@code
-   * ingestAspectsToLocalDB}: {@code exists()} locks key-aspect rows, then {@code
-   * getLatestAspects()} locks batch-aspect rows, so two ingests touching overlapping entities
-   * interlock across statements.
-   *
-   * <p>This test asserts the deadlock DOES occur, characterizing the defect. A fix that collapses
-   * lock acquisition into a single wave (or otherwise prevents the interlock) should flip this
-   * assertion to zero deadlocks.
-   */
-  @Test(timeOut = 300_000)
-  public void crossWaveForUpdate_overlappingSets_deadlocks() throws Exception {
-    Set<EntityAspectIdentifier> firstHalf = new HashSet<>(allKeys.subList(0, 100));
-    Set<EntityAspectIdentifier> secondHalf = new HashSet<>(allKeys.subList(100, 200));
-
-    // Both threads hold their wave-1 locks before either starts wave 2.
-    CyclicBarrier midTransactionBarrier = new CyclicBarrier(2);
-    AtomicInteger deadlocks = new AtomicInteger();
-    AtomicInteger commits = new AtomicInteger();
-    AtomicInteger unexpectedFailures = new AtomicInteger();
-
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    try {
-      Future<?> workerA =
-          executor.submit(
-              () ->
-                  twoWaveTransaction(
-                      firstHalf,
-                      secondHalf,
-                      midTransactionBarrier,
-                      deadlocks,
-                      commits,
-                      unexpectedFailures));
-      Future<?> workerB =
-          executor.submit(
-              () ->
-                  twoWaveTransaction(
-                      secondHalf,
-                      firstHalf,
-                      midTransactionBarrier,
-                      deadlocks,
-                      commits,
-                      unexpectedFailures));
-      workerA.get(120, TimeUnit.SECONDS);
-      workerB.get(120, TimeUnit.SECONDS);
-    } finally {
-      executor.shutdownNow();
-    }
-
-    assertEquals(unexpectedFailures.get(), 0, "Non-deadlock failures during cross-wave locking");
-    // PostgreSQL picks exactly one victim; the survivor's second wave proceeds and commits.
-    assertEquals(
-        deadlocks.get(),
-        1,
-        "Cross-wave FOR UPDATE lock acquisition should deadlock (production failure mode); "
-            + "if this now reports 0, the locking strategy changed — update this test to assert "
-            + "the fixed behavior");
-    assertEquals(commits.get(), 1, "The non-victim transaction should commit successfully");
-  }
-
   private void singleStatementLoop(
       Set<EntityAspectIdentifier> keys,
       CyclicBarrier barrier,
@@ -225,34 +149,6 @@ public class EbeanAspectDaoConcurrentLockPostgresIT {
         } else {
           unexpectedFailures.incrementAndGet();
         }
-      }
-    }
-  }
-
-  private void twoWaveTransaction(
-      Set<EntityAspectIdentifier> waveOne,
-      Set<EntityAspectIdentifier> waveTwo,
-      CyclicBarrier midTransactionBarrier,
-      AtomicInteger deadlocks,
-      AtomicInteger commits,
-      AtomicInteger unexpectedFailures) {
-    try (Transaction transaction = database.beginTransaction()) {
-      forceIndexPlan();
-      aspectDao.batchGet(opContext, waveOne, true);
-      try {
-        midTransactionBarrier.await(30, TimeUnit.SECONDS);
-      } catch (Exception e) {
-        unexpectedFailures.incrementAndGet();
-        return;
-      }
-      aspectDao.batchGet(opContext, waveTwo, true);
-      transaction.commit();
-      commits.incrementAndGet();
-    } catch (Exception e) {
-      if (isDeadlock(e)) {
-        deadlocks.incrementAndGet();
-      } else {
-        unexpectedFailures.incrementAndGet();
       }
     }
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EntityServiceConcurrentIngestPostgresIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EntityServiceConcurrentIngestPostgresIT.java
@@ -1,0 +1,174 @@
+package com.linkedin.metadata.entity.ebean;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.AspectGenerationUtils;
+import com.linkedin.metadata.EbeanTestUtils;
+import com.linkedin.metadata.PostgresTestUtils;
+import com.linkedin.metadata.config.EbeanConfiguration;
+import com.linkedin.metadata.config.PreProcessHooks;
+import com.linkedin.metadata.entity.EntityServiceImpl;
+import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
+import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
+import com.linkedin.metadata.entity.storage.PrimaryStorageTestUtils;
+import com.linkedin.metadata.event.EventProducer;
+import com.linkedin.metadata.service.UpdateIndicesService;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import io.ebean.Database;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * End-to-end regression test for the ingest deadlock (RetryLimitReached under concurrent
+ * overlapping batches): two threads repeatedly ingest aspect batches over overlapping URN sets
+ * through the real {@link EntityServiceImpl} path against PostgreSQL.
+ *
+ * <p>Before single-wave lock acquisition ({@code AspectDao.lockLatestRows}), each ingest
+ * transaction locked rows in multiple statements — {@code exists()} inside {@code
+ * withAdditionalChanges}, then {@code getLatestAspects} — so concurrent overlapping batches could
+ * interlock crosswise and exhaust the retry budget. With the fix, every batch's locks are acquired
+ * in a single up-front statement and concurrent ingests serialize instead of deadlocking. See
+ * {@link EbeanAspectDaoConcurrentLockPostgresIT} for the statement-level characterization.
+ */
+public class EntityServiceConcurrentIngestPostgresIT {
+
+  private static final int TOTAL_URNS = 150;
+  private static final int OVERLAP_START = 50; // thread A: [0,100), thread B: [50,150)
+  private static final int ROUNDS = 10;
+
+  private final OperationContext opContext =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+
+  private PostgreSQLContainer<?> postgres;
+  private Database database;
+  private EntityServiceImpl entityService;
+  private List<Urn> urns;
+
+  @BeforeClass
+  public void init() {
+    postgres = PostgresTestUtils.startPostgres();
+    database =
+        PostgresTestUtils.createEbeanPrimaryDatabase(
+            postgres,
+            PostgresTestUtils.uniqueServerName("concurrent_ingest_it"),
+            PostgresTestUtils.newIntegrationNamespace("concurrent_ingest").getSchema());
+
+    EbeanAspectDao aspectDao =
+        new EbeanAspectDao(
+            PrimaryStorageTestUtils.ebeanResolver(database),
+            EbeanConfiguration.testDefault,
+            null,
+            List.of(),
+            null);
+    PreProcessHooks preProcessHooks = new PreProcessHooks();
+    preProcessHooks.setUiEnabled(true);
+    entityService =
+        new EntityServiceImpl(aspectDao, mock(EventProducer.class), false, preProcessHooks, true);
+    entityService.setUpdateIndicesService(mock(UpdateIndicesService.class));
+    entityService.setRetentionService(null);
+
+    urns = new ArrayList<>(TOTAL_URNS);
+    for (int i = 0; i < TOTAL_URNS; i++) {
+      urns.add(
+          UrnUtils.getUrn(
+              String.format(
+                  "urn:li:dataset:(urn:li:dataPlatform:concurrent,ingest_it_%d,PROD)", i)));
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void tearDown() {
+    EbeanTestUtils.shutdownDatabase(database);
+  }
+
+  @Test(timeOut = 600_000)
+  public void concurrentOverlappingIngests_succeedWithoutRetryExhaustion() throws Exception {
+    List<Urn> urnsA = urns.subList(0, TOTAL_URNS - OVERLAP_START);
+    List<Urn> urnsB = urns.subList(OVERLAP_START, TOTAL_URNS);
+
+    CyclicBarrier barrier = new CyclicBarrier(2);
+    AtomicInteger successfulIngests = new AtomicInteger();
+    List<Throwable> failures = new ArrayList<>();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> workerA =
+          executor.submit(() -> ingestLoop(urnsA, barrier, successfulIngests, failures));
+      Future<?> workerB =
+          executor.submit(() -> ingestLoop(urnsB, barrier, successfulIngests, failures));
+      workerA.get(540, TimeUnit.SECONDS);
+      workerB.get(540, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertTrue(
+        failures.isEmpty(),
+        "Concurrent overlapping ingests failed (deadlock/retry exhaustion?): " + failures);
+    assertEquals(successfulIngests.get(), 2 * ROUNDS);
+
+    // Sanity: aspects actually landed
+    Status status =
+        (Status)
+            entityService.getLatestAspect(
+                opContext, urns.get(OVERLAP_START), "status"); // in both threads' ranges
+    assertEquals(status.isRemoved(), Boolean.FALSE);
+  }
+
+  private void ingestLoop(
+      List<Urn> targetUrns,
+      CyclicBarrier barrier,
+      AtomicInteger successfulIngests,
+      List<Throwable> failures) {
+    for (int round = 0; round < ROUNDS; round++) {
+      try {
+        barrier.await(60, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        synchronized (failures) {
+          failures.add(e);
+        }
+        return;
+      }
+      try {
+        List<ChangeItemImpl> items = new ArrayList<>(targetUrns.size());
+        for (Urn urn : targetUrns) {
+          items.add(
+              ChangeItemImpl.builder()
+                  .urn(urn)
+                  .aspectName("status")
+                  .recordTemplate(new Status().setRemoved(false))
+                  .systemMetadata(AspectGenerationUtils.createSystemMetadata())
+                  .auditStamp(AspectGenerationUtils.createAuditStamp())
+                  .build(TestOperationContexts.emptyActiveUsersAspectRetriever(null)));
+        }
+        AspectsBatchImpl batch =
+            AspectsBatchImpl.builder()
+                .retrieverContext(opContext.getRetrieverContext())
+                .items(items)
+                .build(opContext);
+        entityService.ingestAspects(opContext, batch, true, true);
+        successfulIngests.incrementAndGet();
+      } catch (Throwable t) {
+        synchronized (failures) {
+          failures.add(t);
+        }
+      }
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EntityServiceConcurrentIngestPostgresIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EntityServiceConcurrentIngestPostgresIT.java
@@ -39,12 +39,12 @@ import org.testng.annotations.Test;
  * overlapping batches): two threads repeatedly ingest aspect batches over overlapping URN sets
  * through the real {@link EntityServiceImpl} path against PostgreSQL.
  *
- * <p>Before single-wave lock acquisition ({@code AspectDao.lockLatestRows}), each ingest
- * transaction locked rows in multiple statements — {@code exists()} inside {@code
- * withAdditionalChanges}, then {@code getLatestAspects} — so concurrent overlapping batches could
- * interlock crosswise and exhaust the retry budget. With the fix, every batch's locks are acquired
- * in a single up-front statement and concurrent ingests serialize instead of deadlocking. See
- * {@link EbeanAspectDaoConcurrentLockPostgresIT} for the statement-level characterization.
+ * <p>Before single-wave lock acquisition, each ingest transaction locked rows in multiple
+ * statements — {@code exists()} inside {@code withAdditionalChanges}, then {@code getLatestAspects}
+ * — so concurrent overlapping batches could interlock crosswise and exhaust the retry budget. With
+ * the fix, every batch's locks are acquired by a single up-front locking read and concurrent
+ * ingests serialize instead of deadlocking. See {@link EbeanAspectDaoConcurrentLockPostgresIT} for
+ * the statement-level characterization.
  */
 public class EntityServiceConcurrentIngestPostgresIT {
 

--- a/metadata-io/src/test/resources/testng-other.xml
+++ b/metadata-io/src/test/resources/testng-other.xml
@@ -17,6 +17,17 @@
 
         <!-- Explicitly exclude the specific test class -->
         <classes>
+            <!-- PostgreSQL Testcontainers ITs run in the testPostgresql leg (testng-postgresql.xml) -->
+            <class name="com.linkedin.metadata.entity.ebean.EbeanAspectDaoConcurrentLockPostgresIT">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
+            <class name="com.linkedin.metadata.entity.ebean.EntityServiceConcurrentIngestPostgresIT">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
             <class name="com.linkedin.metadata.entity.EbeanEntityServiceOptimizationTest">
                 <methods>
                     <exclude name=".*" />

--- a/metadata-io/src/test/resources/testng-postgresql.xml
+++ b/metadata-io/src/test/resources/testng-postgresql.xml
@@ -7,5 +7,9 @@
             <package name="com.linkedin.metadata.sqlsetup.postgres.pgqueue"/>
             <package name="com.linkedin.metadata.entity.storage"/>
         </packages>
+        <classes>
+            <class name="com.linkedin.metadata.entity.ebean.EbeanAspectDaoConcurrentLockPostgresIT"/>
+            <class name="com.linkedin.metadata.entity.ebean.EntityServiceConcurrentIngestPostgresIT"/>
+        </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Summary

Concurrent ingest transactions over overlapping entities can deadlock in PostgreSQL and exhaust the transaction retry budget, failing the request with `RetryLimitReached: Failed to add after 3 retries` and dropping the write. Observed in production on the logical-model link endpoint (`setLogicalParents`), where each request writes ~280 schemaField aspects and concurrent requests/propagation share rows.

### Root cause

Each ingest transaction acquired `FOR UPDATE` row locks in **multiple statements** ("waves"):

1. `exists(..., forUpdate=true)` inside `DefaultAspectsUtil.withAdditionalChanges` — locks key-aspect rows
2. `getLatestAspects(..., forUpdate=true)` — locks batch-aspect rows

Two transactions whose waves overlap crosswise interlock: each holds rows from its first statement that the other's second statement needs. Notably, per-statement key ordering (the `Collections.sort` used elsewhere in `EbeanAspectDao` with a "required to avoid deadlocks" comment) **cannot** fix this on PostgreSQL: multi-row `FOR UPDATE` locks are acquired in physical scan order (Seq Scan / BitmapOr → Bitmap Heap Scan), not IN-list order — verified by `EXPLAIN` and by test, see "Proof of the mechanism" below.

### Fix

- **Single-wave lock acquisition**: the ingest transaction's FIRST statement is now one unchunked `getLatestAspects(forUpdate=true)` over the union of the batch's aspect rows and each entity's key-aspect row. That single read supplies (a) all row locks in one statement, (b) the entity-existence answer for `DefaultAspectsUtil.withAdditionalChanges` (new overload accepting the existing-urns set — the separate locking `exists()` query is gone), and (c) the initial batch state (filtered to the batch's pairs; a follow-up read covers default aspects generated for new entities, normally matching zero rows). Locking the key-aspect row preserves the per-entity write mutex previously provided by the locking `exists()`, so `CreateIfNotExists` semantics, new-aspect version calculation, and delete-vs-ingest serialization are unchanged. `getLatestAspects` no longer chunks **locking** reads (chunked `FOR UPDATE` acquires locks in deadlock-prone waves); non-locking reads keep the existing chunking.
- **`TransactionContext.backoffBeforeRetry`**: exponential backoff with jitter (50ms base, 2s cap) between transaction retries. Previously retries were immediate, so colliding workloads retried in lockstep and re-collided until the budget was exhausted. This also covers residual multi-wave cases (mid-transaction side-effect lock acquisition).

### Performance

Measured with a local ingest benchmark against a PostgreSQL testcontainer (p50 wall time of `EntityServiceImpl.ingestAspects`):

| workload | before | this PR |
|---|---|---|
| 1 aspect, new entity | 3.13ms | 2.91ms |
| 1 aspect, existing entity | 1.09ms | 0.85ms |
| 100-aspect batch (existing) | 9.32ms | 11.35ms |
| 300-aspect batch (existing) | 26.44ms | 38.27ms |

Single-aspect writes — the highest-volume path — get faster (one SQL statement removed per transaction). Large batches pay a residual cost for planning one 2N-tuple row-IN instead of two N-tuple statements; that cannot be split back into multiple statements without reintroducing the multi-wave deadlock. An earlier iteration of this PR used a separate lock-only statement (`lockLatestRows`, commit ce5d49f8d1a); it was replaced after benchmarking showed the double-read cost (+67% p50 on 300-aspect batches vs +45% here on the same run conditions... see commit aaf21354d8f for the full comparison).

### Proof of the mechanism

Commit ce5d49f8d1a included a `crossWaveForUpdate_overlappingSets_deadlocks` test that **deterministically reproduced** the production deadlock: two transactions each lock 100 rows in one `FOR UPDATE` statement, then (with both holding their first wave, coordinated by a barrier) request each other's rows in a second statement — PostgreSQL detects the deadlock after `deadlock_timeout` (~1s) and kills exactly one victim, matching the production failure signature. The companion single-statement test in the same class shows the same overlapping key sets can NOT deadlock when each transaction acquires all locks in one statement — the invariant this fix relies on.

The cross-wave test was removed in b42e99f4d90: it characterized PostgreSQL behavior rather than guarding our code, and cost a guaranteed ~1s per CI run. Interested parties can check out ce5d49f8d1a to run the reproduction. The single-statement invariant test remains in CI.

### Tests

- `EbeanAspectDaoConcurrentLockPostgresIT` (Testcontainers PostgreSQL): guards the locking invariant — single-statement `FOR UPDATE` over overlapping sets never deadlocks.
- `EntityServiceConcurrentIngestPostgresIT`: end-to-end regression test — two threads concurrently ingest overlapping aspect batches through the real `EntityServiceImpl` path against PostgreSQL.
- `TransactionContextTest`: backoff bounds/jitter.
- `EbeanEntityServiceOptimizationTest`: SELECT counts updated — existing-entity transactions now issue one fewer SELECT than before this PR.
- `PostgresTestUtils`: per-class schema isolation for tests that run aspect DDL (parallel suite classes raced on `metadata_aspect_v2` drop/create).
- Both ITs wired into the `testPostgresql` CI leg (`testng-postgresql.xml`), excluded from `testng-other.xml`.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)