### PR TITLE
fix(ingest): show rollback button for runs that succeeded with warnings

### DIFF
--- a/datahub-web-react/src/app/ingest/source/executions/IngestionExecutionTableColumns.tsx
+++ b/datahub-web-react/src/app/ingest/source/executions/IngestionExecutionTableColumns.tsx
@@ -12,6 +12,7 @@ import {
     MANUAL_INGESTION_SOURCE,
     RUNNING,
     SCHEDULED_INGESTION_SOURCE,
+    SUCCEEDED_WITH_WARNINGS,
     SUCCESS,
     getExecutionRequestStatusDisplayColor,
     getExecutionRequestStatusDisplayText,
@@ -146,7 +147,7 @@ export function ButtonsColumn({
                     CANCEL
                 </Button>
             )}
-            {record.status === SUCCESS && record.showRollback && (
+            {(record.status === SUCCESS || record.status === SUCCEEDED_WITH_WARNINGS) && record.showRollback && (
                 <Button style={{ marginRight: 16 }} onClick={() => handleRollbackExecution(record.id)}>
                     ROLLBACK
                 </Button>

--- a/datahub-web-react/src/app/ingestV2/executions/components/columns/ActionsColumn.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/columns/ActionsColumn.tsx
@@ -3,7 +3,11 @@ import { ArrowUUpLeft } from '@phosphor-icons/react/dist/csr/ArrowUUpLeft';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { EXECUTION_REQUEST_STATUS_RUNNING, EXECUTION_REQUEST_STATUS_SUCCESS } from '@app/ingestV2/executions/constants';
+import {
+    EXECUTION_REQUEST_STATUS_RUNNING,
+    EXECUTION_REQUEST_STATUS_SUCCEEDED_WITH_WARNINGS,
+    EXECUTION_REQUEST_STATUS_SUCCESS,
+} from '@app/ingestV2/executions/constants';
 import { ExecutionRequestRecord } from '@app/ingestV2/executions/types';
 import BaseActionsColumn, { MenuItem } from '@app/ingestV2/shared/components/columns/BaseActionsColumn';
 
@@ -57,7 +61,9 @@ export function ActionsColumn({ record, handleViewDetails, handleRollback, handl
         <BaseActionsColumn
             dropdownItems={items}
             extraActions={
-                record.status === EXECUTION_REQUEST_STATUS_SUCCESS && record.showRollback ? (
+                (record.status === EXECUTION_REQUEST_STATUS_SUCCESS ||
+                    record.status === EXECUTION_REQUEST_STATUS_SUCCEEDED_WITH_WARNINGS) &&
+                record.showRollback ? (
                     <Icon
                         icon={ArrowUUpLeft}
                         onClick={() => handleRollback(record.id)}


### PR DESCRIPTION
## Summary

`SUCCEEDED_WITH_WARNINGS` is a frontend-only synthetic status: the backend stores the run as `SUCCESS`, but `getIngestionSourceStatus()` remaps it to `SUCCEEDED_WITH_WARNINGS` when `warnCount > 0`. The rollback eligibility checks compared against `SUCCESS` only, so the rollback button never appeared for runs that completed with warnings — even though the data was fully loaded and is perfectly valid to roll back.

This treats `SUCCEEDED_WITH_WARNINGS` identically to `SUCCESS` in both rollback eligibility checks.

## Changes

- `datahub-web-react/src/app/ingestV2/executions/components/columns/ActionsColumn.tsx` — add `SUCCEEDED_WITH_WARNINGS` to the rollback condition (v2 executions table)
- `datahub-web-react/src/app/ingest/source/executions/IngestionExecutionTableColumns.tsx` — same fix for the legacy executions table

Both constants were already exported (`EXECUTION_REQUEST_STATUS_SUCCEEDED_WITH_WARNINGS` in `ingestV2/executions/constants.ts`, `SUCCEEDED_WITH_WARNINGS` in `ingest/source/utils.ts`); no new status plumbing was needed.

## Test plan

- [ ] Run an ingestion that produces warnings → rollback button appears
- [ ] Rollback button still appears for clean `SUCCESS` runs
- [ ] Rollback button does NOT appear for `FAILURE` or `RUNNING` runs

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated — no existing test files for either component; the change is a two-clause status conditional
- [ ] Docs added/updated (n/a)
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (n/a — bug fix, no behavior contract change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)