### PR TITLE
refactor(ingest): split lineage URN casing processor into a package

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/__init__.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/__init__.py
@@ -1,0 +1,11 @@
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
+    AutoResolveLineageUrnsProcessorReport,
+)
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.processor import (
+    AutoResolveLineageUrnsProcessor,
+)
+
+__all__ = [
+    "AutoResolveLineageUrnsProcessor",
+    "AutoResolveLineageUrnsProcessorReport",
+]

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/bulk.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/bulk.py
@@ -1,0 +1,233 @@
+# NOTE: `from __future__ import annotations` keeps the schema_resolver type hints (imported
+# only under TYPE_CHECKING) as strings. The sqlglot-heavy schema_resolver import is deferred
+# to a single chokepoint in __init__, and the processor imports this module lazily, so
+# neither happens on the module-load path (guarded by
+# test_module_import_does_not_pull_sqlglot).
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set
+
+from datahub.ingestion.api.workunit_processor import WorkunitProcessorContext
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
+    EXACT,
+    NORMALIZED,
+    UNRESOLVED,
+    Resolution,
+)
+from datahub.metadata.urns import DataPlatformUrn, DatasetUrn
+
+if TYPE_CHECKING:
+    from datahub.ingestion.graph.client import DataHubGraph
+    from datahub.ingestion.run.pipeline_config import UpstreamPlatformCasing
+    from datahub.sql_parsing.schema_resolver import SchemaResolver
+
+logger = logging.getLogger(__name__)
+
+# Above this many URNs per platform, the bulk-loaded SchemaResolver cache is large
+# enough to warrant an explicit heads-up to operators rather than letting it surface as
+# unexplained memory pressure.
+_CATALOG_SIZE_WARN_THRESHOLD = 500_000
+
+
+class BulkCatalogStrategy:
+    """Resolve casing against each configured platform's catalog, downloaded up front.
+
+    For every configured upstream platform this bulk-loads that platform's URNs and
+    schemas once (via ``SchemaResolverProvider``) and resolves every reference locally
+    via ``SchemaResolver.resolve_table``, which tries the reference's original,
+    lowercased, and mixed-instance casings (see :meth:`resolve`). No casing index of its
+    own is kept here — matching is entirely delegated to SchemaResolver.
+
+    Casings none of those three candidates reach (an UPPER / Pascal / Mixed-cased table)
+    are unreachable by this strategy and reported UNRESOLVED.
+    """
+
+    def __init__(self, ctx: WorkunitProcessorContext) -> None:
+        self._ctx = ctx
+        graph = ctx.pipeline_context.graph
+        # assert for the type checker; should_enable guarantees a graph exists.
+        assert graph is not None
+        self._graph: DataHubGraph = graph
+        self._config: List[UpstreamPlatformCasing] = (
+            ctx.pipeline_context.flags.auto_resolve_lineage_urns.upstream_platforms
+        )
+        # Resolve the sqlglot-backed schema_resolver callable once, here — a single honest
+        # chokepoint rather than an import buried in a leaf method. Deferred into __init__
+        # (not module level) so importing the processor package stays sqlglot-free;
+        # __init__ runs only after should_enable() confirmed the feature is on. The sqlglot
+        # dependency itself is validated up front by AutoResolveLineageUrnsConfig (fail-fast
+        # at config parse when enabled), so this import is guaranteed to succeed here.
+        from datahub.sql_parsing.schema_resolver_provider import provide_schema_resolver
+
+        self._provide_schema_resolver: Callable[..., SchemaResolver] = (
+            provide_schema_resolver
+        )
+        # Per-platform SchemaResolvers, bulk-initialized up front by _load_catalogs().
+        self._resolvers_by_platform: Dict[str, List[SchemaResolver]] = {}
+        # Platforms actually referenced by this source's lineage, so finish() can flag
+        # configured platforms that no reference used (usually a case/spelling typo).
+        self._seen_reference_platforms: Set[str] = set()
+        self._load_catalogs()
+
+    def _load_catalogs(self) -> None:
+        """Bulk-load every configured platform's SchemaResolver once, up front.
+
+        ``provide_schema_resolver`` does a single bulk scroll per (platform, instance, env)
+        and is globally cached, warming each resolver's schema cache so the per-reference
+        ``resolve_table`` calls in :meth:`resolve` stay local (no per-reference round
+        trips).
+        """
+        entries_by_platform: Dict[str, List[UpstreamPlatformCasing]] = {}
+        for entry in self._config:
+            entries_by_platform.setdefault(entry.platform, []).append(entry)
+
+        for platform, entries in entries_by_platform.items():
+            # Emitted before the (potentially long, paginated) fetch so operators see a
+            # signal during the stall, not only after.
+            logger.info(
+                f"Loading '{platform}' catalog from DataHub for lineage casing "
+                f"reconciliation; this may take a while on large warehouses..."
+            )
+            resolvers: List[SchemaResolver] = []
+            try:
+                for entry in entries:
+                    resolvers.append(
+                        self._provide_schema_resolver(
+                            graph=self._graph,
+                            platform=entry.platform,
+                            platform_instance=entry.platform_instance,
+                            env=entry.env,
+                        )
+                    )
+            except Exception as e:
+                # A catalog-load failure must not crash the pipeline: report it and leave
+                # the platform unloaded, so its references are emitted unchanged.
+                self._ctx.source_report.warning(
+                    title="Lineage URN casing: upstream catalog not loaded",
+                    message="Failed to bulk-load an upstream platform's catalog from "
+                    "DataHub; references to it are emitted unchanged.",
+                    context=platform,
+                    exc=e,
+                )
+                continue
+            # The resolver caches are held for the pipeline's lifetime; log their size,
+            # escalating to WARNING once large enough to matter.
+            count = sum(len(r.get_urns()) for r in resolvers)
+            message = (
+                f"Loaded {count} '{platform}' dataset URNs for lineage casing "
+                f"reconciliation."
+            )
+            if count > _CATALOG_SIZE_WARN_THRESHOLD:
+                logger.warning(
+                    f"{message} This is a large catalog and may use significant memory; "
+                    f"consider narrowing upstream_platforms (platform_instance / env) to "
+                    f"the assets this source references."
+                )
+            else:
+                logger.info(message)
+            self._resolvers_by_platform[platform] = resolvers
+
+    @staticmethod
+    def _strip_platform_instance(name: str, platform_instance: Optional[str]) -> str:
+        # A dataset URN name fuses any platform_instance as a leading ``<instance>.``
+        # prefix; resolve_table re-prepends the resolver's instance, so strip it here
+        # (matched case-insensitively, since that prefix's own casing may differ) to avoid
+        # a doubled prefix.
+        if platform_instance and name.lower().startswith(
+            f"{platform_instance.lower()}."
+        ):
+            return name[len(platform_instance) + 1 :]
+        return name
+
+    def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution:
+        """Resolve `urn` to the casing DataHub already stores, via SchemaResolver.
+
+        ``need_schema`` is ignored: the bulk catalog already holds every schema it loaded,
+        so a schema costs nothing extra here.
+
+        Delegates matching to ``SchemaResolver.resolve_table``, which tries three casing
+        candidates for the reference and returns the first that exists in DataHub:
+
+        1. **original** — the reference's name exactly as given.
+        2. **lowercased** — name *and* platform_instance lowercased.
+        3. **mixed** — name lowercased but the platform_instance's casing kept.
+
+        (2) and (3) differ only when a platform_instance has non-lowercase casing. Example,
+        instance ``ProdWarehouse`` stored as ``ProdWarehouse.db.schema.table``, reference
+        ``ProdWarehouse.DB.SCHEMA.TABLE``: (1) misses (table cased wrong), (2) misses
+        (instance lowercased to ``prodwarehouse``), (3) matches.
+
+        A hit under the reference's own casing is EXACT; a hit under a different candidate
+        is NORMALIZED; no hit is UNRESOLVED. The resolved entity's schema is returned too,
+        for column-casing correction.
+        """
+        try:
+            dataset_urn = DatasetUrn.from_string(urn)
+            platform = DataPlatformUrn.from_string(dataset_urn.platform).platform_name
+        except Exception:
+            return Resolution(urn, None, None)
+        # Track referenced platforms so finish() can flag configured platforms that no
+        # reference used (usually a case/spelling typo in the config).
+        self._seen_reference_platforms.add(platform)
+        resolvers = self._resolvers_by_platform.get(platform)
+        if not resolvers:
+            return Resolution(urn, None, None)
+
+        name = dataset_urn.name
+        # A platform can have several configured resolvers (one per platform_instance /
+        # env); we iterate and take the first schema match. We deliberately don't index by
+        # platform_instance because it isn't recoverable from the URN — it's fused into the
+        # name, and separating it would require fetching the dataPlatformInstance aspect
+        # (overkill). env *is* recoverable from the URN, so we could additionally
+        # disambiguate on it (e.g. avoid healing a PROD ref to a DEV entity), but that
+        # collision is unlikely in practice, so it's left as a possible follow-up.
+        for resolver in resolvers:
+            table = self._strip_platform_instance(name, resolver.platform_instance)
+            try:
+                # We pass the whole name as `table` and rely on get_urn_for_table
+                # concatenating the parts back into the name. This leans on SchemaResolver
+                # internals and is a bit fragile (get_urn_for_table carries a TODO about
+                # 2/3-layer hierarchy).
+                resolved_urn, schema = resolver.resolve_table_parts(
+                    database=None, db_schema=None, table=table
+                )
+            except Exception:
+                continue
+            # resolve_table returns a best-effort URN even on a miss; a non-None schema is
+            # the signal that an existing entity actually matched.
+            if schema is not None:
+                match_type = EXACT if resolved_urn == urn else NORMALIZED
+                return Resolution(resolved_urn, schema, match_type)
+        # On a configured platform but no existing entity matched under a casing
+        # resolve_table covers: leave the URN unchanged but flag it UNRESOLVED so
+        # potentially broken lineage is visible rather than indistinguishable from clean.
+        return Resolution(urn, None, UNRESOLVED)
+
+    def finish(self) -> None:
+        """Surface configured platforms that no reference used, in the pipeline report.
+
+        The usual cause is a case/spelling mismatch in the config (platform names are
+        compared case-sensitively). Emitting it as a structured (UI-visible) warning lets
+        the operator either fix the platform name or drop the platform if it isn't
+        actually referenced by this source.
+        """
+        # Defense in depth: this runs outside the per-workunit try/except, so guard
+        # against a non-list config (should_enable already fails closed on a mock ctx).
+        if not isinstance(self._config, list):
+            return
+        unmatched = {
+            entry.platform for entry in self._config
+        } - self._seen_reference_platforms
+        if not unmatched:
+            return
+        self._ctx.source_report.warning(
+            title="Configured upstream platform matched no lineage references",
+            message="An upstream platform configured under auto_resolve_lineage_urns was "
+            "not referenced by any lineage in this run, so nothing was reconciled for it. "
+            "Platform names are matched case-sensitively against the dataset URN's "
+            "platform (e.g. 'snowflake', not 'Snowflake') — fix the name if it's a typo, "
+            "or remove the platform from upstream_platforms if this source doesn't "
+            "reference it.",
+            context=f"{sorted(unmatched)}",
+        )

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/models.py
@@ -1,0 +1,77 @@
+# NOTE: `from __future__ import annotations` keeps the SchemaInfo type hint (imported only
+# under TYPE_CHECKING) as a string, so importing this module does not pull in sqlglot. This
+# module is reachable from every source's get_workunit_processors() path, so module load
+# must stay sqlglot-free (guarded by test_module_import_does_not_pull_sqlglot).
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional, Protocol
+
+from datahub.ingestion.api.workunit_processor import WorkunitProcessorReport
+from datahub.metadata.schema_classes import LineageMatchTypeClass
+from datahub.utilities.lossy_collections import LossyList
+
+if TYPE_CHECKING:
+    from datahub.sql_parsing.schema_resolver import SchemaInfo
+
+# The closed set of matchType verdicts, as a Literal so the if/elif verdict chains that
+# drive correctness can be typo- and exhaustiveness-checked. LineageMatchTypeClass
+# renders these as plain ``str`` (codegen), so we bind Literal-typed aliases and assert
+# they stay in sync with the generated class.
+MatchType = Literal["EXACT", "NORMALIZED", "UNRESOLVED"]
+EXACT: MatchType = "EXACT"
+NORMALIZED: MatchType = "NORMALIZED"
+UNRESOLVED: MatchType = "UNRESOLVED"
+assert (EXACT, NORMALIZED, UNRESOLVED) == (
+    LineageMatchTypeClass.EXACT,
+    LineageMatchTypeClass.NORMALIZED,
+    LineageMatchTypeClass.UNRESOLVED,
+), "MatchType literals drifted from LineageMatchTypeClass"
+
+
+@dataclass
+class AutoResolveLineageUrnsProcessorReport(WorkunitProcessorReport):
+    """Report for AutoResolveLineageUrnsProcessor metrics."""
+
+    num_dataset_urns_normalized: int = 0  # Upstream dataset URNs rewritten
+    num_column_urns_normalized: int = 0  # Fine-grained field URNs rewritten
+    num_refs_unchanged: int = 0  # Left as-is (exact match, or out of scope)
+    num_refs_unresolved: int = 0  # In scope, no unique match (flagged)
+    num_exceptions: int = 0  # Failed to process a workunit
+    # Lineage aspect emitted as a PATCH (not UPSERT); can't be reconciled, so skipped.
+    num_patch_lineage_skipped: int = 0
+    num_workunits_with_lineage_aspect: int = 0
+    num_workunits_modified: int = 0
+    # Bounded sample of references left UNRESOLVED, alongside the num_refs_unresolved
+    # count, so the report shows *which* lineage looks broken, not just how much.
+    unresolved_refs_sample: LossyList[str] = field(default_factory=LossyList)
+
+
+@dataclass
+class Resolution:
+    """Outcome of resolving one dataset URN against the entities DataHub already stores."""
+
+    urn: str  # The (possibly rewritten) URN to emit.
+    schema: Optional[SchemaInfo]  # Schema of the resolved entity, if known.
+    # EXACT / NORMALIZED / UNRESOLVED / None (no reconciliation performed).
+    match_type: Optional[MatchType]
+
+
+class ResolutionStrategy(Protocol):
+    """How the processor turns a reference URN into the URN DataHub actually stores.
+
+    Implementations differ only in where the answer comes from; the processor's rewrite
+    and reporting logic is identical either way.
+    """
+
+    def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution:
+        """Resolve one upstream reference.
+
+        ``need_schema`` is set only on the column-level path, so a strategy that pays per
+        schema fetch can skip it for table-level-only references.
+        """
+        ...
+
+    def finish(self) -> None:
+        """Emit end-of-run reporting that only this strategy can produce."""
+        ...

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
@@ -1,22 +1,17 @@
-# NOTE: `from __future__ import annotations` keeps the schema_resolver type hints
-# (imported only under TYPE_CHECKING) as strings, so importing this module does not
-# pull in sqlglot. This module is imported eagerly on every source's
-# get_workunit_processors() path, so module load must stay sqlglot-free (guarded by
-# test_module_import_does_not_pull_sqlglot). The sqlglot-heavy schema_resolver imports
-# are therefore deferred to a single chokepoint in __init__, which runs only after
-# should_enable() confirms the feature is on and a graph exists — off the module-load
-# path, but honest about the dependency (see __init__).
+# NOTE: `from __future__ import annotations` keeps the schema_resolver type hints (imported
+# only under TYPE_CHECKING) as strings, so importing this module does not pull in sqlglot.
+# This module is imported eagerly on every source's get_workunit_processors() path, so
+# module load must stay sqlglot-free (guarded by test_module_import_does_not_pull_sqlglot).
+# The sqlglot-heavy imports are therefore deferred: match_columns_to_schema to a chokepoint
+# in __init__, and the strategy module to the same place — both run only after
+# should_enable() confirms the feature is on and a graph exists.
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Callable,
-    Dict,
     Iterable,
     List,
