### PR TITLE
feat(ingest): add batched lowercased-URN lookup and alias capability check

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import textwrap
 import time
+from collections import defaultdict
 from datetime import datetime
 from json.decoder import JSONDecodeError
 from typing import (
@@ -52,6 +53,7 @@ from datahub.ingestion.graph.filters import (
     RawSearchFilter,
     RawSearchFilterRule,
     RemovedStatusFilter,
+    SearchFilterRule,
     generate_filter,
 )
 from datahub.ingestion.graph.links import make_url_for_urn
@@ -68,6 +70,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
 from datahub.metadata.schema_classes import (
     ASPECT_NAME_MAP,
     KEY_ASPECTS,
+    AliasesClass,
     AspectBag,
     BrowsePathsClass,
     DatasetPropertiesClass,
@@ -93,7 +96,9 @@ from datahub.metadata.urns import (
 )
 from datahub.telemetry.telemetry import telemetry_instance
 from datahub.utilities.server_state_disk_cache import ServerStateDiskCache
+from datahub.utilities.urns.error import InvalidUrnError
 from datahub.utilities.urns.urn import guess_entity_type
+from datahub.utilities.urns.urn_iter import lowercase_dataset_urn
 
 if TYPE_CHECKING:
     from datahub.ingestion.sink.datahub_rest import (
@@ -113,6 +118,11 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# Keys per lowercasedUrn lookup request. The filter compiles to a single terms query, so
+# this bounds request size only -- resolve_lowercased_urns chunks internally, so callers
+# never have to think about the limit.
+_LOWERCASED_URN_LOOKUP_CHUNK_SIZE = 500
 _MISSING_SERVER_ID = "missing"
 _GRAPH_DUMMY_RUN_ID = "__datahub-graph-client"
 
@@ -535,6 +545,24 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             _ENTITY_SPECS_CACHE.put(self._gms_server, commit_hash, specs.to_dict())
         self._entity_aspect_specs = (commit_hash, specs)
         return specs
+
+    def supports_dataset_aliases(self) -> bool:
+        """Whether this server registers the ``aliases`` aspect on datasets.
+
+        Gates :meth:`resolve_lowercased_urns`, which is otherwise indistinguishable from a
+        lookup that matched nothing: a filter on a field the server does not index returns
+        zero hits rather than an error. Returns False rather than raising when the registry
+        API is unreachable or ``dataset`` is not registered at all, for the same reason --
+        a caller needs to tell "unsupported" from "nothing matched".
+        """
+        specs = self.get_entity_aspect_specs()
+        if specs is None:
+            return False
+        try:
+            return specs.supports("dataset", AliasesClass.ASPECT_NAME)
+        except ValueError:
+            # The server does not register the dataset entity type at all.
+            return False
 
     def get_ownership(self, entity_urn: str) -> Optional[OwnershipClass]:
         return self.get_aspect(entity_urn=entity_urn, aspect_type=OwnershipClass)
@@ -1197,6 +1225,60 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
 
         for entity in self._scroll_across_entities(graphql_query, variables):
             yield entity["urn"]
+
+    def resolve_lowercased_urns(self, keys: Iterable[str]) -> Dict[str, List[str]]:
+        """Map each lowercased dataset URN to every dataset URN stored under it.
+
+        GMS derives ``aliases.lowercasedUrn`` for every dataset and indexes it for exact
+        match, so a reference in any casing resolves to the URN DataHub actually stores in
+        one batchable lookup. Build keys with
+        :func:`datahub.utilities.urns.urn_iter.lowercase_dataset_urn` -- it computes the
+        same value the server indexes.
+
+        Requires :meth:`supports_dataset_aliases`; on a server without the aspect this
+        returns no matches rather than failing, which is why callers must check first.
+
+        Returns *every* URN sharing a key, not one: on a case-sensitive platform two
+        distinct tables can share a key, and a caller has to be able to see that collision
+        instead of being handed an arbitrary winner. Keys with no match are absent.
+        """
+        requested = sorted({key for key in keys if key})
+        matches: Dict[str, List[str]] = defaultdict(list)
+        for start in range(0, len(requested), _LOWERCASED_URN_LOOKUP_CHUNK_SIZE):
+            chunk = requested[start : start + _LOWERCASED_URN_LOOKUP_CHUNK_SIZE]
+            chunk_keys = set(chunk)
+            for urn in self.get_urns_by_filter(
+                entity_types=["dataset"],
+                extra_or_filters=[
+                    {
+                        "and": [
+                            SearchFilterRule(
+                                field=AliasesClass.RECORD_SCHEMA.fields[0].name,
+                                condition="EQUAL",
+                                values=chunk,
+                            ).to_raw()
+                        ]
+                    }
+                ],
+            ):
+                # Group by re-deriving each hit's key locally rather than asking the server
+                # to return the field: it is the same derivation that built the query, so
+                # this is consistent by construction, and it keeps the lookup to a single
+                # request on any server (fetchExtraFields is DataHub Cloud only).
+                try:
+                    key = lowercase_dataset_urn(urn)
+                except InvalidUrnError:
+                    continue
+                if key not in chunk_keys:
+                    # Only reachable if this derivation and the server's have diverged,
+                    # which would otherwise present as "nothing matched".
+                    logger.debug(
+                        f"Ignoring hit {urn} whose derived key {key} was not requested; "
+                        f"client and server lowercasing may have diverged"
+                    )
+                    continue
+                matches[key].append(urn)
+        return dict(matches)
 
     def get_results_by_filter(
         self,

--- a/metadata-ingestion/src/datahub/utilities/urns/urn_iter.py
+++ b/metadata-ingestion/src/datahub/utilities/urns/urn_iter.py
@@ -132,6 +132,15 @@ def _modify_at_path(
 
 
 def lowercase_dataset_urn(dataset_urn: str) -> str:
+    """Lowercase a dataset URN's name, leaving its platform and env untouched.
+
+    This is also the case-insensitive resolution key GMS derives and indexes as
+    ``aliases.lowercasedUrn`` (see ``AliasesUtils.lowercaseDatasetUrn``), so changing the
+    rule here silently breaks every lookup against that field -- filtering on a value
+    nothing was indexed under returns zero hits, not an error. The parametrized cases in
+    tests/unit/serde/test_urn_iterator.py mirror the server's own test suite; keep both in
+    sync.
+    """
     cur_urn = DatasetUrn.from_string(dataset_urn)
     new_urn = DatasetUrn(
         platform=cur_urn.platform, name=cur_urn.name.lower(), env=cur_urn.env

--- a/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
@@ -1,4 +1,4 @@
-"""Unit tests for DataHubGraph: offset pagination and entity aspect specs fetch."""
+"""Unit tests for DataHubGraph: pagination, aspect specs, and lowercased-URN lookup."""
 
 import pathlib
 from typing import List
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.entity_aspect_specs import EntityAspectSpecs
 
 
 def _page(elements: List[dict], total: int, count: int) -> MagicMock:
@@ -160,3 +161,99 @@ class TestGetEntityAspectSpecs:
         specs2 = _graph(session2).get_entity_aspect_specs()
         assert specs2 is not None and specs2.supports("dataset", "status")
         assert session2.request.call_count == 0
+
+
+class TestSupportsDatasetAliases:
+    """The check gating resolve_lowercased_urns.
+
+    It must answer False rather than raise on every failure mode: a filter on a field the
+    server does not index returns zero hits rather than an error, so a caller has to be able
+    to tell an unsupported server from a lookup that matched nothing.
+    """
+
+    @staticmethod
+    def _graph_with_specs(entity_aspects: dict) -> DataHubGraph:
+        graph = DataHubGraph.__new__(DataHubGraph)
+        graph.get_entity_aspect_specs = MagicMock(  # type: ignore[method-assign]
+            return_value=EntityAspectSpecs(
+                entity_aspects={k: set(v) for k, v in entity_aspects.items()}
+            )
+        )
+        return graph
+
+    def test_supported_when_aliases_registered(self) -> None:
+        graph = self._graph_with_specs({"dataset": ["datasetKey", "aliases"]})
+        assert graph.supports_dataset_aliases() is True
+
+    def test_unsupported_when_aliases_absent(self) -> None:
+        graph = self._graph_with_specs({"dataset": ["datasetKey"]})
+        assert graph.supports_dataset_aliases() is False
+
+    def test_unsupported_when_dataset_not_registered(self) -> None:
+        # EntityAspectSpecs.supports raises ValueError for an unregistered entity type.
+        graph = self._graph_with_specs({"chart": ["chartKey"]})
+        assert graph.supports_dataset_aliases() is False
+
+    def test_unsupported_when_registry_unavailable(self) -> None:
+        # get_entity_aspect_specs returns None when the registry API can't be reached, e.g.
+        # a token without MANAGE_SYSTEM_OPERATIONS.
+        graph = DataHubGraph.__new__(DataHubGraph)
+        graph.get_entity_aspect_specs = MagicMock(return_value=None)  # type: ignore[method-assign]
+        assert graph.supports_dataset_aliases() is False
+
+
+class TestResolveLowercasedUrns:
+    STORED = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.orders,PROD)"
+    UPPER = "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.ORDERS,PROD)"
+
+    @staticmethod
+    def _graph_returning(urns: List[str]) -> DataHubGraph:
+        graph = DataHubGraph.__new__(DataHubGraph)
+        graph.get_urns_by_filter = MagicMock(return_value=iter(urns))  # type: ignore[method-assign]
+        return graph
+
+    def test_groups_hits_by_key(self) -> None:
+        graph = self._graph_returning([self.STORED])
+        assert graph.resolve_lowercased_urns([self.STORED]) == {
+            self.STORED: [self.STORED]
+        }
+
+        kwargs = graph.get_urns_by_filter.call_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["entity_types"] == ["dataset"]
+        rule = kwargs["extra_or_filters"][0]["and"][0]
+        assert rule["field"] == "lowercasedUrn"
+        assert rule["values"] == [self.STORED]
+
+    def test_collision_returns_every_match(self) -> None:
+        # Two entities sharing one key on a case-sensitive platform. Both must come back so
+        # the caller can decline to guess between them.
+        graph = self._graph_returning([self.STORED, self.UPPER])
+        assert sorted(
+            graph.resolve_lowercased_urns([self.STORED])[self.STORED]
+        ) == sorted([self.STORED, self.UPPER])
+
+    def test_missing_key_is_absent(self) -> None:
+        graph = self._graph_returning([])
+        assert graph.resolve_lowercased_urns([self.STORED]) == {}
+
+    def test_no_keys_makes_no_request(self) -> None:
+        graph = self._graph_returning([])
+        assert graph.resolve_lowercased_urns([]) == {}
+        graph.get_urns_by_filter.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_keys_are_deduplicated_and_chunked(self) -> None:
+        # Callers pass any number of keys and never think about request limits.
+        keys = [
+            f"urn:li:dataset:(urn:li:dataPlatform:snowflake,db.t{i},PROD)"
+            for i in range(1200)
+        ]
+        graph = DataHubGraph.__new__(DataHubGraph)
+        graph.get_urns_by_filter = MagicMock(side_effect=lambda **_: iter([]))  # type: ignore[method-assign]
+
+        graph.resolve_lowercased_urns(keys + keys)  # duplicated on purpose
+
+        sent = [
+            len(call.kwargs["extra_or_filters"][0]["and"][0]["values"])
+            for call in graph.get_urns_by_filter.call_args_list  # type: ignore[attr-defined]
+        ]
+        assert sent == [500, 500, 200]

--- a/metadata-ingestion/tests/unit/serde/test_urn_iterator.py
+++ b/metadata-ingestion/tests/unit/serde/test_urn_iterator.py
@@ -1,3 +1,5 @@
+import pytest
+
 import datahub.emitter.mce_builder as builder
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
@@ -8,7 +10,11 @@ from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
     Upstream,
     UpstreamLineage,
 )
-from datahub.utilities.urns.urn_iter import list_urns_with_path, lowercase_dataset_urns
+from datahub.utilities.urns.urn_iter import (
+    list_urns_with_path,
+    lowercase_dataset_urn,
+    lowercase_dataset_urns,
+)
 
 
 def _datasetUrn(tbl: str) -> str:
@@ -151,3 +157,49 @@ def test_dataset_urn_lowercase_transformer():
 
     lowercase_dataset_urns(original)
     assert original == expected
+
+
+# Mirrors metadata-io AliasesUtilsTest case for case. GMS derives aliases.lowercasedUrn with
+# the same rule and indexes it for exact match, so these pairs are a cross-language
+# contract: if the two derivations drift by a single character, every lookup against that
+# field misses *silently* -- a filter on a value nothing was indexed under returns zero hits
+# rather than an error. Keep this list in sync with AliasesUtilsTest.
+LOWERCASE_DATASET_URN_CASES = [
+    # Platform casing is preserved; only the name is lowercased.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:adlsGen2,Container/Folder,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:adlsGen2,container/folder,PROD)",
+    ),
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.Schema.Table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+    ),
+    # env is untouched.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,DEV)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,DEV)",
+    ),
+    # A platform instance is fused into the name, so it lowercases with it.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,My_Instance.DB.Schema.Table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.db.schema.table,PROD)",
+    ),
+    # Non-ASCII: Java uses Locale.ROOT so the key cannot depend on the JVM locale, and
+    # Python's str.lower() is locale-independent. Both must land on the same string.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,CAFÉ.Ñ_TITLE,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,café.ñ_title,PROD)",
+    ),
+    # Idempotent on an already-lowercased URN.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+    ),
+]
+
+
+@pytest.mark.parametrize("urn,expected", LOWERCASE_DATASET_URN_CASES)
+def test_lowercase_dataset_urn_matches_server_derivation(
+    urn: str, expected: str
+) -> None:
+    assert lowercase_dataset_urn(urn) == expected


