### PR TITLE
perf(graphql): resolve batch mutation validation in one existence check

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
@@ -17,6 +17,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -61,20 +62,23 @@ public class BatchAddOwnersResolver implements DataFetcher<CompletableFuture<Boo
   }
 
   private void validateOwners(@Nonnull OperationContext opContext, List<OwnerInput> owners) {
-    for (OwnerInput ownerInput : owners) {
-      OwnerUtils.validateOwner(opContext, ownerInput, _entityService);
-    }
+    OwnerUtils.validateOwners(opContext, owners, _entityService);
   }
 
   private void validateInputResources(
       @Nonnull OperationContext opContext, List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(opContext, resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(opContext, resource, context);
+      validateInputResource(opContext, resource, context, existingResourceUrns);
     }
   }
 
   private void validateInputResource(
-      @Nonnull OperationContext opContext, ResourceRefInput resource, QueryContext context) {
+      @Nonnull OperationContext opContext,
+      ResourceRefInput resource,
+      QueryContext context,
+      Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
 
     if (resource.getSubResource() != null) {
@@ -86,6 +90,7 @@ public class BatchAddOwnersResolver implements DataFetcher<CompletableFuture<Boo
         context, resourceUrn, _entityClient, _entityService);
     LabelUtils.validateResource(
         opContext,
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTagsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTagsResolver.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -129,20 +130,23 @@ public class BatchAddTagsResolver implements DataFetcher<CompletableFuture<Boole
   }
 
   private void validateTags(@Nonnull OperationContext opContext, List<Urn> tagUrns) {
-    for (Urn tagUrn : tagUrns) {
-      LabelUtils.validateLabel(opContext, tagUrn, Constants.TAG_ENTITY_NAME, _entityService);
-    }
+    LabelUtils.validateLabels(opContext, tagUrns, Constants.TAG_ENTITY_NAME, _entityService);
   }
 
   private void validateInputResources(
       List<ResourceRefInput> resources, QueryContext context, Collection<Urn> tagUrns) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(context.getOperationContext(), resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(resource, context, tagUrns);
+      validateInputResource(resource, context, tagUrns, existingResourceUrns);
     }
   }
 
   private void validateInputResource(
-      ResourceRefInput resource, QueryContext context, Collection<Urn> tagUrns) {
+      ResourceRefInput resource,
+      QueryContext context,
+      Collection<Urn> tagUrns,
+      Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!LabelUtils.isAuthorizedToUpdateTags(
         context, resourceUrn, resource.getSubResource(), tagUrns)) {
@@ -151,6 +155,7 @@ public class BatchAddTagsResolver implements DataFetcher<CompletableFuture<Boole
     }
     LabelUtils.validateResource(
         context.getOperationContext(),
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTermsResolver.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -128,19 +129,20 @@ public class BatchAddTermsResolver implements DataFetcher<CompletableFuture<Bool
   }
 
   private void validateTerms(@Nonnull OperationContext opContext, List<Urn> termUrns) {
-    for (Urn termUrn : termUrns) {
-      LabelUtils.validateLabel(
-          opContext, termUrn, Constants.GLOSSARY_TERM_ENTITY_NAME, _entityService);
-    }
+    LabelUtils.validateLabels(
+        opContext, termUrns, Constants.GLOSSARY_TERM_ENTITY_NAME, _entityService);
   }
 
   private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(context.getOperationContext(), resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(resource, context);
+      validateInputResource(resource, context, existingResourceUrns);
     }
   }
 
-  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+  private void validateInputResource(
+      ResourceRefInput resource, QueryContext context, Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!LabelUtils.isAuthorizedToUpdateTerms(context, resourceUrn, resource.getSubResource())) {
       throw new AuthorizationException(
@@ -148,6 +150,7 @@ public class BatchAddTermsResolver implements DataFetcher<CompletableFuture<Bool
     }
     LabelUtils.validateResource(
         context.getOperationContext(),
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveOwnersResolver.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -61,12 +62,15 @@ public class BatchRemoveOwnersResolver implements DataFetcher<CompletableFuture<
   }
 
   private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(context.getOperationContext(), resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(resource, context);
+      validateInputResource(resource, context, existingResourceUrns);
     }
   }
 
-  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+  private void validateInputResource(
+      ResourceRefInput resource, QueryContext context, Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
 
     if (resource.getSubResource() != null) {
@@ -78,6 +82,7 @@ public class BatchRemoveOwnersResolver implements DataFetcher<CompletableFuture<
         context, resourceUrn, _entityClient, _entityService);
     LabelUtils.validateResource(
         context.getOperationContext(),
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTagsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTagsResolver.java
@@ -16,6 +16,7 @@ import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -63,8 +64,10 @@ public class BatchRemoveTagsResolver implements DataFetcher<CompletableFuture<Bo
       List<ResourceRefInput> resources,
       QueryContext context,
       Collection<Urn> tagUrns) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(opContext, resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(opContext, resource, context, tagUrns);
+      validateInputResource(opContext, resource, context, tagUrns, existingResourceUrns);
     }
   }
 
