### PR TITLE
fix(ingest/openapi): handle empty servers list when resolving basepath

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -121,9 +121,10 @@ def get_swag_json(
 def get_url_basepath(sw_dict: dict) -> str:
     if "basePath" in sw_dict:
         return sw_dict["basePath"]
-    if "servers" in sw_dict:
-        # When the API path doesn't match the OAS path
-        return sw_dict["servers"][0]["url"]
+    if sw_dict.get("servers"):
+        # When the API path doesn't match the OAS path.
+        # Some specs declare "servers": [] or entries without a "url" key.
+        return sw_dict["servers"][0].get("url", "")
 
     return ""
 

--- a/metadata-ingestion/tests/unit/test_openapi.py
+++ b/metadata-ingestion/tests/unit/test_openapi.py
@@ -17,7 +17,7 @@ from datahub.ingestion.source.openapi_parser import (
 )
 
 
-class TestGetUrlBasepath(unittest.TestCase):
+class TestGetUrlBasepath:
     def test_base_path_v2(self):
         assert get_url_basepath({"swagger": "2.0", "basePath": "/api/v2"}) == "/api/v2"
 

--- a/metadata-ingestion/tests/unit/test_openapi.py
+++ b/metadata-ingestion/tests/unit/test_openapi.py
@@ -9,11 +9,31 @@ from datahub.ingestion.source.openapi import APISource, OpenApiConfig
 from datahub.ingestion.source.openapi_parser import (
     flatten2list,
     get_endpoints,
+    get_url_basepath,
     guessing_url_name,
     maybe_theres_simple_id,
     resolve_schema_references,
     try_guessing,
 )
+
+
+class TestGetUrlBasepath(unittest.TestCase):
+    def test_base_path_v2(self):
+        assert get_url_basepath({"swagger": "2.0", "basePath": "/api/v2"}) == "/api/v2"
+
+    def test_servers_v3(self):
+        sw_dict = {"openapi": "3.0.0", "servers": [{"url": "/api/v3"}]}
+        assert get_url_basepath(sw_dict) == "/api/v3"
+
+    def test_empty_servers_list(self):
+        assert get_url_basepath({"openapi": "3.0.0", "servers": []}) == ""
+
+    def test_server_entry_without_url(self):
+        sw_dict = {"openapi": "3.0.0", "servers": [{"description": "prod"}]}
+        assert get_url_basepath(sw_dict) == ""
+
+    def test_no_base_path_or_servers(self):
+        assert get_url_basepath({"openapi": "3.0.0"}) == ""
 
 
 class TestGetEndpoints(unittest.TestCase):


### PR DESCRIPTION
## Summary

An OpenAPI 3.x spec may declare `"servers": []` (or a server entry without a `"url"` key), which is valid per the OpenAPI spec and simply defaults the server URL to `/`. `get_url_basepath()` in `openapi_parser.py` only checked for the presence of the `servers` key before indexing `servers[0]["url"]`, so ingesting such a spec crashed the entire pipeline before producing any workunits:

```
File ".../datahub/ingestion/source/openapi_parser.py", line 126, in get_url_basepath
    return sw_dict["servers"][0]["url"]
IndexError: list index out of range
```

This change falls back to an empty basepath when the servers list is empty, and uses `.get("url", "")` to also cover a server entry that lacks a `url` key (previously a latent `KeyError`). An empty basepath is correct for these specs since their paths are already absolute.

Verified locally against a real-world public API spec exhibiting `"servers": []`: pre-fix the pipeline fails with 0 events; post-fix it completes and emits all endpoint datasets with schemas.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)