### PR TITLE
perf(gms): improve batching during application set/unset

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtils.java
@@ -15,6 +15,8 @@ import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.service.ApplicationService;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -85,11 +87,16 @@ public class ApplicationAuthorizationUtils {
       @Nonnull ApplicationService applicationService,
       @Nonnull QueryContext context,
       @Nonnull String operationName) {
-    for (String resource : resources) {
-      Urn resourceUrn = UrnUtils.getUrn(resource);
-      if (!applicationService.verifyEntityExists(context.getOperationContext(), resourceUrn)) {
+    final List<Urn> resourceUrns =
+        resources.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+    final Set<Urn> existingUrns =
+        applicationService.filterExistingUrns(context.getOperationContext(), resourceUrns);
+
+    for (Urn resourceUrn : resourceUrns) {
+      if (!existingUrns.contains(resourceUrn)) {
         throw new RuntimeException(
-            String.format("Failed to %s, %s in resources does not exist", operationName, resource));
+            String.format(
+                "Failed to %s, %s in resources does not exist", operationName, resourceUrn));
       }
       verifyEditApplicationsAuthorization(resourceUrn, context);
     }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtilsTest.java
@@ -9,6 +9,10 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.metadata.service.ApplicationService;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -24,17 +28,30 @@ public class ApplicationAuthorizationUtilsTest {
   private ApplicationService mockApplicationService;
   private QueryContext mockAllowContext;
   private QueryContext mockDenyContext;
+  private final Set<Urn> existingUrns = new HashSet<>();
 
   @BeforeMethod
   public void setupTest() {
     mockApplicationService = Mockito.mock(ApplicationService.class);
     mockAllowContext = getMockAllowContext(TEST_ACTOR_URN);
     mockDenyContext = getMockDenyContext(TEST_ACTOR_URN);
+    existingUrns.clear();
+    Mockito.when(mockApplicationService.filterExistingUrns(Mockito.any(), Mockito.anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream()
+                  .filter(existingUrns::contains)
+                  .collect(Collectors.toSet());
+            });
   }
 
   private void mockExists(Urn urn, boolean exists) {
-    Mockito.when(mockApplicationService.verifyEntityExists(Mockito.any(), Mockito.eq(urn)))
-        .thenReturn(exists);
+    if (exists) {
+      existingUrns.add(urn);
+    } else {
+      existingUrns.remove(urn);
+    }
   }
 
   @Test
@@ -60,9 +77,11 @@ public class ApplicationAuthorizationUtilsTest {
         "test operation");
 
     Mockito.verify(mockApplicationService, Mockito.times(1))
-        .verifyEntityExists(Mockito.any(), Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)));
-    Mockito.verify(mockApplicationService, Mockito.times(1))
-        .verifyEntityExists(Mockito.any(), Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)));
+        .filterExistingUrns(
+            Mockito.any(),
+            Mockito.eq(
+                ImmutableList.of(
+                    UrnUtils.getUrn(TEST_ENTITY_URN_1), UrnUtils.getUrn(TEST_ENTITY_URN_2))));
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/BatchSetApplicationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/BatchSetApplicationResolverTest.java
@@ -12,7 +12,11 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.BatchSetApplicationInput;
 import com.linkedin.metadata.service.ApplicationService;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -30,6 +34,7 @@ public class BatchSetApplicationResolverTest {
   private BatchSetApplicationResolver resolver;
   private QueryContext mockContext;
   private DataFetchingEnvironment mockEnv;
+  private final Set<Urn> existingUrns = new HashSet<>();
 
   @BeforeMethod
   public void setupTest() {
@@ -38,9 +43,23 @@ public class BatchSetApplicationResolverTest {
     mockContext = getMockAllowContext(TEST_ACTOR_URN);
     mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    existingUrns.clear();
+    Mockito.when(mockApplicationService.filterExistingUrns(any(), Mockito.anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream()
+                  .filter(existingUrns::contains)
+                  .collect(Collectors.toSet());
+            });
   }
 
   private void mockExists(Urn urn, boolean exists) {
+    if (exists) {
+      existingUrns.add(urn);
+    } else {
+      existingUrns.remove(urn);
+    }
     Mockito.when(mockApplicationService.verifyEntityExists(any(), eq(urn))).thenReturn(exists);
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/BatchUnsetApplicationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/BatchUnsetApplicationResolverTest.java
@@ -12,7 +12,11 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.BatchUnsetApplicationInput;
 import com.linkedin.metadata.service.ApplicationService;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -30,6 +34,7 @@ public class BatchUnsetApplicationResolverTest {
   private BatchUnsetApplicationResolver resolver;
   private QueryContext mockContext;
   private DataFetchingEnvironment mockEnv;
+  private final Set<Urn> existingUrns = new HashSet<>();
 
   @BeforeMethod
   public void setupTest() {
@@ -38,9 +43,23 @@ public class BatchUnsetApplicationResolverTest {
     mockContext = getMockAllowContext(TEST_ACTOR_URN);
     mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    existingUrns.clear();
+    Mockito.when(mockApplicationService.filterExistingUrns(any(), Mockito.anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream()
+                  .filter(existingUrns::contains)
+                  .collect(Collectors.toSet());
+            });
   }
 
   private void mockExists(Urn urn, boolean exists) {
+    if (exists) {
+      existingUrns.add(urn);
+    } else {
+      existingUrns.remove(urn);
+    }
     Mockito.when(mockApplicationService.verifyEntityExists(any(), eq(urn))).thenReturn(exists);
   }
 
@@ -141,11 +160,13 @@ public class BatchUnsetApplicationResolverTest {
 
     assertTrue(resolver.get(mockEnv).get());
 
-    // Verify that all resources were checked for existence
+    // Verify that all resources were checked for existence in a single batched call
     Mockito.verify(mockApplicationService, Mockito.times(1))
-        .verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)));
-    Mockito.verify(mockApplicationService, Mockito.times(1))
-        .verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)));
+        .filterExistingUrns(
+            any(),
+            eq(
+                ImmutableList.of(
+                    UrnUtils.getUrn(TEST_ENTITY_URN_1), UrnUtils.getUrn(TEST_ENTITY_URN_2))));
     Mockito.verify(mockApplicationService, Mockito.times(1))
         .verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_APPLICATION_URN)));
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/ApplicationService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/ApplicationService.java
@@ -18,8 +18,14 @@ import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -193,11 +199,17 @@ public class ApplicationService {
         resourceUrns.size(),
         resourceUrns);
 
