### PR TITLE
refactor(ingest): make the resolution contract batch-shaped

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/bulk.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/bulk.py
@@ -140,11 +140,19 @@ class BulkCatalogStrategy:
             return name[len(platform_instance) + 1 :]
         return name
 
-    def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution:
-        """Resolve `urn` to the casing DataHub already stores, via SchemaResolver.
+    def resolve_many(
+        self, *, urns: Set[str], schema_urns: Set[str]
+    ) -> Dict[str, Resolution]:
+        """Resolve each reference against the in-memory catalogs.
 
-        ``need_schema`` is ignored: the bulk catalog already holds every schema it loaded,
-        so a schema costs nothing extra here.
+        There is nothing to batch: the catalogs were downloaded up front, so every lookup
+        is local. ``schema_urns`` is ignored because the catalog already holds a schema for
+        everything it loaded, so column data costs nothing extra here.
+        """
+        return {urn: self._resolve_one(urn) for urn in urns}
+
+    def _resolve_one(self, urn: str) -> Resolution:
+        """Resolve `urn` to the casing DataHub already stores, via SchemaResolver.
 
         Delegates matching to ``SchemaResolver.resolve_table``, which tries three casing
         candidates for the reference and returns the first that exists in DataHub:

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/models.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, Optional, Protocol
+from typing import TYPE_CHECKING, Dict, Literal, Optional, Protocol, Set
 
 from datahub.ingestion.api.workunit_processor import WorkunitProcessorReport
 from datahub.metadata.schema_classes import LineageMatchTypeClass
@@ -47,7 +47,9 @@ class AutoResolveLineageUrnsProcessorReport(WorkunitProcessorReport):
     unresolved_refs_sample: LossyList[str] = field(default_factory=LossyList)
 
 
-@dataclass
+# Frozen: one Resolution is shared by every reference that resolves to the same entity, so
+# mutating one in place would silently change the others.
+@dataclass(frozen=True)
 class Resolution:
     """Outcome of resolving one dataset URN against the entities DataHub already stores."""
 
@@ -58,17 +60,31 @@ class Resolution:
 
 
 class ResolutionStrategy(Protocol):
-    """How the processor turns a reference URN into the URN DataHub actually stores.
+    """How the processor turns reference URNs into the URNs DataHub actually stores.
 
-    Implementations differ only in where the answer comes from; the processor's rewrite
+    Implementations differ only in where the answers come from; the processor's rewrite
     and reporting logic is identical either way.
     """
 
-    def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution:
-        """Resolve one upstream reference.
+    def resolve_many(
+        self, *, urns: Set[str], schema_urns: Set[str]
+    ) -> Dict[str, Resolution]:
+        """Resolve a batch of upstream references.
 
-        ``need_schema`` is set only on the column-level path, so a strategy that pays per
-        schema fetch can skip it for table-level-only references.
+        Batch-shaped rather than one URN at a time so that a strategy which pays per
+        request can amortise it. ``BulkCatalogStrategy`` gains nothing from this -- its
+        catalog is already in memory -- but a strategy that queries the server per lookup
+        does, and widening the batch beyond a single work unit then becomes a change to the
+        processor's stream handling alone.
+
+        ``schema_urns`` is the subset of ``urns`` reached by column-level lineage, i.e. the
+        only ones whose ``Resolution.schema`` needs populating. A strategy that pays per
+        schema fetch can therefore skip it entirely for a table-level-only source.
+
+        Must return an entry for *every* URN in ``urns``, using ``match_type=None`` for
+        references it considers out of scope. The processor treats a missing key as a bug
+        rather than as "out of scope", so that a reference it rewrites but never collected
+        fails loudly instead of being silently skipped.
         """
         ...
 

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
@@ -2,14 +2,15 @@
 # only under TYPE_CHECKING) as strings, so importing this module does not pull in sqlglot.
 # This module is imported eagerly on every source's get_workunit_processors() path, so
 # module load must stay sqlglot-free (guarded by test_module_import_does_not_pull_sqlglot).
