### PR TITLE
fix(agent-context): expose document excerpt completeness

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
@@ -579,7 +579,8 @@ def grep_documents(
       - title: Document title
       - matches: List of excerpts with position info (positions are absolute)
       - total_matches: Total matches found (may exceed max_matches_per_doc)
-      - content_length: Total length of document content (when start_offset is used)
+      - content_length: Total length of the complete document content
+      - is_truncated: Whether any returned excerpt omits document content
     - total_matches: Total matches across all documents
     - documents_with_matches: Number of documents containing matches
 
@@ -660,6 +661,7 @@ def grep_documents(
         # but count all matches without keeping them in memory
         excerpts: List[Dict[str, Any]] = []
         doc_total_matches = 0
+        is_truncated = start_offset > 0
 
         for match in regex.finditer(text):
             doc_total_matches += 1
@@ -668,6 +670,7 @@ def grep_documents(
             if len(excerpts) < max_matches_per_doc:
                 start_pos = max(0, match.start() - context_chars)
                 end_pos = min(len(text), match.end() + context_chars)
+                is_truncated = is_truncated or start_pos > 0 or end_pos < len(text)
 
                 # Extract excerpt
                 excerpt = text[start_pos:end_pos]
@@ -699,11 +702,9 @@ def grep_documents(
             "title": title,
             "matches": excerpts,
             "total_matches": doc_total_matches,
+            "content_length": full_content_length,
+            "is_truncated": is_truncated,
         }
-
-        # Include content_length when using start_offset to help with pagination
-        if start_offset > 0:
-            result_entry["content_length"] = full_content_length
 
         results.append(result_entry)
 

--- a/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
@@ -341,6 +341,8 @@ def test_grep_documents_context_chars(mock_client):
     assert excerpt.startswith("...")
     assert excerpt.endswith("...")
     assert "MATCH" in excerpt
+    assert result["results"][0]["content_length"] == len(text)
+    assert result["results"][0]["is_truncated"] is True
 
 
 def test_grep_documents_empty_urns(mock_client):
@@ -540,17 +542,19 @@ def test_grep_documents_start_offset_includes_content_length(mock_client):
 
     # Should include content_length for pagination awareness
     assert result["results"][0]["content_length"] == len(text)
+    assert result["results"][0]["is_truncated"] is True
 
 
-def test_grep_documents_start_offset_zero_no_content_length(mock_client):
-    """Test that content_length is NOT included when start_offset=0."""
+def test_grep_documents_start_offset_zero_reports_completeness(mock_client):
+    """Test that first-page callers can distinguish complete and partial excerpts."""
+    text = "Some MATCH text"
     mock_client._graph.execute_graphql.return_value = {
         "entities": [
             {
                 "urn": "urn:li:document:doc1",
                 "info": {
                     "title": "Test Doc",
-                    "contents": {"text": "Some MATCH text"},
+                    "contents": {"text": text},
                 },
             }
         ]
@@ -563,8 +567,8 @@ def test_grep_documents_start_offset_zero_no_content_length(mock_client):
             start_offset=0,
         )
 
-    # Should NOT include content_length when not using offset
-    assert "content_length" not in result["results"][0]
+    assert result["results"][0]["content_length"] == len(text)
+    assert result["results"][0]["is_truncated"] is False
 
 
 def test_grep_documents_start_offset_beyond_document_length(mock_client):


### PR DESCRIPTION
## Summary

- always return the full document content length from grep_documents`n- expose an explicit is_truncated boolean instead of requiring clients to infer completeness from ellipses
- cover complete first-page, partial excerpt, and offset behavior

This is additive and backward-compatible. It lets MCP clients make fail-closed decisions about whether an excerpt is complete, including on the first page.

## Validation

- ./gradlew :datahub-agent-context:lint`n- ./gradlew :datahub-agent-context:testFull (637 passed)