### PR TITLE
fix(cli): send version-skew warning to stderr so stdout stays parseable

### DIFF
--- a/metadata-ingestion/src/datahub/upgrade/upgrade.py
+++ b/metadata-ingestion/src/datahub/upgrade/upgrade.py
@@ -407,7 +407,8 @@ def _maybe_print_upgrade_message(
                 + click.style(
                     f"➡️ Downgrade via `\"pip install 'acryl-datahub=={version_stats.server.current.version}'\"",
                     fg="cyan",
-                )
+                ),
+                err=True,
             )
     elif client_server_compat > 0:
         with contextlib.suppress(Exception):

--- a/metadata-ingestion/tests/unit/cli/test_check_upgrade.py
+++ b/metadata-ingestion/tests/unit/cli/test_check_upgrade.py
@@ -139,3 +139,7 @@ def test_non_cloud_server_shows_version_warnings(mock_echo):
     assert "❗Client-Server Incompatible❗" in call_args
     assert "0.9.7" in call_args  # Client version
     assert "0.9.5" in call_args  # Server version
+
+    # The warning must go to stderr, so that stdout stays machine-parseable
+    # for commands that emit JSON (e.g. `datahub get`).
+    assert mock_echo.call_args[1].get("err") is True


### PR DESCRIPTION
## Summary

When the CLI is newer than the server, the `❗Client-Server Incompatible❗` warning is written to
**stdout** rather than stderr. For commands whose stdout is machine-readable — `datahub get` emits
JSON — the warning is appended after the payload, so `json.loads(stdout)` fails with
`Extra data: line N column 1`.

The three sibling branches in `_maybe_print_upgrade_message` already pass `err=True`; only the
`client_server_compat < 0` branch did not. This adds it, so all four are consistent.

Fixes #18862

## Before

```console
$ datahub get --urn "<dataset-urn>" --aspect upstreamLineage 2>/dev/null > out.json
$ python -c "import json; json.load(open('out.json'))"
json.decoder.JSONDecodeError: Extra data: line 136 column 1 (char 5594)
```

stderr was already redirected, so the warning was definitely on stdout.

## After

stdout is pure JSON; the warning still reaches the user on stderr.

## Why it matters

Agent skills in [`datahub-project/datahub-skills`](https://github.com/datahub-project/datahub-skills)
instruct LLM agents to shell out to `datahub get` and parse the result. On a version-skewed setup —
the normal state after `pip install -U acryl-datahub` against an older quickstart — the agent fails
at the parse step with an error that points nowhere near the real cause.

## Testing

`test_non_cloud_server_shows_version_warnings` exercises exactly this branch (client 0.9.7, server
0.9.5) and asserts against `mock_echo.call_args[0][0]`, i.e. the positional argument. Adding the
`err=True` keyword does not change positional args, so the existing assertion still holds.

Verified locally against CLI `1.6.0.13` / server `v1.5.0.6` (OSS quickstart).
