### PR TITLE
fix(ingest/lookml): allow shared view files across models with same connection

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
@@ -842,7 +842,10 @@ class LookMLSource(StatefulIngestionSourceBase):
 
             for include in model.resolved_includes:
                 logger.debug(f"Considering {include} for model {model_name}")
-                if include.include in processed_view_files:
+                if (
+                    include.include in processed_view_files
+                    and "model" not in self.source_config.view_naming_pattern.pattern
+                ):
                     logger.debug(f"view '{include}' already processed, skipping it")
                     continue
                 logger.debug(f"Attempting to load view file: {include}")

--- a/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/model_one.model.lkml
+++ b/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/model_one.model.lkml
@@ -1,0 +1,7 @@
+connection: "my_connection"
+
+include: "shared.view.lkml"
+
+explore: explore_one {
+  from: shared_view
+}

--- a/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/model_two.model.lkml
+++ b/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/model_two.model.lkml
@@ -1,0 +1,7 @@
+connection: "my_connection"
+
+include: "shared.view.lkml"
+
+explore: explore_two {
+  from: shared_view
+}

--- a/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/shared.view.lkml
+++ b/metadata-ingestion/tests/integration/looker/lookml/lkml_samples_shared_view_same_connection/shared.view.lkml
@@ -1,0 +1,18 @@
+view: shared_view {
+  sql_table_name: public.shared_table ;;
+
+  dimension: id {
+    type: number
+    primary_key: yes
+    sql: ${TABLE}.id ;;
+  }
+
+  dimension: name {
+    type: string
+    sql: ${TABLE}.name ;;
+  }
+
+  measure: count {
+    type: count
+  }
+}

--- a/metadata-ingestion/tests/integration/looker/lookml/refinement_include_order_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/refinement_include_order_golden.json
@@ -948,6 +948,243 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "view: book {\n  sql_table_name: public.book ;;\n\n  dimension: name {\n    type: string\n    sql: ${TABLE}.\"name\" ;;\n  }\n\n  measure: count {\n    type: count\n    drill_fields: [name]\n  }\n}\n\nview: +book {\n  dimension: date {\n    type: string\n    sql: ${TABLE}.\"date\" ;;\n  }\n}\n",
+            "viewLanguage": "lookml"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:looker"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "book",
+            "platform": "urn:li:dataPlatform:looker",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "name",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "date",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "issue_date_2",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "issue_date_4",
+                    "nullable": false,
+                    "description": "Dimension. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "count",
+                    "nullable": false,
+                    "description": "Measure. ",
+                    "label": "",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "count",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ],
+            "primaryKeys": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1586847600000,
+                        "actor": "urn:li:corpuser:datahub"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD)",
+                    "type": "VIEW"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD),name)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD),name)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD),date)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD),date)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD),date)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD),issue_date_2)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD),date)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD),issue_date_4)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:conn,.public.book,PROD),count)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD),count)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_1.view.order,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1001,6 +1238,61 @@
             "materialized": false,
             "viewLogic": "include: \"book.view\"\n\nview: issue_history {\n  sql_table_name: public.issue_history ;;\n\n  dimension: book_name {\n    type: string\n    sql: ${TABLE}.\"book_name\" ;;\n  }\n\n  dimension: user_name {\n    type: string\n    sql: ${TABLE}.\"user_name\" ;;\n  }\n\n  measure: count {\n    type: count\n    drill_fields: [book_name, user_name]\n  }\n}\n\n\nview: +book {\n  dimension: issue_date_2 {\n    type: string\n    sql: ${TABLE}.\"date\" ;;\n  }\n}\n\nview: +book {\n  dimension: issue_date_4 {\n    type: string\n    sql: ${TABLE}.\"date\" ;;\n  }\n}\n",
             "viewLanguage": "lookml"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "looker.file.path": "views/book.view.lkml",
+                "looker.model": "model_2"
+            },
+            "name": "book",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:6f4a333fac5ec55b27b0e65bfb57ef0d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
         }
     },
     "systemMetadata": {
@@ -1186,6 +1478,33 @@
                 }
             ],
             "primaryKeys": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_refinement_sample1.model_2.view.book,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "Develop"
+                },
+                {
+                    "id": "urn:li:container:6f4a333fac5ec55b27b0e65bfb57ef0d",
+                    "urn": "urn:li:container:6f4a333fac5ec55b27b0e65bfb57ef0d"
+                },
+                {
+                    "id": "views"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/looker/lookml/test_lookml.py
+++ b/metadata-ingestion/tests/integration/looker/lookml/test_lookml.py
@@ -109,6 +109,53 @@ def test_lookml_ingest(pytestconfig, tmp_path, mock_time):
 
 
 @time_machine.travel(FROZEN_TIME, tick=False)
+def test_lookml_shared_view_same_connection(pytestconfig, tmp_path, mock_time):
+    """Test that a view file shared between two models with the same connection
+    is ingested for both models when view_naming_pattern includes {model}.
+    See https://github.com/datahub-project/datahub/issues/12043
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/looker/lookml"
+    mce_out_file = "shared_view_same_connection_mces.json"
+
+    new_recipe = {
+        "run_id": "lookml-test",
+        "source": {
+            "type": "lookml",
+            "config": {
+                "base_folder": f"{test_resources_dir}/lkml_samples_shared_view_same_connection",
+                "connection_to_platform_map": {"my_connection": "postgres"},
+                "parse_table_names_from_sql": True,
+                "tag_measures_and_dimensions": False,
+                "project_name": "shared_view_project",
+                "emit_reachable_views_only": False,
+                "view_naming_pattern": {"pattern": "{project}.{model}.view.{name}"},
+            },
+        },
+        "sink": {
+            "type": "file",
+            "config": {
+                "filename": f"{tmp_path}/{mce_out_file}",
+            },
+        },
+    }
+
+    pipeline = Pipeline.create(new_recipe)
+    pipeline.run()
+    pipeline.pretty_print_summary()
+    pipeline.raise_from_status(raise_warnings=False)
+
+    report = pipeline.source.get_report()
+    assert isinstance(report, LookMLSourceReport)
+
+    # The shared view must be discovered twice: once per model
+    assert report.views_discovered == 2, (
+        f"Expected 2 views (one per model), got {report.views_discovered}. "
+        "The shared view file should be ingested for each model when "
+        "view_naming_pattern includes {{model}}."
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
 def test_lookml_refinement_ingest(pytestconfig, tmp_path, mock_time):
     """Test backwards compatibility with previous form of config with new flags turned off"""
     test_resources_dir = pytestconfig.rootpath / "tests/integration/looker/lookml"


### PR DESCRIPTION


When view_naming_pattern includes {model}, a view file included by multiple models should produce separate datasets per model, even when those models share the same database connection.

Previously, processed_view_files was keyed by connection name, so once a view file was processed for the first model, the second model skipped it entirely. This caused missing datasets and broken explore-to-view lineage.

The fix adds a check: skip the deduplication only when 'model' is part of view_naming_pattern, since in that case each model produces a distinct URN (e.g. {project}.{model_1}.view.{name} vs {project}.{model_2}.view.{name}).

Closes #12043

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
