### PR TITLE
fix(agent-context): allow caller-supplied document creation

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
@@ -119,9 +119,6 @@ def _get_current_user_info() -> Optional[Dict]:
         )
         me_data = result.get("me", {})
         return me_data.get("corpUser") if me_data else None
-    except ItemNotFoundError:
-        logger.debug(f"Document {document_urn} does not exist, allowing creation")
-        return True, None
     except Exception as e:
         logger.warning(f"Failed to get current user info: {e}")
         return None
@@ -253,6 +250,9 @@ def _is_document_in_shared_folder(document_urn: str) -> Tuple[bool, Optional[str
             "Only documents in this folder can be updated."
         )
 
+    except ItemNotFoundError:
+        logger.debug(f"Document {document_urn} does not exist, allowing creation")
+        return True, None
     except Exception as e:
         logger.error(f"Failed to validate document hierarchy: {e}", exc_info=True)
         # Fail closed - if we can't validate, don't allow the update

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
@@ -18,6 +18,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Tuple
 
+from datahub.errors import ItemNotFoundError
 from datahub.metadata import schema_classes as models
 from datahub.sdk import Document
 from datahub_agent_context.context import get_datahub_client
@@ -118,6 +119,9 @@ def _get_current_user_info() -> Optional[Dict]:
         )
         me_data = result.get("me", {})
         return me_data.get("corpUser") if me_data else None
+    except ItemNotFoundError:
+        logger.debug(f"Document {document_urn} does not exist, allowing creation")
+        return True, None
     except Exception as e:
         logger.warning(f"Failed to get current user info: {e}")
         return None

--- a/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
@@ -1,9 +1,9 @@
 import os
 from unittest.mock import Mock, patch
 
-from datahub.errors import ItemNotFoundError
 import pytest
 
+from datahub.errors import ItemNotFoundError
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.save_document import (
     ROOT_PARENT_DOC_ID,

--- a/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
@@ -1,8 +1,8 @@
 import os
 from unittest.mock import Mock, patch
 
-import pytest
 from datahub.errors import ItemNotFoundError
+import pytest
 
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.save_document import (

--- a/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
+from datahub.errors import ItemNotFoundError
 
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.save_document import (
@@ -543,6 +544,18 @@ class TestDocumentInSharedFolder:
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
                 "urn:li:document:new-doc-123"
+            )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_nonexistent_document_exception_allows_creation(self, mock_client):
+        """The SDK raises ItemNotFoundError instead of returning None on a live GMS."""
+        mock_client.entities.get.side_effect = ItemNotFoundError("document not found")
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:caller-supplied-id"
             )
 
         assert is_valid is True


### PR DESCRIPTION
## Summary

- treat ItemNotFoundError as the expected create path when validating a caller-supplied Document URN
- retain fail-closed hierarchy validation for every other lookup error
- add coverage for the live SDK behavior, which raises instead of returning None`n
Without this, save_document(urn=...) advertises update-or-create semantics but rejects a new caller-supplied URN before the upsert. The fix enables retry-safe content-addressed Document IDs without weakening update restrictions.

## Validation

- Ruff check and format check
- full Agent Context suite: 633 passed, 3 expected xfails
- mypy: no issues in 106 source files