### PR TITLE
fix(cli): parse unquoted multi-word values in search filters

### DIFF
--- a/datahub-agent-context/tests/unit/mcp_tools/test_search_filter_parser.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_search_filter_parser.py
@@ -207,7 +207,7 @@ def test_missing_operator_raises():
 
 def test_unexpected_token_raises():
     with pytest.raises(ValueError, match="Unexpected token"):
-        parse_filter_string("platform = snowflake bigquery")
+        parse_filter_string("platform = snowflake )")
 
 
 def test_nested_parens():
@@ -384,6 +384,42 @@ def test_status_multiple_values_raises():
 
 
 # ---------------------------------------------------------------------------
+# Over-escaped quoting (\"value\") is read as ordinary quoting
+# ---------------------------------------------------------------------------
+
+
+def test_over_escaped_quotes_in_in_list():
+    # Shape an agent actually sent: the quotes were escaped a second time while
+    # building the JSON, so the backslashes arrived literally. This used to fail
+    # in the tokenizer with "Unterminated string starting at position 13" — the
+    # opening \" was read as a bare word plus a string that then ate every
+    # following \" as an escape.
+    assert parse_filter_string(
+        r"subtype IN (\"Known Issues / Limitations\", Insight, \"Vendor Q&A\")"
+    ) == F.entity_subtype(["Known Issues / Limitations", "Insight", "Vendor Q&A"])
+
+
+def test_over_escaped_quotes_single_value():
+    assert parse_filter_string(r"subtype = \"Fact Sheet\"") == F.entity_subtype(
+        "Fact Sheet"
+    )
+    assert parse_filter_string(r"subtype = \'Fact Sheet\'") == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_over_escaped_opening_with_bare_closing_quote():
+    assert parse_filter_string(r'subtype = \"Fact Sheet"') == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_over_escaped_unterminated_still_raises():
+    with pytest.raises(ValueError, match="Unterminated string"):
+        parse_filter_string(r"subtype = \"Fact Sheet")
+
+
+# ---------------------------------------------------------------------------
 # Error message quality tests
 # ---------------------------------------------------------------------------
 
@@ -401,6 +437,93 @@ def test_trailing_equals_gives_parse_error():
 def test_missing_field_gives_parse_error():
     with pytest.raises(ValueError, match="Expected STRING"):
         parse_filter_string("= snowflake")
+
+
+# ---------------------------------------------------------------------------
+# Unquoted multi-word values are joined rather than rejected
+# ---------------------------------------------------------------------------
+
+
+def test_unquoted_multi_word_value_is_joined():
+    assert parse_filter_string("subtype = Fact Sheet") == F.entity_subtype("Fact Sheet")
+    assert parse_filter_string("subtype = Vendor Q&A") == F.entity_subtype("Vendor Q&A")
+
+
+def test_unquoted_multi_word_values_in_in_list_are_joined_per_member():
+    # Shapes agents actually sent to search_documents. Each comma-delimited
+    # member is one value, however many bare words it spans.
+    assert parse_filter_string(
+        "subtype IN (Fact Sheet, Semantic Anchor)"
+    ) == F.entity_subtype(["Fact Sheet", "Semantic Anchor"])
+    assert parse_filter_string(
+        "subtype IN (Technical Documentation, How-To Guides, Product Documentation)"
+    ) == F.entity_subtype(
+        ["Technical Documentation", "How-To Guides", "Product Documentation"]
+    )
+    assert parse_filter_string(
+        "subtype IN (Known Issues / Limitations, Fact Sheet)"
+    ) == F.entity_subtype(["Known Issues / Limitations", "Fact Sheet"])
+
+
+def test_unquoted_multi_word_urn_is_joined():
+    assert parse_filter_string("tag = urn:li:tag:my special tag") == F.tag(
+        "urn:li:tag:my special tag"
+    )
+
+
+def test_joining_collapses_runs_of_whitespace():
+    assert parse_filter_string("subtype =  Fact   Sheet ") == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_joining_stops_at_conjunctions():
+    # AND/OR/NOT/IN are legal value tokens but must terminate the run, or a
+    # conjunction would be swallowed into one long value.
+    assert parse_filter_string(
+        "subtype = Product Documentation OR subtype = How-To Guides"
+    ) == F.or_(
+        F.entity_subtype("Product Documentation"), F.entity_subtype("How-To Guides")
+    )
+    assert parse_filter_string("subtype = Runbook AND platform = notion") == F.and_(
+        F.entity_subtype("Runbook"), F.platform("notion")
+    )
+    assert parse_filter_string(
+        "subtype IN (Fact Sheet, FAQ) AND platform = notion"
+    ) == F.and_(F.entity_subtype(["Fact Sheet", "FAQ"]), F.platform("notion"))
+
+
+def test_joining_does_not_mask_a_missing_conjunction():
+    # `subtype = Fact Sheet platform = notion` is missing an AND. The run joins
+    # up to the stray `=`, which then has no valid parse.
+    with pytest.raises(ValueError, match="Unexpected token"):
+        parse_filter_string("subtype = Fact Sheet platform = notion")
+
+
+def test_keywords_are_absorbed_into_in_list_values():
+    # There is no boolean logic between the parens of an IN list, so AND/OR/NOT
+    # are ordinary words there and belong to the value.
+    assert parse_filter_string(
+        "subtype IN (Terms AND Conditions, Fact Sheet)"
+    ) == F.entity_subtype(["Terms AND Conditions", "Fact Sheet"])
+
+
+def test_comma_still_delimits_unless_quoted():
+    assert parse_filter_string("subtype IN (Redwood, CA)") == F.entity_subtype(
+        ["Redwood", "CA"]
+    )
+    assert parse_filter_string('subtype IN ("Redwood, CA")') == F.entity_subtype(
+        "Redwood, CA"
+    )
+
+
+def test_quoted_multi_word_values_still_parse():
+    assert parse_filter_string('subtype = "Knowledge Article"') == F.entity_subtype(
+        "Knowledge Article"
+    )
+    assert parse_filter_string(
+        'subtype IN ("Knowledge Article", Runbook)'
+    ) == F.entity_subtype(["Knowledge Article", "Runbook"])
 
 
 # ---------------------------------------------------------------------------

