### PR TITLE
test(ingest/doris): pin positional DATA_LENGTH access in profiling enrichment

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -376,8 +376,8 @@ class MySQLSource(TwoTierSQLAlchemySource):
         if not self.config.is_profiling_enabled():
             return
         with inspector.engine.connect() as conn:
-            # MySQL upper-cases information_schema labels; MariaDB keeps the
-            # selected case. Unpack positionally so access is case-independent.
+            # MySQL upper-cases information_schema labels; MariaDB/Doris/TiDB keep
+            # the selected case — unpack positionally so access is case-independent.
             for table_schema, table_name, data_length in conn.execute(
                 text(
                     "SELECT table_schema, table_name, data_length "

--- a/metadata-ingestion/tests/unit/doris/test_doris_source.py
+++ b/metadata-ingestion/tests/unit/doris/test_doris_source.py
@@ -9,6 +9,39 @@ from datahub.ingestion.source.sql.doris.doris_dialect import DorisDialect
 from datahub.ingestion.source.sql.doris.doris_source import DorisConfig, DorisSource
 
 
+def _profiling_source() -> DorisSource:
+    config = DorisConfig(
+        host_port="localhost:9030",
+        profiling={"enabled": True},
+    )
+    return DorisSource(config, PipelineContext(run_id="doris-profiling-test"))
+
+
+def _inspector_returning(rows: list) -> MagicMock:
+    conn = MagicMock()
+    conn.execute.return_value = rows
+    inspector = MagicMock()
+    inspector.engine.connect.return_value.__enter__.return_value = conn
+    return inspector
+
+
+def test_add_profile_metadata_reads_storage_bytes_positionally() -> None:
+    source = _profiling_source()
+    inspector = _inspector_returning(
+        [
+            ("dorisdb", "orders", 4096),
+            ("dorisdb", "customers", 8192),
+        ]
+    )
+
+    source.add_profile_metadata(inspector)
+
+    assert source.profile_metadata_info.dataset_name_to_storage_bytes == {
+        "dorisdb.orders": 4096,
+        "dorisdb.customers": 8192,
+    }
+
+
 def test_doris_uses_native_dialect():
     config = DorisConfig(host_port="localhost:9030", database="test")
     assert config.scheme == "doris+pymysql"

--- a/metadata-ingestion/tests/unit/doris/test_doris_source.py
+++ b/metadata-ingestion/tests/unit/doris/test_doris_source.py
@@ -9,39 +9,6 @@ from datahub.ingestion.source.sql.doris.doris_dialect import DorisDialect
 from datahub.ingestion.source.sql.doris.doris_source import DorisConfig, DorisSource
 
 
-def _profiling_source() -> DorisSource:
-    config = DorisConfig(
-        host_port="localhost:9030",
-        profiling={"enabled": True},
-    )
-    return DorisSource(config, PipelineContext(run_id="doris-profiling-test"))
-
-
-def _inspector_returning(rows: list) -> MagicMock:
-    conn = MagicMock()
-    conn.execute.return_value = rows
-    inspector = MagicMock()
-    inspector.engine.connect.return_value.__enter__.return_value = conn
-    return inspector
-
-
-def test_add_profile_metadata_reads_storage_bytes_positionally() -> None:
-    source = _profiling_source()
-    inspector = _inspector_returning(
-        [
-            ("dorisdb", "orders", 4096),
-            ("dorisdb", "customers", 8192),
-        ]
-    )
-
-    source.add_profile_metadata(inspector)
-
-    assert source.profile_metadata_info.dataset_name_to_storage_bytes == {
-        "dorisdb.orders": 4096,
-        "dorisdb.customers": 8192,
-    }
-
-
 def test_doris_uses_native_dialect():
     config = DorisConfig(host_port="localhost:9030", database="test")
     assert config.scheme == "doris+pymysql"

--- a/metadata-ingestion/tests/unit/test_mysql_profiling.py
+++ b/metadata-ingestion/tests/unit/test_mysql_profiling.py
@@ -21,8 +21,6 @@ def _inspector_returning(rows: list) -> MagicMock:
 
 
 def test_add_profile_metadata_reads_storage_bytes_positionally() -> None:
-    # Tuple rows (no named attributes) prove access is positional, not by the
-    # case-sensitive attribute name that differs between MySQL and MariaDB.
     source = _source()
     inspector = _inspector_returning(
         [

--- a/metadata-ingestion/tests/unit/test_mysql_profiling.py
+++ b/metadata-ingestion/tests/unit/test_mysql_profiling.py
@@ -1,18 +1,14 @@
+from typing import List, Tuple, Type
 from unittest.mock import MagicMock
 
+import pytest
+
 from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sql.doris.doris_source import DorisConfig, DorisSource
 from datahub.ingestion.source.sql.mysql import MySQLConfig, MySQLSource
 
 
-def _source() -> MySQLSource:
-    config = MySQLConfig(
-        host_port="localhost:3306",
-        profiling={"enabled": True},
-    )
-    return MySQLSource(config, PipelineContext(run_id="mysql-profiling-test"))
-
-
-def _inspector_returning(rows: list) -> MagicMock:
+def _inspector_returning(rows: List[Tuple[str, str, int]]) -> MagicMock:
     conn = MagicMock()
     conn.execute.return_value = rows
     inspector = MagicMock()
@@ -20,8 +16,26 @@ def _inspector_returning(rows: list) -> MagicMock:
     return inspector
 
 
-def test_add_profile_metadata_reads_storage_bytes_positionally() -> None:
-    source = _source()
+@pytest.mark.parametrize(
+    "source_cls,config_cls,host_port",
+    [
+        (MySQLSource, MySQLConfig, "localhost:3306"),
+        # Doris inherits add_profile_metadata, so an override there has to keep
+        # reading positionally too.
+        (DorisSource, DorisConfig, "localhost:9030"),
+    ],
+)
+def test_add_profile_metadata_reads_storage_bytes_positionally(
+    source_cls: Type[MySQLSource],
+    config_cls: Type[MySQLConfig],
+    host_port: str,
+) -> None:
+    # Tuple rows (no named attributes) prove access is positional, not by the
+    # label whose case differs across MySQL/MariaDB/Doris/TiDB.
+    source = source_cls(
+        config_cls(host_port=host_port, profiling={"enabled": True}),
+        PipelineContext(run_id="mysql-family-profiling-test"),
+    )
     inspector = _inspector_returning(
         [
             ("my_db", "orders", 4096),


### PR DESCRIPTION
## Summary

**No behavior change in this diff** — #18298 already fixed Doris via the inherited `MySQLSource.add_profile_metadata`. This PR is a regression pin for that fix plus a comment tweak.

- https://github.com/datahub-project/datahub/issues/16600: with profiling enabled, Doris ingestion logged `Failed to get enrichment data for profile Could not locate column in row for column 'DATA_LENGTH'`.
- Doris (like MariaDB/TiDB) preserves selected `information_schema` label case, so named access fails. `MySQLSource.add_profile_metadata` unpacks rows positionally, and `DorisSource` inherits it.
- Pins that behavior by parametrizing the existing profiling test over `(MySQLSource, MySQLConfig)` and `(DorisSource, DorisConfig)`, so a future Doris override that reverts to named access fails a test.
- Notes Doris/TiDB in the shared reader comment.

## Test plan

- [x] `./gradlew :metadata-ingestion:lintFix`
- [x] `pytest tests/unit/test_mysql_profiling.py tests/unit/doris`

Closes #16600