### PR TITLE
fix(ingest/oracle): pin denormalized schema name in procedure test mocks

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/models.py
@@ -28,10 +28,6 @@ class BaseProcedure(BaseModel):
     to ensure procedure lineage URNs match table/view URN formats.
     """
 
-    # Reject unknown fields so a mistyped kwarg fails loudly instead of being dropped.
-    # Frozen because a procedure's metadata is fixed once read from the catalogue —
-    # nothing in ingestion mutates it after construction, and making that explicit
-    # lets the value be safely shared/hashed.
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     name: str

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -1353,10 +1353,8 @@ def test_get_procedures_for_database_maps_rows_to_base_procedure():
     """``get_procedures_for_database`` groups SHOW PROCEDURES rows by schema and
     maps each into a ``BaseProcedure``.
 
-    Also pins two behaviours the Pydantic model now enforces at construction:
-    real driver ``datetime`` values for ``created``/``last_altered`` round-trip
-    unchanged, and an ``argument_signature`` (Snowflake overloads procedures by
-    signature) produces a hash-suffixed identifier so overloads get distinct
+    Snowflake overloads procedures by signature, so an ``argument_signature``
+    must produce a hash-suffixed identifier to keep overloads on distinct
     DataJob URNs.
     """
     created = datetime.datetime(2024, 1, 2, 3, 4, 5)
@@ -1391,9 +1389,7 @@ def test_get_procedures_for_database_maps_rows_to_base_procedure():
     assert proc.return_type == "VARCHAR"
     assert proc.procedure_definition == "BEGIN CALL child(); END"
     assert proc.comment == "loads the fact tables"
-    # Driver datetimes round-trip unchanged (Pydantic does not reformat them).
     assert proc.created == created
     assert proc.last_altered == altered
-    # An argument signature disambiguates overloaded procedures via a hash suffix.
     assert proc.get_procedure_identifier() != "load_facts"
     assert proc.get_procedure_identifier().startswith("load_facts_")

--- a/metadata-ingestion/tests/unit/stored_procedure/test_procedure_lineage.py
+++ b/metadata-ingestion/tests/unit/stored_procedure/test_procedure_lineage.py
@@ -75,9 +75,7 @@ def _call_lineage_datajobs(
     ``generate_procedure_workunits`` and return the resolved ``inputDatajobs``.
 
     The container keys always carry real ``realdb``/``realschema`` names, so the
-    only thing that changes the outcome is the procedure's own
-    ``default_db``/``default_schema`` and the three-value logic in
-    ``generate_procedure_workunits`` that interprets them.
+    procedure's own ``default_db``/``default_schema`` is the only variable.
     """
     procedure = BaseProcedure(
         name="caller",
@@ -125,6 +123,5 @@ def test_empty_string_default_db_schema_suppresses_container_keys() -> None:
     """Empty-string ``default_db``/``default_schema`` means "explicitly no
     database/schema segment", NOT "fall back to the container keys". With no
     db/schema to compose and no qualifier on the call, the call is unresolvable
-    and dropped — proving ``""`` overrides the ``realdb``/``realschema`` fallback
-    that ``None`` would have used above."""
+    and dropped."""
     assert _call_lineage_datajobs(default_db="", default_schema="") == []

--- a/metadata-ingestion/tests/unit/test_oracle_source.py
+++ b/metadata-ingestion/tests/unit/test_oracle_source.py
@@ -469,8 +469,6 @@ class TestOracleSource:
 
         # Mock inspector and connection
         mock_inspector = Mock()
-        # denormalize_name returns a real str in production; give the mock a
-        # concrete value so BaseProcedure's schema field validates.
         mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
 
@@ -560,6 +558,7 @@ class TestOracleSource:
         source = OracleSource(self.config, self.ctx)
 
         mock_inspector = Mock()
+        mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
         mock_context_manager = Mock()
         mock_context_manager.__enter__ = Mock(return_value=mock_connection)
@@ -705,6 +704,7 @@ class TestOracleSource:
         source = OracleSource(self.config, self.ctx)
 
         mock_inspector = Mock()
+        mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
         mock_context_manager = Mock()
         mock_context_manager.__enter__ = Mock(return_value=mock_connection)
@@ -801,6 +801,7 @@ class TestOracleSource:
         source = OracleSource(self.config, self.ctx)
 
         mock_inspector = Mock()
+        mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
         mock_context_manager = Mock()
         mock_context_manager.__enter__ = Mock(return_value=mock_connection)
@@ -971,6 +972,7 @@ class TestOracleSource:
         source = OracleSource(self.config, self.ctx)
 
         mock_inspector = Mock()
+        mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
         mock_context_manager = Mock()
         mock_context_manager.__enter__ = Mock(return_value=mock_connection)
@@ -1032,6 +1034,7 @@ class TestOracleSource:
         source = OracleSource(self.config, self.ctx)
 
         mock_inspector = Mock()
+        mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
         mock_connection = Mock()
         mock_context_manager = Mock()
         mock_context_manager.__enter__ = Mock(return_value=mock_connection)


### PR DESCRIPTION
Fixes the `testQuick` failures on master introduced by #18165.

## What broke

#18165 converted `BaseProcedure` from a `@dataclass` to a pydantic `BaseModel`, which validates field types at construction where the dataclass did not.

Five `TestOracleSource` cases build their inspector as a bare `Mock()`, so `inspector.dialect.denormalize_name(schema)` returns a `Mock` instead of a `str`. That `Mock` is passed as `default_schema`, pydantic rejects it, and `OracleSource.get_procedures_for_schema` swallows the `ValidationError` in its broad `except Exception` and returns an empty list. The tests therefore failed on empty results (`assert 0 == 50`) rather than surfacing the type error.

#18165 already added this exact mock fix to `test_get_procedures_for_schema`; the five sibling tests were missed.

Failing on Python 3.10 / 3.11 / 3.12:

- `test_get_procedures_for_schema_runs_constant_query_count`
- `test_get_procedures_for_schema_package_definition_includes_body`
- `test_get_procedures_for_schema_emits_unenriched_when_helpers_fail`
- `test_get_procedures_for_schema_dependency_string_is_deterministic`
- `test_get_procedures_for_schema_mixed_types_set_subtypes`

## The fix

One line per affected test, matching the pattern #18165 already established:

```python
mock_inspector.dialect.denormalize_name.return_value = "TEST_SCHEMA"
```

The tests are fixed rather than the source: a real SQLAlchemy Oracle dialect returns a string, and the existing `or schema.upper()` already covers the `None` case, so production behaviour is correct and the mocks were simply under-specified.

I also checked the rest of the blast radius of `extra="forbid"` / `frozen=True`, since those could break at runtime rather than in tests. Nothing mutates a `BaseProcedure` field after construction and nothing calls `dataclasses.replace`/`asdict`/`fields` on it, so the other construction sites (Snowflake, MySQL, Postgres, DB2, HANA, MSSQL) are unaffected.

Separately, this trims a few comments and docstring passages from #18165 that restated the assertion or config flag on the following line.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests updated
- [ ] Docs — n/a
- [ ] Breaking changes — n/a