-    Literal,
     Optional,
     Set,
     Tuple,
@@ -35,7 +30,15 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.api.workunit_processor import (
     WorkunitProcessor,
     WorkunitProcessorContext,
-    WorkunitProcessorReport,
+)
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
+    EXACT,
+    NORMALIZED,
+    UNRESOLVED,
+    AutoResolveLineageUrnsProcessorReport,
+    MatchType,
+    Resolution,
+    ResolutionStrategy,
 )
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
@@ -44,69 +47,15 @@ from datahub.metadata.schema_classes import (
     DataJobInputOutputClass,
     EdgeClass,
     FineGrainedLineageClass,
-    LineageMatchTypeClass,
     MetadataChangeProposalClass,
     UpstreamLineageClass,
     _Aspect,
 )
-from datahub.metadata.urns import DataPlatformUrn, DatasetUrn, SchemaFieldUrn
-from datahub.utilities.lossy_collections import LossyList
+from datahub.metadata.urns import DatasetUrn, SchemaFieldUrn
 from datahub.utilities.urns.error import InvalidUrnError
 
 if TYPE_CHECKING:
-    from datahub.ingestion.graph.client import DataHubGraph
-    from datahub.ingestion.run.pipeline_config import UpstreamPlatformCasing
-    from datahub.sql_parsing.schema_resolver import SchemaInfo, SchemaResolver
-
-logger = logging.getLogger(__name__)
-
-# Above this many URNs per platform, the bulk-loaded SchemaResolver cache is large
-# enough to warrant an explicit heads-up to operators rather than letting it surface as
-# unexplained memory pressure. (A disk-backed, casing-aware resolver owned by
-# SchemaResolver is the planned follow-up; see the normalizedUrn backlog task.)
-_CATALOG_SIZE_WARN_THRESHOLD = 500_000
-
-# The closed set of matchType verdicts, as a Literal so the if/elif verdict chains that
-# drive correctness can be typo- and exhaustiveness-checked. LineageMatchTypeClass
-# renders these as plain ``str`` (codegen), so we bind Literal-typed aliases and assert
-# they stay in sync with the generated class.
-MatchType = Literal["EXACT", "NORMALIZED", "UNRESOLVED"]
-_EXACT: MatchType = "EXACT"
-_NORMALIZED: MatchType = "NORMALIZED"
-_UNRESOLVED: MatchType = "UNRESOLVED"
-assert (_EXACT, _NORMALIZED, _UNRESOLVED) == (
-    LineageMatchTypeClass.EXACT,
-    LineageMatchTypeClass.NORMALIZED,
-    LineageMatchTypeClass.UNRESOLVED,
-), "MatchType literals drifted from LineageMatchTypeClass"
-
-
-@dataclass
-class AutoResolveLineageUrnsProcessorReport(WorkunitProcessorReport):
-    """Report for AutoResolveLineageUrnsProcessor metrics."""
-
-    num_dataset_urns_normalized: int = 0  # Upstream dataset URNs rewritten
-    num_column_urns_normalized: int = 0  # Fine-grained field URNs rewritten
-    num_refs_unchanged: int = 0  # Left as-is (exact match, or out of scope)
-    num_refs_unresolved: int = 0  # Configured platform, no unique match (flagged)
-    num_exceptions: int = 0  # Failed to process a workunit
-    # Lineage aspect emitted as a PATCH (not UPSERT); can't be reconciled, so skipped.
-    num_patch_lineage_skipped: int = 0
-    num_workunits_with_lineage_aspect: int = 0
-    num_workunits_modified: int = 0
-    # Bounded sample of references left UNRESOLVED, alongside the num_refs_unresolved
-    # count, so the report shows *which* lineage looks broken, not just how much.
-    unresolved_refs_sample: LossyList[str] = field(default_factory=LossyList)
-
-
-@dataclass
-class _Resolution:
-    """Outcome of resolving one dataset URN against the configured platform(s)."""
-
-    urn: str  # The (possibly rewritten) URN to emit.
-    schema: Optional[SchemaInfo]  # Cached schema of the resolved entity, if known.
-    # EXACT / NORMALIZED / UNRESOLVED / None (no reconciliation performed).
-    match_type: Optional[MatchType]
+    from datahub.sql_parsing.schema_resolver import SchemaInfo
 
 
 def _parent_dataset_urn(field_urn: str) -> Optional[str]:
@@ -160,60 +109,35 @@ class AutoResolveLineageUrnsProcessor(
 
     Heals casing mismatches between sources (e.g. a lowercase-stored Snowflake table
     referenced in a different casing by a BI tool) that would otherwise create two
-    disconnected lineage nodes. For each configured upstream platform it bulk-loads that
-    platform's URNs and schemas once (via ``SchemaResolverProvider``) and resolves every
-    reference locally via ``SchemaResolver.resolve_table`` (which tries the original,
-    lowercased, and mixed-instance casings — see ``_resolve_dataset``) against the casing
-    DataHub already stores — table-level (``UpstreamLineage``,
-    ``DashboardInfo``) and column-level (``FineGrainedLineage`` field paths). Broader
-    any-casing resolution is a tracked SchemaResolver follow-up (the ``normalizedUrn``
-    aspect).
+    disconnected lineage nodes. Reconciliation covers table-level (``UpstreamLineage``,
+    ``DashboardInfo``, ``ChartInfo``, ``DataJobInputOutput``) and column-level
+    (``FineGrainedLineage`` field paths) references.
 
-    Only references *to* warehouse assets found in this source's metadata are fixed;
-    the entity the aspect is attached to and downstream fields are never touched. It
-    must be enabled on BI-tool / cross-platform ingestions and configured with the
-    upstream platform(s) — never on the warehouse ingestion, whose reported casing and
-    identity must be respected.
+    Finding the URN DataHub actually stores is delegated to a :class:`ResolutionStrategy`;
+    this class owns everything that is the same regardless of how a reference resolves —
+    which aspects carry upstream references, how they are rewritten, and how verdicts are
+    counted and reported.
+
+    Only references *to* warehouse assets are fixed; the entity the aspect is attached to
+    and downstream fields are never touched. It must be enabled on BI-tool / cross-platform
+    ingestions — never on the warehouse ingestion, whose reported casing and identity must
+    be respected.
     """
 
     def __init__(self, ctx: WorkunitProcessorContext) -> None:
         super().__init__(ctx)
-        graph = ctx.pipeline_context.graph
-        # assert for the type checker.
-        assert graph is not None
-        self._graph: DataHubGraph = graph
-        self._config: List[UpstreamPlatformCasing] = (
-            ctx.pipeline_context.flags.auto_resolve_lineage_urns.upstream_platforms
+        # Deferred imports, for the same reason the module docstring gives: both of these
+        # reach sqlglot-backed code, and this __init__ runs only once should_enable() has
+        # confirmed the feature is on.
+        from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.bulk import (
+            BulkCatalogStrategy,
         )
-        # Resolve the sqlglot-backed schema_resolver callables once, here — a single
-        # honest chokepoint rather than imports buried in two leaf methods. Deferred into
-        # __init__ (not module level) so importing this module stays sqlglot-free
-        # (guarded by test_module_import_does_not_pull_sqlglot); __init__ runs only after
-        # should_enable() confirmed the feature is on. The sqlglot dependency itself is
-        # validated up front by AutoResolveLineageUrnsConfig (fail-fast at config parse
-        # when enabled), so these imports are guaranteed to succeed here.
         from datahub.sql_parsing.schema_resolver import match_columns_to_schema
-        from datahub.sql_parsing.schema_resolver_provider import provide_schema_resolver
 
-        self._provide_schema_resolver: Callable[..., SchemaResolver] = (
-            provide_schema_resolver
-        )
         self._match_columns_to_schema: Callable[[SchemaInfo, List[str]], List[str]] = (
             match_columns_to_schema
         )
-        # Per-platform SchemaResolvers, bulk-initialized up front by _load_catalogs().
-        # Casing matching is delegated to SchemaResolver.resolve_table (which tries the
-        # reference's original, lowercased, and mixed-instance casings — see
-        # _resolve_dataset) — the processor keeps no parallel casing index of its own.
-        # Broader casing coverage (a non-lowercase table stored as Pascal / Mixed /
-        # arbitrary) and casing-aware resolution are a tracked SchemaResolver follow-up
-        # (the planned `normalizedUrn` aspect). Until that lands, only casings resolve_table
-        # covers are reconciled here.
-        self._resolvers_by_platform: Dict[str, List["SchemaResolver"]] = {}
-        # Platforms actually referenced by this source's lineage, so
-        # _warn_unmatched_platforms can flag configured platforms that no reference used
-        # (usually a case/spelling typo in the config).
-        self._seen_reference_platforms: Set[str] = set()
+        self._strategy: ResolutionStrategy = BulkCatalogStrategy(ctx)
         # (aspect class -> in-place normalizer, returns True iff it mutated the aspect).
         # These are the aspects a BI / orchestration source emits that carry *upstream
         # dataset* references — the only refs affected by cross-source casing mismatch:
@@ -224,7 +148,7 @@ class AutoResolveLineageUrnsProcessor(
         # check for MCE/MCPW (live aspect) and, for a raw MCP, short-circuits on aspectName
         # before any deserialization — so a work unit is deserialized at most once (for the
         # aspect it actually carries), and covering four vs. one adds only three constant
-        # comparisons. The one real cost, the up-front catalog load, is independent of this.
+        # comparisons.
         # Callable[..., bool] (not Callable[[_Aspect], bool]): each normalizer takes a
         # specific aspect subtype, and function args are contravariant, so the precise
         # signature won't accept them in a heterogeneous table (mypy list-item error).
@@ -239,7 +163,6 @@ class AutoResolveLineageUrnsProcessor(
         self._lineage_aspect_names: Set[str] = {
             aspect_cls.ASPECT_NAME for aspect_cls, _ in self._normalizers
         }
-        self._load_catalogs()
 
     @classmethod
     def should_enable(cls, ctx: WorkunitProcessorContext) -> bool:
@@ -277,7 +200,7 @@ class AutoResolveLineageUrnsProcessor(
                     exc=e,
                 )
             yield wu
-        self._warn_unmatched_platforms()
+        self._strategy.finish()
         self._warn_unresolved_refs()
         self._warn_patch_lineage_skipped()
 
@@ -316,34 +239,6 @@ class AutoResolveLineageUrnsProcessor(
             if normalize(aspect):
                 self._write_back_if_mcp(wu, aspect)
                 self.report.num_workunits_modified += 1
-
-    def _warn_unmatched_platforms(self) -> None:
-        """Surface configured platforms that no reference used, in the pipeline report.
-
-        The usual cause is a case/spelling mismatch in the config (platform names are
-        compared case-sensitively). Emitting it as a structured (UI-visible) warning lets
-        the operator either fix the platform name or drop the platform if it isn't
-        actually referenced by this source.
-        """
-        # Defense in depth: this runs outside the per-workunit try/except, so guard
-        # against a non-list config (should_enable already fails closed on a mock ctx).
-        if not isinstance(self._config, list):
-            return
-        unmatched = {
-            entry.platform for entry in self._config
-        } - self._seen_reference_platforms
-        if not unmatched:
-            return
-        self.ctx.source_report.warning(
-            title="Configured upstream platform matched no lineage references",
-            message="An upstream platform configured under auto_resolve_lineage_urns was "
-            "not referenced by any lineage in this run, so nothing was reconciled for it. "
-            "Platform names are matched case-sensitively against the dataset URN's "
-            "platform (e.g. 'snowflake', not 'Snowflake') — fix the name if it's a typo, "
-            "or remove the platform from upstream_platforms if this source doesn't "
-            "reference it.",
-            context=f"{sorted(unmatched)}",
-        )
 
     def _warn_unresolved_refs(self) -> None:
         """Surface UNRESOLVED references in the pipeline report, once, aggregated.
@@ -394,160 +289,22 @@ class AutoResolveLineageUrnsProcessor(
         if isinstance(wu.metadata, MetadataChangeProposalClass):
             wu.metadata.aspect = _make_generic_aspect(aspect)
 
-    # --- resolution -------------------------------------------------------------
-
-    def _load_catalogs(self) -> None:
-        """Bulk-load every configured platform's SchemaResolver once, up front.
-
-        ``provide_schema_resolver`` does a single bulk scroll per (platform, instance, env)
-        and is globally cached, warming each resolver's schema cache so the per-reference
-        ``resolve_table`` calls in _resolve_dataset stay local (no per-reference round
-        trips). Matching itself is delegated to SchemaResolver; this processor keeps no
-        casing index of its own.
-        """
-        entries_by_platform: Dict[str, List["UpstreamPlatformCasing"]] = {}
-        for entry in self._config:
-            entries_by_platform.setdefault(entry.platform, []).append(entry)
-
-        for platform, entries in entries_by_platform.items():
-            # Emitted before the (potentially long, paginated) fetch so operators see a
-            # signal during the stall, not only after.
-            logger.info(
-                f"Loading '{platform}' catalog from DataHub for lineage casing "
-                f"reconciliation; this may take a while on large warehouses..."
-            )
-            resolvers: List[SchemaResolver] = []
-            try:
-                for entry in entries:
-                    resolvers.append(
-                        self._provide_schema_resolver(
-                            graph=self._graph,
-                            platform=entry.platform,
-                            platform_instance=entry.platform_instance,
-                            env=entry.env,
-                        )
-                    )
-            except Exception as e:
-                # A catalog-load failure must not crash the pipeline: report it and leave
-                # the platform unloaded, so its references are emitted unchanged.
-                self.ctx.source_report.warning(
-                    title="Lineage URN casing: upstream catalog not loaded",
-                    message="Failed to bulk-load an upstream platform's catalog from "
-                    "DataHub; references to it are emitted unchanged.",
-                    context=platform,
-                    exc=e,
-                )
-                continue
-            # The resolver caches are held for the pipeline's lifetime; log their size,
-            # escalating to WARNING once large enough to matter.
-            count = sum(len(r.get_urns()) for r in resolvers)
-            message = (
-                f"Loaded {count} '{platform}' dataset URNs for lineage casing "
-                f"reconciliation."
-            )
-            if count > _CATALOG_SIZE_WARN_THRESHOLD:
-                logger.warning(
-                    f"{message} This is a large catalog and may use significant memory; "
-                    f"consider narrowing upstream_platforms (platform_instance / env) to "
-                    f"the assets this source references."
-                )
-            else:
-                logger.info(message)
-            self._resolvers_by_platform[platform] = resolvers
-
-    @staticmethod
-    def _strip_platform_instance(name: str, platform_instance: Optional[str]) -> str:
-        # A dataset URN name fuses any platform_instance as a leading ``<instance>.``
-        # prefix; resolve_table re-prepends the resolver's instance, so strip it here
-        # (matched case-insensitively, since that prefix's own casing may differ) to avoid
-        # a doubled prefix.
-        if platform_instance and name.lower().startswith(
-            f"{platform_instance.lower()}."
-        ):
-            return name[len(platform_instance) + 1 :]
-        return name
-
-    def _resolve_dataset(self, urn: str) -> _Resolution:
-        """Resolve `urn` to the casing DataHub already stores, via SchemaResolver.
-
-        Delegates matching to ``SchemaResolver.resolve_table``, which tries three casing
-        candidates for the reference and returns the first that exists in DataHub:
-
-        1. **original** — the reference's name exactly as given.
-        2. **lowercased** — name *and* platform_instance lowercased.
-        3. **mixed** — name lowercased but the platform_instance's casing kept.
-
-        (2) and (3) differ only when a platform_instance has non-lowercase casing. Example,
-        instance ``ProdWarehouse`` stored as ``ProdWarehouse.db.schema.table``, reference
-        ``ProdWarehouse.DB.SCHEMA.TABLE``: (1) misses (table cased wrong), (2) misses
-        (instance lowercased to ``prodwarehouse``), (3) matches.
-
-        A hit under the reference's own casing is EXACT; a hit under a different candidate
-        is NORMALIZED; no hit is UNRESOLVED — the latter includes casings none of the three
-        candidates reach (e.g. an UPPER/Pascal/Mixed-cased *table* in the warehouse), which
-        are the tracked ``normalizedUrn`` SchemaResolver follow-up. The resolved entity's
-        schema is returned too, for column-casing correction.
-        """
-        try:
-            dataset_urn = DatasetUrn.from_string(urn)
-            platform = DataPlatformUrn.from_string(dataset_urn.platform).platform_name
-        except Exception:
-            return _Resolution(urn, None, None)
-        # Track referenced platforms so _warn_unmatched_platforms can flag configured
-        # platforms that no reference used (usually a case/spelling typo in the config).
-        self._seen_reference_platforms.add(platform)
-        resolvers = self._resolvers_by_platform.get(platform)
-        if not resolvers:
-            return _Resolution(urn, None, None)
-
-        name = dataset_urn.name
-        # A platform can have several configured resolvers (one per platform_instance /
-        # env); we iterate and take the first schema match. We deliberately don't index by
-        # platform_instance because it isn't recoverable from the URN — it's fused into the
-        # name, and separating it would require fetching the dataPlatformInstance aspect
-        # (overkill). env *is* recoverable from the URN, so we could additionally
-        # disambiguate on it (e.g. avoid healing a PROD ref to a DEV entity), but that
-        # collision is unlikely in practice, so it's left as a possible follow-up.
-        for resolver in resolvers:
-            table = self._strip_platform_instance(name, resolver.platform_instance)
-            try:
-                # We pass the whole name as `table` and rely on get_urn_for_table
-                # concatenating the parts back into the name. This leans on SchemaResolver
-                # internals and is a bit fragile (get_urn_for_table carries a TODO about
-                # 2/3-layer hierarchy). A read-only resolve_dataset_urn(urn) helper on
-                # SchemaResolver is a tracked follow-up (additive, separate from the
-                # normalizedUrn work).
-                resolved_urn, schema = resolver.resolve_table_parts(
-                    database=None, db_schema=None, table=table
-                )
-            except Exception:
-                continue
-            # resolve_table returns a best-effort URN even on a miss; a non-None schema is
-            # the signal that an existing entity actually matched.
-            if schema is not None:
-                match_type = _EXACT if resolved_urn == urn else _NORMALIZED
-                return _Resolution(resolved_urn, schema, match_type)
-        # On a configured platform but no existing entity matched under a casing
-        # resolve_table covers: leave the URN unchanged but flag it UNRESOLVED so
-        # potentially broken lineage is visible rather than indistinguishable from clean.
-        self.report.unresolved_refs_sample.append(urn)
-        return _Resolution(urn, None, _UNRESOLVED)
-
     # --- aspect rewriters -------------------------------------------------------
     #
     # Each returns True iff it mutated the aspect (rewrote a reference or stamped a
     # matchType), so process() can skip the raw-MCP re-serialization when nothing in the
     # aspect was in scope.
 
-    def _tally_table_ref(self, res: _Resolution) -> bool:
+    def _tally_table_ref(self, res: Resolution) -> bool:
         """Record report counters for a table-level reference; return True iff it was
         normalized (so the caller can rewrite the URN). Shared by the three table-level
         paths; the column-level path (_resolve_field_urn) counts separately."""
-        if res.match_type == _NORMALIZED:
+        if res.match_type == NORMALIZED:
             self.report.num_dataset_urns_normalized += 1
             return True
-        if res.match_type == _UNRESOLVED:
+        if res.match_type == UNRESOLVED:
             self.report.num_refs_unresolved += 1
+            self.report.unresolved_refs_sample.append(res.urn)
         else:
             self.report.num_refs_unchanged += 1
         return False
@@ -558,10 +315,9 @@ class AutoResolveLineageUrnsProcessor(
             dataset = getattr(upstream, "dataset", None)
             if not _is_dataset_urn(dataset):
                 continue
-            res = self._resolve_dataset(dataset)
-            # Stamp the verdict (EXACT / NORMALIZED / UNRESOLVED) for any reference on
-            # a configured platform; out-of-scope refs get res.match_type=None and are
-            # left untouched.
+            res = self._strategy.resolve(dataset)
+            # Stamp the verdict (EXACT / NORMALIZED / UNRESOLVED) for any reference in
+            # scope; out-of-scope refs get res.match_type=None and are left untouched.
             if res.match_type is not None:
                 upstream.matchType = res.match_type
                 changed = True
@@ -601,12 +357,12 @@ class AutoResolveLineageUrnsProcessor(
         # field couldn't be matched) > EXACT (all verified). Absent only when every
         # field was out of scope.
         aggregate: Optional[str] = None
-        if _NORMALIZED in match_types:
-            aggregate = _NORMALIZED
-        elif _UNRESOLVED in match_types:
-            aggregate = _UNRESOLVED
-        elif _EXACT in match_types:
-            aggregate = _EXACT
+        if NORMALIZED in match_types:
+            aggregate = NORMALIZED
+        elif UNRESOLVED in match_types:
+            aggregate = UNRESOLVED
+        elif EXACT in match_types:
+            aggregate = EXACT
         if aggregate is not None:
             fine_grained.matchType = aggregate
             changed = True
@@ -620,14 +376,15 @@ class AutoResolveLineageUrnsProcessor(
             return field_urn, None
 
         # Column-level: we need the parent's schema to correct the column casing.
-        res = self._resolve_dataset(parent)
+        res = self._strategy.resolve(parent, need_schema=True)
         new_field_path = field_path
         if res.schema:
             new_field_path = self._match_columns_to_schema(res.schema, [field_path])[0]
 
         if res.urn == parent and new_field_path == field_path:
-            if res.match_type == _UNRESOLVED:
+            if res.match_type == UNRESOLVED:
                 self.report.num_refs_unresolved += 1
+                self.report.unresolved_refs_sample.append(res.urn)
             else:
                 self.report.num_refs_unchanged += 1
             return field_urn, res.match_type
@@ -638,7 +395,7 @@ class AutoResolveLineageUrnsProcessor(
         # even when the parent dataset matched exactly, so report NORMALIZED in that
         # case rather than the parent's (EXACT) match type.
         self.report.num_column_urns_normalized += 1
-        match_type = _NORMALIZED if new_field_path != field_path else res.match_type
+        match_type = NORMALIZED if new_field_path != field_path else res.match_type
         return make_schema_field_urn(res.urn, new_field_path), match_type
 
     def _normalize_dashboard_info(self, aspect: DashboardInfoClass) -> bool:
@@ -689,7 +446,7 @@ class AutoResolveLineageUrnsProcessor(
             if not _is_dataset_urn(dataset):
                 healed.append(dataset)
                 continue
-            res = self._resolve_dataset(dataset)
+            res = self._strategy.resolve(dataset)
             # A plain URN list / Edge has no matchType field to stamp, but the counters
             # must still distinguish UNRESOLVED (broken) from a clean ref so a
             # dashboard/datajob pointing at broken lineage isn't invisible in the report.
@@ -704,7 +461,7 @@ class AutoResolveLineageUrnsProcessor(
             destination = getattr(edge, "destinationUrn", None)
             if not _is_dataset_urn(destination):
                 continue
-            res = self._resolve_dataset(destination)
+            res = self._strategy.resolve(destination)
             if self._tally_table_ref(res):
                 edge.destinationUrn = res.urn
                 changed = True

--- a/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
@@ -610,7 +610,7 @@ def test_field_helpers_reject_non_schemafield_urns():
     # A dataset URN is not a schemaField URN -> both helpers return None. Previously
     # _field_path returned the dataset *name* as a bogus field path (positional
     # entity_ids[1]); SchemaFieldUrn parsing rejects it.
-    from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns import (
+    from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.processor import (
         _field_path,
         _parent_dataset_urn,
     )
@@ -757,6 +757,9 @@ def test_unresolved_refs_surface_one_aggregated_warning():
         patcher.stop()
 
     assert processor.report.num_refs_unresolved == 2
+    # The sample names *which* references look broken, so the warning is actionable —
+    # the count alone doesn't tell an operator where to look.
+    assert list(processor.report.unresolved_refs_sample) == [UPPER, LOWER]
     report = cast(mock.MagicMock, processor.ctx.source_report)
     report.warning.assert_called_once()
     kwargs = report.warning.call_args.kwargs


### PR DESCRIPTION
> **Stack 1 of 2.** Follow-up: #18857 settles the resolution interface. This PR is pure code motion and stands alone.

`AutoResolveLineageUrnsProcessor` was one 712-line module doing two jobs: deciding **what to rewrite** (which aspects carry upstream dataset references, how to rewrite them, how to report the outcome) and deciding **how to find the URN DataHub actually stores** (download each configured platform's catalog, then match three casing candidates locally).

Only the second is about to change — follow-up work adds a direct lookup that downloads nothing and covers every casing, plus buffering so lookups batch across work units. Landing that on top of the current file would be a diff hard to review against existing behaviour. So this PR separates the two jobs and does nothing else.

## What

Split into a package behind a `ResolutionStrategy` Protocol:

| File | Owns |
| --- | --- |
| `models.py` | `MatchType`, `Resolution`, the `ResolutionStrategy` Protocol, the report |
| `processor.py` | Everything independent of how a reference resolves |
| `bulk.py` | Today's catalog download and casing match, moved verbatim |

The processor talks to a strategy in five places and names a concrete one in exactly one. An alternative path plugs in without touching the rewriters, and removing one later is a file deletion plus a single line.

`bulk.py` is imported lazily in `__init__`, keeping sqlglot off the module-load path every source hits (`test_module_import_does_not_pull_sqlglot` guards this).

## Behaviour is unchanged

The package keeps the old module's import path, so no call site moves.

One line is not pure code motion: **the unresolved-refs report sample** now gets appended by the processor's counting paths rather than inside the strategy. `create()` assigns `self.report` only after `__init__` returns, so a strategy built in `__init__` can't receive it. The entries are identical either way, since every `UNRESOLVED` path already went through those counters and `bulk` returns the reference URN unchanged on a miss. That line had no coverage, so a new assertion pins it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Refactors **`AutoResolveLineageUrnsProcessor`** from one large module into a small package so **aspect rewriting/reporting** and **how upstream URNs are resolved** are separate concerns, ahead of alternate resolution strategies (e.g. direct lookup without bulk catalog download).
> 
> A **`ResolutionStrategy`** protocol (`resolve` / `finish`) is introduced in **`models.py`** together with **`MatchType`**, **`Resolution`**, and the processor report. **`processor.py`** keeps lineage aspect normalizers and calls **`self._strategy.resolve(...)`** instead of inlined catalog logic; end-of-run unmatched-platform warnings move to **`BulkCatalogStrategy.finish()`**. Today’s bulk **`SchemaResolver`** catalog load and casing match live in **`bulk.py`** (`BulkCatalogStrategy`), imported **lazily** in the processor **`__init__`** so **sqlglot** stays off the module-load path. The public import path **`auto_resolve_lineage_urns`** is preserved via **`__init__.py`**.
> 
> The only intentional behavior tweak: **`unresolved_refs_sample`** is populated in the processor’s UNRESOLVED counting paths (not inside the strategy), because **`self.report`** is not available when the strategy is constructed; tests now assert the sample lists the unresolved URNs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d00505da5af281e1d3b0a11ef2631132f48e4c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->