### PR TITLE
feat(dataproducts): ingestion support for parent data products

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/dataproduct/dataproduct.py
+++ b/metadata-ingestion/src/datahub/api/entities/dataproduct/dataproduct.py
@@ -37,6 +37,11 @@ from datahub.utilities.registries.data_product_registry import DataProductRegist
 from datahub.utilities.registries.domain_registry import DomainRegistry
 from datahub.utilities.urns.urn import Urn
 
+_PARENT_CHAIN_MAX_DEPTH = 20
+_NESTING_CYCLE_ERROR = (
+    "Cannot nest a data product under itself or one of its own descendants."
+)
+
 
 def patch_list(
     orig_list: Optional[list],
@@ -82,6 +87,35 @@ def patch_resolved_urn_field(
         return False
     mutable_dictionary[field_name] = new_value
     return True
+
+
+def walk_parent_chain(graph: DataHubGraph, seed_urn: str) -> List[str]:
+    chain: List[str] = []
+    visited = {seed_urn}
+    current = _resolve_parent_urn(graph, seed_urn)
+    while (
+        current is not None
+        and current not in visited
+        and len(chain) < _PARENT_CHAIN_MAX_DEPTH
+    ):
+        chain.append(current)
+        visited.add(current)
+        current = _resolve_parent_urn(graph, current)
+    return chain
+
+
+def _resolve_parent_urn(graph: DataHubGraph, urn: str) -> Optional[str]:
+    props = graph.get_aspect(urn, DataProductPropertiesClass)
+    if props is None or not props.parentDataProduct:
+        return None
+    return props.parentDataProduct
+
+
+def assert_parent_is_not_descendant(
+    graph: DataHubGraph, child_urn: str, parent_urn: str
+) -> None:
+    if parent_urn == child_urn or child_urn in walk_parent_chain(graph, parent_urn):
+        raise ValueError(_NESTING_CYCLE_ERROR)
 
 
 class Ownership(ConfigModel):
@@ -302,6 +336,9 @@ class DataProduct(ConfigModel):
                 f"data product {self.parent_data_product} to an urn."
             )
 
+        if self._resolved_parent_data_product_urn == self.urn:
+            raise ValueError(_NESTING_CYCLE_ERROR)
+
         yield from self._generate_properties_mcp(upsert_mode=upsert)
 
         mcp = MetadataChangeProposalWrapper(
@@ -409,6 +446,11 @@ class DataProduct(ConfigModel):
                 )
                 parsed_data_product._resolved_parent_data_product_urn = (
                     builder.make_data_product_urn(parent_identifier)
+                )
+                assert_parent_is_not_descendant(
+                    graph,
+                    parsed_data_product.urn,
+                    parsed_data_product._resolved_parent_data_product_urn,
                 )
 
             parsed_data_product._original_yaml_dict = orig_dictionary

--- a/metadata-ingestion/src/datahub/api/entities/dataproduct/dataproduct.py
+++ b/metadata-ingestion/src/datahub/api/entities/dataproduct/dataproduct.py
@@ -33,6 +33,7 @@ from datahub.metadata.schema_classes import (
     TagAssociationClass,
 )
 from datahub.specific.dataproduct import DataProductPatchBuilder
+from datahub.utilities.registries.data_product_registry import DataProductRegistry
 from datahub.utilities.registries.domain_registry import DomainRegistry
 from datahub.utilities.urns.urn import Urn
 
@@ -65,6 +66,22 @@ def patch_list(
             for element_to_add in list_elements:
                 mutable_dictionary[field_name].append(element_to_add)
     return update_needed
+
+
+def patch_resolved_urn_field(
+    original_value: Optional[str],
+    new_value: Optional[str],
+    resolved_original: Optional[str],
+    mutable_dictionary: dict,
+    field_name: str,
+) -> bool:
+    """Update a YAML field that may be a bare name or URN, skipping if only the form differs."""
+    if original_value == new_value:
+        return False
+    if resolved_original == new_value:
+        return False
+    mutable_dictionary[field_name] = new_value
+    return True
 
 
 class Ownership(ConfigModel):
@@ -100,6 +117,7 @@ class DataProduct(ConfigModel):
         tags (Optional[List[str]]): An array of tags (either bare ids or urns) for the Data Product
         terms (Optional[List[str]]): An array of terms (either bare ids or urns) for the Data Product
         assets (List[str]): An array of entity urns that are part of the Data Product
+        parent_data_product (Optional[str]): Parent Data Product as a name or fully-qualified urn.
     """
 
     id: str
@@ -115,6 +133,8 @@ class DataProduct(ConfigModel):
     properties: Optional[Dict[str, LaxStr]] = None
     external_url: Optional[str] = None
     output_ports: Optional[List[str]] = None
+    parent_data_product: Optional[str] = None
+    _resolved_parent_data_product_urn: Optional[str] = None
     _original_yaml_dict: Optional[dict] = None
 
     @field_validator("assets", mode="before")
@@ -168,14 +188,21 @@ class DataProduct(ConfigModel):
         else:
             return f"urn:li:dataProduct:{self.id}"
 
-    # If domain is an urn, we cache it in the private _resolved_domain_urn field
-    # Otherwise, we expect the caller to populate this by using an external DomainRegistry
+    # If domain / parent_data_product is an urn, we cache it in the private resolved field.
+    # Otherwise, we expect the caller to populate this via DomainRegistry / DataProductRegistry.
     def __init__(self, **data):
         super().__init__(**data)
         if self.domain.startswith("urn:li:domain:"):
             self._resolved_domain_urn = self.domain
         else:
             self._resolved_domain_urn = None
+
+        if self.parent_data_product and self.parent_data_product.startswith(
+            "urn:li:dataProduct:"
+        ):
+            self._resolved_parent_data_product_urn = self.parent_data_product
+        else:
+            self._resolved_parent_data_product_urn = None
 
     def _mint_auditstamp(self, message: str) -> AuditStampClass:
         return AuditStampClass(
@@ -231,6 +258,11 @@ class DataProduct(ConfigModel):
                     external_url=self.external_url
                 )
 
+            if self._resolved_parent_data_product_urn is not None:
+                dataproduct_patch_builder.set_parent_data_product(
+                    parent_urn=self._resolved_parent_data_product_urn
+                )
+
             yield from dataproduct_patch_builder.build()
         else:
             mcp = MetadataChangeProposalWrapper(
@@ -248,6 +280,7 @@ class DataProduct(ConfigModel):
                     ],
                     customProperties=self.properties if self.properties else None,
                     externalUrl=self.external_url if self.external_url else None,
+                    parentDataProduct=self._resolved_parent_data_product_urn,
                 ),
             )
             yield mcp
@@ -258,6 +291,15 @@ class DataProduct(ConfigModel):
         if self._resolved_domain_urn is None:
             raise Exception(
                 f"Unable to generate MCP-s because we were unable to resolve the domain {self.domain} to an urn."
+            )
+
+        if (
+            self.parent_data_product is not None
+            and self._resolved_parent_data_product_urn is None
+        ):
+            raise Exception(
+                f"Unable to generate MCP-s because we were unable to resolve the parent "
+                f"data product {self.parent_data_product} to an urn."
             )
 
         yield from self._generate_properties_mcp(upsert_mode=upsert)
@@ -356,6 +398,19 @@ class DataProduct(ConfigModel):
             )
             domain_urn = domain_registry.get_domain_urn(parsed_data_product.domain)
             parsed_data_product._resolved_domain_urn = domain_urn
+
+            if parsed_data_product.parent_data_product:
+                data_product_registry = DataProductRegistry(
+                    cached_data_products=[parsed_data_product.parent_data_product],
+                    graph=graph,
+                )
+                parent_identifier = data_product_registry.get_data_product_urn(
+                    parsed_data_product.parent_data_product
+                )
+                parsed_data_product._resolved_parent_data_product_urn = (
+                    builder.make_data_product_urn(parent_identifier)
+                )
+
             parsed_data_product._original_yaml_dict = orig_dictionary
             return parsed_data_product
 
@@ -415,6 +470,11 @@ class DataProduct(ConfigModel):
             ]
             if data_product_properties
             else None,
+            parent_data_product=(
+                data_product_properties.parentDataProduct
+                if data_product_properties
+                else None
+            ),
         )
 
     def _patch_ownership(
@@ -514,11 +574,26 @@ class DataProduct(ConfigModel):
                 update_needed = True
                 orig_dictionary[simple_field] = this_dataproduct_dict.get(simple_field)
 
-        if original_dataproduct.domain != self.domain:
-            # we check if the resolved domain urn is the same
-            if original_dataproduct._resolved_domain_urn != self.domain:
-                update_needed = True
-                orig_dictionary["domain"] = self.domain
+        update_needed = (
+            patch_resolved_urn_field(
+                original_dataproduct.domain,
+                self.domain,
+                original_dataproduct._resolved_domain_urn,
+                orig_dictionary,
+                "domain",
+            )
+            or update_needed
+        )
+        update_needed = (
+            patch_resolved_urn_field(
+                original_dataproduct.parent_data_product,
+                self.parent_data_product,
+                original_dataproduct._resolved_parent_data_product_urn,
+                orig_dictionary,
+                "parent_data_product",
+            )
+            or update_needed
+        )
 
         if set(original_dataproduct.assets or []) != set(self.assets or []):
             update_needed = True

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -873,19 +873,15 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "filter": {"or": filters},
         }
         results: Dict = self._post_generic(self._search_endpoint, search_body)
-        num_entities = results.get("value", {}).get("numEntities", 0)
+        value = results.get("value", {})
+        entities = value.get("entities") or []
+        num_entities = value.get("numEntities", 0)
         if num_entities > 1:
             logger.warning(
                 f"Got {num_entities} results for data product name {data_product_name}. "
                 f"Will return the first match."
             )
-        entities_yielded: int = 0
-        entities = []
-        for x in results["value"]["entities"]:
-            entities_yielded += 1
-            logger.debug(f"yielding {x['entity']}")
-            entities.append(x["entity"])
-        return entities[0] if entities_yielded else None
+        return entities[0]["entity"] if entities else None
 
     def get_connection_json(self, urn: str) -> Optional[dict]:
         """Retrieve a connection config.

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -852,6 +852,41 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             entities.append(x["entity"])
         return entities[0] if entities_yielded else None
 
+    def get_data_product_urn_by_name(self, data_product_name: str) -> Optional[str]:
+        """Retrieve a data product urn based on its name. Returns None if there is no match found"""
+
+        filters = []
+        filter_criteria = [
+            {
+                "field": "name",
+                "values": [data_product_name],
+                "condition": "EQUAL",
+            }
+        ]
+
+        filters.append({"and": filter_criteria})
+        search_body = {
+            "input": "*",
+            "entity": "dataProduct",
+            "start": 0,
+            "count": 10,
+            "filter": {"or": filters},
+        }
+        results: Dict = self._post_generic(self._search_endpoint, search_body)
+        num_entities = results.get("value", {}).get("numEntities", 0)
+        if num_entities > 1:
+            logger.warning(
+                f"Got {num_entities} results for data product name {data_product_name}. "
+                f"Will return the first match."
+            )
+        entities_yielded: int = 0
+        entities = []
+        for x in results["value"]["entities"]:
+            entities_yielded += 1
+            logger.debug(f"yielding {x['entity']}")
+            entities.append(x["entity"])
+        return entities[0] if entities_yielded else None
+
     def get_connection_json(self, urn: str) -> Optional[dict]:
         """Retrieve a connection config.
 

--- a/metadata-ingestion/src/datahub/specific/dataproduct.py
+++ b/metadata-ingestion/src/datahub/specific/dataproduct.py
@@ -105,3 +105,12 @@ class DataProductPatchBuilder(
             value=external_url,
         )
         return self
+
+    def set_parent_data_product(self, parent_urn: str) -> "DataProductPatchBuilder":
+        self._add_patch(
+            DataProductProperties.ASPECT_NAME,
+            "add",
+            path=("parentDataProduct",),
+            value=parent_urn,
+        )
+        return self

--- a/metadata-ingestion/src/datahub/utilities/registries/data_product_registry.py
+++ b/metadata-ingestion/src/datahub/utilities/registries/data_product_registry.py
@@ -1,10 +1,19 @@
 import logging
+import uuid
 from typing import Dict, List, Optional
 
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import DataProductPropertiesClass
 
 logger = logging.getLogger(__name__)
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        return False
+    return True
 
 
 class DataProductRegistry:
@@ -17,18 +26,18 @@ class DataProductRegistry:
     ):
         self.data_product_registry: Dict[str, str] = {}
         if cached_data_products:
-            # Isolate identifiers that don't look fully specified (URN or UUID-like id).
+            # Isolate identifiers that don't look fully specified (URN or UUID id).
             needing_resolution = [
                 d
                 for d in cached_data_products
-                if (not d.startswith("urn:li:dataProduct") and d.count("-") != 4)
+                if (not d.startswith("urn:li:dataProduct") and not _is_uuid(d))
             ]
             if needing_resolution and not graph:
                 raise ValueError(
                     f"Following data products need server-side resolution {needing_resolution} "
-                    f"but a DataHub server wasn't provided. Either use fully qualified data "
-                    f"product urns (e.g. urn:li:dataProduct:my_product) or provide a "
-                    f"datahub_api config in your recipe."
+                    f"but a DataHub server wasn't provided. Either use a fully qualified data "
+                    f"product urn (e.g. urn:li:dataProduct:my_product) or a UUID id, or ensure "
+                    f"the CLI is connected to DataHub (e.g. via datahub init)."
                 )
             for identifier in needing_resolution:
                 assert graph

--- a/metadata-ingestion/src/datahub/utilities/registries/data_product_registry.py
+++ b/metadata-ingestion/src/datahub/utilities/registries/data_product_registry.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Dict, List, Optional
+
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import DataProductPropertiesClass
+
+logger = logging.getLogger(__name__)
+
+
+class DataProductRegistry:
+    """Resolve Data Product identifiers (name or id) to URNs using DataHub."""
+
+    def __init__(
+        self,
+        cached_data_products: Optional[List[str]] = None,
+        graph: Optional[DataHubGraph] = None,
+    ):
+        self.data_product_registry: Dict[str, str] = {}
+        if cached_data_products:
+            # Isolate identifiers that don't look fully specified (URN or UUID-like id).
+            needing_resolution = [
+                d
+                for d in cached_data_products
+                if (not d.startswith("urn:li:dataProduct") and d.count("-") != 4)
+            ]
+            if needing_resolution and not graph:
+                raise ValueError(
+                    f"Following data products need server-side resolution {needing_resolution} "
+                    f"but a DataHub server wasn't provided. Either use fully qualified data "
+                    f"product urns (e.g. urn:li:dataProduct:my_product) or provide a "
+                    f"datahub_api config in your recipe."
+                )
+            for identifier in needing_resolution:
+                assert graph
+                maybe_urn = f"urn:li:dataProduct:{identifier}"
+                maybe_properties = graph.get_aspect(
+                    maybe_urn, DataProductPropertiesClass
+                )
+                if maybe_properties:
+                    self.data_product_registry[identifier] = maybe_urn
+                else:
+                    data_product_urn = graph.get_data_product_urn_by_name(identifier)
+                    if data_product_urn:
+                        self.data_product_registry[identifier] = data_product_urn
+                    else:
+                        logger.error(
+                            f"Failed to retrieve data product id for {identifier}"
+                        )
+                        raise ValueError(
+                            f"data product {identifier} doesn't seem to be provisioned on "
+                            f"DataHub. Either provision it first and re-run, or provide a "
+                            f"fully qualified data product urn "
+                            f"(e.g. urn:li:dataProduct:my_product) to skip this check."
+                        )
+
+    def get_data_product_urn(self, data_product_identifier: str) -> str:
+        return (
+            self.data_product_registry.get(data_product_identifier)
+            or data_product_identifier
+        )

--- a/metadata-ingestion/tests/test_helpers/graph_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/graph_helpers.py
@@ -18,6 +18,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
 )
 from datahub.metadata.schema_classes import (
     ASPECT_NAME_MAP,
+    DataProductPropertiesClass,
     DomainPropertiesClass,
     SystemMetadataClass,
     UsageAggregationClass,
@@ -100,6 +101,30 @@ class MockDataHubGraph(DataHubGraph):
             urn
             for urn, name in domain_properties_metadata.items()
             if name == domain_name
+        ]
+        if urn_match:
+            return urn_match[0]
+        else:
+            return None
+
+    def get_data_product_urn_by_name(self, data_product_name: str) -> Optional[str]:
+        data_product_metadata = {
+            urn: metadata
+            for urn, metadata in self.entity_graph.items()
+            if urn.startswith("urn:li:dataProduct:")
+        }
+        data_product_properties_metadata = {
+            urn: metadata["dataProductProperties"].name
+            for urn, metadata in data_product_metadata.items()
+            if "dataProductProperties" in metadata
+            and isinstance(
+                metadata["dataProductProperties"], DataProductPropertiesClass
+            )
+        }
+        urn_match = [
+            urn
+            for urn, name in data_product_properties_metadata.items()
+            if name == data_product_name
         ]
         if urn_match:
             return urn_match[0]

--- a/metadata-ingestion/tests/unit/api/entities/dataproducts/dataproduct_with_parent.yaml
+++ b/metadata-ingestion/tests/unit/api/entities/dataproducts/dataproduct_with_parent.yaml
@@ -1,0 +1,12 @@
+id: portfolio_analytics
+domain: Marketing
+display_name: Portfolio Analytics
+description: Internal product derived from the vendor equities feed.
+parent_data_product: urn:li:dataProduct:vendor_equities
+
+assets:
+  - urn:li:container:DATABASE
+
+owners:
+  - id: urn:li:corpuser:jdoe
+    type: BUSINESS_OWNER

--- a/metadata-ingestion/tests/unit/api/entities/dataproducts/dataproduct_with_parent_by_name.yaml
+++ b/metadata-ingestion/tests/unit/api/entities/dataproducts/dataproduct_with_parent_by_name.yaml
@@ -1,0 +1,8 @@
+id: portfolio_analytics
+domain: Marketing
+display_name: Portfolio Analytics
+description: Internal product derived from the vendor equities feed.
+parent_data_product: Vendor Equities
+
+assets:
+  - urn:li:container:DATABASE

--- a/metadata-ingestion/tests/unit/api/entities/dataproducts/test_dataproduct.py
+++ b/metadata-ingestion/tests/unit/api/entities/dataproducts/test_dataproduct.py
@@ -1,4 +1,5 @@
 import difflib
+import json
 from pathlib import Path
 from typing import Any, Dict
 
@@ -6,11 +7,16 @@ import pytest
 import time_machine
 
 from datahub.api.entities.dataproduct.dataproduct import DataProduct
-from datahub.metadata.schema_classes import DomainPropertiesClass
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DataProductPropertiesClass,
+    DomainPropertiesClass,
+)
 from datahub.testing.mce_helpers import check_golden_file
 from tests.test_helpers.graph_helpers import MockDataHubGraph
 
 FROZEN_TIME = "2023-04-14 07:00:00+00:00"
+PARENT_DATA_PRODUCT_URN = "urn:li:dataProduct:vendor_equities"
 
 
 @pytest.fixture
@@ -20,7 +26,13 @@ def base_entity_metadata():
             "domainProperties": DomainPropertiesClass(
                 name="Marketing", description="Marketing Domain"
             )
-        }
+        },
+        PARENT_DATA_PRODUCT_URN: {
+            "dataProductProperties": DataProductPropertiesClass(
+                name="Vendor Equities",
+                description="Vendor equities feed",
+            )
+        },
     }
 
 
@@ -213,6 +225,84 @@ def test_dataproduct_ownership_type_urn_patch_yaml(
         str(dataproduct_output_file),
         str(test_resources_dir / "dataproduct_ownership_type_urn.yaml"),
     )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@pytest.mark.parametrize(
+    "data_product_filename",
+    [
+        "dataproduct_with_parent.yaml",
+        "dataproduct_with_parent_by_name.yaml",
+    ],
+    ids=["parent_urn", "parent_name"],
+)
+def test_dataproduct_parent_from_yaml(
+    test_resources_dir: Path,
+    base_mock_graph: MockDataHubGraph,
+    data_product_filename: str,
+) -> None:
+    data_product = DataProduct.from_yaml(
+        test_resources_dir / data_product_filename, base_mock_graph
+    )
+    assert data_product._resolved_parent_data_product_urn == PARENT_DATA_PRODUCT_URN
+
+    mcps = list(data_product.generate_mcp(upsert=False))
+    properties_mcp = next(
+        mcp
+        for mcp in mcps
+        if isinstance(mcp, MetadataChangeProposalWrapper)
+        and mcp.aspectName == "dataProductProperties"
+    )
+    assert isinstance(properties_mcp.aspect, DataProductPropertiesClass)
+    assert properties_mcp.aspect.parentDataProduct == PARENT_DATA_PRODUCT_URN
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_dataproduct_parent_upsert_from_yaml(
+    test_resources_dir: Path,
+    base_mock_graph: MockDataHubGraph,
+) -> None:
+    data_product = DataProduct.from_yaml(
+        test_resources_dir / "dataproduct_with_parent.yaml", base_mock_graph
+    )
+    mcps = list(data_product.generate_mcp(upsert=True))
+    properties_mcp = next(
+        mcp
+        for mcp in mcps
+        if getattr(mcp, "aspectName", None) == "dataProductProperties"
+    )
+    patch_ops = json.loads(properties_mcp.aspect.value)  # type: ignore[union-attr]
+    assert {
+        "op": "add",
+        "path": "/parentDataProduct",
+        "value": PARENT_DATA_PRODUCT_URN,
+    } in patch_ops
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+def test_dataproduct_parent_round_trip_from_datahub(
+    test_resources_dir: Path,
+    base_mock_graph: MockDataHubGraph,
+) -> None:
+    data_product = DataProduct.from_yaml(
+        test_resources_dir / "dataproduct_with_parent.yaml", base_mock_graph
+    )
+    for mcp in data_product.generate_mcp(upsert=False):
+        if (
+            isinstance(mcp, MetadataChangeProposalWrapper)
+            and mcp.entityUrn
+            and mcp.aspectName
+            and mcp.aspect
+        ):
+            if mcp.entityUrn not in base_mock_graph.entity_graph:
+                base_mock_graph.entity_graph[mcp.entityUrn] = {}
+            base_mock_graph.entity_graph[mcp.entityUrn][mcp.aspectName] = mcp.aspect
+
+    loaded = DataProduct.from_datahub(
+        base_mock_graph, id="urn:li:dataProduct:portfolio_analytics"
+    )
+    assert loaded.parent_data_product == PARENT_DATA_PRODUCT_URN
+    assert loaded._resolved_parent_data_product_urn == PARENT_DATA_PRODUCT_URN
 
 
 def test_dataproduct_output_ports_validation_not_urn(

--- a/metadata-ingestion/tests/unit/api/entities/dataproducts/test_dataproduct.py
+++ b/metadata-ingestion/tests/unit/api/entities/dataproducts/test_dataproduct.py
@@ -305,6 +305,65 @@ def test_dataproduct_parent_round_trip_from_datahub(
     assert loaded._resolved_parent_data_product_urn == PARENT_DATA_PRODUCT_URN
 
 
+def _write_parent_yaml(tmp_path: Path, product_id: str, parent: str) -> Path:
+    path = tmp_path / f"{product_id}.yaml"
+    path.write_text(
+        "\n".join(
+            [
+                f"id: {product_id}",
+                "domain: Marketing",
+                f"parent_data_product: {parent}",
+                "assets:",
+                "  - urn:li:container:DATABASE",
+                "",
+            ]
+        )
+    )
+    return path
+
+
+def test_dataproduct_rejects_self_parent_from_yaml(
+    tmp_path: Path,
+    base_mock_graph: MockDataHubGraph,
+) -> None:
+    yaml_file = _write_parent_yaml(tmp_path, "vendor_equities", PARENT_DATA_PRODUCT_URN)
+    with pytest.raises(ValueError, match="Cannot nest a data product"):
+        DataProduct.from_yaml(yaml_file, base_mock_graph)
+
+
+def test_dataproduct_rejects_descendant_parent_from_yaml(
+    tmp_path: Path,
+    base_mock_graph: MockDataHubGraph,
+) -> None:
+    research_urn = "urn:li:dataProduct:research"
+    leaf_urn = "urn:li:dataProduct:portfolio_analytics"
+    base_mock_graph.entity_graph[research_urn] = {
+        "dataProductProperties": DataProductPropertiesClass(
+            name="Research",
+            parentDataProduct=PARENT_DATA_PRODUCT_URN,
+        )
+    }
+    base_mock_graph.entity_graph[leaf_urn] = {
+        "dataProductProperties": DataProductPropertiesClass(
+            name="Portfolio Analytics",
+            parentDataProduct=research_urn,
+        )
+    }
+    yaml_file = _write_parent_yaml(tmp_path, "vendor_equities", leaf_urn)
+    with pytest.raises(ValueError, match="Cannot nest a data product"):
+        DataProduct.from_yaml(yaml_file, base_mock_graph)
+
+
+def test_dataproduct_rejects_self_parent_on_generate_mcp() -> None:
+    data_product = DataProduct(
+        id="vendor_equities",
+        domain="urn:li:domain:12345",
+        parent_data_product=PARENT_DATA_PRODUCT_URN,
+    )
+    with pytest.raises(ValueError, match="Cannot nest a data product"):
+        list(data_product.generate_mcp(upsert=False))
+
+
 def test_dataproduct_output_ports_validation_not_urn(
     base_mock_graph: MockDataHubGraph,
 ) -> None:

--- a/metadata-ingestion/tests/unit/patch/test_patch_builder.py
+++ b/metadata-ingestion/tests/unit/patch/test_patch_builder.py
@@ -30,6 +30,7 @@ from datahub.metadata.schema_classes import (
 from datahub.specific.chart import ChartPatchBuilder
 from datahub.specific.dashboard import DashboardPatchBuilder
 from datahub.specific.datajob import DataJobPatchBuilder
+from datahub.specific.dataproduct import DataProductPatchBuilder
 from datahub.specific.dataset import DatasetPatchBuilder
 from datahub.testing import mce_helpers
 
@@ -195,6 +196,26 @@ def test_complex_dataset_patch(
         out_path,
         pytestconfig.rootpath / "tests/unit/patch/complex_dataset_patch.json",
     )
+
+
+def test_dataproduct_set_parent_data_product():
+    parent_urn = "urn:li:dataProduct:vendor_equities"
+    patcher = DataProductPatchBuilder(
+        "urn:li:dataProduct:portfolio_analytics"
+    ).set_parent_data_product(parent_urn)
+
+    mcps = patcher.build()
+    assert len(mcps) == 1
+    assert mcps[0].entityUrn == "urn:li:dataProduct:portfolio_analytics"
+    assert mcps[0].aspectName == "dataProductProperties"
+    payload = json.loads(mcps[0].aspect.value)  # type: ignore[union-attr]
+    assert payload == [
+        {
+            "op": "add",
+            "path": "/parentDataProduct",
+            "value": parent_urn,
+        }
+    ]
 
 
 def test_basic_chart_patch_builder():

--- a/metadata-ingestion/tests/unit/utilities/test_data_product_registry.py
+++ b/metadata-ingestion/tests/unit/utilities/test_data_product_registry.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict
+
+import pytest
+
+from datahub.metadata.schema_classes import DataProductPropertiesClass
+from datahub.utilities.registries.data_product_registry import DataProductRegistry
+from tests.test_helpers.graph_helpers import MockDataHubGraph
+
+PARENT_URN = "urn:li:dataProduct:north_america_finance"
+
+
+@pytest.fixture
+def mock_graph() -> MockDataHubGraph:
+    entity_graph: Dict[str, Dict[str, Any]] = {
+        PARENT_URN: {
+            "dataProductProperties": DataProductPropertiesClass(
+                name="North-America-Finance-Data-Platform",
+            )
+        }
+    }
+    return MockDataHubGraph(entity_graph=entity_graph)
+
+
+def test_resolves_display_name_with_four_hyphens(mock_graph: MockDataHubGraph) -> None:
+    registry = DataProductRegistry(
+        cached_data_products=["North-America-Finance-Data-Platform"],
+        graph=mock_graph,
+    )
+    assert (
+        registry.get_data_product_urn("North-America-Finance-Data-Platform")
+        == PARENT_URN
+    )
+
+
+def test_uuid_identifier_skips_server_resolution() -> None:
+    uuid_id = "ec428203-ce86-4db3-985d-5a8ee6df32ba"
+    registry = DataProductRegistry(cached_data_products=[uuid_id], graph=None)
+    assert registry.get_data_product_urn(uuid_id) == uuid_id
+
+
+def test_unprovisioned_name_raises(mock_graph: MockDataHubGraph) -> None:
+    with pytest.raises(ValueError, match="doesn't seem to be provisioned"):
+        DataProductRegistry(cached_data_products=["Missing Product"], graph=mock_graph)
+
+
+def test_name_without_graph_raises() -> None:
+    with pytest.raises(ValueError, match="need server-side resolution"):
+        DataProductRegistry(cached_data_products=["Vendor Equities"], graph=None)


### PR DESCRIPTION
## Summary

- Add `set_parent_data_product` to `DataProductPatchBuilder` for patching `parentDataProduct`
- Add optional `parent_data_product` YAML/CLI field on the Data Product entity, resolved by name or URN (mirrors `domain` via a new `DataProductRegistry` + `get_data_product_urn_by_name`)
- Unit tests for the patch builder and YAML round-trip (URN and display-name resolution)

Depends on model/codegen from #18890 (`parentDataProduct` on `DataProductProperties`). 

Linear: [CAT-2791](https://linear.app/acryl-data/issue/CAT-2791/data-product-hierarchy-ingestion-python-sdk-patchbuilder-yamlcli-tests)
