### PR TITLE
docs(rfc): caller-provided identity for idempotent Incident creation

### DIFF
--- a/docs/rfcs/active/incident-idempotency-key.md
+++ b/docs/rfcs/active/incident-idempotency-key.md
@@ -13,14 +13,14 @@ Add an optional, caller-supplied external identity to `raiseIncident` so automat
 
 ```graphql
 mutation {
-    raiseIncident(
-        input: {
-            type: OPERATIONAL
-            resourceUrns: ["urn:li:dataset:(...)"]
-            sourceId: "checkout-drift-2026-08-01-poll-status"
-            title: "Route divergence detected on checkout status endpoint"
-        }
-    )
+  raiseIncident(
+    input: {
+      type: OPERATIONAL
+      resourceUrns: ["urn:li:dataset:(...)"]
+      sourceId: "checkout-drift-2026-08-01-poll-status"
+      title: "Route divergence detected on checkout status endpoint"
+    }
+  )
 }
 ```
 

--- a/docs/rfcs/active/incident-idempotency-key.md
+++ b/docs/rfcs/active/incident-idempotency-key.md
@@ -3,11 +3,11 @@
 - Discussion Issue: none yet, opening the RFC directly to get concrete design feedback
 - Implementation PR(s): none, this RFC proposes no code yet
 
-# External Source Identity for Idempotent Incident Creation
+# Caller-Provided Identity for Idempotent Incident Creation
 
 ## Summary
 
-Add an optional, caller-supplied external identity to `raiseIncident` so automated callers (agents, pipelines) can retry the mutation after a network failure without risking a duplicate Incident.
+Add an optional, caller-provided `id` to `raiseIncident` so automated callers (agents, pipelines) can retry the mutation after a network failure without risking a duplicate Incident. Retrying with an `id` that already exists fails with a conflict rather than silently succeeding, so the caller can treat the conflict as confirmation that the first write landed and recover by fetching the Incident at the URN it already chose.
 
 ## Basic example
 
