### PR TITLE
fix(ingest/dbt): warn when column lineage is dropped due to missing c…

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -2407,6 +2407,16 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     sql_result = self._parse_cll(node, cte_mapping, schema_resolver)
                 else:
                     self.report.sql_parser_skipped_missing_code.append(node.dbt_name)
+                    if self.config.include_column_lineage:
+                        self.report.warning(
+                            title="Missing compiled code, skipping column lineage",
+                            message="Column-level lineage requires compiled SQL, which is not present "
+                            "in the manifest for this node. Manifests written by `dbt test` or "
+                            "`dbt source freshness` do not include compiled model SQL; generate "
+                            "the manifest with `dbt compile`, `dbt build`, or `dbt docs generate` "
+                            "and point the ingestion at that manifest instead.",
+                            context=node.dbt_name,
+                        )
 
                 # Save the column lineage.
                 if self.config.include_column_lineage and sql_result:


### PR DESCRIPTION
## Problem

With `infer_dbt_schemas` + `include_column_lineage` enabled, nodes whose manifest entries lack `compiled_code` are silently skipped for column-level lineage. The only signal is the `sql_parser_skipped_missing_code` counter buried in the ingestion report — no warning is emitted, even though the user explicitly requested column lineage.

The same method already warns for this exact condition on semantic views (`"Semantic View Missing compiled_code"`); regular SQL models — the common case — fail silently.

## How this bites in practice (verified repro)

Environment: dbt-core 1.12.0 / dbt-postgres 1.11.0, acryl-datahub CLI 1.6.0.17, GMS v1.5.0.6 (docker quickstart), Python 3.12.

1. A dbt project ingests fine with column lineage after `dbt docs generate` (compiled manifest): `sql_parser_successes: 2`, `fineGrainedLineages` emitted.
2. Later, `dbt test` runs (e.g. to refresh `run_results.json` for assertion ingestion). **`dbt test` rewrites `manifest.json` without compiled model SQL.**
3. The next ingestion consumes that manifest. Report shows:
   ```
   'sql_parser_skipped_missing_code': ['model.<project>.stg_invoice_lines', 'model.<project>.customer_metrics'],
   'sql_parser_successes': 0,
   ```
   No warning. The emitted `upstreamLineage` aspect has no `fineGrainedLineages` — and **replaces the fine-grained lineage ingested by the earlier good run**, so column lineage disappears from previously-correct datasets.

`dbt_pre.md` does document the recommended artifact workflow (`dbt build` → snapshot `run_results.json` → `dbt docs generate`), but when a pipeline deviates from it, the failure is invisible: downstream consumers (impact analysis, column-level tooling) just see missing column lineage with no explanation.

## Change

Emit a structured report warning when a node needing CLL has no compiled code, gated on `include_column_lineage` so schema-inference-only runs are unaffected. Mirrors the existing semantic-view warning in the same method. Report-only change — no emitted aspects are affected.

## Verification

- Exercised the patched source against a live quickstart with a `dbt test`-generated manifest; the warning fires with node context:
  ```
  WARNING {datahub.ingestion.source.dbt.dbt_common:2411} - Missing compiled code, skipping column lineage:
  Column-level lineage requires compiled SQL, which is not present in the manifest for this node. Manifests
  written by `dbt test` or `dbt source freshness` do not include compiled model SQL; generate the manifest
  with `dbt compile`, `dbt build`, or `dbt docs generate` and point the ingestion at that manifest instead.
  => model.pareis_retail.stg_invoice_lines
  ```
- Re-ingesting a `dbt docs generate` manifest emits no warning (`sql_parser_successes: 2`, fine-grained lineage restored).
- `python -m py_compile` clean; no golden files touched.
