### PR TITLE
fix(patch): register a patch template for institutionalMemory

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/InstitutionalMemoryTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/common/InstitutionalMemoryTemplate.java
@@ -1,0 +1,51 @@
+package com.linkedin.metadata.aspect.patch.template.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.InstitutionalMemoryMetadataArray;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.patch.template.ArrayMergingTemplate;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+
+public class InstitutionalMemoryTemplate implements ArrayMergingTemplate<InstitutionalMemory> {
+
+  private static final String ELEMENTS_FIELD_NAME = "elements";
+  private static final String URL_FIELD_NAME = "url";
+
+  @Override
+  public InstitutionalMemory getSubtype(RecordTemplate recordTemplate) throws ClassCastException {
+    if (recordTemplate instanceof InstitutionalMemory) {
+      return (InstitutionalMemory) recordTemplate;
+    }
+    throw new ClassCastException("Unable to cast RecordTemplate to InstitutionalMemory");
+  }
+
+  @Override
+  public Class<InstitutionalMemory> getTemplateType() {
+    return InstitutionalMemory.class;
+  }
+
+  @Nonnull
+  @Override
+  public InstitutionalMemory getDefault() {
+    InstitutionalMemory institutionalMemory = new InstitutionalMemory();
+    institutionalMemory.setElements(new InstitutionalMemoryMetadataArray());
+
+    return institutionalMemory;
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode transformFields(JsonNode baseNode) {
+    return arrayFieldToMap(
+        baseNode, ELEMENTS_FIELD_NAME, Collections.singletonList(URL_FIELD_NAME));
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode rebaseFields(JsonNode patched) {
+    return transformedMapToArray(
+        patched, ELEMENTS_FIELD_NAME, Collections.singletonList(URL_FIELD_NAME));
+  }
+}

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
@@ -112,8 +112,7 @@ public class SnapshotEntityRegistry implements EntityRegistry {
     aspectSpecTemplateMap.put(
         EDITABLE_SCHEMA_METADATA_ASPECT_NAME, new EditableSchemaMetadataTemplate());
     aspectSpecTemplateMap.put(GLOSSARY_TERMS_ASPECT_NAME, new GlossaryTermsTemplate());
-    aspectSpecTemplateMap.put(
-        INSTITUTIONAL_MEMORY_ASPECT_NAME, new InstitutionalMemoryTemplate());
+    aspectSpecTemplateMap.put(INSTITUTIONAL_MEMORY_ASPECT_NAME, new InstitutionalMemoryTemplate());
     aspectSpecTemplateMap.put(DATA_FLOW_INFO_ASPECT_NAME, new DataFlowInfoTemplate());
     aspectSpecTemplateMap.put(DATA_JOB_INFO_ASPECT_NAME, new DataJobInfoTemplate());
     aspectSpecTemplateMap.put(

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
@@ -12,6 +12,7 @@ import com.linkedin.metadata.aspect.patch.template.common.DocumentationTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.DomainsTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.GlobalTagsTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.GlossaryTermsTemplate;
+import com.linkedin.metadata.aspect.patch.template.common.InstitutionalMemoryTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.OwnershipTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.SiblingsTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.StatusTemplate;
@@ -111,6 +112,8 @@ public class SnapshotEntityRegistry implements EntityRegistry {
     aspectSpecTemplateMap.put(
         EDITABLE_SCHEMA_METADATA_ASPECT_NAME, new EditableSchemaMetadataTemplate());
     aspectSpecTemplateMap.put(GLOSSARY_TERMS_ASPECT_NAME, new GlossaryTermsTemplate());
+    aspectSpecTemplateMap.put(
+        INSTITUTIONAL_MEMORY_ASPECT_NAME, new InstitutionalMemoryTemplate());
     aspectSpecTemplateMap.put(DATA_FLOW_INFO_ASPECT_NAME, new DataFlowInfoTemplate());
     aspectSpecTemplateMap.put(DATA_JOB_INFO_ASPECT_NAME, new DataJobInfoTemplate());
     aspectSpecTemplateMap.put(

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
@@ -25,23 +25,35 @@ public class InstitutionalMemoryTemplateTest {
             new AuditStamp().setActor(UrnUtils.getUrn("urn:li:corpuser:datahub")).setTime(0L));
   }
 
+  /**
+   * JSON Pointer escaping, which matters more here than for the urn-keyed aspects: a URL contains
+   * slashes, and an unescaped slash is a path separator rather than part of the key.
+   */
+  private static String pointer(String url) {
+    return "/elements/" + url.replace("~", "~0").replace("/", "~1");
+  }
+
   private static JsonPatch addElement(String url, String description) {
     return Json.createPatch(
         Json.createArrayBuilder()
             .add(
                 Json.createObjectBuilder()
                     .add("op", "add")
-                    .add("path", "/elements/" + url)
+                    .add("path", pointer(url))
+                    // ArrayMergingTemplate maps each key to a *list* of entries, so the
+                    // patch value is an array, as in GlobalTagsTemplateTest.
                     .add(
                         "value",
-                        Json.createObjectBuilder()
-                            .add("url", url)
-                            .add("description", description)
+                        Json.createArrayBuilder()
                             .add(
-                                "createStamp",
                                 Json.createObjectBuilder()
-                                    .add("actor", "urn:li:corpuser:datahub")
-                                    .add("time", 0))))
+                                    .add("url", url)
+                                    .add("description", description)
+                                    .add(
+                                        "createStamp",
+                                        Json.createObjectBuilder()
+                                            .add("actor", "urn:li:corpuser:datahub")
+                                            .add("time", 0)))))
             .build());
   }
 
@@ -93,7 +105,7 @@ public class InstitutionalMemoryTemplateTest {
                 .add(
                     Json.createObjectBuilder()
                         .add("op", "remove")
-                        .add("path", "/elements/https://example.org/a"))
+                        .add("path", pointer("https://example.org/a")))
                 .build());
 
     InstitutionalMemory result = TEMPLATE.applyPatch(initial, patch);

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
@@ -22,9 +22,7 @@ public class InstitutionalMemoryTemplateTest {
         .setUrl(new Url(url))
         .setDescription(description)
         .setCreateStamp(
-            new AuditStamp()
-                .setActor(UrnUtils.getUrn("urn:li:corpuser:datahub"))
-                .setTime(0L));
+            new AuditStamp().setActor(UrnUtils.getUrn("urn:li:corpuser:datahub")).setTime(0L));
   }
 
   private static JsonPatch addElement(String url, String description) {
@@ -64,7 +62,8 @@ public class InstitutionalMemoryTemplateTest {
     Assert.assertEquals(result.getElements().size(), 2);
     List<String> urls = result.getElements().stream().map(e -> e.getUrl().toString()).toList();
     Assert.assertTrue(urls.contains("https://example.org/a"), "first writer's link should survive");
-    Assert.assertTrue(urls.contains("https://example.org/b"), "second writer's link should be added");
+    Assert.assertTrue(
+        urls.contains("https://example.org/b"), "second writer's link should be added");
   }
 
   @Test

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/InstitutionalMemoryTemplateTest.java
@@ -1,0 +1,113 @@
+package com.linkedin.metadata.aspect.patch.template;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.InstitutionalMemoryMetadata;
+import com.linkedin.common.InstitutionalMemoryMetadataArray;
+import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.aspect.patch.template.common.InstitutionalMemoryTemplate;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class InstitutionalMemoryTemplateTest {
+
+  private static final InstitutionalMemoryTemplate TEMPLATE = new InstitutionalMemoryTemplate();
+
+  private static InstitutionalMemoryMetadata element(String url, String description) {
+    return new InstitutionalMemoryMetadata()
+        .setUrl(new Url(url))
+        .setDescription(description)
+        .setCreateStamp(
+            new AuditStamp()
+                .setActor(UrnUtils.getUrn("urn:li:corpuser:datahub"))
+                .setTime(0L));
+  }
+
+  private static JsonPatch addElement(String url, String description) {
+    return Json.createPatch(
+        Json.createArrayBuilder()
+            .add(
+                Json.createObjectBuilder()
+                    .add("op", "add")
+                    .add("path", "/elements/" + url)
+                    .add(
+                        "value",
+                        Json.createObjectBuilder()
+                            .add("url", url)
+                            .add("description", description)
+                            .add(
+                                "createStamp",
+                                Json.createObjectBuilder()
+                                    .add("actor", "urn:li:corpuser:datahub")
+                                    .add("time", 0))))
+            .build());
+  }
+
+  @Test
+  public void testTwoWritersBothSurvive() throws Exception {
+    // The reason this template is worth having: institutionalMemory is an
+    // append-shaped aspect, and without patch support the only way to add a link
+    // is read-modify-write, which drops whatever another writer added in between.
+    InstitutionalMemory initial = new InstitutionalMemory();
+    initial.setElements(new InstitutionalMemoryMetadataArray());
+
+    InstitutionalMemory afterFirst =
+        TEMPLATE.applyPatch(initial, addElement("https://example.org/a", "first writer"));
+    InstitutionalMemory result =
+        TEMPLATE.applyPatch(afterFirst, addElement("https://example.org/b", "second writer"));
+
+    Assert.assertNotNull(result.getElements());
+    Assert.assertEquals(result.getElements().size(), 2);
+    List<String> urls = result.getElements().stream().map(e -> e.getUrl().toString()).toList();
+    Assert.assertTrue(urls.contains("https://example.org/a"), "first writer's link should survive");
+    Assert.assertTrue(urls.contains("https://example.org/b"), "second writer's link should be added");
+  }
+
+  @Test
+  public void testAddOnSameUrlUpserts() throws Exception {
+    InstitutionalMemory initial = new InstitutionalMemory();
+    initial.setElements(
+        new InstitutionalMemoryMetadataArray(element("https://example.org/a", "before")));
+
+    InstitutionalMemory result =
+        TEMPLATE.applyPatch(initial, addElement("https://example.org/a", "after"));
+
+    Assert.assertNotNull(result.getElements());
+    Assert.assertEquals(result.getElements().size(), 1, "url is the key, so this is an update");
+    Assert.assertEquals(result.getElements().get(0).getDescription(), "after");
+  }
+
+  @Test
+  public void testRemoveOneOfTwoEntries() throws Exception {
+    InstitutionalMemory initial = new InstitutionalMemory();
+    initial.setElements(
+        new InstitutionalMemoryMetadataArray(
+            element("https://example.org/a", "a"), element("https://example.org/b", "b")));
+
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createArrayBuilder()
+                .add(
+                    Json.createObjectBuilder()
+                        .add("op", "remove")
+                        .add("path", "/elements/https://example.org/a"))
+                .build());
+
+    InstitutionalMemory result = TEMPLATE.applyPatch(initial, patch);
+
+    Assert.assertNotNull(result.getElements());
+    Assert.assertEquals(result.getElements().size(), 1);
+    Assert.assertEquals(result.getElements().get(0).getUrl().toString(), "https://example.org/b");
+  }
+
+  @Test
+  public void testDefaultIsEmptyNotNull() {
+    InstitutionalMemory defaultValue = TEMPLATE.getDefault();
+    Assert.assertNotNull(defaultValue.getElements());
+    Assert.assertTrue(defaultValue.getElements().isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes #18851.

`PATCH /openapi/v3/entity/{entityName}/{urn}/institutionalMemory` currently returns a 500 with an
unhandled `NullPointerException`, because no template is registered for the aspect:

```
java.lang.NullPointerException: Cannot invoke
  "com.linkedin.metadata.aspect.patch.template.Template.applyPatch(...)" because "template" is null
  at AspectTemplateEngine.applyPatch(AspectTemplateEngine.java:86)
```

Probing ten dataset aspects on Core v1.5.0.6 separates them cleanly — `globalTags`,
`upstreamLineage`, `ownership`, `glossaryTerms`, `datasetProperties`, `editableSchemaMetadata`,
`domains` and `structuredProperties` all reach the template engine; `institutionalMemory` does
not. So this is a per-aspect gap rather than a missing feature. (`status` also threw on the
version I tested, but `StatusTemplate` exists on master, so that appears already fixed.)

## Why it matters

`institutionalMemory` is an append-shaped aspect — several writers add links to the same entity
over time, which is the shape patch support exists for. Without a template the only route is
read-append-write of the whole aspect, which silently drops whatever another writer added between
the read and the write. `If-Version-Match` does not rescue it either: a write carrying a stale
version returns 200 rather than 412, so a version-checked retry never fires.

## The change

`InstitutionalMemoryTemplate` follows `GlobalTagsTemplate` exactly — `ArrayMergingTemplate` over
`elements`, keyed by `url`, which is the natural primary key for the array. The aspect has no
deprecated top-level audit stamp to backfill, so it needs none of the `transformFields` handling
`GlossaryTermsTemplate` carries.

Registered in `SnapshotEntityRegistry` beside the other common templates.

## Tests

`InstitutionalMemoryTemplateTest` covers the case that motivated the fix — two writers adding
different links, both surviving — plus upsert on the same url, removal of one of two entries, and
a non-null empty default.

## Disclosure

I wrote this against a shallow clone and have not run the Gradle build locally, so I am relying
on CI for compilation. Every identifier is checked against existing usage in
`InstitutionalMemoryChangeEventGenerator` and `li-utils`, but a second pair of eyes on the
generated-class names would be welcome. Happy to adjust the keying if `url` is not the primary
key you would choose.

Found while building an agent that writes decision certificates back into `institutionalMemory`,
where the non-atomic append had to be documented as a known limitation rather than fixed.