### PR TITLE
perf(search): trim home-widget result fragment

### DIFF
--- a/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/__tests__/useGetSearchAssets.test.tsx
+++ b/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/__tests__/useGetSearchAssets.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGetSearchAssets } from '@app/homeV2/content/tabs/discovery/sections/insight/cards/useGetSearchAssets';
+
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
+import { EntityType } from '@types';
+
+vi.mock('@graphql/search.generated', () => ({
+    useGetSearchResultsForMultipleCardsQuery: vi.fn(),
+}));
+
+vi.mock('@src/app/useAppConfig', () => ({
+    useIsShowSeparateSiblingsEnabled: () => false,
+}));
+
+vi.mock('@src/app/search/utils/combineSiblingsInSearchResults', () => ({
+    combineSiblingsInSearchResults: (_showSeparate: boolean, results: unknown) => results || [],
+}));
+
+describe('useGetSearchAssets', () => {
+    const queryMock = useGetSearchResultsForMultipleCardsQuery as unknown as Mock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        queryMock.mockReturnValue({
+            loading: false,
+            data: undefined,
+        });
+    });
+
+    it('uses the cards search query with cache-first policy', () => {
+        renderHook(() => useGetSearchAssets([EntityType.Dataset], 'customers'));
+
+        expect(queryMock).toHaveBeenCalledWith({
+            variables: {
+                input: {
+                    types: [EntityType.Dataset],
+                    query: 'customers',
+                    start: 0,
+                    count: 5,
+                    orFilters: null,
+                    sortInput: null,
+                    viewUrn: undefined,
+                    searchFlags: {
+                        skipAggregates: true,
+                    },
+                },
+            },
+            fetchPolicy: 'cache-first',
+        });
+    });
+
+    it('returns assets from search results', () => {
+        const entity = { urn: 'urn:li:dataset:1', type: EntityType.Dataset };
+        queryMock.mockReturnValue({
+            loading: false,
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [{ entity }],
+                },
+            },
+        });
+
+        const { result } = renderHook(() => useGetSearchAssets([EntityType.Dataset]));
+
+        expect(result.current.assets).toEqual([entity]);
+        expect(result.current.loading).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/useGetSearchAssets.tsx
+++ b/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/useGetSearchAssets.tsx
@@ -3,8 +3,8 @@ import { UnionType } from '@app/searchV2/utils/constants';
 import { combineSiblingsInSearchResults } from '@src/app/search/utils/combineSiblingsInSearchResults';
 import { useIsShowSeparateSiblingsEnabled } from '@src/app/useAppConfig';
 