-# The sqlglot-heavy imports are therefore deferred: match_columns_to_schema to a chokepoint
-# in __init__, and the strategy module to the same place — both run only after
-# should_enable() confirms the feature is on and a graph exists.
+# The sqlglot-heavy imports are therefore deferred to a single chokepoint in __init__, which
+# runs only after should_enable() confirms the feature is on and a graph exists.
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Callable,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -56,6 +57,23 @@ from datahub.utilities.urns.error import InvalidUrnError
 
 if TYPE_CHECKING:
     from datahub.sql_parsing.schema_resolver import SchemaInfo
+
+
+@dataclass(frozen=True)
+class _AspectHandler:
+    """A lineage aspect and the paired passes that read and then rewrite it.
+
+    Collect and apply must agree on exactly which references they touch: a reference the
+    rewriter resolves but the collector never gathered is absent from the resolution map,
+    which the rewriter treats as a bug rather than silently skipping. Pairing them in one
+    record is what keeps them from drifting.
+    """
+
+    aspect_cls: Type[_Aspect]
+    # (aspect, urns, schema_urns) -> None. Gathers references, mutating nothing.
+    collect: Callable[..., None]
+    # (aspect, resolutions) -> True iff the aspect was mutated.
+    apply: Callable[..., bool]
 
 
 def _parent_dataset_urn(field_urn: str) -> Optional[str]:
@@ -126,7 +144,7 @@ class AutoResolveLineageUrnsProcessor(
 
     def __init__(self, ctx: WorkunitProcessorContext) -> None:
         super().__init__(ctx)
-        # Deferred imports, for the same reason the module docstring gives: both of these
+        # Deferred imports, both for the same reason the module comment gives: these
         # reach sqlglot-backed code, and this __init__ runs only once should_enable() has
         # confirmed the feature is on.
         from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.bulk import (
@@ -138,9 +156,8 @@ class AutoResolveLineageUrnsProcessor(
             match_columns_to_schema
         )
         self._strategy: ResolutionStrategy = BulkCatalogStrategy(ctx)
-        # (aspect class -> in-place normalizer, returns True iff it mutated the aspect).
-        # These are the aspects a BI / orchestration source emits that carry *upstream
-        # dataset* references — the only refs affected by cross-source casing mismatch:
+        # The aspects a BI / orchestration source emits that carry *upstream dataset*
+        # references — the only refs affected by cross-source casing mismatch:
         # upstreamLineage (table + fineGrained columns), dashboardInfo / chartInfo inputs,
         # and dataJobInputOutput inputs (dbt / Airflow / Spark). Other lineage aspects
         # don't target datasets or are the entity's own outputs (see the dev guide).
@@ -149,19 +166,30 @@ class AutoResolveLineageUrnsProcessor(
         # before any deserialization — so a work unit is deserialized at most once (for the
         # aspect it actually carries), and covering four vs. one adds only three constant
         # comparisons.
-        # Callable[..., bool] (not Callable[[_Aspect], bool]): each normalizer takes a
-        # specific aspect subtype, and function args are contravariant, so the precise
-        # signature won't accept them in a heterogeneous table (mypy list-item error).
-        self._normalizers: List[Tuple[Type[_Aspect], Callable[..., bool]]] = [
-            (UpstreamLineageClass, self._normalize_upstream_lineage),
-            (DashboardInfoClass, self._normalize_dashboard_info),
-            (DataJobInputOutputClass, self._normalize_datajob_io),
-            (ChartInfoClass, self._normalize_chart_info),
+        self._handlers: List[_AspectHandler] = [
+            _AspectHandler(
+                UpstreamLineageClass,
+                self._collect_upstream_lineage,
+                self._normalize_upstream_lineage,
+            ),
+            _AspectHandler(
+                DashboardInfoClass,
+                self._collect_dashboard_info,
+                self._normalize_dashboard_info,
+            ),
+            _AspectHandler(
+                DataJobInputOutputClass,
+                self._collect_datajob_io,
+                self._normalize_datajob_io,
+            ),
+            _AspectHandler(
+                ChartInfoClass, self._collect_chart_info, self._normalize_chart_info
+            ),
         ]
         # Aspect names of the above, used to detect a lineage aspect that arrived as a
-        # PATCH (which get_aspect_of_type can't surface — see _resolve_workunit).
+        # PATCH (which get_aspect_of_type can't surface — see _is_unreconcilable_patch).
         self._lineage_aspect_names: Set[str] = {
-            aspect_cls.ASPECT_NAME for aspect_cls, _ in self._normalizers
+            handler.aspect_cls.ASPECT_NAME for handler in self._handlers
         }
 
     @classmethod
@@ -186,26 +214,104 @@ class AutoResolveLineageUrnsProcessor(
     def process(self, stream: Iterable[MetadataWorkUnit]) -> Iterable[MetadataWorkUnit]:
         for wu in stream:
             try:
-                self._resolve_workunit(wu)
+                self._reconcile(wu)
             except Exception as e:
-                self.report.num_exceptions += 1
-                # Surface in the pipeline report (not just this processor's sub-report),
-                # so a run that fails to reconcile part of a source's lineage doesn't
-                # look clean. Keeps the processor counter above; logs via the report.
-                self.ctx.source_report.warning(
-                    title="Lineage URN casing not reconciled",
-                    message="Failed to reconcile lineage URN casing for a work unit; "
-                    "its lineage is emitted unchanged.",
-                    context=wu.get_urn(),
-                    exc=e,
-                )
+                self._report_workunit_failure(wu, e)
             yield wu
         self._strategy.finish()
         self._warn_unresolved_refs()
         self._warn_patch_lineage_skipped()
 
-    def _resolve_workunit(self, wu: MetadataWorkUnit) -> None:
-        """Reconcile casing on each lineage aspect the workunit carries, in place.
+    def _reconcile(self, wu: MetadataWorkUnit) -> None:
+        """Collect this work unit's references, resolve them together, then rewrite.
+
+        Two passes rather than resolving inline: the batch has to be known before any of it
+        can be resolved. The batch is currently one work unit, which already collapses a
+        dashboard's forty upstreams into a single resolve_many call. Widening it across work
+        units is a change to this method alone.
+        """
+        urns: Set[str] = set()
+        schema_urns: Set[str] = set()
+        self._collect_workunit(wu, urns, schema_urns)
+        resolutions = self._resolve(urns, schema_urns)
+        # None distinguishes a failed resolve from one that legitimately found nothing to
+        # do: on failure the aspect is left alone, but an empty batch must still run the
+        # rewriters, whose per-reference bookkeeping covers references that were never
+        # resolvable (a malformed schemaField URN, say).
+        if resolutions is not None:
+            self._apply_workunit(wu, resolutions)
+
+    def _resolve(
+        self, urns: Set[str], schema_urns: Set[str]
+    ) -> Optional[Dict[str, Resolution]]:
+        """Resolve a batch, or None if the strategy failed outright."""
+        if not urns:
+            return {}
+        try:
+            return self._strategy.resolve_many(urns=urns, schema_urns=schema_urns)
+        except Exception as e:
+            self.report.num_exceptions += 1
+            self.ctx.source_report.warning(
+                title="Lineage URN casing not reconciled",
+                message="Failed to resolve a batch of upstream lineage references; the "
+                "affected lineage is emitted unchanged.",
+                context=f"{len(urns)} reference(s)",
+                exc=e,
+            )
+            return None
+
+    def _report_workunit_failure(self, wu: MetadataWorkUnit, e: Exception) -> None:
+        self.report.num_exceptions += 1
+        # Surface in the pipeline report (not just this processor's sub-report), so a run
+        # that fails to reconcile part of a source's lineage doesn't look clean.
+        self.ctx.source_report.warning(
+            title="Lineage URN casing not reconciled",
+            message="Failed to reconcile lineage URN casing for a work unit; "
+            "its lineage is emitted unchanged.",
+            context=wu.get_urn(),
+            exc=e,
+        )
+
+    def _is_unreconcilable_patch(self, wu: MetadataWorkUnit) -> bool:
+        """Whether this is a lineage aspect we can't reconcile because it's a PATCH.
+
+        get_aspect_of_type routes a raw MCP through try_from_mcpc, which returns None for
+        non-upserts, so a patched aspect is invisible to both passes and would pass through
+        silently. (dataJobInputOutput can be emitted as a patch by dbt/Airflow/Spark; BI
+        sources emit full upserts and are unaffected.)
+        """
+        md = wu.metadata
+        return (
+            isinstance(md, MetadataChangeProposalClass)
+            and md.changeType != ChangeTypeClass.UPSERT
+            and md.aspectName in self._lineage_aspect_names
+        )
+
+    def _collect_workunit(
+        self, wu: MetadataWorkUnit, urns: Set[str], schema_urns: Set[str]
+    ) -> None:
+        """Pass 1: gather the upstream references this work unit carries.
+
+        Mutates nothing. Counts the work unit as carrying lineage, and counts a patch skip,
+        here rather than in pass 2 so those totals hold even if resolution then fails.
+        """
+        if self._is_unreconcilable_patch(wu):
+            self.report.num_patch_lineage_skipped += 1
+            return
+        # At most one of the four aspects is present per work unit (each belongs to a
+        # different entity type — dataset / dashboard / chart / dataJob — and a work unit
+        # targets one entity), so incrementing inside the loop still counts work units.
+        for handler in self._handlers:
+            aspect = wu.get_aspect_of_type(handler.aspect_cls)
+            if aspect is None:
+                continue
+            self.report.num_workunits_with_lineage_aspect += 1
+            handler.collect(aspect, urns, schema_urns)
+
+    def _apply_workunit(
+        self, wu: MetadataWorkUnit, resolutions: Dict[str, Resolution]
+    ) -> None:
+        """Pass 2: reconcile casing on each lineage aspect the work unit carries, in place.
 
         We edit the typed aspect (via get_aspect_of_type) rather than the uniform
         transform_urns() helper: we must be selective (only upstream refs, never the
@@ -214,29 +320,13 @@ class AutoResolveLineageUrnsProcessor(
         a raw MCP is deserialized to inspect, and re-serialized (via _write_back_if_mcp)
         only when something actually changed.
         """
-        # A lineage aspect emitted as a raw MCP PATCH (not UPSERT) can't be reconciled:
-        # get_aspect_of_type routes a raw MCP through try_from_mcpc, which returns None for
-        # non-upserts, so the aspect is invisible to the normalizers below and would pass
-        # through silently. Count it so the skip surfaces in the report. (dataJobInputOutput
-        # can be emitted as a patch by dbt/Airflow/Spark; BI sources emit full upserts and
-        # are unaffected.)
-        md = wu.metadata
-        if (
-            isinstance(md, MetadataChangeProposalClass)
-            and md.changeType != ChangeTypeClass.UPSERT
-            and md.aspectName in self._lineage_aspect_names
-        ):
-            self.report.num_patch_lineage_skipped += 1
+        if self._is_unreconcilable_patch(wu):
             return
-        # At most one of the four aspects is present per work unit (each belongs to a
-        # different entity type — dataset / dashboard / chart / dataJob — and a work unit
-        # targets one entity), so incrementing inside the loop still counts work units.
-        for aspect_cls, normalize in self._normalizers:
-            aspect = wu.get_aspect_of_type(aspect_cls)
+        for handler in self._handlers:
+            aspect = wu.get_aspect_of_type(handler.aspect_cls)
             if aspect is None:
                 continue
-            self.report.num_workunits_with_lineage_aspect += 1
-            if normalize(aspect):
+            if handler.apply(aspect, resolutions):
                 self._write_back_if_mcp(wu, aspect)
                 self.report.num_workunits_modified += 1
 
@@ -289,11 +379,78 @@ class AutoResolveLineageUrnsProcessor(
         if isinstance(wu.metadata, MetadataChangeProposalClass):
             wu.metadata.aspect = _make_generic_aspect(aspect)
 
-    # --- aspect rewriters -------------------------------------------------------
+    # --- collectors (pass 1) ----------------------------------------------------
+    #
+    # Each gathers the upstream dataset references its aspect carries, without touching
+    # anything. `schema_urns` is the subset reached by column-level lineage, i.e. the only
+    # parents whose schema needs fetching. Each must gather exactly the references its
+    # paired rewriter below resolves — see _AspectHandler.
+
+    def _collect_upstream_lineage(
+        self, aspect: UpstreamLineageClass, urns: Set[str], schema_urns: Set[str]
+    ) -> None:
+        for upstream in aspect.upstreams:
+            dataset = getattr(upstream, "dataset", None)
+            if _is_dataset_urn(dataset):
+                urns.add(dataset)
+        for fine_grained in aspect.fineGrainedLineages or []:
+            self._collect_fine_grained(fine_grained, urns, schema_urns)
+
+    def _collect_fine_grained(
+        self,
+        fine_grained: FineGrainedLineageClass,
+        urns: Set[str],
+        schema_urns: Set[str],
+    ) -> None:
+        for field_urn in fine_grained.upstreams or []:
+            parent = _parent_dataset_urn(field_urn)
+            # Deliberately not filtered by _is_dataset_urn, matching _resolve_field_urn:
+            # it resolves whatever parent it finds and lets the strategy decline. Filtering
+            # here would leave that lookup absent from the map.
+            if parent is not None and _field_path(field_urn) is not None:
+                urns.add(parent)
+                schema_urns.add(parent)
+
+    def _collect_dashboard_info(
+        self, aspect: DashboardInfoClass, urns: Set[str], schema_urns: Set[str]
+    ) -> None:
+        self._collect_dataset_urns(aspect.datasets or [], urns)
+        self._collect_dataset_edges(aspect.datasetEdges or [], urns)
+
+    def _collect_datajob_io(
+        self, aspect: DataJobInputOutputClass, urns: Set[str], schema_urns: Set[str]
+    ) -> None:
+        self._collect_dataset_urns(aspect.inputDatasets or [], urns)
+        self._collect_dataset_edges(aspect.inputDatasetEdges or [], urns)
+        for fine_grained in aspect.fineGrainedLineages or []:
+            self._collect_fine_grained(fine_grained, urns, schema_urns)
+
+    def _collect_chart_info(
+        self, aspect: ChartInfoClass, urns: Set[str], schema_urns: Set[str]
+    ) -> None:
+        self._collect_dataset_urns(aspect.inputs or [], urns)
+        self._collect_dataset_edges(aspect.inputEdges or [], urns)
+
+    @staticmethod
+    def _collect_dataset_urns(refs: List[str], urns: Set[str]) -> None:
+        for dataset in refs:
+            if _is_dataset_urn(dataset):
+                urns.add(dataset)
+
+    @staticmethod
+    def _collect_dataset_edges(edges: List[EdgeClass], urns: Set[str]) -> None:
+        for edge in edges:
+            destination = getattr(edge, "destinationUrn", None)
+            if _is_dataset_urn(destination):
+                urns.add(destination)
+
+    # --- aspect rewriters (pass 2) ----------------------------------------------
     #
     # Each returns True iff it mutated the aspect (rewrote a reference or stamped a
-    # matchType), so process() can skip the raw-MCP re-serialization when nothing in the
-    # aspect was in scope.
+    # matchType), so _apply_workunit can skip the raw-MCP re-serialization when nothing in
+    # the aspect was in scope. `resolutions` is indexed directly rather than with .get():
+    # the strategy contract guarantees an entry per collected reference, so a missing key
+    # means collect and apply have drifted and should fail loudly, not silently skip.
 
     def _tally_table_ref(self, res: Resolution) -> bool:
         """Record report counters for a table-level reference; return True iff it was
@@ -309,13 +466,15 @@ class AutoResolveLineageUrnsProcessor(
             self.report.num_refs_unchanged += 1
         return False
 
-    def _normalize_upstream_lineage(self, aspect: UpstreamLineageClass) -> bool:
+    def _normalize_upstream_lineage(
+        self, aspect: UpstreamLineageClass, resolutions: Dict[str, Resolution]
+    ) -> bool:
         changed = False
         for upstream in aspect.upstreams:
             dataset = getattr(upstream, "dataset", None)
             if not _is_dataset_urn(dataset):
                 continue
-            res = self._strategy.resolve(dataset)
+            res = resolutions[dataset]
             # Stamp the verdict (EXACT / NORMALIZED / UNRESOLVED) for any reference in
             # scope; out-of-scope refs get res.match_type=None and are left untouched.
             if res.match_type is not None:
@@ -331,12 +490,14 @@ class AutoResolveLineageUrnsProcessor(
                 upstream.dataset = res.urn
 
         for fine_grained in aspect.fineGrainedLineages or []:
-            if self._normalize_fine_grained_upstreams(fine_grained):
+            if self._normalize_fine_grained_upstreams(fine_grained, resolutions):
                 changed = True
         return changed
 
     def _normalize_fine_grained_upstreams(
-        self, fine_grained: FineGrainedLineageClass
+        self,
+        fine_grained: FineGrainedLineageClass,
+        resolutions: Dict[str, Resolution],
     ) -> bool:
         # Only upstream references are healed; downstream fields belong to the entity
         # this aspect describes and must keep its casing.
@@ -346,7 +507,7 @@ class AutoResolveLineageUrnsProcessor(
         rewritten: List[str] = []
         match_types: List[Optional[MatchType]] = []
         for field_urn in fine_grained.upstreams:
-            new_urn, match_type = self._resolve_field_urn(field_urn)
+            new_urn, match_type = self._resolve_field_urn(field_urn, resolutions)
             rewritten.append(new_urn)
             match_types.append(match_type)
             if new_urn != field_urn:
@@ -368,7 +529,9 @@ class AutoResolveLineageUrnsProcessor(
             changed = True
         return changed
 
-    def _resolve_field_urn(self, field_urn: str) -> Tuple[str, Optional[MatchType]]:
+    def _resolve_field_urn(
+        self, field_urn: str, resolutions: Dict[str, Resolution]
+    ) -> Tuple[str, Optional[MatchType]]:
         parent = _parent_dataset_urn(field_urn)
         field_path = _field_path(field_urn)
         if parent is None or field_path is None:
@@ -376,7 +539,7 @@ class AutoResolveLineageUrnsProcessor(
             return field_urn, None
 
         # Column-level: we need the parent's schema to correct the column casing.
-        res = self._strategy.resolve(parent, need_schema=True)
+        res = resolutions[parent]
         new_field_path = field_path
         if res.schema:
             new_field_path = self._match_columns_to_schema(res.schema, [field_path])[0]
@@ -398,45 +561,55 @@ class AutoResolveLineageUrnsProcessor(
         match_type = NORMALIZED if new_field_path != field_path else res.match_type
         return make_schema_field_urn(res.urn, new_field_path), match_type
 
-    def _normalize_dashboard_info(self, aspect: DashboardInfoClass) -> bool:
+    def _normalize_dashboard_info(
+        self, aspect: DashboardInfoClass, resolutions: Dict[str, Resolution]
+    ) -> bool:
         changed = False
         if aspect.datasets:
-            aspect.datasets, c = self._heal_dataset_urns(aspect.datasets)
+            aspect.datasets, c = self._heal_dataset_urns(aspect.datasets, resolutions)
             changed = changed or c
-        if self._heal_dataset_edges(aspect.datasetEdges or []):
+        if self._heal_dataset_edges(aspect.datasetEdges or [], resolutions):
             changed = True
         return changed
 
-    def _normalize_datajob_io(self, aspect: DataJobInputOutputClass) -> bool:
+    def _normalize_datajob_io(
+        self, aspect: DataJobInputOutputClass, resolutions: Dict[str, Resolution]
+    ) -> bool:
         # A DataJob's *inputs* are upstream warehouse references (the dbt / Airflow /
         # Spark warehouse-upstream path) and are healed like any other upstream. The
         # job's outputs are its declared products and are left untouched, matching the
         # processor's rule of never rewriting an entity's own / downstream side.
         changed = False
         if aspect.inputDatasets:
-            aspect.inputDatasets, c = self._heal_dataset_urns(aspect.inputDatasets)
+            aspect.inputDatasets, c = self._heal_dataset_urns(
+                aspect.inputDatasets, resolutions
+            )
             changed = changed or c
-        if self._heal_dataset_edges(aspect.inputDatasetEdges or []):
+        if self._heal_dataset_edges(aspect.inputDatasetEdges or [], resolutions):
             changed = True
         for fine_grained in aspect.fineGrainedLineages or []:
-            if self._normalize_fine_grained_upstreams(fine_grained):
+            if self._normalize_fine_grained_upstreams(fine_grained, resolutions):
                 changed = True
         return changed
 
-    def _normalize_chart_info(self, aspect: ChartInfoClass) -> bool:
+    def _normalize_chart_info(
+        self, aspect: ChartInfoClass, resolutions: Dict[str, Resolution]
+    ) -> bool:
         # A chart's `inputs` / `inputEdges` are the upstream datasets it reads from.
         # For BI tools that query the warehouse directly (e.g. Superset, Mode, Redash,
         # Metabase) these point straight at warehouse tables, so casing mismatches
         # there break lineage just like any other upstream reference.
         changed = False
         if aspect.inputs:
-            aspect.inputs, c = self._heal_dataset_urns(aspect.inputs)
+            aspect.inputs, c = self._heal_dataset_urns(aspect.inputs, resolutions)
             changed = changed or c
-        if self._heal_dataset_edges(aspect.inputEdges or []):
+        if self._heal_dataset_edges(aspect.inputEdges or [], resolutions):
             changed = True
         return changed
 
-    def _heal_dataset_urns(self, urns: List[str]) -> Tuple[List[str], bool]:
+    def _heal_dataset_urns(
+        self, urns: List[str], resolutions: Dict[str, Resolution]
+    ) -> Tuple[List[str], bool]:
         healed: List[str] = []
         changed = False
         for dataset in urns:
@@ -446,7 +619,7 @@ class AutoResolveLineageUrnsProcessor(
             if not _is_dataset_urn(dataset):
                 healed.append(dataset)
                 continue
-            res = self._strategy.resolve(dataset)
+            res = resolutions[dataset]
             # A plain URN list / Edge has no matchType field to stamp, but the counters
             # must still distinguish UNRESOLVED (broken) from a clean ref so a
             # dashboard/datajob pointing at broken lineage isn't invisible in the report.
@@ -455,13 +628,15 @@ class AutoResolveLineageUrnsProcessor(
             healed.append(res.urn)
         return healed, changed
 
-    def _heal_dataset_edges(self, edges: List[EdgeClass]) -> bool:
+    def _heal_dataset_edges(
+        self, edges: List[EdgeClass], resolutions: Dict[str, Resolution]
+    ) -> bool:
         changed = False
         for edge in edges:
             destination = getattr(edge, "destinationUrn", None)
             if not _is_dataset_urn(destination):
                 continue
-            res = self._strategy.resolve(destination)
+            res = resolutions[destination]
             if self._tally_table_ref(res):
                 edge.destinationUrn = res.urn
                 changed = True

--- a/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
@@ -606,6 +606,35 @@ def test_malformed_fine_grained_field_left_unchanged():
     assert _fine_grained(out).upstreams == ["not-a-valid-urn"]
 
 
+def test_unresolvable_refs_are_still_counted_when_nothing_is_resolvable():
+    # An aspect whose only references can't be parsed yields an *empty* batch to resolve.
+    # That is not the same as a failed resolve: the rewriters must still run, because their
+    # per-reference bookkeeping is what accounts for references nothing could be done with.
+    # Skipping them on an empty batch loses the count silently.
+    aspect = UpstreamLineageClass(
+        upstreams=[],
+        fineGrainedLineages=[
+            FineGrainedLineageClass(
+                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                upstreams=["not-a-valid-urn"],
+                downstreams=[],
+            )
+        ],
+    )
+    wu = MetadataChangeProposalWrapper(
+        entityUrn=DOWNSTREAM, aspect=aspect
+    ).as_workunit()
+    processor, provide_mock, patcher = _make_processor({})
+    try:
+        list(processor.process(iter([wu])))
+    finally:
+        patcher.stop()
+
+    assert processor.report.num_refs_unchanged == 1
+    assert processor.report.num_refs_unresolved == 0
+
+
 def test_field_helpers_reject_non_schemafield_urns():
     # A dataset URN is not a schemaField URN -> both helpers return None. Previously
     # _field_path returned the dataset *name* as a bogus field path (positional


### PR DESCRIPTION
> **Stack 2 of 2**, on top of #18855. Review that one first — this PR's diff is only the interface change.

#18855 split the lineage casing processor so that resolution sits behind a `ResolutionStrategy`. That interface is still one-URN-at-a-time:

```python
def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution: ...
```

That shape is right for a catalog held in memory and wrong for any strategy that pays per request — a dashboard's forty upstreams would be forty round trips. Fixing it later would mean reworking the rewriters in the same PR that introduces the new resolution path, so it is worth settling now, where the existing suite proves it changes nothing.

## What

```python
def resolve_many(self, *, urns: Set[str], schema_urns: Set[str]) -> Dict[str, Resolution]: ...
def finish(self) -> None: ...
```

The processor now runs two passes: collect a work unit's references without mutating anything, resolve them together, then rewrite from the result.

`schema_urns` is the subset reached by column-level lineage, so a strategy that pays per schema fetch skips it entirely for a table-level-only source.

Collect and apply are paired per aspect in an `_AspectHandler` record, because they must agree on exactly which references they touch. The rewriters index the resolution map directly rather than with `.get()`: the contract guarantees an entry per collected reference, so a reference that is rewritten but was never collected raises and is reported, rather than silently resolving to nothing. `Resolution` is frozen for a related reason — one is now shared by every reference resolving to the same entity, so in-place mutation would alias.

**No buffering here.** The batch is one work unit, which already collapses a dashboard's upstreams into a single call. Widening it across work units is a later change to `_reconcile` alone.

## Behaviour is unchanged

`bulk.resolve_many` is a loop over the same local lookups, so results are identical.

One subtlety worth a look: **`_resolve` returns `None` on failure and a dict on success, including an empty one.** An empty batch is not a failed batch — the rewriters must still run over it, because their per-reference bookkeeping is what accounts for references nothing could be done with (a malformed `schemaField` URN, say). Gating the rewriters on a non-empty dict instead drops that count silently. Measured against master:

| gate | `num_refs_unchanged` |
| --- | --- |
| master (single pass) | 1 |
| `if resolutions is not None` | 1 |
| `if resolutions` | 0 |

The existing suite didn't cover it, so a test now pins it.

## Testing

The existing 52-test suite passes unmodified.

- `pytest tests/unit/workunit_processors/` — 69 passed
- `mypy` clean (the Protocol is enforced at the assignment site, verified by deliberately breaking a signature); `ruff check` / `ruff format --check` clean

## Checklist

- [x] PR conforms to the Contributing Guideline, particularly PR Title Format
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs added/updated — n/a, no user-visible change
- [ ] Breaking change entry in Updating DataHub — n/a, no behaviour change