### PR TITLE
fix(ingest): fail the run when every document fails to process

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -79,6 +79,7 @@ class DataHubDocumentsReport(StatefulIngestionReport):
 
     num_documents_fetched: int = 0
     num_documents_processed: int = 0
+    num_documents_failed: int = 0
     num_documents_skipped: int = 0
     num_documents_skipped_unchanged: int = 0
     num_documents_skipped_empty: int = 0
@@ -98,6 +99,9 @@ class DataHubDocumentsReport(StatefulIngestionReport):
     def report_document_processed(self, num_chunks: int) -> None:
         self.num_documents_processed += 1
         self.num_chunks_created += num_chunks
+
+    def report_document_failed(self) -> None:
+        self.num_documents_failed += 1
 
     def report_document_skipped(self) -> None:
         self.num_documents_skipped += 1
@@ -329,6 +333,25 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             logger.error(f"Failed to run Unstructured pipeline: {e}", exc_info=True)
             self.report.failure(message="Failed to run Unstructured pipeline", exc=e)
         finally:
+            # Every attempted document failing the same way is a systemic problem --
+            # a dependency or environment break -- not per-document data. Without
+            # this the run exits 0 having indexed nothing, and the only trace is a
+            # pile of per-document warnings. Same reasoning as the whole-batch
+            # hydration failure above. Read the chunking source's counter directly:
+            # self.report.num_documents_processed is only populated in get_report(),
+            # so it is still stale here.
+            if (
+                self.report.num_documents_failed > 0
+                and self.chunking_source.report.num_documents_processed == 0
+            ):
+                self.report.failure(
+                    title="Every document failed to process",
+                    message="No document could be processed, so nothing was "
+                    "indexed. This usually means a dependency or environment "
+                    "problem rather than bad document data; see the per-document "
+                    "warnings for the underlying error.",
+                    context=f"attempted={self.report.num_documents_failed}",
+                )
             # Save state after processing
             if self.config.incremental.enabled:
                 self._save_state()
@@ -1506,8 +1529,16 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             if self.chunking_source.report.num_documents_limit_reached:
                 self.report.num_documents_limit_reached = True
                 raise
-            error_msg = f"Failed to process document {doc.get('urn', 'unknown')}: {e}"
-            logger.warning(error_msg, exc_info=True)
+            # Structured rather than a bare logger call: a document that silently
+            # produces no semanticContent is invisible to operators otherwise.
+            self.report.report_document_failed()
+            self.report.warning(
+                title="Failed to process document",
+                message="The document could not be partitioned or chunked, so no "
+                "semanticContent was written for it.",
+                context=doc.get("urn", "unknown"),
+                exc=e,
+            )
 
     def get_report(self) -> SourceReport:
         # Forward stats from the chunking sub-component into our report

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -4222,3 +4222,44 @@ class TestSystemicAbortHandling:
                     list(source._process_event_mode())
 
             assert mock_batch.call_count == 1
+
+
+class TestTotalProcessingFailure:
+    """A run where every attempted document failed is systemic, not bad data."""
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @pytest.fixture
+    def mock_graph(self):
+        return patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        )
+
+    def _run(
+        self, ctx: PipelineContext, failed: int, processed: int
+    ) -> DataHubDocumentsSource:
+        source = DataHubDocumentsSource(ctx, _make_config())
+        with patch.object(source, "_process_batch_mode", return_value=iter([])):
+            source.report.num_documents_failed = failed
+            source.chunking_source.report.num_documents_processed = processed
+            list(source.get_workunits_internal())
+        return source
+
+    def test_all_documents_failed_fails_the_run(self, ctx, mock_graph):
+        # Otherwise the run exits 0 having indexed nothing, and a dependency
+        # break looks identical to "there was nothing to do".
+        with mock_graph:
+            source = self._run(ctx, failed=3, processed=0)
+
+        assert source.report.failures
+
+    def test_partial_failure_does_not_fail_the_run(self, ctx, mock_graph):
+        # Also pins the counter this reads: self.report.num_documents_processed is
+        # only populated in get_report(), so reading it here would still be 0 and
+        # would fail every run that had any per-document error.
+        with mock_graph:
+            source = self._run(ctx, failed=2, processed=5)
+
+        assert not source.report.failures


### PR DESCRIPTION
## Summary

A `datahub-documents` run in which **every attempted document failed** still exited 0 and
reported success, having indexed nothing. The only trace was a bare `logger.warning` per
document, so the failure never reached the structured report, the UI, or the exit code.

A dependency or environment break was therefore indistinguishable from *"there was nothing to
do"* — and typically surfaced weeks later as semantic search quietly returning no results.

## The three gaps

All in the per-document handler in `datahub_documents_source.py`:

1. **Bare `logger.warning`, not `self.report.warning`** — failures were invisible to operators
   outside raw logs.
2. **No counter.** The report has a counter for every *skip* reason
   (`num_documents_skipped`, `_unchanged`, `_empty`, `_existing_embeddings`, `_orphaned`) and
   none for a processing *failure*. It could not express "N documents failed" at all;
   `num_documents_processed: 0` reads identically to an empty run.
3. **No escalation** — `report.failure()` is what drives a non-zero exit via
   `raise_from_status()`; a logger call doesn't touch it.

The inconsistency is stark within the same file: five other sites use
`self.report.failure(...)`, including the whole-batch hydration path that already reasons
*"every URN in the batch failed the same way — a systemic error […] not per-document data.
Abort."* So: fail to **find** documents → hard failure. Fail to **process** every single
document → silent success.

## Changes

- `num_documents_failed` counter and `report_document_failed()`
- Per-document failures go through `self.report.warning(title=…, context=urn, exc=e)` instead
  of a bare logger call
- Fail the run when documents were attempted and **none** succeeded

The escalation is gated on *every* document failing rather than *any* document failing, so a
source with a few genuinely unprocessable documents still succeeds. That deliberately mirrors
the existing whole-batch hydration behaviour.

## One subtlety worth reviewing

The check reads `self.chunking_source.report.num_documents_processed`, **not**
`self.report.num_documents_processed`. The latter is only populated in `get_report()`, so it
is still `0` inside the `finally` block — using it would hard-fail every run that had even a
single per-document error.

`test_partial_failure_does_not_fail_the_run` pins this. Verified by mutation: swapping in the
naive counter makes that test fail, and restoring it makes it pass.

## Verification

```
154 passed          # full tests/unit/test_datahub_documents_source.py
ruff check .        # All checks passed
ruff format --check # 2777 files already formatted
mypy .              # Success: no issues found in 2522 source files
```

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated — two focused behavioural tests; one is mutation-verified
- [x] Docs added/updated — n/a
- [x] Breaking changes documented — see note below

**Behaviour change worth calling out:** a run where every document fails now exits non-zero
instead of 0. That is the point of the change, but anyone whose documents ingestion is
currently failing wholesale will start seeing a red run where they previously saw green. That
is the correct signal, and it is what this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