@@ -72,7 +75,8 @@ public class BatchRemoveTagsResolver implements DataFetcher<CompletableFuture<Bo
       @Nonnull OperationContext opContext,
       ResourceRefInput resource,
       QueryContext context,
-      Collection<Urn> tagUrns) {
+      Collection<Urn> tagUrns,
+      Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!LabelUtils.isAuthorizedToUpdateTags(
         context, resourceUrn, resource.getSubResource(), tagUrns)) {
@@ -81,6 +85,7 @@ public class BatchRemoveTagsResolver implements DataFetcher<CompletableFuture<Bo
     }
     LabelUtils.validateResource(
         opContext,
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTermsResolver.java
@@ -15,6 +15,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -59,13 +60,18 @@ public class BatchRemoveTermsResolver implements DataFetcher<CompletableFuture<B
 
   private void validateInputResources(
       @Nonnull OperationContext opContext, List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(opContext, resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(opContext, resource, context);
+      validateInputResource(opContext, resource, context, existingResourceUrns);
     }
   }
 
   private void validateInputResource(
-      @Nonnull OperationContext opContext, ResourceRefInput resource, QueryContext context) {
+      @Nonnull OperationContext opContext,
+      ResourceRefInput resource,
+      QueryContext context,
+      Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!LabelUtils.isAuthorizedToUpdateTerms(context, resourceUrn, resource.getSubResource())) {
       throw new AuthorizationException(
@@ -73,6 +79,7 @@ public class BatchRemoveTermsResolver implements DataFetcher<CompletableFuture<B
     }
     LabelUtils.validateResource(
         opContext,
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchSetDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchSetDomainResolver.java
@@ -17,6 +17,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -69,12 +70,15 @@ public class BatchSetDomainResolver implements DataFetcher<CompletableFuture<Boo
   }
 
   private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(context.getOperationContext(), resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(resource, context);
+      validateInputResource(resource, context, existingResourceUrns);
     }
   }
 
-  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+  private void validateInputResource(
+      ResourceRefInput resource, QueryContext context, Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!DomainUtils.isAuthorizedToUpdateDomainsForEntity(context, resourceUrn, _entityClient)) {
       throw new AuthorizationException(
@@ -82,6 +86,7 @@ public class BatchSetDomainResolver implements DataFetcher<CompletableFuture<Boo
     }
     LabelUtils.validateResource(
         context.getOperationContext(),
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateDeprecationResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateDeprecationResolver.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -62,12 +63,15 @@ public class BatchUpdateDeprecationResolver implements DataFetcher<CompletableFu
   }
 
   private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    final Set<Urn> existingResourceUrns =
+        LabelUtils.existingResourceUrns(context.getOperationContext(), resources, _entityService);
     for (ResourceRefInput resource : resources) {
-      validateInputResource(resource, context);
+      validateInputResource(resource, context, existingResourceUrns);
     }
   }
 
-  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+  private void validateInputResource(
+      ResourceRefInput resource, QueryContext context, Set<Urn> existingResourceUrns) {
     final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
     if (!DeprecationUtils.isAuthorizedToUpdateDeprecationForEntity(context, resourceUrn)) {
       throw new AuthorizationException(
@@ -75,6 +79,7 @@ public class BatchUpdateDeprecationResolver implements DataFetcher<CompletableFu
     }
     LabelUtils.validateResource(
         context.getOperationContext(),
+        existingResourceUrns,
         resourceUrn,
         resource.getSubResource(),
         resource.getSubResourceType(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateSoftDeletedResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateSoftDeletedResolver.java
@@ -13,7 +13,9 @@ import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,18 +59,23 @@ public class BatchUpdateSoftDeletedResolver implements DataFetcher<CompletableFu
   }
 
   private void validateInputUrns(List<String> urnStrs, QueryContext context) {
+    final Set<Urn> existingUrns =
+        MutationUtils.existingUrns(
+            context.getOperationContext(),
+            urnStrs.stream().map(UrnUtils::getUrn).collect(Collectors.toList()),
+            _entityService);
     for (String urnStr : urnStrs) {
-      validateInputUrn(urnStr, context);
+      validateInputUrn(urnStr, context, existingUrns);
     }
   }
 
-  private void validateInputUrn(String urnStr, QueryContext context) {
+  private void validateInputUrn(String urnStr, QueryContext context, Set<Urn> existingUrns) {
     final Urn urn = UrnUtils.getUrn(urnStr);
     if (!DeleteUtils.isAuthorizedToDeleteEntity(context, urn)) {
       throw new AuthorizationException(
           "Unauthorized to perform this action. Please contact your DataHub administrator.");
     }
-    if (!_entityService.exists(context.getOperationContext(), urn, true)) {
+    if (!existingUrns.contains(urn)) {
       throw new IllegalArgumentException(
           String.format("Failed to soft delete entity with urn %s. Entity does not exist.", urn));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
@@ -20,7 +20,11 @@ import com.linkedin.schema.EditableSchemaMetadata;
 import com.linkedin.schema.SchemaField;
 import com.linkedin.schema.SchemaMetadata;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -128,6 +132,20 @@ public class MutationUtils {
       editableSchemaMetadataArray.add(newFieldInfo);
       return newFieldInfo;
     }
+  }
+
+  /**
+   * Resolves which of the given urns exist using a single call. Batch mutations validate many urns
+   * at once, so resolving them one at a time turns a single request into one round trip per urn.
+   */
+  public static Set<Urn> existingUrns(
+      @Nonnull OperationContext opContext,
+      @Nonnull Collection<Urn> urns,
+      EntityService<?> entityService) {
+    if (urns.isEmpty()) {
+      return Collections.emptySet();
+    }
+    return entityService.exists(opContext, new LinkedHashSet<>(urns), true);
   }
 
   public static Boolean validateSubresourceExists(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DomainUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DomainUtils.java
@@ -116,7 +116,7 @@ public class DomainUtils {
 
   public static void validateDomain(
       @Nonnull OperationContext opContext, Urn domainUrn, EntityService<?> entityService) {
-    if (!entityService.exists(opContext, domainUrn, true)) {
+    if (!existingUrns(opContext, List.of(domainUrn), entityService).contains(domainUrn)) {
       throw new IllegalArgumentException(
           String.format("Failed to validate Domain with urn %s. Urn does not exist.", domainUrn));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -33,6 +33,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -294,16 +296,45 @@ public class LabelUtils {
       Urn labelUrn,
       String labelEntityType,
       EntityService<?> entityService) {
-    if (!labelUrn.getEntityType().equals(labelEntityType)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Failed to validate label with urn %s. Urn type does not match entity type %s..",
-              labelUrn, labelEntityType));
+    validateLabels(opContext, List.of(labelUrn), labelEntityType, entityService);
+  }
+
+  /**
+   * Batched form of {@link #validateLabel}: resolves existence for every label in a single call
+   * rather than one per label. Labels are still inspected in input order, so the same label is
+   * rejected first as when validating one at a time.
+   */
+  public static void validateLabels(
+      @Nonnull OperationContext opContext,
+      @Nonnull Collection<Urn> labelUrns,
+      String labelEntityType,
+      EntityService<?> entityService) {
+    final Set<Urn> existingLabelUrns = existingUrns(opContext, labelUrns, entityService);
+    for (Urn labelUrn : labelUrns) {
+      if (!labelUrn.getEntityType().equals(labelEntityType)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Failed to validate label with urn %s. Urn type does not match entity type %s..",
+                labelUrn, labelEntityType));
+      }
+      if (!existingLabelUrns.contains(labelUrn)) {
+        throw new IllegalArgumentException(
+            String.format("Failed to validate label with urn %s. Urn does not exist.", labelUrn));
+      }
     }
-    if (!entityService.exists(opContext, labelUrn, true)) {
-      throw new IllegalArgumentException(
-          String.format("Failed to validate label with urn %s. Urn does not exist.", labelUrn));
-    }
+  }
+
+  /** Resolves, in a single call, which of the given resources exist. */
+  public static Set<Urn> existingResourceUrns(
+      @Nonnull OperationContext opContext,
+      @Nonnull Collection<ResourceRefInput> resources,
+      EntityService<?> entityService) {
+    return existingUrns(
+        opContext,
+        resources.stream()
+            .map(resource -> UrnUtils.getUrn(resource.getResourceUrn()))
+            .collect(Collectors.toList()),
+        entityService);
   }
 
   // TODO: Move this out into a separate utilities class.
@@ -313,7 +344,28 @@ public class LabelUtils {
       String subResource,
       SubResourceType subResourceType,
       EntityService<?> entityService) {
-    if (!entityService.exists(opContext, resourceUrn, true)) {
+    validateResource(
+        opContext,
+        existingUrns(opContext, List.of(resourceUrn), entityService),
+        resourceUrn,
+        subResource,
+        subResourceType,
+        entityService);
+  }
+
+  /**
+   * Variant of {@link #validateResource} taking a pre-resolved set of existing urns, so a caller
+   * validating many resources can resolve existence once for the whole batch instead of once per
+   * resource. Obtain the set from {@link #existingResourceUrns}.
+   */
+  public static void validateResource(
+      @Nonnull OperationContext opContext,
+      @Nonnull Set<Urn> existingResourceUrns,
+      Urn resourceUrn,
+      String subResource,
+      SubResourceType subResourceType,
+      EntityService<?> entityService) {
+    if (!existingResourceUrns.contains(resourceUrn)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to update resource with urn %s. Entity does not exist.", resourceUrn));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -30,7 +30,9 @@ import com.linkedin.metadata.service.util.OwnerServiceUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -210,9 +212,8 @@ public class OwnerUtils {
       List<OwnerInput> owners,
       Urn resourceUrn,
       EntityService<?> entityService) {
-    for (OwnerInput owner : owners) {
-      validateAddOwnerInput(opContext, owner, resourceUrn, entityService);
-    }
+    validateResourceExists(opContext, resourceUrn, entityService);
+    validateOwners(opContext, owners, entityService);
   }
 
   public static void validateAddOwnerInput(
@@ -220,19 +221,38 @@ public class OwnerUtils {
       OwnerInput owner,
       Urn resourceUrn,
       EntityService<?> entityService) {
-
-    if (!entityService.exists(opContext, resourceUrn, true)) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));
-    }
-
-    validateOwner(opContext, owner, entityService);
+    validateAddOwnerInput(opContext, List.of(owner), resourceUrn, entityService);
   }
 
   public static void validateOwner(
       @Nonnull OperationContext opContext, OwnerInput owner, EntityService<?> entityService) {
+    validateOwners(opContext, List.of(owner), entityService);
+  }
 
+  /**
+   * Batched form of {@link #validateOwner}: resolves every owner urn and custom ownership type urn
+   * in one call rather than one or two per owner. Owners are still inspected in input order, so the
+   * same owner is rejected first as when validating one at a time.
+   */
+  public static void validateOwners(
+      @Nonnull OperationContext opContext,
+      @Nonnull Collection<OwnerInput> owners,
+      EntityService<?> entityService) {
+    final List<Urn> urnsToResolve = new ArrayList<>();
+    for (OwnerInput owner : owners) {
+      urnsToResolve.add(UrnUtils.getUrn(owner.getOwnerUrn()));
+      if (owner.getOwnershipTypeUrn() != null) {
+        urnsToResolve.add(UrnUtils.getUrn(owner.getOwnershipTypeUrn()));
+      }
+    }
+
+    final Set<Urn> resolvedUrns = existingUrns(opContext, urnsToResolve, entityService);
+    for (OwnerInput owner : owners) {
+      validateOwner(owner, resolvedUrns);
+    }
+  }
+
+  private static void validateOwner(OwnerInput owner, @Nonnull Set<Urn> resolvedUrns) {
     OwnerEntityType ownerEntityType = owner.getOwnerEntityType();
     Urn ownerUrn = UrnUtils.getUrn(owner.getOwnerUrn());
 
@@ -252,7 +272,7 @@ public class OwnerUtils {
               ownerUrn));
     }
 
-    if (!entityService.exists(opContext, ownerUrn, true)) {
+    if (!resolvedUrns.contains(ownerUrn)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource(s). Owner with urn %s does not exist.",
@@ -260,7 +280,7 @@ public class OwnerUtils {
     }
 
     if (owner.getOwnershipTypeUrn() != null
-        && !entityService.exists(opContext, UrnUtils.getUrn(owner.getOwnershipTypeUrn()), true)) {
+        && !resolvedUrns.contains(UrnUtils.getUrn(owner.getOwnershipTypeUrn()))) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource(s). Custom Ownership type with "
@@ -277,7 +297,12 @@ public class OwnerUtils {
 
   public static void validateRemoveInput(
       @Nonnull OperationContext opContext, Urn resourceUrn, EntityService<?> entityService) {
-    if (!entityService.exists(opContext, resourceUrn, true)) {
+    validateResourceExists(opContext, resourceUrn, entityService);
+  }
+
+  private static void validateResourceExists(
+      @Nonnull OperationContext opContext, Urn resourceUrn, EntityService<?> entityService) {
+    if (!existingUrns(opContext, List.of(resourceUrn), entityService).contains(resourceUrn)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -1,6 +1,8 @@
 package com.linkedin.datahub.graphql;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -221,6 +223,33 @@ public class TestUtils {
     when(mockContext.getOperationContext()).thenReturn(operationContext);
 
     return mockContext;
+  }
+
+  /**
+   * Stubs batched existence resolution so that exactly the given urns are reported as existing.
+   * Batch mutations resolve existence for a whole group of urns in one call, so the stub answers
+   * with the requested urns intersected against {@code existing} rather than a fixed set.
+   */
+  public static void stubExistingUrns(EntityService<?> mockService, Urn... existing) {
+    final Set<Urn> existingUrns = Set.of(existing);
+    when(mockService.exists(any(), anyCollection(), eq(true)))
+        .thenAnswer(
+            invocation -> {
+              final Collection<Urn> requested = invocation.getArgument(1);
+              return requested.stream().filter(existingUrns::contains).collect(Collectors.toSet());
+            });
+  }
+
+  /**
+   * Asserts that existence was resolved in {@code expectedBatchCalls} batched calls and never one
+   * urn at a time.
+   */
+  public static void verifyExistenceResolvedInBatches(
+      EntityService<?> mockService, int expectedBatchCalls) {
+    Mockito.verify(mockService, Mockito.times(expectedBatchCalls))
+        .exists(any(), anyCollection(), eq(true));
+    Mockito.verify(mockService, Mockito.never())
+        .exists(any(), any(Urn.class), Mockito.anyBoolean());
   }
 
   public static void verifyIngestProposal(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -242,12 +242,20 @@ public class TestUtils {
 
   /**
    * Asserts that existence was resolved in {@code expectedBatchCalls} batched calls and never one
-   * urn at a time.
+   * urn at a time. Use this where the number of groups is the point of the test; prefer {@link
+   * #verifyExistenceResolvedInBatches(EntityService)} elsewhere, so tests do not pin down a call
+   * count they are not actually asserting anything about.
    */
   public static void verifyExistenceResolvedInBatches(
       EntityService<?> mockService, int expectedBatchCalls) {
     Mockito.verify(mockService, Mockito.times(expectedBatchCalls))
         .exists(any(), anyCollection(), eq(true));
+    verifyExistenceResolvedInBatches(mockService);
+  }
+
+  /** Asserts that existence was resolved via the batched call and never one urn at a time. */
+  public static void verifyExistenceResolvedInBatches(EntityService<?> mockService) {
+    Mockito.verify(mockService, Mockito.atLeastOnce()).exists(any(), anyCollection(), eq(true));
     Mockito.verify(mockService, Mockito.never())
         .exists(any(), any(Urn.class), Mockito.anyBoolean());
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.delete;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -51,10 +50,10 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 
@@ -78,6 +77,8 @@ public class BatchUpdateSoftDeletedResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), STATUS_ASPECT_NAME, newStatus);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -102,10 +103,10 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalStatus);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 
@@ -129,6 +130,8 @@ public class BatchUpdateSoftDeletedResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), STATUS_ASPECT_NAME, newStatus);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -150,10 +153,8 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.deprecation;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -52,10 +51,10 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 
@@ -90,6 +89,8 @@ public class BatchUpdateDeprecationResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), DEPRECATION_ASPECT_NAME, newDeprecation);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -118,10 +119,10 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDeprecation);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 
@@ -156,6 +157,8 @@ public class BatchUpdateDeprecationResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), DEPRECATION_ASPECT_NAME, newDeprecation);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -177,10 +180,8 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -59,15 +58,12 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_DOMAIN_1_URN),
+        Urn.createFromString(TEST_DOMAIN_2_URN));
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService, mockClient);
 
@@ -97,8 +93,7 @@ public class BatchSetDomainResolverTest {
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -126,15 +121,12 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDomain);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_DOMAIN_1_URN),
+        Urn.createFromString(TEST_DOMAIN_2_URN));
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService, mockClient);
 
@@ -169,8 +161,7 @@ public class BatchSetDomainResolverTest {
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -198,15 +189,12 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDomain);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_DOMAIN_1_URN),
+        Urn.createFromString(TEST_DOMAIN_2_URN));
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService, mockClient);
 
