### PR TITLE
fix(ingest/vertexai): reset regional caches per region

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai.py
@@ -382,6 +382,10 @@ class VertexAISource(StatefulIngestionSourceBase):
             )
             self._current_region = region
 
+            # Vertex resources are regional; reset before this region's fetch.
+            self.training_extractor.reset_regional_caches()
+            self.model_extractor.reset_regional_caches()
+
             if (
                 self.config.use_ml_metadata_for_lineage
                 or self.config.extract_execution_metrics

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_model_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_model_extractor.py
@@ -98,6 +98,11 @@ class VertexAIModelExtractor:
         self.endpoints: Optional[Dict[str, List[Endpoint]]] = None
         self._models_cache: Optional[List[Model]] = None
 
+    def reset_regional_caches(self) -> None:
+        """Clear the cached models and endpoints, which are region-specific."""
+        self._models_cache = None
+        self.endpoints = None
+
     def _list_versions(self, model: Model) -> List[VersionInfo]:
         registry = model.versioning_registry
         request = ListModelVersionsRequest(name=registry.model_resource_name)
@@ -128,10 +133,6 @@ class VertexAIModelExtractor:
 
     def get_model_workunits(self) -> Iterable[MetadataWorkUnit]:
         logger.info("Fetching Models from Vertex AI")
-        # Reset so each region gets its own fetch; get_evaluation_workunits reuses
-        # the cache while still in the same region.
-        self._models_cache = None
-
         last_checkpoint_millis = self.state_handler.get_last_update_time(
             ResourceTypes.MODEL
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/vertexai/vertexai_training_extractor.py
@@ -120,6 +120,10 @@ class VertexAITrainingExtractor:
 
         self.datasets: Optional[Dict[str, VertexAiResourceNoun]] = None
 
+    def reset_regional_caches(self) -> None:
+        """Clear the cached datasets, which are region-specific."""
+        self.datasets = None
+
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         """Main entry point for training job extraction."""
         for class_name in TrainingJobTypes.all():

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
@@ -146,16 +146,16 @@ def test_model_reset_regional_caches_refetches_endpoints(
     """Test that endpoints are refetched per region."""
     ext = source.model_extractor
     region1_model = MagicMock()
-    region1_model.resource_name = "projects/x/locations/r1/models/m1"
+    region1_model.resource_name = "projects/p/locations/r1/models/m1"
     ext.endpoints = {region1_model.resource_name: [MagicMock()]}
 
     ext.reset_regional_caches()
 
     region2_model = MagicMock()
-    region2_model.resource_name = "projects/y/locations/r2/models/m2"
+    region2_model.resource_name = "projects/p/locations/r2/models/m2"
     region2_endpoint = MagicMock()
     region2_endpoint.list_models.return_value = [
-        MagicMock(model="projects/y/locations/r2/models/m2")
+        MagicMock(model="projects/p/locations/r2/models/m2")
     ]
     with patch(
         "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
@@ -165,24 +165,62 @@ def test_model_reset_regional_caches_refetches_endpoints(
         assert ext._search_endpoint(region1_model) == []
 
 
+def test_model_reset_regional_caches_refetches_models(
+    source: VertexAISource,
+) -> None:
+    """Test that models are refetched per region."""
+    ext = source.model_extractor
+    ext._models_cache = [MagicMock()]  # cache from a prior region
+
+    ext.reset_regional_caches()
+
+    region2_model = MagicMock()
+    with patch(
+        "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
+        return_value=[region2_model],
+    ):
+        assert ext._list_models() == [region2_model]
+
+
 def test_evaluation_reuses_models_cache_within_region(
     source: VertexAISource,
 ) -> None:
-    """Test that the model listing is reused within a region."""
+    """Test that evaluations are produced from a model listing reused within a region."""
     ext = source.model_extractor
     ext.reset_regional_caches()
 
-    with patch(
-        "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
-        return_value=[],
-    ) as mock_list:
+    model = MagicMock()
+    model.display_name = "m"
+    model.name = "m"
+    model.resource_name = "projects/p/locations/r/models/m"
+    evaluation = MagicMock()
+    evaluation.name = "eval-1"
+    evaluation.create_time = None
+
+    def gapic_side_effect(cls: object, *args: object, **kwargs: object) -> list:
+        # Model registry listing vs per-model evaluation listing share one patch.
+        return [model] if cls is ext.client.Model else [evaluation]
+
+    evaluation_wu = MagicMock()
+    with (
+        patch(
+            "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
+            side_effect=gapic_side_effect,
+        ) as mock_list,
+        patch.object(ext, "_list_versions", return_value=[]),
+        patch.object(
+            ext, "_gen_model_evaluation_mcps", return_value=iter([evaluation_wu])
+        ) as gen_eval,
+    ):
         list(ext.get_model_workunits())
-        list(ext.get_evaluation_workunits())
+        eval_wus = list(ext.get_evaluation_workunits())
 
     model_list_calls = [
         c for c in mock_list.call_args_list if c.args and c.args[0] is ext.client.Model
     ]
     assert len(model_list_calls) == 1
+    gen_eval.assert_called_once_with(model, evaluation)
+    assert eval_wus == [evaluation_wu]
 
 
 def test_region_loop_resets_caches_each_region() -> None:
@@ -195,6 +233,8 @@ def test_region_loop_resets_caches_each_region() -> None:
             regions=["us-west1", "europe-west4"],
             use_ml_metadata_for_lineage=False,
             extract_execution_metrics=False,
+            # Reduce phase 1 to a single training-jobs fetch per region, so the
+            # side effect below fires exactly once per region deterministically.
             include_pipelines=False,
             include_experiments=False,
             include_models=False,

--- a/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
+++ b/metadata-ingestion/tests/unit/vertexai/test_vertexai_source.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Iterator, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +15,7 @@ from google.rpc.error_details_pb2 import ErrorInfo
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StatefulStaleMetadataRemovalConfig,
 )
@@ -118,6 +119,128 @@ def test_pipeline_task_with_none_timestamps(
     ):
         mcps = list(source.pipeline_extractor.get_workunits())
         assert len(mcps) > 0, "Should generate MCPs for pipeline task"
+
+
+def test_training_reset_regional_caches_refetches_datasets(
+    source: VertexAISource,
+) -> None:
+    """Test that datasets are refetched per region."""
+    ext = source.training_extractor
+    ext.datasets = {"ds-region-1": MagicMock()}  # cache from a prior region
+
+    ext.reset_regional_caches()
+
+    region2_dataset = MagicMock()
+    region2_dataset.name = "ds-region-2"
+    with patch(
+        "datahub.ingestion.source.vertexai.vertexai_training_extractor.rate_limited_gapic_list",
+        return_value=[region2_dataset],
+    ):
+        assert ext._search_dataset("ds-region-2") is region2_dataset
+        assert ext._search_dataset("ds-region-1") is None
+
+
+def test_model_reset_regional_caches_refetches_endpoints(
+    source: VertexAISource,
+) -> None:
+    """Test that endpoints are refetched per region."""
+    ext = source.model_extractor
+    region1_model = MagicMock()
+    region1_model.resource_name = "projects/x/locations/r1/models/m1"
+    ext.endpoints = {region1_model.resource_name: [MagicMock()]}
+
+    ext.reset_regional_caches()
+
+    region2_model = MagicMock()
+    region2_model.resource_name = "projects/y/locations/r2/models/m2"
+    region2_endpoint = MagicMock()
+    region2_endpoint.list_models.return_value = [
+        MagicMock(model="projects/y/locations/r2/models/m2")
+    ]
+    with patch(
+        "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
+        return_value=[region2_endpoint],
+    ):
+        assert ext._search_endpoint(region2_model) == [region2_endpoint]
+        assert ext._search_endpoint(region1_model) == []
+
+
+def test_evaluation_reuses_models_cache_within_region(
+    source: VertexAISource,
+) -> None:
+    """Test that the model listing is reused within a region."""
+    ext = source.model_extractor
+    ext.reset_regional_caches()
+
+    with patch(
+        "datahub.ingestion.source.vertexai.vertexai_model_extractor.rate_limited_gapic_list",
+        return_value=[],
+    ) as mock_list:
+        list(ext.get_model_workunits())
+        list(ext.get_evaluation_workunits())
+
+    model_list_calls = [
+        c for c in mock_list.call_args_list if c.args and c.args[0] is ext.client.Model
+    ]
+    assert len(model_list_calls) == 1
+
+
+def test_region_loop_resets_caches_each_region() -> None:
+    """Test that region transitions clear stale caches before the next region fetches."""
+    source = VertexAISource(
+        ctx=PipelineContext(run_id="region-reset-test"),
+        config=VertexAIConfig(
+            project_ids=["test-project"],
+            region="us-west1",
+            regions=["us-west1", "europe-west4"],
+            use_ml_metadata_for_lineage=False,
+            extract_execution_metrics=False,
+            include_pipelines=False,
+            include_experiments=False,
+            include_models=False,
+            include_evaluations=False,
+        ),
+    )
+    source._project_to_regions = {"test-project": ["us-west1", "europe-west4"]}
+    region1_dataset_key = "ds-region-1"
+    region1_model_key = "projects/test-project/locations/us-west1/models/m1"
+
+    # Snapshot each region's caches as its fetch begins
+    seen: list[tuple[str, dict, dict]] = []
+
+    def fetch_phase1_side_effect(resource_type: str) -> Iterator[MetadataWorkUnit]:
+        assert resource_type == "training_jobs"
+        region = source._get_region()
+        seen.append(
+            (
+                region,
+                dict(source.training_extractor.datasets or {}),
+                dict(source.model_extractor.endpoints or {}),
+            )
+        )
+        if region == "us-west1":
+            # Simulate caches populated during region-1's fetch.
+            source.training_extractor.datasets = {region1_dataset_key: MagicMock()}
+            source.model_extractor.endpoints = {region1_model_key: [MagicMock()]}
+        return iter([])
+
+    def empty(*args: object, **kwargs: object) -> Iterator[MetadataWorkUnit]:
+        return iter([])
+
+    with (
+        patch("datahub.ingestion.source.vertexai.vertexai.aiplatform.init"),
+        patch.object(source, "_gen_project_workunits", side_effect=empty),
+        patch.object(
+            source, "_fetch_phase1_resource", side_effect=fetch_phase1_side_effect
+        ),
+    ):
+        list(source.get_workunits_internal())
+
+    assert [region for region, _, _ in seen] == ["us-west1", "europe-west4"]
+    # region-2's fetch began with region-1's caches already cleared.
+    _, region2_datasets, region2_endpoints = seen[1]
+    assert region1_dataset_key not in region2_datasets
+    assert region1_model_key not in region2_endpoints
 
 
 def test_experiment_run_with_none_timestamps(source: VertexAISource) -> None:


### PR DESCRIPTION
## Motivation

Vertex AI datasets and endpoints are regional resources, and the connector ingests each project across all of its configured regions. The training extractor caches datasets and the model extractor caches endpoints, but those caches were populated once and never invalidated when the connector advanced to the next region. For any project ingested across more than one region, every region after the first reused the first region's cached data:

- Model → endpoint associations resolved against the first region's endpoints, so models in later regions got wrong or missing deployment metadata.
- AutoML training jobs resolved input-dataset lineage against the first region's datasets, so later-region jobs got wrong or missing dataset lineage.
- The model cache was previously reset only during model ingestion. So when `include_models` disabled and `include_evaluations` enabled, model cache was never reset across regions, so evaluations in later regions resolved against the first region's models.

## Changes

- Added `reset_regional_caches()` to the training extractor (clears the dataset cache) and the model extractor (clears the endpoint and model caches).
- The region loop in `get_workunits_internal` calls both once per region, right after `aiplatform.init(...)` and before that region's fetch, so each region starts from a clean cache and the accessors lazily refetch region-local data.
- Cache invalidation now lives at the region boundary that owns region transitions, so it applies regardless of which `include_*` resources are enabled.  The model-cache reset moves here from `get_model_workunits`, so it applies even when model ingestion is disabled; within a region the model listing is still fetched once and shared between model and evaluation extraction..

## Testing

- `tests/unit/vertexai/test_vertexai_source.py`: datasets, endpoints, and models each refetch after a reset; evaluations are produced from a model listing reused within a region (listed once, not per method); and the region loop clears both extractors' caches before each region's fetch.

No integration/golden changes: the fix is caching and control flow, with no new entities or aspects.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [x] Tests for the changes have been added/updated
- [ ] Docs (n/a — no new config or user-facing surface)
- [ ] Breaking change / updating-datahub entry (n/a — no breaking change)
