### PR TITLE
feat(data products): GraphQL layer for data product parent hierarchies

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -77,6 +77,7 @@ import com.linkedin.datahub.graphql.resolvers.dataproduct.BulkEntityDataProducts
 import com.linkedin.datahub.graphql.resolvers.dataproduct.CreateDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.DeleteDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.ListDataProductAssetsResolver;
+import com.linkedin.datahub.graphql.resolvers.dataproduct.ParentDataProductsResolver;
 import com.linkedin.datahub.graphql.resolvers.dataproduct.UpdateDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.dataset.DatasetOperationsStatsResolver;
 import com.linkedin.datahub.graphql.resolvers.dataset.DatasetStatsSummaryResolver;
@@ -191,6 +192,7 @@ import com.linkedin.datahub.graphql.resolvers.mutate.BatchRemoveTermsResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.BatchSetDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.BatchUpdateDeprecationResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.BatchUpdateSoftDeletedResolver;
+import com.linkedin.datahub.graphql.resolvers.mutate.MoveDataProductResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.MoveDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.MutableTypeBatchResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.MutableTypeResolver;
@@ -1419,6 +1421,10 @@ public class GmsGraphQLEngine {
                   new UpdateLogicalModelSchemaResolver(this.entityClient, this.graphClient))
               .dataFetcher(
                   "moveDomain", new MoveDomainResolver(this.entityService, this.entityClient))
+              .dataFetcher(
+                  "moveDataProduct",
+                  new MoveDataProductResolver(
+                      this.entityService, this.entityClient, this.dataProductService))
               .dataFetcher("deleteDomain", new DeleteDomainResolver(entityClient))
               .dataFetcher(
                   "setDomain", new SetDomainResolver(this.entityClient, this.entityService))
@@ -1547,7 +1553,8 @@ public class GmsGraphQLEngine {
                   "createDataProduct",
                   new CreateDataProductResolver(this.dataProductService, this.entityService))
               .dataFetcher(
-                  "updateDataProduct", new UpdateDataProductResolver(this.dataProductService))
+                  "updateDataProduct",
+                  new UpdateDataProductResolver(this.dataProductService, this.entityClient))
               .dataFetcher(
                   "deleteDataProduct", new DeleteDataProductResolver(this.dataProductService))
               .dataFetcher(
@@ -3349,6 +3356,8 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("entities", new ListDataProductAssetsResolver(this.entityClient))
+                .dataFetcher(
+                    "parentDataProducts", new ParentDataProductsResolver(this.entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver())
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
@@ -3357,6 +3366,20 @@ public class GmsGraphQLEngine {
                     "relatedDocuments",
                     new com.linkedin.datahub.graphql.resolvers.knowledge.RelatedDocumentsResolver(
                         documentService, entityClient)));
+    builder.type(
+        "DataProductProperties",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "parentDataProduct",
+                new LoadableTypeResolver<>(
+                    dataProductType,
+                    (env) -> {
+                      final com.linkedin.datahub.graphql.generated.DataProductProperties props =
+                          env.getSource();
+                      return props.getParentDataProduct() != null
+                          ? props.getParentDataProduct().getUrn()
+                          : null;
+                    })));
   }
 
   private void configureApplicationResolvers(final RuntimeWiring.Builder builder) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/CreateDataProductResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/CreateDataProductResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.dataproduct;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
-import com.datahub.authentication.Authentication;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -14,6 +13,7 @@ import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.datahub.graphql.types.dataproduct.mappers.DataProductMapper;
 import com.linkedin.entity.EntityResponse;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.service.DataProductService;
 import graphql.schema.DataFetcher;
@@ -36,7 +36,6 @@ public class CreateDataProductResolver implements DataFetcher<CompletableFuture<
     final QueryContext context = environment.getContext();
     final CreateDataProductInput input =
         bindArgument(environment.getArgument("input"), CreateDataProductInput.class);