@@ -233,6 +221,9 @@ public class BatchSetDomainResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), DOMAINS_ASPECT_NAME, newDomains);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    // No domain urn to validate when unsetting, so only the resources are resolved.
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -248,10 +239,8 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
-        .thenReturn(false);
+    // The requested domain does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN_1));
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService, mockClient);
 
@@ -291,12 +280,11 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_DOMAIN_1_URN));
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService, mockClient);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.DOMAIN_PROPERTIES_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -183,25 +182,16 @@ public class CreateDomainResolverTest {
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_PARENT_DOMAIN_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(any(), Mockito.eq(TEST_OWNER_URN), eq(true))).thenReturn(true);
+    // Includes the ownership type urns that OwnerUtils.addOwnersToResources checks for.
+    stubExistingUrns(
+        mockService,
+        TEST_OWNER_URN,
+        UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner"),
+        UrnUtils.getUrn("urn:li:ownershipType:__system__none"));
 
     // Mock the domain URN that will be returned from ingestProposal
     Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
         .thenReturn(TEST_DOMAIN_URN.toString());
-
-    // Mock ownership type URNs that OwnerUtils.addOwnersToResources checks for
-    Mockito.when(
-            mockService.exists(
-                any(),
-                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner")),
-                Mockito.eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(
-                any(),
-                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__none")),
-                Mockito.eq(true)))
-        .thenReturn(true);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -255,25 +245,16 @@ public class CreateDomainResolverTest {
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(any(), Mockito.eq(TEST_OWNER_URN), eq(true))).thenReturn(true);
+    // Includes the ownership type urns that OwnerUtils.addOwnersToResources checks for.
+    stubExistingUrns(
+        mockService,
+        TEST_OWNER_URN,
+        UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner"),
+        UrnUtils.getUrn("urn:li:ownershipType:__system__none"));
 
     // Mock the domain URN that will be returned from ingestProposal
     Mockito.when(mockClient.ingestProposal(any(), any(), Mockito.eq(false)))
         .thenReturn(TEST_DOMAIN_URN.toString());
-
-    // Mock ownership type URNs that OwnerUtils.addOwnersToResources checks for
-    Mockito.when(
-            mockService.exists(
-                any(),
-                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__technical_owner")),
-                Mockito.eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(
-                any(),
-                Mockito.eq(UrnUtils.getUrn("urn:li:ownershipType:__system__none")),
-                Mockito.eq(true)))
-        .thenReturn(true);
 
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.owner;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -50,23 +49,14 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_OWNER_1_URN),
+        Urn.createFromString(TEST_OWNER_2_URN),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name())));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 
@@ -94,11 +84,7 @@ public class AddOwnersResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -125,21 +111,13 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_OWNER_1_URN),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name())));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 
@@ -164,8 +142,7 @@ public class AddOwnersResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -192,18 +169,13 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(any(), any(Urn.class), eq(true))).thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_OWNER_1_URN),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name())));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 
@@ -228,8 +200,7 @@ public class AddOwnersResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -256,35 +227,18 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_3_URN)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_OWNER_1_URN),
+        Urn.createFromString(TEST_OWNER_2_URN),
+        Urn.createFromString(TEST_OWNER_3_URN),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name())),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER.name())));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 
@@ -321,14 +275,7 @@ public class AddOwnersResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_3_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -344,10 +291,8 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
-        .thenReturn(false);
+    // The owner does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 
@@ -383,10 +328,8 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
-        .thenReturn(true);
+    // The resource does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_OWNER_1_URN));
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService, mockClient);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.owner;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -58,26 +57,15 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1),
+        Urn.createFromString(TEST_OWNER_URN_2),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER.name())));
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService, mockClient);
 
