### PR TITLE
fix(docker): unblock Chainguard CI Python image builds on arm64

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -323,7 +323,7 @@ jobs:
       - id: uv-creds
         uses: ./.github/actions/setup-uv-credentials
         with:
-          base_profile: ${{ vars.CI_BASE_UV_DOCKER_PROFILE || 'default' }}
+          base_profile: ${{ vars.CI_BASE_UV_DOCKER_PROFILE || 'chainguard-ci' }}
           chainguard_python_identity_id: ${{ vars.CHAINGUARD_PYTHON_IDENTITY_ID }}
           chainguard_python_token: ${{ secrets.CHAINGUARD_PYTHON_TOKEN }}
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -323,7 +323,7 @@ jobs:
       - id: uv-creds
         uses: ./.github/actions/setup-uv-credentials
         with:
-          base_profile: ${{ vars.CI_BASE_UV_DOCKER_PROFILE || 'chainguard-ci' }}
+          base_profile: 'chainguard-ci'
           chainguard_python_identity_id: ${{ vars.CHAINGUARD_PYTHON_IDENTITY_ID }}
           chainguard_python_token: ${{ secrets.CHAINGUARD_PYTHON_TOKEN }}
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -323,7 +323,7 @@ jobs:
       - id: uv-creds
         uses: ./.github/actions/setup-uv-credentials
         with:
-          base_profile: 'chainguard-ci'
+          base_profile: ${{ vars.CI_BASE_UV_DOCKER_PROFILE || 'default' }}
           chainguard_python_identity_id: ${{ vars.CHAINGUARD_PYTHON_IDENTITY_ID }}
           chainguard_python_token: ${{ secrets.CHAINGUARD_PYTHON_TOKEN }}
 

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -52,6 +52,9 @@ RUN ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
 USER datahub
 WORKDIR $HOME
 RUN uv venv --python "${PYTHON_VERSION}"
+# Pre-create as datahub so BuildKit cache mounts at $HOME/.cache/uv do not leave
+# the parent root-owned (siblings like puccinialin then hit PermissionError).
+RUN mkdir -p $HOME/.cache
 ENV VIRTUAL_ENV=$HOME/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 

--- a/docker/datahub-ingestion-base/Dockerfile
+++ b/docker/datahub-ingestion-base/Dockerfile
@@ -70,6 +70,9 @@ ENV UV_DEFAULT_INDEX=${PIP_MIRROR_URL}
 USER datahub
 WORKDIR $HOME
 RUN uv venv --python "$PYTHON_VERSION"
+# Pre-create as datahub so BuildKit cache mounts at $HOME/.cache/uv do not leave
+# the parent root-owned (siblings like puccinialin then hit PermissionError).
+RUN mkdir -p $HOME/.cache
 ENV VIRTUAL_ENV=$HOME/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -68,6 +68,9 @@ RUN uv python install ${PYTHON_VERSION}
 USER datahub
 WORKDIR $HOME
 RUN uv venv --python "$PYTHON_VERSION"
+# Pre-create as datahub so BuildKit cache mounts at $HOME/.cache/uv do not leave
+# the parent root-owned (siblings like puccinialin then hit PermissionError).
+RUN mkdir -p $HOME/.cache
 ENV VIRTUAL_ENV=$HOME/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 

--- a/docker/snippets/ubuntu_python_base
+++ b/docker/snippets/ubuntu_python_base
@@ -70,6 +70,9 @@ ENV UV_INDEX_URL=${PIP_MIRROR_URL}
 USER datahub
 WORKDIR $HOME
 RUN uv venv --python "$PYTHON_VERSION"
+# Pre-create as datahub so BuildKit cache mounts at $HOME/.cache/uv do not leave
+# the parent root-owned (siblings like puccinialin then hit PermissionError).
+RUN mkdir -p $HOME/.cache
 ENV VIRTUAL_ENV=$HOME/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 

--- a/docker/snippets/uv/profiles/chainguard-ci.toml
+++ b/docker/snippets/uv/profiles/chainguard-ci.toml
@@ -22,6 +22,11 @@
 
 index-strategy = "unsafe-best-match"
 