+    final Map<Urn, Applications> existingApplicationsByResource =
+        batchGetExistingApplications(opContext, resourceUrns);
+
     final List<MetadataChangeProposal> proposals =
         resourceUrns.stream()
             .map(
                 resourceUrn ->
-                    buildAddApplicationAssetsProposal(opContext, applicationUrn, resourceUrn))
+                    buildAddApplicationAssetsProposal(
+                        applicationUrn,
+                        resourceUrn,
+                        existingApplicationsByResource.get(resourceUrn)))
             .collect(Collectors.toList());
 
     try {
@@ -211,8 +223,14 @@ public class ApplicationService {
   }
 
   private MetadataChangeProposal buildAddApplicationAssetsProposal(
-      @Nonnull OperationContext opContext, @Nonnull Urn applicationUrn, Urn resourceUrn) {
-    Applications applications = getExistingApplications(opContext, resourceUrn);
+      @Nonnull Urn applicationUrn, Urn resourceUrn, @Nullable Applications existingApplications) {
+    Applications applications;
+    if (existingApplications != null) {
+      applications = existingApplications;
+    } else {
+      log.info("No existing applications aspect found for resource {}", resourceUrn);
+      applications = emptyApplications();
+    }
 
     if (!applications.getApplications().contains(applicationUrn)) {
       applications.getApplications().add(applicationUrn);
@@ -239,37 +257,48 @@ public class ApplicationService {
         resourceUrn, Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME, applications);
   }
 
-  private Applications getExistingApplications(
-      @Nonnull OperationContext opContext, @Nonnull Urn resourceUrn) {
-    try {
-      final EntityResponse response =
-          this.entityClient.getV2(
-              opContext,
-              resourceUrn.getEntityType(),
-              resourceUrn,
-              ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME));
-
-      if (response != null
-          && response.getAspects().containsKey(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME)) {
-        return new Applications(
-            response
-                .getAspects()
-                .get(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME)
-                .getValue()
-                .data());
-      } else {
-        log.info(
-            "No existing applications aspect found for resource {} (response: {})",
-            resourceUrn,
-            response != null ? "present but no aspect" : "null");
-      }
-    } catch (Exception e) {
-      log.warn(
-          "Failed to retrieve existing Applications for resource {}, will create new aspect",
-          resourceUrn,
-          e);
+  private Map<Urn, Applications> batchGetExistingApplications(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> resourceUrns) {
+    if (resourceUrns.isEmpty()) {
+      return Collections.emptyMap();
     }
 
+    final Map<Urn, Applications> existingApplicationsByResource = new HashMap<>();
+    try {
+      final Map<Urn, EntityResponse> responses =
+          this.entityClient.batchGetV2(
+              opContext,
+              resourceUrns.iterator().next().getEntityType(),
+              new HashSet<>(resourceUrns),
+              ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME));
+
+      for (Map.Entry<Urn, EntityResponse> entry : responses.entrySet()) {
+        final EntityResponse response = entry.getValue();
+        if (response != null
+            && response.getAspects().containsKey(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME)) {
+          existingApplicationsByResource.put(
+              entry.getKey(),
+              new Applications(
+                  response
+                      .getAspects()
+                      .get(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME)
+                      .getValue()
+                      .data()));
+        }
+      }
+    } catch (Exception e) {
+      log.error(
+          "Failed to batch retrieve existing Applications for {} resource(s): {}",
+          resourceUrns,
+          e.getMessage(),
+          e);
+      throw new RuntimeException("Failed to batch retrieve existing Applications", e);
+    }
+
+    return existingApplicationsByResource;
+  }
+
+  private static Applications emptyApplications() {
     Applications applications = new Applications(new DataMap());
     applications.setApplications(new UrnArray());
     return applications;
@@ -329,11 +358,17 @@ public class ApplicationService {
     log.info(
         "Batch unsetting application {} from {} resources", applicationUrn, resourceUrns.size());
 
+    final Map<Urn, Applications> existingApplicationsByResource =
+        batchGetExistingApplications(opContext, resourceUrns);
+
     final List<MetadataChangeProposal> proposals =
         resourceUrns.stream()
             .map(
                 resourceUrn ->
-                    buildUnsetApplicationProposal(opContext, applicationUrn, resourceUrn))
+                    buildUnsetApplicationProposal(
+                        applicationUrn,
+                        resourceUrn,
+                        existingApplicationsByResource.get(resourceUrn)))
             .collect(Collectors.toList());
 
     try {
@@ -346,8 +381,14 @@ public class ApplicationService {
   }
 
   private MetadataChangeProposal buildUnsetApplicationProposal(
-      @Nonnull OperationContext opContext, @Nonnull Urn applicationUrn, Urn resourceUrn) {
-    Applications applications = getExistingApplications(opContext, resourceUrn);
+      @Nonnull Urn applicationUrn, Urn resourceUrn, @Nullable Applications existingApplications) {
+    Applications applications;
+    if (existingApplications != null) {
+      applications = existingApplications;
+    } else {
+      log.info("No existing applications aspect found for resource {}", resourceUrn);
+      applications = emptyApplications();
+    }
 
     // Remove the specific application from the list
     applications.getApplications().remove(applicationUrn);
@@ -359,6 +400,22 @@ public class ApplicationService {
   public boolean verifyEntityExists(@Nonnull OperationContext opContext, @Nonnull Urn entityUrn) {
     try {
       return this.entityClient.exists(opContext, entityUrn);
+    } catch (RemoteInvocationException e) {
+      throw new RuntimeException("Failed to check entity existence: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Returns the subset of the given urns that currently exist, resolving them in a single round
+   * trip instead of one existence check per urn.
+   */
+  public Set<Urn> filterExistingUrns(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> entityUrns) {
+    if (entityUrns.isEmpty()) {
+      return Collections.emptySet();
+    }
+    try {
+      return this.entityClient.filterExistingUrns(opContext, entityUrns);
     } catch (RemoteInvocationException e) {
       throw new RuntimeException("Failed to check entity existence: " + e.getMessage(), e);
     }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/ApplicationServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/ApplicationServiceTest.java
@@ -28,6 +28,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collections;
@@ -221,6 +222,13 @@ public class ApplicationServiceTest {
   @Test
   public void testBatchSetApplicationAssets() throws Exception {
     List<Urn> assetUrns = ImmutableList.of(TEST_ASSET_URN, TEST_ASSET_URN_2);
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            eq(TEST_ASSET_URN.getEntityType()),
+            eq(ImmutableSet.of(TEST_ASSET_URN, TEST_ASSET_URN_2)),
+            eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
+        .thenReturn(Collections.emptyMap());
+
     _applicationService.batchSetApplicationAssets(
         _opContext, TEST_APPLICATION_URN, assetUrns, TEST_USER_URN);
 
@@ -253,6 +261,20 @@ public class ApplicationServiceTest {
             mcp2.getAspect().getValue(), mcp2.getAspect().getContentType(), Applications.class);
     assertEquals(apps2.getApplications().size(), 1);
     assertEquals(apps2.getApplications().get(0), TEST_APPLICATION_URN);
+  }
+
+  @Test
+  public void testBatchSetApplicationAssetsWithEmptyResourceList() throws Exception {
+    _applicationService.batchSetApplicationAssets(
+        _opContext, TEST_APPLICATION_URN, Collections.emptyList(), TEST_USER_URN);
+
+    verify(_entityClient, Mockito.never()).batchGetV2(any(), any(), any(), any());
+
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpListCaptor =
+        ArgumentCaptor.forClass(List.class);
+    verify(_entityClient, times(1))
+        .batchIngestProposals(eq(_opContext), mcpListCaptor.capture(), eq(false));
+    assertTrue(mcpListCaptor.getValue().isEmpty());
   }
 
   @Test
@@ -318,12 +340,12 @@ public class ApplicationServiceTest {
   @Test
   public void testBatchUnsetApplicationFromEmptyList() throws Exception {
     // Mock: Resource has no existing applications
-    when(_entityClient.getV2(
+    when(_entityClient.batchGetV2(
             any(OperationContext.class),
             eq(TEST_ASSET_URN.getEntityType()),
-            eq(TEST_ASSET_URN),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
             eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(null);
+        .thenReturn(Collections.emptyMap());
 
     List<Urn> resourceUrns = ImmutableList.of(TEST_ASSET_URN);
     _applicationService.batchUnsetApplication(
@@ -364,12 +386,12 @@ public class ApplicationServiceTest {
     response.setEntityName(TEST_ASSET_URN.getEntityType());
     response.setUrn(TEST_ASSET_URN);
 
-    when(_entityClient.getV2(
+    when(_entityClient.batchGetV2(
             any(OperationContext.class),
             eq(TEST_ASSET_URN.getEntityType()),
-            eq(TEST_ASSET_URN),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
             eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(response);
+        .thenReturn(Collections.singletonMap(TEST_ASSET_URN, response));
 
     List<Urn> resourceUrns = ImmutableList.of(TEST_ASSET_URN);
     _applicationService.batchUnsetApplication(
@@ -398,12 +420,12 @@ public class ApplicationServiceTest {
   public void testBatchUnsetApplicationHandlesException() throws Exception {
     List<Urn> resourceUrns = ImmutableList.of(TEST_ASSET_URN);
 
-    when(_entityClient.getV2(
+    when(_entityClient.batchGetV2(
             any(OperationContext.class),
             eq(TEST_ASSET_URN.getEntityType()),
-            eq(TEST_ASSET_URN),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
             eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(null);
+        .thenReturn(Collections.emptyMap());
 
     when(_entityClient.batchIngestProposals(eq(_opContext), any(List.class), eq(false)))
         .thenThrow(new RuntimeException("Batch ingest failed"));
@@ -413,6 +435,27 @@ public class ApplicationServiceTest {
         () ->
             _applicationService.batchUnsetApplication(
                 _opContext, TEST_APPLICATION_URN, resourceUrns, TEST_USER_URN));
+  }
+
+  @Test
+  public void testBatchUnsetApplicationFailsLoudlyWhenBatchFetchThrows() throws Exception {
+    List<Urn> resourceUrns = ImmutableList.of(TEST_ASSET_URN);
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            eq(TEST_ASSET_URN.getEntityType()),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
+            eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
+        .thenThrow(new RuntimeException("Batch fetch failed"));
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            _applicationService.batchUnsetApplication(
+                _opContext, TEST_APPLICATION_URN, resourceUrns, TEST_USER_URN));
+
+    verify(_entityClient, Mockito.never())
+        .batchIngestProposals(any(), any(List.class), any(Boolean.class));
   }
 
   @Test
@@ -430,12 +473,12 @@ public class ApplicationServiceTest {
                 Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME, envelopedAspect)));
     response.setUrn(TEST_ASSET_URN);
 
-    when(_entityClient.getV2(
+    when(_entityClient.batchGetV2(
             any(OperationContext.class),
             eq(TEST_ASSET_URN.getEntityType()),
-            eq(TEST_ASSET_URN),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
             eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(response);
+        .thenReturn(Collections.singletonMap(TEST_ASSET_URN, response));
 
     List<Urn> assetUrns = ImmutableList.of(TEST_ASSET_URN);
     _applicationService.batchSetApplicationAssets(
@@ -475,12 +518,12 @@ public class ApplicationServiceTest {
                 Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME, envelopedAspect)));
     response.setUrn(TEST_ASSET_URN);
 
-    when(_entityClient.getV2(
+    when(_entityClient.batchGetV2(
             any(OperationContext.class),
             eq(TEST_ASSET_URN.getEntityType()),
-            eq(TEST_ASSET_URN),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
             eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
-        .thenReturn(response);
+        .thenReturn(Collections.singletonMap(TEST_ASSET_URN, response));
 
     List<Urn> assetUrns = ImmutableList.of(TEST_ASSET_URN);
     _applicationService.batchSetApplicationAssets(
@@ -502,5 +545,49 @@ public class ApplicationServiceTest {
     // Should still only have one application (no duplicate)
     assertEquals(apps.getApplications().size(), 1);
     assertEquals(apps.getApplications().get(0), TEST_APPLICATION_URN);
+  }
+
+  @Test
+  public void testBatchSetApplicationAssetsFailsLoudlyWhenBatchFetchThrows() throws Exception {
+    List<Urn> assetUrns = ImmutableList.of(TEST_ASSET_URN);
+
+    when(_entityClient.batchGetV2(
+            any(OperationContext.class),
+            eq(TEST_ASSET_URN.getEntityType()),
+            eq(ImmutableSet.of(TEST_ASSET_URN)),
+            eq(ImmutableSet.of(Constants.APPLICATION_MEMBERSHIP_ASPECT_NAME))))
+        .thenThrow(new RuntimeException("Batch fetch failed"));
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            _applicationService.batchSetApplicationAssets(
+                _opContext, TEST_APPLICATION_URN, assetUrns, TEST_USER_URN));
+
+    verify(_entityClient, Mockito.never())
+        .batchIngestProposals(any(), any(List.class), any(Boolean.class));
+  }
+
+  @Test
+  public void testFilterExistingUrns() throws Exception {
+    when(_entityClient.filterExistingUrns(
+            eq(_opContext), eq(ImmutableList.of(TEST_ASSET_URN, TEST_ASSET_URN_2))))
+        .thenReturn(ImmutableSet.of(TEST_ASSET_URN));
+
+    assertEquals(
+        _applicationService.filterExistingUrns(
+            _opContext, ImmutableList.of(TEST_ASSET_URN, TEST_ASSET_URN_2)),
+        ImmutableSet.of(TEST_ASSET_URN));
+
+    assertEquals(
+        _applicationService.filterExistingUrns(_opContext, Collections.emptyList()),
+        Collections.emptySet());
+
+    when(_entityClient.filterExistingUrns(eq(_opContext), eq(ImmutableList.of(TEST_DOMAIN_URN))))
+        .thenThrow(new RemoteInvocationException("Client error"));
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            _applicationService.filterExistingUrns(_opContext, ImmutableList.of(TEST_DOMAIN_URN)));
   }
 }


### PR DESCRIPTION
## Summary
While the batchSetApplication and batchUnsetApplication operations are already written with batching in mind (i.e. they use the Batch API to ingest multiple proposals at once), their pre-ingestion phase still requires some O(Asset count) queries that could be avoided through a batch fetch.

This PR address this by replacing using batch fetches instead of a for-loop in two areas during the fetch phase:
 - Check for existence of all assets to be associated with the application in one go.
 - Fetch existing applications associated with all assets in one go.

**Comparison of queries fired during the fetch phase before and after (excluding authn/authz):**
 _Before_: 2*(Asset count) + 1
 _After_:  3

## Changes
- `ApplicationAuthorizationUtils`:  Updated to check for existence of resources in one go.
- `ApplicationService`: Updated to bulk fetch all applications associated with all resources and collect them into an in-memory map.

## Test Plan
- Added/updated unit tests as required
- All existing coverage should pass
- Manually verified through MySQL query logs that batchSetApplications / batchUnsetApplications now fire fewer queries

## Breaking Changes
None

## Checklist

- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Linked related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (if applicable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved batching for application set/unset to eliminate per-asset pre-fetches, reducing queries from 2*(asset count)+1 to 3. This speeds up batch operations and lowers DB/API load.

- **Refactors**
  - `ApplicationAuthorizationUtils`: batch existence checks using `ApplicationService.filterExistingUrns`.
  - `ApplicationService`: batch fetch application membership with `entityClient.batchGetV2` and build proposals from a pre-fetched map.
  - Added `filterExistingUrns`, improved error handling, and updated unit tests.

<sup>Written for commit 77a11ffa563a1a27d9aaf5585bce4647302938a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

