### PR TITLE
docs(langchain): add metadata-aware code generation workflow

### DIFF
--- a/docs/dev-guides/agent-context/langchain.md
+++ b/docs/dev-guides/agent-context/langchain.md
@@ -62,6 +62,75 @@ llm = ChatBedrock(
 
 Full working example: [simple_search.py](https://github.com/datahub-project/datahub/blob/master/datahub-agent-context/examples/langchain/simple_search.py)
 
+## Metadata-aware Code Generation Workflow
+
+Many AI-powered data engineering workflows use DataHub as the source of truth before generating production-ready artifacts. Rather than generating code solely from user prompts, applications can first retrieve metadata from DataHub to provide richer context to the LLM.
+
+A typical workflow looks like this:
+
+```text
+Developer Request
+        │
+        ▼
+Search DataHub
+        │
+        ▼
+Retrieve Metadata
+(schema, lineage,
+owners, glossary)
+        │
+        ▼
+Build LLM Prompt
+        │
+        ▼
+Generate Code
+        │
+        ▼
+Validate Output
+        │
+        ▼
+Git Pull Request
+```
+
+Typical metadata retrieved from DataHub includes:
+
+- Dataset schema
+- Ownership
+- Lineage
+- Tags
+- Glossary terms
+- Documentation
+- Sample queries
+
+For example, a LangChain agent can retrieve metadata before generating code:
+
+```python
+response = agent.invoke(
+    {
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Find the orders dataset, inspect its schema and lineage, "
+                    "then generate a dbt model using that metadata."
+                ),
+            }
+        ]
+    }
+)
+```
+
+Grounding prompts with DataHub metadata helps AI assistants generate artifacts that align with existing schemas, governance policies, and organizational standards instead of relying on assumptions.
+
+Common generated artifacts include:
+
+- SQL transformations
+- Apache Airflow DAGs
+- dbt models
+- Pipeline configuration files
+- Data ingestion scripts
+
+
 ## Troubleshooting
 
 - **Tool execution errors?** Verify your DataHub connection with `client.test_connection()` and check token permissions.

--- a/docs/dev-guides/agent-context/langchain.md
+++ b/docs/dev-guides/agent-context/langchain.md
@@ -130,7 +130,6 @@ Common generated artifacts include:
 - Pipeline configuration files
 - Data ingestion scripts
 
-
 ## Troubleshooting
 
 - **Tool execution errors?** Verify your DataHub connection with `client.test_connection()` and check token permissions.


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

## Summary

This PR adds a new **Metadata-aware Code Generation Workflow** section to the LangChain Agent Context guide.

The new documentation demonstrates how AI-powered data engineering workflows can use DataHub metadata before generating production-ready artifacts.

Specifically, it includes:

- A workflow diagram illustrating metadata-aware code generation
- An explanation of grounding LLM prompts using DataHub metadata
- A LangChain example showing metadata retrieval before code generation
- Examples of generated artifacts including SQL, dbt models, Airflow DAGs, and pipeline configuration files

## Why

Many AI engineering workflows use DataHub as the source of truth before generating code.

Documenting this pattern helps users understand how to build metadata-aware AI assistants that generate artifacts aligned with schemas, lineage, ownership, and governance rather than relying solely on natural language prompts.

## Testing

- Documentation only
- No code changes
