### PR TITLE
fix(smoke-test): remove vestigial pytest dependency marks in domains test

### DIFF
--- a/smoke-test/tests/domains/domains_test.py
+++ b/smoke-test/tests/domains/domains_test.py
@@ -49,7 +49,6 @@ def _ensure_domain_readable(
     return domain
 
 
-@pytest.mark.dependency()
 def test_create_list_get_domain(auth_session):
     # Run-unique id so parallel workers never collide on urn:li:domain:test id.
     domain_id = f"test-id-{unique_suffix()}"
@@ -88,7 +87,6 @@ def test_create_list_get_domain(auth_session):
             logger.warning("Failed to clean up domain %s: %s", domain_urn, exc)
 
 
-@pytest.mark.dependency(depends=["test_create_list_get_domain"])
 def test_set_unset_domain(auth_session, dataset_urn):
     # Set and Unset a Domain for a dataset. Note that this doesn't test for adding domains to charts, dashboards, charts, & jobs.
     domain_urn = "urn:li:domain:engineering"


### PR DESCRIPTION
### Context

This PR originally fixed the flaky global-count assertion in `test_create_list_get_domain` (`listDomains.total == before + 1`). #18923 landed the same fix first, so that work is dropped and the branch has been reset onto master.

What remains is the one item #18923 did not cover, raised in review here: the two `@pytest.mark.dependency` marks.

### Change

Remove both marks from `smoke-test/tests/domains/domains_test.py`:

- `@pytest.mark.dependency()` on `test_create_list_get_domain`
- `@pytest.mark.dependency(depends=["test_create_list_get_domain"])` on `test_set_unset_domain`

### Why

The dependency was never real. `test_set_unset_domain` operates on `urn:li:domain:engineering`, which is ingested by the module's `dataset_urn` fixture from `tests/domains/data.json` — it never references the domain that `test_create_list_get_domain` creates. The marks date back to #3952 (2022), the commit that introduced both tests.

The marks are not merely inert. `pytest-dependency` defaults to module scope, so any failure of `test_create_list_get_domain` also **skips** `test_set_unset_domain`. While the count assertion was flaky, a single racy assertion silently cost two tests' worth of coverage — and a skip is quieter than a failure.

Behaviour change: `test_set_unset_domain` now runs even when `test_create_list_get_domain` fails. That is the intent — its data comes from the fixture, so it is independent. A genuine regression in domain creation now surfaces as one failure rather than one failure plus one silent skip.

`import pytest` is still required for the `dataset_urn` fixture.

### Checklist

- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md), particularly PR Title Format
- [x] Tests for the changes have been added/updated — test-only change
- [ ] Docs — not applicable
- [ ] Breaking changes — none
