### PR TITLE
feat(ui/lineage): Show hidden column lineage counts beside columns

### DIFF
--- a/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
@@ -68,7 +68,7 @@ export default function LineageDisplay({
     useBulkDataProductMemberships();
 
     const { highlightedNodes, highlightedEdges } = useNodeHighlighting(hoveredNode, displayedAdjacencyList);
-    const { cllHighlightedNodes, highlightedColumns } = useColumnHighlighting(
+    const { cllHighlightedNodes, highlightedColumns, shownRelatedColumns } = useColumnHighlighting(
         selectedColumn,
         hoveredColumn,
         fineGrainedLineage.indirect,
@@ -141,6 +141,7 @@ export default function LineageDisplay({
                 highlightedNodes,
                 cllHighlightedNodes,
                 highlightedColumns,
+                shownRelatedColumns,
                 highlightedEdges,
                 fineGrainedLineage: fineGrainedLineage.indirect,
                 fineGrainedOperations: fineGrainedLineage.fineGrainedOperations,

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.hooks.ts
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.hooks.ts
@@ -1,0 +1,114 @@
+import { useCallback, useContext, useMemo, useRef } from 'react';
+
+import { DBT_URN } from '@app/ingestV2/source/builder/constants';
+import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
+import {
+    LineageNodesContext,
+    generateIgnoreAsHops,
+    getSiblingUrns,
+    useIgnoreSchemaFieldStatus,
+} from '@app/lineageV3/common';
+import { ColumnAsset } from '@app/lineageV3/types';
+import { DEGREE_FILTER_NAME } from '@app/search/utils/constants';
+
+import { useGetColumnLineageCountsLazyQuery } from '@graphql/lineage.generated';
+import { AndFilterInput, EntityType, FacetFilterInput, FilterOperator } from '@types';
+
+/** Field holding a schema field's parent dataset urn. Schema fields have no platform field. */
+const PARENT_FILTER_NAME = 'parent';
+
+/**
+ * Filters that keep a column's related column count comparable to the columns the graph draws:
+ * only direct relations, and none belonging to a node the graph never draws on its own. Those are
+ * dbt models, which the graph walks through as hops, and `mergedUrns` -- siblings, which are drawn
+ * folded into the node they are a sibling of. Without this, a column whose only extra "relation" is
+ * its own dbt sibling reads as `1 / 2`.
+ */
+export function buildRelatedColumnFilters(mergedUrns: Set<string>): AndFilterInput[] {
+    const and: FacetFilterInput[] = [
+        { field: DEGREE_FILTER_NAME, values: ['1'] },
+        // Matched inside the parent urn, as the platform is not indexed for schema fields
+        { field: PARENT_FILTER_NAME, values: [DBT_URN], condition: FilterOperator.Contain, negated: true },
+    ];
+    if (mergedUrns.size) {
+        and.push({ field: PARENT_FILTER_NAME, values: Array.from(mergedUrns), negated: true });
+    }
+    return [{ and }];
+}
+
+/** Urns drawn as part of `urn`'s node rather than as nodes of their own, i.e. its siblings. */
+function useMergedUrns(urn: string): Set<string> {
+    const { nodes, dataVersion } = useContext(LineageNodesContext);
+    return useMemo(() => {
+        return new Set(getSiblingUrns(urn, nodes));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [nodes, urn, dataVersion]);
+}
+
+/**
+ * Fetches how much lineage a column has in each direction, writing the counts onto its
+ * `lineageAsset`. Requests are debounced and cancellable, as they are driven by hover.
+ */
+export default function useFetchColumnCounts(
+    parentUrn: string,
+    schemaFieldUrn: string,
+    lineageAsset: ColumnAsset,
+    onDisabled: () => void,
+) {
+    const { rootType, showGhostEntities, setColumnEdgeVersion } = useContext(LineageNodesContext);
+    const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
+    const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
+    const mergedUrns = useMergedUrns(parentUrn);
+
+    // Counts are written through a ref: the graph rebuilds its column assets as it fetches, so the
+    // asset captured when the request went out may no longer be the one being rendered
+    const assetToWrite = useRef(lineageAsset);
+    assetToWrite.current = lineageAsset;
+
+    const [fetchCounts, { loading }] = useGetColumnLineageCountsLazyQuery({
+        variables: {
+            urn: schemaFieldUrn,
+            startTimeMillis,
+            endTimeMillis,
+            // Same hops the graph walks through, so the counts match the columns it draws. The
+            // schema field entry is dropped: GMS fails to read a platform from a schema field urn.
+            ignoreAsHops: generateIgnoreAsHops(rootType).filter((hop) => hop.entityType !== EntityType.SchemaField),
+            includeSoftDeleted: showGhostEntities || ignoreSchemaFieldStatus,
+            orFilters: buildRelatedColumnFilters(mergedUrns),
+        },
+        onCompleted: (data) => {
+            const asset = assetToWrite.current;
+            asset.lineageCountsFetched = true;
+            asset.numUpstream = data.upstream?.total ?? 0;
+            asset.numDownstream = data.downstream?.total ?? 0;
+            if (!asset.numUpstream && !asset.numDownstream) {
+                onDisabled();
+            }
+            setColumnEdgeVersion((v) => v + 1);
+        },
+    });
+
+    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const cancelRequest = useCallback(() => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+        }
+    }, []);
+    const initiateRequest = useCallback(
+        (delay = 0) => {
+            // Guarded on the counts themselves rather than `lineageCountsFetched`, which is also set
+            // without fetching anything once all of a node's neighbors are loaded. A request already
+            // waiting is left alone, so that re-rendering -- which the graph does plenty of -- can
+            // never restart the delay out from under it.
+            if (lineageAsset.numUpstream === undefined && !loading && timeoutRef.current === null) {
+                timeoutRef.current = setTimeout(() => {
+                    timeoutRef.current = null;
+                    fetchCounts();
+                }, delay);
+            }
+        },
+        [lineageAsset.numUpstream, fetchCounts, loading],
+    );
+    return { initiateRequest, cancelRequest, loading };
+}

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
@@ -11,10 +11,12 @@ import { EventType } from '@app/analytics';
 import analytics from '@app/analytics/analytics';
 import { generateSchemaFieldUrn } from '@app/entityV2/shared/tabs/Lineage/utils';
 import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
-import { LineageDisplayColumn } from '@app/lineageV3/LineageEntityNode/useDisplayedColumns';
+import { ColumnLineageControl } from '@app/lineageV3/LineageEntityNode/ColumnLineageControl';
+import { LineageDisplayColumn, columnHasLineage } from '@app/lineageV3/LineageEntityNode/useDisplayedColumns';
 import {
     LineageNodesContext,
     createColumnRef,
+    generateIgnoreAsHops,
     onClickPreventSelect,
     useIgnoreSchemaFieldStatus,
 } from '@app/lineageV3/common';
@@ -23,14 +25,20 @@ import { useGetLineageUrl } from '@app/lineageV3/utils/lineageUtils';
 import { CompactFieldIconWithTooltip } from '@app/sharedV2/icons/CompactFieldIcon';
 import { useAppConfig } from '@app/useAppConfig';
 
-import { useGetLineageCountsLazyQuery } from '@graphql/lineage.generated';
-import { EntityType } from '@types';
+import { useGetColumnLineageCountsLazyQuery } from '@graphql/lineage.generated';
+import { EntityType, LineageDirection } from '@types';
 
 import LinkOut from '@images/link-out.svg?react';
 
 const HOVER_REQUEST_DELAY = 300;
 
 const LinkOutIcon = styled(LinkOut)``;
+
+// Anchors the column's lineage controls, which render outside the node on either side
+const ColumnPositioner = styled.div`
+    position: relative;
+    width: 100%;
+`;
 
 const ColumnWrapper = styled.div<{
     selected: boolean;
@@ -126,10 +134,11 @@ export default function Column({
     entityType,
     fieldPath,
     highlighted,
-    hasLineage,
+    connectedToHomeNode,
     type,
     nativeDataType,
     lineageAsset,
+    shownRelated,
     allNeighborsFetched,
     selectedColumn,
     setSelectedColumn,
@@ -140,6 +149,8 @@ export default function Column({
     const { config } = useAppConfig();
     const id = useMemo(() => createColumnRef(parentUrn, fieldPath), [parentUrn, fieldPath]);
     const selected = selectedColumn === id;
+    // Lineage filter nodes cover hidden column lineage themselves, with an edge to the filter node
+    const showLineageControls = !!shownRelated && !config.featureFlags.showLineageFilterNodes;
 
     let columnName = fieldPath;
     try {
@@ -160,6 +171,9 @@ export default function Column({
         lineageAsset,
         turnOnDisabledTooltipOnHover,
     );
+    // Recomputed here rather than taken from props: counts are written onto `lineageAsset` when the
+    // query resolves, which re-renders this component but leaves its props stale
+    const hasLineage = columnHasLineage(lineageAsset, connectedToHomeNode);
     const isFullyFetched = lineageAsset.lineageCountsFetched || allNeighborsFetched;
     const showAsDisabled = !hasLineage && isFullyFetched;
 
@@ -171,6 +185,13 @@ export default function Column({
             setTimeout(() => setShowDisabledTooltipOnSelect(false), 3000);
         }
     }, [selectedColumn, id, hasLineage, isFullyFetched, setSelectedColumn]);
+
+    // Counts back the controls of every column in the traversal, not just the one under the cursor
+    useEffect(() => {
+        if (!showLineageControls || isFullyFetched) return undefined;
+        initiateRequest(HOVER_REQUEST_DELAY);
+        return cancelRequest;
+    }, [showLineageControls, isFullyFetched, initiateRequest, cancelRequest]);
 
     const handleMouseEnter = useCallback(() => {
         if (!selectedColumn && !showAsDisabled) {
@@ -190,62 +211,80 @@ export default function Column({
 
     // TODO: Add hover text if overflowed
     const contents = (
-        <ColumnWrapper
-            highlighted={highlighted && !showAsDisabled}
-            fromSelect={!!selectedColumn}
-            selected={selected}
-            disabled={showAsDisabled}
-            onClick={(e) => {
-                if (!showAsDisabled) {
-                    onClickPreventSelect(e);
-                    if (selectedColumn !== id && !allNeighborsFetched) {
-                        initiateRequest();
+        <ColumnPositioner>
+            <ColumnWrapper
+                highlighted={highlighted && !showAsDisabled}
+                fromSelect={!!selectedColumn}
+                selected={selected}
+                disabled={showAsDisabled}
+                onClick={(e) => {
+                    if (!showAsDisabled) {
+                        onClickPreventSelect(e);
+                        if (selectedColumn !== id && !allNeighborsFetched) {
+                            initiateRequest();
+                        }
+                        // Toggle if already selected
+                        setSelectedColumn((v) => (v === id ? null : id));
+                        analytics.event({
+                            type: EventType.DrillDownLineageEvent,
+                            action: selectedColumn === id ? 'deselect' : 'select',
+                            parentUrn,
+                            parentEntityType: entityType,
+                            entityUrn: schemaFieldUrn,
+                            entityType: EntityType.SchemaField,
+                            dataType: type,
+                        });
                     }
-                    // Toggle if already selected
-                    setSelectedColumn((v) => (v === id ? null : id));
-                    analytics.event({
-                        type: EventType.DrillDownLineageEvent,
-                        action: selectedColumn === id ? 'deselect' : 'select',
-                        parentUrn,
-                        parentEntityType: entityType,
-                        entityUrn: schemaFieldUrn,
-                        entityType: EntityType.SchemaField,
-                        dataType: type,
-                    });
-                }
-            }}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            data-testid={`column-${columnName}`}
-        >
-            <CustomHandle id={id} type="target" position={Position.Left} isConnectable={false} />
-            {type && (
-                <TypeWrapper>
-                    <CompactFieldIconWithTooltip type={type} nativeDataType={nativeDataType} />
-                </TypeWrapper>
+                }}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                data-testid={`column-${columnName}`}
+            >
+                <CustomHandle id={id} type="target" position={Position.Left} isConnectable={false} />
+                {type && (
+                    <TypeWrapper>
+                        <CompactFieldIconWithTooltip type={type} nativeDataType={nativeDataType} />
+                    </TypeWrapper>
+                )}
+                <ColumnText ellipsis={{ tooltip: { showArrow: false } }}>{columnName}</ColumnText>
+                {loading && !hasLineage && <Spin indicator={<StyledLoadingIndicator />} />}
+                {config.featureFlags.schemaFieldCLLEnabled && (
+                    <ColumnLinkWrapper
+                        to={lineageUrl}
+                        onClick={(e) => e.stopPropagation()}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <Tooltip title={t('column.exploreCompleteLineage.tooltip')} mouseEnterDelay={0.3}>
+                            <LinkOutIcon />
+                        </Tooltip>
+                    </ColumnLinkWrapper>
+                )}
+                <CustomHandle id={id} type="source" position={Position.Right} isConnectable={false} />
+            </ColumnWrapper>
+            {showLineageControls && shownRelated && (
+                <>
+                    <ColumnLineageControl
+                        direction={LineageDirection.Upstream}
+                        lineageAsset={lineageAsset}
+                        shownRelated={shownRelated}
+                    />
+                    <ColumnLineageControl
+                        direction={LineageDirection.Downstream}
+                        lineageAsset={lineageAsset}
+                        shownRelated={shownRelated}
+                    />
+                </>
             )}
-            <ColumnText ellipsis={{ tooltip: { showArrow: false } }}>{columnName}</ColumnText>
-            {loading && !hasLineage && <Spin indicator={<StyledLoadingIndicator />} />}
-            {config.featureFlags.schemaFieldCLLEnabled && (
-                <ColumnLinkWrapper
-                    to={lineageUrl}
-                    onClick={(e) => e.stopPropagation()}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    <Tooltip title={t('column.exploreCompleteLineage.tooltip')} mouseEnterDelay={0.3}>
-                        <LinkOutIcon />
-                    </Tooltip>
-                </ColumnLinkWrapper>
-            )}
-            <CustomHandle id={id} type="source" position={Position.Right} isConnectable={false} />
-        </ColumnWrapper>
+        </ColumnPositioner>
     );
 
     return (
         <Tooltip
             title={t('column.noLineage.tooltip')}
-            open={(showDisabledTooltipOnHover && hoveredColumn === id) || showDisabledTooltipOnSelect}
+            // Only claim a column has no lineage if nothing says otherwise: the counts query can
+            // come back empty for a column that has column lineage drawn on the graph
+            open={(showDisabledTooltipOnHover && hoveredColumn === id && !hasLineage) || showDisabledTooltipOnSelect}
             placement="right"
             showArrow={false}
         >
@@ -255,28 +294,25 @@ export default function Column({
 }
 
 function useFetchColumnCounts(schemaFieldUrn: string, lineageAsset: ColumnAsset, onDisabled: () => void) {
-    const { showGhostEntities, setColumnEdgeVersion } = useContext(LineageNodesContext);
+    const { rootType, showGhostEntities, setColumnEdgeVersion } = useContext(LineageNodesContext);
     const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
     const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
 
     const assetToWrite = lineageAsset;
-    const [fetchCounts, { loading }] = useGetLineageCountsLazyQuery({
+    const [fetchCounts, { loading }] = useGetColumnLineageCountsLazyQuery({
         variables: {
             urn: schemaFieldUrn,
             startTimeMillis,
             endTimeMillis,
-            separateSiblings: true,
-            includeGhostEntities: showGhostEntities || ignoreSchemaFieldStatus,
+            // Same hops the graph walks through, so the counts match the columns it draws. The
+            // schema field entry is dropped: GMS fails to read a platform from a schema field urn.
+            ignoreAsHops: generateIgnoreAsHops(rootType).filter((hop) => hop.entityType !== EntityType.SchemaField),
+            includeSoftDeleted: showGhostEntities || ignoreSchemaFieldStatus,
         },
         onCompleted: (data) => {
             assetToWrite.lineageCountsFetched = true;
-            if (data.entity && 'upstream' in data?.entity && data.entity.upstream?.total !== undefined) {
-                assetToWrite.numUpstream = (data.entity.upstream.total || 0) - (data.entity.upstream.filtered || 0);
-            }
-            if (data.entity && 'downstream' in data?.entity && data.entity.downstream?.total !== undefined) {
-                assetToWrite.numDownstream =
-                    (data.entity.downstream.total || 0) - (data.entity.downstream.filtered || 0);
-            }
+            assetToWrite.numUpstream = data.upstream?.total ?? 0;
+            assetToWrite.numDownstream = data.downstream?.total ?? 0;
             if (!assetToWrite.numUpstream && !assetToWrite.numDownstream) {
                 onDisabled();
             }
@@ -285,18 +321,19 @@ function useFetchColumnCounts(schemaFieldUrn: string, lineageAsset: ColumnAsset,
     });
 
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const initiateRequest = useCallback(
-        (delay = 0) => {
-            if (!lineageAsset.lineageCountsFetched && !loading) {
-                timeoutRef.current = setTimeout(() => fetchCounts(), delay);
-            }
-        },
-        [lineageAsset.lineageCountsFetched, fetchCounts, loading],
-    );
     const cancelRequest = useCallback(() => {
         if (timeoutRef.current) {
             clearTimeout(timeoutRef.current);
         }
     }, []);
+    const initiateRequest = useCallback(
+        (delay = 0) => {
+            if (!lineageAsset.lineageCountsFetched && !loading) {
+                cancelRequest(); // Several callers can ask for the same counts; keep one timer
+                timeoutRef.current = setTimeout(() => fetchCounts(), delay);
+            }
+        },
+        [lineageAsset.lineageCountsFetched, fetchCounts, loading, cancelRequest],
+    );
     return { initiateRequest, cancelRequest, loading };
 }

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
@@ -1,7 +1,7 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { Tooltip } from '@components';
 import { Spin, Typography } from 'antd';
-import React, { Dispatch, SetStateAction, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Handle, Position } from 'reactflow';
@@ -10,22 +10,14 @@ import styled from 'styled-components';
 import { EventType } from '@app/analytics';
 import analytics from '@app/analytics/analytics';
 import { generateSchemaFieldUrn } from '@app/entityV2/shared/tabs/Lineage/utils';
-import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
+import useFetchColumnCounts from '@app/lineageV3/LineageEntityNode/Column.hooks';
 import { ColumnLineageControl } from '@app/lineageV3/LineageEntityNode/ColumnLineageControl';
 import { LineageDisplayColumn, columnHasLineage } from '@app/lineageV3/LineageEntityNode/useDisplayedColumns';
-import {
-    LineageNodesContext,
-    createColumnRef,
-    generateIgnoreAsHops,
-    onClickPreventSelect,
-    useIgnoreSchemaFieldStatus,
-} from '@app/lineageV3/common';
-import { ColumnAsset } from '@app/lineageV3/types';
+import { createColumnRef, onClickPreventSelect } from '@app/lineageV3/common';
 import { useGetLineageUrl } from '@app/lineageV3/utils/lineageUtils';
 import { CompactFieldIconWithTooltip } from '@app/sharedV2/icons/CompactFieldIcon';
 import { useAppConfig } from '@app/useAppConfig';
 
-import { useGetColumnLineageCountsLazyQuery } from '@graphql/lineage.generated';
 import { EntityType, LineageDirection } from '@types';
 
 import LinkOut from '@images/link-out.svg?react';
@@ -123,6 +115,8 @@ type Props = LineageDisplayColumn & {
     parentUrn: string;
     entityType: EntityType;
     allNeighborsFetched: boolean;
+    mayHideUpstreamLineage: boolean;
+    mayHideDownstreamLineage: boolean;
     selectedColumn: string | null;
     setSelectedColumn: Dispatch<SetStateAction<string | null>>;
     hoveredColumn: string | null;
@@ -140,6 +134,8 @@ export default function Column({
     lineageAsset,
     shownRelated,
     allNeighborsFetched,
+    mayHideUpstreamLineage,
+    mayHideDownstreamLineage,
     selectedColumn,
     setSelectedColumn,
     hoveredColumn,
@@ -151,6 +147,8 @@ export default function Column({
     const selected = selectedColumn === id;
     // Lineage filter nodes cover hidden column lineage themselves, with an edge to the filter node
     const showLineageControls = !!shownRelated && !config.featureFlags.showLineageFilterNodes;
+    const showUpstreamControl = showLineageControls && mayHideUpstreamLineage;
+    const showDownstreamControl = showLineageControls && mayHideDownstreamLineage;
 
     let columnName = fieldPath;
     try {
@@ -167,6 +165,7 @@ export default function Column({
     const turnOnDisabledTooltipOnHover = useCallback(() => setShowDisabledTooltipOnHover(true), []);
 
     const { initiateRequest, cancelRequest, loading } = useFetchColumnCounts(
+        parentUrn,
         schemaFieldUrn,
         lineageAsset,
         turnOnDisabledTooltipOnHover,
@@ -174,6 +173,7 @@ export default function Column({
     // Recomputed here rather than taken from props: counts are written onto `lineageAsset` when the
     // query resolves, which re-renders this component but leaves its props stale
     const hasLineage = columnHasLineage(lineageAsset, connectedToHomeNode);
+    const hasFetchedCounts = lineageAsset.numUpstream !== undefined || lineageAsset.numDownstream !== undefined;
     const isFullyFetched = lineageAsset.lineageCountsFetched || allNeighborsFetched;
     const showAsDisabled = !hasLineage && isFullyFetched;
 
@@ -186,12 +186,16 @@ export default function Column({
         }
     }, [selectedColumn, id, hasLineage, isFullyFetched, setSelectedColumn]);
 
-    // Counts back the controls of every column in the traversal, not just the one under the cursor
+    // Counts back the controls of every column in the traversal, not just the one under the cursor.
+    // `isFullyFetched` is not enough to skip the request: it is set without fetching counts when a
+    // node's neighbors are all loaded, which is also true of a node whose lineage is contracted.
     useEffect(() => {
-        if (!showLineageControls || isFullyFetched) return undefined;
-        initiateRequest(HOVER_REQUEST_DELAY);
-        return cancelRequest;
-    }, [showLineageControls, isFullyFetched, initiateRequest, cancelRequest]);
+        if ((!showUpstreamControl && !showDownstreamControl) || hasFetchedCounts) {
+            cancelRequest(); // No longer interested, e.g. the cursor moved on to another column
+        } else {
+            initiateRequest(HOVER_REQUEST_DELAY);
+        }
+    }, [showUpstreamControl, showDownstreamControl, hasFetchedCounts, initiateRequest, cancelRequest]);
 
     const handleMouseEnter = useCallback(() => {
         if (!selectedColumn && !showAsDisabled) {
@@ -262,19 +266,19 @@ export default function Column({
                 )}
                 <CustomHandle id={id} type="source" position={Position.Right} isConnectable={false} />
             </ColumnWrapper>
-            {showLineageControls && shownRelated && (
-                <>
-                    <ColumnLineageControl
-                        direction={LineageDirection.Upstream}
-                        lineageAsset={lineageAsset}
-                        shownRelated={shownRelated}
-                    />
-                    <ColumnLineageControl
-                        direction={LineageDirection.Downstream}
-                        lineageAsset={lineageAsset}
-                        shownRelated={shownRelated}
-                    />
-                </>
+            {shownRelated && showUpstreamControl && (
+                <ColumnLineageControl
+                    direction={LineageDirection.Upstream}
+                    lineageAsset={lineageAsset}
+                    shownRelated={shownRelated}
+                />
+            )}
+            {shownRelated && showDownstreamControl && (
+                <ColumnLineageControl
+                    direction={LineageDirection.Downstream}
+                    lineageAsset={lineageAsset}
+                    shownRelated={shownRelated}
+                />
             )}
         </ColumnPositioner>
     );
@@ -291,49 +295,4 @@ export default function Column({
             {contents}
         </Tooltip>
     );
-}
-
-function useFetchColumnCounts(schemaFieldUrn: string, lineageAsset: ColumnAsset, onDisabled: () => void) {
-    const { rootType, showGhostEntities, setColumnEdgeVersion } = useContext(LineageNodesContext);
-    const { startTimeMillis, endTimeMillis } = useGetLineageTimeParams();
-    const ignoreSchemaFieldStatus = useIgnoreSchemaFieldStatus();
-
-    const assetToWrite = lineageAsset;
-    const [fetchCounts, { loading }] = useGetColumnLineageCountsLazyQuery({
-        variables: {
-            urn: schemaFieldUrn,
-            startTimeMillis,
-            endTimeMillis,
-            // Same hops the graph walks through, so the counts match the columns it draws. The
-            // schema field entry is dropped: GMS fails to read a platform from a schema field urn.
-            ignoreAsHops: generateIgnoreAsHops(rootType).filter((hop) => hop.entityType !== EntityType.SchemaField),
-            includeSoftDeleted: showGhostEntities || ignoreSchemaFieldStatus,
-        },
-        onCompleted: (data) => {
-            assetToWrite.lineageCountsFetched = true;
-            assetToWrite.numUpstream = data.upstream?.total ?? 0;
-            assetToWrite.numDownstream = data.downstream?.total ?? 0;
-            if (!assetToWrite.numUpstream && !assetToWrite.numDownstream) {
-                onDisabled();
-            }
-            setColumnEdgeVersion((v) => v + 1);
-        },
-    });
-
-    const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const cancelRequest = useCallback(() => {
-        if (timeoutRef.current) {
-            clearTimeout(timeoutRef.current);
-        }
-    }, []);
-    const initiateRequest = useCallback(
-        (delay = 0) => {
-            if (!lineageAsset.lineageCountsFetched && !loading) {
-                cancelRequest(); // Several callers can ask for the same counts; keep one timer
-                timeoutRef.current = setTimeout(() => fetchCounts(), delay);
-            }
-        },
-        [lineageAsset.lineageCountsFetched, fetchCounts, loading, cancelRequest],
-    );
-    return { initiateRequest, cancelRequest, loading };
 }

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
@@ -41,31 +41,32 @@ interface Props {
 }
 
 /**
- * How much of a column's lineage in one direction is missing from the graph, e.g. `2 / 5`. Rendered
- * to the left and right of the hovered or selected column, and of every column related to it, for
- * as long as it may have lineage it isn't showing. The total is only known once
- * `getColumnLineageCounts` resolves, so a loading indicator stands in for it until then; both
- * numbers count columns the way the graph draws them, so showing every related node clears it.
+ * How much of a column's lineage in one direction is on the graph, e.g. `2 / 5`. Rendered to the
+ * left and right of the hovered or selected column, and of every column related to it, from the
+ * moment `getColumnLineageCounts` is asked for its total until the column is no longer part of the
+ * traversal -- a loading indicator stands in for the total in the meantime. Both numbers count
+ * columns the way the graph draws them, so showing every related node brings them level.
  *
  * TODO: Expand on hover into a panel of controls, as `ContractLineageControl` does.
  */
 export function ColumnLineageControl({ direction, lineageAsset, shownRelated }: Props) {
     const numShown = shownRelated[direction];
-    const numRelated = direction === LineageDirection.Upstream ? lineageAsset.numUpstream : lineageAsset.numDownstream;
-    // Counts are marked fetched without running the query when all of the node's neighbors are
-    // already on the graph, in which case what's shown is all there is
-    const total = lineageAsset.lineageCountsFetched ? (numRelated ?? numShown ?? 0) : undefined;
+    const total = direction === LineageDirection.Upstream ? lineageAsset.numUpstream : lineageAsset.numDownstream;
 
     if (numShown === undefined) {
         return null; // Lineage was never traversed this way, so there is nothing to say about it
     }
-    if (total !== undefined && total <= numShown) {
-        return null; // Nothing hidden this way; while the total is unknown, there still might be
+    if (total === undefined && lineageAsset.lineageCountsFetched) {
+        // Counts are marked fetched without querying when the node's every neighbor is on the
+        // graph. Nothing was hidden to begin with, so there is no count worth showing.
+        return null;
     }
     return (
         <ControlWrapper direction={direction} data-testid={`column-lineage-control-${lineageAsset.name}-${direction}`}>
             <Counts>
-                {numShown} / {total === undefined ? <Spin indicator={<StyledLoadingIndicator />} /> : total}
+                {/* Cached counts can lag behind the graph, so never show more shown than exist */}
+                {total === undefined ? numShown : Math.min(numShown, total)} /{' '}
+                {total === undefined ? <Spin indicator={<StyledLoadingIndicator />} /> : total}
             </Counts>
         </ControlWrapper>
     );

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
@@ -61,6 +61,9 @@ export function ColumnLineageControl({ direction, lineageAsset, shownRelated }: 
         // graph. Nothing was hidden to begin with, so there is no count worth showing.
         return null;
     }
+    if (total === 0) {
+        return null; // The column has no lineage this way at all, so there is nothing to count
+    }
     return (
         <ControlWrapper direction={direction} data-testid={`column-lineage-control-${lineageAsset.name}-${direction}`}>
             <Counts>

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
@@ -1,0 +1,72 @@
+import { LoadingOutlined } from '@ant-design/icons';
+import { Spin } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+
+import { CountText, SideControlWrapper } from '@app/lineageV3/LineageEntityNode/components';
+import { ShownRelatedCounts } from '@app/lineageV3/common';
+import { ColumnAsset } from '@app/lineageV3/types';
+
+import { LineageDirection } from '@types';
+
+const ControlWrapper = styled(SideControlWrapper)<{ direction: LineageDirection }>`
+    ${({ direction }) =>
+        direction === LineageDirection.Upstream ? 'right: calc(100% + 10px);' : 'left: calc(100% + 10px);'}
+    top: 50%;
+
+    // Neither brand color nor interactive, unlike the node's side controls: these counts are only a
+    // readout for now. Both go away once there are controls behind them.
+    color: ${(props) => props.theme.colors.textSecondary};
+    pointer-events: none;
+`;
+
+// Matches the padding and height of the buttons inside the node's own side controls
+const Counts = styled(CountText)`
+    align-items: center;
+    display: flex;
+    gap: 3px;
+    line-height: 18px;
+    padding: 4px;
+`;
+
+const StyledLoadingIndicator = styled(LoadingOutlined)`
+    display: flex;
+    font-size: inherit;
+`;
+
+interface Props {
+    direction: LineageDirection;
+    lineageAsset: ColumnAsset;
+    shownRelated: ShownRelatedCounts;
+}
+
+/**
+ * How much of a column's lineage in one direction is missing from the graph, e.g. `2 / 5`. Rendered
+ * to the left and right of the hovered or selected column, and of every column related to it, for
+ * as long as it may have lineage it isn't showing. The total is only known once
+ * `getColumnLineageCounts` resolves, so a loading indicator stands in for it until then; both
+ * numbers count columns the way the graph draws them, so showing every related node clears it.
+ *
+ * TODO: Expand on hover into a panel of controls, as `ContractLineageControl` does.
+ */
+export function ColumnLineageControl({ direction, lineageAsset, shownRelated }: Props) {
+    const numShown = shownRelated[direction];
+    const numRelated = direction === LineageDirection.Upstream ? lineageAsset.numUpstream : lineageAsset.numDownstream;
+    // Counts are marked fetched without running the query when all of the node's neighbors are
+    // already on the graph, in which case what's shown is all there is
+    const total = lineageAsset.lineageCountsFetched ? (numRelated ?? numShown ?? 0) : undefined;
+
+    if (numShown === undefined) {
+        return null; // Lineage was never traversed this way, so there is nothing to say about it
+    }
+    if (total !== undefined && total <= numShown) {
+        return null; // Nothing hidden this way; while the total is unknown, there still might be
+    }
+    return (
+        <ControlWrapper direction={direction} data-testid={`column-lineage-control-${lineageAsset.name}-${direction}`}>
+            <Counts>
+                {numShown} / {total === undefined ? <Spin indicator={<StyledLoadingIndicator />} /> : total}
+            </Counts>
+        </ControlWrapper>
+    );
+}

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ColumnLineageControl.tsx
@@ -42,10 +42,10 @@ interface Props {
 
 /**
  * How much of a column's lineage in one direction is on the graph, e.g. `2 / 5`. Rendered to the
- * left and right of the hovered or selected column, and of every column related to it, from the
- * moment `getColumnLineageCounts` is asked for its total until the column is no longer part of the
- * traversal -- a loading indicator stands in for the total in the meantime. Both numbers count
- * columns the way the graph draws them, so showing every related node brings them level.
+ * left and right of the hovered or selected column, and of every column related to it, in the
+ * directions where its node may be hiding lineage -- see `mayHideLineage`. A loading indicator
+ * stands in for the total until `getColumnLineageCounts` resolves; both numbers count columns the
+ * way the graph draws them.
  *
  * TODO: Expand on hover into a panel of controls, as `ContractLineageControl` does.
  */
@@ -56,18 +56,13 @@ export function ColumnLineageControl({ direction, lineageAsset, shownRelated }: 
     if (numShown === undefined) {
         return null; // Lineage was never traversed this way, so there is nothing to say about it
     }
-    if (total === undefined && lineageAsset.lineageCountsFetched) {
-        // Counts are marked fetched without querying when the node's every neighbor is on the
-        // graph. Nothing was hidden to begin with, so there is no count worth showing.
-        return null;
-    }
     if (total === 0) {
         return null; // The column has no lineage this way at all, so there is nothing to count
     }
     return (
         <ControlWrapper direction={direction} data-testid={`column-lineage-control-${lineageAsset.name}-${direction}`}>
             <Counts>
-                {/* Cached counts can lag behind the graph, so never show more shown than exist */}
+                {/* Counts are fetched per column, so they can lag behind the graph */}
                 {total === undefined ? numShown : Math.min(numShown, total)} /{' '}
                 {total === undefined ? <Spin indicator={<StyledLoadingIndicator />} /> : total}
             </Counts>

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Columns.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Columns.tsx
@@ -99,6 +99,8 @@ interface Props {
     setSelectedColumn: Dispatch<SetStateAction<string | null>>;
     hoveredColumn: string | null;
     setHoveredColumn: Dispatch<SetStateAction<string | null>>;
+    mayHideUpstreamLineage: boolean;
+    mayHideDownstreamLineage: boolean;
 }
 
 export default function DelayedColumns(props: Props) {
@@ -145,6 +147,8 @@ function Columns(props: Props) {
         setSelectedColumn,
         hoveredColumn,
         setHoveredColumn,
+        mayHideUpstreamLineage,
+        mayHideDownstreamLineage,
     } = props;
 
     const updateNodeInternals = useUpdateNodeInternals();
@@ -194,6 +198,8 @@ function Columns(props: Props) {
         setSelectedColumn,
         hoveredColumn,
         setHoveredColumn,
+        mayHideUpstreamLineage,
+        mayHideDownstreamLineage,
     };
     const handleMouseLeave = useCallback(() => {
         setHoveredColumn(null);

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/ContractLineageControl.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/ContractLineageControl.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 
 import analytics, { EventType } from '@app/analytics';
 import { ContractLineageButton } from '@app/lineageV3/LineageEntityNode/ContractLineageButton';
-import { Button } from '@app/lineageV3/LineageEntityNode/components';
+import { Button, CountText, SideControlWrapper } from '@app/lineageV3/LineageEntityNode/components';
 import LineageFilterSearch from '@app/lineageV3/LineageFilterNode/LineageFilterSearch';
 import LineageFilterSummary from '@app/lineageV3/LineageFilterNode/LineageFilterSummary';
 import { ShowMoreButton } from '@app/lineageV3/LineageFilterNode/ShowMoreButton';
@@ -22,27 +22,10 @@ import {
 
 import { LineageDirection } from '@types';
 
-const ControlWrapper = styled.div<{ direction: LineageDirection }>`
-    position: absolute;
+const ControlWrapper = styled(SideControlWrapper)<{ direction: LineageDirection }>`
     ${({ direction }) =>
         direction === LineageDirection.Upstream ? 'right: calc(100% + 10px);' : 'left: calc(100% + 10px);'}
-    transform: translateY(-50%);
-
-    background-color: ${(props) => props.theme.colors.bg};
-    border-radius: 4px;
-    box-shadow: ${(props) => props.theme.colors.shadowXs};
-    color: ${(props) => props.theme.colors.iconBrand};
     cursor: pointer;
-    font-size: 18px;
-
-    display: flex;
-    align-items: center;
-`;
-
-const CountText = styled.span`
-    font-size: 12px;
-    font-weight: 600;
-    white-space: nowrap;
 `;
 
 const Panel = styled.div<{ direction: LineageDirection; visible: boolean }>`

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/LineageEntityNode.tsx
@@ -104,7 +104,9 @@ export default function LineageEntityNode(props: NodeProps<LineageEntity>) {
             setDisplayedMenuNode={setDisplayedMenuNode}
             selectedColumn={selectedColumnUrn === urn ? selectedColumn : null}
             setSelectedColumn={setSelectedColumn}
-            hoveredColumn={hoveredColumnUrn === urn ? hoveredColumn : null}
+            // A selected column anywhere on the graph takes precedence over a hovered one, as it
+            // does when computing column highlights, so don't report a hover alongside a selection
+            hoveredColumn={!selectedColumn && hoveredColumnUrn === urn ? hoveredColumn : null}
             setHoveredColumn={setHoveredColumn}
             paginatedColumns={paginatedColumns}
             extraHighlightedColumns={extraHighlightedColumns}

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/LineageEntityNode.tsx
@@ -9,6 +9,8 @@ import {
     LineageEntity,
     LineageNodesContext,
     TRANSITION_DURATION_MS,
+    createLineageFilterNodeId,
+    mayHideLineage,
     parseColumnRef,
     useIgnoreSchemaFieldStatus,
 } from '@app/lineageV3/common';
@@ -38,6 +40,7 @@ export default function LineageEntityNode(props: NodeProps<LineageEntity>) {
         setHoveredNode,
         displayedMenuNode,
         setDisplayedMenuNode,
+        lineageFilters,
     } = useContext(LineageDisplayContext);
     const { searchQuery, searchedEntity } = useContext(LineageVisualizationContext);
 
@@ -73,6 +76,32 @@ export default function LineageEntityNode(props: NodeProps<LineageEntity>) {
     const [hoveredColumnUrn] = hoveredColumn ? parseColumnRef(hoveredColumn) : [null];
 
     const hasParentDataJob = parentDataJob ? true : undefined;
+    // Data flow lineage: members count only the neighbors outside their own data job
+    const numUpstreams =
+        hasParentDataJob &&
+        Array.from(adjacencyList[LineageDirection.Upstream].get(urn) || []).filter(
+            (upstream) => nodes.get(upstream)?.parentDataJob !== parentDataJob,
+        ).length;
+    const numDownstreams =
+        hasParentDataJob &&
+        Array.from(adjacencyList[LineageDirection.Downstream].get(urn) || []).filter(
+            (downstream) => nodes.get(downstream)?.parentDataJob !== parentDataJob,
+        ).length;
+
+    // Columns only claim to hide lineage in directions where their node does, and pay for the
+    // counts query only then. Passed as booleans to keep `NodeContents` memoized.
+    const mayHideLineageIn = (
+        direction: LineageDirection,
+        numNeighbors: number | undefined,
+        numChildren: number | undefined,
+    ) =>
+        mayHideLineage(
+            direction,
+            data,
+            !!(numNeighbors ?? !!numChildren), // Matches `NodeContents`
+            !!lineageFilters.get(createLineageFilterNodeId(urn, direction)),
+        );
+
     return (
         <NodeContents
             id={id}
@@ -115,18 +144,18 @@ export default function LineageEntityNode(props: NodeProps<LineageEntity>) {
             numColumnsTotal={numColumnsTotal}
             refetch={refetch}
             ignoreSchemaFieldStatus={ignoreSchemaFieldStatus}
-            numUpstreams={
-                hasParentDataJob &&
-                Array.from(adjacencyList[LineageDirection.Upstream].get(urn) || []).filter(
-                    (upstream) => nodes.get(upstream)?.parentDataJob !== parentDataJob,
-                ).length
-            }
-            numDownstreams={
-                hasParentDataJob &&
-                Array.from(adjacencyList[LineageDirection.Downstream].get(urn) || []).filter(
-                    (downstream) => nodes.get(downstream)?.parentDataJob !== parentDataJob,
-                ).length
-            }
+            numUpstreams={numUpstreams}
+            numDownstreams={numDownstreams}
+            mayHideUpstreamLineage={mayHideLineageIn(
+                LineageDirection.Upstream,
+                numUpstreams,
+                entity?.numUpstreamChildren,
+            )}
+            mayHideDownstreamLineage={mayHideLineageIn(
+                LineageDirection.Downstream,
+                numDownstreams,
+                entity?.numDownstreamChildren,
+            )}
         />
     );
 }

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
@@ -27,6 +27,7 @@ import {
     LINEAGE_NODE_HEIGHT,
     LineageEntity,
     VERTICAL_HANDLE,
+    createHiddenLineageRef,
     isGhostEntity,
     onClickPreventSelect,
 } from '@app/lineageV3/common';
@@ -65,6 +66,21 @@ const VerticalHandle = styled(Handle)<{ position: Position }>`
     border: initial;
     left: 50%;
     ${({ position }) => (position === Position.Top ? 'top: 0;' : 'bottom: 0;')}
+`;
+
+/**
+ * Handle for column edges to hidden nodes, positioned at the expand / contract lineage control.
+ * Always rendered, even when no control is: react-flow only re-measures handles when a node's
+ * dimensions change, and the controls are absolutely positioned, so appearing later would be missed.
+ */
+const HiddenLineageHandle = styled(Handle)<{ direction: LineageDirection }>`
+    background: initial;
+    border: initial;
+    // Both sides must be set, as react-flow's own handle styles set the one we aren't using
+    ${({ direction }) =>
+        direction === LineageDirection.Upstream
+            ? 'left: auto; right: calc(100% + 10px);'
+            : 'left: calc(100% + 10px); right: auto;'}
 `;
 
 const PropertyBadgeWrapper = styled.div`
@@ -390,6 +406,20 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
                         <>
                             <HorizontalHandle type="target" position={Position.Left} isConnectable={false} />
                             <HorizontalHandle type="source" position={Position.Right} isConnectable={false} />
+                            <HiddenLineageHandle
+                                id={createHiddenLineageRef(urn, LineageDirection.Upstream)}
+                                direction={LineageDirection.Upstream}
+                                type="source"
+                                position={Position.Left}
+                                isConnectable={false}
+                            />
+                            <HiddenLineageHandle
+                                id={createHiddenLineageRef(urn, LineageDirection.Downstream)}
+                                direction={LineageDirection.Downstream}
+                                type="target"
+                                position={Position.Right}
+                                isConnectable={false}
+                            />
                             {hasUpstreamChildren &&
                                 ([FetchStatus.UNFETCHED, FetchStatus.LOADING].includes(
                                     fetchStatus[LineageDirection.Upstream],

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
@@ -27,7 +27,6 @@ import {
     LINEAGE_NODE_HEIGHT,
     LineageEntity,
     VERTICAL_HANDLE,
-    createHiddenLineageRef,
     isGhostEntity,
     onClickPreventSelect,
 } from '@app/lineageV3/common';
@@ -68,21 +67,6 @@ const VerticalHandle = styled(Handle)<{ position: Position }>`
     ${({ position }) => (position === Position.Top ? 'top: 0;' : 'bottom: 0;')}
 `;
 
-/**
- * Handle for column edges to hidden nodes, positioned at the expand / contract lineage control.
- * Always rendered, even when no control is: react-flow only re-measures handles when a node's
- * dimensions change, and the controls are absolutely positioned, so appearing later would be missed.
- */
-const HiddenLineageHandle = styled(Handle)<{ direction: LineageDirection }>`
-    background: initial;
-    border: initial;
-    // Both sides must be set, as react-flow's own handle styles set the one we aren't using
-    ${({ direction }) =>
-        direction === LineageDirection.Upstream
-            ? 'left: auto; right: calc(100% + 10px);'
-            : 'left: calc(100% + 10px); right: auto;'}
-`;
-
 const PropertyBadgeWrapper = styled.div`
     position: absolute;
     right: 12px;
@@ -106,7 +90,9 @@ const ColumnsWrapper = styled.div<{
 }>`
     max-height: ${({ height }) => height}px;
     transition: max-height ${({ transitionDuration }) => transitionDuration}ms ease-in-out;
-    overflow-y: hidden;
+    // Clip, not hidden: hidden on one axis forces the other to auto, which would cut off the
+    // column lineage controls that render outside the node
+    overflow-y: clip;
     width: 100%;
 `;
 
@@ -406,20 +392,6 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
                         <>
                             <HorizontalHandle type="target" position={Position.Left} isConnectable={false} />
                             <HorizontalHandle type="source" position={Position.Right} isConnectable={false} />
-                            <HiddenLineageHandle
-                                id={createHiddenLineageRef(urn, LineageDirection.Upstream)}
-                                direction={LineageDirection.Upstream}
-                                type="source"
-                                position={Position.Left}
-                                isConnectable={false}
-                            />
-                            <HiddenLineageHandle
-                                id={createHiddenLineageRef(urn, LineageDirection.Downstream)}
-                                direction={LineageDirection.Downstream}
-                                type="target"
-                                position={Position.Right}
-                                isConnectable={false}
-                            />
                             {hasUpstreamChildren &&
                                 ([FetchStatus.UNFETCHED, FetchStatus.LOADING].includes(
                                     fetchStatus[LineageDirection.Upstream],

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/NodeContents.tsx
@@ -165,6 +165,9 @@ interface Props {
     ignoreSchemaFieldStatus: boolean;
     numUpstreams?: number;
     numDownstreams?: number;
+    /** Whether the node may be hiding lineage in each direction, i.e. it shows a control saying so. */
+    mayHideUpstreamLineage: boolean;
+    mayHideDownstreamLineage: boolean;
 }
 
 const MemoizedNodeContents = React.memo(NodeContents);
@@ -210,6 +213,8 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
         ignoreSchemaFieldStatus,
         numUpstreams,
         numDownstreams,
+        mayHideUpstreamLineage,
+        mayHideDownstreamLineage,
     } = props;
 
     const { t } = useTranslation('lineage');
@@ -491,6 +496,8 @@ function NodeContents(props: Props & LineageEntity & DisplayedColumns) {
                             setSelectedColumn={setSelectedColumn}
                             hoveredColumn={hoveredColumn}
                             setHoveredColumn={setHoveredColumn}
+                            mayHideUpstreamLineage={mayHideUpstreamLineage}
+                            mayHideDownstreamLineage={mayHideDownstreamLineage}
                         />
                     )}
                     {entity && (

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.hooks.test.ts
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.hooks.test.ts
@@ -1,0 +1,31 @@
+import { buildRelatedColumnFilters } from '@app/lineageV3/LineageEntityNode/Column.hooks';
+
+import { FilterOperator } from '@types';
+
+const SIBLING = 'urn:li:dataset:(urn:li:dataPlatform:dbt,db.schema.customers,PROD)';
+
+function filters(mergedUrns: Set<string>) {
+    return buildRelatedColumnFilters(mergedUrns)[0].and ?? [];
+}
+
+describe('buildRelatedColumnFilters', () => {
+    it('counts only direct relations, excluding columns on dbt nodes', () => {
+        const and = filters(new Set());
+
+        expect(and).toHaveLength(2);
+        expect(and[0]).toEqual({ field: 'degree', values: ['1'] });
+        expect(and[1]).toEqual({
+            field: 'parent',
+            values: ['urn:li:dataPlatform:dbt'],
+            condition: FilterOperator.Contain,
+            negated: true,
+        });
+    });
+
+    it('excludes columns on nodes drawn as part of the same node', () => {
+        const and = filters(new Set([SIBLING]));
+
+        expect(and).toHaveLength(3);
+        expect(and[2]).toEqual({ field: 'parent', values: [SIBLING], negated: true });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
@@ -43,25 +43,20 @@ describe('ColumnLineageControl', () => {
     });
 
     it('keeps showing the counts once all of the column lineage is on the graph', () => {
+        // The node still reports hidden lineage, or this control would not be rendered at all
         const { getByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(2));
+
+        expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
+    });
+
+    it('never shows more as shown than exist, as per-column counts can lag behind the graph', () => {
+        const { getByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(3));
 
         expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
     });
 
     it('renders nothing when the column has no lineage in this direction', () => {
         const { queryByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
-
-        expect(queryByTestId(TEST_ID)).toBeNull();
-    });
-
-    it('never shows more as shown than exist, as cached counts can lag behind the graph', () => {
-        const { getByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(3));
-
-        expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
-    });
-
-    it('renders nothing when counts were never queried, as every neighbor is already shown', () => {
-        const { queryByTestId } = renderControl({ lineageCountsFetched: true }, upstream(3));
 
         expect(queryByTestId(TEST_ID)).toBeNull();
     });

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { ColumnLineageControl } from '@app/lineageV3/LineageEntityNode/ColumnLineageControl';
+import { ShownRelatedCounts } from '@app/lineageV3/common';
+import { ColumnAsset, LineageAssetType } from '@app/lineageV3/types';
+import CustomThemeProvider from '@src/CustomThemeProvider';
+
+import { LineageDirection } from '@types';
+
+const FIELD = 'id';
+const TEST_ID = `column-lineage-control-${FIELD}-UPSTREAM`;
+
+function renderControl(asset: Partial<ColumnAsset>, shownRelated: ShownRelatedCounts) {
+    const lineageAsset: ColumnAsset = { name: FIELD, type: LineageAssetType.Column, ...asset };
+    return render(
+        <CustomThemeProvider>
+            <ColumnLineageControl
+                direction={LineageDirection.Upstream}
+                lineageAsset={lineageAsset}
+                shownRelated={shownRelated}
+            />
+        </CustomThemeProvider>,
+    );
+}
+
+function upstream(numShown: number): ShownRelatedCounts {
+    return { [LineageDirection.Upstream]: numShown };
+}
+
+describe('ColumnLineageControl', () => {
+    it('shows a loading indicator in place of the total until counts are fetched', () => {
+        const { getByTestId, container } = renderControl({}, upstream(1));
+
+        expect(getByTestId(TEST_ID).textContent).toEqual('1 / ');
+        expect(container.querySelector('.anticon-loading')).toBeTruthy();
+    });
+
+    it('shows how many related columns are on the graph out of the fetched total', () => {
+        const { getByTestId } = renderControl({ numUpstream: 5, lineageCountsFetched: true }, upstream(2));
+
+        expect(getByTestId(TEST_ID).textContent).toEqual('2 / 5');
+    });
+
+    it('renders nothing once all of the column lineage is on the graph', () => {
+        const { queryByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(2));
+
+        expect(queryByTestId(TEST_ID)).toBeNull();
+    });
+
+    it('renders nothing when the column has no lineage in this direction', () => {
+        const { queryByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
+
+        expect(queryByTestId(TEST_ID)).toBeNull();
+    });
+
+    it('renders nothing when counts are fetched without a total, as all neighbors are shown', () => {
+        const { queryByTestId } = renderControl({ lineageCountsFetched: true }, upstream(3));
+
+        expect(queryByTestId(TEST_ID)).toBeNull();
+    });
+
+    it('renders nothing in a direction the traversal never explored', () => {
+        const { queryByTestId } = renderControl(
+            { numUpstream: 5, lineageCountsFetched: true },
+            { [LineageDirection.Downstream]: 1 },
+        );
+
+        expect(queryByTestId(TEST_ID)).toBeNull();
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
@@ -48,10 +48,10 @@ describe('ColumnLineageControl', () => {
         expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
     });
 
-    it('shows zero when the column turns out to have no lineage in this direction', () => {
-        const { getByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
+    it('renders nothing when the column has no lineage in this direction', () => {
+        const { queryByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
 
-        expect(getByTestId(TEST_ID).textContent).toEqual('0 / 0');
+        expect(queryByTestId(TEST_ID)).toBeNull();
     });
 
     it('never shows more as shown than exist, as cached counts can lag behind the graph', () => {

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/ColumnLineageControl.test.tsx
@@ -42,19 +42,25 @@ describe('ColumnLineageControl', () => {
         expect(getByTestId(TEST_ID).textContent).toEqual('2 / 5');
     });
 
-    it('renders nothing once all of the column lineage is on the graph', () => {
-        const { queryByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(2));
+    it('keeps showing the counts once all of the column lineage is on the graph', () => {
+        const { getByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(2));
 
-        expect(queryByTestId(TEST_ID)).toBeNull();
+        expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
     });
 
-    it('renders nothing when the column has no lineage in this direction', () => {
-        const { queryByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
+    it('shows zero when the column turns out to have no lineage in this direction', () => {
+        const { getByTestId } = renderControl({ numUpstream: 0, lineageCountsFetched: true }, upstream(0));
 
-        expect(queryByTestId(TEST_ID)).toBeNull();
+        expect(getByTestId(TEST_ID).textContent).toEqual('0 / 0');
     });
 
-    it('renders nothing when counts are fetched without a total, as all neighbors are shown', () => {
+    it('never shows more as shown than exist, as cached counts can lag behind the graph', () => {
+        const { getByTestId } = renderControl({ numUpstream: 2, lineageCountsFetched: true }, upstream(3));
+
+        expect(getByTestId(TEST_ID).textContent).toEqual('2 / 2');
+    });
+
+    it('renders nothing when counts were never queried, as every neighbor is already shown', () => {
         const { queryByTestId } = renderControl({ lineageCountsFetched: true }, upstream(3));
 
         expect(queryByTestId(TEST_ID)).toBeNull();

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/components.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/components.tsx
@@ -37,10 +37,38 @@ export const DownstreamWrapper = styled(ExpandContractButton)`
     transform: translateY(-50%);
 `;
 
+/**
+ * Shared look for the small controls anchored just outside a node's left or right edge, e.g. the
+ * expand / contract lineage controls and a column's lineage controls. Consumers position it, as
+ * they anchor to different parts of the node.
+ */
+export const SideControlWrapper = styled.div`
+    position: absolute;
+    transform: translateY(-50%);
+
+    // Slightly translucent, so edges passing under a control aren't hidden
+    background-color: color-mix(in srgb, ${(props) => props.theme.colors.bg} 90%, transparent);
+    border-radius: 4px;
+    box-shadow: ${(props) => props.theme.colors.shadowXs};
+    color: ${(props) => props.theme.colors.iconBrand};
+    font-size: 18px;
+
+    display: flex;
+    align-items: center;
+`;
+
+/** Counts shown inside a side control, e.g. `3/7`. */
+export const CountText = styled.span`
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+`;
+
 export const Button = styled.span`
     display: flex;
     align-items: center;
     cursor: pointer;
+    border-radius: 4px;
     font-size: 12px;
 
     line-height: 0;

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/useDisplayedColumns.ts
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/useDisplayedColumns.ts
@@ -1,10 +1,16 @@
 import { useContext, useMemo, useRef } from 'react';
 
-import { FineGrainedLineage, LineageDisplayContext, createColumnRef } from '@app/lineageV3/common';
+import {
+    FineGrainedLineage,
+    LineageDisplayContext,
+    ShownRelatedColumns,
+    ShownRelatedCounts,
+    createColumnRef,
+} from '@app/lineageV3/common';
 import { NUM_COLUMNS_PER_PAGE } from '@app/lineageV3/constants';
 import { ColumnAsset, FetchedEntityV2, LineageAssetType } from '@app/lineageV3/types';
 
-import { SchemaFieldDataType } from '@types';
+import { LineageDirection, SchemaFieldDataType } from '@types';
 
 type FieldPath = string;
 
@@ -16,6 +22,8 @@ export interface LineageDisplayColumn {
     type?: SchemaFieldDataType;
     nativeDataType?: string | null;
     lineageAsset: ColumnAsset;
+    /** Undefined unless the column is part of the current column lineage traversal. */
+    shownRelated?: ShownRelatedCounts;
 }
 
 interface Arguments {
@@ -44,6 +52,25 @@ interface NormalizedReturn {
     numColumnsTotal: number;
 }
 
+/**
+ * Whether a column has any lineage: counts fetched for it, or column lineage already on the graph.
+ * `lineageAsset` is written to in place as counts resolve, so compute this where it is read rather
+ * than passing the result around, which goes stale.
+ */
+export function columnHasLineage(lineageAsset: ColumnAsset, connectedToHomeNode: boolean): boolean {
+    return !!lineageAsset.numUpstream || !!lineageAsset.numDownstream || connectedToHomeNode;
+}
+
+/** Identifies a column by everything about it that is rendered, so that changed counts re-render. */
+function describe(column: LineageDisplayColumn): string {
+    const { shownRelated } = column;
+    return [
+        column.fieldPath,
+        shownRelated?.[LineageDirection.Upstream],
+        shownRelated?.[LineageDirection.Downstream],
+    ].join('␟');
+}
+
 export default function useDisplayedColumns(args: Arguments): DisplayedColumns {
     // Prevent unnecessary NodeContents rerenders
     const oldVals = useRef<DisplayedColumns>({
@@ -63,9 +90,9 @@ export default function useDisplayedColumns(args: Arguments): DisplayedColumns {
 
 function normalize(val: DisplayedColumns): NormalizedReturn {
     return {
-        plainColumns: val.paginatedColumns.filter((col) => !col.highlighted).map((col) => col.fieldPath),
-        highlightedColumns: val.paginatedColumns.filter((col) => col.highlighted).map((col) => col.fieldPath),
-        extraHighlightedColumns: val.extraHighlightedColumns.map((col) => col.fieldPath),
+        plainColumns: val.paginatedColumns.filter((col) => !col.highlighted).map(describe),
+        highlightedColumns: val.paginatedColumns.filter((col) => col.highlighted).map(describe),
+        extraHighlightedColumns: val.extraHighlightedColumns.map(describe),
         numFilteredColumns: val.numFilteredColumns,
         numColumnsWithLineage: val.numColumnsWithLineage,
         numColumnsTotal: val.numColumnsTotal,
@@ -80,7 +107,7 @@ function useComputeValues({
     filterText,
     onlyWithLineage,
 }: Arguments): DisplayedColumns {
-    const { highlightedColumns, fineGrainedLineage } = useContext(LineageDisplayContext);
+    const { highlightedColumns, shownRelatedColumns, fineGrainedLineage } = useContext(LineageDisplayContext);
 
     return useMemo(() => {
         if (!entity) {
@@ -94,7 +121,7 @@ function useComputeValues({
         }
 
         const columnHighlights = highlightedColumns.get(urn) || new Set<string>();
-        const columns = getDisplayColumns(urn, entity, columnHighlights, fineGrainedLineage);
+        const columns = getDisplayColumns(urn, entity, columnHighlights, shownRelatedColumns, fineGrainedLineage);
 
         const columnsWithLineage = columns.filter((field) => field.hasLineage);
         const filteredColumns = filterColumnsByText(onlyWithLineage ? columnsWithLineage : columns, filterText);
@@ -114,13 +141,24 @@ function useComputeValues({
             numColumnsTotal: columns.length,
             numColumnsWithLineage: columnsWithLineage.length,
         };
-    }, [urn, entity, showColumns, pageIndex, filterText, highlightedColumns, onlyWithLineage, fineGrainedLineage]);
+    }, [
+        urn,
+        entity,
+        showColumns,
+        pageIndex,
+        filterText,
+        highlightedColumns,
+        shownRelatedColumns,
+        onlyWithLineage,
+        fineGrainedLineage,
+    ]);
 }
 
 function getDisplayColumns(
     urn: string,
     entity: FetchedEntityV2,
     columnHighlights: Set<string>,
+    shownRelatedColumns: ShownRelatedColumns,
     fineGrainedLineage: FineGrainedLineage,
 ): LineageDisplayColumn[] {
     if (!entity.lineageAssets) return [];
@@ -137,9 +175,10 @@ function getDisplayColumns(
                 type: columnAsset.dataType,
                 nativeDataType: columnAsset.nativeDataType,
                 highlighted: columnHighlights.has(columnAsset.name),
-                hasLineage: !!columnAsset.numUpstream || !!columnAsset.numDownstream || connectedToHomeNode,
+                hasLineage: columnHasLineage(columnAsset, connectedToHomeNode),
                 connectedToHomeNode,
                 lineageAsset: columnAsset,
+                shownRelated: shownRelatedColumns.get(columnRef),
             };
         });
 }

--- a/datahub-web-react/src/app/lineageV3/__tests__/getSiblingUrns.test.ts
+++ b/datahub-web-react/src/app/lineageV3/__tests__/getSiblingUrns.test.ts
@@ -1,0 +1,45 @@
+import { LineageEntity, NodeContext, getSiblingUrns } from '@app/lineageV3/common';
+
+import { EntityType } from '@types';
+
+const TABLE = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,db.addresses,PROD)';
+const SIBLING = 'urn:li:dataset:(urn:li:dataPlatform:dbt,db.addresses,PROD)';
+
+/**
+ * `siblings` and `siblingsSearch` are populated in different circumstances -- notably whether
+ * `hideDbtSourceInLineage` merged the pair -- so both shapes have to be understood.
+ */
+function node(urn: string, properties?: Record<string, unknown>): LineageEntity {
+    return {
+        id: urn,
+        urn,
+        type: EntityType.Dataset,
+        entity: { urn, type: EntityType.Dataset, name: urn, genericEntityProperties: properties } as any,
+        isExpanded: {} as any,
+        fetchStatus: {} as any,
+        filters: {} as any,
+    };
+}
+
+function nodes(...entries: LineageEntity[]): NodeContext['nodes'] {
+    return new Map(entries.map((entry) => [entry.urn, entry]));
+}
+
+describe('getSiblingUrns', () => {
+    it('reads siblings of a combined entity, given as a sibling search', () => {
+        const graph = nodes(node(TABLE, { siblingsSearch: { searchResults: [{ entity: { urn: SIBLING } }] } }));
+
+        expect(getSiblingUrns(TABLE, graph)).toEqual([SIBLING]);
+    });
+
+    it('reads siblings of a separated entity, given as sibling properties', () => {
+        const graph = nodes(node(TABLE, { siblings: { isPrimary: true, siblings: [{ urn: SIBLING }] } }));
+
+        expect(getSiblingUrns(TABLE, graph)).toEqual([SIBLING]);
+    });
+
+    it('returns nothing for an entity without siblings, or one not on the graph', () => {
+        expect(getSiblingUrns(TABLE, nodes(node(TABLE)))).toEqual([]);
+        expect(getSiblingUrns(TABLE, nodes())).toEqual([]);
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/__tests__/mayHideLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/__tests__/mayHideLineage.test.ts
@@ -1,0 +1,42 @@
+import { FetchStatus, mayHideLineage } from '@app/lineageV3/common';
+
+import { LineageDirection } from '@types';
+
+const UP = LineageDirection.Upstream;
+const DOWN = LineageDirection.Downstream;
+
+function node(status: FetchStatus, isExpandedUpstream: boolean) {
+    return {
+        fetchStatus: { [UP]: status, [DOWN]: FetchStatus.UNNEEDED },
+        isExpanded: { [UP]: isExpandedUpstream, [DOWN]: false },
+    };
+}
+
+describe('mayHideLineage', () => {
+    it('is true while lineage is unfetched or loading, as an expand control is shown', () => {
+        expect(mayHideLineage(UP, node(FetchStatus.UNFETCHED, false), true, false)).toBe(true);
+        expect(mayHideLineage(UP, node(FetchStatus.LOADING, false), true, false)).toBe(true);
+    });
+
+    it('is true while lineage is contracted, as an expand control is shown', () => {
+        expect(mayHideLineage(UP, node(FetchStatus.COMPLETE, false), true, false)).toBe(true);
+    });
+
+    it('is true when expanded children are filtered out, as the contract control counts them', () => {
+        expect(mayHideLineage(UP, node(FetchStatus.COMPLETE, true), true, true)).toBe(true);
+    });
+
+    it('is false once every child is expanded onto the graph', () => {
+        expect(mayHideLineage(UP, node(FetchStatus.COMPLETE, true), true, false)).toBe(false);
+    });
+
+    it('is false without children in that direction, where no control is shown', () => {
+        expect(mayHideLineage(UP, node(FetchStatus.UNFETCHED, false), false, true)).toBe(false);
+        expect(mayHideLineage(DOWN, node(FetchStatus.UNFETCHED, false), false, false)).toBe(false);
+    });
+
+    it('is false for a direction that is not being explored', () => {
+        // Nodes upstream of the home node are not searched downstream, so no control is shown
+        expect(mayHideLineage(DOWN, node(FetchStatus.COMPLETE, true), true, false)).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/__tests__/useColumnHighlighting.test.ts
+++ b/datahub-web-react/src/app/lineageV3/__tests__/useColumnHighlighting.test.ts
@@ -1,4 +1,11 @@
-import { FineGrainedLineage, NodeContext, createColumnRef } from '@app/lineageV3/common';
+import { TENTATIVE_EDGE_NAME } from '@app/lineageV3/LineageEdge/TentativeEdge';
+import {
+    FineGrainedLineage,
+    NodeContext,
+    createColumnRef,
+    createHiddenLineageRef,
+    createLineageFilterNodeId,
+} from '@app/lineageV3/common';
 import { computeSingleColumnHighlights } from '@app/lineageV3/useColumnHighlighting';
 import { createMemberNodeId } from '@app/lineageV3/useComputeGraph/dataProduct/dataProduct.utils';
 
@@ -13,12 +20,31 @@ const FIELD = 'id';
 const upstreamRef = createColumnRef(UPSTREAM, FIELD);
 const downstreamRef = createColumnRef(DOWNSTREAM, FIELD);
 
-function node(urn: string, direction?: LineageDirection) {
-    // Counts are marked fetched so no tentative edges to lineage filter nodes are emitted
-    const lineageAssets = new Map([
-        [FIELD, { name: FIELD, numUpstream: 0, numDownstream: 0, lineageCountsFetched: true }],
-    ]);
-    return { id: urn, urn, type: EntityType.Dataset, direction, entity: { lineageAssets } } as any;
+interface NodeOverrides {
+    numUpstream?: number;
+    numDownstream?: number;
+    lineageCountsFetched?: boolean;
+    numUpstreamChildren?: number;
+    numDownstreamChildren?: number;
+}
+
+function node(urn: string, direction?: LineageDirection, overrides: NodeOverrides = {}) {
+    const {
+        numUpstream = 0,
+        numDownstream = 0,
+        // Counts default to fetched so no tentative hidden lineage edges are emitted
+        lineageCountsFetched = true,
+        numUpstreamChildren = 1,
+        numDownstreamChildren = 1,
+    } = overrides;
+    const lineageAssets = new Map([[FIELD, { name: FIELD, numUpstream, numDownstream, lineageCountsFetched }]]);
+    return {
+        id: urn,
+        urn,
+        type: EntityType.Dataset,
+        direction,
+        entity: { lineageAssets, numUpstreamChildren, numDownstreamChildren },
+    } as any;
 }
 
 function fineGrainedLineage(): FineGrainedLineage {
@@ -28,22 +54,24 @@ function fineGrainedLineage(): FineGrainedLineage {
     };
 }
 
-function run(nodeIdsByUrn: Map<string, string[]>) {
-    const nodes: NodeContext['nodes'] = new Map([
-        [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream)],
-        [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
-    ]);
+function run(nodeIdsByUrn: Map<string, string[]>, nodes?: NodeContext['nodes'], showFilterNodes = false) {
     return computeSingleColumnHighlights(
         upstreamRef,
         {
             fineGrainedLineage: fineGrainedLineage(),
-            nodes,
+            nodes:
+                nodes ??
+                new Map([
+                    [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream)],
+                    [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
+                ]),
             adjacencyList: { [LineageDirection.Upstream]: new Map(), [LineageDirection.Downstream]: new Map() },
             displayedNodeIds: new Set([UPSTREAM, DOWNSTREAM]),
             nodeIdsByUrn,
             validQueryIds: new Set<string>(),
             rootUrn: DP_A,
             rootType: EntityType.DataProduct,
+            showFilterNodes,
         },
         'red',
     );
@@ -93,5 +121,63 @@ describe('column edges attach to rendered node ids', () => {
 
         const targets = Array.from(columnEdges.values()).map((edge) => edge.target);
         expect(targets.sort()).toEqual([downstreamA, downstreamB].sort());
+    });
+});
+
+describe('column edges to hidden nodes', () => {
+    const hiddenUpstreamRef = createHiddenLineageRef(UPSTREAM, LineageDirection.Upstream);
+    const hiddenDownstreamRef = createHiddenLineageRef(UPSTREAM, LineageDirection.Downstream);
+
+    /** Edges other than the upstream column -> downstream column edge every case emits. */
+    function hiddenEdges(overrides: NodeOverrides, showFilterNodes = false) {
+        const nodes: NodeContext['nodes'] = new Map([
+            [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream, overrides)],
+            [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
+        ]);
+        const { columnEdges } = run(new Map(), nodes, showFilterNodes);
+        return Array.from(columnEdges.values()).filter((edge) => edge.targetHandle !== downstreamRef);
+    }
+
+    it('emits a tentative edge in each direction while counts are unfetched', () => {
+        const edges = hiddenEdges({ lineageCountsFetched: false });
+
+        expect(edges).toHaveLength(2);
+        expect(edges.every((edge) => edge.type === TENTATIVE_EDGE_NAME)).toBe(true);
+        // Self edges: the control is part of the node's own DOM
+        expect(edges.every((edge) => edge.source === UPSTREAM && edge.target === UPSTREAM)).toBe(true);
+        expect(edges.map((edge) => [edge.sourceHandle, edge.targetHandle])).toEqual(
+            expect.arrayContaining([
+                [upstreamRef, hiddenDownstreamRef],
+                [hiddenUpstreamRef, upstreamRef],
+            ]),
+        );
+    });
+
+    it('emits a solid edge once counts show more lineage than is on the graph', () => {
+        const edges = hiddenEdges({ numDownstream: 2 });
+
+        expect(edges).toHaveLength(1);
+        expect(edges[0].type).toEqual('default');
+        expect(edges[0].sourceHandle).toEqual(upstreamRef);
+        expect(edges[0].targetHandle).toEqual(hiddenDownstreamRef);
+    });
+
+    it('emits no edge once counts show all lineage is on the graph', () => {
+        expect(hiddenEdges({ numDownstream: 1 })).toHaveLength(0);
+    });
+
+    it('emits no edge in a direction the entity has no children in', () => {
+        const edges = hiddenEdges({ lineageCountsFetched: false, numUpstreamChildren: 0 });
+
+        expect(edges).toHaveLength(1);
+        expect(edges[0].targetHandle).toEqual(hiddenDownstreamRef);
+    });
+
+    it('targets the lineage filter node when filter nodes are shown', () => {
+        const edges = hiddenEdges({ numDownstream: 2 }, true);
+
+        expect(edges).toHaveLength(1);
+        expect(edges[0].target).toEqual(createLineageFilterNodeId(UPSTREAM, LineageDirection.Downstream));
+        expect(edges[0].targetHandle).toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/lineageV3/__tests__/useColumnHighlighting.test.ts
+++ b/datahub-web-react/src/app/lineageV3/__tests__/useColumnHighlighting.test.ts
@@ -1,10 +1,11 @@
 import { TENTATIVE_EDGE_NAME } from '@app/lineageV3/LineageEdge/TentativeEdge';
 import {
+    ColumnRef,
     FineGrainedLineage,
     NodeContext,
     createColumnRef,
-    createHiddenLineageRef,
     createLineageFilterNodeId,
+    setDefault,
 } from '@app/lineageV3/common';
 import { computeSingleColumnHighlights } from '@app/lineageV3/useColumnHighlighting';
 import { createMemberNodeId } from '@app/lineageV3/useComputeGraph/dataProduct/dataProduct.utils';
@@ -13,6 +14,7 @@ import { EntityType, LineageDirection } from '@types';
 
 const UPSTREAM = 'urn:li:dataset:upstream';
 const DOWNSTREAM = 'urn:li:dataset:downstream';
+const DOWNSTREAM_OF_DOWNSTREAM = 'urn:li:dataset:downstreamOfDownstream';
 const DP_A = 'urn:li:dataProduct:A';
 const DP_B = 'urn:li:dataProduct:B';
 const FIELD = 'id';
@@ -20,58 +22,57 @@ const FIELD = 'id';
 const upstreamRef = createColumnRef(UPSTREAM, FIELD);
 const downstreamRef = createColumnRef(DOWNSTREAM, FIELD);
 
-interface NodeOverrides {
+interface AssetOverrides {
     numUpstream?: number;
     numDownstream?: number;
     lineageCountsFetched?: boolean;
-    numUpstreamChildren?: number;
-    numDownstreamChildren?: number;
 }
 
-function node(urn: string, direction?: LineageDirection, overrides: NodeOverrides = {}) {
-    const {
-        numUpstream = 0,
-        numDownstream = 0,
-        // Counts default to fetched so no tentative hidden lineage edges are emitted
-        lineageCountsFetched = true,
-        numUpstreamChildren = 1,
-        numDownstreamChildren = 1,
-    } = overrides;
-    const lineageAssets = new Map([[FIELD, { name: FIELD, numUpstream, numDownstream, lineageCountsFetched }]]);
-    return {
-        id: urn,
-        urn,
-        type: EntityType.Dataset,
-        direction,
-        entity: { lineageAssets, numUpstreamChildren, numDownstreamChildren },
-    } as any;
+function node(urn: string, direction?: LineageDirection, asset?: AssetOverrides) {
+    // Counts default to fetched, so a node without overrides emits no tentative edges
+    const lineageAssets = asset && new Map([[FIELD, { name: FIELD, lineageCountsFetched: true, ...asset }]]);
+    return { id: urn, urn, type: EntityType.Dataset, direction, entity: { lineageAssets } } as any;
+}
+
+/** Builds fine grained lineage from `[upstreamColumn, downstreamColumn]` pairs. */
+function lineageFromEdges(edges: [ColumnRef, ColumnRef][]): FineGrainedLineage {
+    const lineage: FineGrainedLineage = { downstream: new Map(), upstream: new Map() };
+    edges.forEach(([from, to]) => {
+        setDefault(lineage.downstream, from, new Map()).set(to, null);
+        setDefault(lineage.upstream, to, new Map()).set(from, null);
+    });
+    return lineage;
 }
 
 function fineGrainedLineage(): FineGrainedLineage {
-    return {
-        downstream: new Map([[upstreamRef, new Map([[downstreamRef, null]])]]),
-        upstream: new Map([[downstreamRef, new Map([[upstreamRef, null]])]]),
-    };
+    return lineageFromEdges([[upstreamRef, downstreamRef]]);
 }
 
-function run(nodeIdsByUrn: Map<string, string[]>, nodes?: NodeContext['nodes'], showFilterNodes = false) {
+interface Overrides {
+    fineGrainedLineage?: FineGrainedLineage;
+    nodes?: NodeContext['nodes'];
+    displayedNodeIds?: Set<string>;
+    showFilterNodes?: boolean;
+}
+
+function run(nodeIdsByUrn: Map<string, string[]>, overrides: Overrides = {}) {
     return computeSingleColumnHighlights(
         upstreamRef,
         {
-            fineGrainedLineage: fineGrainedLineage(),
+            fineGrainedLineage: overrides.fineGrainedLineage ?? fineGrainedLineage(),
             nodes:
-                nodes ??
+                overrides.nodes ??
                 new Map([
                     [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream)],
                     [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
                 ]),
             adjacencyList: { [LineageDirection.Upstream]: new Map(), [LineageDirection.Downstream]: new Map() },
-            displayedNodeIds: new Set([UPSTREAM, DOWNSTREAM]),
+            displayedNodeIds: overrides.displayedNodeIds ?? new Set([UPSTREAM, DOWNSTREAM]),
             nodeIdsByUrn,
             validQueryIds: new Set<string>(),
             rootUrn: DP_A,
             rootType: EntityType.DataProduct,
-            showFilterNodes,
+            showFilterNodes: overrides.showFilterNodes ?? false,
         },
         'red',
     );
@@ -124,60 +125,138 @@ describe('column edges attach to rendered node ids', () => {
     });
 });
 
-describe('column edges to hidden nodes', () => {
-    const hiddenUpstreamRef = createHiddenLineageRef(UPSTREAM, LineageDirection.Upstream);
-    const hiddenDownstreamRef = createHiddenLineageRef(UPSTREAM, LineageDirection.Downstream);
+// Numerator of the column lineage controls, compared against the counts fetched for each column
+describe('related columns shown on the graph', () => {
+    const QUERY = 'urn:li:query:transform';
+    const MISSING = 'urn:li:dataset:missing';
+    const OTHER_FIELD = 'name';
+    const queryRef = createColumnRef(QUERY, FIELD);
+    const missingRef = createColumnRef(MISSING, FIELD);
+
+    it('counts both directions for the column under the cursor', () => {
+        const { shownRelatedColumns } = run(new Map());
+
+        expect(shownRelatedColumns.get(upstreamRef)).toEqual({
+            [LineageDirection.Downstream]: 1,
+            [LineageDirection.Upstream]: 0,
+        });
+    });
+
+    it('counts related columns only on the side the traversal reached them from', () => {
+        const { shownRelatedColumns } = run(new Map(), {
+            fineGrainedLineage: lineageFromEdges([
+                [upstreamRef, downstreamRef],
+                [downstreamRef, createColumnRef(DOWNSTREAM_OF_DOWNSTREAM, FIELD)],
+            ]),
+            nodes: new Map([
+                [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream)],
+                [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
+                [DOWNSTREAM_OF_DOWNSTREAM, node(DOWNSTREAM_OF_DOWNSTREAM, LineageDirection.Upstream)],
+            ]),
+            displayedNodeIds: new Set([UPSTREAM, DOWNSTREAM, DOWNSTREAM_OF_DOWNSTREAM]),
+        });
+
+        // Nothing is known about what is upstream of the downstream column, as we never looked
+        expect(shownRelatedColumns.get(downstreamRef)).toEqual({ [LineageDirection.Downstream]: 1 });
+    });
+
+    it('leaves out columns on nodes that are not displayed', () => {
+        const { shownRelatedColumns } = run(new Map(), {
+            fineGrainedLineage: lineageFromEdges([
+                [upstreamRef, missingRef],
+                [missingRef, downstreamRef],
+            ]),
+        });
+
+        expect(shownRelatedColumns.has(missingRef)).toBe(false);
+        expect(shownRelatedColumns.has(downstreamRef)).toBe(true);
+    });
+
+    it('counts each related column once, no matter how many paths reach it', () => {
+        const { shownRelatedColumns } = run(new Map(), {
+            fineGrainedLineage: lineageFromEdges([
+                [upstreamRef, downstreamRef],
+                [upstreamRef, createColumnRef(DOWNSTREAM, OTHER_FIELD)],
+                [upstreamRef, queryRef],
+                [queryRef, downstreamRef],
+            ]),
+            displayedNodeIds: new Set([UPSTREAM, QUERY, DOWNSTREAM]),
+        });
+
+        expect(shownRelatedColumns.get(upstreamRef)?.[LineageDirection.Downstream]).toEqual(2);
+    });
+
+    it('counts through transformations, which are not rendered as columns of their own', () => {
+        const { shownRelatedColumns } = run(new Map(), {
+            fineGrainedLineage: lineageFromEdges([
+                [upstreamRef, queryRef],
+                [queryRef, downstreamRef],
+            ]),
+            displayedNodeIds: new Set([UPSTREAM, QUERY, DOWNSTREAM]),
+        });
+
+        expect(shownRelatedColumns.get(upstreamRef)?.[LineageDirection.Downstream]).toEqual(1);
+    });
+
+    it('counts through nodes missing from the graph', () => {
+        const { shownRelatedColumns } = run(new Map(), {
+            fineGrainedLineage: lineageFromEdges([
+                [upstreamRef, missingRef],
+                [missingRef, downstreamRef],
+            ]),
+        });
+
+        expect(shownRelatedColumns.get(upstreamRef)?.[LineageDirection.Downstream]).toEqual(1);
+    });
+});
+
+// How hidden column lineage is shown when lineage filter nodes are rendered, in place of the
+// column lineage controls
+describe('column edges to lineage filter nodes', () => {
+    const upstreamFilterNode = createLineageFilterNodeId(UPSTREAM, LineageDirection.Upstream);
+    const downstreamFilterNode = createLineageFilterNodeId(UPSTREAM, LineageDirection.Downstream);
 
     /** Edges other than the upstream column -> downstream column edge every case emits. */
-    function hiddenEdges(overrides: NodeOverrides, showFilterNodes = false) {
-        const nodes: NodeContext['nodes'] = new Map([
-            [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream, overrides)],
-            [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream)],
-        ]);
-        const { columnEdges } = run(new Map(), nodes, showFilterNodes);
+    function filterNodeEdges(asset: AssetOverrides, showFilterNodes = true) {
+        const { columnEdges } = run(new Map(), {
+            nodes: new Map([
+                [UPSTREAM, node(UPSTREAM, LineageDirection.Upstream, asset)],
+                // Counts fetched, so only the column under test emits filter node edges
+                [DOWNSTREAM, node(DOWNSTREAM, LineageDirection.Upstream, {})],
+            ]),
+            showFilterNodes,
+        });
         return Array.from(columnEdges.values()).filter((edge) => edge.targetHandle !== downstreamRef);
     }
 
     it('emits a tentative edge in each direction while counts are unfetched', () => {
-        const edges = hiddenEdges({ lineageCountsFetched: false });
+        const edges = filterNodeEdges({ lineageCountsFetched: false });
 
         expect(edges).toHaveLength(2);
         expect(edges.every((edge) => edge.type === TENTATIVE_EDGE_NAME)).toBe(true);
-        // Self edges: the control is part of the node's own DOM
-        expect(edges.every((edge) => edge.source === UPSTREAM && edge.target === UPSTREAM)).toBe(true);
-        expect(edges.map((edge) => [edge.sourceHandle, edge.targetHandle])).toEqual(
+        // Edges point away from the column, so the filter node is the target only downstream
+        expect(edges.map((edge) => [edge.source, edge.target])).toEqual(
             expect.arrayContaining([
-                [upstreamRef, hiddenDownstreamRef],
-                [hiddenUpstreamRef, upstreamRef],
+                [UPSTREAM, downstreamFilterNode],
+                [upstreamFilterNode, UPSTREAM],
             ]),
         );
     });
 
     it('emits a solid edge once counts show more lineage than is on the graph', () => {
-        const edges = hiddenEdges({ numDownstream: 2 });
+        const edges = filterNodeEdges({ numDownstream: 2 });
 
         expect(edges).toHaveLength(1);
         expect(edges[0].type).toEqual('default');
         expect(edges[0].sourceHandle).toEqual(upstreamRef);
-        expect(edges[0].targetHandle).toEqual(hiddenDownstreamRef);
+        expect(edges[0].target).toEqual(downstreamFilterNode);
     });
 
     it('emits no edge once counts show all lineage is on the graph', () => {
-        expect(hiddenEdges({ numDownstream: 1 })).toHaveLength(0);
+        expect(filterNodeEdges({ numDownstream: 1 })).toHaveLength(0);
     });
 
-    it('emits no edge in a direction the entity has no children in', () => {
-        const edges = hiddenEdges({ lineageCountsFetched: false, numUpstreamChildren: 0 });
-
-        expect(edges).toHaveLength(1);
-        expect(edges[0].targetHandle).toEqual(hiddenDownstreamRef);
-    });
-
-    it('targets the lineage filter node when filter nodes are shown', () => {
-        const edges = hiddenEdges({ numDownstream: 2 }, true);
-
-        expect(edges).toHaveLength(1);
-        expect(edges[0].target).toEqual(createLineageFilterNodeId(UPSTREAM, LineageDirection.Downstream));
-        expect(edges[0].targetHandle).toBeUndefined();
+    it('emits no edge when filter nodes are not rendered, as the controls show the counts', () => {
+        expect(filterNodeEdges({ lineageCountsFetched: false }, false)).toHaveLength(0);
     });
 });

--- a/datahub-web-react/src/app/lineageV3/common.ts
+++ b/datahub-web-react/src/app/lineageV3/common.ts
@@ -201,6 +201,22 @@ export function parseColumnRef(columnRef: ColumnRef): [Urn, string] {
     return [urn, field];
 }
 
+/** Sentinel "field" naming the handle at a node's side control, which stands in for lineage to
+ *  nodes that are not on the graph. Prefixed with `␟` so it cannot collide with a field path. */
+const HIDDEN_LINEAGE_FIELD: Record<LineageDirection, string> = {
+    [LineageDirection.Upstream]: '␟hidden-upstream',
+    [LineageDirection.Downstream]: '␟hidden-downstream',
+};
+
+/**
+ * Column ref for the handle placed where a node's expand / contract lineage control renders.
+ * Column edges to hidden nodes terminate here, as the control is part of the node's own DOM rather
+ * than a node of its own.
+ */
+export function createHiddenLineageRef(urn: Urn, direction: LineageDirection): ColumnRef {
+    return createColumnRef(urn, HIDDEN_LINEAGE_FIELD[direction]);
+}
+
 export function createFineGrainedOperationRef(
     queryUrn: Urn,
     upstreams: Maybe<SchemaFieldRef[]>,

--- a/datahub-web-react/src/app/lineageV3/common.ts
+++ b/datahub-web-react/src/app/lineageV3/common.ts
@@ -72,6 +72,28 @@ export interface LineageEntity extends NodeBase {
     boundingBoxLimit?: number;
 }
 
+/**
+ * Whether a node advertises that it may be hiding lineage in one direction, by rendering either an
+ * expand control -- its lineage is unfetched, loading, or contracted -- or a contract control that
+ * reports only some of its children as shown. A column's lineage can only be hidden if its node's
+ * is, so the column lineage controls follow this.
+ *
+ * Kept in sync with the controls `NodeContents` renders.
+ */
+export function mayHideLineage(
+    direction: LineageDirection,
+    { fetchStatus, isExpanded }: Pick<LineageEntity, 'fetchStatus' | 'isExpanded'>,
+    hasChildren: boolean,
+    hasFilteredChildren: boolean,
+): boolean {
+    if (!hasChildren) return false;
+    const isComplete = fetchStatus[direction] === FetchStatus.COMPLETE;
+    const showsExpandControl =
+        [FetchStatus.UNFETCHED, FetchStatus.LOADING].includes(fetchStatus[direction]) ||
+        (isComplete && !isExpanded[direction]);
+    return showsExpandControl || (isComplete && hasFilteredChildren);
+}
+
 export const LINEAGE_FILTER_TYPE = 'lineage-filter';
 const LINEAGE_FILTER_ID_PREFIX = 'lf:';
 
@@ -320,6 +342,21 @@ export const LineageNodesContext = React.createContext<NodeContext>({
     outputPortsOnly: false,
     setOutputPortsOnly: () => {},
 });
+
+/**
+ * Urns of the entities drawn as a single node with `urn`, i.e. its siblings -- a dbt model and the
+ * warehouse table it produces, say. Both shapes are read, as the lineage query populates
+ * `siblingsSearch` for a combined entity and `siblings` for a separated one.
+ */
+export function getSiblingUrns(urn: Urn, nodes: NodeContext['nodes']): Urn[] {
+    const properties = nodes.get(urn)?.entity?.genericEntityProperties;
+    return [
+        ...(properties?.siblings?.siblings ?? []),
+        ...(properties?.siblingsSearch?.searchResults?.map((result) => result?.entity) ?? []),
+    ]
+        .map((sibling) => sibling?.urn)
+        .filter((siblingUrn): siblingUrn is Urn => !!siblingUrn);
+}
 
 export function getParents(node: LineageNode, adjacencyList: NodeContext['adjacencyList']): string[] {
     if (node.type === LINEAGE_FILTER_TYPE) return [node.parent];

--- a/datahub-web-react/src/app/lineageV3/common.ts
+++ b/datahub-web-react/src/app/lineageV3/common.ts
@@ -201,22 +201,6 @@ export function parseColumnRef(columnRef: ColumnRef): [Urn, string] {
     return [urn, field];
 }
 
-/** Sentinel "field" naming the handle at a node's side control, which stands in for lineage to
- *  nodes that are not on the graph. Prefixed with `␟` so it cannot collide with a field path. */
-const HIDDEN_LINEAGE_FIELD: Record<LineageDirection, string> = {
-    [LineageDirection.Upstream]: '␟hidden-upstream',
-    [LineageDirection.Downstream]: '␟hidden-downstream',
-};
-
-/**
- * Column ref for the handle placed where a node's expand / contract lineage control renders.
- * Column edges to hidden nodes terminate here, as the control is part of the node's own DOM rather
- * than a node of its own.
- */
-export function createHiddenLineageRef(urn: Urn, direction: LineageDirection): ColumnRef {
-    return createColumnRef(urn, HIDDEN_LINEAGE_FIELD[direction]);
-}
-
 export function createFineGrainedOperationRef(
     queryUrn: Urn,
     upstreams: Maybe<SchemaFieldRef[]>,
@@ -396,6 +380,14 @@ export function buildHighlightAdjacencyList(
 export type FineGrainedLineageMap = Map<ColumnRef, Map<ColumnRef, FineGrainedOperationRef | null>>;
 export type FineGrainedLineage = { downstream: FineGrainedLineageMap; upstream: FineGrainedLineageMap };
 export type HighlightedColumns = Map<Urn, Set<string>>;
+/**
+ * How many of a column's related columns are rendered on the graph, per direction. A direction is
+ * absent when the column lineage traversal never went that way, i.e. nothing is known about that
+ * side of the column.
+ */
+export type ShownRelatedCounts = Partial<Record<LineageDirection, number>>;
+/** `ShownRelatedCounts` for the hovered / selected column and every column related to it. */
+export type ShownRelatedColumns = Map<ColumnRef, ShownRelatedCounts>;
 
 interface DisplayContext {
     // Params
@@ -415,6 +407,7 @@ interface DisplayContext {
     highlightedNodes: Set<Urn>; // TODO: Remove? Not currently used
     cllHighlightedNodes: Map<Urn, Set<FineGrainedOperationRef> | null>;
     highlightedColumns: HighlightedColumns;
+    shownRelatedColumns: ShownRelatedColumns;
     highlightedEdges: Set<string>;
     fineGrainedLineage: FineGrainedLineage;
     fineGrainedOperations: Map<FineGrainedOperationRef, FineGrainedOperation>;
@@ -435,6 +428,7 @@ export const LineageDisplayContext = React.createContext<DisplayContext>({
     highlightedNodes: new Set(),
     cllHighlightedNodes: new Map(),
     highlightedColumns: new Map(),
+    shownRelatedColumns: new Map(),
     highlightedEdges: new Set(),
     fineGrainedLineage: {
         downstream: new Map(),

--- a/datahub-web-react/src/app/lineageV3/useColumnHighlighting.ts
+++ b/datahub-web-react/src/app/lineageV3/useColumnHighlighting.ts
@@ -12,14 +12,17 @@ import {
     LineageNodesContext,
     NodeContext,
     createColumnRef,
+    createHiddenLineageRef,
     createLineageFilterNodeId,
     isTransformational,
     isUrnQuery,
+    isUrnTransformational,
     parseColumnRef,
     setDefault,
     setDifference,
 } from '@app/lineageV3/common';
 import { LINEAGE_ARROW_MARKER } from '@app/lineageV3/lineageSVGs';
+import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { EntityType, LineageDirection } from '@types';
@@ -37,6 +40,7 @@ export default function useColumnHighlighting(
     const entityRegistry = useEntityRegistryV2();
     const theme = useTheme();
     const { setEdges } = useReactFlow();
+    const { showLineageFilterNodes } = useAppConfig().config.featureFlags;
     const {
         nodes,
         adjacencyList,
@@ -68,6 +72,7 @@ export default function useColumnHighlighting(
                 validQueryIds,
                 rootUrn,
                 rootType,
+                showFilterNodes: showLineageFilterNodes,
             },
             theme.colors.borderSelected,
             theme.colors.borderHover,
@@ -83,6 +88,7 @@ export default function useColumnHighlighting(
         shownUrns,
         nodeIdsByUrn,
         entityRegistry,
+        showLineageFilterNodes,
     ]);
 
     useEffect(() => {
@@ -117,6 +123,8 @@ interface ArgumentBundle {
     validQueryIds: Set<string>;
     rootUrn: string;
     rootType: EntityType;
+    /** Whether lineage filter nodes are rendered, rather than the node-attached side controls. */
+    showFilterNodes: boolean;
 }
 
 function processColumnHighlights(
@@ -143,6 +151,7 @@ export function computeSingleColumnHighlights(
         validQueryIds,
         rootUrn,
         rootType,
+        showFilterNodes,
     }: ArgumentBundle,
     stroke: string,
 ): {
@@ -220,16 +229,18 @@ export function computeSingleColumnHighlights(
             if (ref === undefined) {
                 break;
             }
-            const { filterNodeRef, showFilterNodeEdge, isTentative } = addEdgeToLineageFilterNode(
+            const { hiddenLineageRef, showHiddenLineageEdge, isTentative } = getHiddenLineageEdge(
                 ref,
                 direction,
                 fgl,
                 nodes,
                 displayedNodeIds,
+                rootType,
+                showFilterNodes,
             );
             const [currentUrn] = parseColumnRef(ref);
-            if (displayedNodeIds.has(currentUrn) && showFilterNodeEdge) {
-                addEdge(ref, filterNodeRef, isTentative);
+            if (displayedNodeIds.has(currentUrn) && showHiddenLineageEdge) {
+                addEdge(ref, hiddenLineageRef, isTentative);
             }
 
             fgl.get(ref)?.forEach((fineGrainedOperationRef, childRef) => {
@@ -319,34 +330,73 @@ function getTopologicalOrder(missingNodes: Set<ColumnRef>, fgl: FineGrainedLinea
     return topologicalOrder;
 }
 
-function addEdgeToLineageFilterNode(
+/**
+ * Computes the edge representing a column's lineage to nodes that aren't on the graph. It terminates
+ * on the node's expand / contract lineage control, or on its lineage filter node if those are shown.
+ */
+function getHiddenLineageEdge(
     ref: ColumnRef,
     direction: LineageDirection,
     fgl: FineGrainedLineageMap,
     nodes: NodeContext['nodes'],
     displayedNodeIds: Set<string>,
+    rootType: EntityType,
+    showFilterNodes: boolean,
 ): {
-    filterNodeRef: ColumnRef;
-    showFilterNodeEdge: boolean;
+    hiddenLineageRef: ColumnRef;
+    showHiddenLineageEdge: boolean;
     isTentative: boolean;
 } {
     const [urn, field] = parseColumnRef(ref);
-    const filterNodeRef = createLineageFilterNodeId(urn, direction);
+    const hiddenLineageRef = showFilterNodes
+        ? createLineageFilterNodeId(urn, direction)
+        : createHiddenLineageRef(urn, direction);
 
     const entity = nodes.get(urn)?.entity;
     const lineageAsset = entity?.lineageAssets?.get(field);
 
     const cachedNumRelated =
         direction === LineageDirection.Downstream ? lineageAsset?.numDownstream : lineageAsset?.numUpstream;
-    const numRelatedOnGraph = Array.from(fgl.get(ref)?.keys() || []).filter((neighbor) =>
-        displayedNodeIds.has(neighbor),
-    ).length;
+    const numRelatedOnGraph = countRelatedColumnsOnGraph(ref, fgl, displayedNodeIds, rootType);
 
+    // A control only renders if the entity has children in this direction, so without them the edge
+    // would point at empty space
+    const hasChildren =
+        direction === LineageDirection.Downstream ? !!entity?.numDownstreamChildren : !!entity?.numUpstreamChildren;
     // Show tentative edge if we haven't fetched counts yet, even if we have cached value
     const isTentative = !lineageAsset?.lineageCountsFetched;
     return {
-        filterNodeRef,
-        showFilterNodeEdge: (cachedNumRelated ?? 0) > numRelatedOnGraph || isTentative,
+        hiddenLineageRef,
+        showHiddenLineageEdge: hasChildren && ((cachedNumRelated ?? 0) > numRelatedOnGraph || isTentative),
         isTentative,
     };
+}
+
+/**
+ * Number of columns related to `ref` that are rendered on the graph, to compare against the count
+ * fetched for the column. Traverses through refs that aren't rendered as their own column -- both
+ * transformations and nodes missing from the graph -- as those aren't counted for the column either.
+ */
+function countRelatedColumnsOnGraph(
+    ref: ColumnRef,
+    fgl: FineGrainedLineageMap,
+    displayedNodeIds: Set<string>,
+    rootType: EntityType,
+): number {
+    const related = new Set<ColumnRef>();
+    const seen = new Set<ColumnRef>([ref]);
+    const toVisit = Array.from(fgl.get(ref)?.keys() || []);
+    while (toVisit.length) {
+        const neighbor = toVisit.pop();
+        if (neighbor !== undefined && !seen.has(neighbor)) {
+            seen.add(neighbor);
+            const [neighborUrn] = parseColumnRef(neighbor);
+            if (displayedNodeIds.has(neighborUrn) && !isUrnTransformational(neighborUrn, rootType)) {
+                related.add(neighbor);
+            } else {
+                toVisit.push(...(fgl.get(neighbor)?.keys() || []));
+            }
+        }
+    }
+    return related.size;
 }

--- a/datahub-web-react/src/app/lineageV3/useColumnHighlighting.ts
+++ b/datahub-web-react/src/app/lineageV3/useColumnHighlighting.ts
@@ -11,8 +11,8 @@ import {
     HighlightedColumns,
     LineageNodesContext,
     NodeContext,
+    ShownRelatedColumns,
     createColumnRef,
-    createHiddenLineageRef,
     createLineageFilterNodeId,
     isTransformational,
     isUrnQuery,
@@ -36,6 +36,7 @@ export default function useColumnHighlighting(
 ): {
     cllHighlightedNodes: Map<string, Set<FineGrainedOperationRef> | null>;
     highlightedColumns: HighlightedColumns;
+    shownRelatedColumns: ShownRelatedColumns;
 } {
     const entityRegistry = useEntityRegistryV2();
     const theme = useTheme();
@@ -53,7 +54,7 @@ export default function useColumnHighlighting(
         showDataProcessInstances,
     } = useContext(LineageNodesContext);
 
-    const { cllHighlightedNodes, highlightedColumns, columnEdges } = useMemo(() => {
+    const { cllHighlightedNodes, highlightedColumns, shownRelatedColumns, columnEdges } = useMemo(() => {
         const displayedNodeIds = new Set(shownUrns);
         const validQueryIds = new Set(
             Array.from(edges.values())
@@ -110,7 +111,7 @@ export default function useColumnHighlighting(
         );
     }, [nodeVersion, hideTransformations, showDataProcessInstances, columnEdges, setEdges]);
 
-    return { cllHighlightedNodes, highlightedColumns };
+    return { cllHighlightedNodes, highlightedColumns, shownRelatedColumns };
 }
 
 interface ArgumentBundle {
@@ -123,7 +124,7 @@ interface ArgumentBundle {
     validQueryIds: Set<string>;
     rootUrn: string;
     rootType: EntityType;
-    /** Whether lineage filter nodes are rendered, rather than the node-attached side controls. */
+    /** Whether lineage filter nodes are rendered, rather than the column lineage controls. */
     showFilterNodes: boolean;
 }
 
@@ -157,15 +158,17 @@ export function computeSingleColumnHighlights(
 ): {
     cllHighlightedNodes: Map<string, Set<FineGrainedOperationRef> | null>;
     highlightedColumns: HighlightedColumns;
+    shownRelatedColumns: ShownRelatedColumns;
     columnEdges: Map<string, Edge>;
 } {
     const cllHighlightedNodes = new Map<string, Set<FineGrainedOperationRef> | null>();
     const highlightedColumns = new Map<string, Set<string>>();
+    const shownRelatedColumns: ShownRelatedColumns = new Map();
     const columnEdges = new Map<string, Edge>();
     const nodeIdsFor = (urn: string) => nodeIdsByUrn.get(urn) ?? [urn];
 
     if (column === null) {
-        return { cllHighlightedNodes, highlightedColumns, columnEdges };
+        return { cllHighlightedNodes, highlightedColumns, shownRelatedColumns, columnEdges };
     }
 
     const [urn, field] = parseColumnRef(column);
@@ -229,18 +232,25 @@ export function computeSingleColumnHighlights(
             if (ref === undefined) {
                 break;
             }
-            const { hiddenLineageRef, showHiddenLineageEdge, isTentative } = getHiddenLineageEdge(
-                ref,
-                direction,
-                fgl,
-                nodes,
-                displayedNodeIds,
-                rootType,
-                showFilterNodes,
-            );
+            // Every column reached in this direction reports how much of its own lineage is on the
+            // graph, so each can show what it is hiding -- but only on the side we traversed, as
+            // the other side of it was never explored
             const [currentUrn] = parseColumnRef(ref);
-            if (displayedNodeIds.has(currentUrn) && showHiddenLineageEdge) {
-                addEdge(ref, hiddenLineageRef, isTentative);
+            if (displayedNodeIds.has(currentUrn)) {
+                const numRelatedOnGraph = countRelatedColumnsOnGraph(ref, fgl, displayedNodeIds, rootType);
+                setDefault(shownRelatedColumns, ref, {})[direction] = numRelatedOnGraph;
+
+                if (showFilterNodes) {
+                    const { filterNodeRef, showFilterNodeEdge, isTentative } = getLineageFilterNodeEdge(
+                        ref,
+                        direction,
+                        nodes,
+                        numRelatedOnGraph,
+                    );
+                    if (showFilterNodeEdge) {
+                        addEdge(ref, filterNodeRef, isTentative);
+                    }
+                }
             }
 
             fgl.get(ref)?.forEach((fineGrainedOperationRef, childRef) => {
@@ -294,7 +304,7 @@ export function computeSingleColumnHighlights(
         });
     });
 
-    return { cllHighlightedNodes, highlightedColumns, columnEdges };
+    return { cllHighlightedNodes, highlightedColumns, shownRelatedColumns, columnEdges };
 }
 
 function getTopologicalOrder(missingNodes: Set<ColumnRef>, fgl: FineGrainedLineageMap) {
@@ -331,43 +341,33 @@ function getTopologicalOrder(missingNodes: Set<ColumnRef>, fgl: FineGrainedLinea
 }
 
 /**
- * Computes the edge representing a column's lineage to nodes that aren't on the graph. It terminates
- * on the node's expand / contract lineage control, or on its lineage filter node if those are shown.
+ * Computes the edge from a column to the lineage filter node holding the lineage it has that isn't
+ * on the graph: tentative while counts are unknown, solid once they show there is more to see, and
+ * absent once everything is displayed. Only used when lineage filter nodes are rendered; otherwise
+ * the column lineage controls carry these counts.
  */
-function getHiddenLineageEdge(
+function getLineageFilterNodeEdge(
     ref: ColumnRef,
     direction: LineageDirection,
-    fgl: FineGrainedLineageMap,
     nodes: NodeContext['nodes'],
-    displayedNodeIds: Set<string>,
-    rootType: EntityType,
-    showFilterNodes: boolean,
+    numRelatedOnGraph: number,
 ): {
-    hiddenLineageRef: ColumnRef;
-    showHiddenLineageEdge: boolean;
+    filterNodeRef: ColumnRef;
+    showFilterNodeEdge: boolean;
     isTentative: boolean;
 } {
     const [urn, field] = parseColumnRef(ref);
-    const hiddenLineageRef = showFilterNodes
-        ? createLineageFilterNodeId(urn, direction)
-        : createHiddenLineageRef(urn, direction);
-
-    const entity = nodes.get(urn)?.entity;
-    const lineageAsset = entity?.lineageAssets?.get(field);
+    const filterNodeRef = createLineageFilterNodeId(urn, direction);
+    const lineageAsset = nodes.get(urn)?.entity?.lineageAssets?.get(field);
 
     const cachedNumRelated =
         direction === LineageDirection.Downstream ? lineageAsset?.numDownstream : lineageAsset?.numUpstream;
-    const numRelatedOnGraph = countRelatedColumnsOnGraph(ref, fgl, displayedNodeIds, rootType);
 
-    // A control only renders if the entity has children in this direction, so without them the edge
-    // would point at empty space
-    const hasChildren =
-        direction === LineageDirection.Downstream ? !!entity?.numDownstreamChildren : !!entity?.numUpstreamChildren;
     // Show tentative edge if we haven't fetched counts yet, even if we have cached value
     const isTentative = !lineageAsset?.lineageCountsFetched;
     return {
-        hiddenLineageRef,
-        showHiddenLineageEdge: hasChildren && ((cachedNumRelated ?? 0) > numRelatedOnGraph || isTentative),
+        filterNodeRef,
+        showFilterNodeEdge: (cachedNumRelated ?? 0) > numRelatedOnGraph || isTentative,
         isTentative,
     };
 }

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/__tests__/getFineGrainedLineage.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { LineageEntity } from '@app/lineageV3/common';
-import { schemaFieldExists } from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
+import getFineGrainedLineage, { schemaFieldExists } from '@app/lineageV3/useComputeGraph/getFineGrainedLineage';
 
 import { EntityType } from '@types';
 
@@ -158,5 +158,108 @@ describe('schemaFieldExists', () => {
         expect(schemaFieldExists('urn:li:dataset:1', 'UserId', nodes)).toBe(true);
         expect(schemaFieldExists('urn:li:dataset:1', 'userid', nodes)).toBe(false);
         expect(schemaFieldExists('urn:li:dataset:1', 'USERID', nodes)).toBe(false);
+    });
+});
+
+describe('getFineGrainedLineage', () => {
+    const TABLE = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,db.addresses,PROD)';
+    const SIBLING = 'urn:li:dataset:(urn:li:dataPlatform:dbt,db.addresses,PROD)';
+    const DOWNSTREAM = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,db.order_details,PROD)';
+    const FIELD = 'address_id';
+    const OTHER_FIELD = 'customer_id';
+
+    interface Overrides {
+        siblings?: string[];
+        /** Siblings arrive as a search for a combined entity and as properties for a separated one,
+         *  depending on whether `hideDbtSourceInLineage` is what merged the pair. */
+        siblingShape?: 'search' | 'properties';
+        fields?: string[];
+        fineGrainedLineages?: {
+            upstreams: { urn: string; path: string }[];
+            downstreams: { urn: string; path: string }[];
+        }[];
+    }
+
+    function node(
+        urn: string,
+        { siblings, siblingShape = 'search', fields = [FIELD], fineGrainedLineages }: Overrides = {},
+    ): LineageEntity {
+        const siblingEntities = siblings?.map((sibling) => ({ urn: sibling }));
+        return {
+            id: urn,
+            urn,
+            type: EntityType.Dataset,
+            entity: {
+                urn,
+                type: EntityType.Dataset,
+                name: urn,
+                schemaMetadata: { fields: fields.map((fieldPath) => ({ fieldPath })) },
+                fineGrainedLineages,
+                genericEntityProperties:
+                    siblingEntities &&
+                    (siblingShape === 'search'
+                        ? { siblingsSearch: { searchResults: siblingEntities.map((entity) => ({ entity })) } }
+                        : { siblings: { isPrimary: true, siblings: siblingEntities } }),
+            } as any,
+            isExpanded: {} as any,
+            fetchStatus: {} as any,
+            filters: {} as any,
+        };
+    }
+
+    function run(nodes: Map<string, LineageEntity>) {
+        return getFineGrainedLineage({ nodes, edges: new Map(), rootType: EntityType.Dataset }).indirect;
+    }
+
+    function columnEdge(fromUrn: string, fromField: string, toUrn: string, toField: string) {
+        return {
+            upstreams: [{ urn: fromUrn, path: fromField }],
+            downstreams: [{ urn: toUrn, path: toField }],
+        };
+    }
+
+    // Only dbt emits this edge, and the two siblings are drawn as a single node whether or not
+    // `hideDbtSourceInLineage` is what merged them
+    it.each(['search', 'properties'] as const)(
+        'drops the edge between a column and the same column on a sibling, given as a sibling %s',
+        (siblingShape) => {
+            const fgl = run(
+                new Map([
+                    [TABLE, node(TABLE, { siblings: [SIBLING], siblingShape })],
+                    [SIBLING, node(SIBLING, { fineGrainedLineages: [columnEdge(TABLE, FIELD, SIBLING, FIELD)] })],
+                ]),
+            );
+
+            expect(fgl.downstream.size).toEqual(0);
+            expect(fgl.upstream.size).toEqual(0);
+        },
+    );
+
+    it('keeps an edge between different columns on siblings, which is real lineage', () => {
+        const fields = [FIELD, OTHER_FIELD];
+        const fgl = run(
+            new Map([
+                [TABLE, node(TABLE, { siblings: [SIBLING], fields })],
+                [
+                    SIBLING,
+                    node(SIBLING, { fields, fineGrainedLineages: [columnEdge(TABLE, FIELD, SIBLING, OTHER_FIELD)] }),
+                ],
+            ]),
+        );
+
+        expect(Array.from(fgl.downstream.get(`${TABLE}::${FIELD}`)?.keys() ?? [])).toEqual([
+            `${SIBLING}::${OTHER_FIELD}`,
+        ]);
+    });
+
+    it('keeps an edge to a column on a node of its own', () => {
+        const fgl = run(
+            new Map([
+                [TABLE, node(TABLE, { siblings: [SIBLING] })],
+                [DOWNSTREAM, node(DOWNSTREAM, { fineGrainedLineages: [columnEdge(TABLE, FIELD, DOWNSTREAM, FIELD)] })],
+            ]),
+        );
+
+        expect(Array.from(fgl.downstream.get(`${TABLE}::${FIELD}`)?.keys() ?? [])).toEqual([`${DOWNSTREAM}::${FIELD}`]);
     });
 });

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getFineGrainedLineage.ts
@@ -7,6 +7,7 @@ import {
     createColumnRef,
     createEdgeId,
     createFineGrainedOperationRef,
+    getSiblingUrns,
     isUrnTransformational,
     parseColumnRef,
     setDefault,
@@ -51,6 +52,14 @@ export function schemaFieldExists(datasetUrn: string, fieldPath: string, nodes: 
 }
 
 /**
+ * Whether two datasets are drawn as one node because they are siblings, e.g. a dbt model and the
+ * warehouse table it produces. Either node's sibling list settles it, as only one may be loaded.
+ */
+export function areSiblings(urnA: string, urnB: string, nodes: NodeContext['nodes']): boolean {
+    return getSiblingUrns(urnA, nodes).includes(urnB) || getSiblingUrns(urnB, nodes).includes(urnA);
+}
+
+/**
  * Piece together column-level lineage directly from aspects,
  * e.g. dataset upstreamLineage, chart inputFields, and datajob dataJobInputOutput
  *
@@ -81,6 +90,15 @@ export default function getFineGrainedLineage(
 
         // Drop ghost edges and self edges
         if (!nodes.has(upstreamUrn) || !nodes.has(downstreamUrn) || upstreamRef === downstreamRef) return;
+
+        // Siblings are drawn as a single node, so an edge between the same column on two of them is
+        // a self edge too. It can never be drawn, and would make the column look like it has lineage
+        if (
+            downgradeV2FieldPath(upstreamField) === downgradeV2FieldPath(downstreamField) &&
+            areSiblings(upstreamUrn, downstreamUrn, nodes)
+        ) {
+            return;
+        }
 
         // Validate that both upstream and downstream schema fields actually exist in their datasets
         // This prevents phantom lineage connections when fine-grained lineage references non-existent fields

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -983,14 +983,16 @@ query getLineageCounts(
     }
 }
 
-# How many columns a column is directly related to, counted the way the lineage graph draws them:
-# transformations are walked through rather than counted, and siblings are combined.
+# How many columns a column is directly related to, counted the way the lineage graph draws them.
+# `orFilters` carries the degree filter plus the exclusions that keep this comparable to the drawn
+# graph -- see `buildRelatedColumnFilters`.
 query getColumnLineageCounts(
     $urn: String!
     $startTimeMillis: Long
     $endTimeMillis: Long
     $ignoreAsHops: [EntityTypeToPlatforms!]
     $includeSoftDeleted: Boolean = false
+    $orFilters: [AndFilterInput!]
 ) {
     upstream: searchAcrossLineage(
         input: {
@@ -999,7 +1001,7 @@ query getColumnLineageCounts(
             types: [SCHEMA_FIELD]
             start: 0
             count: 0
-            orFilters: [{ and: [{ field: "degree", values: ["1"] }] }]
+            orFilters: $orFilters
             lineageFlags: {
                 startTimeMillis: $startTimeMillis
                 endTimeMillis: $endTimeMillis
@@ -1021,7 +1023,7 @@ query getColumnLineageCounts(
             types: [SCHEMA_FIELD]
             start: 0
             count: 0
-            orFilters: [{ and: [{ field: "degree", values: ["1"] }] }]
+            orFilters: $orFilters
             lineageFlags: {
                 startTimeMillis: $startTimeMillis
                 endTimeMillis: $endTimeMillis

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -983,6 +983,61 @@ query getLineageCounts(
     }
 }
 
+# How many columns a column is directly related to, counted the way the lineage graph draws them:
+# transformations are walked through rather than counted, and siblings are combined.
+query getColumnLineageCounts(
+    $urn: String!
+    $startTimeMillis: Long
+    $endTimeMillis: Long
+    $ignoreAsHops: [EntityTypeToPlatforms!]
+    $includeSoftDeleted: Boolean = false
+) {
+    upstream: searchAcrossLineage(
+        input: {
+            urn: $urn
+            direction: UPSTREAM
+            types: [SCHEMA_FIELD]
+            start: 0
+            count: 0
+            orFilters: [{ and: [{ field: "degree", values: ["1"] }] }]
+            lineageFlags: {
+                startTimeMillis: $startTimeMillis
+                endTimeMillis: $endTimeMillis
+                ignoreAsHops: $ignoreAsHops
+            }
+            searchFlags: {
+                groupingSpec: { groupingCriteria: [] }
+                filterNonLatestVersions: false
+                includeSoftDeleted: $includeSoftDeleted
+            }
+        }
+    ) {
+        total
+    }
+    downstream: searchAcrossLineage(
+        input: {
+            urn: $urn
+            direction: DOWNSTREAM
+            types: [SCHEMA_FIELD]
+            start: 0
+            count: 0
+            orFilters: [{ and: [{ field: "degree", values: ["1"] }] }]
+            lineageFlags: {
+                startTimeMillis: $startTimeMillis
+                endTimeMillis: $endTimeMillis
+                ignoreAsHops: $ignoreAsHops
+            }
+            searchFlags: {
+                groupingSpec: { groupingCriteria: [] }
+                filterNonLatestVersions: false
+                includeSoftDeleted: $includeSoftDeleted
+            }
+        }
+    ) {
+        total
+    }
+}
+
 query getSearchAcrossLineageCounts(
     $urn: String!
     $startTimeMillis: Long

--- a/e2e-test/ui/playwright/tests/column-lineage-controls/column-lineage-controls.spec.ts
+++ b/e2e-test/ui/playwright/tests/column-lineage-controls/column-lineage-controls.spec.ts
@@ -28,66 +28,65 @@ const LINEAGE_COLUMN = 'order_mode'; // Has lineage to the downstream table
 const SIBLING_ONLY_COLUMN = 'order_id'; // Only "lineage" is to the same column on its dbt sibling
 
 for (const hideDbtSourceInLineage of [true, false]) {
-    test.describe(`column lineage controls, hideDbtSourceInLineage=${hideDbtSourceInLineage}`, () => {
-        let lineagePage: LineageV3Page;
+  test.describe(`column lineage controls, hideDbtSourceInLineage=${hideDbtSourceInLineage}`, () => {
+    let lineagePage: LineageV3Page;
 
-        test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
-            lineagePage = new LineageV3Page(page, logger, logDir);
-            await apiMock.setFeatureFlags({
-                themeV2Enabled: true,
-                themeV2Default: true,
-                showNavBarRedesign: true,
-                hideDbtSourceInLineage,
-                // The controls stand in for lineage filter nodes, so they only render without them
-                showLineageFilterNodes: false,
-            });
-            await lineagePage.navigateToDatasetLineage(WAREHOUSE_URN);
-            await lineagePage.waitForGraphToRender();
-            await lineagePage.expandContractColumns(WAREHOUSE_URN);
-        });
-
-        test('says nothing while the node is showing all of its lineage', async ({ page }) => {
-            await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
-            await page.waitForTimeout(TIMEOUTS.SHORT);
-
-            // The node has nothing to hide downstream, so neither does its column
-            await expect(page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
-        });
-
-        test('reports how much of a column lineage is on the graph once the node contracts', async ({ page }) => {
-            await lineagePage.contract(WAREHOUSE_URN);
-            // Contracting re-lays out the graph, which moves the column out from under the cursor
-            await page.waitForTimeout(TIMEOUTS.MEDIUM);
-            await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
-
-            // One downstream column exists, and contracting took it off the graph
-            const control = page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`);
-            await expect(control).toHaveText(/0 \/ 1/, { timeout: TIMEOUTS.MEDIUM });
-        });
-
-        test('leaves a column whose only lineage is to its sibling out of it', async ({ page }) => {
-            await lineagePage.hoverColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
-            await page.waitForTimeout(TIMEOUTS.SHORT);
-
-            // A sibling is drawn folded into this node, so that lineage can never be drawn: the
-            // column has none, and gets no control in either direction
-            await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
-            await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-UPSTREAM`)).toHaveCount(0);
-        });
-
-        test('highlights nothing elsewhere for a column whose only lineage is to its sibling', async ({ page }) => {
-            await lineagePage.selectColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
-            await page.waitForTimeout(TIMEOUTS.SHORT);
-
-            const highlightedElsewhere = await page.evaluate((homeUrn) => {
-                const home = document.querySelector(`[data-testid="lineage-node-${homeUrn}"]`);
-                return Array.from(document.querySelectorAll('[data-testid^="column-"]')).filter(
-                    (element) =>
-                        !home?.contains(element) && getComputedStyle(element).backgroundColor !== 'rgba(0, 0, 0, 0)',
-                ).length;
-            }, WAREHOUSE_URN);
-
-            expect(highlightedElsewhere).toEqual(0);
-        });
+    test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+      lineagePage = new LineageV3Page(page, logger, logDir);
+      await apiMock.setFeatureFlags({
+        themeV2Enabled: true,
+        themeV2Default: true,
+        showNavBarRedesign: true,
+        hideDbtSourceInLineage,
+        // The controls stand in for lineage filter nodes, so they only render without them
+        showLineageFilterNodes: false,
+      });
+      await lineagePage.navigateToDatasetLineage(WAREHOUSE_URN);
+      await lineagePage.waitForGraphToRender();
+      await lineagePage.expandContractColumns(WAREHOUSE_URN);
     });
+
+    test('says nothing while the node is showing all of its lineage', async ({ page }) => {
+      await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
+      await page.waitForTimeout(TIMEOUTS.SHORT);
+
+      // The node has nothing to hide downstream, so neither does its column
+      await expect(page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
+    });
+
+    test('reports how much of a column lineage is on the graph once the node contracts', async ({ page }) => {
+      await lineagePage.contract(WAREHOUSE_URN);
+      // Contracting re-lays out the graph, which moves the column out from under the cursor
+      await page.waitForTimeout(TIMEOUTS.MEDIUM);
+      await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
+
+      // One downstream column exists, and contracting took it off the graph
+      const control = page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`);
+      await expect(control).toHaveText(/0 \/ 1/, { timeout: TIMEOUTS.MEDIUM });
+    });
+
+    test('leaves a column whose only lineage is to its sibling out of it', async ({ page }) => {
+      await lineagePage.hoverColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
+      await page.waitForTimeout(TIMEOUTS.SHORT);
+
+      // A sibling is drawn folded into this node, so that lineage can never be drawn: the
+      // column has none, and gets no control in either direction
+      await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
+      await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-UPSTREAM`)).toHaveCount(0);
+    });
+
+    test('highlights nothing elsewhere for a column whose only lineage is to its sibling', async ({ page }) => {
+      await lineagePage.selectColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
+      await page.waitForTimeout(TIMEOUTS.SHORT);
+
+      const highlightedElsewhere = await page.evaluate((homeUrn) => {
+        const home = document.querySelector(`[data-testid="lineage-node-${homeUrn}"]`);
+        return Array.from(document.querySelectorAll('[data-testid^="column-"]')).filter(
+          (element) => !home?.contains(element) && getComputedStyle(element).backgroundColor !== 'rgba(0, 0, 0, 0)',
+        ).length;
+      }, WAREHOUSE_URN);
+
+      expect(highlightedElsewhere).toEqual(0);
+    });
+  });
 }

--- a/e2e-test/ui/playwright/tests/column-lineage-controls/column-lineage-controls.spec.ts
+++ b/e2e-test/ui/playwright/tests/column-lineage-controls/column-lineage-controls.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Column lineage controls — the `n / total` readouts beside a hovered or selected column.
+ *
+ * DATA SEEDING: static datasets from fixtures/data.json (auto-seeded via test.use below).
+ *
+ * The seeded graph is a warehouse table with a dbt sibling, which is drawn folded into it:
+ *
+ *   orders (snowflake)  ──order_mode──▶  order_details (snowflake)
+ *     └── orders (dbt), its sibling, emitting only `order_id ──▶ order_id` onto itself
+ *
+ * So `order_mode` has column lineage the graph can draw, and `order_id` has none: its only column
+ * lineage is to the same column on its own sibling, which is never drawn as a node of its own.
+ *
+ * Every case runs with `hideDbtSourceInLineage` both on and off. That flag decides whether a dbt
+ * source is merged into its warehouse sibling, which changes the shape the sibling data arrives
+ * in, so the controls have to read the same either way.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { LineageV3Page } from '../../pages/lineage-v3.page';
+import { TIMEOUTS } from '../../utils/constants';
+
+test.use({ featureName: 'column-lineage-controls' });
+
+const WAREHOUSE_URN = 'urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD)';
+
+const LINEAGE_COLUMN = 'order_mode'; // Has lineage to the downstream table
+const SIBLING_ONLY_COLUMN = 'order_id'; // Only "lineage" is to the same column on its dbt sibling
+
+for (const hideDbtSourceInLineage of [true, false]) {
+    test.describe(`column lineage controls, hideDbtSourceInLineage=${hideDbtSourceInLineage}`, () => {
+        let lineagePage: LineageV3Page;
+
+        test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+            lineagePage = new LineageV3Page(page, logger, logDir);
+            await apiMock.setFeatureFlags({
+                themeV2Enabled: true,
+                themeV2Default: true,
+                showNavBarRedesign: true,
+                hideDbtSourceInLineage,
+                // The controls stand in for lineage filter nodes, so they only render without them
+                showLineageFilterNodes: false,
+            });
+            await lineagePage.navigateToDatasetLineage(WAREHOUSE_URN);
+            await lineagePage.waitForGraphToRender();
+            await lineagePage.expandContractColumns(WAREHOUSE_URN);
+        });
+
+        test('says nothing while the node is showing all of its lineage', async ({ page }) => {
+            await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
+            await page.waitForTimeout(TIMEOUTS.SHORT);
+
+            // The node has nothing to hide downstream, so neither does its column
+            await expect(page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
+        });
+
+        test('reports how much of a column lineage is on the graph once the node contracts', async ({ page }) => {
+            await lineagePage.contract(WAREHOUSE_URN);
+            // Contracting re-lays out the graph, which moves the column out from under the cursor
+            await page.waitForTimeout(TIMEOUTS.MEDIUM);
+            await lineagePage.hoverColumn(WAREHOUSE_URN, LINEAGE_COLUMN);
+
+            // One downstream column exists, and contracting took it off the graph
+            const control = page.getByTestId(`column-lineage-control-${LINEAGE_COLUMN}-DOWNSTREAM`);
+            await expect(control).toHaveText(/0 \/ 1/, { timeout: TIMEOUTS.MEDIUM });
+        });
+
+        test('leaves a column whose only lineage is to its sibling out of it', async ({ page }) => {
+            await lineagePage.hoverColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
+            await page.waitForTimeout(TIMEOUTS.SHORT);
+
+            // A sibling is drawn folded into this node, so that lineage can never be drawn: the
+            // column has none, and gets no control in either direction
+            await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-DOWNSTREAM`)).toHaveCount(0);
+            await expect(page.getByTestId(`column-lineage-control-${SIBLING_ONLY_COLUMN}-UPSTREAM`)).toHaveCount(0);
+        });
+
+        test('highlights nothing elsewhere for a column whose only lineage is to its sibling', async ({ page }) => {
+            await lineagePage.selectColumn(WAREHOUSE_URN, SIBLING_ONLY_COLUMN);
+            await page.waitForTimeout(TIMEOUTS.SHORT);
+
+            const highlightedElsewhere = await page.evaluate((homeUrn) => {
+                const home = document.querySelector(`[data-testid="lineage-node-${homeUrn}"]`);
+                return Array.from(document.querySelectorAll('[data-testid^="column-"]')).filter(
+                    (element) =>
+                        !home?.contains(element) && getComputedStyle(element).backgroundColor !== 'rgba(0, 0, 0, 0)',
+                ).length;
+            }, WAREHOUSE_URN);
+
+            expect(highlightedElsewhere).toEqual(0);
+        });
+    });
+}

--- a/e2e-test/ui/playwright/tests/column-lineage-controls/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/column-lineage-controls/fixtures/data.json
@@ -1,0 +1,204 @@
+[
+  {
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "name": "orders",
+              "description": "orders",
+              "tags": []
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+              "schemaName": "playwright_column_controls.orders",
+              "platform": "urn:li:dataPlatform:snowflake",
+              "version": 0,
+              "hash": "",
+              "platformSchema": {
+                "com.linkedin.pegasus2avro.schema.OtherSchema": {
+                  "rawSchema": ""
+                }
+              },
+              "fields": [
+                {
+                  "fieldPath": "order_id",
+                  "nullable": true,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "order_mode",
+                  "nullable": true,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_column_controls.orders,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "name": "orders",
+              "description": "orders",
+              "tags": []
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+              "schemaName": "playwright_column_controls.orders",
+              "platform": "urn:li:dataPlatform:dbt",
+              "version": 0,
+              "hash": "",
+              "platformSchema": {
+                "com.linkedin.pegasus2avro.schema.OtherSchema": {
+                  "rawSchema": ""
+                }
+              },
+              "fields": [
+                {
+                  "fieldPath": "order_id",
+                  "nullable": true,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "order_mode",
+                  "nullable": true,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
+                }
+              ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "auditStamp": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:datahub"
+                  },
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD)",
+                  "type": "TRANSFORMED"
+                }
+              ],
+              "fineGrainedLineages": [
+                {
+                  "upstreamType": "FIELD_SET",
+                  "downstreamType": "FIELD",
+                  "upstreams": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD),order_id)"
+                  ],
+                  "downstreams": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_column_controls.orders,PROD),order_id)"
+                  ],
+                  "confidenceScore": 1.0
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.order_details,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "name": "order_details",
+              "description": "order_details",
+              "tags": []
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+              "schemaName": "playwright_column_controls.order_details",
+              "platform": "urn:li:dataPlatform:snowflake",
+              "version": 0,
+              "hash": "",
+              "platformSchema": {
+                "com.linkedin.pegasus2avro.schema.OtherSchema": {
+                  "rawSchema": ""
+                }
+              },
+              "fields": [
+                {
+                  "fieldPath": "order_mode",
+                  "nullable": true,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
+                }
+              ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "auditStamp": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:datahub"
+                  },
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD)",
+                  "type": "TRANSFORMED"
+                }
+              ],
+              "fineGrainedLineages": [
+                {
+                  "upstreamType": "FIELD_SET",
+                  "downstreamType": "FIELD",
+                  "upstreams": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.orders,PROD),order_mode)"
+                  ],
+                  "downstreams": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_column_controls.order_details,PROD),order_mode)"
+                  ],
+                  "confidenceScore": 1.0
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
## What this does

When you hover or select a column in the lineage graph, there was no way to tell whether that column had more lineage than the graph was showing you. We used to hint at it by drawing a dotted edge from the column out to its lineage filter node while we were unsure, which then solidified or disappeared once a per-column count query came back. That only worked when lineage filter nodes were enabled.

This replaces that hint, for graphs without filter nodes, with a small readout on each side of the column:
<img width="1435" height="527" alt="Screenshot 2026-08-05 at 5 05 45 PM" src="https://github.com/user-attachments/assets/dd2fc591-5b4c-48f8-b1c9-03cffe51e1c8" />

It reads "this many of the column's related columns are drawn, out of this many that exist" — so you can see at a glance that a column has three upstream columns you aren't looking at. The total shows a spinner until the query resolves.

Loading state:
<img width="525" height="104" alt="Screenshot 2026-08-05 at 1 24 15 PM" src="https://github.com/user-attachments/assets/941a4370-4b7f-471b-a5b1-553ea13497c5" />

Both directions:
<img width="1053" height="529" alt="Screenshot 2026-08-05 at 5 06 40 PM" src="https://github.com/user-attachments/assets/5975c72b-f926-4c2f-8d22-c8cde0e80fb2" />

We now also show users how much CLL they can expect for unexpanded nodes:
<img width="773" height="281" alt="Screenshot 2026-08-05 at 5 03 53 PM" src="https://github.com/user-attachments/assets/bf1a41a3-9269-4811-bb48-7161ab1c2fb4" />

This goes away after expansion if there is no truncation of upstreams / downstream, to reduce clutter.
<img width="1171" height="294" alt="Screenshot 2026-08-05 at 5 04 31 PM" src="https://github.com/user-attachments/assets/4fcd05eb-c18e-4094-a89a-2aed47d27746" />

Graphs **with** lineage filter nodes keep the old dotted edge, unchanged. The two experiences are mutually exclusive.

The control is deliberately inert for now (not clickable, no hover state). It's structured so a follow-up can expand it on hover into a panel of controls, the way `ContractLineageControl` already does.

## When exactly the counts are shown

For a given column and direction, all of these must hold:

1. **Lineage filter nodes are off.** With them on, the dotted edge to the filter node does this job instead.
2. **The column is part of the current column-lineage traversal** — either the hovered/selected column itself, or a column reachable from it. Related columns only get a readout on the side they were reached from: a downstream column shows only its downstream count, because we never went looking at its upstreams.
3. **The column's own node says it may be hiding lineage in that direction** — it's showing an expand control (lineage unfetched, loading, or contracted) or a contract control reporting only some of its children as shown. If the node is fully expanded with nothing filtered out, its columns say nothing either. Contracting the node brings the readouts back. This is to reduce clutter.
4. **The column has some lineage that way.** No `0 / 0`.

Both numbers count columns the way the graph draws them: transformations (dbt models, queries, data jobs) are walked through rather than counted, and siblings are excluded because they're drawn as a single node. That's what makes the two numbers comparable, so expanding everything actually reads `4 / 4` rather than sitting at `2 / 4` forever.

## Bugs fixed along the way

- **Counts were inflated.** The old query counted raw one-hop schema-field relationships with siblings separated, so a query node and the column's own dbt sibling both counted as "upstreams" — a column with exactly one real upstream read `1 / 3`, and no amount of expanding could close the gap. Replaced with `getColumnLineageCounts`, which counts degree-1 schema-field lineage with the graph's own hop rules and excludes dbt and sibling parents.
- **Phantom column lineage.** dbt emits a column-level edge from a warehouse column to the same column on its dbt sibling. Siblings render as one node, so that edge can never be drawn — but it made the column look like it had lineage: not greyed out, highlightable, no edges when you clicked it. It's now dropped like any other self-edge.
- **"This column has no lineage" on columns that have it.** That popup was decided purely by the count query, ignoring column lineage already drawn on the graph. Its `hasLineage` input could also be stale relative to the counts written onto the column.
- **Two stuck-spinner bugs**, both found by the Playwright spec: the count request's timer was cancelled and rescheduled on every re-render, so during a graph relayout it never fired; and counts could be written to a column-asset object that had since been replaced, so the render never saw them.

## Testing

**Unit tests** — 175 tests across 24 files in `lineageV3` pass. New coverage for: per-column shown counts including direction-only entries; `mayHideLineage`; the control's render rules; the counts query's filters; `getSiblingUrns` reading both shapes sibling data arrives in; and `getFineGrainedLineage` dropping the sibling self-edge while keeping real edges and genuine cross-column sibling edges.

**Playwright** — new spec at `e2e-test/ui/playwright/tests/column-lineage-controls/`, seeded with a warehouse table, its dbt sibling (emitting only the phantom self-edge), and a real downstream. 8 tests pass: 4 cases run against `hideDbtSourceInLineage` both on and off, since that flag changes the shape sibling data arrives in and the readouts must behave identically either way. Cases: no readout while the node shows all its lineage; `0 / 1` once the node contracts; no readout in either direction for a column whose only lineage is to its sibling; and nothing highlighted anywhere when that column is selected.

**Manual** — walked a graph through fully expanded, partially filtered, and contracted states in the browser, confirming the readouts appear and clear as described above, and that dbt-sibling-only columns grey out while columns with real column lineage keep their readouts and highlighting.

## Notes for reviewers

- `getLineageCounts` is left in `lineage.graphql` even though nothing in OSS calls it now, since it predates this feature and is a shared query surface.
- `generateIgnoreAsHops` includes a schema-field + dbt entry that GMS rejects with `Unable to convert urn to platform`. The new counts query drops that entry to work around it. The same bug appears to break schema-field-rooted lineage pages generally — pre-existing, not addressed here, but worth a look.
- The Playwright suite does not load under Node 22 in this repo (existing specs fail identically at import with `context.conditions?.includes is not a function`); I ran it on Node 20.19.5.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated — no user-facing docs cover these controls yet
- [ ] Breaking changes documented in `updating-datahub.md` — none; this is behind the existing lineage filter node flag
