### PR TITLE
feat(entity-registry): enforce one aspect per relationship edge signature

### DIFF
--- a/docs/what/relationship.md
+++ b/docs/what/relationship.md
@@ -22,6 +22,16 @@ using generic URN type for the source and destination.
 We also introduce a `@Relationship` [annotation](../modeling/extending-the-metadata-model.md/#relationship) to
 limit the allowed source and destination URN types.
 
+### Aspect ownership uniqueness
+
+Each directed edge signature — `(source entity type, destination entity type, relationship name)` — may be produced by
+**exactly one aspect** on that source entity. Multiple fields within the same aspect may share a signature (for example
+a legacy URN array and a newer Edge array). The same aspect may be attached to many source entity types.
+
+This is enforced when entity specs are built (model / registry load) and again when registries are merged at GMS
+startup — including custom / plugin entity registries. Relationship edge uniqueness failures from plugins are never
+soft-ignored, even when `IGNORE_FAILURE_WHEN_LOADING_ENTITY_REGISTRY_PLUGIN` is true.
+
 While it’s possible to model relationships in rest.li
 as [association resources](https://linkedin.github.io/rest.li/modeling/modeling#association), which often get stored as
 mapping tables, it is far more common to model them as "foreign keys" field in a metadata aspect. For instance,

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpecBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpecBuilder.java
@@ -230,7 +230,10 @@ public class EntitySpecBuilder {
       @Nonnull final List<AspectSpec> aspectSpecs,
       @Nonnull final String searchGroup,
       final boolean viewUnrestricted) {
-    return new ConfigEntitySpec(entityName, keyAspect, aspectSpecs, searchGroup, viewUnrestricted);
+    EntitySpec entitySpec =
+        new ConfigEntitySpec(entityName, keyAspect, aspectSpecs, searchGroup, viewUnrestricted);
+    RelationshipEdgeUniquenessValidator.validate(entitySpec);
+    return entitySpec;
   }
 
   public EntitySpec buildPartialEntitySpec(
@@ -239,6 +242,7 @@ public class EntitySpecBuilder {
       @Nonnull final List<AspectSpec> aspectSpecs) {
     EntitySpec entitySpec =
         new PartialEntitySpec(aspectSpecs, new EntityAnnotation(entityName, keyAspectName));
+    RelationshipEdgeUniquenessValidator.validate(entitySpec);
     return entitySpec;
   }
 

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpecBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpecBuilder.java
@@ -412,6 +412,8 @@ public class EntitySpecBuilder {
       aspectNames.add(aspectSpec.getName());
     }
 
+    RelationshipEdgeUniquenessValidator.validate(entitySpec);
+
     // Validate entity name
     if (_entityNames.contains(entitySpec.getName().toLowerCase())) {
       // Duplicate entity found.

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessValidator.java
@@ -1,0 +1,182 @@
+package com.linkedin.metadata.models;
+
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Value;
+
+/**
+ * Ensures each directed edge signature maps to exactly one aspect:
+ *
+ * <pre>(sourceEntityType, destinationEntityType, relationshipName) → aspectName</pre>
+ *
+ * Multiple fields within the same aspect may share a signature. The same aspect may be registered
+ * on many source entity types. Two different aspects on the same source must not claim the same
+ * destination + relationship name.
+ *
+ * <p>When {@code entityTypes} is empty on a {@code @Relationship}, destination is treated as {@code
+ * *} and conflicts with any other aspect claiming the same source + relationship for any
+ * destination.
+ */
+public final class RelationshipEdgeUniquenessValidator {
+
+  public static final String WILDCARD_DESTINATION = "*";
+
+  private RelationshipEdgeUniquenessValidator() {}
+
+  @Nonnull
+  public static List<Conflict> findConflicts(@Nonnull final EntityRegistry entityRegistry) {
+    List<Conflict> conflicts = new ArrayList<>();
+    for (EntitySpec entitySpec : entityRegistry.getEntitySpecs().values()) {
+      conflicts.addAll(findConflicts(entitySpec));
+    }
+    return conflicts;
+  }
+
+  @Nonnull
+  public static List<Conflict> findConflicts(@Nonnull final EntitySpec entitySpec) {
+    String sourceEntity = normalize(entitySpec.getName());
+    // edge key → first aspect that claimed it
+    Map<EdgeKey, String> owners = new HashMap<>();
+    List<Conflict> conflicts = new ArrayList<>();
+
+    for (AspectSpec aspectSpec : entitySpec.getAspectSpecs()) {
+      String aspectName = aspectSpec.getName();
+      for (RelationshipFieldSpec fieldSpec : aspectSpec.getRelationshipFieldSpecs()) {
+        String relationshipName = fieldSpec.getRelationshipName();
+        List<String> destinations = fieldSpec.getValidDestinationTypes();
+        if (destinations == null || destinations.isEmpty()) {
+          destinations = Collections.singletonList(WILDCARD_DESTINATION);
+        }
+        for (String destination : destinations) {
+          EdgeKey key = new EdgeKey(sourceEntity, normalize(destination), relationshipName);
+          String existingAspect = owners.putIfAbsent(key, aspectName);
+          if (existingAspect != null && !existingAspect.equals(aspectName)) {
+            conflicts.add(
+                new Conflict(
+                    sourceEntity,
+                    key.getDestination(),
+                    relationshipName,
+                    existingAspect,
+                    aspectName));
+          } else if (existingAspect == null) {
+            // Also conflict with wildcard / concrete counterparts across aspects
+            addCrossWildcardConflicts(
+                owners, key, aspectName, conflicts, sourceEntity, relationshipName);
+          }
+        }
+      }
+    }
+    return conflicts;
+  }
+
+  /**
+   * When a concrete dest is claimed, conflict with an existing wildcard claim (and vice versa) from
+   * a different aspect for the same source + relationship.
+   */
+  private static void addCrossWildcardConflicts(
+      Map<EdgeKey, String> owners,
+      EdgeKey newlyClaimed,
+      String aspectName,
+      List<Conflict> conflicts,
+      String sourceEntity,
+      String relationshipName) {
+    if (WILDCARD_DESTINATION.equals(newlyClaimed.getDestination())) {
+      for (Map.Entry<EdgeKey, String> entry : owners.entrySet()) {
+        EdgeKey other = entry.getKey();
+        if (other.equals(newlyClaimed)) {
+          continue;
+        }
+        if (other.getSource().equals(sourceEntity)
+            && other.getRelationshipName().equals(relationshipName)
+            && !WILDCARD_DESTINATION.equals(other.getDestination())
+            && !entry.getValue().equals(aspectName)) {
+          conflicts.add(
+              new Conflict(
+                  sourceEntity,
+                  other.getDestination(),
+                  relationshipName,
+                  entry.getValue(),
+                  aspectName));
+        }
+      }
+    } else {
+      EdgeKey wildcardKey = new EdgeKey(sourceEntity, WILDCARD_DESTINATION, relationshipName);
+      String wildcardOwner = owners.get(wildcardKey);
+      if (wildcardOwner != null && !wildcardOwner.equals(aspectName)) {
+        conflicts.add(
+            new Conflict(
+                sourceEntity,
+                newlyClaimed.getDestination(),
+                relationshipName,
+                wildcardOwner,
+                aspectName));
+      }
+    }
+  }
+
+  public static void validate(@Nonnull final EntitySpec entitySpec) {
+    List<Conflict> conflicts = findConflicts(entitySpec);
+    if (!conflicts.isEmpty()) {
+      throw new ModelValidationException(formatConflicts(entitySpec.getName(), conflicts));
+    }
+  }
+
+  public static void validate(@Nonnull final EntityRegistry entityRegistry) {
+    List<Conflict> conflicts = findConflicts(entityRegistry);
+    if (!conflicts.isEmpty()) {
+      throw new ModelValidationException(formatConflicts("entity-registry", conflicts));
+    }
+  }
+
+  @Nonnull
+  public static String formatConflicts(
+      @Nonnull final String context, @Nonnull final List<Conflict> conflicts) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Relationship edge uniqueness violated for ")
+        .append(context)
+        .append(
+            ". Each (source, destination, relationship) may be owned by only one aspect. Found ")
+        .append(conflicts.size())
+        .append(" conflict(s):\n");
+    for (Conflict conflict : conflicts) {
+      sb.append("  - ")
+          .append(conflict.getSourceEntity())
+          .append(" --")
+          .append(conflict.getRelationshipName())
+          .append("--> ")
+          .append(conflict.getDestinationEntity())
+          .append(" claimed by aspects '")
+          .append(conflict.getFirstAspect())
+          .append("' and '")
+          .append(conflict.getSecondAspect())
+          .append("'\n");
+    }
+    return sb.toString();
+  }
+
+  private static String normalize(@Nonnull final String name) {
+    return name.toLowerCase(Locale.ROOT);
+  }
+
+  @Value
+  private static class EdgeKey {
+    String source;
+    String destination;
+    String relationshipName;
+  }
+
+  @Value
+  public static class Conflict {
+    String sourceEntity;
+    String destinationEntity;
+    String relationshipName;
+    String firstAspect;
+    String secondAspect;
+  }
+}

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/MergedEntityRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/MergedEntityRegistry.java
@@ -11,6 +11,8 @@ import com.linkedin.metadata.models.ConfigEntitySpec;
 import com.linkedin.metadata.models.DefaultEntitySpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.EventSpec;
+import com.linkedin.metadata.models.ModelValidationException;
+import com.linkedin.metadata.models.RelationshipEdgeUniquenessValidator;
 import com.linkedin.metadata.models.annotation.EntityAnnotation;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,6 +84,24 @@ public class MergedEntityRegistry implements EntityRegistry {
               validationResult.validationFailures.stream().collect(Collectors.joining("\n"))));
     }
 
+    // Compute entity merges first and validate relationship uniqueness before mutating
+    // the live maps, so a uniqueness failure leaves the registry unchanged.
+    Map<String, EntitySpec> pendingEntitySpecs = new HashMap<>();
+    for (Map.Entry<String, EntitySpec> e2Entry : patchEntityRegistry.getEntitySpecs().entrySet()) {
+      EntitySpec candidate;
+      if (entityNameToSpec.containsKey(e2Entry.getKey())) {
+        candidate = mergeEntitySpecs(entityNameToSpec.get(e2Entry.getKey()), e2Entry.getValue());
+      } else {
+        candidate = e2Entry.getValue();
+      }
+      try {
+        RelationshipEdgeUniquenessValidator.validate(candidate);
+      } catch (ModelValidationException e) {
+        throw new RelationshipEdgeUniquenessException(e.getMessage());
+      }
+      pendingEntitySpecs.put(e2Entry.getKey(), candidate);
+    }
+
     // Merge Aspect Specs
     // (Fixed issue where custom defined aspects are not included in the API specification.)
     //
@@ -89,23 +109,12 @@ public class MergedEntityRegistry implements EntityRegistry {
       _aspectNameToSpec.putAll(patchEntityRegistry.getAspectSpecs());
     }
 
-    // Merge Entity Specs
-    for (Map.Entry<String, EntitySpec> e2Entry : patchEntityRegistry.getEntitySpecs().entrySet()) {
-      if (entityNameToSpec.containsKey(e2Entry.getKey())) {
-        EntitySpec mergeEntitySpec =
-            mergeEntitySpecs(entityNameToSpec.get(e2Entry.getKey()), e2Entry.getValue());
-        entityNameToSpec.put(e2Entry.getKey(), mergeEntitySpec);
-      } else {
-        // We are inserting a new entity into the registry
-        entityNameToSpec.put(e2Entry.getKey(), e2Entry.getValue());
-      }
-    }
+    entityNameToSpec.putAll(pendingEntitySpecs);
 
     // Merge Event Specs
     if (!patchEntityRegistry.getEventSpecs().isEmpty()) {
       eventNameToSpec.putAll(patchEntityRegistry.getEventSpecs());
     }
-    // TODO: Validate that the entity registries don't have conflicts among each other
 
     // Merge Plugins
     this.pluginFactory =

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoader.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoader.java
@@ -145,6 +145,9 @@ public class PluginEntityRegistryLoader {
                     x.getName(rootDepth).toString(),
                     x.getName(rootDepth + 1).toString(),
                     x.toString());
+              } catch (RelationshipEdgeUniquenessException e) {
+                // Always fail hard: conflicting edge ownership must not be soft-ignored.
+                initFailure.compareAndSet(null, e);
               } catch (Exception | EntityRegistryException e) {
                 if (!ignoreFailureWhenLoadingRegistry) {
                   initFailure.compareAndSet(null, e);
@@ -173,9 +176,12 @@ public class PluginEntityRegistryLoader {
         lock.unlock();
       }
 
-      // propagate failure to the caller
-      if (!ignoreFailureWhenLoadingRegistry && initFailure.get() != null) {
-        throw new RuntimeException("Failed to initialize plugin registry.", initFailure.get());
+      // propagate failure to the caller — uniqueness conflicts always fail hard
+      Throwable failure = initFailure.get();
+      if (failure != null
+          && (failure instanceof RelationshipEdgeUniquenessException
+              || !ignoreFailureWhenLoadingRegistry)) {
+        throw new RuntimeException("Failed to initialize plugin registry.", failure);
       }
     }
     return this;
@@ -221,6 +227,19 @@ public class PluginEntityRegistryLoader {
       loadResultBuilder.plugins(entityRegistry.getPluginFactory().getPluginLoadResult());
 
       log.info("Loaded registry {} successfully", entityRegistry);
+    } catch (RelationshipEdgeUniquenessException e) {
+      log.error(
+          "{}: Failed to load registry {} due to relationship edge uniqueness violation: {}",
+          this,
+          registryName,
+          e.getMessage(),
+          e);
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      e.printStackTrace(pw);
+      loadResultBuilder.loadResult(LoadStatus.FAILURE).failureReason(sw.toString()).failureCount(1);
+      // Always rethrow — soft-ignore must not swallow edge ownership conflicts
+      throw e;
     } catch (Exception | EntityRegistryException e) {
       log.error("{}: Failed to load registry {} with {}", this, registryName, e.getMessage(), e);
       StringWriter sw = new StringWriter();

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/RelationshipEdgeUniquenessException.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/RelationshipEdgeUniquenessException.java
@@ -1,0 +1,8 @@
+package com.linkedin.metadata.models.registry;
+
+/** Thrown when two aspects claim the same directed relationship edge signature. */
+public class RelationshipEdgeUniquenessException extends EntityRegistryException {
+  public RelationshipEdgeUniquenessException(String message) {
+    super(message);
+  }
+}

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessTest.java
@@ -1,0 +1,198 @@
+package com.linkedin.metadata.models;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.StringDataSchema;
+import com.linkedin.data.schema.TyperefDataSchema;
+import com.linkedin.metadata.models.annotation.EntityAnnotation;
+import com.linkedin.metadata.models.annotation.RelationshipAnnotation;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class RelationshipEdgeUniquenessTest {
+
+  @BeforeTest
+  public void disableAssert() {
+    com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(
+            com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor.class
+                .getName(),
+            false);
+  }
+
+  @Test
+  public void testDefaultRegistryHasUniqueRelationshipEdges() {
+    ConfigEntityRegistry configEntityRegistry =
+        new ConfigEntityRegistry(
+            RelationshipEdgeUniquenessTest.class
+                .getClassLoader()
+                .getResourceAsStream("entity-registry.yml"));
+
+    List<RelationshipEdgeUniquenessValidator.Conflict> conflicts =
+        RelationshipEdgeUniquenessValidator.findConflicts(configEntityRegistry);
+
+    assertEquals(
+        conflicts,
+        Collections.emptyList(),
+        RelationshipEdgeUniquenessValidator.formatConflicts("entity-registry.yml", conflicts));
+  }
+
+  @Test
+  public void testSyntheticConflictDetected() {
+    AspectSpec aspectA = aspectWithRelationship("aspectA", "OwnedBy", ImmutableList.of("corpuser"));
+    AspectSpec aspectB = aspectWithRelationship("aspectB", "OwnedBy", ImmutableList.of("corpuser"));
+    EntitySpec entitySpec = new TestEntitySpec("dataset", ImmutableList.of(aspectA, aspectB));
+
+    List<RelationshipEdgeUniquenessValidator.Conflict> conflicts =
+        RelationshipEdgeUniquenessValidator.findConflicts(entitySpec);
+    assertEquals(conflicts.size(), 1);
+    assertEquals(conflicts.get(0).getRelationshipName(), "OwnedBy");
+    assertEquals(conflicts.get(0).getDestinationEntity(), "corpuser");
+    assertEquals(conflicts.get(0).getFirstAspect(), "aspectA");
+    assertEquals(conflicts.get(0).getSecondAspect(), "aspectB");
+
+    ModelValidationException thrown =
+        expectThrows(
+            ModelValidationException.class,
+            () -> RelationshipEdgeUniquenessValidator.validate(entitySpec));
+    assertTrue(thrown.getMessage().contains("OwnedBy"));
+  }
+
+  @Test
+  public void testSameAspectMultipleFieldsAllowed() {
+    AspectSpec aspect =
+        aspectWithRelationships(
+            "ownership",
+            ImmutableList.of(
+                relationshipField("owners", "OwnedBy", ImmutableList.of("corpuser")),
+                relationshipField("ownerEdges", "OwnedBy", ImmutableList.of("corpuser"))));
+    EntitySpec entitySpec = new TestEntitySpec("dataset", ImmutableList.of(aspect));
+    assertEquals(
+        RelationshipEdgeUniquenessValidator.findConflicts(entitySpec), Collections.emptyList());
+  }
+
+  @Test
+  public void testWildcardConflictsWithConcreteDestination() {
+    AspectSpec concrete =
+        aspectWithRelationship("aspectA", "RelatedTo", ImmutableList.of("dataset"));
+    AspectSpec wildcard = aspectWithRelationship("aspectB", "RelatedTo", Collections.emptyList());
+    EntitySpec entitySpec = new TestEntitySpec("chart", ImmutableList.of(concrete, wildcard));
+
+    List<RelationshipEdgeUniquenessValidator.Conflict> conflicts =
+        RelationshipEdgeUniquenessValidator.findConflicts(entitySpec);
+    assertEquals(conflicts.size(), 1);
+    assertEquals(conflicts.get(0).getRelationshipName(), "RelatedTo");
+  }
+
+  private static AspectSpec aspectWithRelationship(
+      String aspectName, String relationshipName, List<String> destTypes) {
+    return aspectWithRelationships(
+        aspectName, ImmutableList.of(relationshipField("field", relationshipName, destTypes)));
+  }
+
+  private static AspectSpec aspectWithRelationships(
+      String aspectName, List<RelationshipFieldSpec> fields) {
+    AspectSpec aspect =
+        new AspectSpec(
+            new com.linkedin.metadata.models.annotation.AspectAnnotation(
+                aspectName, false, false, null, 1L),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            fields,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null,
+            null);
+    return aspect;
+  }
+
+  private static RelationshipFieldSpec relationshipField(
+      String path, String relationshipName, List<String> destTypes) {
+    return new RelationshipFieldSpec(
+        new PathSpec(path),
+        new RelationshipAnnotation(
+            relationshipName, destTypes, true, false, null, null, null, null, null, null),
+        new StringDataSchema());
+  }
+
+  private static class TestEntitySpec implements EntitySpec {
+    private final String name;
+    private final List<AspectSpec> aspectSpecs;
+
+    TestEntitySpec(String name, List<AspectSpec> aspectSpecs) {
+      this.name = name;
+      this.aspectSpecs = aspectSpecs;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public EntityAnnotation getEntityAnnotation() {
+      return new EntityAnnotation(name, "keyAspect");
+    }
+
+    @Override
+    public String getKeyAspectName() {
+      return "keyAspect";
+    }
+
+    @Override
+    public AspectSpec getKeyAspectSpec() {
+      return aspectSpecs.isEmpty() ? null : aspectSpecs.get(0);
+    }
+
+    @Override
+    public List<AspectSpec> getAspectSpecs() {
+      return aspectSpecs;
+    }
+
+    @Override
+    public Map<String, AspectSpec> getAspectSpecMap() {
+      return aspectSpecs.stream().collect(Collectors.toMap(AspectSpec::getName, spec -> spec));
+    }
+
+    @Override
+    public Boolean hasAspect(String aspectName) {
+      return aspectSpecs.stream().anyMatch(spec -> spec.getName().equals(aspectName));
+    }
+
+    @Override
+    public AspectSpec getAspectSpec(String aspectName) {
+      return aspectSpecs.stream()
+          .filter(spec -> spec.getName().equals(aspectName))
+          .findFirst()
+          .orElse(null);
+    }
+
+    @Override
+    public RecordDataSchema getSnapshotSchema() {
+      return null;
+    }
+
+    @Override
+    public TyperefDataSchema getAspectTyperefSchema() {
+      return null;
+    }
+
+    @Override
+    public String getSearchGroup() {
+      return "testGroup";
+    }
+  }
+}

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/RelationshipEdgeUniquenessTest.java
@@ -95,6 +95,52 @@ public class RelationshipEdgeUniquenessTest {
     assertEquals(conflicts.get(0).getRelationshipName(), "RelatedTo");
   }
 
+  @Test
+  public void testBuildConfigEntitySpecRejectsConflictingEdges() {
+    AspectSpec aspectA = aspectWithRelationship("aspectA", "OwnedBy", ImmutableList.of("corpuser"));
+    AspectSpec aspectB = aspectWithRelationship("aspectB", "OwnedBy", ImmutableList.of("corpuser"));
+    EntitySpecBuilder builder = new EntitySpecBuilder();
+
+    ModelValidationException thrown =
+        expectThrows(
+            ModelValidationException.class,
+            () ->
+                builder.buildConfigEntitySpec(
+                    "dataset", "datasetKey", ImmutableList.of(aspectA, aspectB), "primary"));
+    assertTrue(thrown.getMessage().contains("OwnedBy"));
+  }
+
+  @Test
+  public void testBuildPartialEntitySpecRejectsConflictingEdges() {
+    AspectSpec aspectA = aspectWithRelationship("aspectA", "OwnedBy", ImmutableList.of("corpuser"));
+    AspectSpec aspectB = aspectWithRelationship("aspectB", "OwnedBy", ImmutableList.of("corpuser"));
+    EntitySpecBuilder builder = new EntitySpecBuilder();
+
+    ModelValidationException thrown =
+        expectThrows(
+            ModelValidationException.class,
+            () ->
+                builder.buildPartialEntitySpec(
+                    "dataset", "datasetKey", ImmutableList.of(aspectA, aspectB)));
+    assertTrue(thrown.getMessage().contains("OwnedBy"));
+  }
+
+  @Test
+  public void testBuildConfigAndPartialEntitySpecAllowUniqueEdges() {
+    AspectSpec ownership =
+        aspectWithRelationship("ownership", "OwnedBy", ImmutableList.of("corpuser"));
+    EntitySpecBuilder builder = new EntitySpecBuilder();
+
+    EntitySpec configSpec =
+        builder.buildConfigEntitySpec(
+            "dataset", "datasetKey", ImmutableList.of(ownership), "primary");
+    assertEquals(configSpec.getName(), "dataset");
+
+    EntitySpec partialSpec =
+        builder.buildPartialEntitySpec("dataset", "datasetKey", ImmutableList.of(ownership));
+    assertEquals(partialSpec.getName(), "dataset");
+  }
+
   private static AspectSpec aspectWithRelationship(
       String aspectName, String relationshipName, List<String> destTypes) {
     return aspectWithRelationships(

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/registry/RelationshipEdgeUniquenessMergeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/registry/RelationshipEdgeUniquenessMergeTest.java
@@ -1,0 +1,175 @@
+package com.linkedin.metadata.models.registry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.schema.StringDataSchema;
+import com.linkedin.metadata.aspect.patch.template.AspectTemplateEngine;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.ConfigEntitySpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.EventSpec;
+import com.linkedin.metadata.models.RelationshipFieldSpec;
+import com.linkedin.metadata.models.annotation.AspectAnnotation;
+import com.linkedin.metadata.models.annotation.RelationshipAnnotation;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.testng.annotations.Test;
+
+public class RelationshipEdgeUniquenessMergeTest {
+
+  @Test
+  public void testMergeThrowsWhenPatchAddsConflictingRelationshipAspect() throws Exception {
+    AspectSpec baseAspect =
+        aspectWithRelationship("aspectA", "OwnedBy", ImmutableList.of("corpuser"));
+    AspectSpec patchAspect =
+        aspectWithRelationship("aspectB", "OwnedBy", ImmutableList.of("corpuser"));
+
+    EntitySpec baseEntity =
+        new ConfigEntitySpec(
+            "dataset", "datasetKey", ImmutableList.of(keyAspect(), baseAspect), "primary");
+    // Patch only adds the conflicting aspect — omit keyAspect so schema compatibility is not
+    // checked against a null-schema duplicate key aspect.
+    EntitySpec patchEntity =
+        new ConfigEntitySpec("dataset", "datasetKey", ImmutableList.of(patchAspect), "primary");
+
+    MergedEntityRegistry merged = new MergedEntityRegistry(registryOf(baseEntity));
+    RelationshipEdgeUniquenessException thrown =
+        expectThrows(
+            RelationshipEdgeUniquenessException.class, () -> merged.apply(registryOf(patchEntity)));
+    assertTrue(thrown.getMessage().contains("OwnedBy"));
+    // Registry must remain unchanged (only key + base aspect present)
+    assertEquals(merged.getEntitySpec("dataset").getAspectSpecMap().keySet().size(), 2);
+    assertTrue(merged.getEntitySpec("dataset").hasAspect("aspectA"));
+    assertTrue(!merged.getEntitySpec("dataset").hasAspect("aspectB"));
+  }
+
+  @Test
+  public void testMergeSucceedsWhenPatchAddsNonConflictingAspect() throws EntityRegistryException {
+    AspectSpec baseAspect =
+        aspectWithRelationship("aspectA", "OwnedBy", ImmutableList.of("corpuser"));
+    AspectSpec patchAspect =
+        aspectWithRelationship("aspectB", "Consumes", ImmutableList.of("dataset"));
+
+    EntitySpec baseEntity =
+        new ConfigEntitySpec(
+            "dataset", "datasetKey", ImmutableList.of(keyAspect(), baseAspect), "primary");
+    EntitySpec patchEntity =
+        new ConfigEntitySpec("dataset", "datasetKey", ImmutableList.of(patchAspect), "primary");
+
+    MergedEntityRegistry merged = new MergedEntityRegistry(registryOf(baseEntity));
+    merged.apply(registryOf(patchEntity));
+    assertTrue(merged.getEntitySpec("dataset").hasAspect("aspectA"));
+    assertTrue(merged.getEntitySpec("dataset").hasAspect("aspectB"));
+  }
+
+  @Test
+  public void testPluginLoaderAlwaysFailsOnUniquenessEvenWhenIgnoringFailures()
+      throws InterruptedException, EntityRegistryException {
+    MergedEntityRegistry mergedEntityRegistry = mock(MergedEntityRegistry.class);
+    when(mergedEntityRegistry.apply(any(EntityRegistry.class)))
+        .thenThrow(
+            new RelationshipEdgeUniquenessException(
+                "corpgroup --OwnedBy--> corpuser claimed by aspects 'a' and 'b'"));
+
+    PluginEntityRegistryLoader pluginEntityRegistryLoader =
+        new PluginEntityRegistryLoader(TestConstants.BASE_DIRECTORY, 60, true, null)
+            .withBaseRegistry(mergedEntityRegistry);
+
+    try {
+      pluginEntityRegistryLoader.start(true);
+      fail("Expected RuntimeException for relationship edge uniqueness violation");
+    } catch (RuntimeException e) {
+      assertTrue(
+          e.getCause() instanceof RelationshipEdgeUniquenessException,
+          "Expected uniqueness cause, got: " + e.getCause());
+    }
+  }
+
+  private static AspectSpec keyAspect() {
+    return new AspectSpec(
+        new AspectAnnotation("datasetKey", false, false, null, 1L),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null,
+        null);
+  }
+
+  private static AspectSpec aspectWithRelationship(
+      String aspectName, String relationshipName, List<String> destTypes) {
+    RelationshipFieldSpec field =
+        new RelationshipFieldSpec(
+            new PathSpec("field"),
+            new RelationshipAnnotation(
+                relationshipName, destTypes, true, false, null, null, null, null, null, null),
+            new StringDataSchema());
+    return new AspectSpec(
+        new AspectAnnotation(aspectName, false, false, null, 1L),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        ImmutableList.of(field),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null,
+        null);
+  }
+
+  private static EntityRegistry registryOf(EntitySpec entitySpec) {
+    Map<String, EntitySpec> entitySpecs = new HashMap<>();
+    entitySpecs.put(entitySpec.getName().toLowerCase(), entitySpec);
+    return new EntityRegistry() {
+      @Nonnull
+      @Override
+      public EntitySpec getEntitySpec(@Nonnull String entityName) {
+        return entitySpecs.get(entityName.toLowerCase());
+      }
+
+      @Nonnull
+      @Override
+      public EventSpec getEventSpec(@Nonnull String eventName) {
+        throw new IllegalArgumentException(eventName);
+      }
+
+      @Nonnull
+      @Override
+      public Map<String, EntitySpec> getEntitySpecs() {
+        return entitySpecs;
+      }
+
+      @Nonnull
+      @Override
+      public Map<String, AspectSpec> getAspectSpecs() {
+        return new HashMap<>();
+      }
+
+      @Nonnull
+      @Override
+      public Map<String, EventSpec> getEventSpecs() {
+        return Collections.emptyMap();
+      }
+
+      @Nonnull
+      @Override
+      public AspectTemplateEngine getAspectTemplateEngine() {
+        return new AspectTemplateEngine();
+      }
+    };
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
@@ -9,7 +9,8 @@ import com.linkedin.common.AuditStamp
  * Information about a Corp Group ingested from a third party source
  */
 @Aspect = {
-  "name": "corpGroupInfo"
+  "name": "corpGroupInfo",
+  "schemaVersion": 2
 }
 @Aspect.EntityUrns = [ "com.linkedin.common.CorpGroupUrn" ]
 record CorpGroupInfo {
@@ -36,13 +37,8 @@ record CorpGroupInfo {
   /**
    * owners of this group
    * Deprecated! Replaced by Ownership aspect.
+   * Relationship annotation intentionally omitted so OwnedBy edges are owned solely by the ownership aspect.
    */
-  @Relationship = {
-    "/*": {
-      "name": "OwnedBy",
-      "entityTypes": [ "corpuser" ]
-    }
-  }
   @deprecated
   admins: array[CorpuserUrn]
 


### PR DESCRIPTION
## Summary
- Enforce that each directed edge signature `(source entity type, destination entity type, relationship name)` is owned by exactly one aspect
- Validate at entity-spec build time (`EntitySpecBuilder`) and again on registry merge/startup (`MergedEntityRegistry`); plugin loads hard-fail on uniqueness even when soft-ignore is enabled
- Remove the deprecated `corpGroupInfo.admins` `@Relationship OwnedBy` annotation that conflicted with `ownership` (schema version bumped to 2)

## Test plan
- [x] `:entity-registry:spotlessCheck`
- [x] `RelationshipEdgeUniquenessTest` (default registry + synthetic cases)
- [x] `RelationshipEdgeUniquenessMergeTest` (merge conflict/success + plugin hard-fail)
- [x] Full `:entity-registry:test` suite (621 passing during development)
- [ ] Confirm GMS starts cleanly with default registry after rebuild


Made with [Cursor](https://cursor.com)