### PR TITLE
perf(ingest/vertexai): stream pipeline and training job listings to cut peak memory

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_pipeline_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_pipeline_extractor.py
@@ -58,7 +58,7 @@ from datahub.ingestion.source.vertexai.vertexai_utils import (
     get_actor_from_labels,
     log_checkpoint_time,
     log_progress,
-    rate_limited_gapic_list,
+    rate_limited_gapic_iter,
 )
 from datahub.metadata.schema_classes import (
     AuditStampClass,
@@ -167,7 +167,7 @@ class VertexAIPipelineExtractor:
         if last_checkpoint_millis:
             log_checkpoint_time(last_checkpoint_millis, "PipelineJob")
 
-        pipeline_jobs = rate_limited_gapic_list(
+        pipeline_jobs = rate_limited_gapic_iter(
             self.client.PipelineJob,
             self.rate_limiter,
             order_by=ORDER_BY_UPDATE_TIME_DESC,

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
@@ -58,6 +58,7 @@ from datahub.ingestion.source.vertexai.vertexai_utils import (
     get_actor_from_labels,
     log_checkpoint_time,
     log_progress,
+    rate_limited_gapic_iter,
     rate_limited_gapic_list,
 )
 from datahub.metadata.schema_classes import (
@@ -131,7 +132,7 @@ class VertexAITrainingExtractor:
             if last_checkpoint_millis:
                 log_checkpoint_time(last_checkpoint_millis, class_name)
 
-            jobs = rate_limited_gapic_list(
+            jobs = rate_limited_gapic_iter(
                 getattr(self.client, class_name),
                 self.rate_limiter,
                 order_by=ORDER_BY_UPDATE_TIME_DESC,

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
@@ -122,21 +122,30 @@ def rate_limited_paged_call(
     return pager
 
 
-def rate_limited_gapic_list(
+def rate_limited_gapic_iter(
     cls: Type[T],
     rate_limiter: Union[RateLimiter, AbstractContextManager[None]],
     order_by: Optional[str] = None,
     filter_str: Optional[str] = None,
     parent: Optional[str] = None,
-) -> List[T]:
-    """List SDK resources via GAPIC with one rate-limit token per page fetch."""
+) -> Iterator[T]:
+    """Stream SDK resources via GAPIC, one rate-limit token per page fetch.
+
+    Yields resources lazily so peak memory holds only a single page (plus the
+    resource being constructed), not the whole listing. Use this for large,
+    uncapped listings such as pipeline jobs and training jobs, whose SDK objects
+    each carry a full resource proto. For bounded collections that are sorted,
+    sliced, len()-ed, or iterated more than once, use rate_limited_gapic_list.
+    """
     # sdk_cls typed as Any to access SDK private class attributes (_empty_constructor,
     # _list_method, _construct_sdk_resource_from_gapic) that are not in the public type.
     sdk_cls: Any = cls
 
     if not hasattr(sdk_cls, "_list_method"):
         with rate_limiter:
-            return sdk_cls.list(order_by=order_by) if order_by else sdk_cls.list()
+            fallback = sdk_cls.list(order_by=order_by) if order_by else sdk_cls.list()
+        yield from fallback
+        return
 
     supported_schemas = getattr(sdk_cls, "_supported_training_schemas", None)
     supported_uris = getattr(sdk_cls, "_supported_metadata_schema_uris", None)
@@ -148,6 +157,9 @@ def rate_limited_gapic_list(
             return p.metadata_schema_uri in supported_uris
         return True
 
+    # Pager setup runs before any yield so a class that lacks per-page GAPIC
+    # listing falls back cleanly to the high-level list(). The fallback must not
+    # happen mid-iteration, which would re-yield already-emitted resources.
     try:
         resource = sdk_cls._empty_constructor()
         creds = resource.credentials
@@ -172,18 +184,42 @@ def rate_limited_gapic_list(
                 ),
                 rate_limiter,
             )
-
-        return [
-            sdk_cls._construct_sdk_resource_from_gapic(proto, credentials=creds)
-            for proto in pager
-            if proto_filter(proto)
-        ]
     except (AttributeError, TypeError):
         logger.debug(
             f"Per-page rate limiting unavailable for {cls.__name__}, falling back"
         )
         with rate_limiter:
-            return sdk_cls.list(order_by=order_by) if order_by else sdk_cls.list()
+            fallback = sdk_cls.list(order_by=order_by) if order_by else sdk_cls.list()
+        yield from fallback
+        return
+
+    for proto in pager:
+        if proto_filter(proto):
+            yield sdk_cls._construct_sdk_resource_from_gapic(proto, credentials=creds)
+
+
+def rate_limited_gapic_list(
+    cls: Type[T],
+    rate_limiter: Union[RateLimiter, AbstractContextManager[None]],
+    order_by: Optional[str] = None,
+    filter_str: Optional[str] = None,
+    parent: Optional[str] = None,
+) -> List[T]:
+    """Materialize rate_limited_gapic_iter into a list.
+
+    Prefer rate_limited_gapic_iter for large listings. Use this only when the
+    caller needs list semantics: iterating more than once, sorting, slicing, or
+    len(). Peak memory holds every resource at once.
+    """
+    return list(
+        rate_limited_gapic_iter(
+            cls,
+            rate_limiter,
+            order_by=order_by,
+            filter_str=filter_str,
+            parent=parent,
+        )
+    )
 
 
 def log_progress(

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
@@ -131,11 +131,9 @@ def rate_limited_gapic_iter(
 ) -> Iterator[T]:
     """Stream SDK resources via GAPIC, one rate-limit token per page fetch.
 
-    Yields resources lazily so peak memory holds only a single page (plus the
-    resource being constructed), not the whole listing. Use this for large,
-    uncapped listings such as pipeline jobs and training jobs, whose SDK objects
-    each carry a full resource proto. For bounded collections that are sorted,
-    sliced, len()-ed, or iterated more than once, use rate_limited_gapic_list.
+    Yields lazily, so peak memory holds a single page rather than the whole
+    listing. Prefer this for large listings; use rate_limited_gapic_list only
+    when the caller needs list semantics.
     """
     # sdk_cls typed as Any to access SDK private class attributes (_empty_constructor,
     # _list_method, _construct_sdk_resource_from_gapic) that are not in the public type.
@@ -207,9 +205,8 @@ def rate_limited_gapic_list(
 ) -> List[T]:
     """Materialize rate_limited_gapic_iter into a list.
 
-    Prefer rate_limited_gapic_iter for large listings. Use this only when the
-    caller needs list semantics: iterating more than once, sorting, slicing, or
-    len(). Peak memory holds every resource at once.
+    Use only when the caller needs list semantics: multiple iterations, sort,
+    slice, or len(). Holds every resource in memory at once.
     """
     return list(
         rate_limited_gapic_iter(

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_utils.py
@@ -99,8 +99,12 @@ def patch_vertex_sdk_retry(custom_retry: api_retry.Retry) -> None:
             pass
 
 
+# Retry for the low-level GAPIC listing path
+_LISTING_RETRY = create_vertex_retry_without_429()
+
+
 class _GapicPagedFn(Protocol[T_co]):
-    def __call__(self, *, request: object) -> Iterable[T_co]:
+    def __call__(self, *, request: object, retry: api_retry.Retry) -> Iterable[T_co]:
         pass
 
 
@@ -108,9 +112,10 @@ def rate_limited_paged_call(
     gapic_fn: _GapicPagedFn[T],
     request: object,
     rate_limiter: Union[RateLimiter, AbstractContextManager[None]],
+    retry: api_retry.Retry = _LISTING_RETRY,
 ) -> Iterable[T]:
     with rate_limiter:
-        pager = gapic_fn(request=request)
+        pager = gapic_fn(request=request, retry=retry)
     if hasattr(pager, "_method"):
         _orig = pager._method
 

--- a/metadata-ingestion/tests/integration/vertexai/test_vertexai.py
+++ b/metadata-ingestion/tests/integration/vertexai/test_vertexai.py
@@ -21,8 +21,16 @@ from tests.integration.vertexai.mock_vertexai import (
     get_mock_pipeline_job,
 )
 
+# Modules that materialize listings via rate_limited_gapic_list (models, and
+# the training-job datasets cache).
 _EXTRACTOR_MODULES = [
     "datahub.ingestion.source.vertexai.vertexai_model_extractor",
+    "datahub.ingestion.source.vertexai.vertexai_training_extractor",
+]
+
+# Modules that stream large listings via rate_limited_gapic_iter instead of
+# materializing them with rate_limited_gapic_list.
+_STREAMING_EXTRACTOR_MODULES = [
     "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor",
     "datahub.ingestion.source.vertexai.vertexai_training_extractor",
 ]
@@ -35,6 +43,11 @@ def _patch_gapic_list(
     for module in _EXTRACTOR_MODULES:
         exit_stack.enter_context(
             patch(f"{module}.rate_limited_gapic_list", side_effect=side_effect)
+        )
+    # The mock returns a list, which the streaming callers iterate lazily.
+    for module in _STREAMING_EXTRACTOR_MODULES:
+        exit_stack.enter_context(
+            patch(f"{module}.rate_limited_gapic_iter", side_effect=side_effect)
         )
 
 

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_lineage.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_lineage.py
@@ -238,7 +238,7 @@ def test_model_downstream_lineage_from_pipeline_tasks(source: VertexAISource) ->
 
     # Step 1: Process pipeline - this tracks the resource usage by artifact URI
     with patch(
-        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_list",
+        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_iter",
         return_value=[mock_pipeline],
     ):
         list(source.pipeline_extractor.get_workunits())
@@ -401,7 +401,7 @@ def test_model_group_downstream_lineage_from_pipeline_tasks(
 
     # Step 1: Process pipeline - this tracks resource usage by artifact URI
     with patch(
-        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_list",
+        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_iter",
         return_value=[mock_pipeline],
     ):
         list(source.pipeline_extractor.get_workunits())

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Iterator, List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +13,7 @@ from google.cloud.aiplatform_v1 import PipelineTaskDetail
 from google.cloud.aiplatform_v1.types import PipelineJob as PipelineJobType
 from google.rpc.error_details_pb2 import ErrorInfo
 
+from datahub.configuration.common import AllowDenyPattern
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
@@ -113,11 +114,89 @@ def test_pipeline_task_with_none_timestamps(
     }
 
     with patch(
-        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_list",
+        "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_iter",
         return_value=[mock_pipeline_job],
     ):
         mcps = list(source.pipeline_extractor.get_workunits())
         assert len(mcps) > 0, "Should generate MCPs for pipeline task"
+
+
+def test_training_extractor_stops_pulling_at_max_jobs(source: VertexAISource) -> None:
+    """The training-job stream is consumed lazily: once max_training_jobs_per_type
+    is reached the extractor stops pulling instead of draining the whole listing.
+    Guards against a regression to eager materialization of the listing."""
+    source.config.max_training_jobs_per_type = 2
+    source.config.training_job_type_pattern = AllowDenyPattern(allow=["^CustomJob$"])
+
+    pulled: List[int] = []
+
+    def instrumented_iter(*_args: object, **_kwargs: object) -> Iterator[MagicMock]:
+        for i in range(10):
+            pulled.append(i)
+            yield MagicMock()
+
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_training_extractor.rate_limited_gapic_iter",
+            side_effect=instrumented_iter,
+        ),
+        patch.object(
+            source.training_extractor, "_get_training_job_mcps", return_value=iter([])
+        ),
+    ):
+        list(source.training_extractor.get_workunits())
+
+    assert pulled == [0, 1], "should stop pulling at the cap, not drain all 10"
+
+
+def test_pipeline_extractor_stops_pulling_at_checkpoint(
+    source: VertexAISource,
+) -> None:
+    """The pipeline stream is consumed lazily: once the incremental checkpoint
+    timestamp is reached the extractor stops pulling instead of draining it.
+    Guards against a regression to eager materialization of the listing."""
+    checkpoint_millis = int(
+        (datetime.now(timezone.utc) - timedelta(days=1)).timestamp() * 1000
+    )
+    # order_by=UPDATE_TIME_DESC yields newest first: the first is newer than the
+    # checkpoint (processed), the second is older and trips the early break.
+    newer = MagicMock(spec=PipelineJob)
+    newer.update_time = datetime.now(timezone.utc)
+    older = MagicMock(spec=PipelineJob)
+    older.update_time = datetime.now(timezone.utc) - timedelta(days=2)
+
+    pulled: List[MagicMock] = []
+
+    def instrumented_iter(*_args: object, **_kwargs: object) -> Iterator[MagicMock]:
+        for job in [newer, older, MagicMock(), MagicMock(), MagicMock()]:
+            pulled.append(job)
+            yield job
+
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_pipeline_extractor.rate_limited_gapic_iter",
+            side_effect=instrumented_iter,
+        ),
+        patch.object(
+            source.pipeline_extractor.state_handler,
+            "get_last_update_time",
+            return_value=checkpoint_millis,
+        ),
+        patch.object(
+            source.pipeline_extractor.state_handler, "update_resource_timestamp"
+        ),
+        patch.object(
+            source.pipeline_extractor,
+            "_get_pipeline_metadata",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            source.pipeline_extractor, "_get_pipeline_workunits", return_value=iter([])
+        ),
+    ):
+        list(source.pipeline_extractor.get_workunits())
+
+    assert len(pulled) == 2, "should stop pulling at the checkpoint, not drain all 5"
 
 
 def test_experiment_run_with_none_timestamps(source: VertexAISource) -> None:

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
@@ -122,9 +122,8 @@ def test_pipeline_task_with_none_timestamps(
 
 
 def test_training_extractor_stops_pulling_at_max_jobs(source: VertexAISource) -> None:
-    """The training-job stream is consumed lazily: once max_training_jobs_per_type
-    is reached the extractor stops pulling instead of draining the whole listing.
-    Guards against a regression to eager materialization of the listing."""
+    """Tests that the extractor consumes the training-job stream lazily, stopping
+    once max_training_jobs_per_type is reached rather than draining the listing."""
     source.config.max_training_jobs_per_type = 2
     source.config.training_job_type_pattern = AllowDenyPattern(allow=["^CustomJob$"])
 
@@ -141,20 +140,24 @@ def test_training_extractor_stops_pulling_at_max_jobs(source: VertexAISource) ->
             side_effect=instrumented_iter,
         ),
         patch.object(
+            source.training_extractor.state_handler,
+            "get_last_update_time",
+            return_value=None,
+        ),
+        patch.object(
             source.training_extractor, "_get_training_job_mcps", return_value=iter([])
         ),
     ):
         list(source.training_extractor.get_workunits())
 
-    assert pulled == [0, 1], "should stop pulling at the cap, not drain all 10"
+    assert pulled == [0, 1]
 
 
 def test_pipeline_extractor_stops_pulling_at_checkpoint(
     source: VertexAISource,
 ) -> None:
-    """The pipeline stream is consumed lazily: once the incremental checkpoint
-    timestamp is reached the extractor stops pulling instead of draining it.
-    Guards against a regression to eager materialization of the listing."""
+    """Tests that the extractor consumes the pipeline stream lazily, stopping once
+    the incremental checkpoint timestamp is reached rather than draining it."""
     checkpoint_millis = int(
         (datetime.now(timezone.utc) - timedelta(days=1)).timestamp() * 1000
     )
@@ -196,7 +199,7 @@ def test_pipeline_extractor_stops_pulling_at_checkpoint(
     ):
         list(source.pipeline_extractor.get_workunits())
 
-    assert len(pulled) == 2, "should stop pulling at the checkpoint, not drain all 5"
+    assert len(pulled) == 2
 
 
 def test_experiment_run_with_none_timestamps(source: VertexAISource) -> None:

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
@@ -2,6 +2,7 @@ from contextlib import nullcontext
 from typing import Any, List, cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 from google.api_core.exceptions import ResourceExhausted, ServiceUnavailable
 
 from datahub.ingestion.source.vertexai.vertexai_builder import (
@@ -10,6 +11,7 @@ from datahub.ingestion.source.vertexai.vertexai_builder import (
 )
 from datahub.ingestion.source.vertexai.vertexai_utils import (
     create_vertex_retry_without_429,
+    rate_limited_gapic_iter,
     rate_limited_gapic_list,
     rate_limited_paged_call,
 )
@@ -106,12 +108,13 @@ def test_rate_limited_paged_call_patches_method_for_subsequent_pages() -> None:
 
 
 # ---------------------------------------------------------------------------
-# rate_limited_gapic_list
+# rate_limited_gapic_iter (rate_limited_gapic_list is a thin list() wrapper, so
+# behavior is asserted once here on the real generator implementation)
 # ---------------------------------------------------------------------------
 
 
 def _make_cls(*, supported_schemas=None, supported_uris=None):
-    """Build a minimal mock SDK class for rate_limited_gapic_list."""
+    """Build a minimal mock SDK class for rate_limited_gapic_iter."""
     cls = MagicMock()
     cls.__name__ = "MockCls"
     cls._list_method = "list_things"
@@ -122,38 +125,58 @@ def _make_cls(*, supported_schemas=None, supported_uris=None):
     return cls
 
 
-def test_rate_limited_gapic_list_no_list_method_falls_back() -> None:
-    cls = MagicMock()
-    del cls._list_method
-    cls.list.return_value = ["a", "b"]
+def test_rate_limited_gapic_iter_streams_lazily() -> None:
+    """The streaming variant must pull at most one page item before the first
+    yield, so peak memory does not hold the whole listing."""
+    cls = _make_cls()
+    pulled: List[int] = []
 
-    result: List[Any] = rate_limited_gapic_list(cls, nullcontext())
+    def counting_pager():
+        for i in range(5):
+            pulled.append(i)
+            yield i
 
-    cls.list.assert_called_once()
-    assert result == ["a", "b"]
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.vertex_initializer"
+        ) as mock_init,
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.rate_limited_paged_call",
+            return_value=counting_pager(),
+        ),
+    ):
+        mock_init.global_config.common_location_path.return_value = (
+            "projects/p/locations/l"
+        )
+        stream = rate_limited_gapic_iter(cls, nullcontext())
+        first = next(stream)
+
+    assert first == 0
+    assert pulled == [0]  # only the first proto was materialized
 
 
-def test_rate_limited_gapic_list_passes_filter_str() -> None:
+def test_rate_limited_gapic_iter_matches_list() -> None:
     cls = _make_cls()
     with (
         patch(
             "datahub.ingestion.source.vertexai.vertexai_utils.vertex_initializer"
         ) as mock_init,
         patch(
-            "datahub.ingestion.source.vertexai.vertexai_utils.rate_limited_paged_call"
-        ) as mock_paged,
+            "datahub.ingestion.source.vertexai.vertexai_utils.rate_limited_paged_call",
+            side_effect=lambda *a, **k: iter(["a", "b", "c"]),
+        ),
     ):
         mock_init.global_config.common_location_path.return_value = (
             "projects/p/locations/l"
         )
-        mock_paged.return_value = iter([])
-        rate_limited_gapic_list(cls, nullcontext(), filter_str="my_filter")
+        iter_result = list(rate_limited_gapic_iter(cls, nullcontext()))
+        list_result = rate_limited_gapic_list(cls, nullcontext())
 
-    request = mock_paged.call_args[0][1]
-    assert request["filter"] == "my_filter"
+    assert iter_result == ["a", "b", "c"]
+    assert list_result == iter_result
 
 
-def test_rate_limited_gapic_list_training_schema_filter() -> None:
+def test_rate_limited_gapic_iter_applies_proto_filter() -> None:
     wanted = MagicMock(training_task_definition="gs://schema/custom")
     unwanted = MagicMock(training_task_definition="gs://schema/other")
 
@@ -170,12 +193,86 @@ def test_rate_limited_gapic_list_training_schema_filter() -> None:
             "projects/p/locations/l"
         )
         mock_paged.return_value = iter([wanted, unwanted])
-        result = rate_limited_gapic_list(cls, nullcontext())
+        result = list(rate_limited_gapic_iter(cls, nullcontext()))
 
     assert result == [wanted]
 
 
-def test_rate_limited_gapic_list_metadata_schema_uri_filter() -> None:
+def test_rate_limited_gapic_iter_no_list_method_falls_back() -> None:
+    cls = MagicMock()
+    del cls._list_method
+    cls.list.return_value = ["a", "b"]
+
+    result: List[Any] = list(rate_limited_gapic_iter(cls, nullcontext()))
+
+    cls.list.assert_called_once()
+    assert result == ["a", "b"]
+
+
+def test_rate_limited_gapic_iter_attribute_error_falls_back() -> None:
+    """Setup errors fall back to list(); the fallback must not fire mid-stream."""
+    cls = _make_cls()
+    cls._empty_constructor.side_effect = AttributeError("no constructor")
+    cls.list.return_value = ["fallback"]
+
+    result = list(rate_limited_gapic_iter(cls, nullcontext()))
+
+    cls.list.assert_called_once()
+    assert result == ["fallback"]
+
+
+def test_rate_limited_gapic_iter_does_not_refetch_on_mid_stream_error() -> None:
+    """A failure after streaming has started must propagate, not fall back to
+    list() and re-emit already-yielded resources (the fallback is setup-only)."""
+    cls = _make_cls()
+
+    def pager_then_raise():
+        yield "a"
+        yield "b"
+        raise AttributeError("boom mid-stream")
+
+    emitted = []
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.vertex_initializer"
+        ) as mock_init,
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.rate_limited_paged_call",
+            return_value=pager_then_raise(),
+        ),
+    ):
+        mock_init.global_config.common_location_path.return_value = (
+            "projects/p/locations/l"
+        )
+        with pytest.raises(AttributeError):
+            for item in rate_limited_gapic_iter(cls, nullcontext()):
+                emitted.append(item)
+
+    assert emitted == ["a", "b"]  # no duplicates from a re-run
+    cls.list.assert_not_called()  # did not fall back to the high-level list()
+
+
+def test_rate_limited_gapic_iter_passes_filter_str() -> None:
+    cls = _make_cls()
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.vertex_initializer"
+        ) as mock_init,
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_utils.rate_limited_paged_call"
+        ) as mock_paged,
+    ):
+        mock_init.global_config.common_location_path.return_value = (
+            "projects/p/locations/l"
+        )
+        mock_paged.return_value = iter([])
+        list(rate_limited_gapic_iter(cls, nullcontext(), filter_str="my_filter"))
+
+    request = mock_paged.call_args[0][1]
+    assert request["filter"] == "my_filter"
+
+
+def test_rate_limited_gapic_iter_applies_metadata_schema_uri_filter() -> None:
     wanted = MagicMock(metadata_schema_uri="gs://meta/tabular")
     unwanted = MagicMock(metadata_schema_uri="gs://meta/image")
 
