### PR TITLE
fix(ingest/cassandra): stop the driver's reactor thread at exit

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/cassandra/cassandra_api.py
@@ -1,4 +1,7 @@
+import atexit
+import logging
 import ssl
+import sys
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -14,6 +17,43 @@ from cassandra.cluster import (
 
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.cassandra.cassandra_config import CassandraSourceConfig
+
+logger = logging.getLogger(__name__)
+
+# cassandra-driver runs its connections on a process-global reactor thread and tries to
+# stop it with `atexit.register(partial(_cleanup, _global_loop))` executed at module
+# import, while _global_loop is still None. functools.partial binds that None
+# permanently, so the driver's own cleanup is a no-op and the reactor thread is still
+# executing native code while CPython finalizes -- which intermittently segfaults the
+# interpreter (exit 139) after the work has already completed successfully.
+#
+# Cluster.shutdown() does not cover this: the reactor is shared process-wide rather than
+# owned by a Cluster. Calling _cleanup() ourselves supplies the wake-up and bounded join
+# the driver intended. Affects libev and asyncore; the twisted reactor binds correctly.
+_CASSANDRA_REACTOR_MODULES = (
+    "cassandra.io.libevreactor",
+    "cassandra.io.asyncorereactor",
+)
+
+
+def _shutdown_cassandra_reactor_loops() -> None:
+    for module_name in _CASSANDRA_REACTOR_MODULES:
+        # Look the modules up rather than importing them: importing libevreactor on an
+        # install without the C extension raises, and a reactor that was never imported
+        # cannot have started a thread.
+        module = sys.modules.get(module_name)
+        loop = getattr(module, "_global_loop", None) if module is not None else None
+        if loop is None:
+            continue
+        try:
+            loop._cleanup()
+        except Exception as e:
+            # Never raise from an atexit hook; a noisy traceback here would mask the
+            # exit status of an otherwise successful run.
+            logger.debug(f"Could not shut down {module_name} reactor: {e}")
+
+
+atexit.register(_shutdown_cassandra_reactor_loops)
 
 
 @dataclass

--- a/metadata-ingestion/tests/unit/test_cassandra_source.py
+++ b/metadata-ingestion/tests/unit/test_cassandra_source.py
@@ -1,23 +1,27 @@
 import json
 import logging
 import re
+import sys
+from types import SimpleNamespace
 from typing import Any, Dict, List, Tuple
 
 # Unit tests for CassandraAPI SSL Configuration
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.cassandra.cassandra import CassandraToSchemaFieldConverter
 from datahub.ingestion.source.cassandra.cassandra_api import (
+    _CASSANDRA_REACTOR_MODULES,
     CassandraAPI,
     CassandraColumn,
+    _shutdown_cassandra_reactor_loops,
 )
 from datahub.ingestion.source.cassandra.cassandra_config import (
     CassandraSourceConfig,
 )
-from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 logger = logging.getLogger(__name__)
 
@@ -194,3 +198,36 @@ def test_authenticate_ssl_all_certs():
         mock_cluster.assert_called_once()
         assert mock_cluster.call_args[1].get("ssl_context") == mock_ssl_instance
         report.failure.assert_not_called()
+
+
+def test_reactor_loop_is_shut_down(monkeypatch):
+    """The driver leaves its reactor thread running, which segfaults the interpreter."""
+    loops = {}
+    for module_name in _CASSANDRA_REACTOR_MODULES:
+        loop = MagicMock()
+        monkeypatch.setitem(
+            sys.modules, module_name, SimpleNamespace(_global_loop=loop)
+        )
+        loops[module_name] = loop
+
+    _shutdown_cassandra_reactor_loops()
+
+    for module_name, loop in loops.items():
+        assert loop._cleanup.call_count == 1, module_name
+
+
+def test_reactor_shutdown_never_raises(monkeypatch):
+    """Raising from an atexit hook would corrupt the exit status of a successful run."""
+    exploding = MagicMock()
+    exploding._cleanup.side_effect = RuntimeError("driver internals changed")
+    monkeypatch.setitem(
+        sys.modules,
+        "cassandra.io.libevreactor",
+        SimpleNamespace(_global_loop=exploding),
+    )
+    # A reactor that was never imported must also be tolerated.
+    monkeypatch.delitem(sys.modules, "cassandra.io.asyncorereactor", raising=False)
+
+    _shutdown_cassandra_reactor_loops()
+
+    exploding._cleanup.assert_called_once()


### PR DESCRIPTION
## Root cause of the intermittent exit-139 crashes

Integration batches have been failing intermittently with **exit 139 (SIGSEGV)** ~20s *after* pytest reports every test passed. The diagnostics merged in #18929 named the culprit on the first occurrence:

```
07:27:52  ======= 166 passed ... =======
07:27:52  [atexit] 1 non-main thread(s) alive at interpreter shutdown:
07:27:52  [atexit]   event_loop daemon=True
          (20s of silence)
07:28:14  exit value 139
```

`event_loop` is created at `cassandra/io/libevreactor.py:94`. cassandra-driver runs all connections on a **process-global** reactor thread and tries to stop it with, at module import time:

```python
_global_loop = None
atexit.register(partial(_cleanup, _global_loop))
```

`functools.partial` binds that `None` **permanently**, before `initialize_reactor()` ever assigns the real loop. `_cleanup` is `if loop: loop._cleanup()`, so the driver's own shutdown is a **no-op**. Nothing else calls it except the fork handler. The reactor thread therefore runs until the process dies — still executing native code while CPython finalizes, which intermittently segfaults the interpreter.

That also explains why faulthandler printed nothing: the thread is inside libev C code with no Python frame.

## Not test-only

A `datahub ingest` run using this source can exit 139 *after ingesting successfully*. Exit 139 instead of 0 makes Airflow/cron record a successful run as **failed**.

## Measurement

Against a live Cassandra, threads alive at interpreter exit:

| cleanup | threads alive at exit |
|---|---|
| none | `Task Scheduler`, `event_loop`, `Connection heartbeat` |
| `session.shutdown()` + `cluster.shutdown()` (#18829) | **`event_loop`** |
| the above + this change | **none** |

The middle row is exactly what CI reported, so #18829 was necessary — it cleared two of the three threads — but left the offending one. `Cluster.shutdown()` cannot cover this: the reactor is shared process-wide, not owned by a `Cluster`.

## The change

Invokes `_cleanup()` — supplying the `notify()` wake-up and bounded `join(timeout=1.0)` the driver intended.

- **Registered at exit, not in `close()`** — tearing down a shared reactor mid-run would break a second Cassandra source in the same process.
- **Reactors looked up via `sys.modules`, not imported** — importing `libevreactor` raises on installs without the C extension, and a reactor never imported cannot have started a thread.
- **Never raises** — a traceback from an atexit hook would itself corrupt the exit status.
- Covers libev and asyncore, which share the bug. The twisted reactor binds its handler correctly and is untouched.

## Honest scope

This removes the thread that is demonstrably alive when the crash happens; it does not *prove* the segfault is gone, since the crash is a timing-dependent race I cannot reproduce on demand. There is a built-in check, though: the `[atexit] ... event_loop` line from #18929 should stop appearing in CI. If it disappears and exit-139 persists, the cause is something else.

Worth reporting the `partial` binding upstream to cassandra-driver (still present in 3.29.3).

## Test plan

- [x] End-to-end against a live Cassandra container: reproduced the CI thread state, confirmed this change clears it
- [x] Two unit tests: cleanup is invoked for each affected reactor, and a raising `_cleanup` is swallowed rather than escaping the atexit hook
- [x] Full `test_cassandra_source.py` passes (8 tests); `ruff format` / `ruff check` / `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e30d02c3abede86cb0759e63017fc4722d8969b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `cassandra-driver` reactor thread at process exit to prevent intermittent exit 139 (SIGSEGV) after successful runs. Ensures clean shutdown so CI and orchestrators don’t mark successful ingests as failed.

- **Bug Fixes**
  - Register a safe `atexit` hook that calls `_cleanup()` on active reactor loops for `cassandra.io.libevreactor` and `cassandra.io.asyncorereactor`.
  - Look up reactors via `sys.modules` to avoid importing C-extension-only modules.
  - Swallow errors and log at debug to preserve the correct exit status.
  - Defer shutdown to process exit (not `close()`) to avoid interfering with multiple Cassandra sources in the same process.

<sup>Written for commit e30d02c3abede86cb0759e63017fc4722d8969b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

