### PR TITLE
fix(auth): inherit schemaField OpenAPI/RestLi READ from parent dataset

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -184,13 +184,17 @@ Requirements:
   `VIEW_UNRESTRICTED_ENTITY_TYPES_REMOVE=schemaField`), **View Entity Page** checks inherit from the
   parent dataset encoded in the schemaField URN
   (`urn:li:schemaField:(<datasetUrn>,<fieldPath>)`), then fall back to a direct grant on the column
-  URN. This matches the existing logical-parent write candidate order. **DataHub Cloud Search Access
-  Controls** can also match columns under **URN** dataset grants via a
+  URN. This matches the existing logical-parent write candidate order. **OpenAPI and RestLi
+  READ-by-URN** use the same parent-inheritance rules when REST API authorization is enabled, so
+  GraphQL entity reads and OpenAPI/RestLi GET agree for the same actor and schemaField URN. **DataHub
+  Cloud Search Access Controls** can also match columns under **URN** dataset grants via a
   `urn:li:schemaField:(<datasetUrn>,` prefix, but domain / container / resource-owner filters still do
   not match column docs (those facets are not on schemaField), and policies with `TYPE = dataset`
   continue to exclude `schemaField` hits. See
   [Columns (`schemaField`) after you restrict them](../features/feature-guides/search-access-controls.md#columns-schemafield-after-you-restrict-them).
-  OSS has no SBAC pushdown and still includes `schemaField` in default search.
+  OSS has no SBAC pushdown and still includes `schemaField` in default search. Resource-scoped
+  grants authorize GET-by-URN / entity-page VIEW; they do not by themselves unlock OpenAPI/RestLi
+  list or scroll discovery on OSS.
 
 - **(GMS / search defaults)** Default entity-type lists for GraphQL search, autocomplete, browse V2, and quick-filter priority are now configurable via `elasticsearch.search.*EntityTypes` (`value` / `add` / `remove`) and the matching `SEARCH_*_ENTITY_TYPES{,_ADD,_REMOVE}` environment variables. Stock YAML defaults match the former hardcoded GraphQL lists. An explicitly empty resolved list means GraphQL searches **no** entity types (it does not expand to all indices). Unknown registry names in these lists are soft-dropped with a warn at startup. See [Environment Variables](../deploy/environment-vars.md) and [Customizing Search](search.md#default-search-entity-types).
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAuthorizationUtils.java
@@ -48,8 +48,9 @@ import org.apache.http.HttpStatus;
  * </ul>
  *
  * <p>Default API behavior delegates to {@link AuthUtil}. Entity-specific utilities are consulted
- * only when a URN or MCP requires specialized authorization (currently documents, with query and
- * schema field VIEW handled for search/view paths).
+ * only when a URN or MCP requires specialized authorization (currently documents; schema field API
+ * READ inherits from the parent dataset; query and schema field VIEW are handled on search/view
+ * paths).
  */
 @Slf4j
 public final class EntityAuthorizationUtils {
@@ -59,7 +60,10 @@ public final class EntityAuthorizationUtils {
   /**
    * Authorizes entity URNs for API surfaces (OpenAPI / RestLi). Activation follows {@code
    * authorization.restApiAuthorization}. Document URNs use document-specific CREATE/UPDATE
-   * existence classification and bridge-aware READ; all other entity types use {@link AuthUtil}.
+   * existence classification and bridge-aware READ. Schema field READ inherits from the parent
+   * dataset encoded in the URN (same candidate order as GraphQL VIEW), then falls back to a direct
+   * grant on the schema field; other operations on schema fields use {@link AuthUtil}. All other
+   * entity types use {@link AuthUtil}.
    *
    * <p>Independent of View Authorization: when REST API auth is enabled, READ is enforced even if
    * view/search access controls are disabled.
@@ -70,14 +74,48 @@ public final class EntityAuthorizationUtils {
       @Nonnull Collection<Urn> urns) {
     List<Urn> documents =
         urns.stream().filter(DocumentAuthorizationUtils::isDocumentEntity).toList();
+    List<Urn> schemaFields =
+        urns.stream()
+            .filter(urn -> !DocumentAuthorizationUtils.isDocumentEntity(urn))
+            .filter(EntityAspectAuthorizationUtils::isSchemaFieldEntity)
+            .toList();
     List<Urn> others =
-        urns.stream().filter(urn -> !DocumentAuthorizationUtils.isDocumentEntity(urn)).toList();
+        urns.stream()
+            .filter(urn -> !DocumentAuthorizationUtils.isDocumentEntity(urn))
+            .filter(urn -> !EntityAspectAuthorizationUtils.isSchemaFieldEntity(urn))
+            .toList();
     if (!others.isEmpty() && !AuthUtil.isAPIAuthorizedEntityUrns(opContext, apiOperation, others)) {
+      return false;
+    }
+    if (!schemaFields.isEmpty()
+        && !isAPIAuthorizedSchemaFieldUrns(opContext, apiOperation, schemaFields)) {
       return false;
     }
     return documents.isEmpty()
         || DocumentAuthorizationUtils.isAPIAuthorizedDocumentUrns(
             opContext, apiOperation, documents);
+  }
+
+  /**
+   * Authorizes schema field URNs for API surfaces. READ reuses parent-dataset inheritance via
+   * {@link EntityAspectAuthorizationUtils#canViewSchemaFieldEntity} when REST API authorization is
+   * enabled; other operations use {@link AuthUtil} without inheritance.
+   */
+  private static boolean isAPIAuthorizedSchemaFieldUrns(
+      @Nonnull OperationContext opContext,
+      @Nonnull ApiOperation apiOperation,
+      @Nonnull Collection<Urn> schemaFieldUrns) {
+    if (schemaFieldUrns.isEmpty()) {
+      return true;
+    }
+    if (apiOperation != READ) {
+      return AuthUtil.isAPIAuthorizedEntityUrns(opContext, apiOperation, schemaFieldUrns);
+    }
+    if (!AuthUtil.isRestApiAuthorizationEnabled()) {
+      return true;
+    }
+    return schemaFieldUrns.stream()
+        .allMatch(urn -> EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(opContext, urn));
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAuthorizationUtilsTest.java
@@ -77,6 +77,12 @@ public class EntityAuthorizationUtilsTest {
     documentAuthMock
         .when(() -> DocumentAuthorizationUtils.isDocumentEntity(DATASET_URN))
         .thenReturn(false);
+    documentAuthMock
+        .when(() -> DocumentAuthorizationUtils.isDocumentEntity(SCHEMA_FIELD_URN))
+        .thenReturn(false);
+    documentAuthMock
+        .when(() -> DocumentAuthorizationUtils.isDocumentEntity(QUERY_URN))
+        .thenReturn(false);
   }
 
   @AfterMethod
@@ -117,6 +123,140 @@ public class EntityAuthorizationUtilsTest {
 
     assertTrue(
         EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(opContext, READ, List.of(DATASET_URN)));
+  }
+
+  @Test
+  public void testIsAPIAuthorizedEntityUrns_schemaFieldReadAllowedViaParentInheritance() {
+    authUtilMock.when(AuthUtil::isRestApiAuthorizationEnabled).thenReturn(true);
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(SCHEMA_FIELD_URN))
+          .thenReturn(true);
+      schemaFieldAuth
+          .when(
+              () ->
+                  EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+                      opContext, SCHEMA_FIELD_URN))
+          .thenReturn(true);
+
+      assertTrue(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, READ, List.of(SCHEMA_FIELD_URN)));
+      authUtilMock.verify(
+          () -> AuthUtil.isAPIAuthorizedEntityUrns(opContext, READ, List.of(SCHEMA_FIELD_URN)),
+          Mockito.never());
+    }
+  }
+
+  @Test
+  public void testIsAPIAuthorizedEntityUrns_schemaFieldReadDeniedWithoutGrant() {
+    authUtilMock.when(AuthUtil::isRestApiAuthorizationEnabled).thenReturn(true);
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(SCHEMA_FIELD_URN))
+          .thenReturn(true);
+      schemaFieldAuth
+          .when(
+              () ->
+                  EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+                      opContext, SCHEMA_FIELD_URN))
+          .thenReturn(false);
+
+      assertFalse(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, READ, List.of(SCHEMA_FIELD_URN)));
+    }
+  }
+
+  @Test
+  public void testIsAPIAuthorizedEntityUrns_schemaFieldReadAllowsWhenRestApiAuthDisabled() {
+    authUtilMock.when(AuthUtil::isRestApiAuthorizationEnabled).thenReturn(false);
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(SCHEMA_FIELD_URN))
+          .thenReturn(true);
+
+      assertTrue(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, READ, List.of(SCHEMA_FIELD_URN)));
+      schemaFieldAuth.verify(
+          () ->
+              EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(opContext, SCHEMA_FIELD_URN),
+          Mockito.never());
+    }
+  }
+
+  @Test
+  public void testIsAPIAuthorizedEntityUrns_schemaFieldNonReadUsesAuthUtil() {
+    authUtilMock
+        .when(
+            () -> AuthUtil.isAPIAuthorizedEntityUrns(opContext, UPDATE, List.of(SCHEMA_FIELD_URN)))
+        .thenReturn(true);
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(SCHEMA_FIELD_URN))
+          .thenReturn(true);
+
+      assertTrue(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, UPDATE, List.of(SCHEMA_FIELD_URN)));
+      schemaFieldAuth.verify(
+          () ->
+              EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(opContext, SCHEMA_FIELD_URN),
+          Mockito.never());
+      authUtilMock.verify(
+          () -> AuthUtil.isAPIAuthorizedEntityUrns(opContext, UPDATE, List.of(SCHEMA_FIELD_URN)));
+    }
+  }
+
+  @Test
+  public void testIsAPIAuthorizedEntityUrns_mixedBatchRoutesSchemaFieldsDocumentsAndOthers() {
+    authUtilMock.when(AuthUtil::isRestApiAuthorizationEnabled).thenReturn(true);
+    authUtilMock
+        .when(() -> AuthUtil.isAPIAuthorizedEntityUrns(opContext, READ, List.of(DATASET_URN)))
+        .thenReturn(true);
+    documentAuthMock
+        .when(
+            () ->
+                DocumentAuthorizationUtils.isAPIAuthorizedDocumentUrns(
+                    opContext, READ, List.of(DOCUMENT_URN)))
+        .thenReturn(true);
+    try (MockedStatic<EntityAspectAuthorizationUtils> schemaFieldAuth =
+        Mockito.mockStatic(EntityAspectAuthorizationUtils.class, Mockito.CALLS_REAL_METHODS)) {
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(SCHEMA_FIELD_URN))
+          .thenReturn(true);
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(DATASET_URN))
+          .thenReturn(false);
+      schemaFieldAuth
+          .when(() -> EntityAspectAuthorizationUtils.isSchemaFieldEntity(DOCUMENT_URN))
+          .thenReturn(false);
+      schemaFieldAuth
+          .when(
+              () ->
+                  EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+                      opContext, SCHEMA_FIELD_URN))
+          .thenReturn(true);
+
+      assertTrue(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, READ, List.of(DATASET_URN, SCHEMA_FIELD_URN, DOCUMENT_URN)));
+
+      schemaFieldAuth
+          .when(
+              () ->
+                  EntityAspectAuthorizationUtils.canViewSchemaFieldEntity(
+                      opContext, SCHEMA_FIELD_URN))
+          .thenReturn(false);
+      assertFalse(
+          EntityAuthorizationUtils.isAPIAuthorizedEntityUrns(
+              opContext, READ, List.of(DATASET_URN, SCHEMA_FIELD_URN, DOCUMENT_URN)));
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary
- OpenAPI/RestLi READ-by-URN for `schemaField` now inherits access from the parent dataset encoded in the URN (same candidate order as GraphQL VIEW), then falls back to a direct column grant
- Mirrors the existing document API READ specialization in `EntityAuthorizationUtils.isAPIAuthorizedEntityUrns`; non-READ schemaField ops still use `AuthUtil` without parent inheritance
- Documents the GraphQL/OpenAPI/RestLi READ parity and that OSS resource-scoped grants do not unlock list/scroll discovery

## Checklist
- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (especially **PR Title Format**)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [x] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [`docs/how/updating-datahub.md`](../docs/how/updating-datahub.md) (if applicable)

## Test plan
- [x] `./gradlew :metadata-io:test --tests '*EntityAuthorizationUtils*' --tests '*EntityAspectAuthorizationUtils*'`
- [x] Unit coverage: API READ allow via parent inheritance, deny without grant, allow when REST API auth disabled, non-READ uses AuthUtil, mixed batch routing
- [ ] Manual: OpenAPI GET schemaField URN with VIEW on parent dataset only → 200; without parent/direct grant → 403


Made with [Cursor](https://cursor.com)