### PR TITLE
feat(ci): check org membership for internal contributors in PR-to-Linear routing

### DIFF
--- a/.github/workflows/pr-to-linear-routing-test.yml
+++ b/.github/workflows/pr-to-linear-routing-test.yml
@@ -122,6 +122,9 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # PAT with org Members read access — the default github.token cannot
+          # read private org membership, so a dedicated token is required.
+          ORG_READ_TOKEN: ${{ secrets.ACRYLDATA_ORG_READ_TOKEN }}
         run: |
           if [ "$PR_DRAFT" = "true" ]; then
             echo "should_skip=true" >> "$GITHUB_OUTPUT"
@@ -141,7 +144,21 @@ jobs:
 
           echo "should_skip=false" >> "$GITHUB_OUTPUT"
 
-          if gh api "orgs/datahub-project/members/$PR_AUTHOR" --silent 2>/dev/null; then
+          IS_INTERNAL="false"
+
+          if [ -n "$ORG_READ_TOKEN" ]; then
+            MEMBER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "Authorization: token $ORG_READ_TOKEN" \
+              "https://api.github.com/orgs/acryldata/members/$PR_AUTHOR")
+            if [ "$MEMBER_STATUS" = "204" ]; then
+              IS_INTERNAL="true"
+              echo "✓ $PR_AUTHOR is an acryldata org member"
+            fi
+          else
+            echo "⚠️  ACRYLDATA_ORG_READ_TOKEN secret is not set — org membership check skipped"
+          fi
+
+          if [ "$IS_INTERNAL" = "true" ]; then
             echo "contributor_type=Internal" >> "$GITHUB_OUTPUT"
           else
             echo "contributor_type=External" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -116,6 +116,9 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TEAM_MEMBERS: ${{ vars.DATAHUB_TEAM_MEMBERS }}
+          # PAT with org Members read access — the default github.token cannot
+          # read private org membership, so a dedicated token is required.
+          ORG_READ_TOKEN: ${{ secrets.ACRYLDATA_ORG_READ_TOKEN }}
         run: |
           if [ "$PR_DRAFT" = "true" ]; then
             echo "should_skip=true" >> "$GITHUB_OUTPUT"
@@ -135,12 +138,34 @@ jobs:
 
           echo "should_skip=false" >> "$GITHUB_OUTPUT"
 
-          if [ -z "$TEAM_MEMBERS" ]; then
-            echo "⚠️  DATAHUB_TEAM_MEMBERS variable is not set — defaulting to Internal"
-            echo "contributor_type=Internal" >> "$GITHUB_OUTPUT"
-            echo "should_skip=true" >> "$GITHUB_OUTPUT"
-            echo "⏭️  Skipping - Internal contributor"
-          elif echo "$TEAM_MEMBERS" | jq -e --arg actor "$PR_AUTHOR" '[.[].github] | map(ascii_downcase) | contains([($actor | ascii_downcase)])' > /dev/null 2>&1; then
+          IS_INTERNAL="false"
+
+          # Primary check: acryldata GitHub org membership. New team members are
+          # added to the org during onboarding, so this needs no per-person
+          # maintenance. 204 = member; anything else falls through to the list.
+          if [ -n "$ORG_READ_TOKEN" ]; then
+            MEMBER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+              -H "Authorization: token $ORG_READ_TOKEN" \
+              "https://api.github.com/orgs/acryldata/members/$PR_AUTHOR")
+            if [ "$MEMBER_STATUS" = "204" ]; then
+              IS_INTERNAL="true"
+              echo "✓ $PR_AUTHOR is an acryldata org member"
+            fi
+          else
+            echo "⚠️  ACRYLDATA_ORG_READ_TOKEN secret is not set — org membership check skipped"
+          fi
+
+          # Fallback: static team-member list (also covers non-org maintainers)
+          if [ "$IS_INTERNAL" = "false" ]; then
+            if [ -z "$TEAM_MEMBERS" ]; then
+              echo "⚠️  DATAHUB_TEAM_MEMBERS variable is not set — defaulting to Internal"
+              IS_INTERNAL="true"
+            elif echo "$TEAM_MEMBERS" | jq -e --arg actor "$PR_AUTHOR" '[.[].github] | map(ascii_downcase) | contains([($actor | ascii_downcase)])' > /dev/null 2>&1; then
+              IS_INTERNAL="true"
+            fi
+          fi
+
+          if [ "$IS_INTERNAL" = "true" ]; then
             echo "contributor_type=Internal" >> "$GITHUB_OUTPUT"
             echo "should_skip=true" >> "$GITHUB_OUTPUT"
             echo "⏭️  Skipping - Internal contributor"


### PR DESCRIPTION
## Summary

The PR-to-Linear routing workflow decides whether a PR author is an internal contributor (skip ticket creation) by checking the static `DATAHUB_TEAM_MEMBERS` repo variable, which has to be updated by hand for every new team member.

This adds a primary check against `acryldata` GitHub org membership — which is already maintained as part of onboarding — via a new `ACRYLDATA_ORG_READ_TOKEN` secret (PAT with org **Members: read**). The static list remains as a fallback, and the workflow degrades gracefully (with a log warning) if the secret is not configured. The default `github.token` cannot be used because it can't read private org membership.

Also updates `pr-to-linear-routing-test.yml`, whose existing `gh api orgs/.../members` check silently misclassified private org members as external for the same reason.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)