-    final Authentication authentication = context.getAuthentication();
     final Urn domainUrn = UrnUtils.getUrn(input.getDomainUrn());
 
     return GraphQLConcurrencyUtils.supplyAsync(
@@ -50,12 +49,29 @@ public class CreateDataProductResolver implements DataFetcher<CompletableFuture<
           }
 
           try {
+            final Urn parentDataProductUrn =
+                input.getProperties().getParentDataProduct() != null
+                    ? UrnUtils.getUrn(input.getProperties().getParentDataProduct())
+                    : null;
+            if (parentDataProductUrn != null) {
+              if (!parentDataProductUrn
+                  .getEntityType()
+                  .equals(Constants.DATA_PRODUCT_ENTITY_NAME)) {
+                throw new IllegalArgumentException("Parent entity is not a data product.");
+              }
+              if (!_dataProductService.verifyEntityExists(
+                  context.getOperationContext(), parentDataProductUrn)) {
+                throw new IllegalArgumentException("Parent Data Product does not exist");
+              }
+            }
+
             final Urn dataProductUrn =
                 _dataProductService.createDataProduct(
                     context.getOperationContext(),
                     input.getId(),
                     input.getProperties().getName(),
-                    input.getProperties().getDescription());
+                    input.getProperties().getDescription(),
+                    parentDataProductUrn);
             _dataProductService.setDomain(
                 context.getOperationContext(),
                 dataProductUrn,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DataProductAncestorUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DataProductAncestorUtils.java
@@ -1,0 +1,81 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Shared helpers for walking the Data Product parent chain. Used by parent-list resolvers and move
+ * cycle guards.
+ */
+public final class DataProductAncestorUtils {
+
+  public static final int MAX_DEPTH = 20;
+
+  private static final Set<String> ASPECTS_TO_FETCH =
+      Collections.singleton(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME);
+
+  private DataProductAncestorUtils() {}
+
+  /**
+   * Walks the parentDataProduct chain starting from {@code sourceUrn}. Returns ancestors in
+   * nearest-first order (immediate parent first, root last). Guards against cycles with a visited
+   * set and a depth cap.
+   */
+  @Nonnull
+  public static List<Urn> walkParentChain(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final EntityClient entityClient,
+      @Nonnull final Urn sourceUrn)
+      throws Exception {
+    final List<Urn> chain = new ArrayList<>();
+    final Set<Urn> visited = new HashSet<>();
+    visited.add(sourceUrn);
+
+    Urn current = resolveParent(opContext, entityClient, sourceUrn);
+    while (current != null && !visited.contains(current) && chain.size() < MAX_DEPTH) {
+      chain.add(current);
+      visited.add(current);
+      current = resolveParent(opContext, entityClient, current);
+    }
+    return chain;
+  }
+
+  @Nullable
+  public static Urn resolveParent(
+      @Nonnull final OperationContext opContext,
+      @Nonnull final EntityClient entityClient,
+      @Nonnull final Urn urn)
+      throws Exception {
+    final Map<Urn, EntityResponse> responses =
+        entityClient.batchGetV2(
+            opContext,
+            Constants.DATA_PRODUCT_ENTITY_NAME,
+            Collections.singleton(urn),
+            ASPECTS_TO_FETCH,
+            false);
+    final EntityResponse response = responses.get(urn);
+    if (response == null) {
+      return null;
+    }
+    final EnvelopedAspect enveloped =
+        response.getAspects().get(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME);
+    if (enveloped == null) {
+      return null;
+    }
+    final DataProductProperties props = new DataProductProperties(enveloped.getValue().data());
+    return props.hasParentDataProduct() ? props.getParentDataProduct() : null;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/ParentDataProductsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/ParentDataProductsResolver.java
@@ -1,0 +1,102 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canViewRelationship;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Walks the parentDataProduct chain from the source data product up to the root, returning all
+ * ancestors in nearest-first order.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ParentDataProductsResolver
+    implements DataFetcher<CompletableFuture<List<DataProduct>>> {
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<List<DataProduct>> get(final DataFetchingEnvironment environment) {
+    final QueryContext context = getQueryContext(environment);
+    final Urn sourceUrn = UrnUtils.getUrn(((Entity) environment.getSource()).getUrn());
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            final List<Urn> parentUrns =
+                DataProductAncestorUtils.walkParentChain(
+                        context.getOperationContext(), _entityClient, sourceUrn)
+                    .stream()
+                    .filter(
+                        parentUrn ->
+                            canViewRelationship(
+                                context.getOperationContext(), parentUrn, sourceUrn))
+                    .collect(Collectors.toList());
+
+            final List<DataProduct> result = new ArrayList<>(parentUrns.size());
+            if (!parentUrns.isEmpty()) {
+              final Map<Urn, EntityResponse> responses =
+                  _entityClient.batchGetV2(
+                      context.getOperationContext(),
+                      Constants.DATA_PRODUCT_ENTITY_NAME,
+                      new HashSet<>(parentUrns),
+                      null,
+                      false);
+
+              for (Urn parentUrn : parentUrns) {
+                final EntityResponse response = responses.get(parentUrn);
+                final DataProduct stub = new DataProduct();
+                stub.setUrn(parentUrn.toString());
+                stub.setType(EntityType.DATA_PRODUCT);
+                if (response != null) {
+                  final EnvelopedAspect propsAspect =
+                      response.getAspects().get(Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME);
+                  if (propsAspect != null) {
+                    final DataProductProperties props =
+                        new DataProductProperties(propsAspect.getValue().data());
+                    final com.linkedin.datahub.graphql.generated.DataProductProperties gqlProps =
+                        new com.linkedin.datahub.graphql.generated.DataProductProperties();
+                    gqlProps.setName(props.hasName() ? props.getName() : parentUrn.getId());
+                    if (props.hasParentDataProduct() && props.getParentDataProduct() != null) {
+                      final DataProduct grandparentStub = new DataProduct();
+                      grandparentStub.setUrn(props.getParentDataProduct().toString());
+                      grandparentStub.setType(EntityType.DATA_PRODUCT);
+                      gqlProps.setParentDataProduct(grandparentStub);
+                    }
+                    stub.setProperties(gqlProps);
+                  }
+                }
+                result.add(stub);
+              }
+            }
+            return result;
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to load parent data products for " + sourceUrn, e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/UpdateDataProductResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/UpdateDataProductResolver.java
@@ -2,17 +2,20 @@ package com.linkedin.datahub.graphql.resolvers.dataproduct;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
-import com.datahub.authentication.Authentication;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.DataProduct;
 import com.linkedin.datahub.graphql.generated.UpdateDataProductInput;
 import com.linkedin.datahub.graphql.types.dataproduct.mappers.DataProductMapper;
 import com.linkedin.domain.Domains;
 import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.service.DataProductService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -25,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UpdateDataProductResolver implements DataFetcher<CompletableFuture<DataProduct>> {
 
   private final DataProductService _dataProductService;
+  private final EntityClient _entityClient;
 
   @Override
   public CompletableFuture<DataProduct> get(final DataFetchingEnvironment environment)
@@ -34,7 +38,6 @@ public class UpdateDataProductResolver implements DataFetcher<CompletableFuture<
     final UpdateDataProductInput input =
         bindArgument(environment.getArgument("input"), UpdateDataProductInput.class);
     final Urn dataProductUrn = UrnUtils.getUrn(environment.getArgument("urn"));
-    final Authentication authentication = context.getAuthentication();
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
@@ -53,12 +56,37 @@ public class UpdateDataProductResolver implements DataFetcher<CompletableFuture<
           }
 
           try {
+            final Urn parentDataProductUrn =
+                input.getParentDataProduct() != null
+                    ? UrnUtils.getUrn(input.getParentDataProduct())
+                    : null;
+            if (parentDataProductUrn != null) {
+              if (!parentDataProductUrn
+                  .getEntityType()
+                  .equals(Constants.DATA_PRODUCT_ENTITY_NAME)) {
+                throw new IllegalArgumentException("Parent entity is not a data product.");
+              }
+              if (!_dataProductService.verifyEntityExists(
+                  context.getOperationContext(), parentDataProductUrn)) {
+                throw new IllegalArgumentException("Parent Data Product does not exist");
+              }
+              if (parentDataProductUrn.equals(dataProductUrn)
+                  || DataProductAncestorUtils.walkParentChain(
+                          context.getOperationContext(), _entityClient, parentDataProductUrn)
+                      .contains(dataProductUrn)) {
+                throw new DataHubGraphQLException(
+                    "Cannot move a data product under one of its own descendants.",
+                    DataHubGraphQLErrorCode.BAD_REQUEST);
+              }
+            }
+
             final Urn urn =
                 _dataProductService.updateDataProduct(
                     context.getOperationContext(),
                     dataProductUrn,
                     input.getName(),
-                    input.getDescription());
+                    input.getDescription(),
+                    parentDataProductUrn);
             EntityResponse response =
                 _dataProductService.getDataProductEntityResponse(
                     context.getOperationContext(), urn);
@@ -68,6 +96,8 @@ public class UpdateDataProductResolver implements DataFetcher<CompletableFuture<
             // should never happen
             log.error(String.format("Unable to find data product with urn %s", dataProductUrn));
             return null;
+          } catch (DataHubGraphQLException e) {
+            throw e;
           } catch (Exception e) {
             throw new RuntimeException(
                 String.format("Failed to update DataProduct with urn %s", dataProductUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MoveDataProductResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MoveDataProductResolver.java
@@ -1,0 +1,120 @@
+package com.linkedin.datahub.graphql.resolvers.mutate;
+
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
+import com.linkedin.datahub.graphql.generated.MoveDataProductInput;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.resolvers.dataproduct.DataProductAncestorUtils;
+import com.linkedin.datahub.graphql.resolvers.dataproduct.DataProductAuthorizationUtils;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.EntityUtils;
+import com.linkedin.metadata.service.DataProductService;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MoveDataProductResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityService<?> _entityService;
+  private final EntityClient _entityClient;
+  private final DataProductService _dataProductService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final MoveDataProductInput input =
+        ResolverUtils.bindArgument(environment.getArgument("input"), MoveDataProductInput.class);
+    final QueryContext context = ResolverUtils.getQueryContext(environment);
+    final Urn resourceUrn = UrnUtils.getUrn(input.getResourceUrn());
+    final Urn newParentUrn =
+        input.getParentDataProduct() != null ? UrnUtils.getUrn(input.getParentDataProduct()) : null;
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            if (!resourceUrn.getEntityType().equals(Constants.DATA_PRODUCT_ENTITY_NAME)) {
+              throw new IllegalArgumentException("Resource is not a data product.");
+            }
+
+            final Domains domains =
+                _dataProductService.getDataProductDomains(
+                    context.getOperationContext(), resourceUrn);
+            if (!DataProductAuthorizationUtils.isAuthorizedToManageDataProductsOnAnyDomain(
+                context, domains)) {
+              throw new AuthorizationException(
+                  "Unauthorized to perform this action. Please contact your DataHub administrator.");
+            }
+
+            DataProductProperties properties =
+                (DataProductProperties)
+                    EntityUtils.getAspectFromEntity(
+                        context.getOperationContext(),
+                        resourceUrn.toString(),
+                        Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME,
+                        _entityService,
+                        null);
+
+            if (properties == null) {
+              throw new IllegalArgumentException("Data product properties do not exist.");
+            }
+
+            if (newParentUrn != null) {
+              if (!newParentUrn.getEntityType().equals(Constants.DATA_PRODUCT_ENTITY_NAME)) {
+                throw new IllegalArgumentException("Parent entity is not a data product.");
+              }
+              if (!_entityService.exists(context.getOperationContext(), newParentUrn, true)) {
+                throw new IllegalArgumentException("Parent entity does not exist.");
+              }
+              if (newParentUrn.equals(resourceUrn)
+                  || DataProductAncestorUtils.walkParentChain(
+                          context.getOperationContext(), _entityClient, newParentUrn)
+                      .contains(resourceUrn)) {
+                throw new DataHubGraphQLException(
+                    "Cannot move a data product under one of its own descendants.",
+                    DataHubGraphQLErrorCode.BAD_REQUEST);
+              }
+            }
+
+            properties.setParentDataProduct(newParentUrn, SetMode.REMOVE_IF_NULL);
+            Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
+            MutationUtils.persistAspect(
+                context.getOperationContext(),
+                resourceUrn,
+                Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME,
+                properties,
+                actor,
+                _entityService);
+            return true;
+          } catch (DataHubGraphQLException e) {
+            throw e;
+          } catch (Exception e) {
+            log.error(
+                "Failed to move data product {} to parent {} : {}",
+                input.getResourceUrn(),
+                input.getParentDataProduct(),
+                e.getMessage());
+            throw new RuntimeException(
+                String.format(
+                    "Failed to move data product %s to %s",
+                    input.getResourceUrn(), input.getParentDataProduct()),
+                e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
@@ -163,6 +163,14 @@ public class DataProductMapper implements ModelMapper<EntityResponse, DataProduc
 
     properties.setCreatedOn(createdAuditStamp);
 
+    if (dataProductProperties.hasParentDataProduct()
+        && dataProductProperties.getParentDataProduct() != null) {
+      final DataProduct parentStub = new DataProduct();
+      parentStub.setUrn(dataProductProperties.getParentDataProduct().toString());
+      parentStub.setType(EntityType.DATA_PRODUCT);
+      properties.setParentDataProduct(parentStub);
+    }
+
     dataProduct.setProperties(properties);
   }
 

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -674,6 +674,11 @@ type Mutation {
   moveDomain(input: MoveDomainInput!): Boolean
 
   """
+  Moves a data product to be parented under another data product.
+  """
+  moveDataProduct(input: MoveDataProductInput!): Boolean
+
+  """
   Delete a Domain
   """
   deleteDomain("The urn of the Domain to delete" urn: String!): Boolean
@@ -9686,6 +9691,21 @@ input MoveDomainInput {
 }
 
 """
+Input for updating the parent data product of a data product.
+"""
+input MoveDataProductInput {
+  """
+  The new parent data product urn. If parentDataProduct is null, this will remove the parent from this entity
+  """
+  parentDataProduct: String
+
+  """
+  The primary key of the resource to update the parent data product for
+  """
+  resourceUrn: String!
+}
+
+"""
 Input for updating the name of an entity
 """
 input UpdateNameInput {
@@ -13590,6 +13610,11 @@ type DataProduct implements Entity {
   Whether the Data Product exists in DataHub
   """
   exists: Boolean
+
+  """
+  All ancestor data products from immediate parent up to the root, ordered nearest-first.
+  """
+  parentDataProducts: [DataProduct!]!
 }
 
 """
@@ -13625,6 +13650,11 @@ type DataProductProperties {
   A Resolved Audit Stamp corresponding to the creation of this resource
   """
   createdOn: ResolvedAuditStamp
+
+  """
+  The direct parent Data Product in the taxonomy. Null for root Data Products.
+  """
+  parentDataProduct: DataProduct
 }
 
 """
@@ -13684,6 +13714,11 @@ input CreateDataProductPropertiesInput {
   An optional description for the DataProduct
   """
   description: String
+
+  """
+  Optional URN of the parent Data Product
+  """
+  parentDataProduct: String
 }
 
 """
@@ -13699,6 +13734,11 @@ input UpdateDataProductInput {
   An optional description for the DataProduct
   """
   description: String
+
+  """
+  Optional URN of the parent Data Product. If omitted, the existing parent is unchanged.
+  """
+  parentDataProduct: String
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/MoveDataProductResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/MoveDataProductResolverTest.java
@@ -1,0 +1,168 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.MoveDataProductInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.MoveDataProductResolver;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.service.DataProductService;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class MoveDataProductResolverTest {
+
+  private static final String DOMAIN_URN = "urn:li:domain:test-domain";
+  private static final String PARENT_URN = "urn:li:dataProduct:parent";
+  private static final String CHILD_URN = "urn:li:dataProduct:child";
+  private static final String GRANDCHILD_URN = "urn:li:dataProduct:grandchild";
+  private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
+
+  private static Domains domainsWith(String domainUrn) {
+    return new Domains().setDomains(new UrnArray(UrnUtils.getUrn(domainUrn)));
+  }
+
+  private static EntityResponse propsResponse(Urn urn, Urn parentUrn) {
+    DataProductProperties props = new DataProductProperties().setName(urn.getId());
+    if (parentUrn != null) {
+      props.setParentDataProduct(parentUrn);
+    }
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        DATA_PRODUCT_PROPERTIES_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(props.data())));
+    return new EntityResponse()
+        .setEntityName(DATA_PRODUCT_ENTITY_NAME)
+        .setUrn(urn)
+        .setAspects(new EnvelopedAspectMap(aspects));
+  }
+
+  private void stubResolveParent(EntityClient client, Urn urn, Urn parentUrn) throws Exception {
+    when(client.batchGetV2(
+            any(),
+            eq(DATA_PRODUCT_ENTITY_NAME),
+            eq(Collections.singleton(urn)),
+            eq(Collections.singleton(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)),
+            eq(false)))
+        .thenReturn(Collections.singletonMap(urn, propsResponse(urn, parentUrn)));
+  }
+
+  private void setupAuthorizedMove(
+      DataFetchingEnvironment mockEnv,
+      EntityService<?> mockService,
+      DataProductService mockDataProductService,
+      String resourceUrn)
+      throws Exception {
+    QueryContext mockContext = getMockAllowContext();
+    when(mockContext.getAuthentication()).thenReturn(mock(Authentication.class));
+    when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    when(mockService.getAspect(
+            any(),
+            eq(Urn.createFromString(resourceUrn)),
+            eq(DATA_PRODUCT_PROPERTIES_ASPECT_NAME),
+            eq(0L)))
+        .thenReturn(new DataProductProperties().setName("test"));
+
+    when(mockDataProductService.getDataProductDomains(any(), eq(UrnUtils.getUrn(resourceUrn))))
+        .thenReturn(domainsWith(DOMAIN_URN));
+  }
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    EntityService<?> mockService = mock(EntityService.class);
+    EntityClient mockClient = mock(EntityClient.class);
+    DataProductService mockDataProductService = mock(DataProductService.class);
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+
+    MoveDataProductInput input = new MoveDataProductInput(PARENT_URN, CHILD_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+    when(mockService.exists(any(OperationContext.class), eq(UrnUtils.getUrn(PARENT_URN)), eq(true)))
+        .thenReturn(true);
+    stubResolveParent(mockClient, UrnUtils.getUrn(PARENT_URN), null);
+    setupAuthorizedMove(mockEnv, mockService, mockDataProductService, CHILD_URN);
+
+    MoveDataProductResolver resolver =
+        new MoveDataProductResolver(mockService, mockClient, mockDataProductService);
+    assertTrue(resolver.get(mockEnv).get());
+    Mockito.verify(mockService, Mockito.times(1))
+        .ingestProposal(
+            any(),
+            Mockito.any(MetadataChangeProposal.class),
+            Mockito.any(AuditStamp.class),
+            Mockito.eq(false));
+  }
+
+  @Test
+  public void testRejectsSelfParent() throws Exception {
+    EntityService<?> mockService = mock(EntityService.class);
+    EntityClient mockClient = mock(EntityClient.class);
+    DataProductService mockDataProductService = mock(DataProductService.class);
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+
+    MoveDataProductInput input = new MoveDataProductInput(CHILD_URN, CHILD_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+    when(mockService.exists(any(OperationContext.class), eq(UrnUtils.getUrn(CHILD_URN)), eq(true)))
+        .thenReturn(true);
+    setupAuthorizedMove(mockEnv, mockService, mockDataProductService, CHILD_URN);
+
+    MoveDataProductResolver resolver =
+        new MoveDataProductResolver(mockService, mockClient, mockDataProductService);
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    verifyNoIngestProposal(mockService);
+  }
+
+  @Test
+  public void testRejectsMoveUnderDescendant() throws Exception {
+    EntityService<?> mockService = mock(EntityService.class);
+    EntityClient mockClient = mock(EntityClient.class);
+    DataProductService mockDataProductService = mock(DataProductService.class);
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+
+    // PARENT -> CHILD -> GRANDCHILD. Moving PARENT under GRANDCHILD must fail.
+    MoveDataProductInput input = new MoveDataProductInput(GRANDCHILD_URN, PARENT_URN);
+    when(mockEnv.getArgument("input")).thenReturn(input);
+    when(mockService.exists(
+            any(OperationContext.class), eq(UrnUtils.getUrn(GRANDCHILD_URN)), eq(true)))
+        .thenReturn(true);
+
+    stubResolveParent(mockClient, UrnUtils.getUrn(GRANDCHILD_URN), UrnUtils.getUrn(CHILD_URN));
+    stubResolveParent(mockClient, UrnUtils.getUrn(CHILD_URN), UrnUtils.getUrn(PARENT_URN));
+    stubResolveParent(mockClient, UrnUtils.getUrn(PARENT_URN), null);
+
+    setupAuthorizedMove(mockEnv, mockService, mockDataProductService, PARENT_URN);
+
+    MoveDataProductResolver resolver =
+        new MoveDataProductResolver(mockService, mockClient, mockDataProductService);
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    verifyNoIngestProposal(mockService);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/ParentDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/ParentDataProductsResolverTest.java
@@ -1,0 +1,143 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataProduct;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class ParentDataProductsResolverTest {
+
+  private static final Urn CHILD = UrnUtils.getUrn("urn:li:dataProduct:child");
+  private static final Urn PARENT = UrnUtils.getUrn("urn:li:dataProduct:parent");
+  private static final Urn ROOT = UrnUtils.getUrn("urn:li:dataProduct:root");
+
+  private static EntityResponse responseWithParent(Urn urn, Urn parentUrn) {
+    DataProductProperties props = new DataProductProperties().setName(urn.getId());
+    if (parentUrn != null) {
+      props.setParentDataProduct(parentUrn);
+    }
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(
+        DATA_PRODUCT_PROPERTIES_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(props.data())));
+    return new EntityResponse()
+        .setEntityName(DATA_PRODUCT_ENTITY_NAME)
+        .setUrn(urn)
+        .setAspects(new EnvelopedAspectMap(aspects));
+  }
+
+  private static void stubResolveParent(EntityClient client, Urn urn, Urn parentUrn)
+      throws Exception {
+    when(client.batchGetV2(
+            any(),
+            eq(DATA_PRODUCT_ENTITY_NAME),
+            eq(Collections.singleton(urn)),
+            eq(Collections.singleton(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)),
+            eq(false)))
+        .thenReturn(Collections.singletonMap(urn, responseWithParent(urn, parentUrn)));
+  }
+
+  @Test
+  public void testEmptyParents() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = getMockAllowContext();
+    stubResolveParent(mockClient, CHILD, null);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    DataProduct source = new DataProduct();
+    source.setUrn(CHILD.toString());
+    source.setType(EntityType.DATA_PRODUCT);
+    when(mockEnv.getSource()).thenReturn(source);
+
+    ParentDataProductsResolver resolver = new ParentDataProductsResolver(mockClient);
+    List<DataProduct> result = resolver.get(mockEnv).get();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testWalksParentChainNearestFirst() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = getMockAllowContext();
+
+    stubResolveParent(mockClient, CHILD, PARENT);
+    stubResolveParent(mockClient, PARENT, ROOT);
+    stubResolveParent(mockClient, ROOT, null);
+
+    Map<Urn, EntityResponse> hydrate = new HashMap<>();
+    hydrate.put(PARENT, responseWithParent(PARENT, ROOT));
+    hydrate.put(ROOT, responseWithParent(ROOT, null));
+    when(mockClient.batchGetV2(
+            any(), eq(DATA_PRODUCT_ENTITY_NAME), eq(Set.of(PARENT, ROOT)), eq(null), eq(false)))
+        .thenReturn(hydrate);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    DataProduct source = new DataProduct();
+    source.setUrn(CHILD.toString());
+    source.setType(EntityType.DATA_PRODUCT);
+    when(mockEnv.getSource()).thenReturn(source);
+
+    ParentDataProductsResolver resolver = new ParentDataProductsResolver(mockClient);
+    List<DataProduct> result = resolver.get(mockEnv).get();
+
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(0).getUrn(), PARENT.toString());
+    assertEquals(result.get(1).getUrn(), ROOT.toString());
+  }
+
+  @Test
+  public void testCycleVisitedSetStopsWalk() throws Exception {
+    EntityClient mockClient = mock(EntityClient.class);
+    QueryContext mockContext = getMockAllowContext();
+
+    // CHILD -> PARENT -> CHILD (cycle)
+    stubResolveParent(mockClient, CHILD, PARENT);
+    stubResolveParent(mockClient, PARENT, CHILD);
+
+    Map<Urn, EntityResponse> hydrate = new HashMap<>();
+    hydrate.put(PARENT, responseWithParent(PARENT, CHILD));
+    when(mockClient.batchGetV2(
+            any(), eq(DATA_PRODUCT_ENTITY_NAME), eq(Set.of(PARENT)), eq(null), eq(false)))
+        .thenReturn(hydrate);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    DataProduct source = new DataProduct();
+    source.setUrn(CHILD.toString());
+    source.setType(EntityType.DATA_PRODUCT);
+    when(mockEnv.getSource()).thenReturn(source);
+
+    ParentDataProductsResolver resolver = new ParentDataProductsResolver(mockClient);
+    List<DataProduct> result = resolver.get(mockEnv).get();
+
+    // Visited set includes CHILD from the start, so PARENT is returned once and walk stops
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).getUrn(), PARENT.toString());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/DataProductParentHierarchySearchTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/DataProductParentHierarchySearchTest.java
@@ -1,0 +1,87 @@
+package com.linkedin.metadata.dataproducts;
+
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
+import com.linkedin.metadata.utils.AuditStampUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Optional;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that a 3-level Data Product hierarchy indexes {@code parentDataProduct} / {@code
+ * hasParentDataProduct} correctly, including re-parent and clear-parent cases.
+ */
+public class DataProductParentHierarchySearchTest {
+
+  private static final OperationContext OP_CONTEXT =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+  private static final EntitySpec ENTITY_SPEC =
+      OP_CONTEXT.getEntityRegistry().getEntitySpec(DATA_PRODUCT_ENTITY_NAME);
+  private static final AspectSpec ASPECT_SPEC =
+      ENTITY_SPEC.getAspectSpec(DATA_PRODUCT_PROPERTIES_ASPECT_NAME);
+  private static final SearchDocumentTransformer TRANSFORMER =
+      new SearchDocumentTransformer(1000, 1000, 1000);
+
+  private static final Urn ROOT = UrnUtils.getUrn("urn:li:dataProduct:hierarchy-root");
+  private static final Urn MID = UrnUtils.getUrn("urn:li:dataProduct:hierarchy-mid");
+  private static final Urn LEAF = UrnUtils.getUrn("urn:li:dataProduct:hierarchy-leaf");
+
+  private Optional<ObjectNode> transform(Urn urn, DataProductProperties props) throws Exception {
+    return TRANSFORMER.transformAspect(
+        OP_CONTEXT, urn, props, ASPECT_SPEC, false, AuditStampUtils.createDefaultAuditStamp());
+  }
+
+  @Test
+  public void testThreeLevelCreateReparentAndClear() throws Exception {
+    // Create: root (no parent)
+    DataProductProperties rootProps = new DataProductProperties().setName("Root");
+    Optional<ObjectNode> rootDoc = transform(ROOT, rootProps);
+    assertTrue(rootDoc.isPresent());
+    assertFalse(rootDoc.get().path("hasParentDataProduct").asBoolean(false));
+    assertTrue(
+        !rootDoc.get().has("parentDataProduct")
+            || rootDoc.get().get("parentDataProduct").isNull());
+
+    // Create: mid under root
+    DataProductProperties midProps =
+        new DataProductProperties().setName("Mid").setParentDataProduct(ROOT);
+    Optional<ObjectNode> midDoc = transform(MID, midProps);
+    assertTrue(midDoc.isPresent());
+    assertTrue(midDoc.get().get("hasParentDataProduct").asBoolean());
+    assertEquals(midDoc.get().get("parentDataProduct").asText(), ROOT.toString());
+
+    // Create: leaf under mid
+    DataProductProperties leafProps =
+        new DataProductProperties().setName("Leaf").setParentDataProduct(MID);
+    Optional<ObjectNode> leafDoc = transform(LEAF, leafProps);
+    assertTrue(leafDoc.isPresent());
+    assertTrue(leafDoc.get().get("hasParentDataProduct").asBoolean());
+    assertEquals(leafDoc.get().get("parentDataProduct").asText(), MID.toString());
+
+    // Re-parent: leaf under root
+    DataProductProperties reparented =
+        new DataProductProperties().setName("Leaf").setParentDataProduct(ROOT);
+    Optional<ObjectNode> reparentedDoc = transform(LEAF, reparented);
+    assertTrue(reparentedDoc.isPresent());
+    assertTrue(reparentedDoc.get().get("hasParentDataProduct").asBoolean());
+    assertEquals(reparentedDoc.get().get("parentDataProduct").asText(), ROOT.toString());
+
+    // Clear parent (delete parent pointer / move to root of taxonomy)
+    DataProductProperties cleared = new DataProductProperties().setName("Leaf");
+    Optional<ObjectNode> clearedDoc = transform(LEAF, cleared);
+    assertTrue(clearedDoc.isPresent());
+    assertFalse(clearedDoc.get().path("hasParentDataProduct").asBoolean(false));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/DataProductParentHierarchySearchTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/DataProductParentHierarchySearchTest.java
@@ -51,8 +51,7 @@ public class DataProductParentHierarchySearchTest {
     assertTrue(rootDoc.isPresent());
     assertFalse(rootDoc.get().path("hasParentDataProduct").asBoolean(false));
     assertTrue(
-        !rootDoc.get().has("parentDataProduct")
-            || rootDoc.get().get("parentDataProduct").isNull());
+        !rootDoc.get().has("parentDataProduct") || rootDoc.get().get("parentDataProduct").isNull());
 
     // Create: mid under root
     DataProductProperties midProps =

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
@@ -68,6 +68,26 @@ public class DataProductService {
       @Nullable String id,
       @Nullable String name,
       @Nullable String description) {
+    return createDataProduct(opContext, id, name, description, null);
+  }
+
+  /**
+   * Creates a new Data Product with an optional parent.
+   *
+   * <p>Note that this method does not do authorization validation. It is assumed that users of this
+   * class have already authorized the operation.
+   *
+   * @param name optional name of the DataProduct
+   * @param description optional description of the DataProduct
+   * @param parentDataProduct optional parent Data Product URN
+   * @return the urn of the newly created DataProduct
+   */
+  public Urn createDataProduct(
+      @Nonnull OperationContext opContext,
+      @Nullable String id,
+      @Nullable String name,
+      @Nullable String description,
+      @Nullable Urn parentDataProduct) {
 
     // 1. Generate a unique id for the new DataProduct.
     final DataProductKey key = new DataProductKey();
@@ -89,6 +109,7 @@ public class DataProductService {
     final DataProductProperties properties = new DataProductProperties();
     properties.setName(name, SetMode.IGNORE_NULL);
     properties.setDescription(description, SetMode.IGNORE_NULL);
+    properties.setParentDataProduct(parentDataProduct, SetMode.IGNORE_NULL);
 
     // 3. Write the new dataProduct to GMS, return the new URN.
     try {
@@ -121,6 +142,23 @@ public class DataProductService {
       @Nonnull Urn urn,
       @Nullable String name,
       @Nullable String description) {
+    return updateDataProduct(opContext, urn, name, description, null);
+  }
+
+  /**
+   * Updates an existing DataProduct. If a provided field is null, the previous value will be kept.
+   * When {@code parentDataProduct} is non-null it is written; clearing the parent is done via
+   * {@code moveDataProduct}.
+   *
+   * <p>Note that this method does not do authorization validation. It is assumed that users of this
+   * class have already authorized the operation.
+   */
+  public Urn updateDataProduct(
+      @Nonnull OperationContext opContext,
+      @Nonnull Urn urn,
+      @Nullable String name,
+      @Nullable String description,
+      @Nullable Urn parentDataProduct) {
     Objects.requireNonNull(urn, "urn must not be null");
     Objects.requireNonNull(opContext.getSessionAuthentication(), "authentication must not be null");
 
@@ -139,6 +177,9 @@ public class DataProductService {
     }
     if (description != null) {
       properties.setDescription(description);
+    }
+    if (parentDataProduct != null) {
+      properties.setParentDataProduct(parentDataProduct);
     }
 
     // 3. Write changes to GMS


### PR DESCRIPTION
## Summary

- Stacked on #18890 (PR 1 — model + docs). This is PR 2 of the Data Product hierarchy work (CAT-2790 / CAT-2783).
- Extend GraphQL schema with `parentDataProduct` on properties/create/update inputs, `parentDataProducts` ancestor list on `DataProduct`, and `moveDataProduct` mutation.
- Hand-rolled parent walk (`DataProductAncestorUtils` / `ParentDataProductsResolver`, Metric pattern), `MoveDataProductResolver` with cycle guard, Create/Update threading, mapper + `GmsGraphQLEngine` wiring.
- Unit tests for parent walk + move cycle rejection; search transform coverage for `parentDataProduct` / `hasParentDataProduct`.
