### PR TITLE
docs(graphql): alias properties when selecting across entity types

### DIFF
--- a/docs/api/graphql/graphql-best-practices.md
+++ b/docs/api/graphql/graphql-best-practices.md
@@ -31,6 +31,29 @@ One powerful feature of GraphQL that we recommend you use is [fragments](https:/
 
 This technique makes maintaining your GraphQL queries much more doable. For example, if you want to request a new field for an entity type across many queries, you’re able to update it in one place if you’re leveraging fragments.
 
+### Alias `properties` When Selecting Across Entity Types
+
+Queries that return heterogeneous entities, such as `searchAcrossEntities` and `searchAcrossLineage`, are normally
+written with one inline fragment per entity type. When the same response key is selected in more than one of those
+fragments, GraphQL compares the shapes and rejects the whole query if they differ, so a query fails validation before it
+runs even though each fragment is valid on its own.
+
+`properties` is where this bites, because the per-entity property types do not agree on nullability.
+`DatasetProperties.name`, `DashboardProperties.name`, `ChartProperties.name` and `DataJobProperties.name` are all
+`String!`, while `MLModelProperties.name` is `String`. Selecting `properties { name }` on both `Dataset` and `MLModel`
+in one request is therefore rejected with a fields-conflict error reporting different nullability shapes.
+
+Give each fragment its own response key:
+
+```graphql
+... on Dataset { datasetProps: properties { name } }
+... on Dashboard { dashboardProps: properties { name } }
+... on MLModel { mlModelProps: properties { name } }
+```
+
+The response then carries one key per entity type and the client reads whichever is present. Ownership and other fields
+whose type is shared across entities do not need this and can stay in a fragment, as above.
+
 ## Search Query Best Practices
 
 ### Deep Pagination: search* vs scroll* APIs


### PR DESCRIPTION
Adds a short subsection to the GraphQL best practices page covering a validation error that any query over heterogeneous entities can hit.

### Why

`searchAcrossEntities` and `searchAcrossLineage` return mixed entity types, so callers write one inline fragment per type. Selecting the same response key in several of those fragments makes GraphQL compare their shapes, and the request is rejected at validation if they differ.

`properties` is where this shows up, because the per-entity property types disagree on nullability:

| type | `name` |
|---|---|
| `DatasetProperties` | `String!` |
| `DashboardProperties` | `String!` |
| `ChartProperties` | `String!` |
| `DataJobProperties` | `String!` |
| `MLModelProperties` | `String` |

So `properties { name }` selected on both `Dataset` and `MLModel` fails, even though either fragment is fine alone. The failure is at validation rather than execution, so nothing partial comes back and the message points at shapes rather than at the fragment that introduced the mismatch. The fix is a response key per fragment, which the section shows.

I hit this building a column-level impact tool over `searchAcrossLineage` and lost a while to it, since each fragment reads correctly in isolation.

### Note

The doc describes the schema as it is rather than proposing a change. If `MLModelProperties.name` being nullable is unintended, aligning it with its siblings would remove the need for this note for that pair, though the general point about response keys across fragments still holds. Happy to file that separately if useful.

No schema or code changes here, docs only.
