### PR TITLE
fix(ingest/cassandra): shut down Cluster in addition to Session on close

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra_api.py
@@ -103,6 +103,7 @@ class CassandraAPI:
     def __init__(self, config: CassandraSourceConfig, report: SourceReport):
         self.config = config
         self.report = report
+        self._cassandra_cluster: Optional[Cluster] = None
         self._cassandra_session: Optional[Session] = None
 
     def authenticate(self) -> bool:
@@ -127,6 +128,7 @@ class CassandraAPI:
                     protocol_version=ProtocolVersion.V4,
                 )
 
+                self._cassandra_cluster = cluster
                 self._cassandra_session = cluster.connect()
                 return True
 
@@ -182,6 +184,7 @@ class CassandraAPI:
                     load_balancing_policy=None,
                 )
 
+            self._cassandra_cluster = cluster
             self._cassandra_session = cluster.connect()
             return True
         except OperationTimedOut as e:
@@ -363,6 +366,11 @@ class CassandraAPI:
             return []
 
     def close(self):
-        """Close the Cassandra session."""
+        """Close the Cassandra session and cluster."""
         if self._cassandra_session:
             self._cassandra_session.shutdown()
+        if self._cassandra_cluster:
+            # Session.shutdown() only closes this session's connection pools; the
+            # cluster's control connection and IO reactor thread keep running until
+            # Cluster.shutdown() is called, which can crash the interpreter on exit.
+            self._cassandra_cluster.shutdown()

--- a/metadata-ingestion/tests/unit/test_cassandra_source.py
+++ b/metadata-ingestion/tests/unit/test_cassandra_source.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Tuple
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.cassandra.cassandra import CassandraToSchemaFieldConverter
@@ -18,6 +17,7 @@ from datahub.ingestion.source.cassandra.cassandra_api import (
 from datahub.ingestion.source.cassandra.cassandra_config import (
     CassandraSourceConfig,
 )
+from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 logger = logging.getLogger(__name__)
 

--- a/metadata-ingestion/tests/unit/test_cassandra_source.py
+++ b/metadata-ingestion/tests/unit/test_cassandra_source.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Tuple
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.cassandra.cassandra import CassandraToSchemaFieldConverter
@@ -17,7 +18,6 @@ from datahub.ingestion.source.cassandra.cassandra_api import (
 from datahub.ingestion.source.cassandra.cassandra_config import (
     CassandraSourceConfig,
 )
-from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +111,25 @@ def test_authenticate_no_ssl():
         mock_cluster.assert_called_once()
         assert mock_cluster.call_args[1].get("ssl_context") is None
         report.failure.assert_not_called()
+
+
+def test_close_shuts_down_session_and_cluster():
+    config_dict = _get_base_config_dict()
+    config = CassandraSourceConfig.model_validate(config_dict)
+    report = MagicMock(spec=SourceReport)
+    api = CassandraAPI(config, report)
+
+    with patch(
+        "datahub.ingestion.source.cassandra.cassandra_api.Cluster"
+    ) as mock_cluster:
+        mock_session = MagicMock()
+        mock_cluster.return_value.connect.return_value = mock_session
+        assert api.authenticate()
+
+        api.close()
+
+        mock_session.shutdown.assert_called_once()
+        mock_cluster.return_value.shutdown.assert_called_once()
 
 
 def test_authenticate_ssl_ca_certs():


### PR DESCRIPTION
## Summary

- `CassandraAPI.close()` only called `Session.shutdown()`, never `Cluster.shutdown()`. `Session.shutdown()` closes that session's connection pools, but the parent `Cluster`'s control connection and IO reactor thread keep running until `Cluster.shutdown()` is called.
- The leaked `Cluster` (and its background reactor thread) is never garbage collected in time, and a still-live native thread during CPython interpreter teardown is a known cause of a `SIGSEGV` at process exit.
- This matches the intermittent CI pattern in `testIntegrationBatch3`: all tests pass cleanly, then ~15-20s later the wrapping `bash` process exits with code 139 (SIGSEGV) with no other error output. Confirmed the same exact signature (clean pass → silent gap → exit 139, with `test_cassandra_ingest` present in the batch) in two independent CI runs.
- Fix: store the `Cluster` instance and call `cluster.shutdown()` alongside `session.shutdown()` in `close()`.

## Test plan

- [x] `ruff format` / `ruff check` pass on the changed file
- [x] `mypy` passes on the changed file
- [ ] Monitor `testIntegrationBatch3` CI runs for recurrence of the exit-139 crash after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes incomplete teardown in **`CassandraAPI.close()`** by retaining the driver **`Cluster`** created during **`authenticate()`** (cloud and non-cloud paths) and calling **`cluster.shutdown()`** after **`session.shutdown()`**, so background control/IO threads are stopped instead of lingering into interpreter exit.
> 
> Adds **`test_close_shuts_down_session_and_cluster`** to assert both shutdown paths run on close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5bbec62745cd461d7a85ccca952e57d4e7b0dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->