### PR DESCRIPTION
GMS derives `aliases.lowercasedUrn` for every dataset (#18639) and indexes it for exact match. That makes case-insensitive dataset resolution a single keyword lookup, instead of downloading a platform's whole catalog and guessing at casing variants locally — which is what `AutoResolveLineageUrnsProcessor` does today.

This PR adds the client-side pieces for that lookup and nothing else. **Nothing calls them yet**, so it reverts cleanly and reviews on its own.

## What

Two `DataHubGraph` methods, each placed next to its siblings:

| Method | Where | Does |
| --- | --- | --- |
| `resolve_lowercased_urns(keys)` | beside `get_urns_by_filter` | Batched lookup, chunked internally so callers never think about request limits |
| `supports_dataset_aliases()` | beside `get_entity_aspect_specs` | Whether this server registers the `aliases` aspect on datasets |

No new module — these are filtered-search and capability helpers, which is what every sibling in `client.py` already is.

## The key derivation already existed

`utilities/urns/urn_iter.lowercase_dataset_urn` computes exactly what the server indexes: name lowercased in full (platform-instance prefix included), platform and env untouched. So this PR reuses it rather than adding a second copy.

Worth knowing what that function has quietly become, though: a server-side index now depends on it. If the two derivations drift by a single character, every lookup misses **silently** — filtering on a value nothing was indexed under returns zero hits rather than an error, so the failure looks exactly like "nothing matched."

It had no direct test, and nothing at the function said any of this. So it gains:

- a docstring naming the cross-language contract and pointing at the test cases
- parametrized cases mirroring [`AliasesUtilsTest`](https://github.com/datahub-project/datahub/blob/master/metadata-utils/src/test/java/com/linkedin/metadata/utils/AliasesUtilsTest.java) one for one, including the non-ASCII case that pins Python's `str.lower()` against Java's `Locale.ROOT`

## Two contracts worth a second look

**The lookup returns every URN sharing a key, not one.** On a case-sensitive platform two distinct tables can share a lowercased key. Returning a single match would hand the caller an arbitrary winner and quietly merge two different entities; returning all of them lets the caller decline to guess.

**The capability check returns `False` rather than raising** — both when the registry API is unreachable and when `dataset` isn't registered. Callers need this precisely because an unsupported server is otherwise indistinguishable from a run where nothing matched.

## Testing

- `pytest tests/unit/ingestion/graph/ tests/unit/serde/test_urn_iterator.py` — 28 passed
- Wider sweep over graph / urn / serde / powerbi — 2110 passed
- `mypy` clean; `ruff check` / `ruff format --check` clean

Covered: derivation against the server's own cases; collision returns all matches; a missing key is absent from the result; keys deduplicated and chunked (1200 keys → 500/500/200); no keys makes no request; each capability-check failure mode returns `False`.

## One open question for reviewers

`ESUtils.toKeywordField` appends `.keyword` to any filter field not in its known-keyword set, so a filter on `lowercasedUrn` becomes `lowercasedUrn.keyword`. The v2 index mappings create that subfield for a `KEYWORD` searchable field; the v3 multi-entity mappings look like they map it as a plain `keyword` with a normalizer and no subfield.

If that reading is right, the filter would target a nonexistent field on a v3 index and return zero hits — silently, since that is also what "nothing matched" looks like. I have not verified this against a live v3 instance. **Would appreciate a sanity check from someone who knows the entity-index versions**, since it decides whether this lookup needs an index-version-aware field name.

## Checklist

- [x] PR conforms to the Contributing Guideline, particularly PR Title Format
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs added/updated — n/a, nothing calls this yet; docs land with the feature that uses it
- [ ] Breaking change entry in Updating DataHub — n/a, purely additive