### PR TITLE
feat(ingest): add alias_lookup mode to lineage URN casing resolution

### DIFF
--- a/metadata-ingestion/docs/dev_guides/lineage_urn_casing.md
+++ b/metadata-ingestion/docs/dev_guides/lineage_urn_casing.md
@@ -23,17 +23,19 @@ entire downstream path.
 
 ## Two ways to keep lineage connected
 
-**`convert_urns_to_lowercase` (legacy).** The older mitigation is this per-source flag, which keeps
-lineage connected by **lowercasing every URN**. It works only when enabled consistently across _all_
-sources that reference the same entities, isn't available on some BI connectors (e.g. Looker, Tableau),
-and — because it flattens every identity to lowercase — loses the warehouse's real display casing and can
-even merge two genuinely different tables (`MyTable` and `mytable`) into one entity.
+**`convert_urns_to_lowercase` (legacy)** — a per-source flag that **lowercases every URN**. Drawbacks:
 
-**Lineage URN casing normalization (recommended).** Instead of flattening identities, this feature
-resolves each upstream reference to the casing of the entity that **already exists** in DataHub. It is
-preferred because it **does not alter the identity of your assets**: the warehouse keeps its original
-casing, reconciliation happens per ingestion with no cross-source coordination, and references are only
-rewritten when the match is unambiguous. It is opt-in and **not enabled by default**.
+- must be enabled consistently across _all_ sources referencing the same entities
+- unavailable on some BI connectors (e.g. Looker, Tableau)
+- loses the warehouse's real display casing, and can merge `MyTable` with `mytable`
+
+**Lineage URN casing normalization (recommended)** — rewrites each upstream reference to the casing of the
+entity that **already exists** in DataHub, leaving asset identity untouched:
+
+- the warehouse keeps its original casing
+- reconciliation is per ingestion, with no cross-source coordination
+- references are rewritten only when an existing entity matches
+- opt-in, **not enabled by default**
 
 ## How it works
 
