### PR TITLE
fix(cli): avoid UnicodeEncodeError on legacy Windows code pages

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -76,7 +76,7 @@ WARNING_SIGN = "⚠️" if _console_can_encode("⚠️") else "WARNING:"
 
 MIGRATION_REQUIRED_INSTRUCTIONS = f"""
 Your existing DataHub server was installed with an \
-older CLI and is incompatible with the current CLI (version {nice_version_name}).
+older CLI and is incompatible with the current CLI (version {nice_version_name()}).
 
 Required steps to upgrade:
 1. Backup your data (recommended): datahub docker quickstart --backup

--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -54,6 +54,26 @@ _QUICKSTART_MAX_WAIT_TIME = datetime.timedelta(minutes=10)
 _QUICKSTART_UP_TIMEOUT = datetime.timedelta(seconds=100)
 _QUICKSTART_STATUS_CHECK_INTERVAL = datetime.timedelta(seconds=2)
 
+
+def _console_can_encode(text: str) -> bool:
+    """Whether stdout can represent this text.
+
+    Windows consoles commonly default to a legacy code page such as cp1252 or
+    cp437, neither of which has a code point for U+2714 or U+26A0. Writing one
+    raises UnicodeEncodeError, which is why these symbols are resolved once here
+    rather than embedded directly in output.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+CHECK_MARK = "✔" if _console_can_encode("✔") else "OK:"
+WARNING_SIGN = "⚠️" if _console_can_encode("⚠️") else "WARNING:"
+
 MIGRATION_REQUIRED_INSTRUCTIONS = f"""
 Your existing DataHub server was installed with an \
 older CLI and is incompatible with the current CLI (version {nice_version_name}).
@@ -69,7 +89,7 @@ Required steps to upgrade:
 4. Restore data:
     datahub docker quickstart --restore
 
-⚠️  Without backup, all existing data will be lost.
+{WARNING_SIGN}  Without backup, all existing data will be lost.
 
 For fresh start (if data is not needed):
 1. Remove installation: 
@@ -106,7 +126,7 @@ OPTION 2 - Fresh start (if data not needed):
 2. Start fresh: 
     datahub docker quickstart
 
-⚠️  The current CLI cannot repair installations created by older versions.
+{WARNING_SIGN}  The current CLI cannot repair installations created by older versions.
 
 Additional information on backup and restore: https://docs.datahub.com/docs/quickstart#back-up-datahub
 Troubleshooting guide: https://docs.datahub.com/docs/troubleshooting/quickstart
@@ -155,7 +175,7 @@ def check() -> None:
     status = check_docker_quickstart()
 
     if status.is_ok():
-        click.secho("✔ No issues detected", fg="green")
+        click.secho(f"{CHECK_MARK} No issues detected", fg="green")
         if status.running_unsupported_version:
             show_migration_instructions()
     else:
@@ -843,7 +863,7 @@ def quickstart(
 
     # Handle success condition.
     click.echo()
-    click.secho("✔ DataHub is now running", fg="green")
+    click.secho(f"{CHECK_MARK} DataHub is now running", fg="green")
     click.secho(
         "Load sample data: run `datahub init` then `datahub datapack load showcase-ecommerce`,\n"
         "or head to http://localhost:9002 (username: datahub, password: datahub) to play around with the frontend.",

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -471,3 +471,59 @@ def test_resolve_secrets_generated_values_are_unique(tmp_path: Path) -> None:
 
     assert results[0][0] != results[1][0]
     assert results[0][1] != results[1][1]
+
+
+def test_console_symbols_fall_back_on_legacy_code_pages() -> None:
+    """Windows consoles often default to a code page without U+2714 or U+26A0.
+
+    Writing one raises UnicodeEncodeError, which previously meant a successful
+    quickstart exited non-zero, and the migration and repair instructions threw
+    while explaining how to recover from a broken install.
+    """
+    import io
+
+    from datahub.cli.docker_cli import _console_can_encode
+
+    for encoding in ("cp1252", "cp437", "ascii"):
+        stream = io.TextIOWrapper(io.BytesIO(), encoding=encoding, errors="strict")
+        with patch("datahub.cli.docker_cli.sys.stdout", stream):
+            assert not _console_can_encode("✔")
+            assert not _console_can_encode("⚠️")
+
+    stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", errors="strict")
+    with patch("datahub.cli.docker_cli.sys.stdout", stream):
+        assert _console_can_encode("✔")
+        assert _console_can_encode("⚠️")
+
+
+def test_console_symbols_survive_a_stream_with_no_encoding() -> None:
+    """Some wrapped streams expose no encoding at all; assume ASCII rather than raise."""
+    from datahub.cli.docker_cli import _console_can_encode
+
+    class _NoEncoding:
+        encoding = None
+
+    with patch("datahub.cli.docker_cli.sys.stdout", _NoEncoding()):
+        assert not _console_can_encode("✔")
+        assert _console_can_encode("plain text")
+
+
+def test_resolved_symbols_are_always_encodable_by_the_current_console() -> None:
+    """Whatever was chosen at import must be printable, or the CLI still crashes."""
+    import sys as _sys
+
+    from datahub.cli.docker_cli import (
+        CHECK_MARK,
+        MIGRATION_REQUIRED_INSTRUCTIONS,
+        REPAIR_REQUIRED_INSTRUCTIONS,
+        WARNING_SIGN,
+    )
+
+    encoding = getattr(_sys.stdout, "encoding", None) or "ascii"
+    for text in (
+        CHECK_MARK,
+        WARNING_SIGN,
+        MIGRATION_REQUIRED_INSTRUCTIONS,
+        REPAIR_REQUIRED_INSTRUCTIONS,
+    ):
+        text.encode(encoding)

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -8,6 +8,7 @@ from docker import DockerClient
 
 from datahub.cli.docker_check import DockerComposeVersionError
 from datahub.cli.docker_cli import (
+    CHECK_MARK,
     _check_upgrade_and_show_instructions,
     _docker_compose_v2,
     _resolve_token_service_secrets,
@@ -91,7 +92,9 @@ def test_check_healthy(mock_click, mock_docker_client, click_context):
         click_context.invoke(check)
 
         # Verify
-        mock_click.secho.assert_called_once_with("✔ No issues detected", fg="green")
+        mock_click.secho.assert_called_once_with(
+            f"{CHECK_MARK} No issues detected", fg="green"
+        )
 
 
 def test_check_unhealthy(mock_click, mock_docker_client, click_context):


### PR DESCRIPTION
`datahub docker quickstart` raises `UnicodeEncodeError` and exits non-zero on Windows consoles using a legacy code page. The stack is already healthy when it happens, so a successful install reports failure.

```
Traceback (most recent call last):
  File "...\datahub\cli\docker_cli.py", line 846, in quickstart
    click.secho("✔ DataHub is now running", fg="green")
  File "...\click\utils.py", line 345, in echo
    file.write(out)
  File "...\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input, self.errors, encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '✔' in position 0: character maps to <undefined>
```

Hit on Windows 11, CLI 1.6.0.6, bringing up Core v1.5.0.6. Neither `cp1252` nor `cp437` has a code point for U+2714 or U+26A0.

## Relationship to #18758

#18758 fixes the same class of bug in this file, on the **file path**: `.local-secrets.env` is written and read with the platform default, which breaks on CP949.

This one is the **console path**, which that PR does not touch. Different call sites, no overlapping lines, so the two apply independently. If you would rather have a single change, I am happy to close this and hand the diff to @JJI-Hoon, or rebase on top once theirs lands.

## Scope

Four call sites, in two groups:

| Where | Effect |
|---|---|
| `quickstart` success message | A working install exits non-zero |
| `docker check` success message | `check` fails on a healthy stack |
| `MIGRATION_REQUIRED_INSTRUCTIONS` | Crashes while explaining how to recover |
| `REPAIR_REQUIRED_INSTRUCTIONS` | Same |

The last two are the ones I would flag. Those strings exist to tell a user how to fix a broken installation, and printing them throws before they can be read.

## The change

Resolve the two symbols once against `sys.stdout.encoding`, falling back to ASCII when the console cannot represent them.

```python
CHECK_MARK = "✔" if _console_can_encode("✔") else "OK:"
WARNING_SIGN = "⚠️" if _console_can_encode("⚠️") else "WARNING:"
```

Output on a UTF-8 terminal is byte-identical to today. On `cp1252` it becomes:

```
OK: DataHub is now running
WARNING:  Without backup, all existing data will be lost.
```

## Alternatives considered

Reconfiguring `sys.stdout` to UTF-8 at import would also work, but it changes process-wide behaviour for anything else writing to that stream. Replacing the glyphs unconditionally is simpler, but downgrades output for everyone to fix a subset of users. Choosing the symbol seemed like the smaller blast radius, though I do not feel strongly and will switch if you prefer either.

## Testing

Three regression tests added alongside the existing ones:

- the helper rejects both symbols under `cp1252`, `cp437` and `ascii`, and accepts them under `utf-8`
- a stream exposing no encoding is treated as ASCII rather than raising
- whatever symbols were resolved at import are encodable by the current console, including the two instruction strings

`ruff format --check` passes on both files. Ruff with the repo's configured rules reports 75 findings on `docker_cli.py` before and after, so the change introduces none.
