### PR TITLE
docs: finalize v1.7.0 release notes in updating-datahub.md

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -40,12 +40,31 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ## Next
 
-Draft release notes for the upcoming version. Add entries here as breaking changes, deprecations, and notable fixes land on `master`; promote this section to a versioned heading (for example `## v1.6.1` or `## v1.7.0`) at release cut.
+Draft release notes for the upcoming version. Add entries here as breaking changes, deprecations, and notable fixes land on `master`; promote this section to a versioned heading (for example `## v1.7.1` or `## v1.8.0`) at release cut.
 
 Requirements:
 
 - CLI / Python SDK: (TBD)
 - Helm Chart: (TBD)
+
+### Breaking Changes
+
+### Known Issues
+
+### Potential Downtime
+
+### Deprecations
+
+### Other Notable Changes
+
+## v1.7.0
+
+Requirements:
+
+- CLI / Python SDK: 1.7.0
+- Helm Chart: 1.1.0
+
+**Upgrade path / ZDU (zero-downtime upgrade):** You **must upgrade to [v1.6.0](#v160) before upgrading to v1.7.0** — do not skip 1.6.0. Deploy v1.6.0 with Helm chart **1.0.3**, let system-update complete, then upgrade to v1.7.0 with Helm chart **1.1.0**. Enable Elasticsearch/OpenSearch ZDU (`global.datahub.systemUpdate.zdu`) with the **1.1.0** chart on a subsequent OpenSearch/Elasticsearch version bump — not during the v1.6.0 install. See the [v1.6.0](#v160) ZDU notes for the server-side prerequisite detail.
 
 ### Breaking Changes
 
@@ -154,11 +173,13 @@ Requirements:
 
 - #17443 **(Ingestion / MongoDB)** AWS DocumentDB can now be ingested as its own data platform. The MongoDB source has a new opt-in config field `platform` (default `mongodb`). Set `platform: documentdb` together with `hostingEnvironment: AWS_DOCUMENTDB` to emit entities under the new `documentdb` data platform URN instead of `mongodb`; setting `platform: documentdb` with any other hosting environment is rejected at config validation time. The default is unchanged, so existing recipes continue to emit `mongodb` URNs even when pointed at AWS DocumentDB. If enabled on an existing recipe, both the dataset URNs and the database-level container URNs will change, and the stale `mongodb` entities will need to be cleaned up via stateful ingestion (if enabled) or manual soft-delete.
 
-- **(GMS / Secrets)** `SECRET_SERVICE_CALLER_GUARD_MODE` now defaults to **`ENFORCE`** (was effectively unrestricted for human callers). Browser sessions and user Personal Access Tokens **can no longer** call `getSecretValues` or otherwise decrypt UI secrets through GraphQL. **Rollout (v2.0.0):** new deployments get `ENFORCE` by default; existing deployments should migrate before upgrading or set `AUDIT` during transition. **Action:** If you relied on admins or automation using a user PAT to read plaintext secret values via `getSecretValues`, migrate to [**datahub-actions**](../actions/actions/executor.md) with system client credentials (`DATAHUB_SYSTEM_CLIENT_ID` / `DATAHUB_SYSTEM_CLIENT_SECRET`) or set `SECRET_SERVICE_CALLER_GUARD_MODE=AUDIT` temporarily during rollout. Scheduled UI ingestion via **datahub-actions** is unaffected. See [Environment Variables](../deploy/environment-vars.md) and [Ingestion executor security](../docker/ingestion-executor-security.md).
+- **(GMS / Secrets)** `SECRET_SERVICE_CALLER_GUARD_MODE` now defaults to **`ENFORCE`** (was effectively unrestricted for human callers). Browser sessions and user Personal Access Tokens **can no longer** call `getSecretValues` or otherwise decrypt UI secrets through GraphQL. **Rollout (v1.7.0):** new deployments get `ENFORCE` by default; existing deployments should migrate before upgrading or set `AUDIT` during transition. **Action:** If you relied on admins or automation using a user PAT to read plaintext secret values via `getSecretValues`, migrate to [**datahub-actions**](../actions/actions/executor.md) with system client credentials (`DATAHUB_SYSTEM_CLIENT_ID` / `DATAHUB_SYSTEM_CLIENT_SECRET`) or set `SECRET_SERVICE_CALLER_GUARD_MODE=AUDIT` temporarily during rollout. Scheduled UI ingestion via **datahub-actions** is unaffected. See [Environment Variables](../deploy/environment-vars.md) and [Ingestion executor security](../docker/ingestion-executor-security.md).
 
 - **(Java / Plugin API)** `SecretService.encrypt` and `SecretService.decrypt` no-context overloads are removed; use `encrypt(OperationContext, String)` and `decrypt(OperationContext, String)`. Custom GMS plugins or extensions that call `SecretService` directly must pass `OperationContext` from the request, or `null` for background jobs (allowed by the guard). With `ENFORCE`, `decrypt` throws `SecurityException` for human browser/mobile callers and callers other than trusted ingestion workers (**datahub-actions** in OSS).
 
 - #17721: **(Ingestion / Snowplow)** The connector now fetches pipeline enrichments from the supported `pipelines/v1/{pipelineId}/enrichments` endpoint instead of the deprecated `resources/v1/.../configuration/enrichments` endpoint Snowplow is retiring. Because the new payload no longer returns the per-enrichment UUID, enrichment **DataJob URNs are now derived from the enrichment name** (e.g. `...,campaign-attribution)` instead of `...,07409eac-...)`. Existing enrichment DataJobs ingested under the old UUID-based URNs are re-created under the new name-based URNs on the next run. If stateful ingestion is enabled, the old UUID-based DataJobs are soft-deleted by stale-entity removal; otherwise they persist as stale DataJobs and must be cleaned up manually. No recipe changes are required.
+
+- #18845: **(Metadata Model / Entity Registry)** Each directed relationship edge signature — `(source entity type, destination entity type, relationship name)` — may now be produced by **exactly one aspect** on that source entity. Multiple fields within the same aspect may still share a signature. The check runs when entity specs are built and again when registries are merged at GMS startup, including custom / plugin entity registries. Plugin relationship-edge uniqueness failures are never soft-ignored, even when `IGNORE_FAILURE_WHEN_LOADING_ENTITY_REGISTRY_PLUGIN` is true. **Action:** If you ship a custom or plugin entity registry that declares the same edge signature from two different aspects on one source type, consolidate those fields onto a single aspect or rename the relationship before upgrading — otherwise GMS (or registry load) fails. See [Aspect ownership uniqueness](../what/relationship.md#aspect-ownership-uniqueness).
 
 ### Known Issues
 
@@ -236,11 +257,19 @@ Requirements:
 
 - **(GMS / search indexing)** Inline Elasticsearch indexing and entity-graph cache invalidation on ingest now require explicit `systemMetadata.properties.appSource = ui` (or the sync-index header), not merely a GraphQL request context. `GroupService` and `RoleService` stamp UI source via `AspectUtils.buildSynchronousMetadataChangeProposal`; other GraphQL resolvers that bypass `MutationUtils` revert to async MAE indexing. See [GMS Entity Graph Cache — Invalidation (sync writes)](../deploy/gms-entity-graph-cache.md#invalidation-sync-writes).
 
+- **(GMS / primary storage read pool)** Optional second connection pool (Ebean) or Cassandra session for entity-aspect **reads**, while writes and `FOR UPDATE` reads stay on PRIMARY. Enable with `EBEAN_READ_POOL_ENABLED` / `CASSANDRA_READ_POOL_ENABLED` (default off). Use split-pool (same URL/hosts) to isolate connection limits, or set `EBEAN_READ_POOL_URL` / `CASSANDRA_READ_POOL_HOSTS` to offload to a replica. Separate from `DATAHUB_READ_ONLY=true`, which disables writes and does not register the read pool. See [Primary storage read pool](../deploy/primary-storage-read-pool.md).
+
+- #18393 / #18421: **(Operations / logging)** Core services and the frontend can optionally ship logs to a Loki-compatible aggregator. Set `LOG_AGGREGATOR_ENDPOINT` to enable shipping (also used for support-bundle log collection without relying on the Kubernetes API). Opt-in; unset leaves local logging unchanged.
+
 ### Environment Variables
 
 - `VIEW_UNRESTRICTED_ENTITY_TYPES` / `_ADD` / `_REMOVE` — Replaces `VIEW_RESTRICTED_ENTITY_TYPES`. Overlays on the `entity-registry.yml` `viewUnrestricted` baseline when `VIEW_AUTHORIZATION_ENABLED=true` (shared GMS config for Cloud Search Access Controls and OSS entity-page VBAC). Query-time search filtering remains DataHub Cloud–only. See Breaking Changes above and [Environment Variables](../deploy/environment-vars.md).
 
 - `SEARCH_DEFAULT_ENTITY_TYPES` / `SEARCH_AUTOCOMPLETE_ENTITY_TYPES` / `SEARCH_BROWSE_ENTITY_TYPES` / `SEARCH_PRIORITIZED_*_ENTITY_TYPES` (each with optional `_ADD` / `_REMOVE`) — Configure GraphQL default entity-type lists when callers omit `types`. Unset keeps `application.yaml` defaults. An explicitly empty value searches no entity types. See [Environment Variables](../deploy/environment-vars.md).
+
+- `EBEAN_READ_POOL_ENABLED` / `EBEAN_READ_POOL_URL` / `CASSANDRA_READ_POOL_ENABLED` / `CASSANDRA_READ_POOL_HOSTS` — Optional primary-storage read pool for entity-aspect reads. See Notable Changes above and [Primary storage read pool](../deploy/primary-storage-read-pool.md).
+
+- `LOG_AGGREGATOR_ENDPOINT` — Opt-in endpoint for shipping service logs to a Loki-compatible aggregator (also enables support-bundle log collection). See Notable Changes above.
 
 - #18334 **(GMS / patch)** Fixed keyed-array patch rebase (`ArrayMergingTemplate`) dropping the map key when a patch creates a new element through a deeper path — e.g. adding a field-level tag or term to a schema field with no existing `editableSchemaMetadata` entry produced an `EditableSchemaFieldInfo` with no `fieldPath` and was rejected with `HTTP 422 - fieldPath is required`. The fix applies to every keyed array (tags, terms, ownership, upstreams, etc.). This previously required an SDK-side workaround, now removed: **the Python SDK's `Dataset.patch_builder().add_tag()/add_term()` on a new schema field, and any client that patches a keyed array through a deep path, now depend on this GMS fix.** A new SDK against an older GMS (DataHub Core < 1.8.0 / DataHub Cloud < 2.1.0) regresses to the `422` on those field-level adds. **Action:** upgrade GMS to a version containing this fix before upgrading clients that rely on it.
 
@@ -292,9 +321,9 @@ Requirements:
 Requirements:
 
 - CLI / Python SDK: 1.6.0
-- Helm Chart: 1.0.0
+- Helm Chart: 1.0.3
 
-**ZDU (zero-downtime upgrade):** v1.6.0 is a **must-install** release before enabling Elasticsearch/OpenSearch ZDU. Deploy this version (with Helm chart **1.0.0** or later) and let system-update complete before turning on `global.datahub.systemUpdate.zdu` for a subsequent OpenSearch/Elasticsearch version bump. This release ships the server-side ZDU infrastructure, schema version index, aspect migration sweep safeguards, and Helm values required for staged index upgrades.
+**ZDU (zero-downtime upgrade):** v1.6.0 is a **must-install** release before enabling Elasticsearch/OpenSearch ZDU. Deploy this version with Helm chart **1.0.3** and let system-update complete. Enable `global.datahub.systemUpdate.zdu` later with Helm chart **1.1.0** (for example when upgrading to [v1.7.0](#v170)) for a subsequent OpenSearch/Elasticsearch version bump. This release ships the server-side ZDU infrastructure, schema version index, aspect migration sweep safeguards, and the Helm values foundation required for staged index upgrades.
 
 ### Breaking Changes
 
@@ -306,7 +335,7 @@ Requirements:
 
 - #16982: **(Auth)** The deprecated `corpUserInfo.active` field is **no longer considered** for session eligibility. Users gated on `active` for login must migrate to supported CorpUser status mechanisms.
 
-- #16887: **(Operations / Elasticsearch)** Optional **Elasticsearch side zero-downtime upgrade (ZDU)** for OpenSearch/Elasticsearch version bumps. **v1.6.0 is a must-install prerequisite** — deploy it and complete system-update before enabling ZDU on a later upgrade. When enabled via Helm (`global.datahub.systemUpdate.zdu`), system-update runs staged index upgrades with reduced downtime; scale-down during system-update is disabled automatically when ZDU is enabled. Requires Helm chart **1.0.0** or later. See chart values for `preEnable` / `enable` and index upgrade tuning (`global.elasticsearch.index.upgrade`, `global.elasticsearch.buildIndices`).
+- #16887: **(Operations / Elasticsearch)** Optional **Elasticsearch side zero-downtime upgrade (ZDU)** for OpenSearch/Elasticsearch version bumps. **v1.6.0 is a must-install prerequisite** — deploy it with Helm chart **1.0.3** and complete system-update before enabling ZDU on a later upgrade. When enabled via Helm (`global.datahub.systemUpdate.zdu`), system-update runs staged index upgrades with reduced downtime; scale-down during system-update is disabled automatically when ZDU is enabled. **Enable ZDU with Helm chart 1.1.0** (for example on the [v1.7.0](#v170) upgrade path). See chart values for `preEnable` / `enable` and index upgrade tuning (`global.elasticsearch.index.upgrade`, `global.elasticsearch.buildIndices`).
 
 - #16930: **(Operations / Upgrades)** Background **aspect schema version migration sweep** runs during upgrades on large deployments. The sweep migrates stale aspect schema versions and avoids overwriting aspects that were updated concurrently during the sweep window.
 


### PR DESCRIPTION
## Summary
- Promote `## Next` to `## v1.7.0` in `docs/how/updating-datahub.md` and add a fresh empty `## Next` draft section
- Set Requirements to CLI/SDK **1.7.0** and Helm **1.1.0**, with a callout that operators must upgrade to **v1.6.0** (Helm **1.0.3**) before v1.7.0 and enable ZDU with Helm **1.1.0**
- Backfill larger gaps: relationship edge uniqueness (#18845), primary storage read pool, Loki log shipping; fix secrets rollout wording to v1.7.0; align v1.6.0 Helm pin to **1.0.3**

## Test plan
- [ ] Spot-check rendered Updating DataHub page anchors (`#v170`, `#v160`)
- [ ] Confirm Requirements and ZDU upgrade-path wording match release train pins (CLI 1.7.0, Helm 1.0.3 → 1.1.0)


Made with [Cursor](https://cursor.com)