### PR TITLE
fix(ingestion/datahub-documents): don't record incremental state when a document produces zero output

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -357,11 +357,19 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     self.report.report_document_skipped_unchanged()
                     continue
 
-            # Process document and yield workunits
-            yield from self._process_document_with_throttle(doc)
+            # Process document and yield workunits. Only record incremental state if at
+            # least one workunit was actually produced -- otherwise a document whose
+            # processing silently produced nothing (empty text, partition failure, or a
+            # caught chunking/embedding exception) would be marked "processed" for its
+            # current content hash despite never being embedded, permanently hiding it
+            # from future non-force reindex runs even though Coverage still reports it
+            # as missing.
+            produced_output = False
+            for wu in self._process_document_with_throttle(doc):
+                produced_output = True
+                yield wu
 
-            # Update state after successful processing (we own this document now).
-            if self.config.incremental.enabled:
+            if self.config.incremental.enabled and produced_output:
                 self._update_document_state(doc["urn"], doc.get("text", ""))
 
     def _bootstrap_event_mode_offsets(self, consumer_id: str) -> None:
@@ -509,11 +517,15 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         doc = {"urn": entity_urn, "text": text, "source_type": source_type}
         self.report.report_document_fetched()
 
-        # Process document and yield work units
-        yield from self._process_document_with_throttle(doc)
+        # Process document and yield work units. Only record incremental state if at
+        # least one workunit was actually produced -- see the batch-mode counterpart in
+        # _process_batch_mode for why an unconditional update is wrong.
+        produced_output = False
+        for wu in self._process_document_with_throttle(doc):
+            produced_output = True
+            yield wu
 
-        # Update state (we own this document now).
-        if self.config.incremental.enabled:
+        if self.config.incremental.enabled and produced_output:
             self._update_document_state(entity_urn, text)
 
     def _process_event_mode(self) -> Iterable[MetadataWorkUnit]:
@@ -1425,8 +1437,18 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             if self.chunking_source.report.num_documents_limit_reached:
                 self.report.num_documents_limit_reached = True
                 raise
-            error_msg = f"Failed to process document {doc.get('urn', 'unknown')}: {e}"
-            logger.warning(error_msg, exc_info=True)
+            # report.failure (not .warning/logger.warning) is required here: pipeline.py's
+            # has_failures() -- which decides the SUCCESS/FAILURE status surfaced to the
+            # executor and the Semantic Search Monitoring UI -- only inspects report.failures.
+            # A bare logger.warning() left runs with 100% embedding failure silently
+            # reporting SUCCESS.
+            self.report.failure(
+                title="Failed to process document",
+                message="An error occurred while chunking or embedding a document; "
+                "it was skipped rather than failing the entire run.",
+                context=doc.get("urn", "unknown"),
+                exc=e,
+            )
 
     def get_report(self) -> SourceReport:
         # Forward stats from the chunking sub-component into our report

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -176,6 +176,53 @@ def test_document_processed_without_embeddings_on_failure(
         list(source.process_elements_inline(document_urn, elements))
 
 
+def test_partial_batch_embedding_failure_yields_no_workunits(
+    pipeline_context, chunking_config
+):
+    """A multi-batch embedding call that fails partway through (some chunks already
+    embedded successfully) must still yield ZERO workunits for the document -- there is
+    no code path where a document is partially embedded. Callers (e.g. datahub_documents_
+    source.py's incremental-state recording) rely on "at least one workunit produced"
+    as a proxy for "this document fully succeeded"; that proxy only holds because
+    embedding generation for a document's chunks is all-or-nothing, never partial.
+    """
+    chunking_config.embedding.batch_size = 1
+    # Force the two elements below into separate chunks (the default max_characters=500
+    # would combine them into a single chunk, defeating the multi-batch setup this test needs).
+    chunking_config.chunking.max_characters = 10
+
+    source = DocumentChunkingSource(
+        ctx=pipeline_context,
+        config=chunking_config,
+        standalone=False,
+        graph=None,
+    )
+
+    document_urn = "urn:li:document:(test,doc1,PROD)"
+    elements = [
+        {"type": "Title", "text": "Test Title"},
+        {"type": "NarrativeText", "text": "Test content"},
+    ]
+
+    provider = MagicMock()
+    provider.embed.side_effect = [
+        EmbeddingResult(embeddings=[[0.1, 0.2, 0.3]]),  # first batch succeeds
+        Exception("Second batch failed"),  # second batch fails
+    ]
+
+    workunits = []
+    with (
+        patch.object(source, "_get_provider", return_value=provider),
+        pytest.raises(Exception, match="Second batch failed"),
+    ):
+        for wu in source.process_elements_inline(document_urn, elements):
+            workunits.append(wu)
+
+    assert workunits == []
+    # The failure is reported, but nothing was ever emitted for this document.
+    assert source.report.num_embedding_failures == 1
+
+
 def test_multiple_embedding_failures(pipeline_context, chunking_config):
     """Test that embedding failures propagate in inline mode."""
     # Initialize source in inline mode

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -872,7 +872,11 @@ class TestStateStorage:
                 patch.object(
                     source, "_fetch_documents_graphql", return_value=mock_docs
                 ),
-                patch.object(source, "_process_single_document", return_value=iter([])),
+                patch.object(
+                    source,
+                    "_process_single_document",
+                    side_effect=lambda doc: iter([Mock()]),
+                ),
             ):
                 # Process in batch mode
                 list(source._process_batch_mode())
