### PR TITLE
feat(ui): add drag-resize to HierarchicalBrowseSidebar

### DIFF
--- a/datahub-web-react/src/app/context/ContextRoutes.tsx
+++ b/datahub-web-react/src/app/context/ContextRoutes.tsx
@@ -11,7 +11,7 @@ import {
     HierarchicalBrowseMainContent,
 } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseLayout.components';
 import { SIDEBAR_COLLAPSED_WIDTH } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
-import useSidebarWidth from '@app/sharedV2/sidebar/useSidebarWidth';
+import useHierarchicalBrowseSidebarWidth from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/useHierarchicalBrowseSidebarWidth';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 import { PageRoutes } from '@conf/Global';
@@ -34,7 +34,7 @@ export default function ContextRoutes() {
     const [isCollapsed, setIsCollapsed] = useState(false);
     // Start hidden - DocumentProfile controls visibility based on document type
     const [isSidebarHidden, setIsSidebarHidden] = useState(true);
-    const expandedSidebarWidth = useSidebarWidth(0.2);
+    const { width: expandedSidebarWidth, setWidth: setExpandedSidebarWidth } = useHierarchicalBrowseSidebarWidth();
 
     // Check if we're on an entity profile page (document/:urn)
     const documentPath = `/${entityRegistry.getPathName(EntityType.Document)}/:urn`;
@@ -74,6 +74,7 @@ export default function ContextRoutes() {
                             isCollapsed={isCollapsed}
                             onToggleCollapsed={toggleCollapsed}
                             onExpandSidebar={expandSidebar}
+                            onWidthChange={setExpandedSidebarWidth}
                         />
                     )}
                     <HierarchicalBrowseMainContent>

