### PR TITLE
Fix(hierarchical browse): expand stability ACR-8525

### DIFF
--- a/datahub-web-react/src/app/document/DocumentTreeContext.tsx
+++ b/datahub-web-react/src/app/document/DocumentTreeContext.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
+import { mergeServerChildNode } from '@app/document/utils/documentTreeNodeMerge';
+
 import { DataPlatform, EntityType } from '@types';
 
 /**
@@ -263,72 +265,60 @@ export const DocumentTreeProvider: React.FC<{ children: React.ReactNode }> = ({ 
         }
     }, []);
 
-    // Mutation: Set children for a parent node
-    // IMPORTANT: This merges server data with existing local state to preserve optimistic updates
+    // Merge server pages with local state so optimistic nodes and nested loads survive refetch.
     const setNodeChildren = useCallback((parentUrn: string | null, childNodes: DocumentTreeNode[]) => {
         if (parentUrn === null) {
-            // Setting root nodes - merge with existing roots to preserve optimistic updates
             setRootUrns((prevRootUrns) => {
-                // Merge using Map for deduplication
                 const mergedMap = new Map<string, string>();
 
-                // Add server roots first (fresher data)
                 childNodes.forEach((child) => {
                     mergedMap.set(child.urn, child.urn);
                 });
 
-                // Add existing roots not in server response (optimistic)
                 prevRootUrns.forEach((urn) => {
                     if (!mergedMap.has(urn)) {
                         mergedMap.set(urn, urn);
                     }
                 });
 
-                const mergedRootUrns = Array.from(mergedMap.values());
-
-                return mergedRootUrns;
+                return Array.from(mergedMap.values());
             });
 
             setNodes((prev) => {
                 const updated = new Map(prev);
-                childNodes.forEach((child) => updated.set(child.urn, child));
+                childNodes.forEach((child) => {
+                    updated.set(child.urn, mergeServerChildNode(updated.get(child.urn), child));
+                });
                 return updated;
             });
         } else {
-            // Setting children for a specific parent - merge server data with existing local children
             setNodes((prev) => {
                 const updated = new Map(prev);
                 const parent = updated.get(parentUrn);
                 if (parent) {
-                    // Get existing children (might include optimistic updates)
                     const existingChildren = parent.children || [];
-
-                    // Merge strategy: Server data takes precedence, preserve optimistic updates not yet on server
                     const mergedMap = new Map<string, DocumentTreeNode>();
 
-                    // First, add all server children (fresher data from backend)
                     childNodes.forEach((serverChild) => {
-                        mergedMap.set(serverChild.urn, serverChild);
+                        mergedMap.set(serverChild.urn, mergeServerChildNode(updated.get(serverChild.urn), serverChild));
                     });
 
-                    // Then, add existing children that are NOT in server response (optimistic updates)
                     existingChildren.forEach((existingChild) => {
                         if (!mergedMap.has(existingChild.urn)) {
                             mergedMap.set(existingChild.urn, existingChild);
                         }
                     });
 
-                    // Convert back to array (guaranteed unique by URN)
                     const mergedChildren = Array.from(mergedMap.values());
 
                     updated.set(parentUrn, {
                         ...parent,
                         children: mergedChildren,
-                        hasChildren: mergedChildren.length > 0,
+                        hasChildren: mergedChildren.length > 0 || parent.hasChildren,
                     });
+
+                    mergedChildren.forEach((child) => updated.set(child.urn, child));
                 }
-                // Also add all children to the nodes map
-                childNodes.forEach((child) => updated.set(child.urn, child));
                 return updated;
             });
         }

--- a/datahub-web-react/src/app/document/hooks/__tests__/useNodeChildrenLoading.test.tsx
+++ b/datahub-web-react/src/app/document/hooks/__tests__/useNodeChildrenLoading.test.tsx
@@ -47,6 +47,20 @@ describe('useNodeChildrenLoading', () => {
         expect(result.current.loading.loadingUrns.has('f')).toBe(false);
     });
 
+    it('does not refetch when children are already loaded', async () => {
+        const { result } = render();
+        act(() => {
+            result.current.tree.addNode(makeNode({ urn: 'f', hasChildren: true, children: [] }));
+        });
+
+        await act(async () => {
+            await result.current.loading.handleToggleExpand('f');
+        });
+
+        expect(result.current.tree.expandedUrns.has('f')).toBe(true);
+        expect(loadChildren).not.toHaveBeenCalled();
+    });
+
     it('collapses an already-expanded folder without refetching', async () => {
         const { result } = render();
         act(() => {

--- a/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
+++ b/datahub-web-react/src/app/document/hooks/useNodeChildrenLoading.ts
@@ -1,6 +1,7 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { DocumentTreeNode, useDocumentTree } from '@app/document/DocumentTreeContext';
+import { shouldFetchChildrenOnExpand } from '@app/document/utils/documentTreeNodeMerge';
 
 interface NodeLoaders {
     /** Loads (and returns) the first page of a node's children. */