@@ -111,11 +99,7 @@ public class BatchAddOwnersResolverTest {
 
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -147,37 +131,18 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalOwnership);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                any(),
-                eq(
-                    Urn.createFromString(
-                        OwnerUtils.mapOwnershipTypeToEntity(
-                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                                .name()))),
-                eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1),
+        Urn.createFromString(TEST_OWNER_URN_2),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name())),
+        Urn.createFromString(
+            OwnerUtils.mapOwnershipTypeToEntity(
+                com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER.name())));
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService, mockClient);
 
@@ -211,11 +176,7 @@ public class BatchAddOwnersResolverTest {
 
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -231,10 +192,8 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(false);
+    // The owner does not exist.
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN_1));
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService, mockClient);
 
@@ -289,12 +248,11 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1));
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService, mockClient);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
@@ -54,15 +54,12 @@ public class BatchRemoveOwnersResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1),
+        Urn.createFromString(TEST_OWNER_URN_2));
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService, mockClient);
 
@@ -81,6 +78,8 @@ public class BatchRemoveOwnersResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -122,15 +121,12 @@ public class BatchRemoveOwnersResolverTest {
                 eq(0L)))
         .thenReturn(oldOwners2);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1),
+        Urn.createFromString(TEST_OWNER_URN_2));
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService, mockClient);
 