@@ -50,12 +52,11 @@ downstream fields are never touched — the feature respects the casing the ware
 Column-level casing is corrected the same way, using the schema DataHub stores for the resolved table
 (so a BI tool reporting `AMOUNT` on a lowercase-stored table is reconciled to the warehouse's `amount`).
 
-> **Current coverage limit.** Reconciliation currently heals a reference when the warehouse stores the
-> entity in its **lowercased** form (the common Snowflake/BigQuery default) — regardless of how the BI
-> tool cased it. A warehouse that keeps a **non-lowercase** identity (UPPER / Pascal / Mixed) is **not
-> yet** reconciled, and ambiguous case-collisions are not detected. Full any-casing resolution and
-> collision-safety are planned as backend infrastructure; once it lands, this feature picks it up
-> automatically with no config change.
+> **Coverage depends on the resolution mode.** The default `bulk_catalog` mode heals a reference when the
+> warehouse stores the entity in its **lowercased** form (the common Snowflake/BigQuery default),
+> regardless of how the BI tool cased it; a warehouse that keeps a **non-lowercase** identity
+> (UPPER / Pascal / Mixed) is not reconciled, and case-collisions are not detected. The `alias_lookup`
+> mode covers **every** casing and handles collisions. See [Resolution modes](#resolution-modes).
 
 ### What gets fixed
 
@@ -71,8 +72,43 @@ Column-level casing is corrected the same way, using the schema DataHub stores f
 | `dataProcessInstance` run lineage                       | ❌ not yet covered                        |
 
 A DataJob's **outputs** are its own declared products, so they are deliberately left untouched — the
-feature never rewrites an entity's own or downstream side. The not-yet-covered rows are incremental
-follow-ups; most connectors emit the covered aspects.
+feature never rewrites an entity's own or downstream side.
+
+## Resolution modes
+
+Both modes reconcile the same references and record the same match types; they differ only in how the
+stored URN is found.
+
+**`bulk_catalog` (default).** Downloads each configured upstream platform's catalog once at the start of
+the run and matches against it locally. Because it rebuilds the URN from the table's name parts, it can
+also heal a reference whose platform-instance prefix is missing or miscased — the one thing `alias_lookup`
+cannot do.
+
+**`alias_lookup`.** Looks each reference up directly in DataHub, using an index the server maintains of
+every dataset's lowercased URN:
+
+- downloads no catalog
+- covers **every** casing, not just the lowercased form
+- handles case-collisions instead of missing them (below)
+- resolves any platform, so `upstream_platforms` is not consulted
+- matches **by casing alone**, so a reference with a wrong platform-instance prefix stays unresolved
+
+When two live entities differ only by casing — usually the residue of turning `convert_urns_to_lowercase`
+on or off — the reference resolves to whichever it matches exactly, else to the **lowercased** one, since
+that is the variant the flag produced. Retired duplicates don't interfere: soft-deleted entities are never
+candidates. Only when neither the reference nor the lowercased form exists is it left unchanged and
+reported.
+
+`alias_lookup` requires a DataHub server that registers the `aliases` aspect on datasets. On an older
+server the run **fails at startup** with an actionable message rather than silently resolving nothing.
+
+Start on the default. Switch to `alias_lookup` when your warehouse keeps non-lowercase identities, when
+the catalog is large enough that holding it in memory is a problem, or when you'd rather not maintain
+`upstream_platforms`.
+
+> **Not necessarily faster.** `alias_lookup` trades one large upfront download for one small query per
+> reference, and references are not memoized — a table referenced by fifty dashboards costs fifty
+> lookups. Pick it for coverage and memory, not for run time.
 
 ## Enabling the feature
 
@@ -102,13 +138,24 @@ sink:
 
 ### Configuration reference
 
-| Field                                    | Required           | Default | Description                                                                     |
-| ---------------------------------------- | ------------------ | ------- | ------------------------------------------------------------------------------- |
-| `enabled`                                | yes                | `false` | Whether to reconcile upstream lineage URN casing.                               |
-| `upstream_platforms`                     | yes (when enabled) | `[]`    | Upstream warehouse platform(s) to reconcile against. Others are left unchanged. |
-| `upstream_platforms[].platform`          | yes                | —       | The upstream data platform, e.g. `snowflake`.                                   |
-| `upstream_platforms[].platform_instance` | no                 | `null`  | Platform instance of the upstream platform, if any.                             |
-| `upstream_platforms[].env`               | no                 | `PROD`  | Environment (FabricType) of the upstream platform's assets.                     |
+| Field                                    | Required               | Default        | Description                                                                                                     |
+| ---------------------------------------- | ---------------------- | -------------- | --------------------------------------------------------------------------------------------------------------- |
+| `enabled`                                | yes                    | `false`        | Whether to reconcile upstream lineage URN casing.                                                               |
+| `mode`                                   | no                     | `bulk_catalog` | `bulk_catalog` or `alias_lookup` — see [Resolution modes](#resolution-modes).                                   |
+| `upstream_platforms`                     | in `bulk_catalog` mode | `[]`           | Upstream warehouse platform(s) to reconcile against. Others are left unchanged. Ignored in `alias_lookup` mode. |
+| `upstream_platforms[].platform`          | yes                    | —              | The upstream data platform, e.g. `snowflake`.                                                                   |
+| `upstream_platforms[].platform_instance` | no                     | `null`         | Platform instance of the upstream platform, if any.                                                             |
+| `upstream_platforms[].env`               | no                     | `PROD`         | Environment (FabricType) of the upstream platform's assets.                                                     |
+
+To use `alias_lookup`, set the mode and drop `upstream_platforms` — every platform is resolved without
+being listed:
+
+```yaml
+flags:
+  auto_resolve_lineage_urns:
+    enabled: true
+    mode: alias_lookup
+```
 
 ### Where to enable it
 
@@ -118,24 +165,25 @@ Tableau, Sigma, Redash, Superset, Qlik, etc.), pointing it at the upstream wareh
 Do **not** enable it on the warehouse ingestion itself (e.g. Snowflake) — the warehouse is the source of
 truth for its own casing and identity.
 
-> **Expect mostly `EXACT` if there is no actual mismatch.** The feature only rewrites genuine casing
-> mismatches. If both sides already agree on casing, references are recorded `EXACT` with zero rewrites —
-> that is the feature working correctly. You'll see `NORMALIZED` only where the two sides disagree.
+> **Expect mostly `EXACT`.** Where both sides already agree on casing, references are recorded `EXACT`
+> with zero rewrites — that is the feature working correctly. `NORMALIZED` appears only where they
+> disagree.
 
 ## Match types
 
-For every upstream reference **on a configured platform**, the feature records a `matchType` on the
-lineage aspect:
+For every upstream reference **in scope** — the configured platforms in `bulk_catalog` mode, any dataset
+reference in `alias_lookup` mode — the feature records a `matchType` on the lineage aspect:
 
 - **`EXACT`** — already matched an existing entity exactly, including casing. Left unchanged.
 - **`NORMALIZED`** — rewritten to heal a casing mismatch against an existing entity.
-- **`UNRESOLVED`** — could not be resolved to a single existing entity (no match, or an ambiguous
-  collision). Left unchanged, but flagged so potentially **broken lineage** is visible rather than
-  indistinguishable from a clean edge.
+- **`UNRESOLVED`** — no existing entity matched, or several did with no way to choose between them. Left
+  unchanged, but flagged so potentially **broken lineage** is visible rather than indistinguishable from a
+  clean edge.
 
-**No `matchType` means the reference is out of scope** — its platform isn't configured, the feature is
-disabled for that source, or the data predates the feature. Absence is not a verdict. Stamping is
-ingest-time only: existing metadata is updated only when its source is re-ingested with the feature on.
+**No `matchType` means the reference is out of scope** — it isn't a dataset reference, its platform isn't
+configured (`bulk_catalog` only), the feature is disabled for that source, or the data predates the
+feature. Absence is not a verdict. Stamping is ingest-time only: existing metadata is updated only when
+its source is re-ingested with the feature on.
 
 ## Requirements and limitations
 
@@ -147,17 +195,18 @@ ingest-time only: existing metadata is updated only when its source is re-ingest
   and the BI source re-runs.
 - **Does not retroactively heal existing broken edges.** Re-ingest the affected source after enabling the
   flag to fix them.
-- **Conservative on collisions.** On case-sensitive platforms where two genuinely different tables differ
-  only by case, ambiguous references are left unchanged rather than risk merging distinct entities.
-- **Reconciles against tables that have a schema in DataHub.** A referenced table that exists without a
-  schema (more common on schemaless platforms like Kafka/DynamoDB) is left unchanged and reported
-  `UNRESOLVED`. Broadening this is a tracked follow-up.
+- **Conservative on collisions.** When two entities differ only by casing and neither the reference nor
+  the lowercased form is one of them, the reference is left unchanged rather than risk merging distinct
+  tables. These get their own warning, since the fix (remove the duplicate entity) differs from the fix
+  for an unresolved reference (ingest the upstream). Only `alias_lookup` mode sees collisions at all —
+  see [Resolution modes](#resolution-modes).
+- **In `bulk_catalog` mode, reconciles only against tables that have a schema in DataHub.** A referenced
+  table that exists without a schema (more common on schemaless platforms like Kafka/DynamoDB) is left
+  unchanged and reported `UNRESOLVED`. `alias_lookup` mode resolves on existence and is unaffected.
 - **Requires the SQL-parser dependency (`sqlglot`).** Every intended BI/dashboard connector already
   bundles it, so the target use case needs no extra install. If you enable the flag on a source that
   doesn't, the feature reports a clear failure (`install acryl-datahub[sql-parser]`) and emits lineage
   unchanged.
-- **Only reconciles full-aspect (UPSERT) lineage, not PATCH.** A lineage aspect emitted as a patch
-  (e.g. `dataJobInputOutput` via `DatasetPatchBuilder.add_upstream_lineage` / `DataJobPatchBuilder`,
-  used by some dbt / Airflow / Spark paths) is emitted unchanged and counted under
-  `num_patch_lineage_skipped` with an end-of-run warning. The BI/dashboard targets emit full aspects
-  and are unaffected; broadening this to patches is a tracked follow-up.
+- **Only reconciles full-aspect (UPSERT) lineage, not PATCH.** A lineage aspect emitted as a patch (some
+  dbt / Airflow / Spark paths) is emitted unchanged and counted under `num_patch_lineage_skipped` with an
+  end-of-run warning. The BI/dashboard targets emit full aspects and are unaffected.

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -321,5 +321,7 @@ class PipelineConfig(ConfigModel):
     def get_raw_dict(self) -> Dict:
         result = self._raw_dict
         if result is None:
-            result = self.model_dump()
+            # mode="json" so callers that serialize the recipe (e.g. run-summary
+            # reporting) don't trip over non-JSON-native values like config enums.
+            result = self.model_dump(mode="json")
         return result

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline_config.py
@@ -4,11 +4,17 @@ import datetime
 import logging
 import random
 import string
+from enum import auto
 from typing import Dict, List, Optional
 
 from pydantic import Field, field_validator, model_validator
 
-from datahub.configuration.common import ConfigModel, DynamicTypedConfig, HiddenFromDocs
+from datahub.configuration.common import (
+    ConfigEnum,
+    ConfigModel,
+    DynamicTypedConfig,
+    HiddenFromDocs,
+)
 from datahub.configuration.env_vars import (
     get_progress_report_max_failures,
     get_progress_report_max_infos,
@@ -76,6 +82,13 @@ class UpstreamPlatformCasing(PlatformInstanceConfigMixin, EnvConfigMixin):
         return DataPlatformUrn(v).platform_name
 
 
+class LineageUrnResolutionMode(ConfigEnum):
+    """How a lineage reference is resolved to the URN DataHub actually stores."""
+
+    BULK_CATALOG = auto()
+    ALIAS_LOOKUP = auto()
+
+
 class AutoResolveLineageUrnsConfig(ConfigModel):
     """Configuration for the auto-resolve lineage URNs work unit processor.
 
@@ -92,24 +105,37 @@ class AutoResolveLineageUrnsConfig(ConfigModel):
         "connector extra that bundles it. Every intended BI/dashboard connector already "
         "does, so the target use case needs no extra install.",
     )
+    mode: LineageUrnResolutionMode = Field(
+        default=LineageUrnResolutionMode.BULK_CATALOG,
+        description="How references are resolved. `bulk_catalog` (the default) downloads "
+        "each configured upstream platform's catalog up front and matches references "
+        "against that copy, so it heals only references DataHub stores as-given or "
+        "lowercased. `alias_lookup` queries DataHub per reference instead — no catalog "
+        "download, and matches any casing — but requires a server that registers the "
+        "`aliases` aspect.",
+    )
     upstream_platforms: List[UpstreamPlatformCasing] = Field(
         default_factory=list,
         description="The upstream warehouse platform(s) to bulk-load and reconcile "
         "lineage references against. References to platforms not listed here are "
-        "left unchanged.",
+        "left unchanged. Required in `bulk_catalog` mode; ignored in `alias_lookup` "
+        "mode, which resolves any platform without being told about it.",
     )
 
     @model_validator(mode="after")
     def _require_upstream_platforms_when_enabled(
         self,
     ) -> "AutoResolveLineageUrnsConfig":
-        # Enabled with no upstream_platforms has nothing to reconcile against — every
-        # reference would no-op. Fail fast rather than silently doing nothing.
-        if self.enabled and not self.upstream_platforms:
+        if (
+            self.enabled
+            and self.mode is LineageUrnResolutionMode.BULK_CATALOG
+            and not self.upstream_platforms
+        ):
             raise ValueError(
-                "auto_resolve_lineage_urns is enabled but no upstream_platforms are "
-                "configured; there is nothing to reconcile against. List the upstream "
-                "warehouse platform(s) this source references, or set enabled: false."
+                "auto_resolve_lineage_urns is enabled in bulk_catalog mode but no "
+                "upstream_platforms are configured; there is nothing to reconcile "
+                "against. List the upstream warehouse platform(s) this source "
+                "references, use mode: alias_lookup, or set enabled: false."
             )
         return self
 
@@ -118,7 +144,10 @@ class AutoResolveLineageUrnsConfig(ConfigModel):
         # Fail fast at config parse (only when enabled) if the SQL parser is missing,
         # rather than deep in the processor at run time. Resolution reuses the
         # SchemaResolver, which depends on sqlglot; sqlglot is not in the ingestion core,
-        # so a source whose extra doesn't bundle it would otherwise fail mid-run.
+        # so a source whose extra doesn't bundle it would otherwise fail mid-run. Required
+        # in alias_lookup mode too: it doesn't resolve via SchemaResolver, but the column
+        # matching and schema conversion it uses still live in that sqlglot-importing
+        # module. Extracting those is what will narrow this to bulk_catalog only.
         if self.enabled:
             try:
                 import sqlglot  # noqa: F401

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/alias_lookup.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/alias_lookup.py
@@ -1,0 +1,143 @@
+# Keep sqlglot off the module-load path: annotations stay strings and the schema_resolver
+# import is deferred to __init__ (test_module_import_does_not_pull_sqlglot).
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from datahub.ingestion.api.workunit_processor import WorkunitProcessorContext
+from datahub.ingestion.graph.filters import SearchFilterRule
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
+    EXACT,
+    NORMALIZED,
+    UNRESOLVED,
+    Resolution,
+)
+from datahub.metadata.schema_classes import AliasesClass, SchemaMetadataClass
+from datahub.utilities.urns.error import InvalidUrnError
+from datahub.utilities.urns.urn_iter import lowercase_dataset_urn
+
+if TYPE_CHECKING:
+    from datahub.ingestion.graph.client import DataHubGraph
+    from datahub.sql_parsing.schema_resolver import SchemaInfo
+
+# The keyword field GMS indexes each dataset's lowercased URN under (Aliases.pdl).
+_LOWERCASED_URN_FIELD = "lowercasedUrn"
+
+
+class AliasLookupStrategy:
+    """Resolve casing by looking each reference up in the server's alias index.
+
+    Matches only entities that differ from the reference by casing alone.
+    """
+
+    def __init__(self, ctx: WorkunitProcessorContext) -> None:
+        self._ctx = ctx
+        graph = ctx.pipeline_context.graph
+        assert graph is not None  # should_enable guarantees a graph exists
+        self._graph: DataHubGraph = graph
+        self._require_alias_support()
+        # Reused rather than reimplemented because it drops struct-nested field paths,
+        # which column matching relies on. Private until the schema store is extracted.
+        from datahub.sql_parsing.schema_resolver import _convert_schema_aspect_to_info
+
+        self._to_schema_info: Callable[[SchemaMetadataClass], SchemaInfo] = (
+            _convert_schema_aspect_to_info
+        )
+
+        # References whose collision had no principled winner, for one end-of-run warning.
+        self._ambiguous_refs = 0
+
+    def _require_alias_support(self) -> None:
+        """Fail the run unless the server is known to index dataset aliases.
+
+        Filtering on a field the server doesn't index returns zero hits rather than an
+        error, so continuing would emit unhealed lineage that looks reconciled.
+        """
+        specs = self._graph.get_entity_aspect_specs()
+        if specs is None:
+            raise ValueError(
+                "auto_resolve_lineage_urns mode 'alias_lookup' could not read the "
+                "DataHub server's entity registry, so it cannot confirm that the "
+                "'aliases' aspect is registered on datasets. Retry, or set "
+                "mode: bulk_catalog."
+            )
+        try:
+            supported = specs.supports("dataset", AliasesClass.ASPECT_NAME)
+        except ValueError:
+            supported = False  # dataset entity type not registered at all
+        if not supported:
+            raise ValueError(
+                "auto_resolve_lineage_urns mode 'alias_lookup' needs a DataHub server "
+                "that registers the 'aliases' aspect on datasets, which this one does "
+                "not. Upgrade the server, or set mode: bulk_catalog."
+            )
+
+    def resolve(self, urn: str, *, need_schema: bool = False) -> Resolution:
+        resolution = self._resolve(urn)
+        if need_schema and resolution.match_type in (EXACT, NORMALIZED):
+            return Resolution(
+                resolution.urn, self._schema(resolution.urn), resolution.match_type
+            )
+        return resolution
+
+    def _resolve(self, urn: str) -> Resolution:
+        try:
+            key = lowercase_dataset_urn(urn)
+        except InvalidUrnError:
+            # Not a dataset reference, so there is no key to look up: out of scope.
+            return Resolution(urn, None, None)
+        resolved = self._pick(urn, self._lookup(key))
+        if resolved is None:
+            return Resolution(urn, None, UNRESOLVED)
+        return Resolution(resolved, None, EXACT if resolved == urn else NORMALIZED)
+
+    def _lookup(self, key: str) -> List[str]:
+        """Every live dataset URN stored under `key`, so _pick can see a collision."""
+        return list(
+            self._graph.get_urns_by_filter(
+                entity_types=["dataset"],
+                extra_or_filters=[
+                    {
+                        "and": [
+                            SearchFilterRule(
+                                field=_LOWERCASED_URN_FIELD,
+                                condition="EQUAL",
+                                values=[key],
+                            ).to_raw()
+                        ]
+                    }
+                ],
+            )
+        )
+
+    def _pick(self, urn: str, candidates: List[str]) -> Optional[str]:
+        if not candidates:
+            return None
+        if urn in candidates:
+            return urn
+        if len(candidates) == 1:
+            return candidates[0]
+        # A collision is the residue of convert_urns_to_lowercase being turned on or off,
+        # so of the two the lowercased entity is the one that flag produced.
+        lowercased = lowercase_dataset_urn(urn)
+        if lowercased in candidates:
+            return lowercased
+        self._ambiguous_refs += 1
+        return None
+
+    def _schema(self, urn: str) -> Optional[SchemaInfo]:
+        aspect = self._graph.get_aspect(urn, SchemaMetadataClass)
+        return self._to_schema_info(aspect) if aspect is not None else None
+
+    def finish(self) -> None:
+        """Report collisions apart from plain misses -- they need opposite fixes."""
+        if not self._ambiguous_refs:
+            return
+        self._ctx.source_report.warning(
+            title="Lineage references matched two entities differing only by casing",
+            message="Some upstream references matched more than one existing entity whose "
+            "URNs differ only by casing, so they were emitted unchanged. This usually "
+            "means the same physical table was ingested twice under different casings; "
+            "removing the wrong one lets these references resolve.",
+            context=f"{self._ambiguous_refs} reference(s)",
+        )

--- a/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/workunit_processors/auto_resolve_lineage_urns/processor.py
@@ -31,6 +31,7 @@ from datahub.ingestion.api.workunit_processor import (
     WorkunitProcessor,
     WorkunitProcessorContext,
 )
+from datahub.ingestion.run.pipeline_config import LineageUrnResolutionMode
 from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
     EXACT,
     NORMALIZED,
@@ -126,18 +127,12 @@ class AutoResolveLineageUrnsProcessor(
 
     def __init__(self, ctx: WorkunitProcessorContext) -> None:
         super().__init__(ctx)
-        # Deferred imports, for the same reason the module docstring gives: both of these
-        # reach sqlglot-backed code, and this __init__ runs only once should_enable() has
-        # confirmed the feature is on.
-        from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.bulk import (
-            BulkCatalogStrategy,
-        )
         from datahub.sql_parsing.schema_resolver import match_columns_to_schema
 
         self._match_columns_to_schema: Callable[[SchemaInfo, List[str]], List[str]] = (
             match_columns_to_schema
         )
-        self._strategy: ResolutionStrategy = BulkCatalogStrategy(ctx)
+        self._strategy: ResolutionStrategy = self._make_strategy(ctx)
         # (aspect class -> in-place normalizer, returns True iff it mutated the aspect).
         # These are the aspects a BI / orchestration source emits that carry *upstream
         # dataset* references — the only refs affected by cross-source casing mismatch:
@@ -164,19 +159,35 @@ class AutoResolveLineageUrnsProcessor(
             aspect_cls.ASPECT_NAME for aspect_cls, _ in self._normalizers
         }
 
+    @staticmethod
+    def _make_strategy(ctx: WorkunitProcessorContext) -> ResolutionStrategy:
+        """The resolution strategy the config selects. Lazily imported, as above."""
+        mode = ctx.pipeline_context.flags.auto_resolve_lineage_urns.mode
+        if mode is LineageUrnResolutionMode.ALIAS_LOOKUP:
+            from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.alias_lookup import (
+                AliasLookupStrategy,
+            )
+
+            return AliasLookupStrategy(ctx)
+        from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.bulk import (
+            BulkCatalogStrategy,
+        )
+
+        return BulkCatalogStrategy(ctx)
+
     @classmethod
     def should_enable(cls, ctx: WorkunitProcessorContext) -> bool:
         cfg = ctx.pipeline_context.flags.auto_resolve_lineage_urns
-        # Fail closed on a degenerate/mock config: this processor is in the shared chain
-        # for *every* source, and some connector tests build a source with a bare Mock()
-        # ctx where cfg.enabled / cfg.upstream_platforms are truthy Mocks that bypass
-        # pydantic validation. Require enabled to be exactly True and upstream_platforms a
-        # real, non-empty list. (A real enabled config is guaranteed a non-empty
-        # upstream_platforms list by AutoResolveLineageUrnsConfig's validator, which fails
-        # config parse otherwise.)
+        # Fail closed on a Mock ctx: this processor is in the shared chain for *every*
+        # source, and some connector tests pass a bare Mock() whose cfg fields are truthy
+        # Mocks bypassing pydantic — hence exact-True / isinstance over plain truthiness.
         if cfg.enabled is not True:
             return False
-        if not isinstance(cfg.upstream_platforms, list) or not cfg.upstream_platforms:
+        # Only bulk_catalog needs platforms. The config validator runs at construction only,
+        # so a later `enabled = True` can still reach here with an empty list.
+        if cfg.mode is LineageUrnResolutionMode.BULK_CATALOG and (
+            not isinstance(cfg.upstream_platforms, list) or not cfg.upstream_platforms
+        ):
             return False
         # Use getattr for graph: it's a no-op without a backend, and `graph` is a
         # PipelineContext instance attribute (absent from MagicMock(spec=...) used by

--- a/metadata-ingestion/src/datahub/utilities/urns/urn_iter.py
+++ b/metadata-ingestion/src/datahub/utilities/urns/urn_iter.py
@@ -132,6 +132,11 @@ def _modify_at_path(
 
 
 def lowercase_dataset_urn(dataset_urn: str) -> str:
+    """Lowercase a dataset URN's name, leaving its platform and env untouched.
+
+    Must stay in sync with GMS's ``AliasesUtils.lowercaseDatasetUrn``, which computes the
+    indexed ``aliases.lowercasedUrn`` we filter on -- a mismatch returns zero hits, not an error.
+    """
     cur_urn = DatasetUrn.from_string(dataset_urn)
     new_urn = DatasetUrn(
         platform=cur_urn.platform, name=cur_urn.name.lower(), env=cur_urn.env

--- a/metadata-ingestion/tests/unit/serde/test_urn_iterator.py
+++ b/metadata-ingestion/tests/unit/serde/test_urn_iterator.py
@@ -1,3 +1,5 @@
+import pytest
+
 import datahub.emitter.mce_builder as builder
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
@@ -8,7 +10,11 @@ from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
     Upstream,
     UpstreamLineage,
 )
-from datahub.utilities.urns.urn_iter import list_urns_with_path, lowercase_dataset_urns
+from datahub.utilities.urns.urn_iter import (
+    list_urns_with_path,
+    lowercase_dataset_urn,
+    lowercase_dataset_urns,
+)
 
 
 def _datasetUrn(tbl: str) -> str:
@@ -151,3 +157,47 @@ def test_dataset_urn_lowercase_transformer():
 
     lowercase_dataset_urns(original)
     assert original == expected
+
+
+# Cross-language contract with metadata-io AliasesUtilsTest: GMS derives the indexed
+# aliases.lowercasedUrn with the same rule, and any drift makes lookups miss silently.
+# Keep the two lists in sync.
+LOWERCASE_DATASET_URN_CASES = [
+    # Platform casing is preserved; only the name is lowercased.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:adlsGen2,Container/Folder,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:adlsGen2,container/folder,PROD)",
+    ),
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.Schema.Table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+    ),
+    # env is untouched.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,DEV)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,DEV)",
+    ),
+    # A platform instance is fused into the name, so it lowercases with it.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,My_Instance.DB.Schema.Table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.db.schema.table,PROD)",
+    ),
+    # Non-ASCII: Java uses Locale.ROOT so the key cannot depend on the JVM locale, and
+    # Python's str.lower() is locale-independent. Both must land on the same string.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,CAFÉ.Ñ_TITLE,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,café.ñ_title,PROD)",
+    ),
+    # Idempotent on an already-lowercased URN.
+    (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)",
+    ),
+]
+
+
+@pytest.mark.parametrize("urn,expected", LOWERCASE_DATASET_URN_CASES)
+def test_lowercase_dataset_urn_matches_server_derivation(
+    urn: str, expected: str
+) -> None:
+    assert lowercase_dataset_urn(urn) == expected

--- a/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_auto_resolve_lineage_urns.py
@@ -15,6 +15,7 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.run.pipeline_config import (
     AutoResolveLineageUrnsConfig,
+    LineageUrnResolutionMode,
     UpstreamPlatformCasing,
 )
 from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns import (
@@ -962,6 +963,7 @@ def _ctx(
     enabled: bool,
     graph: object,
     upstream_platforms: Optional[List[UpstreamPlatformCasing]] = None,
+    mode: Optional[str] = None,
 ) -> mock.MagicMock:
     pipeline_ctx = mock.MagicMock()
     pipeline_ctx.graph = graph
@@ -970,6 +972,7 @@ def _ctx(
         upstream_platforms=upstream_platforms
         if upstream_platforms is not None
         else [UpstreamPlatformCasing(platform="snowflake", env="PROD")],
+        **({"mode": mode} if mode is not None else {}),
     )
     ctx = mock.MagicMock()
     ctx.pipeline_context = pipeline_ctx
@@ -992,6 +995,35 @@ def test_enabled_without_upstream_platforms_is_a_config_error():
     # config parse rather than silently no-op.
     with pytest.raises(pydantic.ValidationError, match="upstream_platforms"):
         AutoResolveLineageUrnsConfig(enabled=True, upstream_platforms=[])
+
+
+def test_bulk_catalog_is_the_default_mode():
+    # An existing recipe must behave exactly as it does today on upgrade.
+    cfg = AutoResolveLineageUrnsConfig(
+        enabled=True,
+        upstream_platforms=[UpstreamPlatformCasing(platform="snowflake", env="PROD")],
+    )
+    assert cfg.mode == LineageUrnResolutionMode.BULK_CATALOG
+
+
+def test_alias_lookup_mode_does_not_require_upstream_platforms():
+    # Nothing is downloaded per platform in this mode, so there is nothing to configure.
+    cfg = AutoResolveLineageUrnsConfig(enabled=True, mode="alias_lookup")
+    assert cfg.mode == LineageUrnResolutionMode.ALIAS_LOOKUP
+
+
+def test_unknown_mode_is_rejected():
+    with pytest.raises(pydantic.ValidationError):
+        AutoResolveLineageUrnsConfig(enabled=True, mode="batch")
+
+
+def test_enabled_in_alias_lookup_mode_without_platforms():
+    assert (
+        AutoResolveLineageUrnsProcessor.should_enable(
+            _ctx(True, mock.MagicMock(), upstream_platforms=[], mode="alias_lookup")
+        )
+        is True
+    )
 
 
 def test_enabled_when_flag_on_with_graph():

--- a/metadata-ingestion/tests/unit/workunit_processors/test_lineage_alias_lookup.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_lineage_alias_lookup.py
@@ -1,0 +1,447 @@
+import inspect
+from typing import Dict, List, Optional, Set, Type
+from unittest import mock
+
+import pytest
+
+from datahub.configuration.common import GraphError
+from datahub.emitter.mce_builder import make_dataset_urn, make_schema_field_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.entity_aspect_specs import EntityAspectSpecs
+from datahub.ingestion.graph.filters import RemovedStatusFilter
+from datahub.ingestion.run.pipeline_config import (
+    AutoResolveLineageUrnsConfig,
+    UpstreamPlatformCasing,
+)
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns import (
+    AutoResolveLineageUrnsProcessor,
+)
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.alias_lookup import (
+    AliasLookupStrategy,
+)
+from datahub.ingestion.workunit_processors.auto_resolve_lineage_urns.models import (
+    EXACT,
+    NORMALIZED,
+    UNRESOLVED,
+)
+from datahub.metadata.schema_classes import (
+    AliasesClass,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    StringTypeClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+    _Aspect,
+)
+from datahub.utilities.urns.urn_iter import lowercase_dataset_urn
+
+# Snowflake convention: uppercase. BI-tool convention: lowercase.
+UPPER = make_dataset_urn("snowflake", "DB.SCHEMA.TABLE")
+LOWER = make_dataset_urn("snowflake", "db.schema.table")
+MIXED = make_dataset_urn("snowflake", "Db.Schema.Table")
+
+# The fine-grained path passes whatever parent it finds, including this.
+NOT_A_DATASET = "urn:li:dashboard:(looker,dashboards.1)"
+
+
+def _specs(*, supports_aliases: bool) -> EntityAspectSpecs:
+    aspects = {"status", "schemaMetadata"}
+    if supports_aliases:
+        aspects.add(AliasesClass.ASPECT_NAME)
+    return EntityAspectSpecs(entity_aspects={"dataset": aspects})
+
+
+def _requested_keys(extra_or_filters: object) -> Set[str]:
+    """The keys a lookup asked for, read out of the raw filter the strategy built."""
+    assert isinstance(extra_or_filters, list) and len(extra_or_filters) == 1
+    rules = extra_or_filters[0]["and"]
+    assert len(rules) == 1
+    rule = rules[0]
+    # Pins the field name the strategy hardcodes against the aspect schema, by name
+    # rather than position so adding a field to Aliases.pdl doesn't break every test.
+    assert rule["field"] in {f.name for f in AliasesClass.RECORD_SCHEMA.fields}
+    assert rule["condition"] == "EQUAL"
+    return set(rule["values"])
+
+
+def _schema_metadata(columns: List[str]) -> SchemaMetadataClass:
+    return SchemaMetadataClass(
+        schemaName="test",
+        platform="urn:li:dataPlatform:snowflake",
+        version=0,
+        hash="",
+        platformSchema=mock.MagicMock(),
+        fields=[
+            SchemaFieldClass(
+                fieldPath=column,
+                type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+                nativeDataType="string",
+            )
+            for column in columns
+        ],
+    )
+
+
+class FakeGraph:
+    """Answers lookups from `stored` by real lowercasing, as the server's index would."""
+
+    def __init__(
+        self,
+        stored: List[str],
+        *,
+        supports_aliases: bool = True,
+        schemas: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        self._stored = stored
+        self._supports_aliases = supports_aliases
+        self._schemas = schemas or {}
+        self.lookup_calls: List[Set[str]] = []
+        self.lookup_status: List[object] = []
+        self.schema_fetch_calls: List[str] = []
+
+    def get_entity_aspect_specs(self) -> EntityAspectSpecs:
+        return _specs(supports_aliases=self._supports_aliases)
+
+    def get_urns_by_filter(
+        self, *, entity_types: List[str], extra_or_filters: object, **kwargs: object
+    ) -> List[str]:
+        assert entity_types == ["dataset"]
+        keys = _requested_keys(extra_or_filters)
+        self.lookup_calls.append(keys)
+        self.lookup_status.append(kwargs.get("status"))
+        return [urn for urn in self._stored if lowercase_dataset_urn(urn) in keys]
+
+    def get_aspect(
+        self, entity_urn: str, aspect_type: Type[_Aspect], version: int = 0
+    ) -> Optional[SchemaMetadataClass]:
+        assert aspect_type is SchemaMetadataClass
+        self.schema_fetch_calls.append(entity_urn)
+        columns = self._schemas.get(entity_urn)
+        return _schema_metadata(columns) if columns is not None else None
+
+
+def _ctx_for(graph: FakeGraph) -> mock.MagicMock:
+    ctx = mock.MagicMock()
+    ctx.pipeline_context.graph = graph
+    return ctx
+
+
+def _strategy(
+    graph: FakeGraph, ctx: Optional[mock.MagicMock] = None
+) -> AliasLookupStrategy:
+    return AliasLookupStrategy(ctx if ctx is not None else _ctx_for(graph))
+
+
+def test_fake_graph_stays_compatible_with_the_real_client() -> None:
+    # FakeGraph reaches the strategy through a MagicMock ctx, so nothing else would
+    # notice a renamed parameter on DataHubGraph: these tests would stay green while
+    # production broke on the real call.
+    for name in ("get_urns_by_filter", "get_aspect"):
+        fake = set(inspect.signature(getattr(FakeGraph, name)).parameters) - {"kwargs"}
+        real = set(inspect.signature(getattr(DataHubGraph, name)).parameters)
+        assert fake <= real, f"FakeGraph.{name} has parameters DataHubGraph lacks"
+
+
+# --- capability gate ---------------------------------------------------------------
+
+
+def test_raises_when_server_does_not_register_aliases() -> None:
+    # Continuing would look like "nothing matched" and emit unhealed lineage as healed.
+    with pytest.raises(ValueError):
+        _strategy(FakeGraph([LOWER], supports_aliases=False))
+
+
+def test_raises_when_registry_api_unavailable() -> None:
+    graph = FakeGraph([LOWER])
+    graph.get_entity_aspect_specs = mock.MagicMock(return_value=None)  # type: ignore[method-assign]
+    with pytest.raises(ValueError):
+        _strategy(graph)
+
+
+def test_raises_when_dataset_entity_not_registered() -> None:
+    graph = FakeGraph([LOWER])
+    graph.get_entity_aspect_specs = mock.MagicMock(  # type: ignore[method-assign]
+        return_value=EntityAspectSpecs(entity_aspects={"chart": {"status"}})
+    )
+    with pytest.raises(ValueError):
+        _strategy(graph)
+
+
+# --- verdicts ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reference", [UPPER, MIXED, LOWER])
+def test_resolves_any_casing_to_the_stored_urn(reference: str) -> None:
+    # Where this beats the bulk path, which only tries the original and lowercased forms.
+    assert _strategy(FakeGraph([LOWER])).resolve(reference).urn == LOWER
+
+
+def test_reference_stored_verbatim_is_exact() -> None:
+    resolution = _strategy(FakeGraph([UPPER])).resolve(UPPER)
+    assert resolution.match_type == EXACT
+    assert resolution.urn == UPPER
+
+
+def test_reference_healed_to_other_casing_is_normalized() -> None:
+    assert _strategy(FakeGraph([LOWER])).resolve(UPPER).match_type == NORMALIZED
+
+
+def test_reference_with_no_stored_entity_is_unresolved() -> None:
+    resolution = _strategy(FakeGraph([])).resolve(UPPER)
+    assert resolution.match_type == UNRESOLVED
+    assert resolution.urn == UPPER
+
+
+def test_collision_prefers_the_lowercased_variant() -> None:
+    # Two live entities differing only by casing are what flipping
+    # convert_urns_to_lowercase leaves behind, so the lowercased one is the better guess.
+    resolution = _strategy(FakeGraph([LOWER, UPPER])).resolve(MIXED)
+    assert resolution.match_type == NORMALIZED
+    assert resolution.urn == LOWER
+
+
+def test_soft_deleted_duplicates_cannot_be_candidates() -> None:
+    # Preferring the lowercased variant is only defensible because a duplicate someone
+    # has already retired is never offered: we pass no status override, and the client's
+    # default excludes soft-deleted entities. If that default ever changes, the
+    # preference silently starts resolving lineage onto deleted tables.
+    graph = FakeGraph([LOWER])
+    _strategy(graph).resolve(UPPER)
+
+    assert graph.lookup_status == [None]
+    status = inspect.signature(DataHubGraph.get_urns_by_filter).parameters["status"]
+    assert status.default is RemovedStatusFilter.NOT_SOFT_DELETED
+
+
+def test_collision_without_a_lowercased_variant_is_left_alone() -> None:
+    # Neither the reference nor the lowercased form exists, so there is nothing to
+    # prefer; rewriting to either candidate would merge two distinct tables.
+    resolution = _strategy(FakeGraph([UPPER, MIXED])).resolve(LOWER)
+    assert resolution.match_type == UNRESOLVED
+    assert resolution.urn == LOWER
+
+
+def test_collision_containing_the_reference_is_exact() -> None:
+    # The reference itself wins over the lowercased variant: it demonstrably exists, so
+    # there is no casing mismatch to heal even though a duplicate sits next to it.
+    resolution = _strategy(FakeGraph([LOWER, UPPER])).resolve(UPPER)
+    assert resolution.match_type == EXACT
+    assert resolution.urn == UPPER
+
+
+def test_non_dataset_reference_is_out_of_scope() -> None:
+    graph = FakeGraph([LOWER])
+    resolution = _strategy(graph).resolve(NOT_A_DATASET)
+    assert resolution.match_type is None
+    assert resolution.urn == NOT_A_DATASET
+    assert graph.lookup_calls == []
+
+
+# --- schemas ----------------------------------------------------------------------
+
+
+def test_schema_is_not_fetched_for_a_table_level_reference() -> None:
+    graph = FakeGraph([LOWER], schemas={LOWER: ["amount"]})
+    assert _strategy(graph).resolve(UPPER).schema is None
+    assert graph.schema_fetch_calls == []
+
+
+def test_schema_is_fetched_under_the_resolved_urn() -> None:
+    graph = FakeGraph([LOWER], schemas={LOWER: ["amount"]})
+    resolution = _strategy(graph).resolve(UPPER, need_schema=True)
+    assert resolution.schema == {"amount": "string"}
+    assert graph.schema_fetch_calls == [LOWER]
+
+
+def test_schema_is_not_fetched_for_an_unresolved_reference() -> None:
+    graph = FakeGraph([])
+    assert _strategy(graph).resolve(UPPER, need_schema=True).schema is None
+    assert graph.schema_fetch_calls == []
+
+
+def test_resolved_entity_without_a_schema_still_resolves() -> None:
+    # Existence is the signal here, unlike the bulk path which needs a schema to match.
+    resolution = _strategy(FakeGraph([LOWER], schemas={})).resolve(
+        UPPER, need_schema=True
+    )
+    assert resolution.match_type == NORMALIZED
+    assert resolution.schema is None
+
+
+# --- collision reporting ----------------------------------------------------------
+
+
+def test_collision_is_reported_separately_from_a_plain_miss() -> None:
+    # A miss and an undecidable collision both come out UNRESOLVED but need opposite
+    # fixes: ingest the upstream, versus delete one of two duplicates. Only the
+    # collision warns here.
+    graph = FakeGraph([UPPER, MIXED])
+    ctx = _ctx_for(graph)
+    strategy = _strategy(graph, ctx)
+
+    strategy.resolve(LOWER)  # collides, and no lowercased variant to prefer
+    strategy.resolve(make_dataset_urn("snowflake", "db.schema.absent"))  # plain miss
+    strategy.finish()
+
+    warning = ctx.source_report.warning
+    assert warning.call_count == 1
+    assert "1 reference(s)" in warning.call_args.kwargs["context"]
+
+
+def test_collision_report_counts_every_reference() -> None:
+    # Two references collide on one key, and the count is references. Neither stored
+    # entity is the lowercased form, so both references stay undecidable.
+    stored = [
+        make_dataset_urn("snowflake", "db.schema.AB"),
+        make_dataset_urn("snowflake", "db.schema.Ab"),
+    ]
+    graph = FakeGraph(stored)
+    ctx = _ctx_for(graph)
+    strategy = _strategy(graph, ctx)
+
+    strategy.resolve(make_dataset_urn("snowflake", "db.schema.aB"))
+    strategy.resolve(make_dataset_urn("snowflake", "db.schema.ab"))
+    strategy.finish()
+
+    assert "2 reference(s)" in ctx.source_report.warning.call_args.kwargs["context"]
+
+
+def test_nothing_reported_when_no_collisions() -> None:
+    graph = FakeGraph([LOWER])
+    ctx = _ctx_for(graph)
+    strategy = _strategy(graph, ctx)
+    strategy.resolve(UPPER)
+    strategy.finish()
+
+    ctx.source_report.warning.assert_not_called()
+
+
+# --- mode switch ------------------------------------------------------------------
+
+
+def _processor(
+    graph: FakeGraph, mode: str, ctx: Optional[mock.MagicMock] = None
+) -> AutoResolveLineageUrnsProcessor:
+    ctx = ctx if ctx is not None else _ctx_for(graph)
+    ctx.pipeline_context.flags.auto_resolve_lineage_urns = AutoResolveLineageUrnsConfig(
+        enabled=True,
+        mode=mode,
+        upstream_platforms=[UpstreamPlatformCasing(platform="snowflake", env="PROD")],
+    )
+    return AutoResolveLineageUrnsProcessor.create(ctx)
+
+
+def _upstream_wu(upstream_urn: str) -> MetadataWorkUnit:
+    return MetadataChangeProposalWrapper(
+        entityUrn=make_dataset_urn("looker", "explore.orders"),
+        aspect=UpstreamLineageClass(
+            upstreams=[UpstreamClass(dataset=upstream_urn, type="TRANSFORMED")]
+        ),
+    ).as_workunit()
+
+
+def test_alias_lookup_mode_heals_without_downloading_a_catalog() -> None:
+    graph = FakeGraph([LOWER])
+    with mock.patch(
+        "datahub.sql_parsing.schema_resolver_provider.provide_schema_resolver"
+    ) as provide:
+        processor = _processor(graph, "alias_lookup")
+        [out] = list(processor.process(iter([_upstream_wu(UPPER)])))
+
+    aspect = out.get_aspect_of_type(UpstreamLineageClass)
+    assert aspect is not None
+    assert aspect.upstreams[0].dataset == LOWER
+    provide.assert_not_called()
+    assert graph.lookup_calls == [{lowercase_dataset_urn(UPPER)}]
+
+
+def test_a_failed_lookup_emits_the_lineage_unchanged() -> None:
+    # An unreachable GMS must not drop lineage or halt the run: the reference passes
+    # through as the source produced it, counted and surfaced in the source report.
+    graph = FakeGraph([LOWER])
+    graph.get_urns_by_filter = mock.MagicMock(  # type: ignore[method-assign]
+        side_effect=GraphError("gms unreachable")
+    )
+    ctx = _ctx_for(graph)
+    processor = _processor(graph, "alias_lookup", ctx)
+    [out] = list(processor.process(iter([_upstream_wu(UPPER)])))
+
+    aspect = out.get_aspect_of_type(UpstreamLineageClass)
+    assert aspect is not None
+    assert aspect.upstreams[0].dataset == UPPER
+    assert processor.report.num_exceptions == 1
+    # Carries the exception, so the operator sees the cause and not just a count.
+    assert any(
+        "exc" in call.kwargs for call in ctx.source_report.warning.call_args_list
+    )
+
+
+def test_column_level_lineage_heals_parent_casing_and_column_casing() -> None:
+    # The whole column path end to end: the parent is looked up, its schema fetched
+    # under the resolved urn, and the column matched against it case-insensitively.
+    graph = FakeGraph([LOWER], schemas={LOWER: ["amount"]})
+    upstream_field = make_schema_field_urn(UPPER, "AMOUNT")
+    downstream_field = make_schema_field_urn(
+        make_dataset_urn("looker", "explore.orders"), "Amount"
+    )
+    wu = MetadataChangeProposalWrapper(
+        entityUrn=make_dataset_urn("looker", "explore.orders"),
+        aspect=UpstreamLineageClass(
+            upstreams=[UpstreamClass(dataset=UPPER, type="TRANSFORMED")],
+            fineGrainedLineages=[
+                FineGrainedLineageClass(
+                    upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                    downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                    upstreams=[upstream_field],
+                    downstreams=[downstream_field],
+                )
+            ],
+        ),
+    ).as_workunit()
+
+    processor = _processor(graph, "alias_lookup")
+    [out] = list(processor.process(iter([wu])))
+
+    aspect = out.get_aspect_of_type(UpstreamLineageClass)
+    assert aspect is not None
+    assert aspect.fineGrainedLineages is not None
+    fine_grained = aspect.fineGrainedLineages[0]
+    assert fine_grained.upstreams == [make_schema_field_urn(LOWER, "amount")]
+    # The downstream belongs to the Looker entity itself and keeps its own casing.
+    assert fine_grained.downstreams == [downstream_field]
+    assert graph.schema_fetch_calls == [LOWER]
+
+
+def test_a_platform_outside_upstream_platforms_is_still_looked_up() -> None:
+    # Documents a divergence from bulk_catalog rather than endorsing it: that mode only
+    # heals the configured platforms because it downloads their catalogs, while this one
+    # asks the server about every dataset reference. Change the config gate, not this
+    # assertion, if alias_lookup should honour upstream_platforms too.
+    stored_bigquery = make_dataset_urn("bigquery", "proj.dataset.table")
+    graph = FakeGraph([stored_bigquery])
+    processor = _processor(graph, "alias_lookup")  # configured for snowflake only
+
+    referenced = make_dataset_urn("bigquery", "PROJ.DATASET.TABLE")
+    [out] = list(processor.process(iter([_upstream_wu(referenced)])))
+
+    aspect = out.get_aspect_of_type(UpstreamLineageClass)
+    assert aspect is not None
+    assert aspect.upstreams[0].dataset == stored_bigquery
+    assert len(graph.lookup_calls) == 1
+
+
+def test_bulk_catalog_mode_still_downloads_a_catalog() -> None:
+    graph = FakeGraph([LOWER])
+    with mock.patch(
+        "datahub.sql_parsing.schema_resolver_provider.provide_schema_resolver"
+    ) as provide:
+        _processor(graph, "bulk_catalog")
+
+    provide.assert_called()
+    assert graph.lookup_calls == []


### PR DESCRIPTION
Stacked on #18855 — review that one first; this PR's diff is only the `alias_lookup` mode.

## Problem

`auto_resolve_lineage_urns` today has one strategy, `bulk_catalog`: it downloads each configured upstream platform's catalog and matches references against that local copy. It heals a reference only when DataHub stores the entity **as-given or lowercased**, so a warehouse that keeps an `UPPER` or `Mixed` identity is never reconciled. It also can't tell that two entities differ only by casing, and it holds a whole platform catalog in memory.

## What this adds

An opt-in `mode: alias_lookup` that queries the server's `aliases.lowercasedUrn` index once per reference instead of downloading anything:

- covers **every** casing, not just the lowercased form
- needs no `upstream_platforms` — any platform resolves
- holds no catalog in memory
- resolves on existence, so a table without a `schemaMetadata` still heals (`bulk_catalog` needs a schema to match)
- sees two entities whose URNs differ only by casing

`bulk_catalog` remains the default, so existing recipes behave exactly as they do today.

### Casing collisions

Two live entities differing only by casing are usually the residue of turning `convert_urns_to_lowercase` on or off. A reference resolves to whichever of them it matches **exactly**, and failing that to the **lowercased** one — the variant that flag produced. Soft-deleted entities are never candidates (the search client's default status filter), so a duplicate that has already been retired is skipped.

If neither the reference nor the lowercased form exists, the reference is emitted unchanged and counted under its own end-of-run warning, kept separate from plain unresolved references because the remedies differ: remove the duplicate entity, versus ingest the missing upstream.

### Server requirement

The mode fails at **startup** on a server that doesn't register the `aliases` aspect on datasets, with a message pointing at `mode: bulk_catalog`. Filtering on a field the server doesn't index returns zero hits rather than an error, so a quiet fallback would emit unhealed lineage that looks reconciled.

### Trade-off, and what is deliberately left out

Not necessarily faster: one small query per reference replaces one large upfront download. Pick this mode for coverage and memory, not run time — the docs say so explicitly. Two optimisations are **intentionally not implemented here**, and are follow-up work:

- **Caching / memoization.** Every reference costs a lookup, and a repeated reference re-queries an answer the server already gave — a table referenced by fifty dashboards costs fifty lookups, plus one `schemaMetadata` fetch each where column-level lineage is involved. Part of follow Up work.

- **Buffering / batching.** Each lookup is a single-key `EQUAL` filter, one request per reference. The filter accepts multiple values, so references could be collected and resolved in batches, which is the bigger win of the two on wide sources. That needs the processor to buffer work units before emitting them, which changes its streaming shape, so it's out of scope for this PR. Part of follow up work

Neither is required for correctness, and both are invisible to the config surface — they can land later without changing behaviour or recipes.

## Testing

- `tests/unit/workunit_processors/test_lineage_alias_lookup.py` (new, 27 tests): capability gate, every verdict, schema fetching, collision handling and reporting, the mode switch, column-level lineage end to end through the processor, and a failing lookup (unreachable GMS) leaving lineage untouched.
- `test_urn_iterator.py`: parametrised cases pinning `lowercase_dataset_urn` against GMS's `AliasesUtils.lowercaseDatasetUrn`, including non-ASCII — drift there makes lookups miss silently.
- `test_auto_resolve_lineage_urns.py`: default mode, config validation per mode, unknown mode rejected.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [x] Docs updated — `metadata-ingestion/docs/dev_guides/lineage_urn_casing.md` gains a Resolution modes section
- [x] No breaking change — new mode is opt-in, `bulk_catalog` stays the default
