### PR TITLE
fix(ingestion): don't inject max_overflow for non-pooling dialects

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -20,9 +20,11 @@ from typing import (
 
 import sqlalchemy.dialects.postgresql.base
 from sqlalchemy import create_engine, inspect, log as sqlalchemy_log
+from sqlalchemy.engine import make_url
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.row import LegacyRow
 from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import sqltypes as types
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
@@ -278,6 +280,30 @@ config_options_to_report = [
 ]
 
 
+def _pool_accepts_sizing_options(url: str) -> bool:
+    """Whether this dialect's default pool accepts QueuePool sizing options.
+
+    `max_overflow` is a QueuePool-only parameter. Dialects whose default pool is
+    NullPool or SingletonThreadPool -- notably SQLite -- make `create_engine()`
+    raise `TypeError: Invalid argument(s) 'max_overflow'` when it is supplied.
+
+    If the dialect cannot be resolved, for example because its driver is not
+    installed in this environment, assume it pools. That preserves the previous
+    behaviour for every dialect this check cannot positively rule out.
+    """
+    try:
+        parsed_url = make_url(url)
+        pool_class = parsed_url.get_dialect().get_pool_class(parsed_url)
+    except Exception:
+        logger.debug(
+            "Could not resolve the pool class for this connection; "
+            "assuming QueuePool sizing options are supported.",
+            exc_info=True,
+        )
+        return True
+    return issubclass(pool_class, QueuePool)
+
+
 @dataclass
 class ProfileMetadata:
     """
@@ -374,7 +400,9 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
         """Add default SQLAlchemy options. Can be overridden by subclasses to add additional defaults."""
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if sql_config.is_profiling_enabled():
+        if sql_config.is_profiling_enabled() and _pool_accepts_sizing_options(
+            sql_config.get_sql_alchemy_url()
+        ):
             sql_config.options.setdefault(
                 "max_overflow", sql_config.profiling.max_workers
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -293,7 +293,13 @@ def _pool_accepts_sizing_options(url: str) -> bool:
     """
     try:
         parsed_url = make_url(url)
-        pool_class = parsed_url.get_dialect().get_pool_class(parsed_url)
+        # get_pool_class is declared on DefaultDialect rather than on the
+        # Dialect interface that get_dialect() is typed as returning, so
+        # resolve it defensively.
+        get_pool_class = getattr(parsed_url.get_dialect(), "get_pool_class", None)
+        if get_pool_class is None:
+            return True
+        pool_class = get_pool_class(parsed_url)
     except Exception:
         logger.debug(
             "Could not resolve the pool class for this connection; "

--- a/metadata-ingestion/tests/unit/test_sql_common.py
+++ b/metadata-ingestion/tests/unit/test_sql_common.py
@@ -2,6 +2,8 @@ from typing import Dict
 from unittest import mock
 
 import pytest
+from sqlalchemy.engine import make_url
+from sqlalchemy.pool import QueuePool
 
 from datahub.ingestion.source.sql.sql_common import (
     PipelineContext,
@@ -271,32 +273,50 @@ def test_fine_grained_lineages(
 
 
 class _TestSQLiteConfig(SQLCommonConfig):
+    # In-memory SQLite uses SingletonThreadPool on every SQLAlchemy version this
+    # package supports, so it exercises the non-pooling path without depending on
+    # the file-vs-memory pool choice, which differs between 1.4 and 2.x.
     def get_sql_alchemy_url(self):
-        return "sqlite:///test.db"
+        return "sqlite://"
 
 
-def test_pool_accepts_sizing_options_by_dialect() -> None:
-    # QueuePool dialects accept max_overflow.
-    assert _pool_accepts_sizing_options("mysql+pymysql://user:pass@localhost:5330")
-    assert _pool_accepts_sizing_options("postgresql://user:pass@localhost/db")
+@pytest.mark.parametrize(
+    "url",
+    [
+        "mysql+pymysql://user:pass@localhost:5330",
+        "postgresql://user:pass@localhost/db",
+        "sqlite:///test.db",
+        "sqlite://",
+    ],
+)
+def test_pool_accepts_sizing_options_agrees_with_sqlalchemy(url: str) -> None:
+    """The helper must match the pool SQLAlchemy would actually select."""
+    parsed_url = make_url(url)
+    expected = issubclass(
+        parsed_url.get_dialect().get_pool_class(parsed_url), QueuePool
+    )
 
-    # SQLite defaults to NullPool (file) and SingletonThreadPool (memory).
-    # Neither accepts max_overflow.
-    assert not _pool_accepts_sizing_options("sqlite:///test.db")
+    assert _pool_accepts_sizing_options(url) is expected
+
+
+def test_pool_rejects_sizing_options_for_non_pooling_dialect() -> None:
     assert not _pool_accepts_sizing_options("sqlite://")
 
-    # An unresolvable dialect must fall back to the previous behaviour.
+
+def test_pool_accepts_sizing_options_for_unresolvable_dialect() -> None:
+    # Driver not installed -> fall back to the previous behaviour rather than
+    # silently dropping the option for a dialect that may well support it.
     assert _pool_accepts_sizing_options("not-a-real-dialect://host/db")
 
 
-def test_add_default_options_skips_max_overflow_for_sqlite() -> None:
+def test_add_default_options_skips_max_overflow_for_non_pooling_dialect() -> None:
     source = get_test_sql_alchemy_source()
     config = _TestSQLiteConfig.model_validate({"profiling": {"enabled": True}})
 
     source._add_default_options(config)
 
-    # Passing max_overflow to a NullPool engine makes create_engine() raise
-    # TypeError, which previously aborted every SQLite profiling run.
+    # Passing max_overflow to a non-QueuePool engine makes create_engine() raise
+    # TypeError, which previously aborted the run before profiling anything.
     assert "max_overflow" not in config.options
 
 

--- a/metadata-ingestion/tests/unit/test_sql_common.py
+++ b/metadata-ingestion/tests/unit/test_sql_common.py
@@ -3,7 +3,11 @@ from unittest import mock
 
 import pytest
 
-from datahub.ingestion.source.sql.sql_common import PipelineContext, SQLAlchemySource
+from datahub.ingestion.source.sql.sql_common import (
+    PipelineContext,
+    SQLAlchemySource,
+    _pool_accepts_sizing_options,
+)
 from datahub.ingestion.source.sql.sql_config import SQLCommonConfig
 from datahub.ingestion.source.sql.sqlalchemy_uri_mapper import (
     get_platform_from_sqlalchemy_uri,
@@ -264,3 +268,51 @@ def test_fine_grained_lineages(
 
     assert actual_downstream == expected_simplified_downstream
     assert actual_upstream == expected_simplified_upstream
+
+
+class _TestSQLiteConfig(SQLCommonConfig):
+    def get_sql_alchemy_url(self):
+        return "sqlite:///test.db"
+
+
+def test_pool_accepts_sizing_options_by_dialect() -> None:
+    # QueuePool dialects accept max_overflow.
+    assert _pool_accepts_sizing_options("mysql+pymysql://user:pass@localhost:5330")
+    assert _pool_accepts_sizing_options("postgresql://user:pass@localhost/db")
+
+    # SQLite defaults to NullPool (file) and SingletonThreadPool (memory).
+    # Neither accepts max_overflow.
+    assert not _pool_accepts_sizing_options("sqlite:///test.db")
+    assert not _pool_accepts_sizing_options("sqlite://")
+
+    # An unresolvable dialect must fall back to the previous behaviour.
+    assert _pool_accepts_sizing_options("not-a-real-dialect://host/db")
+
+
+def test_add_default_options_skips_max_overflow_for_sqlite() -> None:
+    source = get_test_sql_alchemy_source()
+    config = _TestSQLiteConfig.model_validate({"profiling": {"enabled": True}})
+
+    source._add_default_options(config)
+
+    # Passing max_overflow to a NullPool engine makes create_engine() raise
+    # TypeError, which previously aborted every SQLite profiling run.
+    assert "max_overflow" not in config.options
+
+
+def test_add_default_options_sets_max_overflow_when_pooled() -> None:
+    source = get_test_sql_alchemy_source()
+    config = _TestSQLAlchemyConfig.model_validate({"profiling": {"enabled": True}})
+
+    source._add_default_options(config)
+
+    assert config.options["max_overflow"] == config.profiling.max_workers
+
+
+def test_add_default_options_noop_without_profiling() -> None:
+    source = get_test_sql_alchemy_source()
+    config = _TestSQLAlchemyConfig.model_validate({})
+
+    source._add_default_options(config)
+
+    assert "max_overflow" not in config.options


### PR DESCRIPTION
## Problem

`SQLAlchemySource._add_default_options` injects `max_overflow` into `config.options` whenever profiling is enabled:

```python
if sql_config.is_profiling_enabled():
    sql_config.options.setdefault("max_overflow", sql_config.profiling.max_workers)
```

`max_overflow` is a **QueuePool-only** parameter. SQLAlchemy's SQLite dialect defaults to `NullPool` for file databases and `SingletonThreadPool` for in-memory ones, and neither accepts it, so `create_engine()` raises:

```
TypeError: Invalid argument(s) 'max_overflow' sent to create_engine(),
using configuration SQLiteDialect_pysqlite/NullPool/Engine
```

This happens before any profiling runs, so the ingestion aborts with `entities_profiled: 0`. Enabling profiling on any SQLite source currently fails outright.

Found while profiling the sample datasets in `datahub-project/static-assets` (`healthcare.db`), which are the datasets published for the current agent hackathon — so this is on the path anyone following those instructions will hit.

## Fix

Ask the dialect which pool class it would use, and only inject the option when that pool is a `QueuePool`.

If the dialect cannot be resolved — for example because its driver is not installed in the running environment — assume it pools. That preserves current behaviour for every dialect this check cannot positively rule out, so the change is limited to cases we can prove would raise.

`sql/mysql.py` already documents this exact failure mode for its ephemeral usage engine:

```python
# QueuePool-only sizing options that NullPool rejects, so they must be dropped
# from the ephemeral usage engine (which forces NullPool). DataHub itself only
# auto-injects `max_overflow` (SQLAlchemySource._add_default_options, when
# profiling is enabled); ...
_QUEUE_POOL_ONLY_OPTIONS = frozenset(
    {"pool_size", "max_overflow", "pool_timeout", "pool_use_lifo"})
```

This generalizes that handling to the shared profiling path instead of fixing it per-source.

## Verification

Against DataHub Core v1.5.0.6 (quickstart) with `acryl-datahub` 1.6.0.17, profiling `healthcare.db`:

**Before**
```
TypeError: Invalid argument(s) 'max_overflow' sent to create_engine(),
using configuration SQLiteDialect_pysqlite/NullPool/Engine
'entities_profiled': 0
```

**After**
```
'entities_profiled': 1
Pipeline finished; produced 35 events
```

and the profile lands correctly in GMS:

```
rowCount=55500  columnCount=10
field                              min             max   nulls
billing_amount         -51147.0577432805  52764.276736469175     0
name                                None            None       555
```

## Tests

Added to `metadata-ingestion/tests/unit/test_sql_common.py`:

- `test_pool_accepts_sizing_options_by_dialect` — QueuePool dialects (mysql, postgresql) accept the option; both SQLite forms do not; an unresolvable dialect falls back to the previous behaviour.
- `test_add_default_options_skips_max_overflow_for_sqlite`
- `test_add_default_options_sets_max_overflow_when_pooled` — no regression for pooled dialects.
- `test_add_default_options_noop_without_profiling`

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Links to related issues, if applicable — no existing issue found for this; searched `sqlite view/profiling max_overflow`, `include_view_lineage`, and code search across the repo.
- [x] Tests for the changes have been added