@@ -149,6 +145,8 @@ public class BatchRemoveOwnersResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -171,12 +169,11 @@ public class BatchRemoveOwnersResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_OWNER_URN_1));
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService, mockClient);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -45,12 +44,11 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN));
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -77,12 +75,6 @@ public class AddTagsResolverTest {
             Urn.createFromString(TEST_ENTITY_URN), GLOBAL_TAGS_ASPECT_NAME, newTags);
 
     verifyIngestProposal(mockService, 1, proposal);
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -104,12 +96,11 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalTags);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN));
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -136,12 +127,6 @@ public class AddTagsResolverTest {
             Urn.createFromString(TEST_ENTITY_URN), GLOBAL_TAGS_ASPECT_NAME, newTags);
 
     verifyIngestProposal(mockService, 1, proposal);
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -156,10 +141,7 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(false);
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN));
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -187,10 +169,7 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(mockService, Urn.createFromString(TEST_TAG_1_URN));
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
@@ -75,6 +75,9 @@ public class AddTagsResolverTest {
             Urn.createFromString(TEST_ENTITY_URN), GLOBAL_TAGS_ASPECT_NAME, newTags);
 
     verifyIngestProposal(mockService, 1, proposal);
+
+    // Tag and resource existence must both go through the batched call.
+    verifyExistenceResolvedInBatches(mockService);
   }
 
   @Test
