### PR TITLE
fix(security-scan): normalize grype Maven package names to groupId:artifactId

### DIFF
--- a/.github/scripts/test/test_security_scan_linear_sync_utils.py
+++ b/.github/scripts/test/test_security_scan_linear_sync_utils.py
@@ -120,6 +120,80 @@ def test_parse_trivy_grype_merged_prefers_trivy_and_records_scanners(
     assert vuln["_datahub_scanners"] == ["trivy", "grype"]
 
 
+def test_grype_pkg_name_normalizes_maven_to_trivy_form():
+    # purl is the primary source
+    assert utils.grype_pkg_name(
+        {
+            "name": "netty-codec-http2",
+            "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.96.Final?type=jar",
+        }
+    ) == "io.netty:netty-codec-http2"
+    # pom metadata fallback when purl is absent
+    assert utils.grype_pkg_name(
+        {
+            "name": "netty-codec-http2",
+            "metadata": {"pomGroupID": "io.netty", "pomArtifactID": "netty-codec-http2"},
+        }
+    ) == "io.netty:netty-codec-http2"
+    # non-maven artifacts keep grype's name
+    assert utils.grype_pkg_name(
+        {"name": "urllib3", "purl": "pkg:pypi/urllib3@1.26.0"}
+    ) == "urllib3"
+    assert utils.grype_pkg_name({"name": "libz"}) == "libz"
+
+
+@pytest.mark.parametrize(
+    ("name", "purl", "expected"),
+    [
+        # Artifact records as they appear in real grype scan reports
+        (
+            "netty-codec-http2",
+            "pkg:maven/io.netty/netty-codec-http2@4.1.96.Final",
+            "io.netty:netty-codec-http2",
+        ),
+        (
+            "jackson-databind",
+            "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.4.2",
+            "com.fasterxml.jackson.core:jackson-databind",
+        ),
+        # groupId == artifactId (Trivy still names these commons-io:commons-io)
+        ("commons-io", "pkg:maven/commons-io/commons-io@2.8.0", "commons-io:commons-io"),
+        # version containing dots and a 'v' segment
+        (
+            "jetty-http",
+            "pkg:maven/org.eclipse.jetty/jetty-http@9.4.43.v20210629",
+            "org.eclipse.jetty:jetty-http",
+        ),
+        # non-maven purl with qualifiers passes through untouched
+        (
+            "python-3.11",
+            "pkg:apk/wolfi/python-3.11@3.11.15-r6?arch=x86_64&distro=wolfi-20230201",
+            "python-3.11",
+        ),
+    ],
+)
+def test_grype_pkg_name_on_real_scan_purls(name: str, purl: str, expected: str):
+    assert utils.grype_pkg_name({"name": name, "purl": purl}) == expected
+
+
+def test_grype_only_maven_finding_titles_like_trivy():
+    vuln = utils.grype_match_to_trivy_vuln(
+        {
+            "vulnerability": {"id": "CVE-2025-55163", "severity": "High"},
+            "artifact": {
+                "name": "netty-codec-http2",
+                "version": "4.1.96.Final",
+                "type": "java-archive",
+                "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.96.Final",
+            },
+        }
+    )
+    title = utils.linear_issue_title(
+        "CVE-2025-55163", vuln, "datahub-gms", scanner="trivy_grype"
+    )
+    assert title == "[datahub-gms] CVE-2025-55163 in io.netty:netty-codec-http2"
+
+
 def test_parse_trivy_grype_merged_filters_out_non_high_critical_grype(tmp_path: Path):
     os_env_key = "DATAHUB_SCAN_SEVERITIES"
     old = os.environ.get(os_env_key)

--- a/.github/scripts/utils/security_scan_utils.py
+++ b/.github/scripts/utils/security_scan_utils.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 # Trivy rows: (artifact_ref, result_target, class/type, vuln). artifact_ref = scanned image ref for scope.
 GroupedRows = dict[str, list[tuple[str, str, str, dict[str, Any]]]]
@@ -221,6 +222,32 @@ def grype_severity_to_trivy_upper(v: dict[str, Any]) -> str:
     return s
 
 
+def grype_pkg_name(art: dict[str, Any]) -> str:
+    """Package name for a Grype artifact, using Trivy's `groupId:artifactId` form for Maven.
+
+    Grype names Java archives by artifactId alone (`netty-codec-http2`) while Trivy uses
+    `io.netty:netty-codec-http2`. Linear issue titles embed this name and dedup is by exact
+    title, so a grype-only detection of a CVE Trivy previously reported would otherwise
+    open a duplicate issue.
+    """
+    name = str(art.get("name") or "").strip()
+    if ":" in name:
+        return name
+    purl = str(art.get("purl") or "").strip()
+    if purl.startswith("pkg:maven/"):
+        path = purl[len("pkg:maven/") :].split("@", 1)[0].split("?", 1)[0]
+        parts = [unquote(p) for p in path.split("/") if p]
+        if len(parts) >= 2:
+            return f"{parts[0]}:{parts[-1]}"
+    meta = art.get("metadata")
+    if isinstance(meta, dict):
+        group = str(meta.get("pomGroupID") or "").strip()
+        artifact = str(meta.get("pomArtifactID") or "").strip() or name
+        if group and artifact:
+            return f"{group}:{artifact}"
+    return name
+
+
 def grype_match_to_trivy_vuln(match: dict[str, Any]) -> dict[str, Any]:
     """Shape a Grype match like a Trivy Vulnerabilities[] entry."""
     v = match.get("vulnerability") or {}
@@ -241,7 +268,7 @@ def grype_match_to_trivy_vuln(match: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {
         "VulnerabilityID": vid,
         "Title": vid,
-        "PkgName": str(art.get("name") or ""),
+        "PkgName": grype_pkg_name(art),
         "InstalledVersion": str(art.get("version") or ""),
         "Severity": sev,
         "PrimaryURL": primary,


### PR DESCRIPTION
## Summary

The security-scan sync dedupes findings by **exact issue title**, and titles embed the scanner's package name (`[image] CVE-XXXX in <PkgName>`). For Java archives the two scanners disagree on naming:

- **Trivy**: `io.netty:netty-codec-http2` (groupId:artifactId)
- **Grype**: `netty-codec-http2` (artifactId only)

The merge step prefers the Trivy row when both scanners detect a CVE, so titles normally use Trivy's form. But when a CVE flips to **grype-only detection** (e.g. the jar moved to a path Trivy stopped flagging), the title is built from grype's bare name, doesn't match the existing issue, and the sync opens a duplicate.

## Fix

Normalize grype Maven artifact names to Trivy's `groupId:artifactId` form at ingestion time (`grype_pkg_name()` in `security_scan_utils.py`):

1. Parse the group from the artifact's `purl` (`pkg:maven/io.netty/netty-codec-http2@...`)
2. Fall back to grype's pom metadata (`pomGroupID`/`pomArtifactID`) when no purl
3. Leave non-Maven ecosystems untouched (they already match Trivy's naming)

This flows through to both the issue title and the description's PkgName row.

## Testing

- New unit tests for the normalization paths (purl, pom fallback, non-Maven passthrough)
- New end-to-end test: a grype-only netty finding now titles as `[datahub-gms] CVE-2025-55163 in io.netty:netty-codec-http2` — matching the Trivy-created form
- Full `.github/scripts/test` suite passes (315 tests), same as CI's `test-github-scripts.yml`

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Links to related issues — n/a
- [ ] Docs added/updated — n/a (internal CI tooling)
- [ ] Breaking changes entry — n/a