@@ -913,7 +917,11 @@ class TestStateStorage:
                 patch.object(
                     source, "_fetch_documents_graphql", return_value=mock_docs
                 ),
-                patch.object(source, "_process_single_document", return_value=iter([])),
+                patch.object(
+                    source,
+                    "_process_single_document",
+                    side_effect=lambda doc: iter([Mock()]),
+                ),
             ):
                 # Process in event mode - should fallback
                 list(source._process_event_mode())
@@ -1188,7 +1196,11 @@ class TestStateStorage:
                 patch.object(
                     source, "_fetch_documents_graphql", return_value=mock_docs
                 ),
-                patch.object(source, "_process_single_document", return_value=iter([])),
+                patch.object(
+                    source,
+                    "_process_single_document",
+                    side_effect=lambda doc: iter([Mock()]),
+                ),
             ):
                 mock_state_handler.update_document_state = Mock()
                 mock_state_handler.update_event_offset = Mock()
@@ -1279,7 +1291,9 @@ class TestStateStorage:
                     source, "_fetch_documents_graphql", return_value=mock_docs
                 ),
                 patch.object(
-                    source, "_process_single_document", return_value=iter([])
+                    source,
+                    "_process_single_document",
+                    side_effect=lambda doc: iter([Mock()]),
                 ) as mock_process,
             ):
                 mock_state_handler.update_document_state = Mock()
@@ -1296,6 +1310,36 @@ class TestStateStorage:
                 new_hash = source._calculate_text_hash(new_text)
                 assert call_args[1] == new_hash
                 assert call_args[1] != old_hash