@@ -127,6 +130,9 @@ public class AddTagsResolverTest {
             Urn.createFromString(TEST_ENTITY_URN), GLOBAL_TAGS_ASPECT_NAME, newTags);
 
     verifyIngestProposal(mockService, 1, proposal);
+
+    // Tag and resource existence must both go through the batched call.
+    verifyExistenceResolvedInBatches(mockService);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -57,15 +56,7 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubAllUrnsExist(mockService);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -99,11 +90,17 @@ public class BatchAddTagsResolverTest {
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
+    verifyBatchedExistenceChecks(mockService);
+  }
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
+  /** Both tags and both resources resolve as existing, via the batched existence check. */
+  private static void stubAllUrnsExist(EntityService<?> mockService) throws Exception {
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN),
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
   }
 
   @Test
@@ -133,15 +130,7 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalTags);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubAllUrnsExist(mockService);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -175,11 +164,12 @@ public class BatchAddTagsResolverTest {
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
+    verifyBatchedExistenceChecks(mockService);
+  }
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
+  /** One batched existence call for the tags, one for the resources — never one per urn. */
+  private static void verifyBatchedExistenceChecks(EntityService<?> mockService) {
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -194,10 +184,9 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(false);
+    // Only the second tag resolves, so validation must reject the first.
+    stubExistingUrns(
+        mockService, Urn.createFromString(TEST_TAG_2_URN), Urn.createFromString(TEST_ENTITY_URN_1));
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -235,12 +224,12 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
+    // Both tags resolve, but the first resource does not.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
@@ -3,7 +3,6 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -59,15 +58,12 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN));
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 
@@ -100,6 +96,8 @@ public class BatchRemoveTagsResolverTest {
     proposal2.setChangeType(ChangeType.UPSERT);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -137,15 +135,12 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldTags2);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_TAG_1_URN),
