### PR TITLE
fix(search): correct structured-property filtering and URN keyword handling

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/__tests__/useSearchFilterDropdown.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/useSearchFilterDropdown.test.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
+import useSearchFilterDropdown from '@app/searchV2/filters/useSearchFilterDropdown';
+import { STRUCTURED_PROPERTIES_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { STRING_TYPE_URN } from '@src/app/shared/constants';
+
+import { FacetMetadata, FilterOperator } from '@types';
+
+// The hook pulls its search context and the aggregation lazy-query from other hooks; stub both so we
+// can exercise updateFilters in isolation. updateFilters does not run the aggregation query, so the
+// lazy-query mock only needs to satisfy the [trigger, state] tuple shape.
+vi.mock('@app/searchV2/useGetSearchQueryInputs', () => ({
+    default: () => ({ entityFilters: [], query: '*', orFilters: [], viewUrn: undefined }),
+}));
+
+vi.mock('@src/graphql/search.generated', () => ({
+    useAggregateAcrossEntitiesLazyQuery: () => [vi.fn(), { data: undefined, loading: false }],
+}));
+
+const businessNameField = `${STRUCTURED_PROPERTIES_FILTER_NAME}.datasetBusinessName`;
+
+// A free-form text structured property: STRING valueType with no constrained allowedValues.
+function freeFormTextSpFacet(): FacetMetadata {
+    return {
+        field: businessNameField,
+        displayName: 'Dataset Business Name',
+        aggregations: [],
+        entity: {
+            definition: { valueType: { urn: STRING_TYPE_URN } },
+        },
+    } as unknown as FacetMetadata;
+}
+
+describe('useSearchFilterDropdown - updateFilters', () => {
+    // Regression guard for the bug where the dropdown showed "contains" but the query sent EQUAL:
+    // updateFilters must forward the field's facet to getNewFilters so a free-form text structured
+    // property resolves to a CONTAINS condition rather than falling back to the backend default (EQUAL).
+    it('applies a CONTAINS condition for free-form text structured properties', () => {
+        const onChangeFilters = vi.fn();
+        const { result } = renderHook(() =>
+            useSearchFilterDropdown({
+                filter: freeFormTextSpFacet(),
+                activeFilters: [],
+                onChangeFilters,
+            }),
+        );
+
+        act(() => {
+            result.current.updateFilters([{ value: 'posted' }]);
+        });
+
+        expect(onChangeFilters).toHaveBeenCalledWith([
+            expect.objectContaining({
+                field: businessNameField,
+                values: ['posted'],
+                condition: FilterOperator.Contain,
+            }),
+        ]);
+    });
+});

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -10,6 +10,7 @@ import {
     deduplicateAggregations,
     filterEmptyAggregations,
     filterOptionsWithSearch,
+    getDynamicFilterField,
     getFilterDisplayName,
     getFilterEntity,
     getFilterIconAndLabel,
@@ -21,12 +22,18 @@ import {
     isAnyOptionSelected,
     isFilterOptionSelected,
 } from '@app/searchV2/filters/utils';
-import { ENTITY_SUB_TYPE_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { ENTITY_SUB_TYPE_FILTER_NAME, STRUCTURED_PROPERTIES_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { dataPlatform, dataPlatformInstance, dataset1, glossaryTerm1, user1 } from '@src/Mocks';
-import { DATE_TYPE_URN } from '@src/app/shared/constants';
+import {
+    DATE_TYPE_URN,
+    NUMBER_TYPE_URN,
+    RICH_TEXT_TYPE_URN,
+    STRING_TYPE_URN,
+    URN_TYPE_URN,
+} from '@src/app/shared/constants';
 import { getTestEntityRegistry } from '@utils/test-utils/TestPageContainer';
 
-import { AggregationMetadata, EntityType } from '@types';
+import { AggregationMetadata, EntityType, FilterOperator } from '@types';
 
 describe('filter utils - getNewFilters', () => {
     it('should get the correct list of filters when adding filters where the filter field did not already exist', () => {
@@ -567,8 +574,15 @@ describe('filter utils - getStructuredPropFilterDisplayName', () => {
         ).toBe('10/01/2024');
     });
 
-    it('should return a properly formatted number if it is a number type', () => {
-        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0')).toBe('90');
+    it('should return a properly formatted number when entity has NUMBER valueType', () => {
+        const entity = { definition: { valueType: { urn: NUMBER_TYPE_URN } } } as any;
+        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0', entity)).toBe('90');
+    });
+
+    it('should return the raw string when no entity is provided (avoids parseFloat corrupting UUIDs)', () => {
+        // Without entity type info we cannot safely call parseFloat — a value like "02d22a5f-..."
+        // would be silently truncated to "2". Fall through to raw rendering instead.
+        expect(getStructuredPropFilterDisplayName('structuredProperties.retentionTime', '90.0')).toBe('90.0');
     });
 
     it('should strip rich text formatting to be displayed', () => {
@@ -598,5 +612,166 @@ describe('filter utils - getFilterDisplayName', () => {
         const option = { value: 'testValue' };
         const field: FilterField = { type: FieldType.ENUM, field: 'test', displayName: 'test' };
         expect(getFilterDisplayName(option, field)).toBe(undefined);
+    });
+});
+
+describe('filter utils - getStructuredPropFilterDisplayName NUMBER type', () => {
+    it('should format a number value correctly when entity has NUMBER valueType', () => {
+        const entity = { definition: { valueType: { urn: NUMBER_TYPE_URN } } } as any;
+        expect(getStructuredPropFilterDisplayName('structuredProperties.count', '42.0', entity)).toBe('42');
+        expect(getStructuredPropFilterDisplayName('structuredProperties.count', '1000.0', entity)).toBe('1000');
+    });
+
+    it('should NOT corrupt a UUID-shaped value when no entity/type info is provided', () => {
+        // parseFloat('550e8400-e29b-41d4-a716-446655440000') === Infinity before the fix
+        const result = getStructuredPropFilterDisplayName(
+            'structuredProperties.uuidProp',
+            '550e8400-e29b-41d4-a716-446655440000',
+        );
+        expect(result).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should NOT corrupt a UUID-shaped value even when entity has STRING valueType', () => {
+        const entity = { definition: { valueType: { urn: STRING_TYPE_URN } } } as any;
+        const result = getStructuredPropFilterDisplayName(
+            'structuredProperties.uuidProp',
+            '550e8400-e29b-41d4-a716-446655440000',
+            entity,
+        );
+        expect(result).toBe('550e8400-e29b-41d4-a716-446655440000');
+    });
+
+    it('should return undefined for URN values regardless of entity type', () => {
+        const entity = { definition: { valueType: { urn: URN_TYPE_URN } } } as any;
+        expect(
+            getStructuredPropFilterDisplayName('structuredProperties.steward', 'urn:li:corpuser:admin', entity),
+        ).toBe(undefined);
+    });
+});
+
+describe('filter utils - getNewFilters with availableFilters (TEXT condition)', () => {
+    const makeStringPropFilter = (hasAllowedValues: boolean) => ({
+        field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+        aggregations: [],
+        entity: {
+            __typename: 'StructuredPropertyEntity',
+            definition: {
+                valueType: { urn: STRING_TYPE_URN },
+                allowedValues: hasAllowedValues ? [{ value: { __typename: 'StringValue', stringValue: 'a' } }] : [],
+            },
+        } as any,
+    });
+
+    it('should set condition=CONTAIN for a free-form STRING structured property', () => {
+        const availableFilters = [makeStringPropFilter(false)];
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+            [],
+            ['550e8400-e29b-41d4-a716-446655440000'],
+            availableFilters,
+        );
+        expect(result[0].condition).toBe(FilterOperator.Contain);
+    });
+
+    it('should NOT set condition=CONTAIN for a STRING structured property with allowedValues (ENUM)', () => {
+        const availableFilters = [makeStringPropFilter(true)];
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`,
+            [],
+            ['someValue'],
+            availableFilters,
+        );
+        expect(result[0].condition).toBeUndefined();
+    });
+
+    it('should set condition=CONTAIN for a free-form RICH_TEXT structured property', () => {
+        const richTextFilter = {
+            field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.notes`,
+            aggregations: [],
+            entity: {
+                __typename: 'StructuredPropertyEntity',
+                definition: {
+                    valueType: { urn: RICH_TEXT_TYPE_URN },
+                    allowedValues: [],
+                },
+            } as any,
+        };
+        const result = getNewFilters(
+            `${STRUCTURED_PROPERTIES_FILTER_NAME}.notes`,
+            [],
+            ['hello world'],
+            [richTextFilter],
+        );
+        expect(result[0].condition).toBe(FilterOperator.Contain);
+    });
+
+    it('should NOT set condition for a NUMBER structured property', () => {
+        const numberFilter = {
+            field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.count`,
+            aggregations: [],
+            entity: {
+                __typename: 'StructuredPropertyEntity',
+                definition: { valueType: { urn: NUMBER_TYPE_URN }, allowedValues: [] },
+            } as any,
+        };
+        const result = getNewFilters(`${STRUCTURED_PROPERTIES_FILTER_NAME}.count`, [], ['42'], [numberFilter]);
+        expect(result[0].condition).toBeUndefined();
+    });
+
+    it('should default to no condition when availableFilters is omitted', () => {
+        const result = getNewFilters('platform', [], ['snowflake']);
+        expect(result[0].condition).toBeUndefined();
+    });
+});
+
+describe('filter utils - getDynamicFilterField structured-property type routing', () => {
+    const makeSpFacet = (fieldSuffix: string, valueTypeUrn: string, allowedValues: any[] = [], typeQualifier?: any) => ({
+        field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.${fieldSuffix}`,
+        aggregations: [],
+        entity: {
+            __typename: 'StructuredPropertyEntity',
+            definition: {
+                valueType: { urn: valueTypeUrn },
+                allowedValues,
+                ...(typeQualifier ? { typeQualifier } : {}),
+            },
+        } as any,
+    });
+
+    it('returns FieldType.TEXT for a free-form STRING structured property', () => {
+        const field = `${STRUCTURED_PROPERTIES_FILTER_NAME}.uuidProp`;
+        const result = getDynamicFilterField(field, [makeSpFacet('uuidProp', STRING_TYPE_URN)]);
+        expect(result.type).toBe(FieldType.TEXT);
+    });
+
+    it('returns FieldType.TEXT for a free-form RICH_TEXT structured property', () => {
+        const field = `${STRUCTURED_PROPERTIES_FILTER_NAME}.notes`;
+        const result = getDynamicFilterField(field, [makeSpFacet('notes', RICH_TEXT_TYPE_URN)]);
+        expect(result.type).toBe(FieldType.TEXT);
+    });
+
+    it('returns FieldType.ENUM for a STRING structured property with allowedValues', () => {
+        const field = `${STRUCTURED_PROPERTIES_FILTER_NAME}.status`;
+        const result = getDynamicFilterField(field, [
+            makeSpFacet('status', STRING_TYPE_URN, [{ value: { __typename: 'StringValue', stringValue: 'open' } }]),
+        ]);
+        expect(result.type).toBe(FieldType.ENUM);
+    });
+
+    it('returns FieldType.ENTITY for a URN structured property', () => {
+        const field = `${STRUCTURED_PROPERTIES_FILTER_NAME}.steward`;
+        const result = getDynamicFilterField(field, [makeSpFacet('steward', URN_TYPE_URN)]);
+        expect(result.type).toBe(FieldType.ENTITY);
+    });
+
+    it('uses typeQualifier.allowedTypes for URN structured property entityTypes', () => {
+        const field = `${STRUCTURED_PROPERTIES_FILTER_NAME}.steward`;
+        const result = getDynamicFilterField(field, [
+            makeSpFacet('steward', URN_TYPE_URN, [], {
+                allowedTypes: [{ type: EntityType.CorpUser }, { type: EntityType.CorpGroup }],
+            }),
+        ]);
+        expect(result.type).toBe(FieldType.ENTITY);
+        expect(result.entityTypes).toEqual([EntityType.CorpUser, EntityType.CorpGroup]);
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -725,7 +725,12 @@ describe('filter utils - getNewFilters with availableFilters (TEXT condition)', 
 });
 
 describe('filter utils - getDynamicFilterField structured-property type routing', () => {
-    const makeSpFacet = (fieldSuffix: string, valueTypeUrn: string, allowedValues: any[] = [], typeQualifier?: any) => ({
+    const makeSpFacet = (
+        fieldSuffix: string,
+        valueTypeUrn: string,
+        allowedValues: any[] = [],
+        typeQualifier?: any,
+    ) => ({
         field: `${STRUCTURED_PROPERTIES_FILTER_NAME}.${fieldSuffix}`,
         aggregations: [],
         entity: {

--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -777,6 +777,9 @@ describe('filter utils - getDynamicFilterField structured-property type routing'
             }),
         ]);
         expect(result.type).toBe(FieldType.ENTITY);
-        expect(result.entityTypes).toEqual([EntityType.CorpUser, EntityType.CorpGroup]);
+        expect(result.type === FieldType.ENTITY && result.entityTypes).toEqual([
+            EntityType.CorpUser,
+            EntityType.CorpGroup,
+        ]);
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
@@ -90,6 +90,10 @@ export default function useSearchFilterDropdown({
                 filter.field,
                 activeFilters,
                 newFilters.map((f) => f.value),
+                // Pass this field's facet so getNewFilters can read the structured-property valueType
+                // and pick the right default condition (free-form TEXT -> CONTAINS). Without it the
+                // condition falls back to the backend default (EQUAL) even though the UI shows "contains".
+                [filter],
             ),
         );
     }

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -51,7 +51,13 @@ import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import getTypeIcon from '@app/sharedV2/icons/getTypeIcon';
 import LogicalPlatformDefaultIcon from '@app/sharedV2/logical/LogicalPlatformDefaultIcon';
 import { removeMarkdown } from '@src/app/entity/shared/components/styled/StripMarkdownText';
-import { DATE_TYPE_URN, URN_TYPE_URN } from '@src/app/shared/constants';
+import {
+    DATE_TYPE_URN,
+    NUMBER_TYPE_URN,
+    RICH_TEXT_TYPE_URN,
+    STRING_TYPE_URN,
+    URN_TYPE_URN,
+} from '@src/app/shared/constants';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { EntityRegistry } from '@src/entityRegistryContext';
 import dayjs from '@utils/dayjs';
@@ -74,10 +80,41 @@ import {
 } from '@types';
 
 // either adds or removes selectedFilterValues to/from activeFilters for a given filterField
+function getDefaultFilterCondition(filterField: string): FilterOperator | undefined {
+    if (filterField === LAST_MODIFIED_FILTER_NAME) {
+        return FilterOperator.GreaterThan;
+    }
+    if (
+        filterField === DOMAINS_FILTER_NAME ||
+        filterField === CONTAINER_FILTER_NAME ||
+        filterField === PARENT_DOCUMENT_FILTER_NAME
+    ) {
+        return FilterOperator.DescendantsIncl;
+    }
+    return undefined;
+}
+
+/**
+ * Picks the backend condition to use when a brand-new filter is created for a field. Mirrors the
+ * field type's natural default: date fields use GreaterThan, free-form TEXT fields use CONTAINS, and
+ * everything else falls back to the backend default (EQUAL). Without this, the "More" menu created
+ * every filter with no condition, so a free-form text property (e.g. a UUID) applied as an exact
+ * EQUAL match and partial values never matched.
+ */
+function getNewFilterCondition(filterField: string, availableFilters: FacetMetadata[]): FilterOperator | undefined {
+    const defaultCondition = getDefaultFilterCondition(filterField);
+    if (defaultCondition !== undefined) {
+        return defaultCondition;
+    }
+    const field = getKnownFilterField(filterField) || getDynamicFilterField(filterField, availableFilters);
+    return field.type === FieldType.TEXT ? FilterOperator.Contain : undefined;
+}
+
 export function getNewFilters(
     filterField: string,
     activeFilters: FacetFilterInput[],
     selectedFilterValues: string[],
+    availableFilters: FacetMetadata[] = [],
 ): FacetFilterInput[] {
     if (activeFilters.find((activeFilter) => activeFilter.field === filterField)) {
         return activeFilters
@@ -91,23 +128,9 @@ export function getNewFilters(
             field: filterField,
             values: selectedFilterValues,
             // TODO: Define on filter field instead
-            condition: getDefaultFilterCondition(filterField),
+            condition: getNewFilterCondition(filterField, availableFilters),
         },
     ].filter((f) => !(f.values?.length === 0));
-}
-
-function getDefaultFilterCondition(filterField: string): FilterOperator | undefined {
-    if (filterField === LAST_MODIFIED_FILTER_NAME) {
-        return FilterOperator.GreaterThan;
-    }
-    if (
-        filterField === DOMAINS_FILTER_NAME ||
-        filterField === CONTAINER_FILTER_NAME ||
-        filterField === PARENT_DOCUMENT_FILTER_NAME
-    ) {
-        return FilterOperator.DescendantsIncl;
-    }
-    return undefined;
 }
 
 export function isFilterOptionSelected(selectedFilterOptions: FilterOptionType[], filterValue: string) {
@@ -487,7 +510,7 @@ function getKnownFilterField(field: string): FilterField | undefined {
     return ALL_FILTER_FIELDS.find((filterField) => filterField.field === field);
 }
 
-function getDynamicFilterField(field: string, availableFilters: FacetMetadata[]): FilterField {
+export function getDynamicFilterField(field: string, availableFilters: FacetMetadata[]): FilterField {
     const associatedAvailableFilter = availableFilters?.find((availableFilter) => availableFilter.field === field);
     const filterDisplayName = associatedAvailableFilter?.displayName;
     const filterAggregations = availableFilters?.find(
@@ -503,6 +526,7 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
     if (field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME) && entity) {
         const structuredPropEntity = entity as StructuredPropertyEntity;
         const valueTypeUrn = structuredPropEntity.definition?.valueType?.urn;
+        const hasAllowedValues = !!structuredPropEntity.definition?.allowedValues?.length;
         if (valueTypeUrn === URN_TYPE_URN) {
             type = FieldType.ENTITY;
             // Prefer the explicit typeQualifier allowedTypes; fall back to inference from aggregations.
@@ -510,6 +534,14 @@ function getDynamicFilterField(field: string, availableFilters: FacetMetadata[])
             if (qualifierTypes?.length) {
                 entityTypes = qualifierTypes.map((t) => t.type).filter(Boolean) as EntityType[];
             }
+        } else if ((valueTypeUrn === STRING_TYPE_URN || valueTypeUrn === RICH_TEXT_TYPE_URN) && !hasAllowedValues) {
+            // Free-form text properties (no constrained allowedValues) are not enumerable — e.g. one
+            // holding arbitrary UUIDs. Render them as a type-a-value TEXT filter (which applies a
+            // CONTAINS query), like the description / field-path text filters, instead of an
+            // aggregation bucket picker that can only surface the top-N distinct values and breaks on
+            // high-cardinality values. Properties WITH allowedValues stay ENUM so users can pick from
+            // the constrained set.
+            type = FieldType.TEXT;
         }
     }
 
@@ -573,8 +605,11 @@ export function getStructuredPropFilterDisplayName(field: string, value: string,
         return dayjs(parseInt(value, 10)).tz('GMT').format('MM/DD/YYYY').toString();
     }
 
-    // check for structured prop number values
-    if (!Number.isNaN(parseFloat(value))) {
+    // check for structured prop number values. Detect by the property's declared value type rather
+    // than sniffing the string with parseFloat — parseFloat parses a leading numeric chunk and
+    // ignores the rest, so values like "550e8400-..." (a UUID) became "Infinity" and "02d22a5f-..."
+    // became "2". When the value type is unknown, fall through to render the raw value verbatim.
+    if (entity && (entity as StructuredPropertyEntity).definition?.valueType?.urn === NUMBER_TYPE_URN) {
         return parseFloat(value).toString();
     }
 
@@ -591,13 +626,17 @@ export function getStructuredPropFilterDisplayName(field: string, value: string,
 function convertToFilterPredicate(filter: FacetFilterInput, availableFilters: FacetMetadata[]): FilterPredicate {
     // First, check whether this is a well-supported filter field.
     const field = getKnownFilterField(filter.field) || getDynamicFilterField(filter.field, availableFilters);
+    // When no explicit condition is set (e.g. an available-but-unapplied filter in the "More" menu),
+    // fall back to the field type's natural default: free-form TEXT fields filter by CONTAINS,
+    // everything else by EQUALS. Mirrors getDefaultFieldOperatorType, inlined to avoid a circular
+    // import between this module and value/utils.
     const operator =
         (filter.condition &&
             convertBackendToFrontendOperatorType({
                 operator: filter.condition,
                 negated: filter.negated || false,
             })) ||
-        FilterOperatorType.EQUALS;
+        (field.type === FieldType.TEXT ? FilterOperatorType.CONTAINS : FilterOperatorType.EQUALS);
 
     const values = getFilterValues(filter, availableFilters);
     const defaultOptions = getDefaultFilterOptions(filter, availableFilters);
@@ -739,6 +778,8 @@ export function getFilterDisplayName(option: FilterValueOption, field: FilterFie
     }
 
     return field.field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME)
-        ? getStructuredPropFilterDisplayName(field.field, option.value)
+        ? // pass the field's structured-property entity so the formatter can detect the value type
+          // (NUMBER/DATE) — without it, numeric buckets render as the raw double (e.g. "42000.0").
+          getStructuredPropFilterDisplayName(field.field, option.value, field.entity)
         : undefined;
 }

--- a/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'react-use';
 
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
@@ -11,6 +12,8 @@ import {
     useLoadSearchOptions,
 } from '@app/searchV2/filters/value/utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+
+const DEBOUNCE_MS = 300;
 
 interface Props {
     field: EntityFilterField;
@@ -41,8 +44,18 @@ export default function EntityValueMenu({
     // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
+    // Debounce the value that drives the server-side autocomplete query so we don't fire a
+    // GetAutoCompleteMultipleResults request on every keystroke. The raw searchQuery still
+    // drives the input and local (client-side) option filtering for instant feedback.
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string | undefined>(undefined);
+    useDebounce(() => setDebouncedSearchQuery(searchQuery), DEBOUNCE_MS, [searchQuery]);
+
     // Here we optionally load the search options, which are the options that are displayed when the user searches.
-    const { options: searchOptions, loading: searchLoading } = useLoadSearchOptions(field, searchQuery, !isSearchable);
+    const { options: searchOptions, loading: searchLoading } = useLoadSearchOptions(
+        field,
+        debouncedSearchQuery,
+        !isSearchable,
+    );
 
     const localSearchOptions = useFilterOptionsBySearchQuery(defaultOptions, searchQuery);
 

--- a/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
@@ -59,7 +59,13 @@ export default function EntityValueMenu({
 
     const localSearchOptions = useFilterOptionsBySearchQuery(defaultOptions, searchQuery);
 
-    const finalSearchOptions = [...localSearchOptions, ...deduplicateOptions(localSearchOptions, searchOptions)];
+    // Only merge remote results once the debounced query is set. While debounce is pending,
+    // useLoadSearchOptions still holds the initial '*' search; merging those would flash
+    // unfiltered entities into the URN structured-property picker.
+    const finalSearchOptions = [
+        ...localSearchOptions,
+        ...(debouncedSearchQuery ? deduplicateOptions(localSearchOptions, searchOptions) : []),
+    ];
 
     // Compute the final options to show to the user.
     const finalDefaultOptions = defaultOptions.length ? defaultOptions : searchOptions;

--- a/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDebounce } from 'react-use';
 
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
@@ -12,6 +13,8 @@ import {
 } from '@app/searchV2/filters/value/utils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { EntityType } from '@src/types.generated';
+
+const DEBOUNCE_MS = 300;
 
 interface Props {
     field: FilterField;
@@ -42,6 +45,12 @@ export default function EnumValueMenu({
     // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
+    // Debounce the value that drives the server-side aggregation query so we don't fire
+    // an aggregateAcrossEntities request on every keystroke. The raw searchQuery still
+    // drives the input and local (client-side) option filtering for instant feedback.
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState<string | undefined>(undefined);
+    useDebounce(() => setDebouncedSearchQuery(searchQuery), DEBOUNCE_MS, [searchQuery]);
+
     // Here we optionally load the aggregation options, which are the options that are displayed by default.
     const { options: aggOptions, loading: aggLoading } = useLoadAggregationOptions({
         field,
@@ -55,10 +64,10 @@ export default function EnumValueMenu({
     // Do an aggregations query with the given search query as a filter to find any values not in the first set of results
     const { options: searchAggOptions, loading: searchAggsLoading } = useLoadAggregationOptions({
         field,
-        visible: !!searchQuery, // only run this query if there's a search query
+        visible: !!debouncedSearchQuery, // only run this query if there's a (debounced) search query
         includeCounts: includeCount,
         aggregationsEntityTypes,
-        extraOrFilters: [{ and: [{ field: field.field, values: [searchQuery || ''] }] }],
+        extraOrFilters: [{ and: [{ field: field.field, values: [debouncedSearchQuery || ''] }] }],
         removeOptionsWithNoCount: true,
     });
 

--- a/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { FilterField, FilterValue } from '@app/searchV2/filters/types';
+import { useFilterDisplayName } from '@app/searchV2/filters/utils';
 import TextValueInput from '@app/searchV2/filters/value/TextValueInput';
 
 const Container = styled.div`
@@ -31,7 +32,9 @@ interface Props {
 export default function TextValueMenu({ field, values, onChangeValues, onApply }: Props) {
     const { t } = useTranslation('search');
     const { t: tc } = useTranslation('common.actions');
-    const { displayName } = field;
+    // Resolve the human-readable label (e.g. "UUID Filter Test") rather than the raw field name
+    // (structuredProperties.uuidFilterTest), consistent with the enum/entity menus.
+    const displayName = useFilterDisplayName(field);
     const value = values.length > 0 ? values[0].displayName || values[0].value : '';
 
     return (

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_MAPPING_FIELD;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_MAPPING_VERSIONED_FIELD;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_MAPPING_VERSIONED_FIELD_PREFIX;
 
 import com.datahub.context.OperationFingerprint;
 import com.google.common.collect.ImmutableSet;
@@ -52,6 +53,14 @@ public class StructuredPropertyUtils {
 
   static final Date MIN_DATE = Date.valueOf("1000-01-01");
   static final Date MAX_DATE = Date.valueOf("9999-12-31");
+
+  // ES multi-field suffixes. Kept here (not imported from metadata-io) because this module
+  // cannot depend on ESUtils / V2MappingsBuilder; keep in sync with those definitions.
+  private static final String KEYWORD_SUBFIELD_SUFFIX = ".keyword";
+  private static final String DELIMITED_SUBFIELD_SUFFIX = ".delimited";
+  private static final String NGRAM_SUBFIELD_SUFFIX = ".ngram";
+  private static final List<String> ES_SUBFIELD_SUFFIXES =
+      List.of(KEYWORD_SUBFIELD_SUFFIX, DELIMITED_SUBFIELD_SUFFIX, NGRAM_SUBFIELD_SUFFIX);
 
   public static final String INVALID_SETTINGS_MESSAGE =
       "Cannot have property isHidden = true while other display location settings are also true.";
@@ -141,12 +150,54 @@ public class StructuredPropertyUtils {
   }
 
   /**
+   * Whether aggregations and exact-match filters should target {@code <field>.keyword} for this
+   * value type. DATE / NUMBER / URN parents are already the typed exact-match field (date, double,
+   * or keyword without a normalizer), so the {@code .keyword} suffix must not be appended.
+   * STRING/RICH_TEXT parents use a normalizer; {@code .keyword} holds the un-normalized value.
+   */
+  public static boolean usesKeywordSubfield(@Nonnull LogicalValueType type) {
+    return type != LogicalValueType.DATE
+        && type != LogicalValueType.NUMBER
+        && type != LogicalValueType.URN;
+  }
+
+  /**
+   * When a filter/facet already uses the versioned ES field path produced by {@link
+   * #toElasticsearchFieldName}, recover the logical value type from the trailing type segment. Used
+   * when definition lookup cannot run against that path (FQN extraction would be wrong).
+   */
+  @Nonnull
+  public static Optional<LogicalValueType> getLogicalValueTypeFromFieldName(
+      @Nonnull String fieldOrFacetName) {
+    if (!fieldOrFacetName.startsWith(STRUCTURED_PROPERTY_MAPPING_VERSIONED_FIELD_PREFIX)) {
+      return Optional.empty();
+    }
+    String path = fieldOrFacetName;
+    for (String suffix : ES_SUBFIELD_SUFFIXES) {
+      if (path.endsWith(suffix)) {
+        path = path.substring(0, path.length() - suffix.length());
+        break;
+      }
+    }
+    // Inverse of toElasticsearchFieldName: type is always the last '.' segment.
+    int lastDot = path.lastIndexOf('.');
+    if (lastDot < 0 || lastDot == path.length() - 1) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(LogicalValueType.valueOf(path.substring(lastDot + 1).toUpperCase()));
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
    * Given a structured property input field or facet name, return a valid structured property facet
    * name
    *
    * @param fieldOrFacetName input name
    * @param aspectRetriever aspect retriever
-   * @return guranteed facet name
+   * @return guaranteed facet name
    */
   public static Optional<String> toStructuredPropertyFacetName(
       @Nullable OperationFingerprint opContext,
@@ -155,18 +206,13 @@ public class StructuredPropertyUtils {
     return lookupDefinitionFromFilterOrFacetName(opContext, fieldOrFacetName, aspectRetriever)
         .map(
             urnDefinition -> {
-              switch (getLogicalValueType(urnDefinition.getSecond())) {
-                case DATE:
-                case NUMBER:
-                  return STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX
+              String base =
+                  STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX
                       + StructuredPropertyUtils.toElasticsearchFieldName(
                           urnDefinition.getFirst(), urnDefinition.getSecond());
-                default:
-                  return STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX
-                      + StructuredPropertyUtils.toElasticsearchFieldName(
-                          urnDefinition.getFirst(), urnDefinition.getSecond())
-                      + ".keyword";
-              }
+              return usesKeywordSubfield(getLogicalValueType(urnDefinition.getSecond()))
+                  ? base + KEYWORD_SUBFIELD_SUFFIX
+                  : base;
             });
   }
 
@@ -402,10 +448,11 @@ public class StructuredPropertyUtils {
   }
 
   private static String fieldOrFacetToFQN(String fieldOrFacet) {
-    return fieldOrFacet
-        .substring(STRUCTURED_PROPERTY_MAPPING_FIELD.length() + 1)
-        .replace(".keyword", "")
-        .replace(".delimited", "");
+    String fqn = fieldOrFacet.substring(STRUCTURED_PROPERTY_MAPPING_FIELD.length() + 1);
+    for (String suffix : ES_SUBFIELD_SUFFIXES) {
+      fqn = fqn.replace(suffix, "");
+    }
+    return fqn;
   }
 
   public static Date toDate(PrimitivePropertyValue value) throws DateTimeParseException {

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/StructuredPropertyUtilsTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/StructuredPropertyUtilsTest.java
@@ -18,6 +18,7 @@ import com.linkedin.util.Pair;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.testng.annotations.Test;
 
@@ -280,5 +281,88 @@ public class StructuredPropertyUtilsTest {
                 new StructuredPropertyUtils.StructuredPropertyFieldMapping(
                     "certification_status", urnB, Map.of("type", "double"))));
     assertTrue(resolved.isEmpty());
+  }
+
+  @Test
+  public void testUsesKeywordSubfield() {
+    assertTrue(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.STRING));
+    assertTrue(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.RICH_TEXT));
+    assertTrue(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.UNKNOWN));
+    assertFalse(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.DATE));
+    assertFalse(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.NUMBER));
+    assertFalse(StructuredPropertyUtils.usesKeywordSubfield(LogicalValueType.URN));
+  }
+
+  @Test
+  public void testGetLogicalValueTypeFromFieldNameVersionedPath() {
+    assertEquals(
+        StructuredPropertyUtils.getLogicalValueTypeFromFieldName(
+            "structuredProperties._versioned.hello.00000000000001.string"),
+        Optional.of(LogicalValueType.STRING));
+    assertEquals(
+        StructuredPropertyUtils.getLogicalValueTypeFromFieldName(
+            "structuredProperties._versioned.owner_ref.00000000000001.urn"),
+        Optional.of(LogicalValueType.URN));
+    assertEquals(
+        StructuredPropertyUtils.getLogicalValueTypeFromFieldName(
+            "structuredProperties._versioned.hello.00000000000001.string.keyword"),
+        Optional.of(LogicalValueType.STRING));
+    assertTrue(
+        StructuredPropertyUtils.getLogicalValueTypeFromFieldName("structuredProperties.hello")
+            .isEmpty());
+  }
+
+  @Test
+  public void testToStructuredPropertyFacetNameSkipsKeywordForUrnDateNumber()
+      throws URISyntaxException {
+    Urn stringUrn = Urn.createFromString("urn:li:structuredProperty:status");
+    Urn urnUrn = Urn.createFromString("urn:li:structuredProperty:steward");
+    Urn dateUrn = Urn.createFromString("urn:li:structuredProperty:reviewedAt");
+    Urn numberUrn = Urn.createFromString("urn:li:structuredProperty:score");
+
+    MockAspectRetriever retriever =
+        new MockAspectRetriever(
+            Map.of(
+                stringUrn,
+                List.of(
+                    new StructuredPropertyDefinition()
+                        .setQualifiedName("status")
+                        .setValueType(Urn.createFromString("urn:li:dataType:datahub.string"))),
+                urnUrn,
+                List.of(
+                    new StructuredPropertyDefinition()
+                        .setQualifiedName("steward")
+                        .setValueType(Urn.createFromString("urn:li:dataType:datahub.urn"))),
+                dateUrn,
+                List.of(
+                    new StructuredPropertyDefinition()
+                        .setQualifiedName("reviewedAt")
+                        .setValueType(Urn.createFromString("urn:li:dataType:datahub.date"))),
+                numberUrn,
+                List.of(
+                    new StructuredPropertyDefinition()
+                        .setQualifiedName("score")
+                        .setValueType(Urn.createFromString("urn:li:dataType:datahub.number")))));
+
+    assertEquals(
+        StructuredPropertyUtils.toStructuredPropertyFacetName(
+                OperationFingerprint.EMPTY, "structuredProperties.status", retriever)
+            .orElseThrow(),
+        "structuredProperties.status.keyword");
+    assertEquals(
+        StructuredPropertyUtils.toStructuredPropertyFacetName(
+                OperationFingerprint.EMPTY, "structuredProperties.steward", retriever)
+            .orElseThrow(),
+        "structuredProperties.steward");
+    assertEquals(
+        StructuredPropertyUtils.toStructuredPropertyFacetName(
+                OperationFingerprint.EMPTY, "structuredProperties.reviewedAt", retriever)
+            .orElseThrow(),
+        "structuredProperties.reviewedAt");
+    assertEquals(
+        StructuredPropertyUtils.toStructuredPropertyFacetName(
+                OperationFingerprint.EMPTY, "structuredProperties.score", retriever)
+            .orElseThrow(),
+        "structuredProperties.score");
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
@@ -145,12 +145,16 @@ public class FieldTypeMapper {
    * Creates a mapping configuration for a keyword field with ignore_above set to prevent indexing
    * failures on long TEXT values. The Lucene keyword term limit is 32,766 bytes; ignore_above
    * silently skips indexing values that exceed the threshold (they remain in _source).
+   *
+   * <p>Includes a {@code .keyword} multi-field so filters/facets that append {@code .keyword} (e.g.
+   * STRING/RICH_TEXT structured properties via {@code usesKeywordSubfield}) resolve.
    */
   @Nonnull
   public static Map<String, Object> getMappingsForKeywordWithIgnoreAbove() {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
     mapping.put(IGNORE_ABOVE, KEYWORD_MAXLENGTH);
+    mapping.put("fields", Map.of(KEYWORD_FIELD_TYPE, Map.of("type", KEYWORD_FIELD_TYPE)));
     return mapping;
   }
 
@@ -163,6 +167,8 @@ public class FieldTypeMapper {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
     mapping.put(IGNORE_ABOVE, keywordIgnoreAboveForMaxBytes(keywordMaxBytes));
+    // Plain keyword subfield for exact-match / aggregation queries that append .keyword.
+    mapping.put("fields", Map.of(KEYWORD_FIELD_TYPE, Map.of("type", KEYWORD_FIELD_TYPE)));
     return mapping;
   }
 
@@ -337,7 +343,8 @@ public class FieldTypeMapper {
       case STRING:
       case RICH_TEXT:
         // ignore_above protects reindex from pre-existing values over the keyword limit;
-        // StructuredPropertiesValidator rejects new oversized writes.
+        // StructuredPropertiesValidator rejects new oversized writes. .keyword multi-field
+        // matches usesKeywordSubfield query/facet resolution.
         return getMappingsForKeywordWithIgnoreAbove(keywordMaxLength);
       case DATE:
         return Map.of("type", DATE_FIELD_TYPE);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapper.java
@@ -154,7 +154,13 @@ public class FieldTypeMapper {
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
     mapping.put(IGNORE_ABOVE, KEYWORD_MAXLENGTH);
-    mapping.put("fields", Map.of(KEYWORD_FIELD_TYPE, Map.of("type", KEYWORD_FIELD_TYPE)));
+    // Subfield must also set ignore_above — filters/facets query .keyword, and Lucene
+    // still rejects oversized terms on multi-fields that omit the limit.
+    mapping.put(
+        "fields",
+        Map.of(
+            KEYWORD_FIELD_TYPE,
+            Map.of("type", KEYWORD_FIELD_TYPE, IGNORE_ABOVE, KEYWORD_MAXLENGTH)));
     return mapping;
   }
 
@@ -164,11 +170,15 @@ public class FieldTypeMapper {
    */
   @Nonnull
   public static Map<String, Object> getMappingsForKeywordWithIgnoreAbove(int keywordMaxBytes) {
+    int ignoreAbove = keywordIgnoreAboveForMaxBytes(keywordMaxBytes);
     Map<String, Object> mapping = new HashMap<>();
     mapping.put("type", KEYWORD_FIELD_TYPE);
-    mapping.put(IGNORE_ABOVE, keywordIgnoreAboveForMaxBytes(keywordMaxBytes));
-    // Plain keyword subfield for exact-match / aggregation queries that append .keyword.
-    mapping.put("fields", Map.of(KEYWORD_FIELD_TYPE, Map.of("type", KEYWORD_FIELD_TYPE)));
+    mapping.put(IGNORE_ABOVE, ignoreAbove);
+    // Subfield mirrors parent ignore_above so exact-match / aggregation queries on .keyword
+    // are protected from Lucene term-length failures on oversized values.
+    mapping.put(
+        "fields",
+        Map.of(KEYWORD_FIELD_TYPE, Map.of("type", KEYWORD_FIELD_TYPE, IGNORE_ABOVE, ignoreAbove)));
     return mapping;
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilder.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.search.elasticsearch.query.request;
 
 import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.models.StructuredPropertyUtils.toStructuredPropertyFacetName;
 import static com.linkedin.metadata.search.utils.ESUtils.toParentField;
 import static com.linkedin.metadata.utils.SearchUtil.*;
 
@@ -199,11 +198,8 @@ public class AggregationQueryBuilder {
       // Boolean hasX field, not a keyword field. Return the name of the original facet.
       return facet;
     }
-    // intercept structured property if it exists
-    return toStructuredPropertyFacetName(
-            (com.datahub.context.OperationFingerprint) opContext, facet, aspectRetriever)
-        // Otherwise assume that this field is of keyword type.
-        .orElse(ESUtils.toKeywordField(opContext, facet, false, aspectRetriever));
+    // Structured properties and keyword fields share one resolver (SP type → parent vs .keyword).
+    return ESUtils.toKeywordField(opContext, facet, false, aspectRetriever);
   }
 
   List<String> getDefaultFacetFieldsFromAnnotation(final SearchableAnnotation annotation) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -12,6 +12,7 @@ import static com.linkedin.metadata.search.elasticsearch.query.request.SearchFie
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.opensearch.core.rest.RestStatus.TOO_MANY_REQUESTS;
 
+import com.datahub.context.OperationFingerprint;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.data.schema.DataSchema;
@@ -20,6 +21,7 @@ import com.linkedin.data.schema.PathSpec;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.dao.throttle.APIThrottleException;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.LogicalValueType;
 import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.StructuredPropertyUtils;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
@@ -758,9 +760,11 @@ public class ESUtils {
       @Nullable final Object opContext,
       @Nonnull final String filterField,
       @Nullable final AspectRetriever aspectRetriever) {
+    // Only structured-property filters need definition lookup to sanitize/version the ES field
+    // name. Non-SP fields pass through unchanged aside from stripping known subfield suffixes.
     String fieldName =
         StructuredPropertyUtils.lookupDefinitionFromFilterOrFacetName(
-                (com.datahub.context.OperationFingerprint) opContext, filterField, aspectRetriever)
+                (OperationFingerprint) opContext, filterField, aspectRetriever)
             .map(
                 urnDefinition ->
                     STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX
@@ -805,24 +809,41 @@ public class ESUtils {
       @Nonnull final String filterField,
       final boolean skipKeywordSuffix,
       @Nullable final AspectRetriever aspectRetriever) {
-    String fieldName =
-        StructuredPropertyUtils.lookupDefinitionFromFilterOrFacetName(
-                (com.datahub.context.OperationFingerprint) opContext, filterField, aspectRetriever)
-            .map(
-                urnDefinition ->
-                    STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX
-                        + StructuredPropertyUtils.toElasticsearchFieldName(
-                            urnDefinition.getFirst(), urnDefinition.getSecond()))
-            .orElse(filterField);
+    // Structured properties: single source of truth for parent vs .keyword is
+    // StructuredPropertyUtils.toStructuredPropertyFacetName (DATE/NUMBER/URN skip .keyword).
+    Optional<String> structuredPropertyField =
+        StructuredPropertyUtils.toStructuredPropertyFacetName(
+            (OperationFingerprint) opContext, filterField, aspectRetriever);
+    if (structuredPropertyField.isPresent()) {
+      return skipKeywordSuffix
+          ? replaceSuffix(structuredPropertyField.get())
+          : structuredPropertyField.get();
+    }
+
+    // Definition lookup failed. If the caller already passed a versioned ES path, infer type from
+    // the trailing segment so STRING still gets .keyword and URN/DATE/NUMBER do not. Unversioned
+    // FQN misses prefer the parent (avoids empty results for typed parents).
+    if (filterField.startsWith(STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX)) {
+      Optional<LogicalValueType> inferredType =
+          StructuredPropertyUtils.getLogicalValueTypeFromFieldName(filterField);
+      if (inferredType.isPresent()) {
+        String parent = replaceSuffix(filterField);
+        if (skipKeywordSuffix || !StructuredPropertyUtils.usesKeywordSubfield(inferredType.get())) {
+          return parent;
+        }
+        return parent + ESUtils.KEYWORD_SUFFIX;
+      }
+      return filterField;
+    }
 
     return skipKeywordSuffix
-            || KEYWORD_FIELDS.contains(fieldName)
+            || KEYWORD_FIELDS.contains(filterField)
             || KEYWORD_FIELDS.stream()
-                .anyMatch(nestedField -> fieldName.endsWith("." + nestedField))
-            || PATH_HIERARCHY_FIELDS.contains(fieldName)
-            || SUBFIELDS.stream().anyMatch(subfield -> fieldName.endsWith("." + subfield))
-        ? fieldName
-        : fieldName + ESUtils.KEYWORD_SUFFIX;
+                .anyMatch(nestedField -> filterField.endsWith("." + nestedField))
+            || PATH_HIERARCHY_FIELDS.contains(filterField)
+            || SUBFIELDS.stream().anyMatch(subfield -> filterField.endsWith("." + subfield))
+        ? filterField
+        : filterField + ESUtils.KEYWORD_SUFFIX;
   }
 
   public static RequestOptions buildReindexTaskRequestOptions(
@@ -1118,7 +1139,7 @@ public class ESUtils {
       // underscores
       finalFieldTypes =
           StructuredPropertyUtils.toElasticsearchFieldType(
-              (com.datahub.context.OperationFingerprint) opContext,
+              (OperationFingerprint) opContext,
               replaceSuffix(criterion.getField()),
               aspectRetriever);
     } else {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -822,7 +822,8 @@ public class ESUtils {
 
     // Definition lookup failed. If the caller already passed a versioned ES path, infer type from
     // the trailing segment so STRING still gets .keyword and URN/DATE/NUMBER do not. Unversioned
-    // FQN misses prefer the parent (avoids empty results for typed parents).
+    // FQN misses prefer the parent (strip any caller-supplied .keyword / other subfields) so
+    // typed parents are not queried on a missing multi-field.
     if (filterField.startsWith(STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX)) {
       Optional<LogicalValueType> inferredType =
           StructuredPropertyUtils.getLogicalValueTypeFromFieldName(filterField);
@@ -833,7 +834,7 @@ public class ESUtils {
         }
         return parent + ESUtils.KEYWORD_SUFFIX;
       }
-      return filterField;
+      return replaceSuffix(filterField);
     }
 
     return skipKeywordSuffix

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -806,6 +806,51 @@ public class V2MappingsBuilderTest {
     }
   }
 
+  @Test
+  public void testUrnStructuredPropertyMapsToKeywordParent() throws URISyntaxException {
+    // URN SPs use the shared URN mapping (parent keyword + delimited/ngram). Facets/filters
+    // target the parent via query-time logic (usesKeywordSubfield), not a .keyword subfield.
+    StructuredPropertyDefinition urnProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("steward")
+            .setDisplayName("Steward")
+            .setEntityTypes(new UrnArray(Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset")))
+            .setValueType(Urn.createFromString("urn:li:dataType:datahub.urn"));
+
+    Urn spUrn = UrnUtils.getUrn("urn:li:structuredProperty:steward");
+    EntityRegistry entityRegistry = operationContext.getEntityRegistry();
+    EntitySpec datasetSpec = entityRegistry.getEntitySpec("dataset");
+
+    Map<String, Object> mappings =
+        mappingsBuilder.getIndexMappings(
+            entityRegistry, datasetSpec, List.of(Pair.of(spUrn, urnProp)));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spProps = (Map<String, Object>) properties.get("structuredProperties");
+    assertNotNull(spProps, "Dataset mapping must have structuredProperties for a URN prop");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> spFields = (Map<String, Object>) spProps.get("properties");
+
+    assertTrue(spFields.containsKey("steward"), "Should contain the steward field");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> stewardMapping = (Map<String, Object>) spFields.get("steward");
+    assertEquals(stewardMapping.get("type"), "keyword", "Top-level type should be keyword");
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> subFields = (Map<String, Object>) stewardMapping.get("fields");
+    assertNotNull(subFields, "URN structured property must have subfields");
+    assertFalse(
+        subFields.containsKey("keyword"),
+        "URN structured property must not require .keyword; query time targets the parent");
+    assertTrue(
+        subFields.containsKey("delimited"),
+        "URN structured property must have .delimited subfield for URN component search");
+  }
+
   private EntityRegistry getTestEntityRegistry() {
     return new ConfigEntityRegistry(
         TestSearchFieldConfig.class

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -15,6 +15,7 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping = FieldTypeMapper.getMappingsForFieldType(FieldType.TEXT);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -22,6 +23,7 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping = FieldTypeMapper.getMappingsForFieldType(FieldType.TEXT_PARTIAL);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -36,6 +38,7 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping = FieldTypeMapper.getMappingsForKeywordWithIgnoreAbove();
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), KEYWORD_MAXLENGTH);
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -44,6 +47,7 @@ public class FieldTypeMapperTest {
     assertEquals(mapping.get("type"), "keyword");
     // Configured value is UTF-8 bytes; ignore_above is character-based and byte-safe (/ 4).
     assertEquals(mapping.get("ignore_above"), 256);
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -53,6 +57,7 @@ public class FieldTypeMapperTest {
             com.linkedin.metadata.models.LogicalValueType.STRING, 2048);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), 512);
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -84,6 +89,7 @@ public class FieldTypeMapperTest {
             com.linkedin.metadata.models.LogicalValueType.STRING);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), keywordIgnoreAboveForMaxBytes(KEYWORD_MAXLENGTH));
+    assertKeywordSubfieldPresent(mapping);
   }
 
   @Test
@@ -93,6 +99,16 @@ public class FieldTypeMapperTest {
             com.linkedin.metadata.models.LogicalValueType.RICH_TEXT);
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), keywordIgnoreAboveForMaxBytes(KEYWORD_MAXLENGTH));
+    assertKeywordSubfieldPresent(mapping);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertKeywordSubfieldPresent(Map<String, Object> mapping) {
+    assertTrue(mapping.containsKey("fields"), "STRING/RICH_TEXT/TEXT mappings need .keyword");
+    Map<String, Object> fields = (Map<String, Object>) mapping.get("fields");
+    assertTrue(fields.containsKey("keyword"), "Must expose .keyword multi-field for exact match");
+    Map<String, Object> keyword = (Map<String, Object>) fields.get("keyword");
+    assertEquals(keyword.get("type"), "keyword");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -60,6 +60,21 @@ public class FieldTypeMapperTest {
     Map<String, Object> mapping = FieldTypeMapper.getMappingsForUrn();
     assertEquals(mapping.get("type"), "keyword");
     assertEquals(mapping.get("ignore_above"), 255);
+    assertFalse(
+        mapping.containsKey("fields"),
+        "URN mapping is parent keyword only; query time skips .keyword for URN SPs");
+  }
+
+  @Test
+  public void testUrnLogicalValueTypeUsesUrnMapping() {
+    Map<String, Object> mapping =
+        FieldTypeMapper.getMappingsForLogicalValueType(
+            com.linkedin.metadata.models.LogicalValueType.URN);
+    assertEquals(mapping.get("type"), "keyword");
+    assertEquals(mapping.get("ignore_above"), 255);
+    assertFalse(
+        mapping.containsKey("fields"),
+        "URN logical value type must use parent keyword mapping without .keyword subfield");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/FieldTypeMapperTest.java
@@ -109,6 +109,10 @@ public class FieldTypeMapperTest {
     assertTrue(fields.containsKey("keyword"), "Must expose .keyword multi-field for exact match");
     Map<String, Object> keyword = (Map<String, Object>) fields.get("keyword");
     assertEquals(keyword.get("type"), "keyword");
+    assertEquals(
+        keyword.get("ignore_above"),
+        mapping.get("ignore_above"),
+        ".keyword subfield must mirror parent ignore_above");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
@@ -198,6 +198,9 @@ public class MultiEntityMappingsBuilderTest {
     Map<String, Object> fieldMapping = (Map<String, Object>) mappings.get(fieldName);
     assertNotNull(fieldMapping.get("type"), "URN structured property must have type for reindex");
     assertEquals(fieldMapping.get("type"), "keyword", "URN type should map to keyword");
+    assertFalse(
+        fieldMapping.containsKey("fields"),
+        "URN structured property uses parent keyword; query time skips .keyword");
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AggregationQueryBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AggregationQueryBuilderTest.java
@@ -62,6 +62,7 @@ public class AggregationQueryBuilderTest {
     Urn abFghTenUrn = Urn.createFromString("urn:li:structuredProperty:ab.fgh.ten");
     Urn underscoresAndDotsUrn =
         Urn.createFromString("urn:li:structuredProperty:under.scores.and.dots_make_a_mess");
+    Urn stewardUrn = Urn.createFromString("urn:li:structuredProperty:steward");
 
     // legacy
     aspectRetriever = mock(CachingAspectRetriever.class);
@@ -94,6 +95,19 @@ public class AggregationQueryBuilderTest {
                 Map.of(
                     STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
                     new Aspect(structPropAbFghTenDefinition.data()))));
+
+    StructuredPropertyDefinition stewardDefinition = new StructuredPropertyDefinition();
+    stewardDefinition.setVersion(null, SetMode.REMOVE_IF_NULL);
+    stewardDefinition.setValueType(Urn.createFromString(DATA_TYPE_URN_PREFIX + "urn"));
+    stewardDefinition.setQualifiedName("steward");
+    when(aspectRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(stewardUrn)), anySet()))
+        .thenReturn(
+            Map.of(
+                stewardUrn,
+                Map.of(
+                    STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                    new Aspect(stewardDefinition.data()))));
 
     StructuredPropertyDefinition structPropUnderscoresAndDotsDefinition =
         new StructuredPropertyDefinition();
@@ -447,6 +461,28 @@ public class AggregationQueryBuilderTest {
             "structuredProperties.under_scores_and_dots_make_a_mess.keyword",
             "structuredProperties.hello.keyword",
             DEFAULT_FILTER));
+  }
+
+  @Test
+  public void testAggregateOverUrnStructuredProperty() {
+    // URN SPs aggregate on the parent keyword field — no .keyword subfield.
+    SearchConfiguration config = TEST_OS_SEARCH_CONFIG.getSearch();
+    config.setMaxTermBucketSize(25);
+
+    AggregationQueryBuilder builder =
+        new AggregationQueryBuilder(
+            config, ImmutableMap.of(mock(EntitySpec.class), ImmutableList.of()));
+
+    List<AggregationBuilder> aggs =
+        builder.getAggregations(
+            TestOperationContexts.systemContextNoSearchAuthorization(aspectRetriever),
+            List.of("structuredProperties.steward"));
+    Assert.assertEquals(aggs.size(), 3);
+    Assert.assertEquals(
+        aggs.stream()
+            .map(aggr -> ((TermsAggregationBuilder) aggr).field())
+            .collect(Collectors.toSet()),
+        Set.of("structuredProperties.steward", DEFAULT_FILTER));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -975,6 +975,28 @@ public class ESUtilsTest {
   }
 
   @Test
+  public void testToKeywordFieldStripsCallerKeywordSuffixWhenDefinitionMissing()
+      throws URISyntaxException {
+    // If the caller already appended .keyword and definition lookup fails, strip the subfield so
+    // typed parents (URN/DATE/NUMBER) are not queried on a missing multi-field.
+    Urn missingUrn = Urn.createFromString("urn:li:structuredProperty:transientMiss");
+    AspectRetriever missingRetriever = mock(AspectRetriever.class);
+    when(missingRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    when(missingRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(missingUrn)), anySet()))
+        .thenReturn(Map.of());
+
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.transientMiss.keyword",
+            false,
+            missingRetriever),
+        "structuredProperties.transientMiss");
+  }
+
+  @Test
   public void testToKeywordFieldVersionedPathWithoutDefinitionInfersStringKeyword() {
     // Callers sometimes pass an already-resolved versioned ES path. Definition lookup cannot use
     // that path as an FQN; infer STRING from the type segment and keep .keyword.

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -61,6 +61,7 @@ public class ESUtilsTest {
     Urn underscoresAndDotsUrn =
         Urn.createFromString("urn:li:structuredProperty:under.scores.and.dots_make_a_mess");
     Urn dateWithDotsUrn = Urn.createFromString("urn:li:structuredProperty:date_here.with_dot");
+    Urn stewardUrn = Urn.createFromString("urn:li:structuredProperty:steward");
 
     // legacy
     aspectRetriever = mock(AspectRetriever.class);
@@ -93,6 +94,19 @@ public class ESUtilsTest {
                 Map.of(
                     STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
                     new Aspect(dateWithDotsDefinition.data()))));
+
+    StructuredPropertyDefinition stewardDefinition = new StructuredPropertyDefinition();
+    stewardDefinition.setVersion(null, SetMode.REMOVE_IF_NULL);
+    stewardDefinition.setValueType(Urn.createFromString(DATA_TYPE_URN_PREFIX + "urn"));
+    stewardDefinition.setQualifiedName("steward");
+    when(aspectRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(stewardUrn)), anySet()))
+        .thenReturn(
+            Map.of(
+                stewardUrn,
+                Map.of(
+                    STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                    new Aspect(stewardDefinition.data()))));
 
     StructuredPropertyDefinition structPropUnderscoresAndDotsDefinition =
         new StructuredPropertyDefinition();
@@ -911,6 +925,208 @@ public class ESUtilsTest {
             + "  }\n"
             + "}";
     assertEquals(result.toString(), expected);
+  }
+
+  @Test
+  public void testGetQueryBuilderFromUrnStructPropEqualsValue() {
+    // URN parents are already keyword (no normalizer); EQUAL must not append .keyword.
+    final Criterion singleValueCriterion =
+        buildCriterion("structuredProperties.steward", Condition.EQUAL, "urn:li:corpuser:jdoe");
+
+    OperationContext opContext = mock(OperationContext.class);
+    when(opContext.getAspectRetriever()).thenReturn(aspectRetriever);
+    QueryBuilder result =
+        ESUtils.getQueryBuilderFromCriterion(
+            singleValueCriterion, false, new HashMap<>(), opContext, QueryFilterRewriteChain.EMPTY);
+    String expected =
+        "{\n"
+            + "  \"terms\" : {\n"
+            + "    \"structuredProperties.steward\" : [\n"
+            + "      \"urn:li:corpuser:jdoe\"\n"
+            + "    ],\n"
+            + "    \"boost\" : 1.0,\n"
+            + "    \"_name\" : \"structuredProperties.steward\"\n"
+            + "  }\n"
+            + "}";
+    assertEquals(result.toString(), expected);
+  }
+
+  @Test
+  public void testToKeywordFieldSkipsKeywordSuffixWhenStructuredPropertyDefinitionMissing()
+      throws URISyntaxException {
+    // Transient aspect miss must not fall back to the STRING-like ".keyword" append — that returns
+    // empty for URN/DATE/NUMBER parents (no usable .keyword subfield). Prefer the parent field.
+    Urn missingUrn = Urn.createFromString("urn:li:structuredProperty:transientMiss");
+    AspectRetriever missingRetriever = mock(AspectRetriever.class);
+    when(missingRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    when(missingRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(missingUrn)), anySet()))
+        .thenReturn(Map.of());
+
+    String resolved =
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.transientMiss",
+            false,
+            missingRetriever);
+
+    assertEquals(resolved, "structuredProperties.transientMiss");
+  }
+
+  @Test
+  public void testToKeywordFieldVersionedPathWithoutDefinitionInfersStringKeyword() {
+    // Callers sometimes pass an already-resolved versioned ES path. Definition lookup cannot use
+    // that path as an FQN; infer STRING from the type segment and keep .keyword.
+    AspectRetriever emptyRetriever = mock(AspectRetriever.class);
+    when(emptyRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    when(emptyRetriever.getLatestAspectObjects(any(OperationFingerprint.class), anySet(), anySet()))
+        .thenReturn(Map.of());
+
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties._versioned.hello.00000000000001.string",
+            false,
+            emptyRetriever),
+        "structuredProperties._versioned.hello.00000000000001.string.keyword");
+  }
+
+  @Test
+  public void testToKeywordFieldVersionedPathWithoutDefinitionInfersUrnParent() {
+    AspectRetriever emptyRetriever = mock(AspectRetriever.class);
+    when(emptyRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    when(emptyRetriever.getLatestAspectObjects(any(OperationFingerprint.class), anySet(), anySet()))
+        .thenReturn(Map.of());
+
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties._versioned.owner_ref.00000000000001.urn",
+            false,
+            emptyRetriever),
+        "structuredProperties._versioned.owner_ref.00000000000001.urn");
+  }
+
+  @Test
+  public void testToKeywordFieldUnversionedUrnSkipsKeywordSuffix() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.steward",
+            false,
+            aspectRetriever),
+        "structuredProperties.steward");
+  }
+
+  @Test
+  public void testToKeywordFieldUnversionedStringAppendsKeywordSuffix() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.ab.fgh.ten",
+            false,
+            aspectRetriever),
+        "structuredProperties.ab_fgh_ten.keyword");
+  }
+
+  @Test
+  public void testToKeywordFieldUnversionedDateSkipsKeywordSuffix() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.date_here.with_dot",
+            false,
+            aspectRetriever),
+        "structuredProperties.date_here_with_dot");
+  }
+
+  @Test
+  public void testToKeywordFieldVersionedUrnSkipsKeywordSuffix() throws URISyntaxException {
+    Urn versionedUrnSp = Urn.createFromString("urn:li:structuredProperty:owner.ref");
+    AspectRetriever versionedUrnRetriever = mock(AspectRetriever.class);
+    when(versionedUrnRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    StructuredPropertyDefinition versionedUrnDef = new StructuredPropertyDefinition();
+    versionedUrnDef.setVersion("00000000000001");
+    versionedUrnDef.setValueType(Urn.createFromString(DATA_TYPE_URN_PREFIX + "urn"));
+    versionedUrnDef.setQualifiedName("owner.ref");
+    when(versionedUrnRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(versionedUrnSp)), anySet()))
+        .thenReturn(
+            Map.of(
+                versionedUrnSp,
+                Map.of(
+                    STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+                    new Aspect(versionedUrnDef.data()))));
+
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.owner.ref",
+            false,
+            versionedUrnRetriever),
+        "structuredProperties._versioned.owner_ref.00000000000001.urn");
+  }
+
+  @Test
+  public void testToKeywordFieldVersionedStringAppendsKeywordSuffix() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.ab.fgh.ten",
+            false,
+            aspectRetrieverV1),
+        "structuredProperties._versioned.ab_fgh_ten.00000000000001.string.keyword");
+  }
+
+  @Test
+  public void testToKeywordFieldUnknownValueTypeAppendsKeywordSuffix() throws URISyntaxException {
+    // UNKNOWN follows the STRING-like path (usesKeywordSubfield=true) so filters still target
+    // .keyword.
+    Urn unknownUrn = Urn.createFromString("urn:li:structuredProperty:mystery");
+    AspectRetriever unknownRetriever = mock(AspectRetriever.class);
+    when(unknownRetriever.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
+    StructuredPropertyDefinition unknownDef = new StructuredPropertyDefinition();
+    unknownDef.setVersion(null, SetMode.REMOVE_IF_NULL);
+    unknownDef.setValueType(Urn.createFromString(DATA_TYPE_URN_PREFIX + "other"));
+    unknownDef.setQualifiedName("mystery");
+    when(unknownRetriever.getLatestAspectObjects(
+            any(OperationFingerprint.class), eq(Set.of(unknownUrn)), anySet()))
+        .thenReturn(
+            Map.of(
+                unknownUrn,
+                Map.of(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME, new Aspect(unknownDef.data()))));
+
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.mystery",
+            false,
+            unknownRetriever),
+        "structuredProperties.mystery.keyword");
+  }
+
+  @Test
+  public void testToKeywordFieldNonStructuredPropertyAppendsKeywordSuffix() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class), "myTestField", false, aspectRetriever),
+        "myTestField.keyword");
+  }
+
+  @Test
+  public void testToKeywordFieldSkipKeywordSuffixFlag() {
+    assertEquals(
+        ESUtils.toKeywordField(
+            mock(OperationFingerprint.class),
+            "structuredProperties.ab.fgh.ten",
+            true,
+            aspectRetriever),
+        "structuredProperties.ab_fgh_ten");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Free-form text structured properties (STRING/RICH_TEXT without allowed values) default to CONTAINS in search filters, while preserving master's DescendantsIncl defaults for domains/container/parentDocument
- URN structured properties are queried/faceted on the parent keyword field (same as DATE/NUMBER) via `usesKeywordSubfield`, so filters no longer silently return empty on existing indexes
- On transient structured-property definition lookup misses: prefer the parent field (and strip any caller-supplied `.keyword`); when the caller already passed a versioned ES path, infer type via `getLogicalValueTypeFromFieldName` so STRING still gets `.keyword` and URN/DATE/NUMBER do not
- V3 STRING/RICH_TEXT (and TEXT) mappings include a `.keyword` multi-field so query-time `.keyword` resolution matches the index
- Debounce server-side queries in enum/entity value menus; add focused unit coverage for filter type routing and `toKeywordField`

## Test plan
- [x] `ESUtilsTest` (including direct `toKeywordField` cases: URN/DATE/STRING/UNKNOWN, versioned, lookup miss, miss with `.keyword` suffix)
- [x] `StructuredPropertyUtilsTest` (`usesKeywordSubfield`, versioned-path type inference)
- [x] Frontend `utils.test.tsx` (DescendantsIncl + CONTAINS + `getDynamicFilterField` routing)
- [x] V2/V3 mapping builder tests (URN parent-only; STRING/RICH_TEXT `.keyword` multi-field)
- [ ] Manually: apply a free-form text structured-property filter with a partial UUID and confirm CONTAINS match
- [ ] Manually: filter/facet on a URN-typed structured property and confirm results appear without reindex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes search filters and Elasticsearch resolution for **structured properties**, especially free-form text and URN types.
> 
> **Frontend:** Free-form STRING/RICH_TEXT properties (no `allowedValues`) now route to **TEXT** filters with **CONTAINS** when applied from the dropdown or “More” menu (`getNewFilterCondition`, facet passed from `useSearchFilterDropdown`). ENUM vs TEXT vs ENTITY routing uses the property definition; display formatting only runs `parseFloat` when the type is NUMBER so UUID-like values are not corrupted. Enum/entity pickers **debounce** server autocomplete/aggregation calls; the entity menu avoids flashing unfiltered results while debounce is pending. Text filter menus use resolved display names.
> 
> **Backend:** `usesKeywordSubfield` centralizes when facets/filters use `.keyword` (STRING/RICH_TEXT yes; DATE/NUMBER/URN no). `ESUtils.toKeywordField` and aggregations share that logic, with fallbacks when definition lookup fails or callers pass versioned ES paths (`getLogicalValueTypeFromFieldName`). V3 STRING/RICH_TEXT/TEXT mappings add a **`.keyword` multi-field** with matching `ignore_above`. FQN parsing strips additional ES subfield suffixes.
> 
> **Tests:** Expanded unit coverage on filter utils, `ESUtils`, `StructuredPropertyUtils`, aggregation builder, and mapping builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1cd5fa5851cbe0ae29027b0f6439ce6f6ae92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->