### PR TITLE
fix(agent-context): correct lineage pagination

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
@@ -27,6 +27,9 @@ from datahub_agent_context.mcp_tools.search_filter_parser import (
 
 logger = logging.getLogger(__name__)
 
+LINEAGE_PATH_PAGE_SIZE = 100
+MAX_LINEAGE_PATH_RESULTS = 1000
+
 # Load GraphQL query
 entity_details_fragment_gql = (
     pathlib.Path(__file__).parent / "gql/entity_details.gql"
@@ -42,6 +45,7 @@ class AssetLineageDirective(BaseModel):
     max_hops: int
     extra_filters: Optional[Filter]
     max_results: int
+    start: int = 0
 
 
 class AssetLineageAPI:
@@ -101,7 +105,7 @@ class AssetLineageAPI:
         variables = {
             "urn": asset_lineage_directive.urn,
             "query": query or "*",
-            "start": 0,
+            "start": asset_lineage_directive.start,
             "count": asset_lineage_directive.max_results,
             "types": types,
             "orFilters": compiled_filters,
@@ -236,6 +240,7 @@ def get_lineage(
         max_hops=max_hops,
         extra_filters=parsed_filters,
         max_results=max_results,
+        start=max(0, offset),
     )
     lineage = lineage_api.get_lineage(asset_lineage_directive, query=query)
     inject_urls_for_urns(graph, lineage, ["*.searchResults[].entity"])
@@ -244,26 +249,14 @@ def get_lineage(
     # Track if this is column-level lineage for metadata
     is_column_level_lineage = column is not None
 
-    # Apply offset, entity-level truncation, and cleaning to upstreams/downstreams
+    # Apply entity-level truncation and cleaning to upstreams/downstreams
     for direction in ["upstreams", "downstreams"]:
         if direction_results := lineage.get(direction):
-            if search_results := direction_results.get("searchResults"):
+            search_results = direction_results.get("searchResults") or []
+            if search_results:
                 # Extract lineageColumns from paths for column-level lineage
                 search_results = _extract_lineage_columns_from_paths(search_results)
                 direction_results["searchResults"] = search_results
-
-                total_available = len(search_results)
-
-                # Apply offset (skip first N entities)
-                if offset >= total_available:
-                    direction_results["searchResults"] = []
-                    direction_results["offset"] = offset
-                    direction_results["returned"] = 0
-                    direction_results["hasMore"] = False
-                    continue
-
-                # Skip offset and apply token budget using generic helper
-                results_after_offset = search_results[offset:]
 
                 # Lambda to clean entity in place and return it for token counting
                 def get_cleaned_entity(result_item: dict) -> dict:
@@ -275,7 +268,7 @@ def get_lineage(
                 # Get results within budget (entities cleaned in place, degree preserved)
                 selected_results = list(
                     _select_results_within_budget(
-                        results=iter(results_after_offset),
+                        results=iter(search_results),
                         fetch_entity=get_cleaned_entity,
                         max_results=max_results,
                     )
@@ -283,19 +276,21 @@ def get_lineage(
 
                 # Update results and add metadata
                 direction_results["searchResults"] = selected_results
-                direction_results["offset"] = offset
-                direction_results["returned"] = len(selected_results)
-                direction_results["hasMore"] = (
-                    offset + len(selected_results)
-                ) < total_available
 
-                if len(selected_results) < len(results_after_offset):
+                if len(selected_results) < len(search_results):
                     direction_results["truncatedDueToTokenBudget"] = True
 
-                logger.info(
-                    f"get_lineage {direction}: Returned {len(selected_results)}/{total_available} entities "
-                    f"(offset={offset}, hasMore={direction_results['hasMore']})"
-                )
+            server_start = direction_results.get("start", max(0, offset))
+            server_total = direction_results.get("total", len(search_results))
+            returned = len(direction_results.get("searchResults") or [])
+            direction_results["offset"] = server_start
+            direction_results["returned"] = returned
+            direction_results["hasMore"] = server_start + returned < server_total
+
+            logger.info(
+                f"get_lineage {direction}: Returned {returned}/{server_total} entities "
+                f"(offset={server_start}, hasMore={direction_results['hasMore']})"
+            )
 
     # Add metadata for column-level lineage responses
     if is_column_level_lineage:
@@ -397,43 +392,60 @@ def _find_upstream_lineage_path(
     graph = get_graph()
     # Get lineage with paths using the API directly (always upstream)
     lineage_api = AssetLineageAPI()
-    asset_lineage_directive = AssetLineageDirective(
-        urn=query_urn,
-        upstream=True,  # Always upstream
-        downstream=False,
-        max_hops=10,  # Higher to ensure we find target
-        extra_filters=None,
-        max_results=100,  # Need enough results to find target
-    )
-    lineage = lineage_api.get_lineage(asset_lineage_directive, query="*")
+    target_result: Optional[dict] = None
+    start = 0
+    total = 0
+    while start < MAX_LINEAGE_PATH_RESULTS:
+        asset_lineage_directive = AssetLineageDirective(
+            urn=query_urn,
+            upstream=True,
+            downstream=False,
+            max_hops=10,
+            extra_filters=None,
+            max_results=LINEAGE_PATH_PAGE_SIZE,
+            start=start,
+        )
+        lineage = lineage_api.get_lineage(asset_lineage_directive, query="*")
+        upstreams = lineage.get("upstreams", {})
+        search_results = upstreams.get("searchResults") or []
+        total = upstreams.get("total", len(search_results))
 
-    # Clean up the response
-    inject_urls_for_urns(graph, lineage, ["*.searchResults[].entity"])
-    truncate_descriptions(lineage)
+        target_result = _find_result_with_target_urn(
+            search_results=search_results,
+            target_urn=search_for_urn,
+            is_column_level=(target_column is not None),
+        )
+        if target_result:
+            break
 
-    # Get upstream results (always querying upstream)
-    search_results = lineage.get("upstreams", {}).get("searchResults", [])
+        returned = len(search_results)
+        if returned == 0 or start + returned >= total:
+            break
+        start += returned
 
-    if not search_results:
+    if target_result is None and total > MAX_LINEAGE_PATH_RESULTS:
+        raise RuntimeError(
+            "Lineage path search is incomplete because the result set exceeds "
+            f"the {MAX_LINEAGE_PATH_RESULTS}-result safety limit"
+        )
+
+    if total == 0:
         raise ItemNotFoundError(
             f"No lineage found from {source_urn}"
             + (f".{source_column}" if source_column else "")
         )
 
-    # Find the result containing the target URN
-    target_result = _find_result_with_target_urn(
-        search_results=search_results,
-        target_urn=search_for_urn,
-        is_column_level=(target_column is not None),
-    )
-
-    if not target_result:
+    if target_result is None:
         raise ItemNotFoundError(
             f"No lineage path found from {source_urn}"
             + (f".{source_column}" if source_column else "")
             + f" to {target_urn}"
             + (f".{target_column}" if target_column else "")
         )
+
+    lineage = {"upstreams": {"searchResults": [target_result]}}
+    inject_urls_for_urns(graph, lineage, ["*.searchResults[].entity"])
+    truncate_descriptions(lineage)
 
     # Extract paths array (with QUERY URNs as-is)
     paths = target_result.get("paths", [])

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
@@ -27,6 +27,7 @@ from datahub_agent_context.mcp_tools.search_filter_parser import (
 
 logger = logging.getLogger(__name__)
 
+# Crossing this bound must remain distinguishable from an exhaustive not-found result.
 LINEAGE_PATH_PAGE_SIZE = 100
 MAX_LINEAGE_PATH_RESULTS = 1000
 

--- a/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
@@ -330,20 +330,26 @@ class TestGetLineagePathsBetween:
 
     def test_column_level_path(self, mock_client):
         """Test finding column-level path."""
+        source_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.source,PROD)"
+        )
+        target_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.target,PROD)"
+        )
         mock_client._graph.execute_graphql.return_value = {
             "searchAcrossLineage": {
                 "searchResults": [
                     {
-                        "entity": {"urn": "urn:li:dataset:source"},
+                        "entity": {"urn": source_urn},
                         "paths": [
                             {
                                 "path": [
                                     {
-                                        "urn": "urn:li:schemaField:(urn:li:dataset:target,customer_id)",
+                                        "urn": f"urn:li:schemaField:({target_urn},customer_id)",
                                         "type": "SCHEMA_FIELD",
                                     },
                                     {
-                                        "urn": "urn:li:schemaField:(urn:li:dataset:source,user_id)",
+                                        "urn": f"urn:li:schemaField:({source_urn},user_id)",
                                         "type": "SCHEMA_FIELD",
                                     },
                                 ]
@@ -356,8 +362,8 @@ class TestGetLineagePathsBetween:
 
         with DataHubContext(mock_client):
             result = get_lineage_paths_between(
-                source_urn="urn:li:dataset:source",
-                target_urn="urn:li:dataset:target",
+                source_urn=source_urn,
+                target_urn=target_urn,
                 source_column="user_id",
                 target_column="customer_id",
                 direction="downstream",
@@ -368,8 +374,12 @@ class TestGetLineagePathsBetween:
         assert result["target"]["column"] == "customer_id"
 
     def test_path_lookup_paginates_until_target(self, mock_client):
-        source_urn = "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.source,PROD)"
-        target_urn = "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.target,PROD)"
+        source_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.source,PROD)"
+        )
+        target_urn = (
+            "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.target,PROD)"
+        )
         unrelated = [
             {
                 "entity": {

--- a/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
@@ -218,6 +218,9 @@ class TestGetLineage:
 
     def test_lineage_with_pagination(self, mock_client, sample_lineage_response):
         """Test lineage pagination with offset."""
+        page = sample_lineage_response["searchAcrossLineage"]
+        page["start"] = 10
+        page["total"] = 40
         mock_client._graph.execute_graphql.return_value = sample_lineage_response
 
         with DataHubContext(mock_client):
@@ -228,12 +231,36 @@ class TestGetLineage:
                 max_results=20,
             )
 
-        assert "upstreams" in result
-        # Check pagination metadata
         upstreams = result["upstreams"]
-        assert "offset" in upstreams
-        assert "returned" in upstreams
-        assert "hasMore" in upstreams
+        variables = mock_client._graph.execute_graphql.call_args.kwargs["variables"]
+        assert variables["input"]["start"] == 10
+        assert variables["input"]["count"] == 20
+        assert upstreams["offset"] == 10
+        assert upstreams["returned"] == 2
+        assert upstreams["hasMore"] is True
+
+    def test_empty_last_page_has_complete_pagination_metadata(self, mock_client):
+        mock_client._graph.execute_graphql.return_value = {
+            "searchAcrossLineage": {
+                "start": 40,
+                "count": 0,
+                "total": 40,
+                "searchResults": [],
+                "facets": [],
+            }
+        }
+
+        with DataHubContext(mock_client):
+            result = get_lineage(
+                urn="urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.table,PROD)",
+                offset=40,
+                max_results=20,
+            )
+
+        upstreams = result["upstreams"]
+        assert upstreams["offset"] == 40
+        assert upstreams["returned"] == 0
+        assert upstreams["hasMore"] is False
 
     def test_column_normalization(self, mock_client, sample_lineage_response):
         """Test that column='null' is normalized to None."""
@@ -260,18 +287,18 @@ class TestGetLineagePathsBetween:
                 "searchResults": [
                     {
                         "entity": {
-                            "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.target,PROD)"
+                            "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.source,PROD)"
                         },
                         "paths": [
                             {
                                 "path": [
                                     {
-                                        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.source,PROD)",
+                                        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.target,PROD)",
                                         "type": "DATASET",
                                     },
                                     {"urn": "urn:li:query:transform1", "type": "QUERY"},
                                     {
-                                        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.target,PROD)",
+                                        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.source,PROD)",
                                         "type": "DATASET",
                                     },
                                 ]
@@ -282,9 +309,6 @@ class TestGetLineagePathsBetween:
             }
         }
 
-    @pytest.mark.xfail(
-        reason="Requires complex mocking of _find_lineage_path internal calls"
-    )
     def test_dataset_level_path_downstream(self, mock_client, sample_path_response):
         """Test finding dataset-level path downstream."""
         mock_client._graph.execute_graphql.return_value = sample_path_response
@@ -301,26 +325,25 @@ class TestGetLineagePathsBetween:
         assert result["pathCount"] > 0
         assert result["source"]["urn"]
         assert result["target"]["urn"]
+        assert result["paths"][0]["path"][0]["urn"] == result["source"]["urn"]
+        assert result["paths"][0]["path"][-1]["urn"] == result["target"]["urn"]
 
-    @pytest.mark.xfail(
-        reason="Requires complex mocking of URN parsing and _find_lineage_path"
-    )
     def test_column_level_path(self, mock_client):
         """Test finding column-level path."""
         mock_client._graph.execute_graphql.return_value = {
             "searchAcrossLineage": {
                 "searchResults": [
                     {
-                        "entity": {"urn": "urn:li:dataset:target"},
+                        "entity": {"urn": "urn:li:dataset:source"},
                         "paths": [
                             {
                                 "path": [
                                     {
-                                        "urn": "urn:li:schemaField:(urn:li:dataset:source,user_id)",
+                                        "urn": "urn:li:schemaField:(urn:li:dataset:target,customer_id)",
                                         "type": "SCHEMA_FIELD",
                                     },
                                     {
-                                        "urn": "urn:li:schemaField:(urn:li:dataset:target,customer_id)",
+                                        "urn": "urn:li:schemaField:(urn:li:dataset:source,user_id)",
                                         "type": "SCHEMA_FIELD",
                                     },
                                 ]
@@ -343,6 +366,63 @@ class TestGetLineagePathsBetween:
         assert result["metadata"]["pathType"] == "column-level"
         assert result["source"]["column"] == "user_id"
         assert result["target"]["column"] == "customer_id"
+
+    def test_path_lookup_paginates_until_target(self, mock_client):
+        source_urn = "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.source,PROD)"
+        target_urn = "urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.target,PROD)"
+        unrelated = [
+            {
+                "entity": {
+                    "urn": f"urn:li:dataset:(urn:li:dataPlatform:test,my_db.my_schema.other_{index},PROD)"
+                },
+                "paths": [],
+            }
+            for index in range(100)
+        ]
+        mock_client._graph.execute_graphql.side_effect = [
+            {
+                "searchAcrossLineage": {
+                    "start": 0,
+                    "count": 100,
+                    "total": 101,
+                    "searchResults": unrelated,
+                }
+            },
+            {
+                "searchAcrossLineage": {
+                    "start": 100,
+                    "count": 1,
+                    "total": 101,
+                    "searchResults": [
+                        {
+                            "entity": {"urn": source_urn},
+                            "paths": [
+                                {
+                                    "path": [
+                                        {"urn": target_urn, "type": "DATASET"},
+                                        {"urn": source_urn, "type": "DATASET"},
+                                    ]
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        ]
+
+        with DataHubContext(mock_client):
+            result = get_lineage_paths_between(
+                source_urn=source_urn,
+                target_urn=target_urn,
+                direction="downstream",
+            )
+
+        starts = [
+            call.kwargs["variables"]["input"]["start"]
+            for call in mock_client._graph.execute_graphql.call_args_list
+        ]
+        assert starts == [0, 100]
+        assert result["pathCount"] == 1
 
     def test_auto_discover_direction(self, mock_client, sample_path_response):
         """Test auto-discovery of lineage direction."""
@@ -403,9 +483,6 @@ class TestGetLineagePathsBetween:
                     target_column=None,  # Mismatch
                 )
 
-    @pytest.mark.xfail(
-        reason="Requires complex mocking of _find_lineage_path internal calls"
-    )
     def test_query_entities_in_path(self, mock_client, sample_path_response):
         """Test that QUERY entities in path trigger metadata note."""
         mock_client._graph.execute_graphql.return_value = sample_path_response


### PR DESCRIPTION
## Summary

- send `get_lineage` offsets to `searchAcrossLineage` instead of slicing the first server page locally
- derive `offset`, `returned`, and `hasMore` from the server's authoritative `start` and `total`
- paginate `get_lineage_paths_between` until the target is found or the result set is exhausted
- return an explicit incomplete-search error at the 1,000-result safety bound instead of a false not-found result
- replace three xfailed path tests with executable coverage and add pagination regressions

## Why

The previous implementation always queried `start: 0`, then applied `offset` to that limited response. An offset at or beyond the first page could therefore return no results even when later pages existed, and `hasMore` was calculated from the current page length rather than the server total.

Exact path lookup had the same correctness problem in another form: it inspected only the first 100 lineage results and reported `ItemNotFoundError` when the target was on a later page. For agent consumers, that turns incomplete evidence into a false negative.

## Validation

- canonical `./gradlew :datahub-agent-context:build` passed in a Linux Codespace with Java 21
- Ruff check and format passed
- mypy passed across 106 source files
- all 637 datahub-agent-context tests passed
- focused regressions cover server-side offset propagation, empty terminal pages, and targets beyond the first 100 results
- three previously xfailed exact-path tests now execute normally

## Compatibility

No schema changes, new dependencies, or breaking API changes. `AssetLineageDirective.start` defaults to zero, preserving existing internal callers.