+# Remediations can list a version without a linux/aarch64 (or other) wheel for our
+# interpreter; unsafe-best-match then picks that index's sdist over a wheel from
+# Chainguard main / PyPI. Force wheels for packages that must not build from source.
+no-build-package = ["orjson"]
+
 [[index]]
 name = "chainguard-remediated"
 url = "https://libraries.cgr.dev/python-remediated/simple/"

--- a/docker/snippets/uv/profiles/chainguard-ci.toml
+++ b/docker/snippets/uv/profiles/chainguard-ci.toml
@@ -22,10 +22,16 @@
 
 index-strategy = "unsafe-best-match"
 
-# Remediations can list a version without a linux/aarch64 (or other) wheel for our
-# interpreter; unsafe-best-match then picks that index's sdist over a wheel from
-# Chainguard main / PyPI. Force wheels for packages that must not build from source.
-no-build-package = ["orjson"]
+# Remediations can list a version as sdist-only (or without a usable platform wheel);
+# unsafe-best-match then prefers that sdist over a wheel from Chainguard main / PyPI.
+# Force wheels for packages known to hit that path in datahub-ingestion full builds.
+no-build-package = [
+    "beautifulsoup4",
+    "orjson",
+    "pydantic",
+    "pypdf",
+    "smmap",
+]
 
 [[index]]
 name = "chainguard-remediated"


### PR DESCRIPTION
## Summary
- Pre-create `$HOME/.cache` as the `datahub` user in Python Docker bases so BuildKit's `$HOME/.cache/uv` mount does not leave the parent directory root-owned (which broke `puccinialin` / Rust installs during source builds).
- In `chainguard-ci`, set `no-build-package` for packages where remediations lists an sdist-only version while Chainguard `python/simple` (or PyPI) already has a wheel, so `unsafe-best-match` does not force a source build:
  - `beautifulsoup4`
  - `orjson`
  - `pydantic`
  - `pypdf`
  - `smmap`

Fixes publish failures on `linux/arm64` when `CI_BASE_UV_DOCKER_PROFILE=chainguard-ci` (e.g. `Failed to build orjson==3.11.9` / `PermissionError` on `/home/datahub/.cache/puccinialin`).

## Test plan
- [x] Local repro without fix: `chainguard-ci` + `:docker:datahub-ingestion:docker -PdockerTarget=full` failed on `orjson` with root-owned `.cache`
- [x] Local verify with `.cache` fix + `orjson` `no-build-package`: `BUILD SUCCESSFUL`; image has `orjson` wheel tag `cp310-cp310-manylinux_2_28_aarch64` (no `Building orjson`)
- [x] Compared source builds under `default` vs `chainguard-ci`; confirmed remediations sdist / simple wheel mismatch for the four pure-Python packages above
- [ ] CI publish / matrix build with `CI_BASE_UV_DOCKER_PROFILE=chainguard-ci` succeeds for `datahub-ingestion` `linux/arm64` `final-full`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unblocks **linux/arm64** Docker builds when CI uses the **`chainguard-ci`** uv profile by fixing cache permissions and steering uv away from unnecessary source builds.
> 
> Python base images (**`datahub-ingestion`**, **`datahub-ingestion-base`**, **`datahub-actions`**, and **`ubuntu_python_base`**) now **`mkdir -p $HOME/.cache`** as the **`datahub`** user before BuildKit mounts **`$HOME/.cache/uv`**, so the parent directory is not left root-owned and downstream steps (e.g. Rust **`puccinialin`**) do not hit **`PermissionError`**.
> 
> **`docker/snippets/uv/profiles/chainguard-ci.toml`** adds **`no-build-package`** for **`beautifulsoup4`**, **`orjson`**, **`pydantic`**, **`pypdf`**, and **`smmap`** so **`unsafe-best-match`** does not prefer remediated sdist-only versions over wheels from Chainguard main or PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aea245f0fa8cae9f295950bccd7954726c44c83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->