--- a/datahub-web-react/src/app/context/ContextSidebar.tsx
+++ b/datahub-web-react/src/app/context/ContextSidebar.tsx
@@ -74,6 +74,7 @@ type Props = {
     isCollapsed?: boolean;
     onToggleCollapsed?: () => void;
     onExpandSidebar?: () => void;
+    onWidthChange?: (width: number) => void;
 };
 
 export default function ContextSidebar({
@@ -81,6 +82,7 @@ export default function ContextSidebar({
     isCollapsed = false,
     onToggleCollapsed,
     onExpandSidebar,
+    onWidthChange,
 }: Props) {
     const { t } = useTranslation('misc');
     const { t: tc } = useTranslation('common.actions');
@@ -275,6 +277,7 @@ export default function ContextSidebar({
             isCollapsed={isCollapsed}
             onToggleCollapsed={onToggleCollapsed}
             onExpandSidebar={onExpandSidebar}
+            onWidthChange={onWidthChange}
             headerActions={headerActions}
             dataTestId="context-documents-sidebar"
             collapseButtonTestId="context-sidebar-collapse-button"

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainFlatItem.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainFlatItem.tsx
@@ -175,7 +175,7 @@ export default function DomainFlatItem({ domain }: Props) {
             </IconSlot>
             <TextStack>
                 <TitleRow>
-                    <Tooltip placement="right" title={displayName} mouseEnterDelay={0.7} mouseLeaveDelay={0}>
+                    <Tooltip placement="right" title={displayName} mouseEnterDelay={0.1} mouseLeaveDelay={0}>
                         <Title $isSelected={isOnEntityPage}>{displayName}</Title>
                     </Tooltip>
                     {deprecation?.deprecated && (
@@ -193,7 +193,7 @@ export default function DomainFlatItem({ domain }: Props) {
                     <Tooltip
                         placement="bottom"
                         title={ancestorNames.join(' / ')}
-                        mouseEnterDelay={0.7}
+                        mouseEnterDelay={0.1}
                         mouseLeaveDelay={0}
                     >
                         <Breadcrumb>

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
@@ -317,7 +317,7 @@ export default function DomainNode({
                         />
                     </ButtonWrapper>
                 )}
-                <Tooltip placement="right" title={displayName} mouseEnterDelay={0.7} mouseLeaveDelay={0}>
+                <Tooltip placement="right" title={displayName} mouseEnterDelay={0.1} mouseLeaveDelay={0}>
                     <NameWrapper
                         onClick={handleSelectDomain}
                         $isSelected={isDomainNodeSelected}
@@ -327,7 +327,7 @@ export default function DomainNode({
                             <Tooltip
                                 placement="right"
                                 title={isCollapsed && displayName}
-                                mouseEnterDelay={0.7}
+                                mouseEnterDelay={0.1}
                                 mouseLeaveDelay={0}
                             >
                                 <DomainColoredIcon domain={domain} size={30} fontSize={14} />

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
@@ -72,6 +72,14 @@ export const CollapsedScrollColumn = styled.div`
     ${scrollbar}
 `;
 
+export const SidebarShell = styled.div`
+    position: relative;
+    flex-shrink: 0;
+    align-self: stretch;
+    height: 100%;
+    max-height: 100%;
+`;
+
 export const SidebarContainer = styled.div<{
     $isCollapsed: boolean;
     $width: number;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
@@ -76,16 +76,19 @@ export const SidebarContainer = styled.div<{
     $isCollapsed: boolean;
     $width: number;
     $isShowNavBarRedesign?: boolean;
+    $isResizing?: boolean;
 }>`
+    position: relative;
     flex-shrink: 0;
     height: 100%;
     max-height: 100%;
     align-self: stretch;
     width: ${(props) => (props.$isCollapsed ? `${SIDEBAR_COLLAPSED_WIDTH}px` : `${props.$width}px`)};
     min-width: ${(props) => (props.$isCollapsed ? `${SIDEBAR_COLLAPSED_WIDTH}px` : `${props.$width}px`)};
-    transition:
-        width ${SIDEBAR_TRANSITION_MS}ms ease-in-out,
-        min-width ${SIDEBAR_TRANSITION_MS}ms ease-in-out;
+    transition: ${(props) =>
+        props.$isResizing
+            ? 'none'
+            : `width ${SIDEBAR_TRANSITION_MS}ms ease-in-out, min-width ${SIDEBAR_TRANSITION_MS}ms ease-in-out`};
     background-color: ${(props) => props.theme.colors.bg};
     border-radius: ${(props) =>
         props.$isShowNavBarRedesign ? props.theme.styles['border-radius-navbar-redesign'] : '8px'};

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.tsx
@@ -13,6 +13,7 @@ import {
     SearchIconButton,
     SearchSlot,
     SidebarContainer,
+    SidebarShell,
     SidebarTitle,
     ThinDivider,
     TreeContainer,
@@ -251,30 +252,32 @@ export default function HierarchicalBrowseSidebar({
     }
 
     return (
-        <SidebarContainer
-            $isCollapsed={isCollapsed}
-            $width={width}
-            $isShowNavBarRedesign={isShowNavBarRedesign}
-            $isResizing={isResizing}
-            data-testid={dataTestId}
-            id={id}
-            className={className}
-        >
-            <HeaderControls $isCollapsed={isCollapsed}>
-                {!isCollapsed && title != null ? <SidebarTitle>{title}</SidebarTitle> : null}
-                <HeaderButtons>
-                    {!isCollapsed && headerActions}
-                    {collapseTooltipTitle ? (
-                        <Tooltip title={collapseTooltipTitle} placement="right" showArrow={false}>
-                            {collapseButton}
-                        </Tooltip>
-                    ) : (
-                        collapseButton
-                    )}
-                </HeaderButtons>
-            </HeaderControls>
-            <ThinDivider />
-            {body}
+        <SidebarShell>
+            <SidebarContainer
+                $isCollapsed={isCollapsed}
+                $width={width}
+                $isShowNavBarRedesign={isShowNavBarRedesign}
+                $isResizing={isResizing}
+                data-testid={dataTestId}
+                id={id}
+                className={className}
+            >
+                <HeaderControls $isCollapsed={isCollapsed}>
+                    {!isCollapsed && title != null ? <SidebarTitle>{title}</SidebarTitle> : null}
+                    <HeaderButtons>
+                        {!isCollapsed && headerActions}
+                        {collapseTooltipTitle ? (
+                            <Tooltip title={collapseTooltipTitle} placement="right" showArrow={false}>
+                                {collapseButton}
+                            </Tooltip>
+                        ) : (
+                            collapseButton
+                        )}
+                    </HeaderButtons>
+                </HeaderControls>
+                <ThinDivider />
+                {body}
+            </SidebarContainer>
             {canResize && !isCollapsed && (
                 <SidebarResizer
                     width={width}
@@ -283,6 +286,6 @@ export default function HierarchicalBrowseSidebar({
                     onResizeEnd={() => setIsResizing(false)}
                 />
             )}
-        </SidebarContainer>
+        </SidebarShell>
     );
 }

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.tsx
@@ -2,7 +2,7 @@ import { Button, Tooltip } from '@components';
 import { ArrowLineLeft } from '@phosphor-icons/react/dist/csr/ArrowLineLeft';
 import { ArrowLineRight } from '@phosphor-icons/react/dist/csr/ArrowLineRight';
 import { MagnifyingGlass } from '@phosphor-icons/react/dist/csr/MagnifyingGlass';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import {
     Content,
@@ -20,12 +20,13 @@ import {
 import SidebarCollapsedIconRail, {
     type SidebarCollapsedIconRailProps,
 } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarCollapsedIconRail';
+import SidebarResizer from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarResizer';
 import { TREE_ROW_ENTITY_ICON_SIZE } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
+import useHierarchicalBrowseSidebarWidth from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/useHierarchicalBrowseSidebarWidth';
 import {
     resolveCollapsedBodyMode,
     shouldPlaceHomeAboveDivider,
 } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/sidebarLayout';
-import useSidebarWidth from '@app/sharedV2/sidebar/useSidebarWidth';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 
 type BodyRenderProps = {
@@ -85,8 +86,13 @@ type Props = {
     collapseButtonTestId?: string;
     expandTooltip?: string;
     collapseTooltip?: string;
-    /** Skip internal width calculation when the parent already owns width. */
+    /**
+     * Skip internal width + resizer when the parent already owns width.
+     * Prefer omitting this so drag-resize + persistence stay enabled.
+     */
     width?: number;
+    /** Fired when the user resizes (and on mount with the resolved width). */
+    onWidthChange?: (width: number) => void;
     className?: string;
 };
 
@@ -117,15 +123,29 @@ export default function HierarchicalBrowseSidebar({
     expandTooltip,
     collapseTooltip,
     width: widthOverride,
+    onWidthChange,
     className,
 }: Props) {
     const isShowNavBarRedesign = useShowNavBarRedesign();
-    const measuredWidth = useSidebarWidth(0.2);
-    const width = widthOverride ?? measuredWidth;
+    const { width: resizableWidth, setWidth } = useHierarchicalBrowseSidebarWidth();
+    const width = widthOverride ?? resizableWidth;
+    const canResize = widthOverride == null;
 
+    const [isResizing, setIsResizing] = useState(false);
     const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(defaultCollapsed);
     const isControlled = controlledCollapsed !== undefined;
     const isCollapsed = isControlled ? controlledCollapsed : uncontrolledCollapsed;
+
+    useEffect(() => {
+        onWidthChange?.(width);
+    }, [width, onWidthChange]);
+
+    const handleResizeWidth = useCallback(
+        (next: number) => {
+            setWidth(next);
+        },
+        [setWidth],
+    );
 
     const toggleCollapsed = useCallback(() => {
         if (onToggleCollapsed) {
@@ -235,6 +255,7 @@ export default function HierarchicalBrowseSidebar({
             $isCollapsed={isCollapsed}
             $width={width}
             $isShowNavBarRedesign={isShowNavBarRedesign}
+            $isResizing={isResizing}
             data-testid={dataTestId}
             id={id}
             className={className}
@@ -254,6 +275,14 @@ export default function HierarchicalBrowseSidebar({
             </HeaderControls>
             <ThinDivider />
             {body}
+            {canResize && !isCollapsed && (
+                <SidebarResizer
+                    width={width}
+                    onWidthChange={handleResizeWidth}
+                    onResizeStart={() => setIsResizing(true)}
+                    onResizeEnd={() => setIsResizing(false)}
+                />
+            )}
         </SidebarContainer>
     );
 }

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
@@ -1,4 +1,4 @@
-import { Pill } from '@components';
+import { Pill, Tooltip } from '@components';
 import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import React from 'react';
@@ -119,18 +119,30 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
             icon
         );
 
+        const titleEl = <TreeRowTitle $isSelected={isSelected}>{label}</TreeRowTitle>;
+        const titledLabel =
+            labelTitle != null && labelTitle !== '' ? (
+                <Tooltip
+                    title={labelTitle}
+                    placement="right"
+                    mouseEnterDelay={0.1}
+                    mouseLeaveDelay={0}
+                    showArrow={false}
+                >
+                    {titleEl}
+                </Tooltip>
+            ) : (
+                titleEl
+            );
+
         const titleBlock =
             afterLabel != null ? (
                 <TitleContent>
-                    <TreeRowTitle $isSelected={isSelected} title={labelTitle}>
-                        {label}
-                    </TreeRowTitle>
+                    {titledLabel}
                     {afterLabel}
                 </TitleContent>
             ) : (
-                <TreeRowTitle $isSelected={isSelected} title={labelTitle}>
-                    {label}
-                </TreeRowTitle>
+                titledLabel
             );
 
         return (

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarResizer.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarResizer.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useRef } from 'react';
+import styled from 'styled-components';
+
+type Props = {
+    width: number;
+    onWidthChange: (width: number) => void;
+    onResizeStart?: () => void;
+    onResizeEnd?: () => void;
+};
+
+/**
+ * Absolute hit target on the sidebar’s right edge — no layout width.
+ * Sits on the border (inside) so the page gap is unchanged.
+ */
+const ResizerBar = styled.div`
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 8px;
+    cursor: col-resize;
+    z-index: 2;
+`;
+
+/** Left-sidebar drag handle — drag right to widen. */
+export default function SidebarResizer({ width, onWidthChange, onResizeStart, onResizeEnd }: Props) {
+    const dragRef = useRef<{ initialX: number; initialWidth: number } | null>(null);
+
+    const onMouseDown = useCallback(
+        (event: React.MouseEvent) => {
+            dragRef.current = { initialX: event.clientX, initialWidth: width };
+            onResizeStart?.();
+
+            const onMove = (moveEvent: MouseEvent) => {
+                const drag = dragRef.current;
+                if (!drag) return;
+                const delta = moveEvent.clientX - drag.initialX;
+                onWidthChange(drag.initialWidth + delta);
+            };
+
+            const onUp = () => {
+                dragRef.current = null;
+                window.removeEventListener('mousemove', onMove);
+                window.removeEventListener('mouseup', onUp);
+                onResizeEnd?.();
+            };
+
+            window.addEventListener('mousemove', onMove);
+            window.addEventListener('mouseup', onUp);
+            event.preventDefault();
+        },
+        [width, onWidthChange, onResizeStart, onResizeEnd],
+    );
+
+    return <ResizerBar role="separator" aria-orientation="vertical" onMouseDown={onMouseDown} />;
+}

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarResizer.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarResizer.tsx
@@ -9,15 +9,16 @@ type Props = {
 };
 
 /**
- * Absolute hit target on the sidebar’s right edge — no layout width.
- * Sits on the border (inside) so the page gap is unchanged.
+ * Hit target centered on the sidebar’s right border, extending into the layout
+ * gap — not over row actions / carets inside the sidebar.
  */
 const ResizerBar = styled.div`
     position: absolute;
     top: 0;
-    right: 0;
     bottom: 0;
+    right: 0;
     width: 8px;
+    transform: translateX(50%);
     cursor: col-resize;
     z-index: 2;
 `;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants.ts
@@ -1,6 +1,13 @@
 export const SIDEBAR_TRANSITION_MS = 300;
 export const SIDEBAR_COLLAPSED_WIDTH = 63;
 
+/** Drag-resize bounds (same ballpark as search BrowseSidebar). */
+export const SIDEBAR_MIN_WIDTH = 260;
+export const SIDEBAR_MAX_WIDTH = 500;
+
+/** Shared across Glossary / Domains / Documents / Metrics. */
+export const SIDEBAR_WIDTH_STORAGE_KEY = 'hierarchicalBrowseSidebarWidth';
+
 /** Gap between the browse sidebar and the page container. */
 export const HIERARCHICAL_BROWSE_GAP_PX = 8;
 

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/useHierarchicalBrowseSidebarWidth.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/useHierarchicalBrowseSidebarWidth.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+
+import {
+    clampSidebarWidth,
+    readStoredSidebarWidth,
+    writeStoredSidebarWidth,
+} from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/sidebarWidth';
+import useSidebarWidth from '@app/sharedV2/sidebar/useSidebarWidth';
+
+/**
+ * Shared expanded width for hierarchical browse sidebars.
+ * Prefers a persisted user drag; otherwise tracks viewport × 0.2 (clamped).
+ */
+export default function useHierarchicalBrowseSidebarWidth(): {
+    width: number;
+    setWidth: (width: number) => void;
+} {
+    const measuredWidth = useSidebarWidth(0.2);
+    const [userWidth, setUserWidth] = useState<number | null>(() => readStoredSidebarWidth());
+
+    const width = userWidth ?? clampSidebarWidth(measuredWidth);
+
+    const setWidth = useCallback((next: number) => {
+        const clamped = clampSidebarWidth(next);
+        setUserWidth(clamped);
+        writeStoredSidebarWidth(clamped);
+    }, []);
+
+    return { width, setWidth };
+}

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/__tests__/sidebarWidth.test.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/__tests__/sidebarWidth.test.ts
@@ -1,0 +1,52 @@
+import {
+    SIDEBAR_MAX_WIDTH,
+    SIDEBAR_MIN_WIDTH,
+    SIDEBAR_WIDTH_STORAGE_KEY,
+} from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
+import {
+    clampSidebarWidth,
+    readStoredSidebarWidth,
+    writeStoredSidebarWidth,
+} from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/sidebarWidth';
+
+describe('clampSidebarWidth', () => {
+    it('clamps below min and above max', () => {
+        expect(clampSidebarWidth(100)).toBe(SIDEBAR_MIN_WIDTH);
+        expect(clampSidebarWidth(900)).toBe(SIDEBAR_MAX_WIDTH);
+    });
+
+    it('passes through values in range', () => {
+        expect(clampSidebarWidth(320)).toBe(320);
+        expect(clampSidebarWidth(SIDEBAR_MIN_WIDTH)).toBe(SIDEBAR_MIN_WIDTH);
+        expect(clampSidebarWidth(SIDEBAR_MAX_WIDTH)).toBe(SIDEBAR_MAX_WIDTH);
+    });
+});
+
+describe('sidebar width localStorage helpers', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('returns null when nothing is stored', () => {
+        expect(readStoredSidebarWidth()).toBeNull();
+    });
+
+    it('writes a clamped width and reads it back', () => {
+        writeStoredSidebarWidth(340);
+        expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe('340');
+        expect(readStoredSidebarWidth()).toBe(340);
+    });
+
+    it('clamps on write and read', () => {
+        writeStoredSidebarWidth(50);
+        expect(readStoredSidebarWidth()).toBe(SIDEBAR_MIN_WIDTH);
+
+        localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, '9999');
+        expect(readStoredSidebarWidth()).toBe(SIDEBAR_MAX_WIDTH);
+    });
+
+    it('returns null for non-numeric storage', () => {
+        localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, 'nope');
+        expect(readStoredSidebarWidth()).toBeNull();
+    });
+});

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/sidebarWidth.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/sidebarWidth.ts
@@ -1,0 +1,34 @@
+import {
+    SIDEBAR_MAX_WIDTH,
+    SIDEBAR_MIN_WIDTH,
+    SIDEBAR_WIDTH_STORAGE_KEY,
+} from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
+
+export function clampSidebarWidth(width: number): number {
+    return Math.min(Math.max(width, SIDEBAR_MIN_WIDTH), SIDEBAR_MAX_WIDTH);
+}
+
+/** Returns a clamped stored width, or null if missing / invalid. */
+export function readStoredSidebarWidth(): number | null {
+    try {
+        const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
+        if (raw == null || raw === '') {
+            return null;
+        }
+        const parsed = Number(raw);
+        if (!Number.isFinite(parsed)) {
+            return null;
+        }
+        return clampSidebarWidth(parsed);
+    } catch {
+        return null;
+    }
+}
+
+export function writeStoredSidebarWidth(width: number): void {
+    try {
+        localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)));
+    } catch {
+        // private mode / quota — ignore
+    }
+}

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -63,14 +63,18 @@ export class DocumentPage extends BasePage {
     this.getDropdownOption = (option: string) => page.getByTestId(`option-${option}`);
     this.getEditorTextbox = () => this.editorSection.getByRole('textbox');
     this.getMoveSearchInput = () => this.movePopover.getByPlaceholder('Search context...');
-    this.getMoveOptionInDropdown = () => this.getDropdownMenu().getByText('Move');
+    this.getMoveOptionInDropdown = () =>
+      // Prefer the visible open menu — Ant may leave hidden menus in the DOM.
+      // eslint-disable-next-line playwright/no-raw-locators
+      this.page.locator('[role="menu"]:visible').getByText(/move/i);
     // Ant Design's SimpleSelect uses .ant-dropdown-trigger for the dropdown trigger element.
     // This is the standard way to identify the clickable element that opens the dropdown.
     // eslint-disable-next-line playwright/no-raw-locators
     this.getStatusSelectTrigger = () => page.getByTestId('document-status-select').locator('.ant-dropdown-trigger');
     // eslint-disable-next-line playwright/no-raw-locators
     this.getTypeSelectTrigger = () => page.getByTestId('document-type-select').locator('.ant-dropdown-trigger');
-    this.getDropdownMenu = () => page.getByRole('menu');
+    // eslint-disable-next-line playwright/no-raw-locators
+    this.getDropdownMenu = () => page.locator('[role="menu"]:visible');
     this.getDeleteMenuOption = () => this.getDropdownMenu().getByText(/delete/i, { exact: false });
     this.getDeleteButton = () => page.getByRole('button', { name: 'Delete' });
     this.getDeleteConfirmDialog = () => page.getByText('Delete Document');
@@ -243,20 +247,21 @@ export class DocumentPage extends BasePage {
 
   async clickTreeItemMenu(urn: string): Promise<void> {
     const treeItem = this.getTreeItem(urn);
-    await expect(treeItem).toBeVisible();
+    await expect(treeItem).toBeVisible({ timeout: TIMEOUTS.LONG });
     await treeItem.scrollIntoViewIfNeeded();
     await treeItem.hover();
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     const menuButton = this.getTreeItemMenuButton(urn);
-    await expect(menuButton).toBeVisible();
+    await expect(menuButton).toBeVisible({ timeout: TIMEOUTS.LONG });
     await menuButton.click();
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // eslint-disable-next-line playwright/no-raw-locators
+    await expect(this.page.locator('[role="menu"]:visible')).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
   }
 
   async clickMoveOption(): Promise<void> {
     const moveOption = this.getMoveOptionInDropdown();
-    await expect(moveOption).toBeVisible();
-    await moveOption.click({ force: true });
+    await expect(moveOption).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await moveOption.click();
   }
 
   async expectMovePopoverVisible(): Promise<void> {
@@ -322,6 +327,11 @@ export class DocumentPage extends BasePage {
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
     const childUrn = await this.createDocumentWithTitle(childTitle);
+
+    // Return to the documents list so both tree rows are mounted before Move.
+    await this.navigateToDocuments();
+    await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+
     await expect(this.getTreeItem(parentUrn)).toBeVisible({ timeout: TIMEOUTS.LONG });
     await expect(this.getTreeItem(childUrn)).toBeVisible({ timeout: TIMEOUTS.LONG });
 

--- a/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
@@ -21,6 +21,9 @@ const TYPE_RUNBOOK = 'Runbook';
 test.use({ featureName: 'documents' });
 
 test.describe('Document Management', () => {
+  // Create → move → verify (and cascade delete) need more than the default 60s.
+  test.setTimeout(120000);
+
   let documentPage: DocumentPage;
 
   test.beforeEach(async ({ apiMock, page }) => {


### PR DESCRIPTION


https://github.com/user-attachments/assets/0f056c46-3e21-4aa4-8441-62bf6f115b17


Let users widen Glossary/Domains/Documents/Metrics sidebars via the right edge, persist width in localStorage, and show node tooltips quickly.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