+        Urn.createFromString(TEST_TAG_2_URN));
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 
@@ -173,6 +168,8 @@ public class BatchRemoveTagsResolverTest {
             Urn.createFromString(TEST_ENTITY_URN_2), GLOBAL_TAGS_ASPECT_NAME, emptyTags);
 
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -194,12 +191,9 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(
+        mockService, Urn.createFromString(TEST_ENTITY_URN_2), Urn.createFromString(TEST_TAG_1_URN));
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
@@ -63,6 +63,9 @@ public class AddTermsResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
         .ingestProposal(any(), Mockito.any(AspectsBatchImpl.class), eq(false));
+
+    // Term and resource existence must both go through the batched call.
+    verifyExistenceResolvedInBatches(mockService);
   }
 
   @Test
@@ -106,6 +109,9 @@ public class AddTermsResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
         .ingestProposal(any(), Mockito.any(AspectsBatchImpl.class), eq(false));
+
+    // Term and resource existence must both go through the batched call.
+    verifyExistenceResolvedInBatches(mockService);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
@@ -42,12 +42,11 @@ public class AddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_TERM_1_URN),
+        Urn.createFromString(TEST_TERM_2_URN));
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -64,12 +63,6 @@ public class AddTermsResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
         .ingestProposal(any(), Mockito.any(AspectsBatchImpl.class), eq(false));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -92,12 +85,11 @@ public class AddTermsResolverTest {
                 eq(0L)))
         .thenReturn(originalTerms);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN),
+        Urn.createFromString(TEST_TERM_1_URN),
+        Urn.createFromString(TEST_TERM_2_URN));
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -114,12 +106,6 @@ public class AddTermsResolverTest {
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
         .ingestProposal(any(), Mockito.any(AspectsBatchImpl.class), eq(false));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -134,10 +120,7 @@ public class AddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(false);
+    stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN));
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -166,10 +149,7 @@ public class AddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(mockService, Urn.createFromString(TEST_TERM_1_URN));
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
@@ -53,17 +53,12 @@ public class BatchAddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_GLOSSARY_TERM_1_URN),
+        Urn.createFromString(TEST_GLOSSARY_TERM_2_URN));
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
 