@@ -23,16 +24,16 @@ interface NodeChildrenLoading {
 /**
  * Per-node expand + lazy child-loading for the document sidebar tree.
  *
- * Owns the two "in flight" sets (first-page vs next-page) and the toggle/load-more
- * handlers, keeping that async bookkeeping out of the render-heavy tree component.
- * The loaders are passed in rather than pulled from `useLoadDocumentTree` here so
- * we don't spin up a second root-loading instance — the tree owns the single
- * loader and hands us the child fetches it already has.
+ * Loaders are injected so DocumentTree keeps a single `useLoadDocumentTree`
+ * instance (a second hook would re-fetch roots).
  */
 export function useNodeChildrenLoading({ loadChildren, loadMoreChildren }: NodeLoaders): NodeChildrenLoading {
     const { getNode, expandedUrns, expandNode, collapseNode } = useDocumentTree();
     const [loadingUrns, setLoadingUrns] = useState<Set<string>>(new Set());
     const [loadingChildrenUrns, setLoadingChildrenUrns] = useState<Set<string>>(new Set());
+    // Sync in-flight sets — React state alone can miss rapid double-clicks before re-render.
+    const loadingUrnsRef = useRef<Set<string>>(new Set());
+    const loadingChildrenUrnsRef = useRef<Set<string>>(new Set());
 
     const handleToggleExpand = useCallback(
         async (urn: string) => {
@@ -45,16 +46,18 @@ export function useNodeChildrenLoading({ loadChildren, loadMoreChildren }: NodeL
             }
 
             expandNode(urn);
-            // Always refetch on expand; the context merges server data with any
-            // optimistic local children rather than clobbering them.
-            if (node.hasChildren) {
-                setLoadingUrns((prev) => new Set(prev).add(urn));
+
+            if (!shouldFetchChildrenOnExpand(node) || loadingUrnsRef.current.has(urn)) {
+                return;
+            }
+
+            loadingUrnsRef.current.add(urn);
+            setLoadingUrns(new Set(loadingUrnsRef.current));
+            try {
                 await loadChildren(urn);
-                setLoadingUrns((prev) => {
-                    const next = new Set(prev);
-                    next.delete(urn);
-                    return next;
-                });
+            } finally {
+                loadingUrnsRef.current.delete(urn);
+                setLoadingUrns(new Set(loadingUrnsRef.current));
             }
         },
         [getNode, expandedUrns, expandNode, collapseNode, loadChildren],
@@ -62,13 +65,16 @@ export function useNodeChildrenLoading({ loadChildren, loadMoreChildren }: NodeL
 
     const handleLoadMoreChildren = useCallback(
         async (parentUrn: string) => {
-            setLoadingChildrenUrns((prev) => new Set(prev).add(parentUrn));
-            await loadMoreChildren(parentUrn);
-            setLoadingChildrenUrns((prev) => {
-                const next = new Set(prev);
-                next.delete(parentUrn);
-                return next;
-            });
+            if (loadingChildrenUrnsRef.current.has(parentUrn)) return;
+
+            loadingChildrenUrnsRef.current.add(parentUrn);
+            setLoadingChildrenUrns(new Set(loadingChildrenUrnsRef.current));
+            try {
+                await loadMoreChildren(parentUrn);
+            } finally {
+                loadingChildrenUrnsRef.current.delete(parentUrn);
+                setLoadingChildrenUrns(new Set(loadingChildrenUrnsRef.current));
+            }
         },
         [loadMoreChildren],
     );

--- a/datahub-web-react/src/app/document/hooks/useSectionExpansion.ts
+++ b/datahub-web-react/src/app/document/hooks/useSectionExpansion.ts
@@ -24,16 +24,15 @@ interface SectionExpansion {
  * Section-scoped expand-all / collapse-all for the document sidebar tree.
  *
  * Each tree "section" (the DataHub group and each per-platform group) exposes a
- * bulk toggle. This hook owns the async expand-all traversal, the collapse-all
- * reset, and a per-section "in flight" set that drives the toggle's disabled
- * state, keeping that orchestration out of the already-large `DocumentTree`.
+ * bulk toggle. Expand-all is a capped BFS (depth / folder / concurrency limits
+ * in `expandAllFolders`) so large libraries cannot freeze the sidebar.
  *
  * `loadChildren` is passed in (rather than pulled from `useLoadDocumentTree`
  * here) so we don't spin up a second root-loading instance — the tree owns the
  * single loader and hands us just the child-fetch it already has.
  */
 export function useSectionExpansion(loadChildren: (urn: string) => Promise<DocumentTreeNode[]>): SectionExpansion {
-    const { expandedUrns, setExpandedUrns } = useDocumentTree();
+    const { expandedUrns, setExpandedUrns, getNode } = useDocumentTree();
     const [expandingSectionIds, setExpandingSectionIds] = useState<Set<string>>(new Set());
 
     const isSectionExpanded = useCallback(
@@ -63,6 +62,7 @@ export function useSectionExpansion(loadChildren: (urn: string) => Promise<Docum
                 await expandAllFolders({
                     roots,
                     loadChildren,
+                    getLoadedChildren: (urn) => getNode(urn)?.children,
                     onExpandLevel: (urns) =>
                         setExpandedUrns((prev) => {
                             const next = new Set(prev);
@@ -78,7 +78,7 @@ export function useSectionExpansion(loadChildren: (urn: string) => Promise<Docum
                 });
             }
         },
-        [expandedUrns, setExpandedUrns, loadChildren],
+        [expandedUrns, setExpandedUrns, loadChildren, getNode],
     );
 
     return { isSectionExpanded, isSectionExpanding, toggleSectionExpandAll };

--- a/datahub-web-react/src/app/document/utils/__tests__/documentTreeExpansion.test.ts
+++ b/datahub-web-react/src/app/document/utils/__tests__/documentTreeExpansion.test.ts
@@ -73,7 +73,7 @@ describe('documentTreeExpansion', () => {
             const loadChildren = vi.fn(async (urn: string) => childrenByUrn[urn] ?? []);
             const levels: string[][] = [];
 
-            await expandAllFolders({
+            const result = await expandAllFolders({
                 roots: [makeNode({ urn: 'root-folder', hasChildren: true })],
                 loadChildren,
                 onExpandLevel: (urns) => levels.push(urns),
@@ -83,6 +83,8 @@ describe('documentTreeExpansion', () => {
             expect(loadChildren).toHaveBeenCalledWith('root-folder');
             expect(loadChildren).toHaveBeenCalledWith('child-folder');
             expect(loadChildren).toHaveBeenCalledTimes(2);
+            expect(result.truncated).toBe(false);
+            expect(result.foldersExpanded).toBe(2);
         });
 
         it('does not revisit a folder reachable by more than one path', async () => {
@@ -109,10 +111,105 @@ describe('documentTreeExpansion', () => {
             const loadChildren = vi.fn(async () => []);
             const onExpandLevel = vi.fn();
 
-            await expandAllFolders({ roots: [makeNode({ urn: 'leaf' })], loadChildren, onExpandLevel });
+            const result = await expandAllFolders({ roots: [makeNode({ urn: 'leaf' })], loadChildren, onExpandLevel });
 
             expect(onExpandLevel).not.toHaveBeenCalled();
             expect(loadChildren).not.toHaveBeenCalled();
+            expect(result.foldersExpanded).toBe(0);
+            expect(result.truncated).toBe(false);
+        });
+
+        it('stops at maxDepth and reports truncated', async () => {
+            const childrenByUrn: Record<string, DocumentTreeNode[]> = {
+                root: [makeNode({ urn: 'l1', hasChildren: true })],
+                l1: [makeNode({ urn: 'l2', hasChildren: true })],
+                l2: [makeNode({ urn: 'l3', hasChildren: true })],
+                l3: [],
+            };
+            const loadChildren = vi.fn(async (urn: string) => childrenByUrn[urn] ?? []);
+            const levels: string[][] = [];
+
+            const result = await expandAllFolders({
+                roots: [makeNode({ urn: 'root', hasChildren: true })],
+                loadChildren,
+                onExpandLevel: (urns) => levels.push(urns),
+                maxDepth: 2,
+            });
+
+            expect(levels).toEqual([['root'], ['l1']]);
+            expect(loadChildren).toHaveBeenCalledTimes(2);
+            expect(result.truncated).toBe(true);
+            expect(result.foldersExpanded).toBe(2);
+        });
+
+        it('stops at maxFolders and reports truncated', async () => {
+            const loadChildren = vi.fn(async (urn: string) => {
+                if (urn === 'root') {
+                    return [
+                        makeNode({ urn: 'a', hasChildren: true }),
+                        makeNode({ urn: 'b', hasChildren: true }),
+                        makeNode({ urn: 'c', hasChildren: true }),
+                    ];
+                }
+                return [];
+            });
+            const expanded: string[] = [];
+
+            const result = await expandAllFolders({
+                roots: [makeNode({ urn: 'root', hasChildren: true })],
+                loadChildren,
+                onExpandLevel: (urns) => expanded.push(...urns),
+                maxFolders: 2,
+            });
+
+            expect(expanded).toEqual(['root', 'a']);
+            expect(loadChildren).toHaveBeenCalledTimes(2);
+            expect(result.truncated).toBe(true);
+            expect(result.foldersExpanded).toBe(2);
+        });
+
+        it('limits concurrent loadChildren calls', async () => {
+            let inFlight = 0;
+            let maxInFlight = 0;
+            const loadChildren = vi.fn(async () => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await Promise.resolve();
+                inFlight -= 1;
+                return [] as DocumentTreeNode[];
+            });
+
+            await expandAllFolders({
+                roots: [
+                    makeNode({ urn: 'a', hasChildren: true }),
+                    makeNode({ urn: 'b', hasChildren: true }),
+                    makeNode({ urn: 'c', hasChildren: true }),
+                    makeNode({ urn: 'd', hasChildren: true }),
+                ],
+                loadChildren,
+                onExpandLevel: () => {},
+                concurrency: 2,
+            });
+
+            expect(maxInFlight).toBeLessThanOrEqual(2);
+            expect(loadChildren).toHaveBeenCalledTimes(4);
+        });
+
+        it('reuses getLoadedChildren instead of refetching', async () => {
+            const loadChildren = vi.fn(async () => []);
+            const getLoadedChildren = vi.fn((urn: string) =>
+                urn === 'root' ? [makeNode({ urn: 'child', hasChildren: true })] : [],
+            );
+
+            await expandAllFolders({
+                roots: [makeNode({ urn: 'root', hasChildren: true })],
+                loadChildren,
+                getLoadedChildren,
+                onExpandLevel: () => {},
+            });
+
+            expect(loadChildren).not.toHaveBeenCalled();
+            expect(getLoadedChildren).toHaveBeenCalled();
         });
     });
 });

--- a/datahub-web-react/src/app/document/utils/__tests__/documentTreeNodeMerge.test.ts
+++ b/datahub-web-react/src/app/document/utils/__tests__/documentTreeNodeMerge.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+import { mergeServerChildNode, shouldFetchChildrenOnExpand } from '@app/document/utils/documentTreeNodeMerge';
+
+function makeNode(overrides: Partial<DocumentTreeNode> = {}): DocumentTreeNode {
+    return {
+        urn: 'urn:li:document:test',
+        title: 'Test',
+        parentUrn: null,
+        hasChildren: false,
+        ...overrides,
+    };
+}
+
+describe('mergeServerChildNode', () => {
+    it('returns the server node when nothing exists locally', () => {
+        const server = makeNode({ urn: 'a', title: 'From server' });
+        expect(mergeServerChildNode(undefined, server)).toBe(server);
+    });
+
+    it('keeps an already-loaded children subtree from the existing node', () => {
+        const grandchild = makeNode({ urn: 'g', title: 'Grandchild' });
+        const existing = makeNode({
+            urn: 'a',
+            title: 'Stale title',
+            hasChildren: true,
+            children: [grandchild],
+        });
+        const server = makeNode({ urn: 'a', title: 'Fresh title', hasChildren: true });
+
+        expect(mergeServerChildNode(existing, server)).toEqual({
+            ...server,
+            title: 'Fresh title',
+            children: [grandchild],
+            hasChildren: true,
+        });
+    });
+
+    it('uses server children when the existing node was never loaded', () => {
+        const existing = makeNode({ urn: 'a', hasChildren: true, children: undefined });
+        const serverChild = makeNode({ urn: 'b' });
+        const server = makeNode({ urn: 'a', hasChildren: true, children: [serverChild] });
+
+        expect(mergeServerChildNode(existing, server).children).toEqual([serverChild]);
+    });
+
+    it('preserves hasChildren if either side reports children', () => {
+        const existing = makeNode({ urn: 'a', hasChildren: true, children: [] });
+        const server = makeNode({ urn: 'a', hasChildren: false });
+        expect(mergeServerChildNode(existing, server).hasChildren).toBe(true);
+    });
+});
+
+describe('shouldFetchChildrenOnExpand', () => {
+    it('fetches when the node has children that have never been loaded', () => {
+        expect(shouldFetchChildrenOnExpand(makeNode({ hasChildren: true, children: undefined }))).toBe(true);
+    });
+
+    it('does not fetch leaves or already-loaded folders', () => {
+        expect(shouldFetchChildrenOnExpand(makeNode({ hasChildren: false }))).toBe(false);
+        expect(shouldFetchChildrenOnExpand(makeNode({ hasChildren: true, children: [] }))).toBe(false);
+        expect(shouldFetchChildrenOnExpand(makeNode({ hasChildren: true, children: [makeNode({ urn: 'c' })] }))).toBe(
+            false,
+        );
+    });
+});

--- a/datahub-web-react/src/app/document/utils/documentTreeExpansion.ts
+++ b/datahub-web-react/src/app/document/utils/documentTreeExpansion.ts
@@ -1,6 +1,14 @@
 import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
 
 /**
+ * Caps for section expand-all. Uncapped BFS + Promise.all freezes large libraries.
+ * Single-caret expand is unaffected (one node, one page of children).
+ */
+export const EXPAND_ALL_MAX_DEPTH = 3;
+export const EXPAND_ALL_MAX_FOLDERS = 75;
+export const EXPAND_ALL_CONCURRENCY = 6;
+
+/**
  * Collect the urns of every expandable node (a node that `hasChildren`) reachable
  * from `roots` through the already-loaded tree, including the roots themselves.
  *
@@ -8,9 +16,6 @@ import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
  * not been fetched yet still contribute their own urn (they are expandable), we
  * just can't see below them until they load. Drives section-level collapse-all
  * (which urns to clear) and the expand-state check below.
- *
- * @param roots - The section's root nodes to walk
- * @returns Urns of expandable nodes in depth-first order
  */
 export function collectExpandableUrns(roots: DocumentTreeNode[]): string[] {
     const urns: string[] = [];
@@ -25,41 +30,65 @@ export function collectExpandableUrns(roots: DocumentTreeNode[]): string[] {
 /**
  * True when any expandable node under `roots` is currently expanded. Drives the
  * section toggle glyph: collapse-all when something is open, expand-all otherwise.
- *
- * @param roots - The section's root nodes to walk
- * @param expandedUrns - The set of currently-expanded node urns
  */
 export function hasExpandedDescendant(roots: DocumentTreeNode[], expandedUrns: Set<string>): boolean {
     return collectExpandableUrns(roots).some((urn) => expandedUrns.has(urn));
 }
 
 interface ExpandAllFoldersArgs {
-    /** The section's root nodes to expand from. */
     roots: DocumentTreeNode[];
-    /** Loads (and returns) the freshly-fetched children of a parent urn. */
     loadChildren: (urn: string) => Promise<DocumentTreeNode[]>;
-    /** Invoked with each breadth-first level's urns so the caller can expand them. */
     onExpandLevel: (urns: string[]) => void;
+    /** When present, reuse already-loaded children instead of refetching. */
+    getLoadedChildren?: (urn: string) => DocumentTreeNode[] | undefined;
+    maxDepth?: number;
+    maxFolders?: number;
+    concurrency?: number;
+}
+
+export type ExpandAllFoldersResult = {
+    truncated: boolean;
+    foldersExpanded: number;
+};
+
+/** Run `fn` over `items` with at most `concurrency` in flight. */
+export async function mapPool<T, R>(items: T[], concurrency: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+    if (items.length === 0) return [];
+    const results: R[] = new Array(items.length);
+    let nextIndex = 0;
+
+    const worker = async () => {
+        while (nextIndex < items.length) {
+            const index = nextIndex;
+            nextIndex += 1;
+            // Sequential per worker so we never exceed `concurrency` in flight.
+            // eslint-disable-next-line no-await-in-loop
+            results[index] = await fn(items[index]);
+        }
+    };
+
+    const poolSize = Math.min(Math.max(1, concurrency), items.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+    return results;
 }
 
 /**
- * Breadth-first expand of every folder under `roots`, loading children one level
- * at a time.
- *
- * `loadChildren` returns the nodes it just loaded, so we discover the next level
- * of folders from its return value rather than reading back potentially-stale
- * tree state. `onExpandLevel` fires per level so expansion state updates as the
- * walk progresses (rather than in one batch at the end). A `seen` set makes the
- * walk resilient to repeats/cycles and prevents redundant fetches.
- *
- * @returns Resolves once the whole reachable folder subtree has been expanded.
+ * Breadth-first expand of folders under `roots`, capped by depth, folder count,
+ * and fetch concurrency so large libraries cannot freeze the sidebar.
  */
-export async function expandAllFolders({ roots, loadChildren, onExpandLevel }: ExpandAllFoldersArgs): Promise<void> {
+export async function expandAllFolders({
+    roots,
+    loadChildren,
+    onExpandLevel,
+    getLoadedChildren,
+    maxDepth = EXPAND_ALL_MAX_DEPTH,
+    maxFolders = EXPAND_ALL_MAX_FOLDERS,
+    concurrency = EXPAND_ALL_CONCURRENCY,
+}: ExpandAllFoldersArgs): Promise<ExpandAllFoldersResult> {
     const seen = new Set<string>();
+    let foldersExpanded = 0;
+    let truncated = false;
 
-    // Keep only urns we haven't queued before, marking them seen as we go. This
-    // dedupes both within a level (two parents sharing a child) and across levels
-    // (a folder reachable by more than one path), so each folder loads/expands once.
     const enqueue = (urns: string[]): string[] => {
         const fresh: string[] = [];
         urns.forEach((urn) => {
@@ -71,19 +100,51 @@ export async function expandAllFolders({ roots, loadChildren, onExpandLevel }: E
         return fresh;
     };
 
+    const resolveChildren = async (urn: string): Promise<DocumentTreeNode[]> => {
+        const loaded = getLoadedChildren?.(urn);
+        if (loaded !== undefined) return loaded;
+        return loadChildren(urn);
+    };
+
     let current = enqueue(roots.filter((node) => node.hasChildren).map((node) => node.urn));
+    let depth = 0;
 
     while (current.length > 0) {
+        if (depth >= maxDepth) {
+            truncated = true;
+            break;
+        }
+
+        const remaining = maxFolders - foldersExpanded;
+        if (remaining <= 0) {
+            truncated = true;
+            break;
+        }
+
+        if (current.length > remaining) {
+            truncated = true;
+            current = current.slice(0, remaining);
+        }
+
         onExpandLevel(current);
+        foldersExpanded += current.length;
 
         // eslint-disable-next-line no-await-in-loop
-        const results = await Promise.all(current.map((urn) => loadChildren(urn)));
+        const results = await mapPool(current, concurrency, resolveChildren);
         const candidates: string[] = [];
         results.forEach((children) => {
             children.forEach((child) => {
                 if (child.hasChildren) candidates.push(child.urn);
             });
         });
+
+        depth += 1;
         current = enqueue(candidates);
+        if (current.length > 0 && (depth >= maxDepth || foldersExpanded >= maxFolders)) {
+            truncated = true;
+            current = [];
+        }
     }
+
+    return { truncated, foldersExpanded };
 }

--- a/datahub-web-react/src/app/document/utils/documentTreeNodeMerge.ts
+++ b/datahub-web-react/src/app/document/utils/documentTreeNodeMerge.ts
@@ -1,0 +1,29 @@
+import { DocumentTreeNode } from '@app/document/DocumentTreeContext';
+
+/**
+ * Merge a server-fetched child into an existing tree node.
+ *
+ * Server metadata wins for title/flags, but any already-loaded `children`
+ * subtree is kept — otherwise re-fetching a parent wipes nested expand state
+ * and the sidebar jumps empty.
+ */
+export function mergeServerChildNode(
+    existing: DocumentTreeNode | undefined,
+    serverChild: DocumentTreeNode,
+): DocumentTreeNode {
+    if (!existing) return serverChild;
+    return {
+        ...serverChild,
+        children: existing.children !== undefined ? existing.children : serverChild.children,
+        hasChildren: serverChild.hasChildren || existing.hasChildren,
+        childCount: serverChild.childCount ?? existing.childCount,
+    };
+}
+
+/**
+ * True when expanding a node should hit the network for its first page of
+ * children. `children === undefined` means never loaded; `[]` means loaded empty.
+ */
+export function shouldFetchChildrenOnExpand(node: DocumentTreeNode): boolean {
+    return node.hasChildren && node.children === undefined;
+}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentActionsMenu.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentActionsMenu.tsx
@@ -1,5 +1,5 @@
 import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
@@ -17,6 +17,9 @@ import { Button, Menu, Popover } from '@src/alchemy-components';
 import { ItemType } from '@src/alchemy-components/components/Menu/types';
 
 const MenuButton = styled(Button)`
+    padding: 2px !important;
+    min-width: 0;
+
     &:hover {
         colors: ${(props) => props.theme.colors.textSecondary};
     }
@@ -47,10 +50,16 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
     const { t: tc } = useTranslation('common.actions');
     const [showMoveDialog, setShowMoveDialog] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
     const { deleteDocument } = useDeleteDocumentTreeMutation();
     const { getNode, getRootNodes } = useDocumentTree();
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
+
+    const pinActions = menuOpen || showMoveDialog || showDeleteConfirm;
+    useEffect(() => {
+        onMenuVisibilityChange?.(pinActions);
+    }, [pinActions, onMenuVisibilityChange]);
 
     const handleDelete = async (e?: React.MouseEvent) => {
         // Prevent event propagation if event is provided
@@ -97,7 +106,6 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
                       title: tc('move'),
                       onClick: () => {
                           setShowMoveDialog(true);
-                          onMenuVisibilityChange?.(true);
                       },
                   },
               ]
@@ -122,7 +130,13 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
 
     return (
         <>
-            <Menu items={menuItems} placement="bottomRight">
+            <Menu
+                items={menuItems}
+                placement="bottomRight"
+                onOpenChange={(open) => {
+                    setMenuOpen(open);
+                }}
+            >
                 <MenuButton
                     data-testid="document-actions-menu-button"
                     icon={{
@@ -133,7 +147,7 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
                     }}
                     variant="text"
                     isCircle
-                    size="md"
+                    size="sm"
                     onClick={(e) => {
                         e.stopPropagation();
                     }}
@@ -145,9 +159,6 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
                 trigger="click"
                 onOpenChange={(visible) => {
                     setShowMoveDialog(visible);
-                    if (!visible) {
-                        onMenuVisibilityChange?.(false);
-                    }
                 }}
                 content={
                     <MoveDocumentPopover
@@ -155,7 +166,6 @@ export const DocumentActionsMenu: React.FC<DocumentActionsMenuProps> = ({
                         currentParentUrn={currentParentUrn}
                         onClose={() => {
                             setShowMoveDialog(false);
-                            onMenuVisibilityChange?.(false);
                         }}
                         onMove={onMove}
                     />

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTree.tsx
@@ -190,7 +190,6 @@ export const DocumentTree: React.FC<DocumentTreeProps> = ({
                         title={node.title}
                         level={level}
                         hasChildren={node.hasChildren}
-                        childCount={node.children?.length ?? node.childCount}
                         isExpanded={isExpanded}
                         isSelected={isSelected}
                         isLoading={isLoading && isExpanded}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
@@ -99,12 +99,17 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
     const [isHovered, setIsHovered] = useState(false);
     const [forceShowActions, setForceShowActions] = useState(false);
     const rowRef = useRef<HTMLDivElement>(null);
+    const didScrollForSelectionRef = useRef(false);
 
-    // Deep links / URL navigation mount the selected row after ancestors expand —
-    // bring it into the sidebar scrollport once it becomes selected.
+    // Deep links mount the selected row after ancestors expand — scroll once (auto).
     useEffect(() => {
-        if (!isSelected || multiSelect) return;
-        rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+        if (!isSelected || multiSelect) {
+            didScrollForSelectionRef.current = false;
+            return;
+        }
+        if (didScrollForSelectionRef.current) return;
+        didScrollForSelectionRef.current = true;
+        rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'auto' });
     }, [isSelected, multiSelect, urn]);
 
     const handleAddChildClick = (e: React.MouseEvent) => {
@@ -120,7 +125,8 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
     };
 
     const showActions = !multiSelect && !hideActions && (isHovered || forceShowActions);
-    const showCount = !multiSelect && !showActions;
+    // Keep the count mounted while actions show so the right edge doesn't jump on hover.
+    const showCount = !multiSelect && hasChildren && !isExpanded && childCount != null && childCount > 0;
 
     const restingIcon = (() => {
         if (isLoading) {
@@ -192,6 +198,7 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
             hasChildren={hasChildren}
             isExpanded={isExpanded}
             count={showCount ? childCount : undefined}
+            countReveal="hover"
             icon={restingIcon}
             label={title}
             labelTitle={title}

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
@@ -195,6 +195,7 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
                 {!hideCreate && (
                     <Tooltip title={t('documents.newDocumentTooltip')} placement="bottom" showArrow={false}>
                         <ActionButton
+                            data-testid="document-tree-create-child-button"
                             icon={{ icon: Plus, color: 'icon', size: 'md' }}
                             variant="text"
                             size="sm"

--- a/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/sidebar/documents/DocumentTreeItem.tsx
@@ -9,6 +9,10 @@ import { DocumentActionsMenu } from '@app/homeV2/layout/sidebar/documents/Docume
 import Loading from '@app/shared/Loading';
 import HierarchicalBrowseTreeRow from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow';
 import { TREE_ROW_ENTITY_ICON_SIZE } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
+import {
+    TREE_ROW_HOVER_ACTIONS_CLASS,
+    TREE_ROW_HOVER_ACTIONS_PINNED_CLASS,
+} from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/treeRow.styles';
 import { Button, Checkbox, Tooltip } from '@src/alchemy-components';
 
 import { DataPlatform } from '@types';
@@ -34,6 +38,9 @@ const IconWrapper = styled.div<{ $isSelected: boolean; $useGradientFill: boolean
 `;
 
 const ActionButton = styled(Button)`
+    padding: 2px !important;
+    min-width: 0;
+
     &:hover {
         background-color: ${(props) => props.theme.colors.bgHover};
     }
@@ -47,9 +54,15 @@ const CheckboxSlot = styled.div`
 `;
 
 const ActionsWrap = styled.div`
-    display: flex;
+    /* Visibility is owned by treeRowHoverChrome (.tree-row-hover-actions). */
     align-items: center;
     gap: 4px;
+
+    /* Tighten ⋮ / + hit padding so the pair reads as one control cluster. */
+    && button {
+        padding: 2px;
+        min-width: 0;
+    }
 `;
 
 interface DocumentTreeItemProps {
@@ -59,7 +72,6 @@ interface DocumentTreeItemProps {
     hasChildren: boolean;
     isExpanded: boolean;
     isSelected: boolean;
-    childCount?: number;
     isLoading?: boolean;
     isUnpublished?: boolean;
     isExternal?: boolean;
@@ -81,7 +93,6 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
     hasChildren,
     isExpanded,
     isSelected,
-    childCount,
     isLoading,
     isUnpublished = false,
     isExternal = false,
@@ -96,7 +107,7 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
     multiSelect = false,
 }) => {
     const { t } = useTranslation('home.v2');
-    const [isHovered, setIsHovered] = useState(false);
+    // Pin ⋮/+ visible while a portaled menu/dialog is open (mouse leaves the row).
     const [forceShowActions, setForceShowActions] = useState(false);
     const rowRef = useRef<HTMLDivElement>(null);
     const didScrollForSelectionRef = useRef(false);
@@ -124,9 +135,7 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
         onClick();
     };
 
-    const showActions = !multiSelect && !hideActions && (isHovered || forceShowActions);
-    // Keep the count mounted while actions show so the right edge doesn't jump on hover.
-    const showCount = !multiSelect && hasChildren && !isExpanded && childCount != null && childCount > 0;
+    const mountActions = !multiSelect && !hideActions && (!hideActionsMenu || !hideCreate);
 
     const restingIcon = (() => {
         if (isLoading) {
@@ -164,9 +173,17 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
                 />
             </CheckboxSlot>
         );
-    } else if (showActions) {
+    } else if (mountActions) {
         trailing = (
-            <ActionsWrap className="tree-item-actions">
+            <ActionsWrap
+                className={[
+                    'tree-item-actions',
+                    TREE_ROW_HOVER_ACTIONS_CLASS,
+                    forceShowActions ? TREE_ROW_HOVER_ACTIONS_PINNED_CLASS : '',
+                ]
+                    .filter(Boolean)
+                    .join(' ')}
+            >
                 {!hideActionsMenu && (
                     <DocumentActionsMenu
                         documentUrn={urn}
@@ -178,8 +195,9 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
                 {!hideCreate && (
                     <Tooltip title={t('documents.newDocumentTooltip')} placement="bottom" showArrow={false}>
                         <ActionButton
-                            icon={{ icon: Plus, color: 'icon' }}
+                            icon={{ icon: Plus, color: 'icon', size: 'md' }}
                             variant="text"
+                            size="sm"
                             onClick={handleAddChildClick}
                         />
                     </Tooltip>
@@ -197,8 +215,6 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
             isSelected={isSelected}
             hasChildren={hasChildren}
             isExpanded={isExpanded}
-            count={showCount ? childCount : undefined}
-            countReveal="hover"
             icon={restingIcon}
             label={title}
             labelTitle={title}
@@ -206,8 +222,6 @@ export const DocumentTreeItem: React.FC<DocumentTreeItemProps> = ({
             onSelect={() => handleItemClick()}
             onToggleExpand={onToggleExpand}
             isLoadingChildren={!!isLoading}
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
         />
     );
 };

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components.tsx
@@ -68,7 +68,7 @@ export const CollapsedScrollColumn = styled.div`
     min-height: 0;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 8px 2px;
+    padding: 8px;
     ${scrollbar}
 `;
 
@@ -163,7 +163,8 @@ export const TreeContainer = styled.div`
     flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 8px 2px 8px 8px;
+    /* Equal L/R inset — asymmetric 8/2 looked lopsided inside the white shell. */
+    padding: 8px;
     ${scrollbar}
 `;
 
@@ -179,7 +180,7 @@ export const HomeNavLink = styled(Link)<{ $isSelected: boolean }>`
     ${treeRowHitTarget}
     display: flex;
     align-items: center;
-    padding: 4px 2px 4px 8px;
+    padding: 4px 8px;
     text-decoration: none;
     cursor: pointer;
     ${treeRowInteractionBg}

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
@@ -7,10 +7,11 @@ import styled, { useTheme } from 'styled-components';
 
 import { TREE_ROW_CARET_SIZE } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants';
 import {
-    TreeRowCaretSlot,
     TreeRowContainer,
-    TreeRowExpandButton,
+    TreeRowCount,
+    TreeRowExpandZone,
     TreeRowIconSlot,
+    TreeRowLeadingExpand,
     TreeRowLeftContent,
     TreeRowRightContent,
     TreeRowTitle,
@@ -43,6 +44,8 @@ export type HierarchicalBrowseTreeRowProps = {
     labelTitle?: string;
     afterLabel?: React.ReactNode;
     trailing?: React.ReactNode;
+    /** Documents use `hover`; Glossary / Domains keep `always`. */
+    countReveal?: 'always' | 'hover';
     onSelect: () => void;
     onToggleExpand?: () => void;
     isLoadingChildren?: boolean;
@@ -66,6 +69,7 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
             labelTitle,
             afterLabel,
             trailing,
+            countReveal = 'always',
             onSelect,
             onToggleExpand,
             isLoadingChildren = false,
@@ -79,45 +83,45 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
         const { t: tc } = useTranslation('common.actions');
         const theme = useTheme();
 
-        const { canExpand, showCount, showRightChrome, reserveCaretSlot } = getTreeRowChromeFlags({
+        const { canExpand, showCount } = getTreeRowChromeFlags({
             isCollapsed,
             hasChildren,
             isExpanded,
             count,
             hasToggle: onToggleExpand != null,
         });
+        const showRightChrome = !isCollapsed && (showCount || trailing != null);
 
-        const handleExpandClick = (e: React.MouseEvent) => {
+        // Single expand path for indent zone + caret button (stopPropagation so row select doesn't fire).
+        const handleExpand = (e: React.MouseEvent) => {
+            if (!canExpand) return;
             e.stopPropagation();
             onToggleExpand?.();
         };
 
-        const caretSlot = reserveCaretSlot ? (
-            <TreeRowCaretSlot>
-                {canExpand ? (
-                    <TreeRowExpandButton
-                        type="button"
-                        onClick={handleExpandClick}
-                        aria-expanded={isExpanded}
-                        aria-label={isExpanded ? tc('collapse') : tc('expand')}
-                    >
-                        {isExpanded ? (
-                            <CaretDown color={theme.colors.icon} size={TREE_ROW_CARET_SIZE} weight="regular" />
-                        ) : (
-                            <CaretRight color={theme.colors.icon} size={TREE_ROW_CARET_SIZE} weight="regular" />
-                        )}
-                    </TreeRowExpandButton>
-                ) : null}
-            </TreeRowCaretSlot>
-        ) : null;
-
-        const entityIcon = isLoadingChildren ? (
-            <TreeRowExpandButton type="button" onClick={handleExpandClick} aria-label={tc('expand')}>
-                {icon}
-            </TreeRowExpandButton>
+        const caret = isExpanded ? (
+            <CaretDown color={theme.colors.icon} size={TREE_ROW_CARET_SIZE} weight="regular" />
         ) : (
-            icon
+            <CaretRight color={theme.colors.icon} size={TREE_ROW_CARET_SIZE} weight="regular" />
         );
+
+        // Loading: keep both CSS slots on the same glyph so hover swap doesn't thrash mid-fetch.
+        let leading: React.ReactNode = icon;
+        if (canExpand) {
+            const caretGlyph = isLoadingChildren ? icon : caret;
+            leading = (
+                <TreeRowLeadingExpand
+                    type="button"
+                    $isExpanded={isExpanded}
+                    onClick={handleExpand}
+                    aria-expanded={isExpanded}
+                    aria-label={isExpanded ? tc('collapse') : tc('expand')}
+                >
+                    <span className="tree-row-entity-icon">{icon}</span>
+                    <span className="tree-row-caret-icon">{caretGlyph}</span>
+                </TreeRowLeadingExpand>
+            );
+        }
 
         const titleBlock =
             afterLabel != null ? (
@@ -138,7 +142,6 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
                 ref={ref}
                 className={className}
                 data-testid={dataTestId}
-                $level={level}
                 $isSelected={isSelected}
                 $isCollapsed={isCollapsed}
                 onClick={onSelect}
@@ -146,14 +149,26 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
                 onMouseLeave={onMouseLeave}
             >
                 <TreeRowLeftContent $isCollapsed={isCollapsed}>
-                    <TreeRowIconSlot $isCollapsed={isCollapsed}>{entityIcon}</TreeRowIconSlot>
+                    {isCollapsed ? (
+                        <TreeRowIconSlot $isCollapsed>{leading}</TreeRowIconSlot>
+                    ) : (
+                        <TreeRowExpandZone $level={level} $expandable={canExpand} onClick={handleExpand}>
+                            <TreeRowIconSlot>{leading}</TreeRowIconSlot>
+                        </TreeRowExpandZone>
+                    )}
                     {!isCollapsed && titleBlock}
                 </TreeRowLeftContent>
                 {showRightChrome && (
                     <TreeRowRightContent>
-                        {showCount && <Pill label={`${count}`} size="sm" />}
+                        {showCount &&
+                            (countReveal === 'hover' ? (
+                                <TreeRowCount>
+                                    <Pill label={`${count}`} size="sm" />
+                                </TreeRowCount>
+                            ) : (
+                                <Pill label={`${count}`} size="sm" />
+                            ))}
                         {trailing}
-                        {caretSlot}
                     </TreeRowRightContent>
                 )}
             </TreeRowContainer>

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseTreeRow.tsx
@@ -51,8 +51,6 @@ export type HierarchicalBrowseTreeRowProps = {
     isLoadingChildren?: boolean;
     'data-testid'?: string;
     className?: string;
-    onMouseEnter?: () => void;
-    onMouseLeave?: () => void;
 };
 
 const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalBrowseTreeRowProps>(
@@ -75,8 +73,6 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
             isLoadingChildren = false,
             'data-testid': dataTestId,
             className,
-            onMouseEnter,
-            onMouseLeave,
         },
         ref,
     ) => {
@@ -145,8 +141,6 @@ const HierarchicalBrowseTreeRow = React.forwardRef<HTMLDivElement, HierarchicalB
                 $isSelected={isSelected}
                 $isCollapsed={isCollapsed}
                 onClick={onSelect}
-                onMouseEnter={onMouseEnter}
-                onMouseLeave={onMouseLeave}
             >
                 <TreeRowLeftContent $isCollapsed={isCollapsed}>
                     {isCollapsed ? (

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/TreeSectionHeader.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/TreeSectionHeader.tsx
@@ -15,7 +15,7 @@ const SectionHeaderRow = styled.div<{ $level: number }>`
     align-items: center;
     gap: 4px;
     width: 100%;
-    padding: 6px 2px 6px ${(props) => getTreeRowPaddingLeft(props.$level)}px;
+    padding: 6px 8px 6px ${(props) => getTreeRowPaddingLeft(props.$level)}px;
     min-height: 32px;
     color: ${(props) => props.theme.colors.textTertiary};
     font-family: Mulish;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/constants.ts
@@ -16,5 +16,5 @@ export const TREE_ROW_ENTITY_ICON_SIZE = 20;
 /** Inner glyph size for colored badge icons (DomainColoredIcon / GlossaryColoredIcon). */
 export const TREE_ROW_ENTITY_ICON_GLYPH_SIZE = 12;
 
-/** Phosphor expand/collapse caret on tree rows (far right). */
+/** Phosphor expand/collapse caret (Notion-style: swaps over the entity icon). */
 export const TREE_ROW_CARET_SIZE = 14;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/treeRow.styles.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/treeRow.styles.ts
@@ -107,9 +107,18 @@ export const TreeRowCount = styled.div`
     flex-shrink: 0;
 `;
 
-/** Row hover: reveal leading caret and child count. */
+/**
+ * Row actions (Documents ⋮ / +) — always mounted, CSS-revealed on hover so large
+ * trees don’t pay React setState per row. Pin with --pinned while a menu or dialog
+ * is open (mouse may leave the row into a portal).
+ */
+export const TREE_ROW_HOVER_ACTIONS_CLASS = 'tree-row-hover-actions';
+export const TREE_ROW_HOVER_ACTIONS_PINNED_CLASS = 'tree-row-hover-actions--pinned';
+
+/** Row hover: reveal leading caret, child count, and optional actions. */
 export const treeRowHoverChrome = css`
-    &:hover ${TreeRowLeadingExpand}:not([aria-expanded='true']) {
+    &:hover ${TreeRowLeadingExpand}:not([aria-expanded='true']),
+    &:focus-within ${TreeRowLeadingExpand}:not([aria-expanded='true']) {
         .tree-row-entity-icon {
             display: none;
         }
@@ -119,12 +128,32 @@ export const treeRowHoverChrome = css`
         }
     }
 
-    &:hover ${TreeRowCount} {
+    &:hover
+        ${TreeRowCount},
+        &:focus-within
+        ${TreeRowCount},
+        &:has(.${TREE_ROW_HOVER_ACTIONS_PINNED_CLASS})
+        ${TreeRowCount} {
         display: flex;
     }
 
-    /* Count-only right column: don't leave an empty margin at rest. */
-    &:not(:hover) ${TreeRowRightContent}:has(> ${TreeRowCount}:only-child) {
+    .${TREE_ROW_HOVER_ACTIONS_CLASS} {
+        display: none;
+        align-items: center;
+        gap: 4px;
+    }
+
+    &:hover
+        .${TREE_ROW_HOVER_ACTIONS_CLASS},
+        &:focus-within
+        .${TREE_ROW_HOVER_ACTIONS_CLASS},
+        .${TREE_ROW_HOVER_ACTIONS_PINNED_CLASS} {
+        display: flex;
+    }
+
+    /* Collapse right column when it only holds hover-revealed chrome. */
+    &:not(:hover):not(:focus-within):not(:has(.${TREE_ROW_HOVER_ACTIONS_PINNED_CLASS}))
+        ${TreeRowRightContent}:not(:has(> :not(${TreeRowCount}):not(.${TREE_ROW_HOVER_ACTIONS_CLASS}))) {
         display: none;
     }
 `;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/treeRow.styles.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/treeRow.styles.ts
@@ -43,8 +43,93 @@ export const treeRowInteractionBg = css<{ $isSelected?: boolean }>`
               `}
 `;
 
+export const TreeRowIconSlot = styled.div<{ $isCollapsed?: boolean }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 20px;
+    margin-right: ${(props) => (props.$isCollapsed ? '0' : '8px')};
+    flex-shrink: 0;
+`;
+
+/**
+ * Notion-style expand control: entity icon at rest, caret on row hover or when
+ * expanded. CSS-only swap avoids React hover state (which flickered on large trees).
+ */
+export const TreeRowLeadingExpand = styled.button<{ $isExpanded: boolean }>`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: ${(props) => props.theme.colors.icon};
+    flex-shrink: 0;
+
+    .tree-row-entity-icon {
+        display: ${(props) => (props.$isExpanded ? 'none' : 'flex')};
+        align-items: center;
+        justify-content: center;
+    }
+
+    .tree-row-caret-icon {
+        display: ${(props) => (props.$isExpanded ? 'flex' : 'none')};
+        align-items: center;
+        justify-content: center;
+    }
+
+    &:hover {
+        opacity: 0.7;
+    }
+
+    &:disabled {
+        cursor: default;
+        opacity: 0.5;
+    }
+`;
+
+export const TreeRowRightContent = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 8px;
+    flex-shrink: 0;
+`;
+
+/** Child count — hidden at rest, shown on row hover. */
+export const TreeRowCount = styled.div`
+    display: none;
+    align-items: center;
+    flex-shrink: 0;
+`;
+
+/** Row hover: reveal leading caret and child count. */
+export const treeRowHoverChrome = css`
+    &:hover ${TreeRowLeadingExpand}:not([aria-expanded='true']) {
+        .tree-row-entity-icon {
+            display: none;
+        }
+
+        .tree-row-caret-icon {
+            display: flex;
+        }
+    }
+
+    &:hover ${TreeRowCount} {
+        display: flex;
+    }
+
+    /* Count-only right column: don't leave an empty margin at rest. */
+    &:not(:hover) ${TreeRowRightContent}:has(> ${TreeRowCount}:only-child) {
+        display: none;
+    }
+`;
+
 export const TreeRowContainer = styled.div<{
-    $level: number;
     $isSelected: boolean;
     $isCollapsed?: boolean;
 }>`
@@ -52,10 +137,25 @@ export const TreeRowContainer = styled.div<{
     display: flex;
     align-items: center;
     justify-content: ${(props) => (props.$isCollapsed ? 'center' : 'space-between')};
-    padding: ${(props) => (props.$isCollapsed ? '4px 0' : `4px 2px 4px ${getTreeRowPaddingLeft(props.$level)}px`)};
+    /* Level indent on ExpandZone; match right inset so selected rows aren’t lopsided. */
+    padding: ${(props) => (props.$isCollapsed ? '4px 0' : '4px 8px 4px 0')};
     cursor: pointer;
 
     ${(props) => !props.$isCollapsed && treeRowInteractionBg}
+    ${(props) => !props.$isCollapsed && treeRowHoverChrome}
+`;
+
+/**
+ * Indent + icon: expand/collapse tap target for parents. Title stays outside so
+ * it remains navigation. Leaves let clicks bubble to the row.
+ */
+export const TreeRowExpandZone = styled.div<{ $level: number; $expandable: boolean }>`
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+    padding-left: ${(props) => getTreeRowPaddingLeft(props.$level)}px;
+    flex-shrink: 0;
+    cursor: ${(props) => (props.$expandable ? 'pointer' : 'inherit')};
 `;
 
 export const TreeRowLeftContent = styled.div<{ $isCollapsed?: boolean }>`
@@ -69,25 +169,6 @@ export const TreeRowLeftContent = styled.div<{ $isCollapsed?: boolean }>`
         min-width: 0;
         overflow: hidden;
     `}
-`;
-
-export const TreeRowCaretSlot = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: ${TREE_ROW_CARET_SIZE + 2}px;
-    height: ${TREE_ROW_CARET_SIZE + 2}px;
-    flex-shrink: 0;
-`;
-
-export const TreeRowIconSlot = styled.div<{ $isCollapsed?: boolean }>`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 20px;
-    margin-right: ${(props) => (props.$isCollapsed ? '0' : '8px')};
-    flex-shrink: 0;
 `;
 
 /** Shared by tree rows and home nav. */
@@ -109,15 +190,7 @@ export const TreeRowTitle = styled.span<{ $isSelected: boolean }>`
     `}
 `;
 
-export const TreeRowRightContent = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    margin-left: 8px;
-    flex-shrink: 0;
-`;
-
-/** Caret / expand-all / section chevron hit target. */
+/** Section expand-all / header chevron hit target. */
 export const TreeRowExpandButton = styled.button`
     display: flex;
     align-items: center;

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/__tests__/treeRowChrome.test.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/__tests__/treeRowChrome.test.ts
@@ -24,12 +24,10 @@ describe('getTreeRowChromeFlags', () => {
         hasToggle: true,
     };
 
-    it('shows caret and count for a collapsed parent', () => {
+    it('mounts count for a collapsed parent (row countReveal controls visibility)', () => {
         expect(getTreeRowChromeFlags(base)).toEqual({
             canExpand: true,
             showCount: true,
-            showRightChrome: true,
-            reserveCaretSlot: true,
         });
     });
 
@@ -38,16 +36,14 @@ describe('getTreeRowChromeFlags', () => {
         expect(getTreeRowChromeFlags({ ...base, isExpanded: true }).canExpand).toBe(true);
     });
 
-    it('hides caret and count when the sidebar is collapsed', () => {
+    it('hides expand and count when the sidebar is collapsed', () => {
         expect(getTreeRowChromeFlags({ ...base, isCollapsed: true })).toEqual({
             canExpand: false,
             showCount: false,
-            showRightChrome: false,
-            reserveCaretSlot: false,
         });
     });
 
-    it('reserves caret slot for leaves so icons stay aligned', () => {
+    it('does not expand leaves', () => {
         const flags = getTreeRowChromeFlags({
             ...base,
             hasChildren: false,
@@ -56,8 +52,6 @@ describe('getTreeRowChromeFlags', () => {
         });
         expect(flags.canExpand).toBe(false);
         expect(flags.showCount).toBe(false);
-        expect(flags.reserveCaretSlot).toBe(true);
-        expect(flags.showRightChrome).toBe(true);
     });
 
     it('hides count when count is zero or missing', () => {
@@ -65,7 +59,7 @@ describe('getTreeRowChromeFlags', () => {
         expect(getTreeRowChromeFlags({ ...base, count: undefined }).showCount).toBe(false);
     });
 
-    it('requires hasToggle to show the caret', () => {
+    it('requires hasToggle to allow expand', () => {
         expect(getTreeRowChromeFlags({ ...base, hasToggle: false }).canExpand).toBe(false);
     });
 });

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/treeRowChrome.ts
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/utils/treeRowChrome.ts
@@ -1,7 +1,7 @@
 /**
  * Pure chrome flags for hierarchical browse tree rows.
  *
- * Kept free of React so count / caret visibility can be unit-tested without
+ * Kept free of React so count / expand visibility can be unit-tested without
  * mounting the row (same idea as documentTreeGrouping / fileImportUtils).
  */
 
@@ -15,22 +15,11 @@ export type TreeRowChromeInput = {
 };
 
 export type TreeRowChromeFlags = {
-    /** Show expand caret (parents only; hidden when sidebar is collapsed). */
     canExpand: boolean;
-    /** Count pill — only while children are collapsed. */
+    /** Mount count when collapsed; `countReveal` on the row controls always vs hover. */
     showCount: boolean;
-    /** Right column: count, trailing actions, and/or reserved caret slot. */
-    showRightChrome: boolean;
-    /** Reserve far-right caret column so leaf/parent icons stay aligned. */
-    reserveCaretSlot: boolean;
 };
 
-/**
- * Derives which chrome pieces HierarchicalBrowseTreeRow should render.
- *
- * Count hides when expanded (children are visible). Caret column is reserved
- * for every expanded-sidebar row so leaves and parents share one vertical line.
- */
 export function getTreeRowChromeFlags({
     isCollapsed,
     hasChildren,
@@ -38,18 +27,9 @@ export function getTreeRowChromeFlags({
     count,
     hasToggle,
 }: TreeRowChromeInput): TreeRowChromeFlags {
-    const canExpand = !isCollapsed && hasChildren && hasToggle;
-    const showCount = !isCollapsed && hasChildren && !isExpanded && count != null && count > 0;
-    const reserveCaretSlot = !isCollapsed;
-    // Always mount the right column when expanded so the caret slot keeps
-    // leaf and parent icons on one vertical line.
-    const showRightChrome = reserveCaretSlot;
-
     return {
-        canExpand,
-        showCount,
-        showRightChrome,
-        reserveCaretSlot,
+        canExpand: !isCollapsed && hasChildren && hasToggle,
+        showCount: !isCollapsed && hasChildren && !isExpanded && count != null && count > 0,
     };
 }
 

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -55,9 +55,7 @@ export class DocumentPage extends BasePage {
     this.typeSelect = page.getByTestId('document-type-select');
     this.searchInput = page.getByPlaceholder('Search documents');
     this.searchResults = page.getByTestId('context-sidebar-search-results');
-    this.actionsMenuButton = page
-      .getByTestId('document-actions-menu-button')
-      .filter({ visible: true });
+    this.actionsMenuButton = page.getByTestId('document-actions-menu-button').filter({ visible: true });
     this.movePopover = page.getByTestId('move-document-popover');
     this.moveConfirmButton = page.getByTestId('move-document-confirm-button');
 

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -39,6 +39,8 @@ export class DocumentPage extends BasePage {
   readonly getDeleteConfirmDialog: () => Locator;
   readonly getParentBreadcrumb: (title: string) => Locator;
   readonly getMoveSearchResultByText: (text: string) => Locator;
+  readonly getDataHubSectionExpandAll: () => Locator;
+  readonly getTreeItemExpandButton: (urn: string) => Locator;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
@@ -76,6 +78,9 @@ export class DocumentPage extends BasePage {
     this.getDeleteConfirmDialog = () => page.getByText('Delete Document');
     this.getParentBreadcrumb = (title: string) => page.getByTestId('parent-breadcrumb-link').filter({ hasText: title });
     this.getMoveSearchResultByText = (text: string) => this.movePopover.getByText(text, { exact: false });
+    this.getDataHubSectionExpandAll = () => page.getByTestId('document-tree-datahub-section-expand-all');
+    this.getTreeItemExpandButton = (urn: string) =>
+      this.getTreeItem(urn).getByRole('button', { name: /^(expand|collapse)$/i });
   }
 
   // ── Navigation and Setup ──────────────────────────────────────────────────
@@ -335,5 +340,90 @@ export class DocumentPage extends BasePage {
     await this.expectMoveSuccessMessage();
 
     return { parentUrn, childUrn };
+  }
+
+  /**
+   * Create a child under `parentUrn` via the row (+) control — avoids move-popover
+   * search / ES lag when we only need a nested pair for expand tests.
+   */
+  async createChildUnderParentViaPlus(parentUrn: string, childTitle: string): Promise<string> {
+    await this.navigateToDocument(parentUrn);
+    await expect(this.titleInput).toBeVisible({ timeout: TIMEOUTS.LONG });
+    const parentRow = this.getTreeItem(parentUrn);
+    await expect(parentRow).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await parentRow.scrollIntoViewIfNeeded();
+    await parentRow.hover();
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
+
+    const createChildButton = parentRow.getByTestId('document-tree-create-child-button');
+    await expect(createChildButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await createChildButton.click();
+
+    await expect
+      .poll(() => this.extractDocumentUrnFromUrl(this.page.url()), { timeout: TIMEOUTS.LONG })
+      .not.toBe(parentUrn);
+
+    const childUrn = this.extractDocumentUrnFromUrl(this.page.url());
+    expect(childUrn).toBeTruthy();
+    await expect(this.titleInput).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await this.setDocumentTitle(childTitle);
+    return childUrn;
+  }
+
+  /** Hover the row so the Notion-style caret is clickable, then toggle expand. */
+  async toggleTreeItemExpand(urn: string): Promise<void> {
+    const treeItem = this.getTreeItem(urn);
+    await expect(treeItem).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await treeItem.scrollIntoViewIfNeeded();
+    await treeItem.hover();
+    const expandButton = this.getTreeItemExpandButton(urn);
+    await expect(expandButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await expandButton.click();
+    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+  }
+
+  async expectTreeItemExpanded(urn: string): Promise<void> {
+    await this.getTreeItem(urn).hover();
+    await expect(this.getTreeItemExpandButton(urn)).toHaveAttribute('aria-expanded', 'true', {
+      timeout: TIMEOUTS.LONG,
+    });
+  }
+
+  async expectTreeItemCollapsed(urn: string): Promise<void> {
+    await this.getTreeItem(urn).hover();
+    await expect(this.getTreeItemExpandButton(urn)).toHaveAttribute('aria-expanded', 'false', {
+      timeout: TIMEOUTS.LONG,
+    });
+  }
+
+  async clickDataHubSectionExpandAll(): Promise<void> {
+    const button = this.getDataHubSectionExpandAll();
+    await expect(button).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await expect(button).toBeEnabled({ timeout: TIMEOUTS.LONG });
+    await button.click();
+    // Expand-all can take a while on large libraries; wait for the control to unlock.
+    await expect(button).toBeEnabled({ timeout: 60_000 });
+    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+  }
+
+  /** If the section is already expanded, collapse-all first so expand-all has work to do. */
+  async ensureDataHubSectionCollapsed(): Promise<void> {
+    const button = this.getDataHubSectionExpandAll();
+    await expect(button).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await expect(button).toBeEnabled({ timeout: TIMEOUTS.LONG });
+    const label = (await button.getAttribute('aria-label')) || '';
+    if (/collapse/i.test(label)) {
+      await button.click();
+      await expect(button).toBeEnabled({ timeout: TIMEOUTS.LONG });
+      await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    }
+  }
+
+  async expectTreeItemVisibleInSidebar(urn: string): Promise<void> {
+    await expect(this.getTreeItem(urn)).toBeVisible({ timeout: TIMEOUTS.LONG });
+  }
+
+  async expectTreeItemHiddenInSidebar(urn: string): Promise<void> {
+    await expect(this.getTreeItem(urn)).toBeHidden({ timeout: TIMEOUTS.LONG });
   }
 }

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -55,7 +55,9 @@ export class DocumentPage extends BasePage {
     this.typeSelect = page.getByTestId('document-type-select');
     this.searchInput = page.getByPlaceholder('Search documents');
     this.searchResults = page.getByTestId('context-sidebar-search-results');
-    this.actionsMenuButton = page.getByTestId('document-actions-menu-button');
+    this.actionsMenuButton = page
+      .getByTestId('document-actions-menu-button')
+      .filter({ visible: true });
     this.movePopover = page.getByTestId('move-document-popover');
     this.moveConfirmButton = page.getByTestId('move-document-confirm-button');
 
@@ -254,13 +256,15 @@ export class DocumentPage extends BasePage {
     const treeItem = this.getTreeItem(urn);
     await expect(treeItem).toBeVisible({ timeout: TIMEOUTS.LONG });
     await treeItem.scrollIntoViewIfNeeded();
+    // Reveal CSS-hover actions, then move onto ⋮ so the title Tooltip doesn't cover it.
     await treeItem.hover();
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
     const menuButton = this.getTreeItemMenuButton(urn);
     await expect(menuButton).toBeVisible({ timeout: TIMEOUTS.LONG });
-    await menuButton.click();
-    // eslint-disable-next-line playwright/no-raw-locators
-    await expect(this.page.locator('[role="menu"]:visible')).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await menuButton.hover();
+    await menuButton.click({ force: true });
+    await expect(this.getDropdownMenu().filter({ visible: true }).first()).toBeVisible({
+      timeout: TIMEOUTS.MEDIUM,
+    });
   }
 
   async clickMoveOption(): Promise<void> {
@@ -362,12 +366,13 @@ export class DocumentPage extends BasePage {
     const parentRow = this.getTreeItem(parentUrn);
     await expect(parentRow).toBeVisible({ timeout: TIMEOUTS.LONG });
     await parentRow.scrollIntoViewIfNeeded();
-    await parentRow.hover();
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
 
+    // Reveal CSS-hover actions, then move onto + so the title Tooltip doesn't cover it.
+    await parentRow.hover();
     const createChildButton = parentRow.getByTestId('document-tree-create-child-button');
     await expect(createChildButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
-    await createChildButton.click();
+    await createChildButton.hover();
+    await createChildButton.click({ force: true });
 
     await expect
       .poll(() => this.extractDocumentUrnFromUrl(this.page.url()), { timeout: TIMEOUTS.LONG })
@@ -385,23 +390,26 @@ export class DocumentPage extends BasePage {
     const treeItem = this.getTreeItem(urn);
     await expect(treeItem).toBeVisible({ timeout: TIMEOUTS.LONG });
     await treeItem.scrollIntoViewIfNeeded();
-    await treeItem.hover();
     const expandButton = this.getTreeItemExpandButton(urn);
+    // Expand control is on the left; hover it directly (not the title) before clicking.
+    await expandButton.hover({ force: true });
     await expect(expandButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
-    await expandButton.click();
+    await expandButton.click({ force: true });
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
   async expectTreeItemExpanded(urn: string): Promise<void> {
-    await this.getTreeItem(urn).hover();
-    await expect(this.getTreeItemExpandButton(urn)).toHaveAttribute('aria-expanded', 'true', {
+    const expandButton = this.getTreeItemExpandButton(urn);
+    await expandButton.hover({ force: true });
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'true', {
       timeout: TIMEOUTS.LONG,
     });
   }
 
   async expectTreeItemCollapsed(urn: string): Promise<void> {
-    await this.getTreeItem(urn).hover();
-    await expect(this.getTreeItemExpandButton(urn)).toHaveAttribute('aria-expanded', 'false', {
+    const expandButton = this.getTreeItemExpandButton(urn);
+    await expandButton.hover({ force: true });
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false', {
       timeout: TIMEOUTS.LONG,
     });
   }

--- a/e2e-test/ui/playwright/tests/documents/document-tree-expand.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-tree-expand.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Documents sidebar tree expand / collapse.
+ *
+ * Validates single-folder toggle and DataHub section expand-all / collapse-all
+ * against a live local frontend (BASE_URL). Creates its own nested docs — no
+ * fixture seeding required.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { withRandomSuffix } from '../../utils/random';
+import { DocumentPage } from '../../pages/entity/document.page';
+import { TIMEOUTS } from '../../utils/constants';
+
+test.describe('Document tree expand / collapse', () => {
+  let documentPage: DocumentPage;
+
+  test.beforeEach(async ({ apiMock, page }) => {
+    test.setTimeout(180_000);
+    await apiMock.setFeatureFlags({
+      contextDocumentsEnabled: true,
+      showNavBarRedesign: true,
+      showHomePageRedesign: true,
+    });
+    documentPage = new DocumentPage(page);
+    await documentPage.navigateToDocuments();
+  });
+
+  test('should expand and collapse a single document folder in the sidebar', async ({ cleanup }) => {
+    const base = withRandomSuffix('doc-expand');
+    const parentTitle = `${base}_parent`;
+    const childTitle = `${base}_child`;
+
+    const parentUrn = await documentPage.createDocumentWithTitle(parentTitle);
+    cleanup.track(parentUrn);
+    const childUrn = await documentPage.createChildUnderParentViaPlus(parentUrn, childTitle);
+    cleanup.track(childUrn);
+
+    // Prefer sidebar selection over full navigation — large libraries keep network busy.
+    await documentPage.getTreeItem(parentUrn).click();
+    await expect(documentPage.titleInput).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await documentPage.expectTreeItemVisibleInSidebar(parentUrn);
+
+    const expandButton = documentPage.getTreeItemExpandButton(parentUrn);
+    await documentPage.getTreeItem(parentUrn).hover();
+    if ((await expandButton.getAttribute('aria-expanded')) === 'true') {
+      await documentPage.toggleTreeItemExpand(parentUrn);
+    }
+    await documentPage.expectTreeItemCollapsed(parentUrn);
+    await documentPage.expectTreeItemHiddenInSidebar(childUrn);
+
+    await documentPage.toggleTreeItemExpand(parentUrn);
+    await documentPage.expectTreeItemExpanded(parentUrn);
+    await documentPage.expectTreeItemVisibleInSidebar(childUrn);
+
+    await documentPage.toggleTreeItemExpand(parentUrn);
+    await documentPage.expectTreeItemCollapsed(parentUrn);
+    await documentPage.expectTreeItemHiddenInSidebar(childUrn);
+  });
+
+  test('should expand and collapse all documents in the DataHub section', async ({ cleanup }) => {
+    const base = withRandomSuffix('doc-expand-all');
+    const parentTitle = `${base}_parent`;
+    const childTitle = `${base}_child`;
+
+    const parentUrn = await documentPage.createDocumentWithTitle(parentTitle);
+    cleanup.track(parentUrn);
+    const childUrn = await documentPage.createChildUnderParentViaPlus(parentUrn, childTitle);
+    cleanup.track(childUrn);
+
+    await documentPage.getTreeItem(parentUrn).click();
+    await expect(documentPage.titleInput).toBeVisible({ timeout: TIMEOUTS.LONG });
+    await documentPage.expectTreeItemVisibleInSidebar(parentUrn);
+
+    // Clear any section-level expansion (other folders / prior navigation).
+    await documentPage.ensureDataHubSectionCollapsed();
+    await documentPage.expectTreeItemCollapsed(parentUrn);
+    await documentPage.expectTreeItemHiddenInSidebar(childUrn);
+
+    await documentPage.clickDataHubSectionExpandAll();
+    await documentPage.expectTreeItemExpanded(parentUrn);
+    await documentPage.expectTreeItemVisibleInSidebar(childUrn);
+
+    await documentPage.clickDataHubSectionExpandAll();
+    await documentPage.expectTreeItemCollapsed(parentUrn);
+    await documentPage.expectTreeItemHiddenInSidebar(childUrn);
+  });
+});

--- a/e2e-test/ui/playwright/tests/documents/document-tree-expand.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-tree-expand.spec.ts
@@ -41,7 +41,7 @@ test.describe('Document tree expand / collapse', () => {
     await documentPage.expectTreeItemVisibleInSidebar(parentUrn);
 
     const expandButton = documentPage.getTreeItemExpandButton(parentUrn);
-    await documentPage.getTreeItem(parentUrn).hover();
+    await expandButton.hover({ force: true });
     if ((await expandButton.getAttribute('aria-expanded')) === 'true') {
       await documentPage.toggleTreeItemExpand(parentUrn);
     }


### PR DESCRIPTION
Stabilize hierarchical browse hover and expand for large trees

Move the caaret back under the entity icons in the  sidebar <!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