@@ -17,14 +17,14 @@ mutation {
     input: {
       type: OPERATIONAL
       resourceUrns: ["urn:li:dataset:(...)"]
-      sourceId: "checkout-drift-2026-08-01-poll-status"
+      id: "checkout-drift-2026-08-01-poll-status"
       title: "Route divergence detected on checkout status endpoint"
     }
   )
 }
 ```
 
-Calling this twice with the same `resourceUrns` and `sourceId` returns the same Incident URN both times. Omitting `sourceId` preserves today's behavior exactly: a fresh random id every call.
+Calling this once creates the Incident at `urn:li:incident:checkout-drift-2026-08-01-poll-status`. Calling it again with the same `id` fails with a conflict: the Incident already exists at that URN, so no second Incident is created and the mutation does not silently return success. Because the caller chose `id` up front, it already knows the target URN and can fetch it directly on conflict instead of treating the mutation's response as evidence of a new creation. Omitting `id` preserves today's behavior exactly: a fresh random id, and thus a new Incident, on every call.
 
 ## Motivation
 
@@ -36,11 +36,21 @@ This is a gap in the mutation's contract, not a gap in any particular client.
 
 ## Requirements
 
-- A caller can supply an external identity scoped to a given `resourceUrns` set.
-- Retrying `raiseIncident` with the same `(resourceUrns, sourceId)` is a no-op that returns the existing Incident's URN, not an error and not a duplicate.
-- Fully backward compatible: omitting the identity preserves current random UUID behavior exactly, with no change for existing callers.
-- Authorization is unchanged: the existing `EDIT_ENTITY_INCIDENTS_PRIVILEGE` check on `resourceUrns` applies identically whether the call creates a new Incident or resolves to an existing one.
-- No new synchronous uniqueness query is required beyond what deterministic identity derivation already gives, so this should not add a network round-trip to the common path.
+- A caller can supply an optional `id` that is used directly as `IncidentKey.id` (`urn:li:incident:{id}`). It is an opaque caller-chosen string, not derived from or scoped to `resourceUrns` or any other input field.
+- Retrying `raiseIncident` with an `id` that already exists produces an explicit conflict, not a silent success and not a duplicate Incident. `raiseIncident` stays create-only; it never becomes get-or-create.
+- Fully backward compatible: omitting `id` preserves current random UUID behavior exactly, with no change for existing callers.
+- Authorization is unchanged: the existing `EDIT_ENTITY_INCIDENTS_PRIVILEGE` check on `resourceUrns` runs before the write is attempted, identically whether or not `id` is supplied.
+- The create-or-conflict decision must be atomic with respect to concurrent callers racing on the same `id`. No separate existence check followed by a write.
+
+The resulting contract:
+
+| Input         | Result                                                               |
+| ------------- | -------------------------------------------------------------------- |
+| `id` omitted  | Existing random UUID behavior; create a new Incident                 |
+| New `id`      | Create the Incident at `urn:li:incident:{id}`                        |
+| Existing `id` | GraphQL conflict; never update or return the existing URN as success |
+
+Authorization runs against the requested `resourceUrns` before the write in all three cases. The caller's known URN (for a new or previously-supplied `id`) is the retry handle it uses to recover after a conflict, not something a server-side get-or-create response hands back.
 
 ### Extensibility
 
@@ -48,64 +58,79 @@ The identity scheme should not be special-cased to agent callers. Any integratio
 
 ## Non-Requirements
 
-- Idempotency for `updateIncident` or `updateIncidentStatus`. This RFC covers creation only.
-- A general-purpose dedup mechanism for other entity types. If this pattern proves useful, extending it elsewhere is future work, not part of this proposal.
-- Changing the default (no-`sourceId`) behavior in any way.
+This proposal is **create idempotency through client-owned identity**. It is explicitly not:
+
+- **Deduplication of active incidents.** `raiseIncident` does not search for or fold into any existing Incident that isn't at the exact `id` the caller supplied.
+- **A permanent get-or-create operation.** An `id` conflict is an error the caller reacts to, not a mutation that transparently hands back an existing URN as if it had just been created.
+- **Re-firing or reopening a resolved incident.** If a caller reuses an `id` whose Incident has since been resolved, the result is still a conflict, not a reopen. A permanent, deterministic get-or-create would be actively wrong here: it would keep returning a stale, resolved Incident as if raising a fresh one, exactly when the caller expects a new signal.
+- **An update or upsert mutation.** A caller that wants to change fields on an existing Incident must call `updateIncident` explicitly. `raiseIncident` never modifies an Incident that already exists at the given `id`.
+- **Idempotency for `updateIncident` or `updateIncidentStatus`.** This RFC covers creation only.
+- **A general-purpose dedup mechanism for other entity types.** If this pattern proves useful, extending it elsewhere is future work, not part of this proposal.
+- **A change to the default (no-`id`) behavior**, in any way.
 
 ## Detailed design
 
-**Where identity lives.** Add `sourceId: optional string` to `RaiseIncidentInput` (GraphQL) and derive the Incident's `IncidentKey.id` deterministically from it when present, instead of `UUID.randomUUID()`:
+**Where identity lives.** Add `id: optional string` to `RaiseIncidentInput` (GraphQL). When present, use it directly as `IncidentKey.id`, producing `urn:li:incident:{id}`. When absent, preserve today's `UUID.randomUUID()` path exactly, unchanged. Identity has no derivation step and no coupling to `resourceUrns`: because the caller owns `id` outright, a later rename of a referenced asset cannot change or invalidate an identity the caller already committed to on retry.
 
-```text
-id = deterministic_hash(sorted(resourceUrns), sourceId)
-```
+**GraphQL contract precedent: `CreateTagResolver`.** `datahub-graphql-core/.../resolvers/tag/CreateTagResolver.java` already has this exact input shape: `final String id = input.getId() != null ? input.getId() : UUID.randomUUID().toString();`, followed by `_entityClient.exists(...)` and, if the key already exists, `throw new IllegalArgumentException("This Tag already exists!")`. This is the precedent for `raiseIncident`'s input field and its create-only, conflict-on-existing contract as seen by the caller.
 
-This is the same pattern DataHub already uses for most other keyed entities. A Dataset's urn, for example, is derived from `platform + name + origin`, not minted randomly. Incident is the outlier today in using an opaque random id as its only identity.
+It is not the precedent for the underlying atomicity: Tag's `exists()`-then-create has its own read-then-write race window between the check and the proposal. Incident should not copy that gap.
 
-**Reuse `CreateIfNotExistsValidator` instead of a new mechanism.** DataHub already has a working create-if-not-exists primitive: a `ChangeType.CREATE_ENTITY` proposal carrying the header `If-None-Match: *` is silently dropped, no exception surfaced, if the entity's key aspect already exists (`entity-registry/.../validation/CreateIfNotExistsValidator.java`). It's already used by `CreateTagResolver`, `CreateDomainResolver`, `CreateSecretResolver`, `CreateGlossaryNodeResolver`, `CreateGlossaryTermResolver`, and `CreateBusinessAttributeResolver`.
+**Atomic create precondition: `CreateIfNotExistsValidator`.** `entity-registry/.../aspect/validation/CreateIfNotExistsValidator.java` is the mechanism that avoids Tag's race: a `ChangeType.CREATE_ENTITY` proposal carrying the header `If-None-Match: *` is validated against whether the entity's key aspect is already present in the batch. If the key aspect is missing from the batch (meaning the entity already exists), the validator raises a `FILTER`-subtype `AspectValidationException` for that item, quoting `"Dropping write per precondition header If-None-Match: *"`.
 
-`RaiseIncidentResolver` doesn't reach this today because the helper it calls, `MutationUtils.buildMetadataChangeProposalWithKey`, hardcodes `ChangeType.UPSERT` and never sets `headers`. When `sourceId` is present, the resolver should build its own proposal instead of using that shared helper (it's used by eight other resolvers, so changing its default isn't appropriate) and set:
+`RaiseIncidentResolver` doesn't reach this today because the helper it calls, `MutationUtils.buildMetadataChangeProposalWithKey`, hardcodes `ChangeType.UPSERT` and never sets `headers`. When `id` is present, the resolver should build its own proposal instead of using that shared helper (it's used by eight other resolvers, so changing its default isn't appropriate) and set:
 
 ```text
 changeType = ChangeType.CREATE_ENTITY
 headers    = {"If-None-Match": "*"}
 ```
 
-Since the deterministically-derived urn either already has a key aspect (entity exists) or doesn't (it's new), the validator either drops the proposal as a filtered no-op or lets the create through. The resolver already knows the target urn before making the call, since it's computed from `(resourceUrns, sourceId)`, so whether the write landed or was dropped, it returns the same urn either way. No separate existence check or read-then-write race is needed, and no new concurrency guarantee needs to be invented: this relies on the same one `CreateIfNotExistsValidator` already provides for every other `CREATE_ENTITY` path in the codebase.
+**Surfacing the conflict through GraphQL, not swallowing it.** This is the part the original design got wrong, and the part that needs the most care. `AspectValidationException.forFilter(...)` produces a `ValidationSubType.FILTER` exception, and `ValidationExceptionCollection.hasFatalExceptions()` explicitly excludes `FILTER` from what counts as fatal: `subTypeHashCodes.keySet().stream().anyMatch(subType -> !ValidationSubType.FILTER.equals(subType))`. A filtered `CREATE_ENTITY` item does not throw all the way up to the caller by default; it is simply excluded from the batch's successful items (`ValidationExceptionCollection.isSuccessful`). That silent-drop behavior is exactly right for the validator's existing producer/emitter use cases (idempotent MCP replay), but it is exactly wrong for a synchronous GraphQL mutation that must tell an already-authenticated caller whether their write happened.
 
-**Authorization when a key already exists.** Unchanged. The resolver checks `EDIT_ENTITY_INCIDENTS_PRIVILEGE` against `resourceUrns` before doing anything else, exactly as it does today. Whether the call turns out to create or resolve to an existing Incident is decided after that check, not before it.
+So `RaiseIncidentResolver` must distinguish "my `CREATE_ENTITY` proposal was applied" from "my proposal was filtered because the key already existed," using the per-item success/filter signal the ingest path already produces (the same distinction `ValidationExceptionCollection` tracks internally), and translate a filtered outcome into a GraphQL error, the same way `CreateTagResolver` throws `IllegalArgumentException` on conflict today. Exact plumbing (how that per-item signal is exposed from `EntityClient.ingestProposal` up to the resolver) is an implementation detail for the eventual PR, not this RFC, but the contract requirement is not optional: **an existing `id` must produce a caller-visible GraphQL error, never a 200-shaped response carrying the existing URN.**
 
-**Conflict and update semantics.** If a caller repeats `(resourceUrns, sourceId)` with different `title`, `description`, or `priority` values, the write is dropped by the validator exactly as any other duplicate `CREATE_ENTITY` would be. The new field values are ignored and the existing Incident's URN is returned unchanged. A caller that wants to change fields on an existing Incident should call `updateIncident` explicitly. This keeps `raiseIncident`'s contract narrow: idempotent by identity, not upsert-by-value.
+**Authorization when a key already exists.** Unchanged. The resolver checks `EDIT_ENTITY_INCIDENTS_PRIVILEGE` against `resourceUrns` before doing anything else, exactly as it does today, before the create-or-conflict outcome is known.
 
-**Compatibility.** Fully additive. Existing Incidents (random ids, created via `UPSERT` as today) and new ones (deterministic ids via `CREATE_ENTITY` plus the precondition header, when `sourceId` is supplied) are both just opaque `id: string` values to every other part of the system. Nothing downstream needs to change.
+**Conflict and retry semantics.** If a caller repeats `id`, the write is rejected as a conflict regardless of whether `title`, `description`, or `priority` differ from the original call. The new field values are never applied and the Incident is never modified as a side effect of the conflicting call. The retry story this supports:
+
+1. The client chooses `id`, so it already knows the target URN (`urn:li:incident:{id}`) before calling `raiseIncident`.
+2. A first request may create the Incident while its response is lost to the client (timeout, connection drop).
+3. A retry with the same input either creates the Incident, if the first write never landed, or receives a conflict error, if the first write did land.
+4. The client treats that conflict as recovery evidence, not failure, and fetches the Incident at the URN it already knew, rather than `raiseIncident` itself silently becoming get-or-create.
+
+A caller that wants to change fields on an existing Incident calls `updateIncident` explicitly. This keeps `raiseIncident`'s contract narrow: idempotent by caller-owned identity, not upsert-by-value.
+
+**Compatibility.** Fully additive. Existing Incidents (random ids, created via `UPSERT` as today) and new ones (caller-provided ids via `CREATE_ENTITY` plus the precondition header, when `id` is supplied) are both just opaque `id: string` values to every other part of the system. Nothing downstream needs to change.
 
 ## How we teach this
 
-Document `sourceId` alongside `raiseIncident` in the GraphQL API reference, and note it in Agent Context guidance as the correct way for automated callers to make Incident creation retry-safe. This is additive documentation, not a change to how Incidents are taught to end users in the UI.
+Document `id` alongside `raiseIncident` in the GraphQL API reference, and note it in Agent Context guidance as the correct way for automated callers to make Incident creation retry-safe, including that a conflict on `id` means "already created, fetch by URN" rather than an error to retry blindly. This is additive documentation, not a change to how Incidents are taught to end users in the UI.
 
 ## Drawbacks
 
-- Two code paths in the resolver (random-id `UPSERT` vs. deterministic-id `CREATE_ENTITY`) add a small amount of complexity, and the new path can't reuse the shared `buildMetadataChangeProposalWithKey` helper as-is.
-- If a Dataset (or other resource) is later renamed or its urn changes, a previously-computed deterministic id tied to the old urn no longer matches on retry. Worth resolving explicitly rather than leaving implicit.
-- The exact hash and derivation function needs to be pinned down precisely (algorithm, encoding, collision behavior) before implementation, not left to resolver code to decide ad hoc.
+- Two code paths in the resolver (random-id `UPSERT` vs. caller-provided-id `CREATE_ENTITY`) add a small amount of complexity, and the new path can't reuse the shared `buildMetadataChangeProposalWithKey` helper as-is.
+- The resolver needs new logic to distinguish a filtered `CREATE_ENTITY` from an applied one and turn the former into a GraphQL conflict. `CreateIfNotExistsValidator`'s `FILTER` subtype is non-fatal by design at the batch/ingest layer today, so this signal has to be threaded up rather than simply caught as a thrown exception.
+- Callers take on responsibility for choosing a unique-enough `id` within their own domain. This is the same tradeoff `CreateTagResolver` already accepts for Tag; it is not a new category of risk for DataHub, but it is a new responsibility for Incident callers specifically.
 
 ## Alternatives
 
-- **Server-side dedup by searching a stored `sourceId` field before insert.** Rejected as the primary mechanism: it has the same search-then-insert race window as the client-side workaround it's meant to replace, just moved server-side, and it ignores that DataHub already has a race-free primitive for this that Incident simply isn't wired to yet.
+- **Deterministic identity derived from a hash of the resource set plus a caller-supplied fingerprint.** This was the design in the original version of this RFC. Rejected: deriving identity from `resourceUrns` ties it to the resource set, so a Dataset rename or any change to the resources referenced silently derives a different id on retry, defeating idempotency exactly when the underlying infrastructure is already unreliable. Caller-owned `id` removes this coupling entirely and matches the precedent DataHub already has for Tag.
+- **Permanent deterministic get-or-create (always return the existing URN on a repeat `id`).** Rejected as the default contract: it is a materially different, stronger operation than create idempotency. It would give `id` permanent, evergreen meaning, so retrying against a resolved Incident's `id` would silently resurface a closed Incident instead of failing or being available for a new one. This RFC scopes `raiseIncident` to create-only; a caller that wants dedup or get-or-create semantics needs a separate, explicit product decision outside this RFC.
+- **Server-side dedup by searching a stored identity field before insert.** Rejected as the primary mechanism: it has the same search-then-insert race window as the client-side workaround it's meant to replace, just moved server-side, and it ignores that DataHub already has a race-free create-if-not-exists primitive that Incident simply isn't wired to yet.
 - **Status quo (client-side fingerprinting).** Rejected. This is the problem being solved; every caller currently reinvents a weaker version of the same thing.
 - **A dedicated idempotency-key store** (Stripe-style key and response cache). Rejected as unnecessary: it would duplicate a guarantee the create-if-not-exists validator already provides at the aspect layer, for a bigger implementation cost.
 
 ## Rollout / Adoption Strategy
 
-Purely additive, no migration. Existing callers are unaffected until they opt in by supplying `sourceId`.
+Purely additive, no migration. Existing callers are unaffected until they opt in by supplying `id`.
 
 ## Future Work
 
-The same pattern, deterministic identity for idempotent creation, could extend to other mutations that currently mint random keys for automation-facing writes, if this proves out.
+- The same pattern, caller-provided identity for idempotent creation, could extend to other mutations that currently mint random keys for automation-facing writes, if this proves out.
+- If search or filtering on `id` beyond direct URN lookup becomes a real need, a copy of `id` on an `IncidentInfo`-adjacent aspect could be added alongside the key. This RFC does not propose that: identity lives on `IncidentKey` only, to avoid two sources of truth for the same value.
 
 ## Unresolved questions
 
-- Exact derivation function for the deterministic id (hash choice, input encoding, handling of `resourceUrns` ordering).
-- Whether `raiseIncident` should signal "created" vs. "already existed" to the caller, or stay silent and just return the URN either way. Since the resolver already knows the urn up front, this is a minor API-ergonomics question, not a correctness one.
-- Whether identity should live on `IncidentKey` (proposed here) or as a field on the `IncidentInfo.source` aspect instead. Key placement keeps identity immutable and query-cheap, but it's a bigger schema decision than a single aspect field and deserves maintainer input.
-- Whether `CreateIfNotExistsValidator` is already registered against the Incident entity's plugin config, or needs to be added there. This RFC assumes it can be, based on how other `CREATE_ENTITY` resolvers use it, but the entity-registry plugin wiring for Incident specifically wasn't traced line by line.
+- How the resolver surfaces a filtered `CREATE_ENTITY` as a GraphQL-level conflict: which exception type or error code carries that signal, given that `ValidationExceptionCollection` treats `FILTER`-subtype outcomes as non-fatal at the batch layer today and this proposal needs that outcome to become caller-visible.
+- Whether the conflict should be a distinct, matchable GraphQL error code or extension (for example `ALREADY_EXISTS`), so retry-safe clients can branch on it programmatically instead of parsing an error message string.
+- Whether `id` needs its own validation (charset, length) beyond what URN construction already implies, or can reuse the same constraints `CreateTagInput.id` uses today.

--- a/docs/rfcs/active/incident-idempotency-key.md
+++ b/docs/rfcs/active/incident-idempotency-key.md
@@ -13,12 +13,14 @@ Add an optional, caller-supplied external identity to `raiseIncident` so automat
 
 ```graphql
 mutation {
-  raiseIncident(input: {
-    type: OPERATIONAL
-    resourceUrns: ["urn:li:dataset:(...)"]
-    sourceId: "checkout-drift-2026-08-01-poll-status"
-    title: "Route divergence detected on checkout status endpoint"
-  })
+    raiseIncident(
+        input: {
+            type: OPERATIONAL
+            resourceUrns: ["urn:li:dataset:(...)"]
+            sourceId: "checkout-drift-2026-08-01-poll-status"
+            title: "Route divergence detected on checkout status endpoint"
+        }
+    )
 }
 ```
 

--- a/docs/rfcs/active/incident-idempotency-key.md
+++ b/docs/rfcs/active/incident-idempotency-key.md
@@ -1,0 +1,109 @@
+- Start Date: 2026-08-01
+- RFC PR: (this PR)
+- Discussion Issue: none yet, opening the RFC directly to get concrete design feedback
+- Implementation PR(s): none, this RFC proposes no code yet
+
+# External Source Identity for Idempotent Incident Creation
+
+## Summary
+
+Add an optional, caller-supplied external identity to `raiseIncident` so automated callers (agents, pipelines) can retry the mutation after a network failure without risking a duplicate Incident.
+
+## Basic example
+
+```graphql
+mutation {
+  raiseIncident(input: {
+    type: OPERATIONAL
+    resourceUrns: ["urn:li:dataset:(...)"]
+    sourceId: "checkout-drift-2026-08-01-poll-status"
+    title: "Route divergence detected on checkout status endpoint"
+  })
+}
+```
+
+Calling this twice with the same `resourceUrns` and `sourceId` returns the same Incident URN both times. Omitting `sourceId` preserves today's behavior exactly: a fresh random id every call.
+
+## Motivation
+
+Any automated caller that must guarantee at-least-once delivery (a retry after timeout, a crash-and-resume, a queue redelivery) currently has no safe way to call `raiseIncident` idempotently. `IncidentKey.id` is set from `UUID.randomUUID()` on every call (`RaiseIncidentResolver.java`), so a retried call after an ambiguous network failure, where the request succeeded server-side but the response was lost, always creates a second Incident.
+
+The only workaround available today is client-side: search existing Incidents for a fingerprint embedded in `title` or `description` before calling `raiseIncident`. This has a race window between the search and the create, and it is not correct under concurrent writers. It also does not scale as the number of automated Incident-raising integrations grows, since every caller ends up inventing its own ad hoc fingerprinting scheme.
+
+This is a gap in the mutation's contract, not a gap in any particular client.
+
+## Requirements
+
+- A caller can supply an external identity scoped to a given `resourceUrns` set.
+- Retrying `raiseIncident` with the same `(resourceUrns, sourceId)` is a no-op that returns the existing Incident's URN, not an error and not a duplicate.
+- Fully backward compatible: omitting the identity preserves current random UUID behavior exactly, with no change for existing callers.
+- Authorization is unchanged: the existing `EDIT_ENTITY_INCIDENTS_PRIVILEGE` check on `resourceUrns` applies identically whether the call creates a new Incident or resolves to an existing one.
+- No new synchronous uniqueness query is required beyond what deterministic identity derivation already gives, so this should not add a network round-trip to the common path.
+
+### Extensibility
+
+The identity scheme should not be special-cased to agent callers. Any integration that needs at-least-once-safe Incident creation (pipelines, external monitoring systems, future MCP tools) should be able to use the same field.
+
+## Non-Requirements
+
+- Idempotency for `updateIncident` or `updateIncidentStatus`. This RFC covers creation only.
+- A general-purpose dedup mechanism for other entity types. If this pattern proves useful, extending it elsewhere is future work, not part of this proposal.
+- Changing the default (no-`sourceId`) behavior in any way.
+
+## Detailed design
+
+**Where identity lives.** Add `sourceId: optional string` to `RaiseIncidentInput` (GraphQL) and derive the Incident's `IncidentKey.id` deterministically from it when present, instead of `UUID.randomUUID()`:
+
+```text
+id = deterministic_hash(sorted(resourceUrns), sourceId)
+```
+
+This is the same pattern DataHub already uses for most other keyed entities. A Dataset's urn, for example, is derived from `platform + name + origin`, not minted randomly. Incident is the outlier today in using an opaque random id as its only identity.
+
+**Reuse `CreateIfNotExistsValidator` instead of a new mechanism.** DataHub already has a working create-if-not-exists primitive: a `ChangeType.CREATE_ENTITY` proposal carrying the header `If-None-Match: *` is silently dropped, no exception surfaced, if the entity's key aspect already exists (`entity-registry/.../validation/CreateIfNotExistsValidator.java`). It's already used by `CreateTagResolver`, `CreateDomainResolver`, `CreateSecretResolver`, `CreateGlossaryNodeResolver`, `CreateGlossaryTermResolver`, and `CreateBusinessAttributeResolver`.
+
+`RaiseIncidentResolver` doesn't reach this today because the helper it calls, `MutationUtils.buildMetadataChangeProposalWithKey`, hardcodes `ChangeType.UPSERT` and never sets `headers`. When `sourceId` is present, the resolver should build its own proposal instead of using that shared helper (it's used by eight other resolvers, so changing its default isn't appropriate) and set:
+
+```text
+changeType = ChangeType.CREATE_ENTITY
+headers    = {"If-None-Match": "*"}
+```
+
+Since the deterministically-derived urn either already has a key aspect (entity exists) or doesn't (it's new), the validator either drops the proposal as a filtered no-op or lets the create through. The resolver already knows the target urn before making the call, since it's computed from `(resourceUrns, sourceId)`, so whether the write landed or was dropped, it returns the same urn either way. No separate existence check or read-then-write race is needed, and no new concurrency guarantee needs to be invented: this relies on the same one `CreateIfNotExistsValidator` already provides for every other `CREATE_ENTITY` path in the codebase.
+
+**Authorization when a key already exists.** Unchanged. The resolver checks `EDIT_ENTITY_INCIDENTS_PRIVILEGE` against `resourceUrns` before doing anything else, exactly as it does today. Whether the call turns out to create or resolve to an existing Incident is decided after that check, not before it.
+
+**Conflict and update semantics.** If a caller repeats `(resourceUrns, sourceId)` with different `title`, `description`, or `priority` values, the write is dropped by the validator exactly as any other duplicate `CREATE_ENTITY` would be. The new field values are ignored and the existing Incident's URN is returned unchanged. A caller that wants to change fields on an existing Incident should call `updateIncident` explicitly. This keeps `raiseIncident`'s contract narrow: idempotent by identity, not upsert-by-value.
+
+**Compatibility.** Fully additive. Existing Incidents (random ids, created via `UPSERT` as today) and new ones (deterministic ids via `CREATE_ENTITY` plus the precondition header, when `sourceId` is supplied) are both just opaque `id: string` values to every other part of the system. Nothing downstream needs to change.
+
+## How we teach this
+
+Document `sourceId` alongside `raiseIncident` in the GraphQL API reference, and note it in Agent Context guidance as the correct way for automated callers to make Incident creation retry-safe. This is additive documentation, not a change to how Incidents are taught to end users in the UI.
+
+## Drawbacks
+
+- Two code paths in the resolver (random-id `UPSERT` vs. deterministic-id `CREATE_ENTITY`) add a small amount of complexity, and the new path can't reuse the shared `buildMetadataChangeProposalWithKey` helper as-is.
+- If a Dataset (or other resource) is later renamed or its urn changes, a previously-computed deterministic id tied to the old urn no longer matches on retry. Worth resolving explicitly rather than leaving implicit.
+- The exact hash and derivation function needs to be pinned down precisely (algorithm, encoding, collision behavior) before implementation, not left to resolver code to decide ad hoc.
+
+## Alternatives
+
+- **Server-side dedup by searching a stored `sourceId` field before insert.** Rejected as the primary mechanism: it has the same search-then-insert race window as the client-side workaround it's meant to replace, just moved server-side, and it ignores that DataHub already has a race-free primitive for this that Incident simply isn't wired to yet.
+- **Status quo (client-side fingerprinting).** Rejected. This is the problem being solved; every caller currently reinvents a weaker version of the same thing.
+- **A dedicated idempotency-key store** (Stripe-style key and response cache). Rejected as unnecessary: it would duplicate a guarantee the create-if-not-exists validator already provides at the aspect layer, for a bigger implementation cost.
+
+## Rollout / Adoption Strategy
+
+Purely additive, no migration. Existing callers are unaffected until they opt in by supplying `sourceId`.
+
+## Future Work
+
+The same pattern, deterministic identity for idempotent creation, could extend to other mutations that currently mint random keys for automation-facing writes, if this proves out.
+
+## Unresolved questions
+
+- Exact derivation function for the deterministic id (hash choice, input encoding, handling of `resourceUrns` ordering).
+- Whether `raiseIncident` should signal "created" vs. "already existed" to the caller, or stay silent and just return the URN either way. Since the resolver already knows the urn up front, this is a minor API-ergonomics question, not a correctness one.
+- Whether identity should live on `IncidentKey` (proposed here) or as a field on the `IncidentInfo.source` aspect instead. Key placement keeps identity immutable and query-cheap, but it's a bigger schema decision than a single aspect field and deserves maintainer input.
+- Whether `CreateIfNotExistsValidator` is already registered against the Incident entity's plugin config, or needs to be added there. This RFC assumes it can be, based on how other `CREATE_ENTITY` resolvers use it, but the entity-registry plugin wiring for Incident specifically wasn't traced line by line.

--- a/docs/rfcs/active/incident-idempotency-key.md
+++ b/docs/rfcs/active/incident-idempotency-key.md
@@ -1,5 +1,5 @@
 - Start Date: 2026-08-01
-- RFC PR: (this PR)
+- RFC PR: https://github.com/datahub-project/datahub/pull/18804
 - Discussion Issue: none yet, opening the RFC directly to get concrete design feedback
 - Implementation PR(s): none, this RFC proposes no code yet
 


### PR DESCRIPTION
## Summary

`raiseIncident` mints `IncidentKey.id` from `UUID.randomUUID()` on every call with no dedup path, so any automated caller that must retry after a network failure (timeout, crash-and-resume, redelivery) has no safe way to avoid creating a duplicate Incident. The only workaround today is client-side fingerprint search, which has a race window and doesn't scale across integrations.

This RFC proposes an optional, caller-provided `id` on `raiseIncident` (mirroring `CreateTagResolver`'s `id` field) that maps directly to `IncidentKey.id`. Omitting `id` preserves today's random-UUID behavior exactly. Supplying an `id` that already exists produces an explicit GraphQL conflict, never a silent success returning the existing URN, so `raiseIncident` stays create-only.

## What changed since the last review

Addresses [@AdrianMachado's feedback](https://github.com/datahub-project/datahub/pull/18804#issuecomment-5170041224):

- Replaced `sourceId` + `hash(sorted(resourceUrns), sourceId)` with a plain, optional, caller-provided `id` that maps 1:1 to `IncidentKey.id`. Identity is no longer coupled to `resourceUrns`, so an asset rename can't invalidate a caller's retry identity.
- `raiseIncident` on an existing `id` now surfaces a GraphQL conflict rather than a silent no-op that returns the existing URN. The RFC spells out the retry story: the client already knows its target URN because it chose `id`, so a conflict on retry is recovery evidence, not failure.
- Added an explicit product-boundary section: this is create idempotency via client-owned identity only, not active-incident dedup, not a permanent get-or-create, not re-firing a resolved incident, and not an update/upsert.
- Corrected precedents: `CreateTagResolver` is now cited for the GraphQL-level `id` + conflict contract (it does an exists-check-then-throw, not a silent create-if-not-exists); `CreateIfNotExistsValidator` is cited only for the atomic create-precondition mechanics. Removed the unresolved question doubting the validator's registration for Incident, since it's confirmed registered for all entities.
- Identity stays on `IncidentKey` only; an aspect-level copy is mentioned solely as optional future work if search/filtering ever needs it.

Every technical claim is grounded in a direct read of `RaiseIncidentResolver.java`, `CreateTagResolver.java`, `CreateIfNotExistsValidator.java`, `AspectValidationException.java`, and `ValidationExceptionCollection.java` on master, not assumed.

No code in this PR, per the RFC process.

## Test plan

N/A, this is a design proposal with no implementation.