@@ -82,11 +77,7 @@ public class BatchAddTermsResolverTest {
 
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -117,17 +108,12 @@ public class BatchAddTermsResolverTest {
                 eq(0L)))
         .thenReturn(originalTerms);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_GLOSSARY_TERM_1_URN),
+        Urn.createFromString(TEST_GLOSSARY_TERM_2_URN));
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
 
@@ -146,11 +132,7 @@ public class BatchAddTermsResolverTest {
 
     verifyIngestProposal(mockService, 1);
 
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true));
-
-    Mockito.verify(mockService, Mockito.times(1))
-        .exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true));
+    verifyExistenceResolvedInBatches(mockService, 2);
   }
 
   @Test
@@ -165,11 +147,11 @@ public class BatchAddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
-        .thenReturn(false);
+    // The first term does not exist.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_GLOSSARY_TERM_2_URN));
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
 
@@ -206,13 +188,12 @@ public class BatchAddTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.exists(any(), eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
+    // Both terms resolve, but the first resource does not.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_GLOSSARY_TERM_1_URN),
+        Urn.createFromString(TEST_GLOSSARY_TERM_2_URN));
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
@@ -52,15 +52,12 @@ public class BatchRemoveTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_TERM_1_URN),
+        Urn.createFromString(TEST_TERM_2_URN));
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -78,6 +75,8 @@ public class BatchRemoveTermsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -118,15 +117,12 @@ public class BatchRemoveTermsResolverTest {
                 eq(0L)))
         .thenReturn(oldTerms2);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
-        .thenReturn(true);
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_TERM_1_URN),
+        Urn.createFromString(TEST_TERM_2_URN));
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -144,6 +140,8 @@ public class BatchRemoveTermsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
+
+    verifyExistenceResolvedInBatches(mockService, 1);
   }
 
   @Test
@@ -165,12 +163,11 @@ public class BatchRemoveTermsResolverTest {
                 eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
-        .thenReturn(false);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
-        .thenReturn(true);
-    Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
-        .thenReturn(true);
+    // The first resource does not exist.
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_2),
+        Urn.createFromString(TEST_TERM_1_URN));
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 


### PR DESCRIPTION
The nine `mutate/Batch*Resolver`s validate each resource with its own
`entityService.exists` call, so a bulk operation issues one database round trip
per resource before its single batched write. Tag, term and owner validation
have the same shape.

Adding 2 tags to 100 datasets currently costs 102 existence round trips before
anything is written.

## Change

Resolve existence for a whole group in one call:

- `MutationUtils.existingUrns` wraps the batched `EntityService.exists`
  overload — the interface javadoc on the single-urn form already says
  *"prefer batched method"*.
- `LabelUtils` gains `validateLabels` and `existingResourceUrns`, plus a
  `validateResource` variant taking a pre-resolved set of urns.
- `OwnerUtils` gains `validateOwners`; `validateAddOwnerInput` no longer
  re-checks the resource once per owner.
- The singular helpers delegate to the batched ones, so validation has a single
  code path instead of two that can drift.

Per-resource authorization stays inside the loop, and urns are still inspected
in input order, so the same urn is rejected first and with the same message as
before.

## Measurements

Against a local stack at 50 resources, both builds compiled, deployed and
warmed identically:

| metric | before | after |
| --- | --- | --- |
| single-urn existence probes | 50 | **0** |
| MySQL statements per mutation | 352 / 202 / 302 | 303 / 153 / 253 |
| Jaeger DB spans | 971 / 677 / 869 | 873 / 579 / 771 |

(columns are `batchAddTags` / `batchSetDomain` / `batchUpdateDeprecation`)

MySQL `general_log` and Jaeger agree exactly: −49 statements, −98 spans, at two
spans per JDBC statement.

## Testing

- `./gradlew :datahub-graphql-core:test` — 1869 passing.
- Each batch resolver test now asserts existence is resolved in batched calls
  and never one urn at a time.
- End-to-end against a live GMS: 27 scenarios covering all nine mutations,
  entity state read back, and 10 validation-failure cases including
  error-ordering when a bad label and a bad resource are supplied together.
  Output is byte-identical before and after.

## Scope

The builder-side `getAspectFromEntity` fanout (~2–3 reads per resource in
`build*Proposal`) is untouched and is the larger remaining cost; it reshapes
helpers shared with ~20 single-entity resolvers, so it belongs in its own PR.
Fanout is reduced from 7 to 6 statements per resource here, not eliminated.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Docs — not applicable, no user-visible behaviour change
- [ ] Updating DataHub — not applicable, no breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
