### PR TITLE
docs(ingest/s3): document S3-compatible endpoint configuration

### DIFF
--- a/metadata-ingestion/docs/sources/s3/s3_pre.md
+++ b/metadata-ingestion/docs/sources/s3/s3_pre.md
@@ -123,3 +123,26 @@ source:
 ```
 
 The connector uses [boto3's assume_role](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts.html#STS.Client.assume_role), so additional parameters like `RoleSessionName`, `DurationSeconds`, and `Policy` are also supported.
+
+#### S3-Compatible Object Stores
+
+The source plugin talks to Amazon S3 through boto3, so it also works against other object stores that implement the S3 API (for example Backblaze B2, Cloudflare R2, and MinIO). Set `aws_config.aws_endpoint_url` to the provider's S3 endpoint, and keep `aws_config.aws_region` set to the region that endpoint belongs to, since the region is still used to sign requests. Continue to use `s3://` in `path_specs`: the endpoint override decides which host is contacted.
+
+```yaml
+source:
+  type: s3
+  config:
+    aws_config:
+      aws_access_key_id: "${AWS_ACCESS_KEY_ID}"
+      aws_secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+      aws_region: example-region
+      aws_endpoint_url: "https://s3.example-region.example.com"
+      # Only needed if the provider requires path-style addressing.
+      aws_advanced_config:
+        s3:
+          addressing_style: path
+    path_specs:
+      - include: "s3://my-bucket/{table}/*.parquet"
+```
+
+The IAM policy steps above are AWS-specific. On other providers, grant the equivalent read and list access with that provider's own credential mechanism.


### PR DESCRIPTION
The `s3` source builds its boto3 client through `AwsConnectionConfig`, which already forwards `aws_endpoint_url` to both the S3 client and the S3 resource, so the source works against any object store that implements the S3 API. Nothing in the connector docs says so, and the generated description for `aws_endpoint_url` ("The AWS service endpoint. This is normally constructed automatically, but can be overridden here.") does not connect the dots for someone trying to catalog a bucket that is not on AWS.

Where this already works today:

- `AwsConnectionConfig.get_s3_client` and `get_s3_resource` pass `endpoint_url=self.aws_endpoint_url` (`metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py`), and the latter unregisters botocore's `fix_s3_host` when a custom endpoint is combined with a proxy.
- Both schema inference (`s3/source.py`) and profiling (`data_lake_common/profiling/profiler.py`) go through that client, so the override covers the whole ingestion path rather than just bucket listing.
- `aws_advanced_config` is passed as keyword arguments into `botocore.config.Config`, so `s3.addressing_style: path` is already reachable from a recipe for stores that require path-style addressing.
- The GCS-over-S3-interoperability handling in `s3/source.py` is an existing example of pointing this source at a non-AWS endpoint.

This adds a short `#### S3-Compatible Object Stores` subsection at the end of `### Prerequisites` in `s3_pre.md`, nested per `metadata-ingestion/docs/sources/AGENTS.md`. It contains a worked recipe, a note that `aws_region` still matters because it is used to sign requests, a note that `path_specs` keep the `s3://` scheme, the optional path-style addressing knob, and a pointer that the IAM policy steps above it are AWS-specific.

Docs only, no code or behavior change. `prettier --check` and `.github/scripts/check_docusaurus_markdown.py` both pass on the changed file.