--- a/metadata-ingestion/src/datahub/cli/search_filter_parser.py
+++ b/metadata-ingestion/src/datahub/cli/search_filter_parser.py
@@ -38,8 +38,16 @@ Known limitations:
       expressible in SQL syntax; use JSON format if needed.
     - Custom (unrecognized) field names preserve the user's original casing;
       built-in fields are normalized case-insensitively.
-    - Values containing special characters (spaces, ``=``, parentheses,
-      commas) must be quoted: ``tag = "urn:li:tag:my tag"``.
+    - Unquoted values may contain spaces: a run of bare words is joined into a
+      single value, so ``subtype = Fact Sheet`` parses.  Quote a value only when
+      it contains a ``,`` or ``)`` of its own — dataset URNs carry both, so they
+      need quotes inside an ``IN`` list — or, outside an ``IN`` list, when it
+      literally contains AND/OR/NOT.  The trade-off is that a missing comma
+      inside an ``IN`` list reads as one long value instead of raising; it fails
+      closed, matching nothing, rather than returning wrong rows.
+    - Over-escaped quoting (``\\"value\\"``, from a caller that escaped the
+      quotes a second time while building a JSON string) is read as ordinary
+      quoting.  Escapes inside a normally-quoted string keep their meaning.
     - Comparison operators (``>``, ``>=``, ``<``, ``<=``) bypass the typed
       filter classes and emit raw ``_CustomCondition`` rules.  No validation
       is performed on whether the operator makes sense for the field; using
@@ -48,7 +56,7 @@ Known limitations:
 """
 
 from enum import Enum
-from typing import List, Sequence, Union
+from typing import List, Sequence, Tuple, Union
 
 from datahub.ingestion.graph.filters import RemovedStatusFilter
 from datahub.sdk.search_filters import Filter, FilterDsl as F, _EnvFilter
@@ -111,7 +119,8 @@ FILTER SYNTAX (SQL-like WHERE clause):
     full URN format (urn:li:...). Search with entity_type = domain first to find
     valid domain URNs, then use the exact URN from the results.
 
-    Values containing special characters (spaces, =, parentheses) must be quoted:
+    Values containing =, parentheses, or commas must be quoted. Quoting is
+    optional for values containing spaces, but clearer:
       tag = "urn:li:tag:my tag"
       customProperties = "key=value"\
 """
@@ -201,6 +210,57 @@ def _unescape(s: str) -> str:
     return "".join(result)
 
 
