### PR TITLE
fix(timeseries): avoid divide-by-zero in batchGetAspectValues when limit is 0

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -509,7 +509,7 @@ public class ElasticSearchTimeseriesAspectService
       @Nullable Filter sharedFilter,
       @Nullable SortCriterion sort) {
 
-    if (urns.isEmpty()) {
+    if (urns.isEmpty() || limit == 0) {
       return Collections.emptyMap();
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
@@ -1028,6 +1028,30 @@ public class TimeseriesAspectServiceUnitTest {
   }
 
   @Test
+  public void testBatchGetAspectValuesZeroLimitDoesNotDivideByZero() throws IOException {
+    // limit=0 survives applyLimit as 0 (it is neither negative nor above max), so it reaches the
+    // batched path and is used as the divisor when deriving the sub-batch size. A caller asking
+    // for zero documents should get empty lists, matching size(0) on the per-URN path.
+    Urn urn1 = UrnUtils.getUrn("urn:li:dataset:123");
+    Urn urn2 = UrnUtils.getUrn("urn:li:dataset:456");
+
+    Map<Urn, List<com.linkedin.metadata.aspect.EnvelopedAspect>> result =
+        _timeseriesAspectService.batchGetAspectValues(
+            opContext,
+            new HashSet<>(Arrays.asList(urn1, urn2)),
+            "dataset",
+            "datasetProfile",
+            null,
+            null,
+            0,
+            null,
+            null);
+
+    verify(searchClient, never()).search(any(), any(), any());
+    Assert.assertTrue(result.isEmpty());
+  }
+
+  @Test
   public void testBatchGetAspectValuesSubBatchFailure() throws IOException {
     // When searchClient.search throws, the failed URN is still present with emptyList.
     String urnString = "urn:li:dataset:123";


### PR DESCRIPTION
### Problem

`ElasticSearchTimeseriesAspectService.batchGetAspectValues` sizes its per-query URN sub-batch by dividing `topHitsThreshold` by the caller-supplied `limit`:

```java
int batchSize = Math.max(1, timeseriesAspectServiceConfig.getTopHitsThreshold() / limit);
```

A `limit` of `0` reaches that line:

- `ConfigUtils.applyLimit` returns `0` unchanged — `0` is neither negative nor above `max`, so neither normalization branch fires.
- The `limit > topHitsPerBucketLimit` guard is `0 > 100` → false, so the batched path is taken.

The result is `java.lang.ArithmeticException: / by zero`, thrown before any Elasticsearch call and outside the surrounding `try`, so every requested URN comes back without a result rather than the documented empty list.

`limit` is declared as plain `limit: Int` in `entity.graphql` with no validation, so this is reachable from the API for any timeseries field whose resolver batches two or more URNs (`Dataset.datasetProfiles`, `Dataset.usageStats`, `Dashboard.usageStats`, ...).

### Fix

Return early when `limit == 0`. This matches what the single-URN path already produces — `getAspectValues` builds a top-level search with `size(0)`, which yields no hits.

Only `limit == 0` is special-cased. Negative limits are deliberately left to fall through, since `applyLimit` maps them to `apiDefault` rather than to "no results", and changing that is a separate behavioral question.

### Testing

Added `testBatchGetAspectValuesZeroLimitDoesNotDivideByZero`, which calls `batchGetAspectValues` with two URNs and `limit=0`, asserting no ES query is issued.

Verified it reproduces the defect: reverting the production change makes the new test fail with `ArithmeticException: / by zero` at the `batchSize` line, and it passes with the fix. Full class green:

```
./gradlew :metadata-io:test --tests "com.linkedin.metadata.timeseries.search.TimeseriesAspectServiceUnitTest"
36 passing
```

### Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs — not applicable, no user-facing behavior change for valid limits
- [ ] Breaking changes — none; `limit == 0` previously threw

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a divide-by-zero in timeseries batch retrieval when limit is 0 by returning an empty result map early. This matches the single-URN path and avoids throwing before any Elasticsearch query.

- **Bug Fixes**
  - Short-circuit `batchGetAspectValues` for `limit == 0` to return empty results instead of error.
  - Added a unit test to ensure no ES search runs and the result is empty when `limit` is 0.

<sup>Written for commit b74379a20b893ff1d5d4e70a60c46e2e68d6ce8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