+
+    def test_incremental_mode_does_not_record_state_when_processing_yields_nothing(
+        self, ctx, config, mock_graph
+    ):
+        """A document whose processing produces zero workunits (e.g. a caught chunking/
+        embedding exception, or empty/unpartitionable text) must NOT be recorded in
+        incremental state -- otherwise it would be permanently skipped as "unchanged" on
+        every future non-force run despite never having been embedded."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.config.incremental.enabled = True
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_document_hash.return_value = None  # New document
+            mock_state_handler.update_document_state = Mock()
+
+            mock_docs = [{"urn": "urn:li:document:1", "text": "Some content"}]
+            with (
+                patch.object(
+                    source, "_fetch_documents_graphql", return_value=mock_docs
+                ),
+                patch.object(
+                    source, "_process_single_document", return_value=iter([])
+                ) as mock_process,
+            ):
+                list(source._process_batch_mode())
+
+            mock_process.assert_called_once()
+            mock_state_handler.update_document_state.assert_not_called()
 
 
 class TestSourceTypeFiltering:
@@ -3225,7 +3269,7 @@ class TestSkipIfSemanticContentExists:
                 patch.object(source, "_fetch_documents_graphql", return_value=[doc]),
                 patch.object(source.graph, "get_aspect", return_value=None),
                 patch.object(
-                    source, "_process_single_document", return_value=iter([])
+                    source, "_process_single_document", return_value=iter([Mock()])
                 ) as mock_proc,
             ):
                 list(source._process_batch_mode())
@@ -3992,3 +4036,57 @@ class TestOrphanedDocumentResilience:
         assert any(
             "entity count" in (w.title or "").lower() for w in source.report.warnings
         )
+
+
+class TestEmbeddingFailureReporting:
+    """A per-document embedding failure must flip the run to FAILURE, not silently
+    report SUCCESS with zero embeddings. pipeline.py's has_failures() -- which
+    decides the status surfaced to the executor and the Semantic Search
+    Monitoring UI -- only inspects report.failures, not report.warnings or the
+    embedding_failures counters that this source already tracks."""
+
+    @pytest.fixture
+    def config(self):
+        return DataHubDocumentsSourceConfig(
+            platform_filter=["notion"],
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            stateful_ingestion={"enabled": False},
+        )
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    def _make_source(self, ctx, config):
+        with patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        ):
+            source = DataHubDocumentsSource(ctx, config)
+        source.graph = Mock()
+        source.graph.config.server = "http://test-server:8080"
+        return source
+
+    def test_embedding_failure_reports_failure_not_warning(self, ctx, config):
+        source = self._make_source(ctx, config)
+        source.chunking_source.process_elements_inline = Mock(
+            side_effect=RuntimeError("Error when retrieving token from sso")
+        )
+
+        doc = {
+            "urn": "urn:li:document:a",
+            "text": "This is a sufficiently long document body for embedding.",
+        }
+        result = list(source._process_single_document(doc))
+
+        assert result == []
+        assert any(
+            "failed to process document" in (f.title or "").lower()
+            for f in source.report.failures
+        )
+        assert not source.report.warnings


### PR DESCRIPTION
## Summary

Two related bugs in the `datahub-documents` source's incremental checkpoint, found while building operational tooling on top of it:

- **Incremental state recorded on silent no-op**: `_process_batch_mode` and `_process_event_mode` called `_update_document_state()` unconditionally after processing a document, even when zero workunits were produced (empty/too-short text, a partitioning failure, or a caught chunking/embedding exception). The document's content hash still got recorded as "processed", so the next run's `_should_process()` saw a matching hash and skipped it forever as "unchanged" — even though no `semanticContent` aspect was ever emitted. Only `force_reprocess=true` could recover such a document; a normal incremental run could never re-embed it no matter how many times it ran, all while the run still reported overall `SUCCESS`.
- **Embedding failures logged as warnings, not failures**: the per-document exception handler used `logger.warning()` instead of `report.failure()`, so `pipeline.py`'s `has_failures()` (which only inspects `report.failures`) never saw it — a run where every document failed to embed still reported `SUCCESS`.

## Fix

- Only call `_update_document_state()` when at least one workunit was actually yielded for the document.
- Report per-document processing failures via `report.failure()` so they surface in the run status.

A new test in `test_chunking_source.py` confirms this is a safe proxy for "fully succeeded" rather than "partially succeeded": a multi-batch embedding call that fails partway through still yields zero workunits for the document, because `_generate_embeddings` is called once for all of a document's chunks together (a batch failure raises before returning), and `_emit_semantic_content` only ever yields a single combined workunit at the very end. There's no code path today where a document is partially embedded.

## Test plan

- [x] `test_datahub_documents_source.py` — added `test_incremental_mode_does_not_record_state_when_processing_yields_nothing`; updated existing state-storage tests that were asserting the old (buggy) behavior to mock realistic non-empty processing output
- [x] `test_chunking_source.py` — added `test_partial_batch_embedding_failure_yields_no_workunits`
- [x] All 144 tests in `test_datahub_documents_source.py` and 48 in `test_chunking_source.py` pass
- [x] `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmysGfPL2caoSHK4ojxvyb