-import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
-import { EntityType, SortCriterion } from '@types';
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
+import { Entity, EntityType, SortCriterion } from '@types';
 
 const buildOrFilters = (filters: FilterSet) => {
     if (filters.unionType === UnionType.AND) {
@@ -27,8 +27,8 @@ export const useGetSearchAssets = (
     filters?: FilterSet,
     sort?: SortCriterion,
     viewUrn?: string | null,
-): any => {
-    const { data, loading } = useGetSearchResultsForMultipleQuery({
+): { assets: Entity[]; loading: boolean } => {
+    const { data, loading } = useGetSearchResultsForMultipleCardsQuery({
         variables: {
             input: {
                 types: types || [],

--- a/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/useGetSearchAssets.tsx
+++ b/datahub-web-react/src/app/homeV2/content/tabs/discovery/sections/insight/cards/useGetSearchAssets.tsx
@@ -51,9 +51,10 @@ export const useGetSearchAssets = (
     });
 
     const showSeparateSiblings = useIsShowSeparateSiblingsEnabled();
+    // The card query omits matchedFields, and only the combined entities are used here.
     const searchResults = combineSiblingsInSearchResults(
         showSeparateSiblings,
-        data?.searchAcrossEntities?.searchResults,
+        data?.searchAcrossEntities?.searchResults?.map((result) => ({ ...result, matchedFields: [] })),
     );
 
     const assets = searchResults?.filter((result) => result.entity).map((result) => result.entity) || [];

--- a/datahub-web-react/src/app/homeV2/reference/sections/assets/__tests__/useGetAssetsYouOwn.test.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/assets/__tests__/useGetAssetsYouOwn.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGetAssetsYouOwn } from '@app/homeV2/reference/sections/assets/useGetAssetsYouOwn';
+import { ASSET_ENTITY_TYPES, OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
+import { CorpUser, EntityType } from '@types';
+
+function mockCorpUser(urn: string): CorpUser {
+    const username = urn.includes(':') ? (urn.split(':').pop() as string) : urn;
+    return {
+        urn,
+        type: EntityType.CorpUser,
+        username,
+    };
+}
+
+vi.mock('@graphql/search.generated', () => ({
+    useGetSearchResultsForMultipleCardsQuery: vi.fn(),
+}));
+
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistryV2: vi.fn(),
+}));
+
+vi.mock('@app/homeV3/module/context/ModuleContext', () => ({
+    useModuleContext: () => ({
+        isReloading: false,
+        onReloadingFinished: vi.fn(),
+    }),
+}));
+
+vi.mock('@src/app/entityV2/user/useGetUserGroupUrns', () => ({
+    default: () => ({
+        groupUrns: [],
+        loading: false,
+    }),
+}));
+
+describe('useGetAssetsYouOwn', () => {
+    const queryMock = useGetSearchResultsForMultipleCardsQuery as unknown as Mock;
+    const registryMock = useEntityRegistryV2 as unknown as Mock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        registryMock.mockReturnValue({
+            getGenericEntityProperties: vi.fn((_type, entity) => ({ urn: entity.urn })),
+        });
+        queryMock.mockReturnValue({
+            loading: false,
+            data: { searchAcrossEntities: { searchResults: [], total: 0 } },
+            error: undefined,
+            refetch: vi.fn(),
+        });
+    });
+
+    it('skips the query when the user has no urn', () => {
+        renderHook(() => useGetAssetsYouOwn(undefined));
+        expect(queryMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                skip: true,
+            }),
+        );
+    });
+
+    it('uses the cards search query for assets owned by the user', () => {
+        const user = mockCorpUser('urn:li:corpuser:alice');
+        renderHook(() => useGetAssetsYouOwn(user));
+
+        expect(queryMock).toHaveBeenCalledWith({
+            variables: {
+                input: {
+                    query: '*',
+                    start: 0,
+                    count: 50,
+                    types: ASSET_ENTITY_TYPES,
+                    filters: [{ field: OWNERS_FILTER_NAME, values: [user.urn] }],
+                    searchFlags: { skipCache: true },
+                },
+            },
+            skip: false,
+            fetchPolicy: 'cache-first',
+            onCompleted: expect.any(Function),
+        });
+    });
+});

--- a/datahub-web-react/src/app/homeV2/reference/sections/assets/useGetAssetsYouOwn.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/assets/useGetAssetsYouOwn.tsx
@@ -5,7 +5,7 @@ import { ASSET_ENTITY_TYPES, OWNERS_FILTER_NAME } from '@app/searchV2/utils/cons
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import useGetUserGroupUrns from '@src/app/entityV2/user/useGetUserGroupUrns';
 
-import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
 import { CorpUser, Entity } from '@types';
 
 const MAX_ASSETS_TO_FETCH = 50;
@@ -39,7 +39,7 @@ export const useGetAssetsYouOwn = (user?: CorpUser | null, initialCount = MAX_AS
         data,
         error,
         refetch,
-    } = useGetSearchResultsForMultipleQuery({
+    } = useGetSearchResultsForMultipleCardsQuery({
         variables: getInputVariables(0, initialCount),
         skip: !user?.urn || groupDataLoading,
         fetchPolicy: isReloading ? 'cache-and-network' : 'cache-first',

--- a/datahub-web-react/src/app/homeV2/reference/sections/domains/useGetDomainsYouOwn.ts
+++ b/datahub-web-react/src/app/homeV2/reference/sections/domains/useGetDomainsYouOwn.ts
@@ -1,14 +1,14 @@
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
 import { CorpUser, EntityType } from '@types';
 
 const MAX_ASSETS_TO_FETCH = 50;
 
 // TODO: Add Group Ownership here as well.
 export const useGetDomainsYouOwn = (user?: CorpUser | null, count = MAX_ASSETS_TO_FETCH) => {
-    const { loading, data, error } = useGetSearchResultsForMultipleQuery({
+    const { loading, data, error } = useGetSearchResultsForMultipleCardsQuery({
         variables: {
             input: {
                 query: '*',

--- a/datahub-web-react/src/app/homeV2/reference/sections/glossary/__tests__/useGetGlossaryNodesYouOwn.test.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/glossary/__tests__/useGetGlossaryNodesYouOwn.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useGetDomainsYouOwn } from '@app/homeV2/reference/sections/domains/useGetDomainsYouOwn';
+import { useGetGlossaryNodesYouOwn } from '@app/homeV2/reference/sections/glossary/useGetGlossaryNodesYouOwn';
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -25,7 +25,7 @@ vi.mock('@app/useEntityRegistry', () => ({
     useEntityRegistry: vi.fn(),
 }));
 
-describe('useGetDomainsYouOwn', () => {
+describe('useGetGlossaryNodesYouOwn', () => {
     const queryMock = useGetSearchResultsForMultipleCardsQuery as unknown as Mock;
     const registryMock = useEntityRegistry as unknown as Mock;
 
@@ -41,8 +41,8 @@ describe('useGetDomainsYouOwn', () => {
         });
     });
 
-    it('skips the query when the user has no urn', () => {
-        renderHook(() => useGetDomainsYouOwn(undefined));
+    it('skips the query when the user is missing', () => {
+        renderHook(() => useGetGlossaryNodesYouOwn(undefined));
         expect(queryMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 skip: true,
@@ -50,9 +50,9 @@ describe('useGetDomainsYouOwn', () => {
         );
     });
 
-    it('uses the cards search query for domains owned by the user', () => {
+    it('uses the cards search query for glossary terms owned by the user', () => {
         const user = mockCorpUser('urn:li:corpuser:alice');
-        renderHook(() => useGetDomainsYouOwn(user));
+        renderHook(() => useGetGlossaryNodesYouOwn(user));
 
         expect(queryMock).toHaveBeenCalledWith({
             variables: {
@@ -60,27 +60,14 @@ describe('useGetDomainsYouOwn', () => {
                     query: '*',
                     start: 0,
                     count: 50,
-                    types: [EntityType.Domain],
-                    searchFlags: { skipCache: true },
+                    types: [EntityType.GlossaryTerm],
                     filters: [{ field: OWNERS_FILTER_NAME, values: [user.urn] }],
+                    searchFlags: { skipCache: true },
                 },
             },
             skip: false,
             fetchPolicy: 'cache-first',
         });
-    });
-
-    it('respects custom count', () => {
-        const user = mockCorpUser('urn:li:corpuser:bob');
-        renderHook(() => useGetDomainsYouOwn(user, 12));
-
-        expect(queryMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                variables: expect.objectContaining({
-                    input: expect.objectContaining({ count: 12 }),
-                }),
-            }),
-        );
     });
 
     it('maps search results through the entity registry', () => {
@@ -92,15 +79,15 @@ describe('useGetDomainsYouOwn', () => {
             loading: false,
             data: {
                 searchAcrossEntities: {
-                    searchResults: [{ entity: { urn: 'urn:li:domain:1', type: EntityType.Domain } }],
+                    searchResults: [{ entity: { urn: 'urn:li:glossaryTerm:1', type: EntityType.GlossaryTerm } }],
                 },
             },
             error: undefined,
         });
 
-        const { result } = renderHook(() => useGetDomainsYouOwn(user));
+        const { result } = renderHook(() => useGetGlossaryNodesYouOwn(user));
 
         expect(getProps).toHaveBeenCalled();
-        expect(result.current.entities).toEqual([{ urn: 'urn:li:domain:1', mapped: true }]);
+        expect(result.current.entities).toEqual([{ urn: 'urn:li:glossaryTerm:1', mapped: true }]);
     });
 });

--- a/datahub-web-react/src/app/homeV2/reference/sections/glossary/useGetGlossaryNodesYouOwn.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/glossary/useGetGlossaryNodesYouOwn.tsx
@@ -1,14 +1,14 @@
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
 import { CorpUser, EntityType } from '@types';
 
 const MAX_ASSETS_TO_FETCH = 50;
 
 // TODO: Add Group Ownership here as well.
 export const useGetGlossaryNodesYouOwn = (user?: CorpUser | null, count = MAX_ASSETS_TO_FETCH) => {
-    const { loading, data, error } = useGetSearchResultsForMultipleQuery({
+    const { loading, data, error } = useGetSearchResultsForMultipleCardsQuery({
         variables: {
             input: {
                 query: '*',

--- a/datahub-web-react/src/app/homeV2/reference/sections/tags/__tests__/useGetTagsYouOwn.test.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/tags/__tests__/useGetTagsYouOwn.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useGetDomainsYouOwn } from '@app/homeV2/reference/sections/domains/useGetDomainsYouOwn';
+import { useGetTagsYouOwn } from '@app/homeV2/reference/sections/tags/useGetTagsYouOwn';
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -25,7 +25,7 @@ vi.mock('@app/useEntityRegistry', () => ({
     useEntityRegistry: vi.fn(),
 }));
 
-describe('useGetDomainsYouOwn', () => {
+describe('useGetTagsYouOwn', () => {
     const queryMock = useGetSearchResultsForMultipleCardsQuery as unknown as Mock;
     const registryMock = useEntityRegistry as unknown as Mock;
 
@@ -42,7 +42,7 @@ describe('useGetDomainsYouOwn', () => {
     });
 
     it('skips the query when the user has no urn', () => {
-        renderHook(() => useGetDomainsYouOwn(undefined));
+        renderHook(() => useGetTagsYouOwn(undefined));
         expect(queryMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 skip: true,
@@ -50,9 +50,9 @@ describe('useGetDomainsYouOwn', () => {
         );
     });
 
-    it('uses the cards search query for domains owned by the user', () => {
+    it('uses the cards search query for tags owned by the user', () => {
         const user = mockCorpUser('urn:li:corpuser:alice');
-        renderHook(() => useGetDomainsYouOwn(user));
+        renderHook(() => useGetTagsYouOwn(user));
 
         expect(queryMock).toHaveBeenCalledWith({
             variables: {
@@ -60,27 +60,13 @@ describe('useGetDomainsYouOwn', () => {
                     query: '*',
                     start: 0,
                     count: 50,
-                    types: [EntityType.Domain],
-                    searchFlags: { skipCache: true },
+                    types: [EntityType.Tag],
                     filters: [{ field: OWNERS_FILTER_NAME, values: [user.urn] }],
                 },
             },
             skip: false,
             fetchPolicy: 'cache-first',
         });
-    });
-
-    it('respects custom count', () => {
-        const user = mockCorpUser('urn:li:corpuser:bob');
-        renderHook(() => useGetDomainsYouOwn(user, 12));
-
-        expect(queryMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                variables: expect.objectContaining({
-                    input: expect.objectContaining({ count: 12 }),
-                }),
-            }),
-        );
     });
 
     it('maps search results through the entity registry', () => {
@@ -92,15 +78,15 @@ describe('useGetDomainsYouOwn', () => {
             loading: false,
             data: {
                 searchAcrossEntities: {
-                    searchResults: [{ entity: { urn: 'urn:li:domain:1', type: EntityType.Domain } }],
+                    searchResults: [{ entity: { urn: 'urn:li:tag:1', type: EntityType.Tag } }],
                 },
             },
             error: undefined,
         });
 
-        const { result } = renderHook(() => useGetDomainsYouOwn(user));
+        const { result } = renderHook(() => useGetTagsYouOwn(user));
 
         expect(getProps).toHaveBeenCalled();
-        expect(result.current.entities).toEqual([{ urn: 'urn:li:domain:1', mapped: true }]);
+        expect(result.current.entities).toEqual([{ urn: 'urn:li:tag:1', mapped: true }]);
     });
 });

--- a/datahub-web-react/src/app/homeV2/reference/sections/tags/useGetTagsYouOwn.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/tags/useGetTagsYouOwn.tsx
@@ -1,14 +1,14 @@
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { useGetSearchResultsForMultipleCardsQuery } from '@graphql/search.generated';
 import { CorpUser, EntityType } from '@types';
 
 const MAX_ASSETS_TO_FETCH = 50;
 
 // TODO: Add Group Ownership here as well.
 export const useGetTagsYouOwn = (user?: CorpUser | null, count = MAX_ASSETS_TO_FETCH) => {
-    const { loading, data, error } = useGetSearchResultsForMultipleQuery({
+    const { loading, data, error } = useGetSearchResultsForMultipleCardsQuery({
         variables: {
             input: {
                 query: '*',

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1,7 +1,9 @@
 #import "./incident.graphql"
 #import "./fragments.graphql"
 
-fragment autoCompleteFields on Entity {
+# Lean fields for compact home-widget cards. Omits ownership, tags, lineage, health,
+# structured properties, and Dataset stats/access (those stay on autoCompleteFields).
+fragment searchResultCardFields on Entity {
     urn
     type
     ... on Dataset {
@@ -84,9 +86,8 @@ fragment autoCompleteFields on Entity {
                 }
             }
         }
-        ...datasetStatsFields
-        access {
-            ...getAccess
+        deprecation {
+            deprecated
         }
         browsePathV2 {
             ...browsePathV2Fields
@@ -135,6 +136,9 @@ fragment autoCompleteFields on Entity {
         subTypes {
             typeNames
         }
+        deprecation {
+            deprecated
+        }
         browsePathV2 {
             ...browsePathV2Fields
         }
@@ -156,6 +160,9 @@ fragment autoCompleteFields on Entity {
         subTypes {
             typeNames
         }
+        deprecation {
+            deprecated
+        }
         browsePathV2 {
             ...browsePathV2Fields
         }
@@ -176,6 +183,9 @@ fragment autoCompleteFields on Entity {
         }
         subTypes {
             typeNames
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on DataJob {
@@ -201,6 +211,9 @@ fragment autoCompleteFields on Entity {
         subTypes {
             typeNames
         }
+        deprecation {
+            deprecated
+        }
     }
     ... on GlossaryTerm {
         name
@@ -213,6 +226,9 @@ fragment autoCompleteFields on Entity {
         }
         displayProperties {
             ...displayPropertiesFields
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on GlossaryNode {
@@ -232,6 +248,12 @@ fragment autoCompleteFields on Entity {
         }
         displayProperties {
             ...displayPropertiesFields
+        }
+        entities(input: { start: 0, count: 0 }) {
+            total
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on DataProduct {
@@ -272,6 +294,9 @@ fragment autoCompleteFields on Entity {
         subTypes {
             typeNames
         }
+        deprecation {
+            deprecated
+        }
         browsePathV2 {
             ...browsePathV2Fields
         }
@@ -282,6 +307,9 @@ fragment autoCompleteFields on Entity {
             name
             colorHex
         }
+        deprecation {
+            deprecated
+        }
     }
     ... on MLFeatureTable {
         name
@@ -290,6 +318,9 @@ fragment autoCompleteFields on Entity {
         }
         dataPlatformInstance {
             ...dataPlatformInstanceFields
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on MLFeature {
@@ -307,6 +338,9 @@ fragment autoCompleteFields on Entity {
                     }
                 }
             }
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on MLPrimaryKey {
@@ -334,6 +368,9 @@ fragment autoCompleteFields on Entity {
         dataPlatformInstance {
             ...dataPlatformInstanceFields
         }
+        deprecation {
+            deprecated
+        }
     }
     ... on MLModelGroup {
         name
@@ -342,6 +379,9 @@ fragment autoCompleteFields on Entity {
         }
         dataPlatformInstance {
             ...dataPlatformInstanceFields
+        }
+        deprecation {
+            deprecated
         }
     }
     ... on DataPlatform {
@@ -407,6 +447,16 @@ fragment autoCompleteFields on Entity {
         id
         info {
             name
+        }
+    }
+}
+
+fragment autoCompleteFields on Entity {
+    ...searchResultCardFields
+    ... on Dataset {
+        ...datasetStatsFields
+        access {
+            ...getAccess
         }
     }
 }
@@ -1637,6 +1687,19 @@ query getSearchResultsForMultipleTrimmed($input: SearchAcrossEntitiesInput!, $sk
         }
         facets {
             ...facetFields
+        }
+    }
+}
+
+query getSearchResultsForMultipleCards($input: SearchAcrossEntitiesInput!, $skipSiblingsSearch: Boolean = false) {
+    searchAcrossEntities(input: $input) {
+        start
+        count
+        total
+        searchResults {
+            entity {
+                ...searchResultCardFields
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Home widgets were calling `getSearchResultsForMultiple`, which pulls the full `searchResults` entity fragment (ownership, tags, glossary terms, lineage, health, structured properties, Dataset stats/access, etc.). Compact card UIs only need display fields.

This change extracts a lean `searchResultCardFields` fragment from today's `autoCompleteFields`, adds `getSearchResultsForMultipleCards` for home widgets, and keeps Dataset stats/access on autocomplete via composition.

### GraphQL
- New `searchResultCardFields` — card-sized entity fields (plus minimal `deprecation { deprecated }` and Domain `entities.total` for card UIs)
- `autoCompleteFields` now spreads `searchResultCardFields` and adds Dataset `...datasetStatsFields` + `access`
- New `getSearchResultsForMultipleCards` next to the existing trimmed query
- Search-page queries (`getSearchResultsForMultiple`, `searchResultFields`, etc.) are unchanged

### Migrated hooks
- `useGetSearchAssets`
- `useGetAssetsYouOwn`
- `useGetDomainsYouOwn`
- `useGetGlossaryNodesYouOwn`
- `useGetTagsYouOwn`

Intentionally not migrated: homeV3 modules and other full-search call sites.

### Note on autocomplete composition
Because `autoCompleteFields` is now defined as `...searchResultCardFields` plus Dataset stats/access, autocomplete surfaces also pick up the card fragment's `deprecation { deprecated }` and Domain `entities.total`. This is an intentional tradeoff to keep a single shared card fragment rather than maintaining a second near-duplicate fragment.
