### PR TITLE
fix(sdk): accept plain strings for `direction` in the openapi graph methods

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/openapi.py
@@ -11,6 +11,7 @@ from typing import (
     Protocol,
     Tuple,
     TypedDict,
+    Union,
 )
 
 import requests
@@ -90,6 +91,21 @@ class RelationshipDirection(StrEnum):
 class LineageDirection(StrEnum):
     UPSTREAM = "UPSTREAM"
     DOWNSTREAM = "DOWNSTREAM"
+
+
+# Both direction enums are StrEnums, so a caller holding the equivalent plain
+# string is passing something already valid on the wire. Accept it.
+RelationshipDirectionInput = Union[RelationshipDirection, str]
+LineageDirectionInput = Union[LineageDirection, str]
+
+
+def _direction_param(direction: Union[StrEnum, str]) -> str:
+    """Render a direction for the query string.
+
+    str() rather than .value: the enums are StrEnums, so this is identical for
+    enum members and also works for the plain string spelling of them.
+    """
+    return str(direction)
 
 
 def _raw_filter_to_v3_body(raw: RawSearchFilter) -> Dict[str, Any]:
@@ -200,7 +216,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         self,
         entity_urn: str,
         relationship_types: List[str],
-        direction: RelationshipDirection,
+        direction: RelationshipDirectionInput,
     ) -> Iterable[RelatedEntity]:
         url = f"{self._gms_server}/openapi/relationships/v1/"
         done = False
@@ -210,7 +226,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
                 url=url,
                 params={
                     "urn": entity_urn,
-                    "direction": direction.value,
+                    "direction": _direction_param(direction),
                     "relationshipTypes": relationship_types,
                     "start": start,
                 },
@@ -340,7 +356,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         relationship_types: Optional[List[str]] = None,
         source_types: Optional[List[str]] = None,
         destination_types: Optional[List[str]] = None,
-        direction: Optional[RelationshipDirection] = None,
+        direction: Optional[RelationshipDirectionInput] = None,
         source_urns: Optional[List[str]] = None,
         destination_urns: Optional[List[str]] = None,
         source_filter: Optional[RawSearchFilter] = None,
@@ -368,8 +384,11 @@ class OpenApiAPI(OpenAPIGraphProtocol):
                 If None or empty, all relationship types are returned.
             source_types: Entity types to filter source nodes (e.g. ["dataset"]).
             destination_types: Entity types to filter destination nodes.
-            direction: Direction of relationships to include (INCOMING or OUTGOING).
-                Defaults to OUTGOING if not specified.
+            direction: Direction of relationships to include, as a
+                RelationshipDirection or the equivalent string ("INCOMING" or
+                "OUTGOING"). Defaults to OUTGOING if not specified. Note that this
+                endpoint wants INCOMING/OUTGOING, while scroll_lineage wants
+                UPSTREAM/DOWNSTREAM.
             source_urns: URNs to filter source entities (OR logic across values).
                 Combined with source_filter via AND if both are provided.
             destination_urns: URNs to filter destination entities (OR logic across values).
@@ -415,7 +434,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         *,
         urns: Optional[List[str]] = None,
         relationship_types: Optional[List[str]] = None,
-        direction: Optional[LineageDirection] = None,
+        direction: Optional[LineageDirectionInput] = None,
         count: Optional[int] = None,
         scroll_id: Optional[str] = None,
         include_soft_delete: Optional[bool] = None,
@@ -439,7 +458,8 @@ class OpenApiAPI(OpenAPIGraphProtocol):
                 and all lineage edges are scrolled.
             relationship_types: Relationship types to include (e.g. ["DownstreamOf"]).
                 If None or empty, all lineage relationship types are returned.
-            direction: UPSTREAM or DOWNSTREAM, applied relative to `urns` as a
+            direction: A LineageDirection or the equivalent string ("UPSTREAM" or
+                "DOWNSTREAM"), applied relative to `urns` as a
                 post-query filter — edges running the opposite way are dropped. Has no
                 effect when `urns` is empty, since there is no anchor to orient from.
                 Because filtering happens after the page is fetched, a given page may
@@ -463,7 +483,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         if relationship_types is not None:
             params["relationshipTypes"] = relationship_types
         if direction is not None:
-            params["direction"] = direction.value
+            params["direction"] = _direction_param(direction)
         if count is not None:
             params["count"] = count
         if scroll_id is not None:
@@ -512,7 +532,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         relationship_types: Optional[List[str]] = None,
         source_types: Optional[List[str]] = None,
         destination_types: Optional[List[str]] = None,
-        direction: Optional[RelationshipDirection] = None,
+        direction: Optional[RelationshipDirectionInput] = None,
         source_urns: Optional[List[str]] = None,
         destination_urns: Optional[List[str]] = None,
         source_filter: Optional[RawSearchFilter] = None,
