### PR TITLE
fix(ingest/hex): cap skipped_cells report growth with LossyList

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/hex/lineage_builder.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/hex/lineage_builder.py
@@ -11,6 +11,7 @@ from datahub.metadata.urns import SchemaFieldUrn
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.sql_parsing_common import get_dialect_str
 from datahub.sql_parsing.sqlglot_lineage import sqlglot_lineage
+from datahub.utilities.lossy_collections import LossyList
 
 _MAX_SAMPLE_MISMATCHES = 5
 
@@ -82,7 +83,7 @@ class LineageBuilderReport:
     sql_cells_no_upstreams: int = 0
     sql_cells_skipped_unresolved_platform: int = 0
     upstream_datasets_found: int = 0
-    skipped_cells: List[SkippedCell] = field(default_factory=list)
+    skipped_cells: LossyList[SkippedCell] = field(default_factory=LossyList)
     projects_lineage_via_queried_tables: int = 0
     projects_lineage_via_sql_parsing: int = 0
     # ENTERPRISE cross-validation: SQL parsing vs queriedTables


### PR DESCRIPTION
## What changed

The Hex connector's `LineageBuilderReport.skipped_cells` was a plain unbounded `list` that accumulated one `SkippedCell` entry per skipped lineage cell across all projects. On large ingestions this grew into thousands/millions of entries, bloating the serialized ingestion report.

This switches `skipped_cells` to a `LossyList` (reservoir-sampled, capped at 10 retained entries):

- `metadata-ingestion/src/datahub/ingestion/source/hex/lineage_builder.py`
  - `skipped_cells: LossyList[SkippedCell] = field(default_factory=LossyList)`
  - Added `from datahub.utilities.lossy_collections import LossyList`

## Why

The report was dumping every skipped cell, which is unbounded and unhelpful in the report output. Every skip is already traced via `logger.debug` (including the `connection_id` to add to `connection_platform_map`), so the full detail remains available in the logs — the report only needs a representative sample.

## Reviewer notes

- The `logger.debug` trace in `_record_skip` is intentionally kept as-is, so no per-skip detail is lost.
- `LossyList` still reports the true total via `len()` (it tracks `total_elements`), so operators don't lose the real skip count.
- `SkippedCell` is a `@dataclass`, so it serializes cleanly through `Report.to_pure_python_obj` (`dataclasses.asdict`). This mirrors the existing `LossyList[UserInfo]` usage in the Tableau connector.
- Scope check: the sibling `enterprise_sample_mismatched_cells` is already bounded (via `_MAX_SAMPLE_MISMATCHES`), and `HexApiReport.api_calls` is keyed by a fixed endpoint set — so `skipped_cells` was the only unbounded collection.

## Testing

- `./gradlew :metadata-ingestion:lintFix` — clean.
- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/hex/test_lineage_builder.py` — 44 passed. Existing tests index `report.skipped_cells[0]` and assert `len(...)`, both of which remain valid under `LossyList` below the cap; no test changes needed.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests: existing unit tests still pass; no behavior change requiring new tests
- [ ] Docs (n/a)
- [ ] Breaking changes (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Caps Hex lineage report size** by changing `LineageBuilderReport.skipped_cells` from an unbounded `list` to a reservoir-sampled `LossyList` (default cap of 10 retained entries).
> 
> Large Hex runs could accumulate one `SkippedCell` per skipped SQL/queriedTables cell and **bloat the serialized ingestion report**; skip counts still come from existing counters and `len(skipped_cells)` (total elements), while per-skip detail remains on `logger.debug` in `_record_skip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4736ec3a6261e8436ac9e844fdf5499af3dff61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->