### PR TITLE
fix(ingest): align Confluent catalog queries with live API

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
@@ -8,9 +8,7 @@ from datahub.ingestion.source.confluent.config import ConfluentStreamCatalogConf
 from datahub.ingestion.source.confluent.constants import (
     DATA_KEY,
     ERRORS_KEY,
-    LIMIT_VARIABLE,
     MESSAGE_KEY,
-    OFFSET_VARIABLE,
 )
 from datahub.ingestion.source.confluent.models import CatalogEntityType
 
@@ -76,16 +74,20 @@ class ConfluentStreamCatalogClient:
     def _fetch_page(
         self, query: str, root_key: str, offset: int
     ) -> Optional[List[Dict[str, object]]]:
-        variables = {
-            LIMIT_VARIABLE: self.config.page_size,
-            OFFSET_VARIABLE: offset,
-        }
+        # The live Confluent Cloud catalog endpoint returns HTTP 500 for any
+        # operation that carries a GraphQL variables map (verified 2026-08-05),
+        # so pagination arguments are inlined into the query text instead. Only
+        # the {limit}/{offset} placeholders are substituted; both values are
+        # integers, so no escaping is needed.
+        inline_query = query.replace("{limit}", str(self.config.page_size)).replace(
+            "{offset}", str(offset)
+        )
         context = f"endpoint={self.endpoint}, entity={root_key}, offset={offset}"
 
         try:
             response = self.session.post(
                 self.endpoint,
-                json={"query": query, "variables": variables},
+                json={"query": inline_query},
                 timeout=self.config.timeout_seconds,
             )
             response.raise_for_status()

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
@@ -57,10 +57,8 @@ class ConfluentStreamCatalogClient:
             if placeholder not in query
         ]
         if missing:
-            # A query that cannot be paginated would otherwise repeat the same
-            # request forever, or silently stop after whatever the server's default
-            # page size is. This is a bug in the query constant, not a catalog
-            # problem, so it is a failure rather than a warning.
+            # Missing {offset} loops forever; missing {limit} silently truncates.
+            # Client bug, not a catalog outage — report as failure.
             self.report.failure(
                 message="Confluent Stream Catalog query is missing its pagination placeholders",
                 context=f"entity={root_key}, missing={sorted(missing)}",
@@ -93,8 +91,7 @@ class ConfluentStreamCatalogClient:
     def _fetch_page(
         self, query: str, root_key: str, offset: int
     ) -> Optional[List[Dict[str, object]]]:
-        # Presence of both placeholders is checked in fetch_entities; both values are
-        # integers, so no escaping is needed.
+        # Integers only — no escaping needed. Placeholder presence checked above.
         inline_query = query.replace(
             LIMIT_PLACEHOLDER, str(self.config.page_size)
         ).replace(OFFSET_PLACEHOLDER, str(offset))
@@ -109,8 +106,8 @@ class ConfluentStreamCatalogClient:
             response.raise_for_status()
             payload = response.json()
         except requests.HTTPError as e:
-            # Carries the server's own explanation, which separates a rejected query
-            # from the routine "catalog not provisioned" case.
+            # Include response body so a rejected query is distinguishable from
+            # "catalog not provisioned".
             self.report.warning(
                 message="The Confluent Stream Catalog rejected the request",
                 context=f"{context}, response={_response_body(e)}",

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/client.py
@@ -8,7 +8,10 @@ from datahub.ingestion.source.confluent.config import ConfluentStreamCatalogConf
 from datahub.ingestion.source.confluent.constants import (
     DATA_KEY,
     ERRORS_KEY,
+    LIMIT_PLACEHOLDER,
+    MAX_ERROR_BODY_CHARS,
     MESSAGE_KEY,
+    OFFSET_PLACEHOLDER,
 )
 from datahub.ingestion.source.confluent.models import CatalogEntityType
 
@@ -48,6 +51,22 @@ class ConfluentStreamCatalogClient:
         Entities that fail to parse are skipped so one malformed record cannot cost
         the caller the whole page.
         """
+        missing = [
+            placeholder
+            for placeholder in (LIMIT_PLACEHOLDER, OFFSET_PLACEHOLDER)
+            if placeholder not in query
+        ]
+        if missing:
+            # A query that cannot be paginated would otherwise repeat the same
+            # request forever, or silently stop after whatever the server's default
+            # page size is. This is a bug in the query constant, not a catalog
+            # problem, so it is a failure rather than a warning.
+            self.report.failure(
+                message="Confluent Stream Catalog query is missing its pagination placeholders",
+                context=f"entity={root_key}, missing={sorted(missing)}",
+            )
+            return []
+
         entities: List[CatalogEntityType] = []
         offset = 0
 
@@ -74,14 +93,11 @@ class ConfluentStreamCatalogClient:
     def _fetch_page(
         self, query: str, root_key: str, offset: int
     ) -> Optional[List[Dict[str, object]]]:
-        # The live Confluent Cloud catalog endpoint returns HTTP 500 for any
-        # operation that carries a GraphQL variables map (verified 2026-08-05),
-        # so pagination arguments are inlined into the query text instead. Only
-        # the {limit}/{offset} placeholders are substituted; both values are
+        # Presence of both placeholders is checked in fetch_entities; both values are
         # integers, so no escaping is needed.
-        inline_query = query.replace("{limit}", str(self.config.page_size)).replace(
-            "{offset}", str(offset)
-        )
+        inline_query = query.replace(
+            LIMIT_PLACEHOLDER, str(self.config.page_size)
+        ).replace(OFFSET_PLACEHOLDER, str(offset))
         context = f"endpoint={self.endpoint}, entity={root_key}, offset={offset}"
 
         try:
@@ -92,6 +108,15 @@ class ConfluentStreamCatalogClient:
             )
             response.raise_for_status()
             payload = response.json()
+        except requests.HTTPError as e:
+            # Carries the server's own explanation, which separates a rejected query
+            # from the routine "catalog not provisioned" case.
+            self.report.warning(
+                message="The Confluent Stream Catalog rejected the request",
+                context=f"{context}, response={_response_body(e)}",
+                exc=e,
+            )
+            return None
         except Exception as e:
             self.report.warning(
                 message="Failed to query the Confluent Stream Catalog",
@@ -143,6 +168,12 @@ class ConfluentStreamCatalogClient:
 
     def close(self) -> None:
         self.session.close()
+
+
+def _response_body(error: requests.HTTPError) -> str:
+    if error.response is None:
+        return ""
+    return error.response.text[:MAX_ERROR_BODY_CHARS]
 
 
 def _summarise_errors(errors: object) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
@@ -13,6 +13,3 @@ MAX_PAGE_SIZE: Final[int] = 1000
 DATA_KEY: Final[str] = "data"
 ERRORS_KEY: Final[str] = "errors"
 MESSAGE_KEY: Final[str] = "message"
-
-LIMIT_VARIABLE: Final[str] = "limit"
-OFFSET_VARIABLE: Final[str] = "offset"

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
@@ -13,3 +13,14 @@ MAX_PAGE_SIZE: Final[int] = 1000
 DATA_KEY: Final[str] = "data"
 ERRORS_KEY: Final[str] = "errors"
 MESSAGE_KEY: Final[str] = "message"
+
+# The live Confluent Cloud catalog endpoint returns HTTP 500 for any operation that
+# carries a GraphQL variables map (verified 2026-08-05), so every catalog query spells
+# its pagination arguments with these placeholders and the client inlines the integers
+# before sending. GraphQL validation used to catch a query/variable mismatch for us;
+# with variables gone, the client checks both placeholders are present instead.
+LIMIT_PLACEHOLDER: Final[str] = "{limit}"
+OFFSET_PLACEHOLDER: Final[str] = "{offset}"
+
+# Enough of a rejected response to identify the cause without flooding the report.
+MAX_ERROR_BODY_CHARS: Final[int] = 500

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
@@ -14,13 +14,9 @@ DATA_KEY: Final[str] = "data"
 ERRORS_KEY: Final[str] = "errors"
 MESSAGE_KEY: Final[str] = "message"
 
-# The live Confluent Cloud catalog endpoint returns HTTP 500 for any operation that
-# carries a GraphQL variables map (verified 2026-08-05), so every catalog query spells
-# its pagination arguments with these placeholders and the client inlines the integers
-# before sending. GraphQL validation used to catch a query/variable mismatch for us;
-# with variables gone, the client checks both placeholders are present instead.
+# Live catalog endpoint returns HTTP 500 for any GraphQL variables map
+# (verified 2026-08-05), so pagination is inlined via these placeholders.
 LIMIT_PLACEHOLDER: Final[str] = "{limit}"
 OFFSET_PLACEHOLDER: Final[str] = "{offset}"
 
-# Enough of a rejected response to identify the cause without flooding the report.
 MAX_ERROR_BODY_CHARS: Final[int] = 500

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class CatalogKafkaTopic(CatalogEntity):
-    cluster_id: Optional[str] = Field(default=None, alias="clusterId")
+    cluster_id: Optional[str] = Field(default=None, alias="logical_cluster_id")
 
 
 class KafkaTopicCatalog:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
@@ -51,9 +51,20 @@ class KafkaTopicCatalog:
             TOPIC_CATALOG_QUERY, TOPIC_ROOT_KEY, CatalogKafkaTopic
         )
         if self.config.cluster_id:
-            topics = [
+            in_cluster = [
                 topic for topic in topics if topic.cluster_id == self.config.cluster_id
             ]
+            if topics and not in_cluster:
+                # Without this the whole enrichment goes dark on a typo, or on a tier
+                # that leaves `logical_cluster_id` unset, showing up only as a zero in
+                # the report.
+                self.report.warning(
+                    message="No Stream Catalog topic carries the configured Kafka cluster id, so no "
+                    "catalog metadata will be applied. Check `confluent_catalog.cluster_id`.",
+                    context=f"cluster_id={self.config.cluster_id}, topics_in_catalog={len(topics)}, "
+                    f"cluster_ids_seen={sorted({str(topic.cluster_id) for topic in topics})}",
+                )
+            topics = in_cluster
         self.report.catalog_topics_fetched = len(topics)
 
         by_name: Dict[str, List[CatalogKafkaTopic]] = defaultdict(list)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
@@ -55,9 +55,7 @@ class KafkaTopicCatalog:
                 topic for topic in topics if topic.cluster_id == self.config.cluster_id
             ]
             if topics and not in_cluster:
-                # Without this the whole enrichment goes dark on a typo, or on a tier
-                # that leaves `logical_cluster_id` unset, showing up only as a zero in
-                # the report.
+                # Typo or unset logical_cluster_id otherwise looks like "0 topics fetched".
                 self.report.warning(
                     message="No Stream Catalog topic carries the configured Kafka cluster id, so no "
                     "catalog metadata will be applied. Check `confluent_catalog.cluster_id`.",

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
@@ -6,12 +6,17 @@ TOPIC_ROOT_KEY: Final[str] = "kafka_topic"
 # Read-only query for the topics in the environment the Schema Registry endpoint
 # belongs to. Kept to fields the catalog has carried since Stream Governance shipped,
 # because an unknown field fails the whole query rather than returning null.
+#
+# Pagination is inlined as {limit}/{offset} placeholders (substituted by the client)
+# rather than GraphQL variables: the live Confluent Cloud catalog endpoint returns
+# HTTP 500 for any operation that carries a variables map, and names the topic's
+# cluster field `logical_cluster_id`, not `clusterId` (verified 2026-08-05).
 TOPIC_CATALOG_QUERY: Final[str] = """
-query DataHubKafkaTopicCatalog($limit: Int, $offset: Int) {
-  kafka_topic(limit: $limit, offset: $offset) {
+{
+  kafka_topic(limit: {limit}, offset: {offset}) {
     name
     qualifiedName
-    clusterId
+    logical_cluster_id
     tags
     business_metadata {
       name

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
@@ -7,10 +7,10 @@ TOPIC_ROOT_KEY: Final[str] = "kafka_topic"
 # belongs to. Kept to fields the catalog has carried since Stream Governance shipped,
 # because an unknown field fails the whole query rather than returning null.
 #
-# Pagination is inlined as {limit}/{offset} placeholders (substituted by the client)
-# rather than GraphQL variables: the live Confluent Cloud catalog endpoint returns
-# HTTP 500 for any operation that carries a variables map, and names the topic's
-# cluster field `logical_cluster_id`, not `clusterId` (verified 2026-08-05).
+# The topic's cluster field is named `logical_cluster_id`, not `clusterId`
+# (verified against the live API 2026-08-05). Pagination placeholders are substituted
+# by the client; see LIMIT_PLACEHOLDER in `datahub.ingestion.source.confluent.constants`
+# for why they are not GraphQL variables.
 TOPIC_CATALOG_QUERY: Final[str] = """
 {
   kafka_topic(limit: {limit}, offset: {offset}) {

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
@@ -3,14 +3,10 @@ from typing import Final
 # GraphQL field the Stream Catalog exposes Kafka topics under.
 TOPIC_ROOT_KEY: Final[str] = "kafka_topic"
 
-# Read-only query for the topics in the environment the Schema Registry endpoint
-# belongs to. Kept to fields the catalog has carried since Stream Governance shipped,
-# because an unknown field fails the whole query rather than returning null.
-#
-# The topic's cluster field is named `logical_cluster_id`, not `clusterId`
-# (verified against the live API 2026-08-05). Pagination placeholders are substituted
-# by the client; see LIMIT_PLACEHOLDER in `datahub.ingestion.source.confluent.constants`
-# for why they are not GraphQL variables.
+# Read-only query for topics in this Schema Registry environment. Unknown fields
+# fail the whole query, so keep the selection tight. Cluster field is
+# `logical_cluster_id` (not `clusterId`; verified 2026-08-05). Pagination
+# placeholders: see LIMIT_PLACEHOLDER in confluent.constants.
 TOPIC_CATALOG_QUERY: Final[str] = """
 {
   kafka_topic(limit: {limit}, offset: {offset}) {

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog.py
@@ -15,7 +15,6 @@ from datahub.ingestion.source.kafka_connect.common import (
 )
 from datahub.ingestion.source.kafka_connect.confluent_catalog_constants import (
     CONNECTOR_CATALOG_QUERY,
-    CONNECTOR_CLASS_FIELD,
     CONNECTOR_ROOT_KEY,
 )
 
@@ -27,10 +26,6 @@ class CatalogTopic(CatalogEntity):
 
 
 class CatalogConnector(CatalogEntity):
-    connector_class: Optional[str] = Field(default=None, alias=CONNECTOR_CLASS_FIELD)
-    type: Optional[str] = None
-    status: Optional[str] = None
-    description: Optional[str] = None
     topics: List[CatalogTopic] = Field(default_factory=list)
 
     @field_validator("topics", mode="before")

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
@@ -17,13 +17,17 @@ CONNECTOR_CLASS_FIELD: Final[str] = "class"
 # Read-only query against the Stream Catalog. `cn_connector.topics` already reflects
 # post-SMT topic names, which is why it can replace the transform-matching heuristic.
 #
-# Deliberately not filtered by `clusterId`: on `cn_connector` that field holds the
-# logical *Connect* cluster id (lcc-*), whereas the Connect REST URI only gives us the
-# Kafka cluster id (lkc-*). The Schema Registry endpoint is already environment-scoped,
-# so connectors are matched by name instead.
+# Pagination is inlined as {limit}/{offset} placeholders (substituted by the client)
+# rather than GraphQL variables: the live Confluent Cloud catalog endpoint returns
+# HTTP 500 for any operation that carries a variables map (verified 2026-08-05).
+#
+# Deliberately not filtered by a cluster-id field: on `cn_connector` that field holds
+# the logical *Connect* cluster id (lcc-*), whereas the Connect REST URI only gives us
+# the Kafka cluster id (lkc-*). The Schema Registry endpoint is already
+# environment-scoped, so connectors are matched by name instead.
 CONNECTOR_CATALOG_QUERY: Final[str] = """
-query DataHubKafkaConnectCatalog($limit: Int, $offset: Int) {
-  cn_connector(limit: $limit, offset: $offset) {
+{
+  cn_connector(limit: {limit}, offset: {offset}) {
     name
     qualifiedName
     class

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
@@ -11,15 +11,16 @@ CONNECTOR_ROOT_KEY: Final[str] = "cn_connector"
 LINEAGE_SOURCE_PROPERTY: Final[str] = "lineage_source"
 LINEAGE_SOURCE_CATALOG: Final[str] = "confluent_stream_catalog"
 
-# `class` is a reserved word in Python, so the model aliases it.
-CONNECTOR_CLASS_FIELD: Final[str] = "class"
-
 # Read-only query against the Stream Catalog. `cn_connector.topics` already reflects
 # post-SMT topic names, which is why it can replace the transform-matching heuristic.
 #
-# Pagination is inlined as {limit}/{offset} placeholders (substituted by the client)
-# rather than GraphQL variables: the live Confluent Cloud catalog endpoint returns
-# HTTP 500 for any operation that carries a variables map (verified 2026-08-05).
+# Selects only fields this source actually consumes. An unknown field fails the whole
+# query, taking tags, business metadata and topics down with it, so a field earns its
+# place here by being both verified against the live API and read downstream — the
+# connector's class, type, status and description are neither.
+#
+# Pagination placeholders are substituted by the client; see LIMIT_PLACEHOLDER in
+# `datahub.ingestion.source.confluent.constants` for why they are not GraphQL variables.
 #
 # Deliberately not filtered by a cluster-id field: on `cn_connector` that field holds
 # the logical *Connect* cluster id (lcc-*), whereas the Connect REST URI only gives us
@@ -30,10 +31,6 @@ CONNECTOR_CATALOG_QUERY: Final[str] = """
   cn_connector(limit: {limit}, offset: {offset}) {
     name
     qualifiedName
-    class
-    type
-    status
-    description
     tags
     business_metadata {
       name

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
@@ -11,21 +11,12 @@ CONNECTOR_ROOT_KEY: Final[str] = "cn_connector"
 LINEAGE_SOURCE_PROPERTY: Final[str] = "lineage_source"
 LINEAGE_SOURCE_CATALOG: Final[str] = "confluent_stream_catalog"
 
-# Read-only query against the Stream Catalog. `cn_connector.topics` already reflects
-# post-SMT topic names, which is why it can replace the transform-matching heuristic.
-#
-# Selects only fields this source actually consumes. An unknown field fails the whole
-# query, taking tags, business metadata and topics down with it, so a field earns its
-# place here by being both verified against the live API and read downstream — the
-# connector's class, type, status and description are neither.
-#
-# Pagination placeholders are substituted by the client; see LIMIT_PLACEHOLDER in
-# `datahub.ingestion.source.confluent.constants` for why they are not GraphQL variables.
-#
-# Deliberately not filtered by a cluster-id field: on `cn_connector` that field holds
-# the logical *Connect* cluster id (lcc-*), whereas the Connect REST URI only gives us
-# the Kafka cluster id (lkc-*). The Schema Registry endpoint is already
-# environment-scoped, so connectors are matched by name instead.
+# `cn_connector.topics` already reflects post-SMT names, so it replaces the
+# transform-matching heuristic. Unknown fields fail the whole query — only select
+# fields that are both live-verified and consumed. Not filtered by cluster id:
+# on `cn_connector` that field is the Connect cluster (lcc-*), not the Kafka
+# cluster (lkc-*) the REST URI gives us; match by name instead. Pagination
+# placeholders: see LIMIT_PLACEHOLDER in confluent.constants.
 CONNECTOR_CATALOG_QUERY: Final[str] = """
 {
   cn_connector(limit: {limit}, offset: {offset}) {

--- a/metadata-ingestion/tests/integration/kafka/test_kafka.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka.py
@@ -38,7 +38,7 @@ CATALOG_TOPICS = [
     {
         "name": "key_value_topic",
         "qualifiedName": "lkc-stub:key_value_topic",
-        "clusterId": "lkc-stub",
+        "logical_cluster_id": "lkc-stub",
         "tags": ["PII", "Tier1"],
         "business_metadata": [
             {"name": "owning_team", "value": "payments"},
@@ -48,14 +48,14 @@ CATALOG_TOPICS = [
     {
         "name": "value_topic",
         "qualifiedName": "lkc-stub:value_topic",
-        "clusterId": "lkc-stub",
+        "logical_cluster_id": "lkc-stub",
         "tags": None,
         "business_metadata": [{"name": "owning_team", "value": "analytics"}],
     },
     {
         "name": "topic_not_on_this_broker",
         "qualifiedName": "lkc-stub:topic_not_on_this_broker",
-        "clusterId": "lkc-stub",
+        "logical_cluster_id": "lkc-stub",
         "tags": ["Deprecated"],
         "business_metadata": None,
     },

--- a/metadata-ingestion/tests/integration/kafka/test_kafka.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -60,6 +61,18 @@ CATALOG_TOPICS = [
         "business_metadata": None,
     },
 ]
+
+
+# The live catalog endpoint 500s on a GraphQL variables map, so pagination has to
+# arrive substituted into the query text.
+INLINED_PAGINATION_RE = re.compile(r"kafka_topic\(limit: \d+, offset: \d+\)")
+
+
+def _pagination_is_inlined(request) -> bool:
+    body = request.json()
+    return "variables" not in body and bool(
+        INLINED_PAGINATION_RE.search(body.get("query", ""))
+    )
 
 
 @pytest.fixture(scope="module")
@@ -153,6 +166,7 @@ def test_kafka_confluent_catalog_ingest(
     with requests_mock.Mocker(real_http=True) as catalog_api:
         catalog_api.post(
             f"{CATALOG_STUB_URL}/catalog/graphql",
+            additional_matcher=_pagination_is_inlined,
             json={"data": {"kafka_topic": CATALOG_TOPICS}},
         )
         run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)

--- a/metadata-ingestion/tests/integration/kafka/test_kafka.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka.py
@@ -63,8 +63,7 @@ CATALOG_TOPICS = [
 ]
 
 
-# The live catalog endpoint 500s on a GraphQL variables map, so pagination has to
-# arrive substituted into the query text.
+# Live endpoint 500s on a variables map — pagination must be inlined.
 INLINED_PAGINATION_RE = re.compile(r"kafka_topic\(limit: \d+, offset: \d+\)")
 
 

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import os
+import re
 from functools import wraps
 from typing import Any, Dict
 
@@ -458,12 +459,21 @@ def get_topic(cluster_id, topic_name):
 @app.route("/catalog/graphql", methods=["POST"])
 @require_auth
 def catalog_graphql():
-    """Minimal stand-in for the Stream Catalog GraphQL API (cn_connector only)."""
-    body = request.get_json(silent=True) or {}
-    variables = body.get("variables") or {}
+    """Minimal stand-in for the Stream Catalog GraphQL API (cn_connector only).
 
-    offset = int(variables.get("offset") or 0)
-    limit = int(variables.get("limit") or len(CATALOG_CONNECTORS_DATA))
+    Mirrors the live Confluent Cloud endpoint (verified 2026-08-05): any
+    request carrying a GraphQL variables map fails with HTTP 500, so
+    pagination must arrive inlined in the query text.
+    """
+    body = request.get_json(silent=True) or {}
+    if "variables" in body:
+        return jsonify({"error": "Internal server error"}), 500
+
+    query = body.get("query") or ""
+    offset_match = re.search(r"offset:\s*(\d+)", query)
+    limit_match = re.search(r"limit:\s*(\d+)", query)
+    offset = int(offset_match.group(1)) if offset_match else 0
+    limit = int(limit_match.group(1)) if limit_match else len(CATALOG_CONNECTORS_DATA)
 
     page = CATALOG_CONNECTORS_DATA[offset : offset + limit]
     return jsonify({"data": {"cn_connector": page}})

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
@@ -21,6 +21,10 @@ def log_request_info():
     logger.info(f"Request - {request.method} {request.path} from {client_ip}")
 
 
+# Pagination reaches the catalog inlined in the query text, never as GraphQL variables.
+OFFSET_ARGUMENT_RE = re.compile(r"offset:\s*(\d+)")
+LIMIT_ARGUMENT_RE = re.compile(r"limit:\s*(\d+)")
+
 VALID_AUTH = {
     "DEV_CONFLUENT_AUTH": "YWRtaW46YWRtaW4=",  # admin:admin in base64
     "test_user": "dGVzdDp0ZXN0",  # test:test in base64
@@ -293,10 +297,6 @@ CATALOG_CONNECTORS_DATA = [
     {
         "name": "source_postgres_cdc_01",
         "qualifiedName": "lcc-source01",
-        "class": "PostgresCdcSource",
-        "type": "SOURCE",
-        "status": "RUNNING",
-        "description": "Postgres CDC into Kafka",
         "tags": ["cdc", "production"],
         "business_metadata": [
             {"name": "team", "value": "data-platform"},
@@ -320,9 +320,6 @@ CATALOG_CONNECTORS_DATA = [
     {
         "name": "sink_postgres_01",
         "qualifiedName": "lcc-sink01",
-        "class": "PostgresSink",
-        "type": "SINK",
-        "status": "RUNNING",
         "tags": ["production"],
         "business_metadata": [],
         "topics": [
@@ -470,10 +467,18 @@ def catalog_graphql():
         return jsonify({"error": "Internal server error"}), 500
 
     query = body.get("query") or ""
-    offset_match = re.search(r"offset:\s*(\d+)", query)
-    limit_match = re.search(r"limit:\s*(\d+)", query)
-    offset = int(offset_match.group(1)) if offset_match else 0
-    limit = int(limit_match.group(1)) if limit_match else len(CATALOG_CONNECTORS_DATA)
+    offset_match = OFFSET_ARGUMENT_RE.search(query)
+    limit_match = LIMIT_ARGUMENT_RE.search(query)
+    if not offset_match or not limit_match:
+        # A real GraphQL server rejects a non-integer argument - an unsubstituted
+        # `{limit}` placeholder included - rather than quietly applying a default
+        # page size, which would hide a broken client from this test.
+        return jsonify(
+            {"errors": [{"message": "Invalid syntax in pagination arguments"}]}
+        ), 400
+
+    offset = int(offset_match.group(1))
+    limit = int(limit_match.group(1))
 
     page = CATALOG_CONNECTORS_DATA[offset : offset + limit]
     return jsonify({"data": {"cn_connector": page}})

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
@@ -21,7 +21,6 @@ def log_request_info():
     logger.info(f"Request - {request.method} {request.path} from {client_ip}")
 
 
-# Pagination reaches the catalog inlined in the query text, never as GraphQL variables.
 OFFSET_ARGUMENT_RE = re.compile(r"offset:\s*(\d+)")
 LIMIT_ARGUMENT_RE = re.compile(r"limit:\s*(\d+)")
 
@@ -456,12 +455,7 @@ def get_topic(cluster_id, topic_name):
 @app.route("/catalog/graphql", methods=["POST"])
 @require_auth
 def catalog_graphql():
-    """Minimal stand-in for the Stream Catalog GraphQL API (cn_connector only).
-
-    Mirrors the live Confluent Cloud endpoint (verified 2026-08-05): any
-    request carrying a GraphQL variables map fails with HTTP 500, so
-    pagination must arrive inlined in the query text.
-    """
+    """cn_connector stand-in. Variables map → 500, like the live endpoint."""
     body = request.get_json(silent=True) or {}
     if "variables" in body:
         return jsonify({"error": "Internal server error"}), 500
@@ -470,9 +464,7 @@ def catalog_graphql():
     offset_match = OFFSET_ARGUMENT_RE.search(query)
     limit_match = LIMIT_ARGUMENT_RE.search(query)
     if not offset_match or not limit_match:
-        # A real GraphQL server rejects a non-integer argument - an unsubstituted
-        # `{limit}` placeholder included - rather than quietly applying a default
-        # page size, which would hide a broken client from this test.
+        # Reject unsubstituted placeholders rather than defaulting the page size.
         return jsonify(
             {"errors": [{"message": "Invalid syntax in pagination arguments"}]}
         ), 400

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_to_file.yml
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_to_file.yml
@@ -30,9 +30,7 @@ source:
       api_secret: "admin"
       # Off by default; enabled here so the golden covers catalog-derived lineage.
       include_lineage: true
-      # Smaller than the number of connectors the mock serves, so the run crosses a
-      # page boundary with the real query constant and the mock verifies the inlined
-      # pagination arguments of every request.
+      # Force a page boundary so the mock verifies inlined pagination.
       page_size: 1
 
     connector_patterns:

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_to_file.yml
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_to_file.yml
@@ -30,6 +30,10 @@ source:
       api_secret: "admin"
       # Off by default; enabled here so the golden covers catalog-derived lineage.
       include_lineage: true
+      # Smaller than the number of connectors the mock serves, so the run crosses a
+      # page boundary with the real query constant and the mock verifies the inlined
+      # pagination arguments of every request.
+      page_size: 1
 
     connector_patterns:
       allow:

--- a/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
+++ b/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
@@ -14,11 +14,13 @@ from datahub.ingestion.source.confluent.models import (
 )
 
 ROOT_KEY = "kafka_topic"
-QUERY = "query Example($limit: Int, $offset: Int) { kafka_topic { name } }"
+# Pagination placeholders are inlined by the client; the live catalog endpoint
+# rejects GraphQL variables with an HTTP 500.
+QUERY = "{ kafka_topic(limit: {limit}, offset: {offset}) { name } }"
 
 
 class SampleEntity(CatalogEntity):
-    cluster_id: Optional[str] = Field(default=None, alias="clusterId")
+    cluster_id: Optional[str] = Field(default=None, alias="logical_cluster_id")
 
 
 def make_config(**overrides: object) -> ConfluentStreamCatalogConfig:
@@ -110,7 +112,7 @@ class TestConfluentStreamCatalogClient:
                         {
                             "name": "orders",
                             "qualifiedName": "lkc-123:orders",
-                            "clusterId": "lkc-123",
+                            "logical_cluster_id": "lkc-123",
                             "tags": None,
                             "business_metadata": None,
                         }
@@ -142,10 +144,10 @@ class TestConfluentStreamCatalogClient:
         session = client.session
         assert isinstance(session, Mock)
         assert session.post.call_count == 2
-        assert session.post.call_args_list[1].kwargs["json"]["variables"] == {
-            "limit": 2,
-            "offset": 2,
-        }
+        # Pagination must be inlined into the query text; a variables map makes
+        # the live catalog endpoint return HTTP 500.
+        second_body = session.post.call_args_list[1].kwargs["json"]
+        assert second_body == {"query": "{ kafka_topic(limit: 2, offset: 2) { name } }"}
 
     def test_graphql_errors_are_reported_and_yield_nothing(self) -> None:
         response = Mock()

--- a/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
+++ b/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Mapping, Optional, Sequence
 from unittest.mock import Mock
 
 import pytest
+import requests
 from pydantic import Field
 
 from datahub.ingestion.api.source import SourceReport
@@ -133,21 +134,61 @@ class TestConfluentStreamCatalogClient:
         client = make_client(
             [
                 make_response([{"name": "topic_0"}, {"name": "topic_1"}]),
-                make_response([{"name": "topic_2"}]),
+                make_response([{"name": "topic_2"}, {"name": "topic_3"}]),
+                make_response([{"name": "topic_4"}]),
             ],
             page_size=2,
         )
 
         entities = fetch(client)
 
-        assert [entity.name for entity in entities] == ["topic_0", "topic_1", "topic_2"]
+        assert [entity.name for entity in entities] == [
+            "topic_0",
+            "topic_1",
+            "topic_2",
+            "topic_3",
+            "topic_4",
+        ]
         session = client.session
         assert isinstance(session, Mock)
-        assert session.post.call_count == 2
-        # Pagination must be inlined into the query text; a variables map makes
-        # the live catalog endpoint return HTTP 500.
-        second_body = session.post.call_args_list[1].kwargs["json"]
-        assert second_body == {"query": "{ kafka_topic(limit: 2, offset: 2) { name } }"}
+        # Pagination must be inlined into the query text with no variables map, which
+        # the live catalog endpoint answers with an HTTP 500. Every request is checked:
+        # the first proves offset 0 is substituted rather than skipped as falsy, and
+        # the last has an offset that differs from the limit, so a swapped substitution
+        # cannot pass.
+        assert [call.kwargs["json"] for call in session.post.call_args_list] == [
+            {"query": "{ kafka_topic(limit: 2, offset: 0) { name } }"},
+            {"query": "{ kafka_topic(limit: 2, offset: 2) { name } }"},
+            {"query": "{ kafka_topic(limit: 2, offset: 4) { name } }"},
+        ]
+
+    def test_query_without_pagination_placeholders_is_a_failure(self) -> None:
+        client = make_client([])
+
+        assert (
+            client.fetch_entities(
+                "{ kafka_topic(limit: 10) { name } }", ROOT_KEY, SampleEntity
+            )
+            == []
+        )
+        session = client.session
+        assert isinstance(session, Mock)
+        assert session.post.call_count == 0
+        assert len(client.report.failures) == 1
+
+    def test_rejected_request_reports_the_server_response(self) -> None:
+        response = Mock()
+        response.text = "Validation error: Field 'clusterId' is undefined"
+        response.raise_for_status.side_effect = requests.HTTPError(
+            "400 Client Error", response=response
+        )
+        client = make_client([response])
+
+        assert fetch(client) == []
+        contexts = [
+            context for warning in client.report.warnings for context in warning.context
+        ]
+        assert any("Field 'clusterId' is undefined" in context for context in contexts)
 
     def test_graphql_errors_are_reported_and_yield_nothing(self) -> None:
         response = Mock()
@@ -162,7 +203,7 @@ class TestConfluentStreamCatalogClient:
 
     def test_http_failure_is_reported_and_yields_nothing(self) -> None:
         session = Mock()
-        session.post.side_effect = Exception("connection refused")
+        session.post.side_effect = requests.ConnectionError("connection refused")
         client = ConfluentStreamCatalogClient(
             make_config(), SourceReport(), session=session
         )
@@ -194,7 +235,8 @@ class TestCatalogEntityHelpers:
             {
                 "name": "orders",
                 "business_metadata": [
-                    {"name": "team", "value": "core"},
+                    # The live catalog names attributes `<definition>.<attribute>`.
+                    {"name": "Governance.owner_team", "value": "core"},
                     {"name": "critical", "value": True},
                     {"name": "tier", "value": 1},
                     {"name": "unset", "value": None},
@@ -203,7 +245,7 @@ class TestCatalogEntityHelpers:
         )
 
         assert entity.properties_from_business_metadata() == {
-            "team": "core",
+            "Governance.owner_team": "core",
             "critical": "True",
             "tier": "1",
         }

--- a/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
+++ b/metadata-ingestion/tests/unit/confluent/test_confluent_stream_catalog.py
@@ -15,8 +15,7 @@ from datahub.ingestion.source.confluent.models import (
 )
 
 ROOT_KEY = "kafka_topic"
-# Pagination placeholders are inlined by the client; the live catalog endpoint
-# rejects GraphQL variables with an HTTP 500.
+# Live endpoint 500s on a variables map — pagination must be inlined.
 QUERY = "{ kafka_topic(limit: {limit}, offset: {offset}) { name } }"
 
 
@@ -151,11 +150,8 @@ class TestConfluentStreamCatalogClient:
         ]
         session = client.session
         assert isinstance(session, Mock)
-        # Pagination must be inlined into the query text with no variables map, which
-        # the live catalog endpoint answers with an HTTP 500. Every request is checked:
-        # the first proves offset 0 is substituted rather than skipped as falsy, and
-        # the last has an offset that differs from the limit, so a swapped substitution
-        # cannot pass.
+        # Check every body: offset 0 (not skipped as falsy) and a page where
+        # offset != limit (so a swapped substitution cannot pass).
         assert [call.kwargs["json"] for call in session.post.call_args_list] == [
             {"query": "{ kafka_topic(limit: 2, offset: 0) { name } }"},
             {"query": "{ kafka_topic(limit: 2, offset: 2) { name } }"},
@@ -235,7 +231,7 @@ class TestCatalogEntityHelpers:
             {
                 "name": "orders",
                 "business_metadata": [
-                    # The live catalog names attributes `<definition>.<attribute>`.
+                    # Live catalog uses `<definition>.<attribute>` names.
                     {"name": "Governance.owner_team", "value": "core"},
                     {"name": "critical", "value": True},
                     {"name": "tier", "value": 1},

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
@@ -154,8 +154,8 @@ class TestTopicLookup:
         report = KafkaSourceReport()
         catalog = make_catalog(
             [
-                CatalogKafkaTopic(name=TOPIC, clusterId="lkc-111"),
-                CatalogKafkaTopic(name=TOPIC, clusterId="lkc-222"),
+                CatalogKafkaTopic(name=TOPIC, logical_cluster_id="lkc-111"),
+                CatalogKafkaTopic(name=TOPIC, logical_cluster_id="lkc-222"),
             ],
             report,
         )
@@ -167,8 +167,12 @@ class TestTopicLookup:
         report = KafkaSourceReport()
         catalog = make_catalog(
             [
-                CatalogKafkaTopic(name=TOPIC, clusterId="lkc-111", tags=["pii"]),
-                CatalogKafkaTopic(name=TOPIC, clusterId="lkc-222", tags=["public"]),
+                CatalogKafkaTopic(
+                    name=TOPIC, logical_cluster_id="lkc-111", tags=["pii"]
+                ),
+                CatalogKafkaTopic(
+                    name=TOPIC, logical_cluster_id="lkc-222", tags=["public"]
+                ),
             ],
             report,
             cluster_id="lkc-222",

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
@@ -183,6 +183,18 @@ class TestTopicLookup:
         assert topic.tags == ["public"]
         assert not report.warnings
 
+    def test_cluster_id_matching_nothing_is_reported(self) -> None:
+        report = KafkaSourceReport()
+        catalog = make_catalog(
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id="lkc-111")],
+            report,
+            cluster_id="lkc-999",
+        )
+
+        assert catalog.get_topic(TOPIC) is None
+        assert report.catalog_topics_fetched == 0
+        assert len(report.warnings) == 1
+
 
 @patch("datahub.ingestion.source.kafka.kafka.confluent_kafka.Consumer", autospec=True)
 class TestCatalogMetadataOnTopics:

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_confluent_catalog.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_confluent_catalog.py
@@ -158,15 +158,12 @@ class TestConfluentCatalogConfig:
 
 
 class TestConnectorCatalog:
-    def test_parses_connector_with_aliased_class_and_null_collections(self) -> None:
+    def test_parses_connector_with_null_collections(self) -> None:
         catalog = make_catalog(
             [
                 {
                     "name": "source_postgres_cdc_01",
                     "qualifiedName": "lcc-111",
-                    "class": "PostgresCdcSource",
-                    "type": "SOURCE",
-                    "status": "RUNNING",
                     "tags": None,
                     "business_metadata": None,
                     "topics": [
@@ -184,7 +181,6 @@ class TestConnectorCatalog:
         connector = catalog.get_connector("source_postgres_cdc_01")
 
         assert connector is not None
-        assert connector.connector_class == "PostgresCdcSource"
         assert connector.tags == []
         assert connector.business_metadata == []
         assert connector.get_topic_names() == ["orders"]


### PR DESCRIPTION
Tested #18764 end-to-end against a live Confluent Cloud cluster (Basic, ap-southeast-2, Stream Governance Advanced) with seeded Stream Catalog tags and business metadata. Two live-API behaviors block the connector as written; with these changes the run is fully green (`catalog_topics_fetched: 3, catalog_tagged_topics: 3, catalog_topics_with_business_metadata: 1`, tags and properties verified on the DataHub topic pages).

1. The catalog GraphQL endpoint returns HTTP 500 for any operation that sends a GraphQL variables map. Pagination arguments are now inlined into the query text (both the kafka and kafka-connect queries); the integration mock reproduces the live behavior so the tests guard it.

2. `kafka_topic.clusterId` does not exist on the live schema - an undefined field fails the whole query with `FieldUndefined`. The live field is `logical_cluster_id`; the query, model alias, fixtures and the kafka integration stub are updated. The `cn_connector` field names were not exercised by this test and deserve the same live verification.

Also observed live, no change needed: business metadata arrives with dotted names (`Governance.owner_team` = `<definition>.<attribute>`) and the name-as-is custom-property mapping handles them correctly - a dotted-name fixture would make the tests more realistic.

Unit suites for the touched modules pass 50/50 (previously 2 failures against the live shapes); ruff clean. The docker-based integration suites were not run locally and should get a CI pass.
