### PR TITLE
feat(data products): add parentDataProduct for data product hierarchies

### DIFF
--- a/docs/dataproducts.md
+++ b/docs/dataproducts.md
@@ -119,6 +119,31 @@ MULTIPLE_DATA_PRODUCTS_PER_ASSET=false
 
 See the [Environment Variables](deploy/environment-vars.md#feature-flags) documentation for more details on configuring feature flags.
 
+### Nesting Data Products
+
+Data Products can nest under other Data Products via an optional `parentDataProduct` pointer, forming a multi-level taxonomy. This is useful when you buy or ingest a vendor product and re-package it into one or more internal products (for example, a vendor equities feed → an internal research product → a portfolio analytics product).
+
+Key behaviors:
+
+- A Data Product may have at most one parent (a tree, not a DAG). Nesting depth is arbitrary.
+- A child may belong to a different Domain than its parent; Domain membership is independent of the parent-child relationship.
+- Permissions remain scoped to each Data Product's own Domain — Manage Data Products is not inherited from the parent.
+- Cycles are rejected (a product cannot be moved under one of its own descendants).
+
+You can set the parent when creating or editing a Data Product in the UI, or declare it in YAML:
+
+```yaml
+id: portfolio_analytics
+domain: Trading
+display_name: Portfolio Analytics
+description: Internal product derived from the vendor equities feed.
+parent_data_product: urn:li:dataProduct:vendor_equities
+assets:
+  - urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.portfolio_summary,PROD)
+```
+
+`parent_data_product` accepts a fully-qualified Data Product URN or a resolvable id/name (same resolution rules as `domain`).
+
 ### Creating a Data Product (YAML + git)
 
 DataHub ships with a YAML-based Data Product spec for defining and managing Data Products as code.

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -59,6 +59,8 @@ Requirements:
 
 ### Other Notable Changes
 
+- **(Metadata Model / Data Products)** `dataProductProperties` now includes an optional `parentDataProduct` URN so Data Products can nest in a parent-child taxonomy (mirroring Domains' `parentDomain`). The field is additive; existing Data Products are unchanged (null parent). No migration or reindex is required. Free-text search may match child products on the parent URN string, the same way `parentDomain` already behaves.
+
 ## v1.7.0
 
 Requirements:

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -818,6 +818,10 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
                 Stream.concat(COMMON.stream(), Stream.of("parentDomain"))
                     .collect(Collectors.toSet()))
             .put(
+                EntityType.DATA_PRODUCT,
+                Stream.concat(COMMON.stream(), Stream.of("parentDataProduct"))
+                    .collect(Collectors.toSet()))
+            .put(
                 EntityType.SCHEMA_FIELD,
                 Stream.concat(COMMON.stream(), Stream.of("schemaFieldAliases", "parent"))
                     .collect(Collectors.toSet()))

--- a/metadata-models/src/main/pegasus/com/linkedin/dataproduct/DataProductProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataproduct/DataProductProperties.pdl
@@ -1,6 +1,7 @@
 namespace com.linkedin.dataproduct
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
+import com.linkedin.common.Urn
 
 /**
  * The main properties of a Data Product
@@ -43,4 +44,18 @@ record DataProductProperties includes CustomProperties, ExternalReference  {
     }
   }
   assets: optional array[DataProductAssociation]
+
+  /**
+   * Optional: parent Data Product, forming a parent-child taxonomy.
+   */
+  @Relationship = {
+    "name": "IsPartOf",
+    "entityTypes": [ "dataProduct" ],
+  }
+  @Searchable = {
+    "fieldName": "parentDataProduct",
+    "fieldType": "URN",
+    "hasValuesFieldName": "hasParentDataProduct"
+  }
+  parentDataProduct: optional Urn
 }


### PR DESCRIPTION
## Summary

- Add optional `parentDataProduct` URN to `DataProductProperties` (`IsPartOf` relationship, searchable with `hasParentDataProduct`), mirroring Domains' `parentDomain`
- Document nesting behavior and YAML example in `docs/dataproducts.md`
- Note the additive model change under Next → Other Notable Changes in `docs/how/updating-datahub.md`

This is Ticket 1 of the Data Product hierarchy work (CAT-2789 / CAT-2783): model + codegen + docs only. GraphQL, ingestion, and UI follow in subsequent PRs.
