### PR TITLE
docs(cloud): add breaking change for context docs views

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -38,6 +38,7 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 - **Subscriptions inherit notification defaults dynamically.** GraphQL callers that omit `notificationConfig` (or send it without `notificationSettings`) when creating a subscription now leave it configured to use the actor's current notification defaults at delivery time, instead of creating a subscription with no sinks. Send `notificationSettings.sinkTypes: []` explicitly for an intentional no-sink subscription.
 - **Removed `REQUEST_MINIMAL_SLACK_PERMISSIONS`.** Its role is now served by `DATAHUB_SLACK_SERVER_SIDE_HISTORY_ENABLED`, which marks the Slack history scopes as optional in the install screen so admins can deselect them per install. Remove the old variable if set.
 - **Lineage scroll endpoint contract.** `POST /openapi/v3/lineage/scroll` now takes a single `urns` list (replacing the separate source/destination/edge filters); `direction` accepts `UPSTREAM`/`DOWNSTREAM`. No known callers, so no migration is expected.
+- **Context Documents in views scope.** [Context Documents] (https://docs.datahub.com/docs/features/feature-guides/context/context-documents) are now in [views] (https://docs.datahub.com/docs/features/feature-guides/views/overview) scope. In order to see context documents, please update your views to include context documents or update context documents to fit the rules of your view definition (add relevant domains, tags, etc.)
 
 #### New Feature Highlights
 


### PR DESCRIPTION
context documents are now in scope for views. this may cause user confusion why they do not see context documents.  related to https://github.com/acryldata/datahub-fork/pull/10667