### PR TITLE
refactor(aliases): make lowercasedUrn a fully lowercased opaque key

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffect.java
@@ -5,7 +5,6 @@ import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 
 import com.datahub.context.OperationFingerprint;
 import com.linkedin.common.Aliases;
-import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.RetrieverContext;
@@ -16,20 +15,17 @@ import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
 import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.utils.AliasesUtils;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Derives the system-computed {@code aliases.lowercasedUrn} field from the entity's URN. Keyed on
  * the dataset key aspect so it runs once, at creation.
  */
-@Slf4j
 @Getter
 @Setter
 @Accessors(chain = true)
@@ -55,19 +51,13 @@ public class AliasesSideEffect extends MCPSideEffect {
   private static Stream<ChangeMCP> buildLowercasedUrn(
       ChangeMCP changeMCP, @Nonnull RetrieverContext retrieverContext) {
     Urn urn = changeMCP.getUrn();
+    // The key derivation is entity-agnostic, but the aliases aspect is only registered on dataset,
+    // so emitting it for anything else would be rejected downstream.
     if (!DATASET_ENTITY_NAME.equals(urn.getEntityType())) {
       return Stream.empty();
     }
 
-    final DatasetUrn lowercasedUrn;
-    try {
-      lowercasedUrn = AliasesUtils.lowercaseDatasetUrn(urn);
-    } catch (URISyntaxException e) {
-      log.warn("Unable to compute lowercasedUrn for {}", urn, e);
-      return Stream.empty();
-    }
-
-    Aliases aspect = new Aliases().setLowercasedUrn(lowercasedUrn);
+    Aliases aspect = new Aliases().setLowercasedUrn(AliasesUtils.lowercasedUrnKey(urn));
     return Stream.of(
         ChangeItemImpl.builder()
             .urn(urn)

--- a/metadata-io/src/test/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffectTest.java
@@ -92,7 +92,7 @@ public class AliasesSideEffectTest {
     Aliases aspect = out.getAspect(Aliases.class);
     assertNotNull(aspect);
     assertEquals(
-        aspect.getLowercasedUrn().toString(),
-        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
+        aspect.getLowercasedUrn(),
+        "urn:li:dataset:(urn:li:dataplatform:snowflake,db.schema.table,prod)");
   }
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Aliases.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Aliases.pdl
@@ -8,17 +8,21 @@ namespace com.linkedin.common
  * field, lowercasedUrn.
  */
 @Aspect = {
-  "name": "aliases"
+  "name": "aliases",
+  "schemaVersion": 2
 }
 record Aliases {
   /**
-   * System-computed. The entity's own URN with the name lowercased in full, including any platform
-   * instance prefix; the platform and environment are unchanged. Indexed as an exact-match keyword,
-   * so a reference in any casing resolves to the entity's real URN in one batchable lookup.
+   * System-computed. The entity's own URN lowercased in full. Indexed as an exact-match keyword, so
+   * a reference in any casing resolves to the entity's real URN in one batchable lookup.
+   *
+   * A lookup key, not a URN, which is why the type is string: every component is lowercased,
+   * including the FabricType, which has no lowercase symbol. The value will not parse back into a
+   * typed URN and must not be dereferenced or followed as a reference.
    */
   @Searchable = {
     "fieldType": "KEYWORD",
     "queryByDefault": false
   }
-  lowercasedUrn: optional Urn
+  lowercasedUrn: optional string
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/AliasesUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/AliasesUtils.java
@@ -1,8 +1,6 @@
 package com.linkedin.metadata.utils;
 
-import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
-import java.net.URISyntaxException;
 import java.util.Locale;
 
 public class AliasesUtils {
@@ -10,15 +8,19 @@ public class AliasesUtils {
   private AliasesUtils() {}
 
   /**
-   * The case-insensitive resolution key for a dataset URN: the name is lowercased in full,
-   * including any platform instance prefix; the platform and environment are unchanged. A
-   * non-dataset URN throws {@link URISyntaxException}.
+   * The case-insensitive lookup key for an entity URN: the whole URN lowercased. Entity-agnostic by
+   * design — one rule covers every entity type, including nested URNs such as the dataset embedded
+   * in a schemaField URN.
+   *
+   * <p>The result is a key, not a URN. Every component is lowercased, so the platform no longer
+   * names an existing dataPlatform entity and the FabricType is not a valid enum symbol.
+   *
+   * <p>Ingestion derives this key client-side to look entities up by it, so the derivation is a
+   * wire contract: a key computed one way finds nothing indexed under a key computed the other, and
+   * the mismatch surfaces as zero hits rather than an error. {@code Locale.ROOT} keeps the result
+   * independent of the JVM's default locale so it matches Python's {@code str.lower()}.
    */
-  public static DatasetUrn lowercaseDatasetUrn(Urn urn) throws URISyntaxException {
-    DatasetUrn dataset = DatasetUrn.createFromUrn(urn);
-    return new DatasetUrn(
-        dataset.getPlatformEntity(),
-        dataset.getDatasetNameEntity().toLowerCase(Locale.ROOT),
-        dataset.getOriginEntity());
+  public static String lowercasedUrnKey(Urn urn) {
+    return urn.toString().toLowerCase(Locale.ROOT);
   }
 }

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/AliasesUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/AliasesUtilsTest.java
@@ -1,50 +1,58 @@
 package com.linkedin.metadata.utils;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertNotEquals;
 
-import com.linkedin.common.FabricType;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
-import java.net.URISyntaxException;
 import java.util.Locale;
 import org.testng.annotations.Test;
 
 public class AliasesUtilsTest {
 
   @Test
-  public void testPreservesPlatformCasing() throws URISyntaxException {
-    Urn mixedPlatform =
+  public void testLowercasesEveryComponent() {
+    Urn mixed =
         UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:adlsGen2,Container/Folder,PROD)");
     assertEquals(
-        AliasesUtils.lowercaseDatasetUrn(mixedPlatform).toString(),
-        "urn:li:dataset:(urn:li:dataPlatform:adlsGen2,container/folder,PROD)");
+        AliasesUtils.lowercasedUrnKey(mixed),
+        "urn:li:dataset:(urn:li:dataplatform:adlsgen2,container/folder,prod)");
   }
 
   @Test
-  public void testLowercasesName() throws URISyntaxException {
-    Urn mixedName =
-        UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.Schema.Table,PROD)");
-    assertEquals(
-        AliasesUtils.lowercaseDatasetUrn(mixedName).toString(),
-        "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
-  }
-
-  @Test
-  public void testPreservesEnv() throws URISyntaxException {
-    Urn dev = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,DEV)");
-    assertEquals(AliasesUtils.lowercaseDatasetUrn(dev).getOriginEntity(), FabricType.DEV);
-    assertEquals(AliasesUtils.lowercaseDatasetUrn(dev).toString(), dev.toString());
-  }
-
-  @Test
-  public void testLowercasesEmbeddedPlatformInstanceAsPartOfName() throws URISyntaxException {
+  public void testLowercasesEmbeddedPlatformInstanceAsPartOfName() {
     Urn withInstance =
         UrnUtils.getUrn(
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,My_Instance.DB.Schema.Table,PROD)");
     assertEquals(
-        AliasesUtils.lowercaseDatasetUrn(withInstance).toString(),
-        "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.db.schema.table,PROD)");
+        AliasesUtils.lowercasedUrnKey(withInstance),
+        "urn:li:dataset:(urn:li:dataplatform:snowflake,my_instance.db.schema.table,prod)");
+  }
+
+  /** Distinct environments stay distinct: lowercasing does not collapse them onto one key. */
+  @Test
+  public void testKeepsEnvironmentsDistinct() {
+    Urn prod = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.t,PROD)");
+    Urn dev = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.t,DEV)");
+    assertNotEquals(AliasesUtils.lowercasedUrnKey(prod), AliasesUtils.lowercasedUrnKey(dev));
+  }
+
+  /** One rule for every entity type, so the side effect needs no per-type derivation. */
+  @Test
+  public void testAppliesToNonDatasetUrns() {
+    Urn chartUrn = UrnUtils.getUrn("urn:li:chart:(Looker,My_Chart)");
+    assertEquals(AliasesUtils.lowercasedUrnKey(chartUrn), "urn:li:chart:(looker,my_chart)");
+  }
+
+  /** The column name is a real source of casing variance, and one rule reaches it. */
+  @Test
+  public void testLowercasesSchemaFieldColumnName() {
+    Urn field =
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.Schema.Table,PROD),ColumnName)");
+    assertEquals(
+        AliasesUtils.lowercasedUrnKey(field),
+        "urn:li:schemafield:(urn:li:dataset:(urn:li:dataplatform:snowflake,db.schema.table,prod),columnname)");
   }
 
   /**
@@ -52,30 +60,25 @@ public class AliasesUtilsTest {
    * Locale.ROOT} the key would depend on the JVM's locale and stop matching what clients compute.
    */
   @Test
-  public void testLowercasesUnicodeNameIndependentOfDefaultLocale() throws URISyntaxException {
+  public void testLowercasesUnicodeIndependentOfDefaultLocale() {
     Locale original = Locale.getDefault();
     try {
       Locale.setDefault(Locale.forLanguageTag("tr"));
       Urn unicodeName =
           UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,CAFÉ.Ñ_TITLE,PROD)");
       assertEquals(
-          AliasesUtils.lowercaseDatasetUrn(unicodeName).toString(),
-          "urn:li:dataset:(urn:li:dataPlatform:snowflake,café.ñ_title,PROD)");
+          AliasesUtils.lowercasedUrnKey(unicodeName),
+          "urn:li:dataset:(urn:li:dataplatform:snowflake,café.ñ_title,prod)");
     } finally {
       Locale.setDefault(original);
     }
   }
 
   @Test
