### PR TITLE
refactor: migrate test-review Claude launcher from command to skill format

### DIFF
--- a/.claude/skills/test-review/SKILL.md
+++ b/.claude/skills/test-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-review
+description: DataHub test review — use when asked to review, check, validate, or audit smoke tests or integration tests
+---
+
 # DataHub Test Review
 
 Review DataHub smoke and integration tests for standards compliance and quality.

--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,7 @@ skills-lock.json
 
 # Claude ignores — ignore everything except committed config
 .claude/*
-!.claude/commands/
+!.claude/skills/
 !.claude/agents/
 !.claude/settings.json
 !.claude/hooks/


### PR DESCRIPTION
<!-- PR TITLE:
refactor: migrate test-review Claude launcher from command to skill format
-->

## Summary

Migrates the **Claude Code launcher** for the existing `test-review` skill from the
legacy `.claude/commands/` format to the native Agent Skills format
(`.claude/skills/test-review/SKILL.md`).

The skill content itself is unchanged and stays tool-neutral in
`.agent-skills/test-review/` — this PR only switches Claude's *launcher* to the
skills format. Per the Claude Code docs, `.claude/commands/` is the legacy format
and `.claude/skills/<name>/SKILL.md` is the recommended one; the CLI continues to
support both. The skills format supports the same `/test-review` invocation **and**
adds description-matched autonomous invocation. This brings the Claude launcher to
parity with the existing `.cursor/rules/test-review.mdc` launcher, which already
auto-triggers via its `description`.

## Changes

- `.claude/commands/test-review.md` → `.claude/skills/test-review/SKILL.md`
  (rename + `name`/`description` frontmatter; body unchanged, still points to
  `.agent-skills/test-review/`)
- `.gitignore`: allow-list `!.claude/skills/` and drop the now-empty `!.claude/commands/` entry

## Behavior

- `/test-review` works exactly as before.
- Additionally, Claude can now invoke the review autonomously when asked to review,
  check, validate, or audit smoke/integration tests.
- No change to review logic, standards, or templates.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] No related issue (small tooling refactor)
- [x] Tests — n/a (Claude Code launcher config)
- [x] Docs — n/a
- [x] No breaking changes

Refs: [Agent Skills](https://code.claude.com/docs/en/skills), [Slash Commands](https://code.claude.com/docs/en/agent-sdk/slash-commands#creating-custom-slash-commands)
