### PR TITLE
feat(): Add Within Operator Support for Containers and Domains by default on search page, Parent Document Filter

### DIFF
--- a/datahub-web-react/src/app/search/utils/constants.ts
+++ b/datahub-web-react/src/app/search/utils/constants.ts
@@ -15,6 +15,7 @@ export const TAGS_FILTER_NAME = 'tags';
 export const GLOSSARY_TERMS_FILTER_NAME = 'glossaryTerms';
 export const CONTAINER_FILTER_NAME = 'container';
 export const DOMAINS_FILTER_NAME = 'domains';
+export const PARENT_DOCUMENT_FILTER_NAME = 'parentDocument';
 export const OWNERS_FILTER_NAME = 'owners';
 export const TYPE_NAMES_FILTER_NAME = 'typeNames';
 export const PLATFORM_FILTER_NAME = 'platform';
@@ -89,6 +90,7 @@ export function getFieldToLabel(): Record<string, string> {
         entityType: i18next.t('search:fieldLabel.entityType'),
         _entityType: i18next.t('search:fieldLabel.entityType'),
         container: i18next.t('search:fieldLabel.container'),
+        parentDocument: i18next.t('search:fieldLabel.parentDocument'),
         typeNames: i18next.t('search:fieldLabel.subType'),
         origin: i18next.t('search:fieldLabel.environment'),
         degree: i18next.t('search:fieldLabel.degree'),
@@ -115,6 +117,7 @@ export const FIELD_TO_LABEL = {
     entityType: 'Entity Type',
     _entityType: 'Entity Type',
     container: 'Container',
+    parentDocument: 'Parent Document',
     typeNames: 'Sub Type',
     origin: 'Environment',
     degree: 'Degree',

--- a/datahub-web-react/src/app/searchV2/filters/AddFilterDropdown.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/AddFilterDropdown.tsx
@@ -11,6 +11,8 @@ import { DEFAULT_FILTER_FIELDS } from '@app/searchV2/filters/field/fields';
 import { FieldType, FilterField, FilterPredicate } from '@app/searchV2/filters/types';
 import ValueMenu from '@app/searchV2/filters/value/ValueMenu';
 import { getDefaultFieldOperatorType } from '@app/searchV2/filters/value/utils';
+import { PARENT_DOCUMENT_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { useIsContextDocumentsEnabled } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 const StyledPlusOutlined = styled(PlusOutlined)`
@@ -74,20 +76,23 @@ interface Props {
 export default function AddFilterDropdown({ fields = DEFAULT_FILTER_FIELDS, onAddFilter, includeCount }: Props) {
     const { t } = useTranslation('search');
     const [dropdownOpen, setDropdownOpen] = useState(false);
+    const isContextDocumentsEnabled = useIsContextDocumentsEnabled();
 
-    const items = fields.map((field) => {
-        return {
-            key: field.field,
-            label: (
-                <FilterPopover
-                    field={field}
-                    onAddFilter={onAddFilter}
-                    setDropdownOpen={setDropdownOpen}
-                    includeCount={includeCount}
-                />
-            ),
-        };
-    });
+    const items = fields
+        .filter((field) => field.field !== PARENT_DOCUMENT_FILTER_NAME || isContextDocumentsEnabled)
+        .map((field) => {
+            return {
+                key: field.field,
+                label: (
+                    <FilterPopover
+                        field={field}
+                        onAddFilter={onAddFilter}
+                        setDropdownOpen={setDropdownOpen}
+                        includeCount={includeCount}
+                    />
+                ),
+            };
+        });
 
     return (
         <Dropdown

--- a/datahub-web-react/src/app/searchV2/filters/OperatorSelector.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/OperatorSelector.tsx
@@ -64,7 +64,7 @@ export default function OperatorSelector({ predicate, onChangeOperator }: Props)
 
     return (
         <Dropdown trigger={['click']} menu={{ items }}>
-            <SelectedOperatorText>{selectedOperatorText}</SelectedOperatorText>
+            <SelectedOperatorText data-testid="active-filter-operator">{selectedOperatorText}</SelectedOperatorText>
         </Dropdown>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
@@ -11,8 +11,8 @@ import { FilterScenarioType } from '@app/searchV2/filters/render/types';
 import { useFilterRendererRegistry } from '@app/searchV2/filters/render/useFilterRenderer';
 import { FilterPredicate } from '@app/searchV2/filters/types';
 import { convertToAvailableFilterPredictes, sortFacets } from '@app/searchV2/filters/utils';
-import { ORIGIN_FILTER_NAME, UnionType } from '@app/searchV2/utils/constants';
-import { useAppConfig } from '@src/app/useAppConfig';
+import { ORIGIN_FILTER_NAME, PARENT_DOCUMENT_FILTER_NAME, UnionType } from '@app/searchV2/utils/constants';
+import { useAppConfig, useIsContextDocumentsEnabled } from '@src/app/useAppConfig';
 
 import { FacetFilterInput, FacetMetadata } from '@types';
 
@@ -53,6 +53,7 @@ export default function SearchFilterOptions({
     const userContext = useUserContext();
     const filterRendererRegistry = useFilterRendererRegistry();
     const { config } = useAppConfig();
+    const isContextDocumentsEnabled = useIsContextDocumentsEnabled();
     const fieldsWithCustomRenderers = Array.from(filterRendererRegistry.fieldNameToRenderer.keys());
     const selectedViewUrn = userContext?.localState?.selectedViewUrn;
     const showSaveViewButton = activeFilters?.length > 0 && selectedViewUrn === undefined;
@@ -60,7 +61,9 @@ export default function SearchFilterOptions({
     let filterSet = availableFilters;
     if (filterSet.length) {
         // Include non-facet filters and remove any duplicates in filterSet
-        const nonFacetFilters = NON_FACET_FILTER_FIELDS.map(
+        const nonFacetFilters = NON_FACET_FILTER_FIELDS.filter(
+            (filterField) => filterField.field !== PARENT_DOCUMENT_FILTER_NAME || isContextDocumentsEnabled,
+        ).map(
             ({ field, displayName }): FacetMetadata => ({
                 field,
                 displayName,
@@ -76,6 +79,7 @@ export default function SearchFilterOptions({
     const dynamicFilterOptions = filterSet
         ?.filter((f) => (f.field === ORIGIN_FILTER_NAME ? f.aggregations.length >= 2 : true)) // only want Environment filter if there's 2 or more envs
         .filter((f) => !FILTERS_TO_REMOVE.includes(f.field))
+        .filter((f) => f.field !== PARENT_DOCUMENT_FILTER_NAME || isContextDocumentsEnabled)
         .filter((f) => {
             if (fieldsWithCustomRenderers.includes(f.field)) {
                 // If there are no true aggregations, these fields needn't be rendered

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/operator.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/operator.test.tsx
@@ -14,6 +14,7 @@ import {
     CONTAINER_FILTER_NAME,
     DOMAINS_FILTER_NAME,
     ENTITY_SUB_TYPE_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
 } from '@src/app/search/utils/constants';
 import { EntityType, FilterOperator } from '@src/types.generated';
 
@@ -78,6 +79,18 @@ describe('operator', () => {
         defaultValueOptions: [],
     } as FilterPredicate;
 
+    const parentDocumentPredicate = {
+        field: {
+            field: PARENT_DOCUMENT_FILTER_NAME,
+            displayName: 'Parent Document',
+            entityTypes: [EntityType.Document],
+            type: FieldType.ENTITY,
+        },
+        operator: FilterOperatorType.EQUALS,
+        values: [{ value: 'urn:li:document:parent', entity: null }],
+        defaultValueOptions: [],
+    } as FilterPredicate;
+
     const expectedEnumOptions = [EQUALS_OPERATOR, NOT_EQUALS_OPERATOR, EXISTS_OPERATOR, NOT_EXISTS_OPERATOR];
 
     const pluralExpectedEnumOptions = [
@@ -122,6 +135,11 @@ describe('operator', () => {
 
     it('should put Within first for container filters', () => {
         const options = getOperatorOptionsForPredicate(containerPredicate, false);
+        expect(options[0]).toMatchObject(WITHIN_OPERATOR);
+    });
+
+    it('should put Within first for parentDocument filters', () => {
+        const options = getOperatorOptionsForPredicate(parentDocumentPredicate, false);
         expect(options[0]).toMatchObject(WITHIN_OPERATOR);
     });
 

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/operator.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/operator.test.tsx
@@ -4,11 +4,18 @@ import {
     EXISTS_OPERATOR,
     NOT_EQUALS_OPERATOR,
     NOT_EXISTS_OPERATOR,
+    WITHIN_OPERATOR,
+    convertBackendToFrontendOperatorType,
+    convertFrontendToBackendOperatorType,
     getOperatorOptionsForPredicate,
 } from '@app/searchV2/filters/operator/operator';
 import { FieldType, FilterOperatorType, FilterPredicate } from '@app/searchV2/filters/types';
-import { ENTITY_SUB_TYPE_FILTER_NAME } from '@src/app/search/utils/constants';
-import { EntityType } from '@src/types.generated';
+import {
+    CONTAINER_FILTER_NAME,
+    DOMAINS_FILTER_NAME,
+    ENTITY_SUB_TYPE_FILTER_NAME,
+} from '@src/app/search/utils/constants';
+import { EntityType, FilterOperator } from '@src/types.generated';
 
 describe('operator', () => {
     const tagPredicate = {
@@ -47,6 +54,30 @@ describe('operator', () => {
         defaultValueOptions: [],
     } as FilterPredicate;
 
+    const domainsPredicate = {
+        field: {
+            field: DOMAINS_FILTER_NAME,
+            displayName: 'Domain',
+            entityTypes: [EntityType.Domain],
+            type: FieldType.ENTITY,
+        },
+        operator: FilterOperatorType.EQUALS,
+        values: [{ value: 'urn:li:domain:marketing', entity: null }],
+        defaultValueOptions: [],
+    } as FilterPredicate;
+
+    const containerPredicate = {
+        field: {
+            field: CONTAINER_FILTER_NAME,
+            displayName: 'Container',
+            entityTypes: [EntityType.Container],
+            type: FieldType.ENTITY,
+        },
+        operator: FilterOperatorType.EQUALS,
+        values: [{ value: 'urn:li:container:abc', entity: null }],
+        defaultValueOptions: [],
+    } as FilterPredicate;
+
     const expectedEnumOptions = [EQUALS_OPERATOR, NOT_EQUALS_OPERATOR, EXISTS_OPERATOR, NOT_EXISTS_OPERATOR];
 
     const pluralExpectedEnumOptions = [
@@ -75,5 +106,40 @@ describe('operator', () => {
     it('should not include allEquals if filter is in an entity subtype filter', () => {
         const options = getOperatorOptionsForPredicate(entitySubtypePredicate, true);
         expect(options).toMatchObject(expectedEnumOptions);
+    });
+
+    it('should put Within first for domains filters', () => {
+        const options = getOperatorOptionsForPredicate(domainsPredicate, false);
+        expect(options[0]).toMatchObject(WITHIN_OPERATOR);
+        expect(options.map((o) => o.type)).toEqual([
+            FilterOperatorType.WITHIN,
+            FilterOperatorType.EQUALS,
+            FilterOperatorType.NOT_EQUALS,
+            FilterOperatorType.EXISTS,
+            FilterOperatorType.NOT_EXISTS,
+        ]);
+    });
+
+    it('should put Within first for container filters', () => {
+        const options = getOperatorOptionsForPredicate(containerPredicate, false);
+        expect(options[0]).toMatchObject(WITHIN_OPERATOR);
+    });
+
+    it('should not include Within for non-hierarchical entity filters', () => {
+        const options = getOperatorOptionsForPredicate(tagPredicate, false);
+        expect(options.map((o) => o.type)).not.toContain(FilterOperatorType.WITHIN);
+    });
+
+    it('should map Within to DescendantsIncl and back', () => {
+        expect(convertFrontendToBackendOperatorType(FilterOperatorType.WITHIN)).toEqual({
+            operator: FilterOperator.DescendantsIncl,
+            negated: false,
+        });
+        expect(
+            convertBackendToFrontendOperatorType({
+                operator: FilterOperator.DescendantsIncl,
+                negated: false,
+            }),
+        ).toBe(FilterOperatorType.WITHIN);
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -81,6 +81,28 @@ describe('filter utils - getNewFilters', () => {
             { field: 'platform', values: ['two'] },
         ]);
     });
+
+    it('should default domains filters to DescendantsIncl (Within)', () => {
+        const newFilters = getNewFilters('domains', [], ['urn:li:domain:marketing']);
+        expect(newFilters).toMatchObject([
+            {
+                field: 'domains',
+                values: ['urn:li:domain:marketing'],
+                condition: 'DESCENDANTS_INCL',
+            },
+        ]);
+    });
+
+    it('should default container filters to DescendantsIncl (Within)', () => {
+        const newFilters = getNewFilters('container', [], ['urn:li:container:abc']);
+        expect(newFilters).toMatchObject([
+            {
+                field: 'container',
+                values: ['urn:li:container:abc'],
+                condition: 'DESCENDANTS_INCL',
+            },
+        ]);
+    });
 });
 
 describe('filter utils - isFilterOptionSelected', () => {

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -103,6 +103,17 @@ describe('filter utils - getNewFilters', () => {
             },
         ]);
     });
+
+    it('should default parentDocument filters to DescendantsIncl (Within)', () => {
+        const newFilters = getNewFilters('parentDocument', [], ['urn:li:document:parent']);
+        expect(newFilters).toMatchObject([
+            {
+                field: 'parentDocument',
+                values: ['urn:li:document:parent'],
+                condition: 'DESCENDANTS_INCL',
+            },
+        ]);
+    });
 });
 
 describe('filter utils - isFilterOptionSelected', () => {

--- a/datahub-web-react/src/app/searchV2/filters/constants.ts
+++ b/datahub-web-react/src/app/searchV2/filters/constants.ts
@@ -1,4 +1,4 @@
-import { LAST_MODIFIED_FILTER } from '@app/searchV2/filters/field/fields';
+import { LAST_MODIFIED_FILTER, PARENT_DOCUMENT_FILTER } from '@app/searchV2/filters/field/fields';
 import { FilterField } from '@app/searchV2/filters/types';
 import {
     BROWSE_PATH_V2_FILTER_NAME,
@@ -13,6 +13,7 @@ import {
     LEGACY_ENTITY_FILTER_NAME,
     ORIGIN_FILTER_NAME,
     OWNERS_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
     PLATFORM_FILTER_NAME,
     TAGS_FILTER_NAME,
     TYPE_NAMES_FILTER_NAME,
@@ -30,6 +31,7 @@ export const SORTED_FILTERS = [
     DOMAINS_FILTER_NAME,
     LAST_MODIFIED_FILTER_NAME,
     CONTAINER_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
 ];
 
 export const FACETS_TO_ENTITY_TYPES = {
@@ -38,6 +40,7 @@ export const FACETS_TO_ENTITY_TYPES = {
     [OWNERS_FILTER_NAME]: [EntityType.CorpUser, EntityType.CorpGroup],
     [TAGS_FILTER_NAME]: [EntityType.Tag],
     [CONTAINER_FILTER_NAME]: [EntityType.Container],
+    [PARENT_DOCUMENT_FILTER_NAME]: [EntityType.Document],
 };
 
 // remove legacy filter options as well as new _index and browsePathV2 filter from dropdowns
@@ -54,5 +57,5 @@ export const FILTERS_TO_REMOVE = [
 // filters that should not be shown in the active filters section
 export const EXCLUDED_ACTIVE_FILTERS = [BROWSE_PATH_V2_FILTER_NAME];
 
-// Filters not based on facets
-export const NON_FACET_FILTER_FIELDS: FilterField[] = [LAST_MODIFIED_FILTER];
+// Filters not based on facets — always available; Parent Document sorts late into More Filters
+export const NON_FACET_FILTER_FIELDS: FilterField[] = [LAST_MODIFIED_FILTER, PARENT_DOCUMENT_FILTER];

--- a/datahub-web-react/src/app/searchV2/filters/field/fields.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/field/fields.tsx
@@ -41,6 +41,7 @@ import {
     LAST_MODIFIED_FILTER_NAME,
     ORIGIN_FILTER_NAME,
     OWNERS_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
     PLATFORM_FILTER_NAME,
     REMOVED_FILTER_NAME,
     STRUCTURED_PROPERTIES_FILTER_NAME,
@@ -136,6 +137,16 @@ const CONTAINER_FILTER: FilterField = {
     type: FieldType.ENTITY,
     entityTypes: [EntityType.Container],
     icon: <FolderOutlined />,
+};
+
+export const PARENT_DOCUMENT_FILTER: FilterField = {
+    field: PARENT_DOCUMENT_FILTER_NAME,
+    get displayName() {
+        return FIELD_TO_LABEL[PARENT_DOCUMENT_FILTER_NAME];
+    },
+    type: FieldType.ENTITY,
+    entityTypes: [EntityType.Document],
+    icon: <FileTextOutlined />,
 };
 
 const FIELD_PATHS_FILTER: FilterField = {
@@ -325,6 +336,7 @@ export const DEFAULT_FILTER_FIELDS: FilterField[] = [
     TAGS_FILTER,
     GLOSSARY_TERMS_FILTER,
     CONTAINER_FILTER,
+    PARENT_DOCUMENT_FILTER,
     FIELD_PATHS_FILTER,
     FIELD_TAGS_FILTER,
     FIELD_GLOSSARY_TERMS_FILTER,

--- a/datahub-web-react/src/app/searchV2/filters/operator/operator.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/operator/operator.tsx
@@ -20,12 +20,13 @@ import {
     CONTAINER_FILTER_NAME,
     DOMAINS_FILTER_NAME,
     ENTITY_SUB_TYPE_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
     PLATFORM_FILTER_NAME,
 } from '@src/app/search/utils/constants';
 
 import { FilterOperator } from '@types';
 
-const HIERARCHICAL_FILTER_FIELDS = new Set([DOMAINS_FILTER_NAME, CONTAINER_FILTER_NAME]);
+const HIERARCHICAL_FILTER_FIELDS = new Set([DOMAINS_FILTER_NAME, CONTAINER_FILTER_NAME, PARENT_DOCUMENT_FILTER_NAME]);
 
 /**
  * This is a flat version of the supported search filtering operations that can be applied

--- a/datahub-web-react/src/app/searchV2/filters/operator/operator.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/operator/operator.tsx
@@ -1,4 +1,10 @@
-import { CheckCircleOutlined, PlusCircleOutlined, PlusOutlined, StopOutlined } from '@ant-design/icons';
+import {
+    ApartmentOutlined,
+    CheckCircleOutlined,
+    PlusCircleOutlined,
+    PlusOutlined,
+    StopOutlined,
+} from '@ant-design/icons';
 import i18next from 'i18next';
 import React from 'react';
 
@@ -10,9 +16,16 @@ import {
     FrontendFilterOperator,
 } from '@app/searchV2/filters/types';
 import { getIsDateRangeFilter } from '@app/searchV2/filters/utils';
-import { ENTITY_SUB_TYPE_FILTER_NAME, PLATFORM_FILTER_NAME } from '@src/app/search/utils/constants';
+import {
+    CONTAINER_FILTER_NAME,
+    DOMAINS_FILTER_NAME,
+    ENTITY_SUB_TYPE_FILTER_NAME,
+    PLATFORM_FILTER_NAME,
+} from '@src/app/search/utils/constants';
 
 import { FilterOperator } from '@types';
+
+const HIERARCHICAL_FILTER_FIELDS = new Set([DOMAINS_FILTER_NAME, CONTAINER_FILTER_NAME]);
 
 /**
  * This is a flat version of the supported search filtering operations that can be applied
@@ -93,6 +106,18 @@ export const NOT_EXISTS_OPERATOR = {
     icon: <StopOutlined />,
 };
 
+export const WITHIN_OPERATOR = {
+    type: FilterOperatorType.WITHIN,
+    get text() {
+        return i18next.t('search:operator.within');
+    },
+    filter: {
+        operator: FilterOperator.DescendantsIncl,
+        negated: false,
+    },
+    icon: <ApartmentOutlined />,
+};
+
 const CONTAINS_OPERATOR = {
     type: FilterOperatorType.CONTAINS,
     get text() {
@@ -171,6 +196,7 @@ const SUPPORTED_OPERATORS: FilterOperatorInfo[] = [
     NOT_EQUALS_OPERATOR,
     EXISTS_OPERATOR,
     NOT_EXISTS_OPERATOR,
+    WITHIN_OPERATOR,
     CONTAINS_OPERATOR,
     NOT_CONTAINS_OPERATOR,
     GREATER_THAN_OPERATOR,
@@ -248,6 +274,9 @@ export const getOperatorOptionsForPredicate = (predicate: FilterPredicate, isPlu
             operatorOptions = BASE_CONDITION_TYPES.map((type) => SEARCH_FILTER_CONDITION_TYPE_TO_INFO.get(type)!);
             break;
         /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    }
+    if (HIERARCHICAL_FILTER_FIELDS.has(predicate.field.field)) {
+        operatorOptions = [WITHIN_OPERATOR, ...operatorOptions];
     }
     return applyFiltersToOperatorOptions(predicate.field.field, operatorOptions, isPlural);
 };

--- a/datahub-web-react/src/app/searchV2/filters/types.ts
+++ b/datahub-web-react/src/app/searchV2/filters/types.ts
@@ -86,6 +86,7 @@ export enum FilterOperatorType {
     LESS_THAN,
     LESS_THAN_OR_EQUALS,
     ALL_EQUALS, // used for splitting criterion values into multiple AND criterions
+    WITHIN, // hierarchical: selected URN + nested descendants (DESCENDANTS_INCL)
 }
 
 export enum FrontendFilterOperator {

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -35,6 +35,7 @@ import {
     LAST_MODIFIED_FILTER_NAME,
     LEGACY_ENTITY_FILTER_NAME,
     OWNERS_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
     PLATFORM_FILTER_NAME,
     PROPOSED_GLOSSARY_TERMS_FILTER_NAME,
     PROPOSED_SCHEMA_GLOSSARY_TERMS_FILTER_NAME,
@@ -99,7 +100,11 @@ function getDefaultFilterCondition(filterField: string): FilterOperator | undefi
     if (filterField === LAST_MODIFIED_FILTER_NAME) {
         return FilterOperator.GreaterThan;
     }
-    if (filterField === DOMAINS_FILTER_NAME || filterField === CONTAINER_FILTER_NAME) {
+    if (
+        filterField === DOMAINS_FILTER_NAME ||
+        filterField === CONTAINER_FILTER_NAME ||
+        filterField === PARENT_DOCUMENT_FILTER_NAME
+    ) {
         return FilterOperator.DescendantsIncl;
     }
     return undefined;

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -90,9 +90,19 @@ export function getNewFilters(
             field: filterField,
             values: selectedFilterValues,
             // TODO: Define on filter field instead
-            condition: filterField === LAST_MODIFIED_FILTER_NAME ? FilterOperator.GreaterThan : undefined,
+            condition: getDefaultFilterCondition(filterField),
         },
     ].filter((f) => !(f.values?.length === 0));
+}
+
+function getDefaultFilterCondition(filterField: string): FilterOperator | undefined {
+    if (filterField === LAST_MODIFIED_FILTER_NAME) {
+        return FilterOperator.GreaterThan;
+    }
+    if (filterField === DOMAINS_FILTER_NAME || filterField === CONTAINER_FILTER_NAME) {
+        return FilterOperator.DescendantsIncl;
+    }
+    return undefined;
 }
 
 export function isFilterOptionSelected(selectedFilterOptions: FilterOptionType[], filterValue: string) {

--- a/datahub-web-react/src/app/searchV2/filters/value/ValueName.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/ValueName.tsx
@@ -37,7 +37,11 @@ export default function ValueName({ field, value }: Props) {
             return <>{getTextFieldName(field, value)}</>;
         case FieldType.ENTITY:
             return (
-                <>{(value.entity && entityRegistry.getDisplayName(value.entity?.type, value.entity)) || undefined}</>
+                <>
+                    {(value.entity && entityRegistry.getDisplayName(value.entity.type, value.entity)) ||
+                        value.displayName ||
+                        value.value}
+                </>
             );
         case FieldType.ENTITY_TYPE:
         case FieldType.NESTED_ENTITY_TYPE:

--- a/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
@@ -454,7 +454,7 @@ describe('getDefaultFieldOperatorType', () => {
         expect(getDefaultFieldOperatorType(booleanField)).toBe(FilterOperatorType.EQUALS);
     });
 
-    it('should return WITHIN for domains and container fields', () => {
+    it('should return WITHIN for domains, container, and parentDocument fields', () => {
         const domainsField: FilterField = {
             field: 'domains',
             displayName: 'Domain',
@@ -469,7 +469,15 @@ describe('getDefaultFieldOperatorType', () => {
             entityTypes: [],
         };
 
+        const parentDocumentField: FilterField = {
+            field: 'parentDocument',
+            displayName: 'Parent Document',
+            type: FieldType.ENTITY,
+            entityTypes: [],
+        };
+
         expect(getDefaultFieldOperatorType(domainsField)).toBe(FilterOperatorType.WITHIN);
         expect(getDefaultFieldOperatorType(containerField)).toBe(FilterOperatorType.WITHIN);
+        expect(getDefaultFieldOperatorType(parentDocumentField)).toBe(FilterOperatorType.WITHIN);
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
@@ -453,4 +453,23 @@ describe('getDefaultFieldOperatorType', () => {
         expect(getDefaultFieldOperatorType(enumField)).toBe(FilterOperatorType.EQUALS);
         expect(getDefaultFieldOperatorType(booleanField)).toBe(FilterOperatorType.EQUALS);
     });
+
+    it('should return WITHIN for domains and container fields', () => {
+        const domainsField: FilterField = {
+            field: 'domains',
+            displayName: 'Domain',
+            type: FieldType.ENTITY,
+            entityTypes: [],
+        };
+
+        const containerField: FilterField = {
+            field: 'container',
+            displayName: 'Container',
+            type: FieldType.ENTITY,
+            entityTypes: [],
+        };
+
+        expect(getDefaultFieldOperatorType(domainsField)).toBe(FilterOperatorType.WITHIN);
+        expect(getDefaultFieldOperatorType(containerField)).toBe(FilterOperatorType.WITHIN);
+    });
 });

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -9,7 +9,7 @@ import {
     FilterValueOption,
 } from '@app/searchV2/filters/types';
 import { filterOptionsWithSearch, getStructuredPropFilterDisplayName } from '@app/searchV2/filters/utils';
-import { FILTER_DELIMITER } from '@app/searchV2/utils/constants';
+import { CONTAINER_FILTER_NAME, DOMAINS_FILTER_NAME, FILTER_DELIMITER } from '@app/searchV2/utils/constants';
 import { combineOrFilters } from '@app/searchV2/utils/filterUtils';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -234,5 +234,8 @@ export const getEntityTypeFilterValueDisplayName = (value: string, entityRegistr
 };
 
 export const getDefaultFieldOperatorType = (field: FilterField) => {
+    if (field.field === DOMAINS_FILTER_NAME || field.field === CONTAINER_FILTER_NAME) {
+        return FilterOperatorType.WITHIN;
+    }
     return field.type === FieldType.TEXT ? FilterOperatorType.CONTAINS : FilterOperatorType.EQUALS;
 };

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -9,7 +9,12 @@ import {
     FilterValueOption,
 } from '@app/searchV2/filters/types';
 import { filterOptionsWithSearch, getStructuredPropFilterDisplayName } from '@app/searchV2/filters/utils';
-import { CONTAINER_FILTER_NAME, DOMAINS_FILTER_NAME, FILTER_DELIMITER } from '@app/searchV2/utils/constants';
+import {
+    CONTAINER_FILTER_NAME,
+    DOMAINS_FILTER_NAME,
+    FILTER_DELIMITER,
+    PARENT_DOCUMENT_FILTER_NAME,
+} from '@app/searchV2/utils/constants';
 import { combineOrFilters } from '@app/searchV2/utils/filterUtils';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -234,7 +239,11 @@ export const getEntityTypeFilterValueDisplayName = (value: string, entityRegistr
 };
 
 export const getDefaultFieldOperatorType = (field: FilterField) => {
-    if (field.field === DOMAINS_FILTER_NAME || field.field === CONTAINER_FILTER_NAME) {
+    if (
+        field.field === DOMAINS_FILTER_NAME ||
+        field.field === CONTAINER_FILTER_NAME ||
+        field.field === PARENT_DOCUMENT_FILTER_NAME
+    ) {
         return FilterOperatorType.WITHIN;
     }
     return field.type === FieldType.TEXT ? FilterOperatorType.CONTAINS : FilterOperatorType.EQUALS;

--- a/datahub-web-react/src/app/searchV2/utils/constants.ts
+++ b/datahub-web-react/src/app/searchV2/utils/constants.ts
@@ -18,6 +18,7 @@ export const PROPOSED_GLOSSARY_TERMS_FILTER_NAME = 'proposedGlossaryTerms';
 export const PROPOSED_SCHEMA_GLOSSARY_TERMS_FILTER_NAME = 'proposedSchemaGlossaryTerms';
 export const CONTAINER_FILTER_NAME = 'container';
 export const DOMAINS_FILTER_NAME = 'domains';
+export const PARENT_DOCUMENT_FILTER_NAME = 'parentDocument';
 export const DATA_PRODUCT_FILTER_NAME = 'dataProduct';
 export const OWNERS_FILTER_NAME = 'owners';
 export const TYPE_NAMES_FILTER_NAME = 'typeNames';
@@ -134,6 +135,9 @@ export const FIELD_TO_LABEL: Record<string, string> = {
     get container() {
         return i18next.t('search:fieldLabel.container');
     },
+    get parentDocument() {
+        return i18next.t('search:fieldLabel.parentDocument');
+    },
     get typeNames() {
         return i18next.t('search:fieldLabel.subType');
     },
@@ -202,6 +206,7 @@ export const ENTITY_FIELDS = new Set([
     PROPOSED_TAGS_FILTER_NAME,
     PROPOSED_SCHEMA_GLOSSARY_TERMS_FILTER_NAME,
     DOMAINS_FILTER_NAME,
+    PARENT_DOCUMENT_FILTER_NAME,
     GLOSSARY_TERMS_FILTER_NAME,
     DATA_PRODUCT_FILTER_NAME,
 ]);

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
@@ -119,18 +119,23 @@ export const EntitySearchValueInput = ({
         const searchedEntities: Entity[] = searchResults.map((result) => result.entity);
 
         const mergedEntities = mergeArraysOfObjects(searchedEntities, selectedEntities, (item) => item.urn);
+        const resolvedUrns = new Set(mergedEntities.map((entity) => entity.urn));
 
         const selectedSet = new Set(selectedUrns);
-        return mergedEntities
-            .map((entity) => ({
-                value: entity.urn,
-                label: entityRegistry.getDisplayName(entity.type, entity),
-            }))
-            .sort((a, b) => {
-                const aSelected = selectedSet.has(a.value) ? 0 : 1;
-                const bSelected = selectedSet.has(b.value) ? 0 : 1;
-                return aSelected - bSelected;
-            });
+        const resolvedOptions = mergedEntities.map((entity) => ({
+            value: entity.urn,
+            label: entityRegistry.getDisplayName(entity.type, entity),
+        }));
+        // Keep selected URNs visible while entity resolution is in flight.
+        const unresolvedOptions = selectedUrns
+            .filter((urn) => !resolvedUrns.has(urn))
+            .map((urn) => ({ value: urn, label: urn }));
+
+        return [...resolvedOptions, ...unresolvedOptions].sort((a, b) => {
+            const aSelected = selectedSet.has(a.value) ? 0 : 1;
+            const bSelected = selectedSet.has(b.value) ? 0 : 1;
+            return aSelected - bSelected;
+        });
     }, [searchResults, entityCache, selectedUrns, entityRegistry]);
 
     const customOptionRenderer = useCallback(

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1569,6 +1569,20 @@ fragment entityDisplayNameFields on Entity {
             name
         }
     }
+    ... on Document {
+        info {
+            title
+        }
+        parentDocuments {
+            documents {
+                urn
+                type
+                info {
+                    title
+                }
+            }
+        }
+    }
 }
 
 fragment ermodelrelationPropertiesFields on ERModelRelationshipProperties {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1432,6 +1432,20 @@ fragment facetFields on FacetMetadata {
                     name
                 }
             }
+            ... on Document {
+                info {
+                    title
+                }
+                parentDocuments {
+                    documents {
+                        urn
+                        type
+                        info {
+                            title
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/datahub-web-react/src/i18n/locales/de/search.json
+++ b/datahub-web-react/src/i18n/locales/de/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Umgebung",
     "fieldLabel.glossaryTerm": "Begriff",
     "fieldLabel.owner": "Owner",
+    "fieldLabel.parentDocument": "Übergeordnetes Dokument",
     "fieldLabel.path": "Pfad",
     "fieldLabel.platform": "Plattform",
     "fieldLabel.platformInstance": "Plattforminstanz",

--- a/datahub-web-react/src/i18n/locales/de/search.json
+++ b/datahub-web-react/src/i18n/locales/de/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "ist kleiner als",
     "operator.isLessThanOrEqualTo": "ist kleiner als oder gleich",
     "operator.isNotAnyOf": "ist keines von",
-    "operator.within": "within",
+    "operator.within": "innerhalb",
     "recommendation.viewResultsIn": "Ergebnisse in <bold>{{label}}</bold> anzeigen",
     "results.showingCount": "Es werden <bold>{{start}}</bold>–<bold>{{end}}</bold> von <bold>{{total}}</bold> Ergebnissen angezeigt",
     "saveAsView.cannotSaveError": "Diese Kombination von Filtern kann derzeit nicht als Ansicht gespeichert werden.",

--- a/datahub-web-react/src/i18n/locales/de/search.json
+++ b/datahub-web-react/src/i18n/locales/de/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "ist kleiner als",
     "operator.isLessThanOrEqualTo": "ist kleiner als oder gleich",
     "operator.isNotAnyOf": "ist keines von",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Ergebnisse in <bold>{{label}}</bold> anzeigen",
     "results.showingCount": "Es werden <bold>{{start}}</bold>–<bold>{{end}}</bold> von <bold>{{total}}</bold> Ergebnissen angezeigt",
     "saveAsView.cannotSaveError": "Diese Kombination von Filtern kann derzeit nicht als Ansicht gespeichert werden.",

--- a/datahub-web-react/src/i18n/locales/en/search.json
+++ b/datahub-web-react/src/i18n/locales/en/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Environment",
     "fieldLabel.glossaryTerm": "Glossary Term",
     "fieldLabel.owner": "Owner",
+    "fieldLabel.parentDocument": "Parent Document",
     "fieldLabel.path": "Path",
     "fieldLabel.platform": "Platform",
     "fieldLabel.platformInstance": "Platform Instance",

--- a/datahub-web-react/src/i18n/locales/en/search.json
+++ b/datahub-web-react/src/i18n/locales/en/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "is less than",
     "operator.isLessThanOrEqualTo": "is less than or equal to",
     "operator.isNotAnyOf": "is not any of",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "View results in <bold>{{label}}</bold>",
     "results.showingCount": "Showing <bold>{{start}}</bold>–<bold>{{end}}</bold> of <bold>{{total}}</bold> results",
     "saveAsView.cannotSaveError": "This combination of filters cannot be saved as a View at this time.",

--- a/datahub-web-react/src/i18n/locales/es/search.json
+++ b/datahub-web-react/src/i18n/locales/es/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "es menor que",
     "operator.isLessThanOrEqualTo": "es menor o igual que",
     "operator.isNotAnyOf": "no es ninguno de",
-    "operator.within": "within",
+    "operator.within": "dentro de",
     "recommendation.viewResultsIn": "Ver resultados en <bold>{{label}}</bold>",
     "results.showingCount": "Mostrando <bold>{{start}}</bold>–<bold>{{end}}</bold> de <bold>{{total}}</bold> resultados",
     "saveAsView.cannotSaveError": "Esta combinación de filtros no se puede guardar como vista en este momento.",

--- a/datahub-web-react/src/i18n/locales/es/search.json
+++ b/datahub-web-react/src/i18n/locales/es/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "es menor que",
     "operator.isLessThanOrEqualTo": "es menor o igual que",
     "operator.isNotAnyOf": "no es ninguno de",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Ver resultados en <bold>{{label}}</bold>",
     "results.showingCount": "Mostrando <bold>{{start}}</bold>–<bold>{{end}}</bold> de <bold>{{total}}</bold> resultados",
     "saveAsView.cannotSaveError": "Esta combinación de filtros no se puede guardar como vista en este momento.",

--- a/datahub-web-react/src/i18n/locales/es/search.json
+++ b/datahub-web-react/src/i18n/locales/es/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Entorno",
     "fieldLabel.glossaryTerm": "Término del glosario",
     "fieldLabel.owner": "Owner",
+    "fieldLabel.parentDocument": "Documento principal",
     "fieldLabel.path": "Ruta",
     "fieldLabel.platform": "Plataforma",
     "fieldLabel.platformInstance": "Instancia de plataforma",

--- a/datahub-web-react/src/i18n/locales/fi/search.json
+++ b/datahub-web-react/src/i18n/locales/fi/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "on pienempi kuin",
     "operator.isLessThanOrEqualTo": "on pienempi tai yhtä suuri kuin",
     "operator.isNotAnyOf": "ei ole mikään seuraavista",
-    "operator.within": "within",
+    "operator.within": "sisällä",
     "recommendation.viewResultsIn": "Näytä tulokset kohteessa <bold>{{label}}</bold>",
     "results.showingCount": "Näytetään <bold>{{start}}</bold>–<bold>{{end}}</bold> / <bold>{{total}}</bold> tulosta",
     "saveAsView.cannotSaveError": "Tätä suodatinyhdistelmää ei voi tallentaa Näkymäksi tällä hetkellä.",

--- a/datahub-web-react/src/i18n/locales/fi/search.json
+++ b/datahub-web-react/src/i18n/locales/fi/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "on pienempi kuin",
     "operator.isLessThanOrEqualTo": "on pienempi tai yhtä suuri kuin",
     "operator.isNotAnyOf": "ei ole mikään seuraavista",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Näytä tulokset kohteessa <bold>{{label}}</bold>",
     "results.showingCount": "Näytetään <bold>{{start}}</bold>–<bold>{{end}}</bold> / <bold>{{total}}</bold> tulosta",
     "saveAsView.cannotSaveError": "Tätä suodatinyhdistelmää ei voi tallentaa Näkymäksi tällä hetkellä.",

--- a/datahub-web-react/src/i18n/locales/fi/search.json
+++ b/datahub-web-react/src/i18n/locales/fi/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Ympäristö",
     "fieldLabel.glossaryTerm": "Sanaston termi",
     "fieldLabel.owner": "Omistaja",
+    "fieldLabel.parentDocument": "Ylätason dokumentti",
     "fieldLabel.path": "Polku",
     "fieldLabel.platform": "Alusta",
     "fieldLabel.platformInstance": "Alustainstanssi",

--- a/datahub-web-react/src/i18n/locales/fr/search.json
+++ b/datahub-web-react/src/i18n/locales/fr/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "est inférieur à",
     "operator.isLessThanOrEqualTo": "est inférieur ou égal à",
     "operator.isNotAnyOf": "n'est aucun de",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Afficher les résultats dans <bold>{{label}}</bold>",
     "results.showingCount": "Affichage de <bold>{{start}}</bold> à <bold>{{end}}</bold> sur <bold>{{total}}</bold> résultats",
     "saveAsView.cannotSaveError": "Cette combinaison de filtres ne peut pas être enregistrée en tant que vue pour le moment.",

--- a/datahub-web-react/src/i18n/locales/fr/search.json
+++ b/datahub-web-react/src/i18n/locales/fr/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "est inférieur à",
     "operator.isLessThanOrEqualTo": "est inférieur ou égal à",
     "operator.isNotAnyOf": "n'est aucun de",
-    "operator.within": "within",
+    "operator.within": "dans",
     "recommendation.viewResultsIn": "Afficher les résultats dans <bold>{{label}}</bold>",
     "results.showingCount": "Affichage de <bold>{{start}}</bold> à <bold>{{end}}</bold> sur <bold>{{total}}</bold> résultats",
     "saveAsView.cannotSaveError": "Cette combinaison de filtres ne peut pas être enregistrée en tant que vue pour le moment.",

--- a/datahub-web-react/src/i18n/locales/fr/search.json
+++ b/datahub-web-react/src/i18n/locales/fr/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Environnement",
     "fieldLabel.glossaryTerm": "Terme",
     "fieldLabel.owner": "Propriétaire",
+    "fieldLabel.parentDocument": "Document parent",
     "fieldLabel.path": "Chemin",
     "fieldLabel.platform": "Plateforme",
     "fieldLabel.platformInstance": "Instance de plateforme",

--- a/datahub-web-react/src/i18n/locales/hu/search.json
+++ b/datahub-web-react/src/i18n/locales/hu/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Környezet",
     "fieldLabel.glossaryTerm": "Fogalomtári kifejezés",
     "fieldLabel.owner": "Tulajdonos",
+    "fieldLabel.parentDocument": "Szülő dokumentum",
     "fieldLabel.path": "Elérési út",
     "fieldLabel.platform": "Platform",
     "fieldLabel.platformInstance": "Platformpéldány",

--- a/datahub-web-react/src/i18n/locales/hu/search.json
+++ b/datahub-web-react/src/i18n/locales/hu/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "kisebb mint",
     "operator.isLessThanOrEqualTo": "kisebb vagy egyenlő mint",
     "operator.isNotAnyOf": "egyik sem ezek közül",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Eredmények megtekintése itt: <bold>{{label}}</bold>",
     "results.showingCount": "<bold>{{start}}</bold>–<bold>{{end}}</bold> megjelenítése, összesen <bold>{{total}}</bold> találatból",
     "saveAsView.cannotSaveError": "Ez a szűrőkombináció jelenleg nem menthető el nézetként.",

--- a/datahub-web-react/src/i18n/locales/hu/search.json
+++ b/datahub-web-react/src/i18n/locales/hu/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "kisebb mint",
     "operator.isLessThanOrEqualTo": "kisebb vagy egyenlő mint",
     "operator.isNotAnyOf": "egyik sem ezek közül",
-    "operator.within": "within",
+    "operator.within": "belül",
     "recommendation.viewResultsIn": "Eredmények megtekintése itt: <bold>{{label}}</bold>",
     "results.showingCount": "<bold>{{start}}</bold>–<bold>{{end}}</bold> megjelenítése, összesen <bold>{{total}}</bold> találatból",
     "saveAsView.cannotSaveError": "Ez a szűrőkombináció jelenleg nem menthető el nézetként.",

--- a/datahub-web-react/src/i18n/locales/it/search.json
+++ b/datahub-web-react/src/i18n/locales/it/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "è minore di",
     "operator.isLessThanOrEqualTo": "è minore o uguale a",
     "operator.isNotAnyOf": "non è nessuno tra",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Visualizza i risultati in <bold>{{label}}</bold>",
     "results.showingCount": "Mostrati <bold>{{start}}</bold>–<bold>{{end}}</bold> di <bold>{{total}}</bold> risultati",
     "saveAsView.cannotSaveError": "Questa combinazione di filtri non può essere salvata come vista in questo momento.",

--- a/datahub-web-react/src/i18n/locales/it/search.json
+++ b/datahub-web-react/src/i18n/locales/it/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "è minore di",
     "operator.isLessThanOrEqualTo": "è minore o uguale a",
     "operator.isNotAnyOf": "non è nessuno tra",
-    "operator.within": "within",
+    "operator.within": "all'interno di",
     "recommendation.viewResultsIn": "Visualizza i risultati in <bold>{{label}}</bold>",
     "results.showingCount": "Mostrati <bold>{{start}}</bold>–<bold>{{end}}</bold> di <bold>{{total}}</bold> risultati",
     "saveAsView.cannotSaveError": "Questa combinazione di filtri non può essere salvata come vista in questo momento.",

--- a/datahub-web-react/src/i18n/locales/it/search.json
+++ b/datahub-web-react/src/i18n/locales/it/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Ambiente",
     "fieldLabel.glossaryTerm": "Termine",
     "fieldLabel.owner": "Proprietario",
+    "fieldLabel.parentDocument": "Documento padre",
     "fieldLabel.path": "Percorso",
     "fieldLabel.platform": "Piattaforma",
     "fieldLabel.platformInstance": "Istanza della piattaforma",

--- a/datahub-web-react/src/i18n/locales/nb/search.json
+++ b/datahub-web-react/src/i18n/locales/nb/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Miljø",
     "fieldLabel.glossaryTerm": "Begrep",
     "fieldLabel.owner": "Eier",
+    "fieldLabel.parentDocument": "Overordnet dokument",
     "fieldLabel.path": "Sti",
     "fieldLabel.platform": "Plattform",
     "fieldLabel.platformInstance": "Plattforminstans",

--- a/datahub-web-react/src/i18n/locales/nb/search.json
+++ b/datahub-web-react/src/i18n/locales/nb/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "er mindre enn",
     "operator.isLessThanOrEqualTo": "er mindre enn eller lik",
     "operator.isNotAnyOf": "er ingen av",
-    "operator.within": "within",
+    "operator.within": "innenfor",
     "recommendation.viewResultsIn": "Vis resultater i <bold>{{label}}</bold>",
     "results.showingCount": "Viser <bold>{{start}}</bold>–<bold>{{end}}</bold> av <bold>{{total}}</bold> resultater",
     "saveAsView.cannotSaveError": "Denne kombinasjonen av filtre kan ikke lagres som en visning nå.",

--- a/datahub-web-react/src/i18n/locales/nb/search.json
+++ b/datahub-web-react/src/i18n/locales/nb/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "er mindre enn",
     "operator.isLessThanOrEqualTo": "er mindre enn eller lik",
     "operator.isNotAnyOf": "er ingen av",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Vis resultater i <bold>{{label}}</bold>",
     "results.showingCount": "Viser <bold>{{start}}</bold>–<bold>{{end}}</bold> av <bold>{{total}}</bold> resultater",
     "saveAsView.cannotSaveError": "Denne kombinasjonen av filtre kan ikke lagres som en visning nå.",

--- a/datahub-web-react/src/i18n/locales/pt-BR/search.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "é menor que",
     "operator.isLessThanOrEqualTo": "é menor ou igual a",
     "operator.isNotAnyOf": "não é nenhum de",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Ver resultados em <bold>{{label}}</bold>",
     "results.showingCount": "Exibindo <bold>{{start}}</bold>–<bold>{{end}}</bold> de <bold>{{total}}</bold> resultados",
     "saveAsView.cannotSaveError": "Esta combinação de filtros não pode ser salva como View no momento.",

--- a/datahub-web-react/src/i18n/locales/pt-BR/search.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Ambiente",
     "fieldLabel.glossaryTerm": "Termo do Glossário",
     "fieldLabel.owner": "Responsável",
+    "fieldLabel.parentDocument": "Documento pai",
     "fieldLabel.path": "Caminho",
     "fieldLabel.platform": "Platform",
     "fieldLabel.platformInstance": "Instância de Plataforma",

--- a/datahub-web-react/src/i18n/locales/pt-BR/search.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "é menor que",
     "operator.isLessThanOrEqualTo": "é menor ou igual a",
     "operator.isNotAnyOf": "não é nenhum de",
-    "operator.within": "within",
+    "operator.within": "dentro de",
     "recommendation.viewResultsIn": "Ver resultados em <bold>{{label}}</bold>",
     "results.showingCount": "Exibindo <bold>{{start}}</bold>–<bold>{{end}}</bold> de <bold>{{total}}</bold> resultados",
     "saveAsView.cannotSaveError": "Esta combinação de filtros não pode ser salva como View no momento.",

--- a/datahub-web-react/src/i18n/locales/sv/search.json
+++ b/datahub-web-react/src/i18n/locales/sv/search.json
@@ -50,6 +50,7 @@
     "fieldLabel.environment": "Miljö",
     "fieldLabel.glossaryTerm": "Term",
     "fieldLabel.owner": "Owner",
+    "fieldLabel.parentDocument": "Överordnat dokument",
     "fieldLabel.path": "Sökväg",
     "fieldLabel.platform": "Plattform",
     "fieldLabel.platformInstance": "Plattformsinstans",

--- a/datahub-web-react/src/i18n/locales/sv/search.json
+++ b/datahub-web-react/src/i18n/locales/sv/search.json
@@ -129,7 +129,7 @@
     "operator.isLessThan": "är mindre än",
     "operator.isLessThanOrEqualTo": "är mindre än eller lika med",
     "operator.isNotAnyOf": "är inte något av",
-    "operator.within": "within",
+    "operator.within": "inom",
     "recommendation.viewResultsIn": "Visa resultat i <bold>{{label}}</bold>",
     "results.showingCount": "Visar <bold>{{start}}</bold>–<bold>{{end}}</bold> av <bold>{{total}}</bold> resultat",
     "saveAsView.cannotSaveError": "Den här filterkombinationen kan inte sparas som en vy just nu.",

--- a/datahub-web-react/src/i18n/locales/sv/search.json
+++ b/datahub-web-react/src/i18n/locales/sv/search.json
@@ -129,6 +129,7 @@
     "operator.isLessThan": "är mindre än",
     "operator.isLessThanOrEqualTo": "är mindre än eller lika med",
     "operator.isNotAnyOf": "är inte något av",
+    "operator.within": "within",
     "recommendation.viewResultsIn": "Visa resultat i <bold>{{label}}</bold>",
     "results.showingCount": "Visar <bold>{{start}}</bold>–<bold>{{end}}</bold> av <bold>{{total}}</bold> resultat",
     "saveAsView.cannotSaveError": "Den här filterkombinationen kan inte sparas som en vy just nu.",

--- a/e2e-test/ui/playwright/pages/search.page.ts
+++ b/e2e-test/ui/playwright/pages/search.page.ts
@@ -401,6 +401,24 @@ export class SearchPage extends BasePage {
     expect(url).not.toContain(urlPart);
   }
 
+  /**
+   * Change the operator on an active filter chip (e.g. Domain equals → within).
+   * @param fieldName URL/field name such as "domains" or "platform"
+   * @param operatorLabel Visible operator text such as "within" or "equals"
+   */
+  async selectActiveFilterOperator(fieldName: string, operatorLabel: string): Promise<void> {
+    const chip = this.page.getByTestId(`active-filter-${fieldName}`);
+    await chip.waitFor({ state: 'visible', timeout: 10000 });
+    await chip.getByTestId('active-filter-operator').click();
+    await this.page.getByRole('menuitem', { name: new RegExp(operatorLabel, 'i') }).click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async expectActiveFilterOperator(fieldName: string, operatorLabel: string): Promise<void> {
+    const chip = this.page.getByTestId(`active-filter-${fieldName}`);
+    await expect(chip.getByTestId('active-filter-operator')).toHaveText(new RegExp(operatorLabel, 'i'));
+  }
+
   async expectTextVisible(text: string): Promise<void> {
     await expect(this.page.getByText(text).first()).toBeVisible({ timeout: 10000 });
   }

--- a/e2e-test/ui/playwright/tests/search/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/search/fixtures/data.json
@@ -496,5 +496,52 @@
       "value": "{\"domains\":[\"urn:li:domain:marketing\"]}",
       "contentType": "application/json"
     }
+  },
+  {
+    "entityType": "domain",
+    "entityUrn": "urn:li:domain:playwright-within-parent",
+    "changeType": "UPSERT",
+    "aspectName": "domainProperties",
+    "aspect": {
+      "value": "{\"name\": \"PlaywrightWithinParent\", \"description\": \"Parent domain for Within operator search tests\"}",
+      "contentType": "application/json"
+    }
+  },
+  {
+    "entityType": "domain",
+    "entityUrn": "urn:li:domain:playwright-within-child",
+    "changeType": "UPSERT",
+    "aspectName": "domainProperties",
+    "aspect": {
+      "value": "{\"name\": \"PlaywrightWithinChild\", \"description\": \"Child domain for Within operator search tests\", \"parentDomain\": \"urn:li:domain:playwright-within-parent\"}",
+      "contentType": "application/json"
+    }
+  },
+  {
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_within_nested,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset only in child domain; used to prove Within expands parent domains",
+              "customProperties": {
+                "encoding": "utf-8"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_within_nested,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+      "value": "{\"domains\":[\"urn:li:domain:playwright-within-child\"]}",
+      "contentType": "application/json"
+    }
   }
 ]

--- a/e2e-test/ui/playwright/tests/search/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/search/fixtures/data.json
@@ -322,9 +322,7 @@
           },
           {
             "com.linkedin.common.BrowsePaths": {
-              "paths": [
-                "/prod/hdfs/SamplePlaywrightHdfsDataset"
-              ]
+              "paths": ["/prod/hdfs/SamplePlaywrightHdfsDataset"]
             }
           },
           {

--- a/e2e-test/ui/playwright/tests/search/search-within-operator.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/search-within-operator.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Search Filters — Within operator for hierarchical Domain filters.
+ *
+ * Seeds nested domains + a dataset only in the child domain. Selecting the
+ * parent Domain with Equals should miss it; Within (DESCENDANTS_INCL) should
+ * include it and round-trip via the URL.
+ */
+
+import { expect, test } from '../../fixtures/base-test';
+import { SearchPage } from '../../pages/search.page';
+
+test.use({ featureName: 'search' });
+
+const PARENT_DOMAIN = 'PlaywrightWithinParent';
+const DATASET_NAME = 'fct_playwright_within_nested';
+
+test.describe('Search Filters — Within operator', () => {
+  let searchPage: SearchPage;
+
+  test.beforeEach(async ({ page, logger, logDir }) => {
+    searchPage = new SearchPage(page, logger, logDir);
+    await searchPage.navigateToHome();
+  });
+
+  test('Domain Within uses DESCENDANTS_INCL and matches nested child entities', async ({ page }) => {
+    await searchPage.searchAndWait(DATASET_NAME, 3000);
+    await searchPage.expectFiltersV2Visible();
+
+    // Dataset is only in the child domain — searching by name alone should find it.
+    await searchPage.expectTextVisible(DATASET_NAME);
+
+    await searchPage.selectFilterOption('Domain', PARENT_DOMAIN);
+    await searchPage.expectActiveFilter(PARENT_DOMAIN);
+
+    // Domain filters default to Within (DESCENDANTS_INCL), which includes nested children.
+    await searchPage.expectActiveFilterOperator('domains', 'within');
+    await searchPage.expectUrlContains('DESCENDANTS_INCL');
+    await searchPage.expectTextVisible(DATASET_NAME);
+    await searchPage.expectHasResults();
+
+    // Switching to Equals on the parent should miss the child-only dataset.
+    await searchPage.selectActiveFilterOperator('domains', 'equals');
+    await searchPage.expectActiveFilterOperator('domains', 'equals');
+    await expect(page.getByText('of 0 results')).toBeVisible({ timeout: 15000 });
+
+    // Reload preserves Within via the URL condition.
+    await searchPage.selectActiveFilterOperator('domains', 'within');
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await searchPage.dismissOnboardingOverlays();
+    await searchPage.expectActiveFilterOperator('domains', 'within');
+    await searchPage.expectUrlContains('DESCENDANTS_INCL');
+    await searchPage.expectTextVisible(DATASET_NAME);
+  });
+});


### PR DESCRIPTION
Adding the "within" (descendants_incl) operator selected by default for Domains, Containers to improve usability of the search interface. 

<img width="729" height="531" alt="Screenshot 2026-07-30 at 4 35 14 PM" src="https://github.com/user-attachments/assets/b4783614-6d48-4a1d-b0a8-d1dfbee3fb11" />


Also, adding support for a new parent document filter in the UI, same predicate settings: 

<img width="358" height="219" alt="Screenshot 2026-07-30 at 5 05 26 PM" src="https://github.com/user-attachments/assets/dbf9f21a-fa60-4470-ba41-84cee8b56267" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
