### PR TITLE
fix(ui): disable edit buttons and show a tooltip when the user lacks permission

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
@@ -144,6 +144,7 @@ export default function FieldDescription({ expandedField, editableFieldInfo, edi
                             <Tooltip title={noPermissionTooltip}>
                                 <AddNewDescription
                                     $disabled={!canEditSchemaFieldDescription}
+                                    aria-disabled={!canEditSchemaFieldDescription}
                                     onClick={() => {
                                         if (!canEditSchemaFieldDescription) return;
                                         setIsModalVisible(true);

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
@@ -23,14 +23,19 @@ import HoverCardAttributionDetails from '@app/sharedV2/propagation/HoverCardAttr
 import { useUpdateDescriptionMutation } from '@graphql/mutations.generated';
 import { EditableSchemaFieldInfo, SchemaField, SubResourceType } from '@types';
 
-const AddNewDescription = styled.div`
+const AddNewDescription = styled.div<{ $disabled?: boolean }>`
     margin: 0px;
     padding: 0px;
-    color: ${(props) => props.theme.colors.textSecondary};
+    color: ${(props) => (props.$disabled ? props.theme.colors.textDisabled : props.theme.colors.textSecondary)};
+    ${(props) =>
+        props.$disabled
+            ? 'cursor: not-allowed;'
+            : `
     :hover {
         cursor: pointer;
-        color: ${(props) => props.theme.colors.textBrand};
+        color: ${props.theme.colors.textBrand};
     }
+    `}
 `;
 
 const AddDescriptionText = styled.span`
@@ -54,13 +59,16 @@ interface Props {
 export default function FieldDescription({ expandedField, editableFieldInfo, editorProps }: Props) {
     const { t } = useTranslation('entity.profile.schema');
     const { t: tc } = useTranslation('common.feedback');
+    const { t: ts } = useTranslation('entity.shared.containers');
     const isSchemaEditable = React.useContext(SchemaEditableContext);
     const urn = useMutationUrn();
     const refetch = useRefetch();
     const schemaRefetch = useSchemaRefetch();
     const [updateDescription] = useUpdateDescriptionMutation();
     const [isModalVisible, setIsModalVisible] = useState(false);
-    const { entityType } = useEntityData();
+    const { entityType, entityData } = useEntityData();
+    const canEditSchemaFieldDescription = !!entityData?.privileges?.canEditSchemaFieldDescription;
+    const noPermissionTooltip = canEditSchemaFieldDescription ? '' : ts('sidebar.noPermissionTooltip');
 
     const sendAnalytics = () => {
         analytics.event({
@@ -126,22 +134,26 @@ export default function FieldDescription({ expandedField, editableFieldInfo, edi
                                 setIsModalVisible(true);
                             }}
                             icon={PencilSimple}
+                            actionPrivilege={canEditSchemaFieldDescription}
                         />
                     )
                 }
                 content={
                     <>
-                        {!displayedDescription &&
-                            isSchemaEditable && [
+                        {!displayedDescription && isSchemaEditable && (
+                            <Tooltip title={noPermissionTooltip}>
                                 <AddNewDescription
+                                    $disabled={!canEditSchemaFieldDescription}
                                     onClick={() => {
+                                        if (!canEditSchemaFieldDescription) return;
                                         setIsModalVisible(true);
                                     }}
                                 >
                                     <Icon icon={Plus} size="sm" />
                                     <AddDescriptionText>{t('fieldDescription.addDescription')}</AddDescriptionText>
-                                </AddNewDescription>,
-                            ]}
+                                </AddNewDescription>
+                            </Tooltip>
+                        )}
                         {!!displayedDescription && (
                             <Tooltip
                                 title={

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/__tests__/FieldDescription.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/__tests__/FieldDescription.test.tsx
@@ -48,7 +48,7 @@ const renderFieldDescription = (
 ) => {
     mockUseEntityData.mockReturnValue({
         entityType: 'DATASET',
-        privileges: { canEditSchemaFieldDescription },
+        entityData: { privileges: { canEditSchemaFieldDescription } },
     });
     return render(
         <MockedProvider mocks={[]} addTypename={false}>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/__tests__/FieldDescription.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/__tests__/FieldDescription.test.tsx
@@ -1,0 +1,108 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import FieldDescription from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription';
+import SchemaEditableContext from '@app/shared/SchemaEditableContext';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { SchemaField, SchemaFieldDataType } from '@types';
+
+const { mockUseEntityData } = vi.hoisted(() => ({ mockUseEntityData: vi.fn() }));
+
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useMutationUrn: () => 'urn:li:dataset:(urn:li:dataPlatform:snowflake,test,PROD)',
+    useRefetch: () => vi.fn(),
+    useEntityData: mockUseEntityData,
+}));
+
+vi.mock('@app/entityV2/shared/tabs/Dataset/Schema/SchemaContext', () => ({
+    useSchemaRefetch: () => vi.fn(),
+}));
+
+vi.mock('@graphql/mutations.generated', () => ({
+    useUpdateDescriptionMutation: () => [vi.fn()],
+}));
+
+const noPermissionTooltipText = 'You do not have permission to change this.';
+
+const fieldWithDescription: SchemaField = {
+    fieldPath: 'order_id',
+    type: SchemaFieldDataType.Number,
+    nativeDataType: 'BIGINT',
+    nullable: false,
+    recursive: false,
+    description: 'An existing description',
+} as SchemaField;
+
+const fieldWithoutDescription: SchemaField = {
+    ...fieldWithDescription,
+    description: '',
+};
+
+const renderFieldDescription = (
+    canEditSchemaFieldDescription: boolean,
+    expandedField: SchemaField,
+    isSchemaEditable = true,
+) => {
+    mockUseEntityData.mockReturnValue({
+        entityType: 'DATASET',
+        privileges: { canEditSchemaFieldDescription },
+    });
+    return render(
+        <MockedProvider mocks={[]} addTypename={false}>
+            <TestPageContainer>
+                <SchemaEditableContext.Provider value={isSchemaEditable}>
+                    <FieldDescription expandedField={expandedField} />
+                </SchemaEditableContext.Provider>
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+};
+
+describe('FieldDescription edit icon permission handling', () => {
+    it('enables the edit icon and shows no tooltip when the user has canEditSchemaFieldDescription', async () => {
+        renderFieldDescription(true, fieldWithDescription);
+
+        const editButton = screen.getByTestId('edit-field-description');
+        expect(editButton).not.toBeDisabled();
+
+        await userEvent.hover(editButton);
+        expect(screen.queryByText(noPermissionTooltipText)).not.toBeInTheDocument();
+    });
+
+    it('disables the edit icon and shows a tooltip when the user lacks canEditSchemaFieldDescription', async () => {
+        renderFieldDescription(false, fieldWithDescription);
+
+        const editButton = screen.getByTestId('edit-field-description');
+        expect(editButton).toBeDisabled();
+
+        await userEvent.hover(editButton);
+        expect(await screen.findByText(noPermissionTooltipText)).toBeInTheDocument();
+    });
+
+    it('does not render the edit icon when the schema is not editable, regardless of privilege', () => {
+        renderFieldDescription(true, fieldWithDescription, false);
+
+        expect(screen.queryByTestId('edit-field-description')).not.toBeInTheDocument();
+    });
+});
+
+describe('FieldDescription add-description affordance permission handling', () => {
+    it('shows no tooltip when the user has canEditSchemaFieldDescription', async () => {
+        renderFieldDescription(true, fieldWithoutDescription);
+
+        const addDescription = screen.getByText('Add Description');
+        await userEvent.hover(addDescription);
+        expect(screen.queryByText(noPermissionTooltipText)).not.toBeInTheDocument();
+    });
+
+    it('shows the permission tooltip when the user lacks canEditSchemaFieldDescription', async () => {
+        renderFieldDescription(false, fieldWithoutDescription);
+
+        const addDescription = screen.getByText('Add Description');
+        await userEvent.hover(addDescription);
+        expect(await screen.findByText(noPermissionTooltipText)).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/DocumentationTab.tsx
@@ -15,7 +15,7 @@ import { DescriptionPreviewModal } from '@app/entityV2/shared/tabs/Documentation
 import { RelatedSection } from '@app/entityV2/shared/tabs/Documentation/components/RelatedSection';
 import { getAssetDescriptionDetails } from '@app/entityV2/shared/tabs/Documentation/utils';
 import { EDITED_DESCRIPTIONS_CACHE_NAME } from '@app/entityV2/shared/utils';
-import { Button, Editor, Text } from '@src/alchemy-components';
+import { Button, Editor, Text, Tooltip } from '@src/alchemy-components';
 
 const DOCUMENTATION_TAB_NAME = 'Documentation';
 const DOCUMENTATION_TAB = 'documentation';
@@ -52,8 +52,11 @@ interface Props {
 export const DocumentationTab = ({ properties }: { properties?: Props }) => {
     const { t } = useTranslation('entity.profile.documentation');
     const { t: tc } = useTranslation('common.actions');
+    const { t: ts } = useTranslation('entity.shared.containers');
     const hideLinksButton = properties?.hideLinksButton;
     const { urn, entityData } = useEntityData();
+    const canEditDescription = !!entityData?.privileges?.canEditDescription;
+    const noPermissionTooltip = canEditDescription ? '' : ts('sidebar.noPermissionTooltip');
 
     const { displayedDescription } = getAssetDescriptionDetails({
         entityProperties: entityData,
@@ -83,16 +86,29 @@ export const DocumentationTab = ({ properties }: { properties?: Props }) => {
                 <>
                     <StyledTabToolbar>
                         <div>
-                            <Button
-                                data-testid="edit-documentation-button"
-                                variant="text"
-                                icon={{ icon: PencilSimple }}
-                                onClick={() =>
-                                    routeToTab({ tabName: DOCUMENTATION_TAB_NAME, tabParams: { editing: true } })
-                                }
-                            >
-                                {tc('edit')}
-                            </Button>
+                            <Tooltip title={noPermissionTooltip}>
+                                <span
+                                    style={{
+                                        display: 'inline-block',
+                                        cursor: canEditDescription ? undefined : 'not-allowed',
+                                    }}
+                                >
+                                    <Button
+                                        data-testid="edit-documentation-button"
+                                        variant="text"
+                                        icon={{ icon: PencilSimple }}
+                                        disabled={!canEditDescription}
+                                        onClick={() =>
+                                            routeToTab({
+                                                tabName: DOCUMENTATION_TAB_NAME,
+                                                tabParams: { editing: true },
+                                            })
+                                        }
+                                    >
+                                        {tc('edit')}
+                                    </Button>
+                                </span>
+                            </Tooltip>
                         </div>
                         <div>
                             <Button
@@ -129,15 +145,25 @@ export const DocumentationTab = ({ properties }: { properties?: Props }) => {
             ) : (
                 <EmptyTabWrapper>
                     <EmptyTab tab={DOCUMENTATION_TAB} hideImage={false}>
-                        <Button
-                            data-testid="add-documentation"
-                            icon={{ icon: Plus }}
-                            onClick={() =>
-                                routeToTab({ tabName: DOCUMENTATION_TAB_NAME, tabParams: { editing: true } })
-                            }
-                        >
-                            {t('addDocumentation')}
-                        </Button>
+                        <Tooltip title={noPermissionTooltip}>
+                            <span
+                                style={{
+                                    display: 'inline-block',
+                                    cursor: canEditDescription ? undefined : 'not-allowed',
+                                }}
+                            >
+                                <Button
+                                    data-testid="add-documentation"
+                                    icon={{ icon: Plus }}
+                                    disabled={!canEditDescription}
+                                    onClick={() =>
+                                        routeToTab({ tabName: DOCUMENTATION_TAB_NAME, tabParams: { editing: true } })
+                                    }
+                                >
+                                    {t('addDocumentation')}
+                                </Button>
+                            </span>
+                        </Tooltip>
                     </EmptyTab>
                 </EmptyTabWrapper>
             )}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
@@ -1,5 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import DOMPurify from 'dompurify';
 import React from 'react';
 
@@ -73,6 +74,75 @@ describe('SchemaDescriptionField', () => {
         );
         expect(getByText('Edited description')).toBeInTheDocument();
         expect(queryByText('This is a description')).not.toBeInTheDocument();
+    });
+});
+
+describe('permission-aware edit affordances', () => {
+    const renderTab = (canEditDescription: boolean, entityData: Record<string, unknown>) =>
+        render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
+                    <EntityContext.Provider
+                        value={{
+                            urn: 'urn:li:dataset:123',
+                            entityType: EntityType.Dataset,
+                            entityData: {
+                                ...entityData,
+                                privileges: { canEditDescription },
+                            },
+                            baseEntity: {},
+                            updateEntity: vi.fn(),
+                            routeToTab: vi.fn(),
+                            loading: true,
+                            lineage: undefined,
+                            dataNotCombinedWithSiblings: null,
+                            refetch: vi.fn(),
+                        }}
+                    >
+                        <DocumentationTab />
+                    </EntityContext.Provider>
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+    it('enables the edit button and shows no tooltip when the user has canEditDescription', async () => {
+        renderTab(true, { properties: { description: 'This is a description' } });
+
+        const editButton = screen.getByTestId('edit-documentation-button');
+        expect(editButton).not.toBeDisabled();
+
+        await userEvent.hover(editButton);
+        expect(screen.queryByText('You do not have permission to change this.')).not.toBeInTheDocument();
+    });
+
+    it('disables the edit button and shows a tooltip when the user lacks canEditDescription', async () => {
+        renderTab(false, { properties: { description: 'This is a description' } });
+
+        const editButton = screen.getByTestId('edit-documentation-button');
+        expect(editButton).toBeDisabled();
+
+        await userEvent.hover(editButton);
+        expect(await screen.findByText('You do not have permission to change this.')).toBeInTheDocument();
+    });
+
+    it('enables the add-documentation button when the user has canEditDescription', async () => {
+        renderTab(true, {});
+
+        const addButton = screen.getByTestId('add-documentation');
+        expect(addButton).not.toBeDisabled();
+
+        await userEvent.hover(addButton);
+        expect(screen.queryByText('You do not have permission to change this.')).not.toBeInTheDocument();
+    });
+
+    it('disables the add-documentation button and shows a tooltip when the user lacks canEditDescription', async () => {
+        renderTab(false, {});
+
+        const addButton = screen.getByTestId('add-documentation');
+        expect(addButton).toBeDisabled();
+
+        await userEvent.hover(addButton);
+        expect(await screen.findByText('You do not have permission to change this.')).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
### Summary

Users without edit permission on a dataset's documentation or a schema field's description
currently see fully-enabled Edit/Add buttons, and only discover they lack permission after
clicking through the whole edit flow and having the save mutation fail server-side. This PR
disables those buttons up front and shows an explanatory tooltip instead, so unprivileged
users get immediate feedback rather than a late, confusing failure. Users who do have the
relevant privilege see no behavior change.

### Test plan

- [x] `FieldDescription.test.tsx` — privilege granted (enabled, no tooltip) / privilege absent
      (disabled, tooltip shown)
- [x] `DocumentationTab.test.tsx` — same coverage for the Documentation tab's Edit/Add buttons
- [x] `./gradlew :datahub-web-react:yarnLint` (ESLint, Prettier, `tsc --noEmit`) passes clean

### Manual testing (local)

- [x] As a user **without** `canEditDescription`: Documentation tab's Edit button and "Add
      documentation" empty-state button render disabled, with a tooltip on hover explaining why —
      confirmed via a fresh no-privilege native test user
- [x] As a user **without** `canEditSchemaFieldDescription` (schema otherwise editable): schema
      field description's edit icon and "Add description" button render disabled, same tooltip —
      confirmed via the same test user
- [x] As a user **with** the relevant privilege: both surfaces behave exactly as before this PR —
      enabled, no tooltip, edit flow completes normally

All three re-verified on a local Docker deployment of this branch's current head: a scripted
Playwright pass (unprivileged user + admin, both surfaces, tooltip-on-hover asserted) run headed
with human visual confirmation at each step, then green headless (3/3).