-  public void testIdempotentOnAlreadyLowercased() throws URISyntaxException {
-    Urn lower =
-        UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
-    assertEquals(AliasesUtils.lowercaseDatasetUrn(lower).toString(), lower.toString());
-  }
-
-  @Test
-  public void testNonDatasetUrnRejected() {
-    Urn chartUrn = UrnUtils.getUrn("urn:li:chart:(looker,my_chart)");
-    assertThrows(URISyntaxException.class, () -> AliasesUtils.lowercaseDatasetUrn(chartUrn));
+  public void testIdempotent() {
+    Urn mixed =
+        UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.Schema.Table,PROD)");
+    String once = AliasesUtils.lowercasedUrnKey(mixed);
+    assertEquals(AliasesUtils.lowercasedUrnKey(UrnUtils.getUrn(once)), once);
   }
 }

--- a/smoke-test/tests/openapi/v3/entities.json
+++ b/smoke-test/tests/openapi/v3/entities.json
@@ -427,7 +427,7 @@
         },
         "aliases": {
           "value": {
-            "lowercasedUrn": "urn:li:dataset:(urn:li:dataPlatform:test,dataset/entityv3,PROD)"
+            "lowercasedUrn": "urn:li:dataset:(urn:li:dataplatform:test,dataset/entityv3,prod)"
           }
         },
         "dataPlatformInstance": {
@@ -498,7 +498,7 @@
           },
           "aliases": {
             "value": {
-              "lowercasedUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetpatchentityv3,PROD)"
+              "lowercasedUrn": "urn:li:dataset:(urn:li:dataplatform:test,datasetpatchentityv3,prod)"
             }
           },
           "dataPlatformInstance": {


### PR DESCRIPTION
`aliases.lowercasedUrn` (#18639) lowercased only the dataset name, keeping the value a parseable dataset URN. Nothing reads it as one — the only writer is `AliasesSideEffect`, the only readers are an exact-match keyword filter and the ingestion client, and Python codegen already types it `str`. The typed shape bought nothing and cost a per-entity-type derivation both sides must reimplement identically. This lowercases the whole URN instead: one rule, no parsing, and it reaches nested URNs for free — notably the column name in a `schemaField` URN, a real source of casing variance the per-part derivation left untouched.

## Changes

- `Aliases.pdl`: `lowercasedUrn` becomes `optional string` at `schemaVersion 2`. `Urn` is `typeref Urn = string`, so the wire format and Elasticsearch keyword mapping are unchanged — only the derived values differ.
- The value is a lookup key, not a URN: every component is lowercased, so the platform no longer names an existing `dataPlatform` entity and the FabricType is not a valid enum symbol. It must not be dereferenced, and the field can never carry `@UrnValidation` or `@Relationship`.
- `AliasesUtils`: entity-agnostic derivation under `Locale.ROOT`, replacing the dataset-specific one. Matching widens from name casing to name **and** platform casing.
- `AliasesSideEffect` keeps its dataset guard, for a new reason: it no longer avoids a parse exception, it avoids emitting an aspect the entity registry only knows on `dataset`.

## Behavioral note

Aspects already written hold the old key until the backfill re-runs. Since the rule changed, whichever of this and #18679 lands second must bump the backfill's versioned upgrade id, or the completion marker will mask stale keys.

## Testing

`AliasesUtilsTest` drops the platform- and env-preserving cases, adds a `schemaField` URN and a non-dataset URN, and pins that distinct environments still map to distinct keys. The `Locale.ROOT` case stays — locale-dependent casing is where Java and Python can still diverge. `AliasesSideEffectTest` and the OpenAPI v3 smoke-test fixture move to the new expected values.

## Checklist

- [x] Conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) ([PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Related issues linked (#18639, #18679)
- [x] Tests updated
- [ ] No docs update: the aspect is system-owned and not user-facing; the operator-facing note ships with the backfill in #18679
- [ ] No [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) entry: wire format and index mapping are unchanged and nothing outside GMS reads the field yet
