### PR TITLE
fix(linear): Update linear routing

### DIFF
--- a/.github/workflows/pr-to-linear-routing-test.yml
+++ b/.github/workflows/pr-to-linear-routing-test.yml
@@ -43,7 +43,7 @@ env:
         "key": "OBS",
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
         "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
-        "description": "Data Quality and Assertions. Any PR touching the Assertions codebase belongs to this team."
+        "description": "Data Quality and Assertions. Any PR touching the Assertions/Monitors or Incidents codebase belongs to this team."
       }
     ]
 

--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -37,7 +37,7 @@ env:
         "key": "OBS",
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
         "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
-        "description": "Data Quality and Assertions. Any PR touching the Assertions codebase belongs to this team."
+        "description": "Data Quality and Assertions. Any PR touching the Assertions/Monitors or Incidents codebase belongs to this team."
       }
     ]
 


### PR DESCRIPTION
## Summary

A few PRs came in around the "Incidents" entity which Observe team typically handles. Updating routing rule to help the AI understand to route to the observe team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the **OBS** team routing hint used by Claude in the PR/issue-to-Linear workflows so Incidents-related work is explicitly in scope, not only Assertions.
> 
> In both `pr-to-linear.yml` and `pr-to-linear-routing-test.yml`, the OBS `description` in `LINEAR_TEAM_CONFIG` now says PRs touching **Assertions/Monitors or Incidents** belong to OBS, instead of only the Assertions codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e525b48893640d49ac7178e04274c26f19f70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->