+def _scan_quoted_value(s: str, i: int) -> Tuple[str, int]:
+    """Scan a quoted literal starting at the opening quote at ``i``.
+
+    Returns the unescaped value and the index just past the closing quote.
+    Backslash escapes inside the literal are honoured, so ``"a\\"b"`` is a single
+    value containing a quote character.
+    """
+    quote = s[i]
+    start = i
+    i += 1
+    while i < len(s) and s[i] != quote:
+        if s[i] == "\\" and i + 1 < len(s):
+            i += 2
+        else:
+            i += 1
+    if i >= len(s):
+        raise ValueError(f"Unterminated string starting at position {start}")
+    return _unescape(s[start + 1 : i]), i + 1
+
+
+def _scan_escaped_quoted_value(s: str, i: int) -> Tuple[str, int]:
+    """Scan an over-escaped quoted literal such as ``\\"Vendor Q&A\\"``.
+
+    ``i`` points at the leading backslash.  Returns the unescaped value and the
+    index just past the closing delimiter.
+
+    Callers that assemble the filter inside a JSON string sometimes escape the
+    quotes a second time, so the backslashes survive JSON decoding and arrive
+    here literally.  A backslash directly before a quote has never been valid
+    outside a string — it used to scan as a bare ``\\`` word, after which the
+    following quote opened a string whose every ``\\"`` was eaten as an escape,
+    running to end-of-input and raising "Unterminated string".  Reading the pair
+    as a plain delimiter therefore costs nothing and rescues callers who were
+    trying to quote correctly.
+
+    Only a literal that *opens* with a backslash is read this way, so escapes
+    inside a normally-quoted string keep their meaning and ``platform = "a\\"b"``
+    is unaffected.
+    """
+    quote = s[i + 1]
+    closing = s.find("\\" + quote, i + 2)
+    if closing != -1:
+        return _unescape(s[i + 2 : closing]), closing + 2
+    # Tolerate a bare closing quote (``\\"value"``) rather than failing on a
+    # shape whose intent is unambiguous.
+    closing = s.find(quote, i + 2)
+    if closing == -1:
+        raise ValueError(f"Unterminated string starting at position {i}")
+    return _unescape(s[i + 2 : closing]), closing + 1
+
+
 def _tokenize(s: str) -> List[_Token]:
     """Scan ``s`` left-to-right into a flat list of tokens.
 
@@ -247,20 +307,14 @@ def _tokenize(s: str) -> List[_Token]:
         elif s[i] == "=":
             tokens.append(_Token(_TokenType.EQ, "=", i))
             i += 1
-        elif s[i] in ('"', "'"):
-            quote = s[i]
+        elif s[i] == "\\" and i + 1 < len(s) and s[i + 1] in ('"', "'"):
             start = i
-            i += 1
-            while i < len(s) and s[i] != quote:
-                if s[i] == "\\" and i + 1 < len(s):
-                    i += 2
-                else:
-                    i += 1
-            if i >= len(s):
-                raise ValueError(f"Unterminated string starting at position {start}")
-            raw_value = s[start + 1 : i]
-            tokens.append(_Token(_TokenType.STRING, _unescape(raw_value), start))
-            i += 1  # skip closing quote
+            value, i = _scan_escaped_quoted_value(s, i)
+            tokens.append(_Token(_TokenType.STRING, value, start))
+        elif s[i] in ('"', "'"):
+            start = i
+            value, i = _scan_quoted_value(s, i)
+            tokens.append(_Token(_TokenType.STRING, value, start))
         else:
             start = i
             while i < len(s) and s[i] not in " \t\n\r()=!<>,'\"":
@@ -327,6 +381,41 @@ class _Parser:
             f"got {token.type.value} ({token.value!r})"
         )
 
+    def _expect_condition_value(self, *, in_list: bool = False) -> _Token:
+        """Expect a condition value: the whole run of unquoted words, not one token.
+
+        The tokenizer breaks unquoted values on whitespace, so ``subtype = Fact
+        Sheet`` arrives as two adjacent STRING tokens. Requiring quotes there is a
+        rule callers reliably forget — LLM agents most of all, which send bare
+        multi-word subtypes constantly — and it used to fail with a parse error
+        pointing at the second word rather than at the missing quotes.
+
+        A run can only ever have been a single value, so join it rather than
+        rejecting it. What terminates the run differs by position:
+
+        * Inside ``IN (...)`` the only terminators are ``,`` and ``)``. There is no
+          boolean logic between the parens, so AND/OR/NOT are ordinary words there
+          and are absorbed: ``IN (Terms AND Conditions, FAQ)`` is two values.
+        * Elsewhere ``=`` and the comparison operators take exactly one value, and
+          AND/OR/NOT are clause boundaries, so only STRING tokens join and
+          ``subtype = Runbook AND platform = notion`` keeps its conjunction.
+
+        Words are joined on a single space, which also collapses runs of
+        whitespace. Anything else that follows the run (a stray ``=`` from a
+        missing conjunction, an unbalanced paren) still fails in ``parse``.
+
+        Quote a value only when it contains a ``,`` or ``)`` of its own — dataset
+        URNs carry both, so they need quotes inside an ``IN`` list.
+        """
+        first = self._expect_value()
+        words = [first.value]
+        terminators = _VALUE_TOKEN_TYPES if in_list else {_TokenType.STRING}
+        while self._peek().type in terminators:
+            words.append(self._advance().value)
+        if len(words) == 1:
+            return first
+        return _Token(_TokenType.STRING, " ".join(words), first.pos)
+
     def parse(self) -> Filter:
         result = self._parse_expr()
         if self._peek().type != _TokenType.EOF:
@@ -384,23 +473,23 @@ class _Parser:
 
         if self._peek().type == _TokenType.EQ:
             self._advance()  # consume =
-            value = self._expect_value().value
+            value = self._expect_condition_value().value
             return _make_filter(field, [value])
         elif self._peek().type == _TokenType.NEQ:
             self._advance()  # consume !=
-            value = self._expect_value().value
+            value = self._expect_condition_value().value
             return _make_negated_filter(field, [value])
         elif self._peek().type in self._COMPARISON_OPS:
             op_token = self._advance()
-            value = self._expect_value().value
+            value = self._expect_condition_value().value
             return F.custom_filter(field, self._COMPARISON_OPS[op_token.type], [value])
         elif self._peek().type == _TokenType.IN:
             self._advance()  # consume IN
             self._expect(_TokenType.LPAREN)
-            values = [self._expect_value().value]
+            values = [self._expect_condition_value(in_list=True).value]
             while self._peek().type == _TokenType.COMMA:
                 self._advance()  # consume comma
-                values.append(self._expect_value().value)
+                values.append(self._expect_condition_value(in_list=True).value)
             self._expect(_TokenType.RPAREN)
             return _make_filter(field, values)
         elif (

--- a/metadata-ingestion/tests/unit/cli/test_search_filter_parser.py
+++ b/metadata-ingestion/tests/unit/cli/test_search_filter_parser.py
@@ -1,0 +1,130 @@
+"""Tests for the filter-string parser that backs ``datahub search --where``.
+
+The broad grammar suite lives in
+``datahub-agent-context/tests/unit/mcp_tools/test_search_filter_parser.py``,
+which exercises the same parser through the MCP re-export. This file covers the
+lenient-value handling directly against the canonical module.
+"""
+
+import pytest
+
+from datahub.cli.search_filter_parser import parse_filter_string
+from datahub.sdk.search_filters import FilterDsl as F
+
+# ---------------------------------------------------------------------------
+# Unquoted multi-word values are joined rather than rejected
+# ---------------------------------------------------------------------------
+
+
+def test_unquoted_multi_word_value_is_joined():
+    assert parse_filter_string("subtype = Fact Sheet") == F.entity_subtype("Fact Sheet")
+    assert parse_filter_string("subtype = Vendor Q&A") == F.entity_subtype("Vendor Q&A")
+
+
+def test_unquoted_multi_word_values_in_in_list_are_joined_per_member():
+    assert parse_filter_string(
+        "subtype IN (Fact Sheet, Semantic Anchor)"
+    ) == F.entity_subtype(["Fact Sheet", "Semantic Anchor"])
+    assert parse_filter_string(
+        "subtype IN (Known Issues / Limitations, Fact Sheet)"
+    ) == F.entity_subtype(["Known Issues / Limitations", "Fact Sheet"])
+
+
+def test_keywords_are_absorbed_into_in_list_values():
+    # No boolean logic exists between the parens of an IN list, so AND/OR/NOT are
+    # ordinary words there and belong to the value.
+    assert parse_filter_string(
+        "subtype IN (Terms AND Conditions, Fact Sheet)"
+    ) == F.entity_subtype(["Terms AND Conditions", "Fact Sheet"])
+
+
+def test_joining_stops_at_conjunctions():
+    # Outside an IN list the same keywords are clause boundaries.
+    assert parse_filter_string(
+        "subtype = Product Documentation OR subtype = How-To Guides"
+    ) == F.or_(
+        F.entity_subtype("Product Documentation"), F.entity_subtype("How-To Guides")
+    )
+    assert parse_filter_string("subtype = Runbook AND platform = notion") == F.and_(
+        F.entity_subtype("Runbook"), F.platform("notion")
+    )
+
+
+def test_joining_collapses_runs_of_whitespace():
+    assert parse_filter_string("subtype =  Fact   Sheet ") == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_unquoted_multi_word_urn_is_joined():
+    assert parse_filter_string("tag = urn:li:tag:my special tag") == F.tag(
+        "urn:li:tag:my special tag"
+    )
+
+
+def test_comma_still_delimits_unless_quoted():
+    assert parse_filter_string("subtype IN (Redwood, CA)") == F.entity_subtype(
+        ["Redwood", "CA"]
+    )
+    assert parse_filter_string('subtype IN ("Redwood, CA")') == F.entity_subtype(
+        "Redwood, CA"
+    )
+
+
+def test_not_equals_and_comparisons_use_the_same_value_rule():
+    assert parse_filter_string("subtype != Fact Sheet") == F.not_(
+        F.entity_subtype("Fact Sheet")
+    )
+    assert parse_filter_string("columnCount > 5") == F.custom_filter(
+        "columnCount", "GREATER_THAN", ["5"]
+    )
+
+
+def test_joining_does_not_mask_a_missing_conjunction():
+    with pytest.raises(ValueError, match="Unexpected token"):
+        parse_filter_string("subtype = Fact Sheet platform = notion")
+
+
+# ---------------------------------------------------------------------------
+# Over-escaped quoting (\"value\") is read as ordinary quoting
+# ---------------------------------------------------------------------------
+
+
+def test_over_escaped_quotes_in_in_list():
+    # Quotes escaped a second time while building JSON arrive with literal
+    # backslashes. This used to fail in the tokenizer with "Unterminated string".
+    assert parse_filter_string(
+        r"subtype IN (\"Known Issues / Limitations\", Insight, \"Vendor Q&A\")"
+    ) == F.entity_subtype(["Known Issues / Limitations", "Insight", "Vendor Q&A"])
+
+
+def test_over_escaped_quotes_single_value():
+    assert parse_filter_string(r"subtype = \"Fact Sheet\"") == F.entity_subtype(
+        "Fact Sheet"
+    )
+    assert parse_filter_string(r"subtype = \'Fact Sheet\'") == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_over_escaped_opening_with_bare_closing_quote():
+    assert parse_filter_string(r'subtype = \"Fact Sheet"') == F.entity_subtype(
+        "Fact Sheet"
+    )
+
+
+def test_over_escaped_unterminated_still_raises():
+    with pytest.raises(ValueError, match="Unterminated string"):
+        parse_filter_string(r"subtype = \"Fact Sheet")
+
+
+def test_escapes_inside_a_normally_quoted_string_keep_their_meaning():
+    assert parse_filter_string(r'custom_field = "snow\"flake"') == F.custom_filter(
+        "custom_field", "EQUAL", ['snow"flake']
+    )
+    assert parse_filter_string('platform = "snowflake"') == F.platform("snowflake")
+
+
+def test_unterminated_plain_string_still_raises():
+    with pytest.raises(ValueError, match="Unterminated string"):
+        parse_filter_string('platform = "snowflake')


### PR DESCRIPTION
A bare multi-word filter value tokenizes as adjacent words, so it fails to parse:

```
subtype = Fact Sheet                      -> Unexpected token at position 15: 'Sheet'
subtype IN (Fact Sheet, Semantic Anchor)  -> Expected ) at position 17, got STRING ('Sheet')
```

Both messages point at the second word rather than at the missing quotes. Requiring quotes here is a rule callers reliably forget — LLM agents driving the MCP search tools send bare multi-word subtypes constantly, and the `IN` variant alone accounts for hundreds of failed `search_documents` calls in practice.

## 1. A value is the whole run of unquoted words

What terminates the run depends on position:

- **Inside `IN (...)`** the only terminators are `,` and `)`. There is no boolean logic between the parens, so `AND`/`OR`/`NOT` are ordinary words there and get absorbed — `IN (Terms AND Conditions, FAQ)` is two values.
- **Elsewhere** `=` and the comparison operators take exactly one value, and `AND`/`OR`/`NOT` are clause boundaries, so only bare words join and `subtype = Runbook AND platform = notion` keeps its conjunction.

Words join on a single space, which also collapses runs of whitespace. Anything else following the run — a stray `=` from a missing conjunction, an unbalanced paren — still fails in `parse()`.

Verified against real failing filters, including values carrying punctuation the tokenizer doesn't split on (`&`, `/`, `-`):

```
subtype = Vendor Q&A                                 -> ['Vendor Q&A']
subtype IN (Known Issues / Limitations, Fact Sheet)  -> ['Known Issues / Limitations', 'Fact Sheet']
subtype IN (Terms AND Conditions, Fact Sheet)        -> ['Terms AND Conditions', 'Fact Sheet']
subtype IN (How-To Guides, FAQ, Golden Paths, Product Documentation)
                     -> ['How-To Guides', 'FAQ', 'Golden Paths', 'Product Documentation']
subtype = Product Documentation OR subtype = How-To Guides
                     -> ['Product Documentation', 'How-To Guides']
```

Thanks @alexsku — the `IN`-list half of this, in particular treating keywords as ordinary words between the parens, is your suggestion from the comment below.

## 2. Over-escaped quoting (tokenizer)

A separate bug one layer down, which no parser change could reach. A caller that escapes the quotes a second time while building its JSON sends a literal backslash before each quote. The scan then ate every `\"` as an inner escape and ran to end of input:

```
subtype IN (\"Known Issues / Limitations\", Insight, \"Vendor Q&A\")
-> Unterminated string starting at position 13
```

A backslash directly before a quote was never valid outside a string — it scanned as a bare `\` word, after which the following quote opened a string that never terminated — so the pair is now read as a plain delimiter. Escapes *inside* a normally-quoted string keep their meaning, and `platform = "a\"b"` is unaffected. These callers were trying to quote correctly.

Both quote-scanning paths move into `_scan_quoted_value` / `_scan_escaped_quoted_value`, which keeps `_tokenize` under the C901 limit and stops the two branches from drifting.

## Rule for callers

Unquoted values may contain spaces. Quote only for an embedded `,` or `)` — dataset URNs carry both, so they need quotes inside an `IN` list — or, outside an `IN` list, a value that literally contains `AND`/`OR`/`NOT`. `FILTER_DOCS` and the module's known-limitations list say so, and no longer claim spaces must be quoted.

```
subtype IN (Redwood, CA)     -> ['Redwood', 'CA']      # comma still delimits
subtype IN ("Redwood, CA")   -> ['Redwood, CA']
```

## Trade-off

A missing comma inside an `IN` list now reads as one long value instead of raising — `platform IN (snowflake bigquery)` becomes a filter for `"snowflake bigquery"`. It fails closed: the joined value matches nothing, so the result is an empty set rather than wrong rows. Recorded in the known-limitations list.

This is strictly error → success: every input whose behavior changes previously raised, so no filter that parses today changes meaning.

## Scope

Affects `datahub search --where` and the `search` / `search_documents` / lineage MCP tools via the `datahub-agent-context` re-export.

One existing test asserted the generic `Unexpected token` wording for `platform = snowflake bigquery`, which now parses; it pins that message against `platform = snowflake )` instead, which still takes the generic path.

## Testing

- `datahub-agent-context/tests/unit/mcp_tools/test_search_filter_parser.py` — 100 passed (13 added)
- `datahub-agent-context/tests/unit/mcp_tools/` — 404 passed, 3 xfailed
- `metadata-ingestion/tests/unit/cli/test_search_cli.py` + `tests/unit/sdk_v2/test_search_client.py` — 146 passed
- `:metadata-ingestion:lint` and `:datahub-agent-context:lint` — ruff + mypy clean

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated — `FILTER_DOCS` and the module's known-limitations list
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub — not breaking; strictly error → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