@@ -533,7 +553,7 @@ class OpenApiAPI(OpenAPIGraphProtocol):
         if destination_types is not None:
             params["destinationTypes"] = destination_types
         if direction is not None:
-            params["direction"] = direction.value
+            params["direction"] = _direction_param(direction)
         if count is not None:
             params["count"] = count
         if scroll_id is not None:

--- a/metadata-ingestion/tests/unit/ingestion/graph/test_openapi_directions.py
+++ b/metadata-ingestion/tests/unit/ingestion/graph/test_openapi_directions.py
@@ -1,0 +1,65 @@
+"""The direction argument of the openapi graph methods accepts strings.
+
+RelationshipDirection and LineageDirection are StrEnums, so "DOWNSTREAM" is as
+valid on the wire as LineageDirection.DOWNSTREAM. These methods used to read
+`direction.value`, which raised AttributeError for the string spelling.
+"""
+
+from typing import Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.graph.openapi import LineageDirection, RelationshipDirection
+
+
+def _graph(response: Dict) -> DataHubGraph:
+    """A DataHubGraph wired with only the attrs these methods touch."""
+    graph = DataHubGraph.__new__(DataHubGraph)
+    graph._gms_server = "http://localhost:8080"
+    graph._post_generic = MagicMock(return_value=response)  # type: ignore[method-assign]
+    graph._get_generic = MagicMock(return_value=response)  # type: ignore[method-assign]
+    return graph
+
+
+def _sent_direction(mock: MagicMock) -> Optional[str]:
+    return mock.call_args.kwargs["params"].get("direction")
+
+
+@pytest.mark.parametrize(
+    "direction", [LineageDirection.DOWNSTREAM, "DOWNSTREAM"], ids=["enum", "str"]
+)
+def test_scroll_lineage_direction(direction) -> None:
+    graph = _graph({"results": []})
+    graph.scroll_lineage(urns=["urn:li:dataset:(a,b,PROD)"], direction=direction)
+    assert _sent_direction(graph._post_generic) == "DOWNSTREAM"
+
+
+@pytest.mark.parametrize(
+    "direction", [RelationshipDirection.OUTGOING, "OUTGOING"], ids=["enum", "str"]
+)
+def test_scroll_relationships_direction(direction) -> None:
+    graph = _graph({"results": []})
+    graph.scroll_relationships(direction=direction)
+    assert _sent_direction(graph._post_generic) == "OUTGOING"
+
+
+@pytest.mark.parametrize(
+    "direction", [RelationshipDirection.INCOMING, "INCOMING"], ids=["enum", "str"]
+)
+def test_get_related_entities_direction(direction) -> None:
+    graph = _graph({"entities": [], "count": 0})
+    list(
+        graph.get_related_entities(
+            "urn:li:dataset:(a,b,PROD)", ["DownstreamOf"], direction
+        )
+    )
+    assert _sent_direction(graph._get_generic) == "INCOMING"
+
+
+def test_omitted_direction_is_not_sent() -> None:
+    """None must stay absent so the server applies its own default."""
+    graph = _graph({"results": []})
+    graph.scroll_lineage(urns=["urn:li:dataset:(a,b,PROD)"])
+    assert _sent_direction(graph._post_generic) is None


### PR DESCRIPTION

## Summary

`RelationshipDirection` and `LineageDirection` are `StrEnum`s, so
`LineageDirection.DOWNSTREAM == "DOWNSTREAM"` and the plain string is exactly as valid on
the wire as the enum member. But three methods on `OpenApiAPI` read `direction.value`,
which raises `AttributeError: 'str' object has no attribute 'value'` for the string
spelling:

| method | line on master @ `7ecec15f` |
|---|---|
| `get_related_entities` | `openapi.py:213` |
| `scroll_lineage` | `openapi.py:466` |
| `scroll_relationships` (via `_scroll_relationships_impl`) | `openapi.py:536` |

Using a `StrEnum` and then rejecting strings is the one combination that surprises
callers: it type-checks as a `str` subclass everywhere else in the SDK, round-trips
through config files and CLI arguments as a string, and the failure is an `AttributeError`
deep inside the client rather than a `TypeError` at the call site.

The fix replaces `.value` with `str(direction)` — identical output for enum members,
correct for strings — and widens the annotations to
`Union[RelationshipDirection, str]` / `Union[LineageDirection, str]`.

## How I hit it

Walking lineage from a dataset into `mlFeature`/`mlModel` on a local DataHub Core
v1.7.0, with `acryl-datahub` 1.6.0.6 (the version
`datahub-agent-context==1.7.0` pins). In that released client, `scroll_lineage` is
type-hinted `Optional[RelationshipDirection]`, whose members are `INCOMING`/`OUTGOING`,
while `/openapi/v3/lineage/scroll` demands `UPSTREAM`/`DOWNSTREAM`. So there was **no way
to call it successfully**:

```
--- CASE 1: the type-hinted enum value ---
OperationalError: ('Unable to get metadata from DataHub',
                   {'error': 'direction must be UPSTREAM or DOWNSTREAM, got: OUTGOING'})

--- CASE 2: the string the server actually wants ---
AttributeError: 'str' object has no attribute 'value'
```

Server contract, confirmed directly:

```
$ curl -X POST "localhost:8080/openapi/v3/lineage/scroll?direction=OUTGOING&count=2" -d '{}'
{"error":"direction must be UPSTREAM or DOWNSTREAM, got: OUTGOING"}   HTTP 400

$ curl -X POST "localhost:8080/openapi/v3/lineage/scroll?direction=DOWNSTREAM&count=2" -d '{}'
{"results":[{"relationshipType":"DownstreamOf", ...}]}                HTTP 200
```

**The enum half of this is already fixed on master** — `LineageDirection` was split out
from `RelationshipDirection` and `scroll_lineage` now takes it, so passing
`LineageDirection.DOWNSTREAM` works. This PR is only about the remaining half, the string
path, which is still broken at `7ecec15f`. I mention the released-version breakage
because it is the reason a caller reaches for the string in the first place: on 1.6.x /
1.7.0 the enum is *wrong*, so every workaround people have written passes
`"DOWNSTREAM"`, and that will keep raising `AttributeError` after they upgrade.

## Reproduction on master

Master's `src/` run against a live DataHub Core v1.7.0 at `localhost:8080` (full
transcript, before and after, in `REPRO.txt`):

```
                                                       BEFORE          AFTER
[A] scroll_lineage(direction=LineageDirection.DOWNSTREAM)   OK             OK
[B] scroll_lineage(direction="DOWNSTREAM")                  AttributeError OK
[C] scroll_relationships(direction=RelationshipDirection.OUTGOING) OK      OK
[D] scroll_relationships(direction="OUTGOING")              AttributeError OK
[E] get_related_entities(direction="INCOMING")              AttributeError OK
```

## Changes

`metadata-ingestion/src/datahub/ingestion/graph/openapi.py`

- Add `RelationshipDirectionInput = Union[RelationshipDirection, str]` and
  `LineageDirectionInput = Union[LineageDirection, str]`, and use them for the `direction`
  parameters of `get_related_entities`, `scroll_relationships`, `scroll_lineage` and
  `_scroll_relationships_impl`.
- Add `_direction_param()`, which is `str(direction)` with a comment explaining why it is
  not `.value`.
- Docstrings: state that the string spelling is accepted, and — on
  `scroll_relationships` — that this endpoint wants `INCOMING`/`OUTGOING` while
  `scroll_lineage` wants `UPSTREAM`/`DOWNSTREAM`. Two adjacent methods on the same class
  taking differently-named directions is the trap that produced the original bug report;
  worth saying out loud in both docstrings.

`metadata-ingestion/tests/unit/ingestion/graph/test_openapi_directions.py` (new)

- Parametrised enum/string coverage for all three methods, asserting the query parameter
  that actually goes out. Fails 3/7 on master today, passes 7/7 with the fix.
- Plus one test that `direction=None` stays absent from the query string so the server
  keeps applying its own default.

Follows the `DataHubGraph.__new__` + injected-attributes style already used by
`tests/unit/ingestion/graph/test_client.py`; no network, no server needed.

## Verification

- Unit tests: 3 failed / 4 passed before, 7 passed after.
- Live server: the table above, against DataHub Core v1.7.0.
- `ruff==0.15.22` (the pinned version): `All checks passed!`, `2 files already formatted`.
- mypy not run — it needs the full `installDev` environment, which I could not build
  here. The change only widens annotations and calls `str()`, so I do not expect
  fallout, but please let CI confirm.

## Open questions for the reviewer

1. **Validate, or pass through?** This patch passes the string through and lets the
   server reject a bad one (its message is good: `direction must be UPSTREAM or
   DOWNSTREAM, got: OUTGOING`). The alternative is coercing through the enum
   (`LineageDirection(direction)`) to fail fast client-side with a clear `ValueError`.
   Happy to switch — it is a one-line change in `_direction_param`, though it would then
   need to know which enum applies per call site.
2. **Should the released 1.6.x/1.7.0 line get a backport?** On those versions
   `scroll_lineage` cannot be called at all, which is arguably worth a patch release
   rather than waiting for the next minor.
3. Should `LineageDirectionInput` / `RelationshipDirectionInput` be re-exported from
   `datahub.ingestion.graph.client`, alongside the existing
   `DataHubGraph.RelationshipDirection` / `.LineageDirection` class attributes?

## Not part of this PR

While reproducing on 1.6.0.6 I noticed that `scroll_lineage(source_urns=[...])` returned
edges unrelated to the given URN, because 1.6.x sent `sourceFilter`/`destinationFilter`
bodies that `/openapi/v3/lineage/scroll` ignores. Master's rework to `body["urns"]`
already fixes that; noted only so the transcript in `REPRO.txt` is not confusing.