@@ -192,12 +289,12 @@ def test_rate_limited_gapic_list_metadata_schema_uri_filter() -> None:
             "projects/p/locations/l"
         )
         mock_paged.return_value = iter([wanted, unwanted])
-        result = rate_limited_gapic_list(cls, nullcontext())
+        result = list(rate_limited_gapic_iter(cls, nullcontext()))
 
     assert result == [wanted]
 
 
-def test_rate_limited_gapic_list_order_by_value_error_retried_without_it() -> None:
+def test_rate_limited_gapic_iter_order_by_value_error_retried_without_it() -> None:
     cls = _make_cls()
     call_count = [0]
 
@@ -222,18 +319,9 @@ def test_rate_limited_gapic_list_order_by_value_error_retried_without_it() -> No
         mock_init.global_config.common_location_path.return_value = (
             "projects/p/locations/l"
         )
-        result = rate_limited_gapic_list(cls, nullcontext(), order_by="update_time")
+        result = list(
+            rate_limited_gapic_iter(cls, nullcontext(), order_by="update_time")
+        )
 
     assert call_count[0] == 2
     assert result == ["item"]
-
-
-def test_rate_limited_gapic_list_attribute_error_falls_back() -> None:
-    cls = _make_cls()
-    cls._empty_constructor.side_effect = AttributeError("no constructor")
-    cls.list.return_value = ["fallback"]
-
-    result = rate_limited_gapic_list(cls, nullcontext())
-
-    cls.list.assert_called_once()
-    assert result == ["fallback"]

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
@@ -126,8 +126,8 @@ def _make_cls(*, supported_schemas=None, supported_uris=None):
 
 
 def test_rate_limited_gapic_iter_streams_lazily() -> None:
-    """The streaming variant must pull at most one page item before the first
-    yield, so peak memory does not hold the whole listing."""
+    """Tests that the generator is lazy, pulling at most one item before the
+    first yield so peak memory never holds the whole listing."""
     cls = _make_cls()
     pulled: List[int] = []
 
@@ -152,10 +152,11 @@ def test_rate_limited_gapic_iter_streams_lazily() -> None:
         first = next(stream)
 
     assert first == 0
-    assert pulled == [0]  # only the first proto was materialized
+    assert pulled == [0]
 
 
 def test_rate_limited_gapic_iter_matches_list() -> None:
+    """Tests that rate_limited_gapic_list yields the same items as the generator."""
     cls = _make_cls()
     with (
         patch(
@@ -177,6 +178,7 @@ def test_rate_limited_gapic_iter_matches_list() -> None:
 
 
 def test_rate_limited_gapic_iter_applies_proto_filter() -> None:
+    """Tests that protos are filtered by the class's supported training schemas."""
     wanted = MagicMock(training_task_definition="gs://schema/custom")
     unwanted = MagicMock(training_task_definition="gs://schema/other")
 
@@ -199,6 +201,7 @@ def test_rate_limited_gapic_iter_applies_proto_filter() -> None:
 
 
 def test_rate_limited_gapic_iter_no_list_method_falls_back() -> None:
+    """Tests that a class without a GAPIC list method falls back to list()."""
     cls = MagicMock()
     del cls._list_method
     cls.list.return_value = ["a", "b"]
@@ -210,7 +213,7 @@ def test_rate_limited_gapic_iter_no_list_method_falls_back() -> None:
 
 
 def test_rate_limited_gapic_iter_attribute_error_falls_back() -> None:
-    """Setup errors fall back to list(); the fallback must not fire mid-stream."""
+    """Tests that a setup-time error falls back to the high-level list()."""
     cls = _make_cls()
     cls._empty_constructor.side_effect = AttributeError("no constructor")
     cls.list.return_value = ["fallback"]
@@ -222,8 +225,8 @@ def test_rate_limited_gapic_iter_attribute_error_falls_back() -> None:
 
 
 def test_rate_limited_gapic_iter_does_not_refetch_on_mid_stream_error() -> None:
-    """A failure after streaming has started must propagate, not fall back to
-    list() and re-emit already-yielded resources (the fallback is setup-only)."""
+    """Tests that a failure after streaming has started propagates instead of
+    falling back to list() and re-emitting already-yielded resources."""
     cls = _make_cls()
 
     def pager_then_raise():
@@ -248,11 +251,12 @@ def test_rate_limited_gapic_iter_does_not_refetch_on_mid_stream_error() -> None:
             for item in rate_limited_gapic_iter(cls, nullcontext()):
                 emitted.append(item)
 
-    assert emitted == ["a", "b"]  # no duplicates from a re-run
-    cls.list.assert_not_called()  # did not fall back to the high-level list()
+    assert emitted == ["a", "b"]
+    cls.list.assert_not_called()
 
 
 def test_rate_limited_gapic_iter_passes_filter_str() -> None:
+    """Tests that filter_str is forwarded on the GAPIC list request."""
     cls = _make_cls()
     with (
         patch(
@@ -273,6 +277,7 @@ def test_rate_limited_gapic_iter_passes_filter_str() -> None:
 
 
 def test_rate_limited_gapic_iter_applies_metadata_schema_uri_filter() -> None:
+    """Tests that protos are filtered by the class's supported metadata schema URIs."""
     wanted = MagicMock(metadata_schema_uri="gs://meta/tabular")
     unwanted = MagicMock(metadata_schema_uri="gs://meta/image")
 
@@ -295,6 +300,7 @@ def test_rate_limited_gapic_iter_applies_metadata_schema_uri_filter() -> None:
 
 
 def test_rate_limited_gapic_iter_order_by_value_error_retried_without_it() -> None:
+    """Tests that an order_by rejected by the gRPC layer is retried without it."""
     cls = _make_cls()
     call_count = [0]
 

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_utils.py
@@ -69,9 +69,10 @@ def test_rate_limited_paged_call_acquires_token_on_first_page() -> None:
         def __exit__(self, *_):
             return False
 
-    result = rate_limited_paged_call(gapic_fn, "req", CountingLimiter())
+    retry = create_vertex_retry_without_429()
+    result = rate_limited_paged_call(gapic_fn, "req", CountingLimiter(), retry=retry)
 
-    gapic_fn.assert_called_once_with(request="req")
+    gapic_fn.assert_called_once_with(request="req", retry=retry)
     assert tokens == [1]
     assert result is pager
 
@@ -105,6 +106,19 @@ def test_rate_limited_paged_call_patches_method_for_subsequent_pages() -> None:
     result._method("arg")
     assert tokens == [1, 1]  # second page consumed another token
     original_method.assert_called_once_with("arg")
+
+
+def test_rate_limited_paged_call_threads_transient_retry_by_default() -> None:
+    """Transient 5xx errors are retried on the GAPIC listing path, but 429 is not."""
+    pager = MagicMock()
+    del pager._method
+    gapic_fn = MagicMock(return_value=pager)
+
+    rate_limited_paged_call(gapic_fn, "req", nullcontext())
+
+    retry = gapic_fn.call_args.kwargs["retry"]
+    assert retry._predicate(ServiceUnavailable("unavailable"))
+    assert not retry._predicate(ResourceExhausted("quota exceeded"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

The Vertex AI connector's shared listing helper `rate_limited_gapic_list` materializes an entire listing into a list before iterating. Two of those listings, pipeline jobs and training jobs, are large and effectively unbounded: a scheduled pipeline emits one `PipelineJob` per run, so a few templates produce thousands of runs, and each SDK object carries its full resource proto (compiled pipeline spec plus every task's detail). Peak memory scales with run count times proto size, and pipeline listing had no cap at all. On a broad multi-project `project_id_pattern` sweep this is enough to OOM the ingestion executor.

The connector already streams its workunits with generators; only the SDK listing step broke that by materializing. This change makes the two large listings stream, matching the BigQuery connector, which already streams its large listings (tables, views) and materializes only bounded ones.

## Changes

- **New `rate_limited_gapic_iter(...) -> Iterator[T]` in `vertexai_utils.py`.** A generator that yields SDK resources off the lazy GAPIC pager one page (~100 protos) at a time, applying the same per-page rate limiting and schema/URI proto filters as before. Peak memory drops from O(N × proto) to about one page plus the in-flight resource.
- **`rate_limited_gapic_list(...) -> List[T]` is now `list(rate_limited_gapic_iter(...))`.** A thin wrapper kept for callers that need list semantics (re-iteration, sort, slice, `len`); its observable behavior is unchanged.
- **The `AttributeError`/`TypeError` fallback to the high-level SDK `.list()` stays at pager-setup time, before any yield.** A mid-iteration fallback would re-run `.list()` and re-emit resources already streamed; keeping it setup-only makes duplicate emission impossible and lets a genuine iteration error surface instead of being masked.
- **The two large listings switch to streaming:** pipeline jobs (`VertexAIPipelineExtractor.get_workunits`) and training jobs (`VertexAITrainingExtractor.get_workunits`). Both iterate once with an early break (checkpoint timestamp / `max_training_jobs_per_type`); with `order_by=UPDATE_TIME_DESC` the break now also stops fetching older pages, not just stops processing them.
- **Bounded or multiply-iterated listings stay on the list variant:** models (cached and reused for evaluations), evaluations (sorted and sliced), experiments, datasets, and endpoints.
- **Extend existing vertex retry logic to `rate_limited_gapic_iter`.** Provides resilience to transient (5xx) erros

## Testing

- `vertexai_utils` tests: laziness (only one proto is pulled before the first yield, catching a regression to eager materialization); wrapper parity (`list` == materialized `iter`); proto filters; setup-time fallback; and a mid-stream failure that asserts exactly the already-yielded items are emitted, with no fallback to `.list()` and no duplicates.
- Extractor tests: each extractor is fed an instrumented generator and asserted to stop pulling on its early break (training `max_jobs` cap, pipeline checkpoint), guarding the streaming guarantee against a silent revert to the list variant.
- `./gradlew :metadata-ingestion:lint` (ruff + mypy) clean; the unit and mock-based integration Vertex AI suites pass (141 tests). The integration golden path confirms pipeline and training output is unchanged after streaming.

No new entities or aspects; the change is memory and iteration behavior only.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs (n/a — no new user-facing config or behavioural surface)
- [ ] Breaking change / updating-datahub entry (n/a — no breaking change)
