### PR TITLE
chore(): bump quickstart default to v1.7.0

### DIFF
--- a/docker/quickstart/quickstart_version_mapping.yaml
+++ b/docker/quickstart/quickstart_version_mapping.yaml
@@ -6,7 +6,7 @@
 # Pre-v1.5.0: when users pass e.g. --version v1.4.0, the CLI downloads the compose file from that
 # version's git tag, which still includes those setup containers. No code changes needed.
 # v1.5.0+ quickstart: compose uses system-update only; no separate setup containers. Default is pinned
-# to git tag v1.5.0.3 (not master). `head` uses compose from master and the `quickstart` docker tag (see manifest).
+# to git tag v1.7.0 (not master). `head` uses compose from master and the `quickstart` docker tag (see manifest).
 # Default must be v1.4.0.3 or later so system-update runs SqlSetup when DATAHUB_SQL_SETUP_ENABLED=true.
 #
 # If --version is specified during CLI run:
@@ -27,8 +27,8 @@
 quickstart_version_map:
   # The "default" key is mandatory and is used if no version is specified.
   default:
-    composefile_git_ref: v1.5.0.6
-    docker_tag: v1.5.0.6
+    composefile_git_ref: v1.7.0
+    docker_tag: v1.7.0
     mysql_tag: "8.2"
   # default:  # Use this to pin default to a specific version.
   #   composefile_git_ref: fd1bd51541a132017a648f4a2f037eec8f70ba26 # v0.10.0 + quickstart compose file fixes


### PR DESCRIPTION
## Summary
- Pin the CLI default quickstart compose/docker tags from `v1.5.0.6` to the new `v1.7.0` release.
- Matches the prior bump pattern in #17454 (`docker/quickstart/quickstart_version_mapping.yaml` only).

## Test plan
- [ ] Confirm `v1.7.0` images/tags exist on Docker Hub / release assets
- [ ] `datahub docker quickstart` (no `--version`) resolves to `v1.7.0` via the mapping
- [ ] Quickstart CI workflow / unit mapping tests remain green

Made with [Cursor](https://cursor.com)