### PR TITLE
fix(netrc): Fix netrc and add validator

### DIFF
--- a/docker/snippets/uv/.netrc.example
+++ b/docker/snippets/uv/.netrc.example
@@ -4,6 +4,8 @@
 # UV reads this file natively for authentication when resolving packages.
 #
 # Copy this file to docker/snippets/uv/.netrc and fill in your credentials.
+# Do not leave blank lines before later #-comment lines (breaks netrc parsers);
+# use a lone '#' instead. Validate with: python3 docker/snippets/uv/validate_netrc.py
 # The .gitignore in this directory ensures it is never committed.
 #
 # The default path is docker/snippets/uv/.netrc (repo root relative).
@@ -17,7 +19,7 @@
 #   machine <hostname> login <username> password <token-or-password>
 #
 # Examples:
-
+#
 # Chainguard Libraries for Python (opt-in via UV_DOCKER_PROFILE=chainguard or
 # chainguard-ci). The host MUST be `libraries.cgr.dev` (not `cgr.dev`) to match
 # the index URL hostname. The pull token must carry a Python entitlement:
@@ -25,6 +27,6 @@
 # Mint a pull token with:
 #   chainctl auth login && chainctl auth pull-token create --repository=python --ttl=720h
 machine libraries.cgr.dev     login <your-chainguard-identity-id> password <your-chainguard-token>
-
+#
 # Corporate / private indexes (generic)
 machine my-nexus.example.com  login <user>     password <password>

--- a/docker/snippets/uv/validate_netrc.py
+++ b/docker/snippets/uv/validate_netrc.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Validate a real .netrc used for uv / Docker private-index auth.
+
+Catches a common footgun: a blank line followed by more #-comment lines makes
+Python's netrc parser fail (uv then reports opaque "Missing credentials").
+
+Usage:
+  python3 docker/snippets/uv/validate_netrc.py [path]
+  python3 docker/snippets/uv/validate_netrc.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import netrc
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+BLANK_THEN_COMMENT_HINT = (
+    "A blank line appears before a #-comment line. Python's netrc parser treats "
+    "that as a hard error (often 'bad toplevel token ...'), so credentials are "
+    "never loaded and uv reports 'Missing credentials'.\n"
+    "Fix: replace blank lines inside the comment header with a lone '#', and do "
+    "not put #-comments after a blank line. See docker/snippets/uv/.netrc.example."
+)
+
+
+def _blank_then_comment_lines(text: str) -> List[int]:
+    lines = text.splitlines()
+    bad: List[int] = []
+    prev_blank = False
+    for i, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            prev_blank = True
+            continue
+        if prev_blank and stripped.startswith("#"):
+            bad.append(i)
+        prev_blank = False
+    return bad
+
+
+def validate(path: Path) -> Tuple[int, List[str]]:
+    """Return (exit_code, errors)."""
+    if not path.is_file():
+        return 1, [f"netrc file not found: {path}"]
+
+    text = path.read_text(encoding="utf-8")
+    blank_comment_lines = _blank_then_comment_lines(text)
+
+    try:
+        netrc.netrc(str(path))
+    except netrc.NetrcParseError as exc:
+        errors = [f"failed to parse {path}: {exc}"]
+        if blank_comment_lines:
+            errors.append(
+                f"likely cause: blank line(s) before #-comment at line(s) "
+                f"{', '.join(map(str, blank_comment_lines))}.\n{BLANK_THEN_COMMENT_HINT}"
+            )
+        else:
+            errors.append(
+                "Tip: keep all #-comments contiguous at the top of the file "
+                "(no blank lines before later comments). See "
+                "docker/snippets/uv/.netrc.example."
+            )
+        return 1, errors
+
+    if blank_comment_lines:
+        return 1, [
+            f"blank line(s) before #-comment at line(s) "
+            f"{', '.join(map(str, blank_comment_lines))}.\n{BLANK_THEN_COMMENT_HINT}"
+        ]
+
+    return 0, []
+
+
+def _self_test() -> int:
+    cases = [
+        (
+            "ok_contiguous_comments",
+            "# header\n# more\nmachine host.example login u password p\n",
+            True,
+        ),
+        (
+            "bad_blank_then_comment",
+            "# header\n\n# Chainguard\nmachine host.example login u password p\n",
+            False,
+        ),
+        (
+            "ok_blank_between_machines",
+            "machine a.example login u password p\n\nmachine b.example login u password p\n",
+            True,
+        ),
+    ]
+    failed = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        for name, content, expect_ok in cases:
+            path = tmp_path / name
+            path.write_text(content, encoding="utf-8")
+            code, errors = validate(path)
+            ok = code == 0
+            if ok != expect_ok:
+                failed += 1
+                print(
+                    f"FAIL {name}: expected_ok={expect_ok} got_ok={ok} errors={errors}",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"ok: self-test {name}")
+    if failed:
+        print(f"error: {failed} self-test case(s) failed", file=sys.stderr)
+        return 1
+    print("ok: all self-tests passed")
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=os.environ.get("DATAHUB_NETRC_PATH")
+        or os.environ.get("NETRC")
+        or str(Path(__file__).resolve().parent / ".netrc"),
+        help="Path to .netrc (default: DATAHUB_NETRC_PATH / NETRC / docker/snippets/uv/.netrc)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Only print errors (no success line)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run built-in regression checks and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    path = Path(args.path).expanduser()
+    code, errors = validate(path)
+    for error in errors:
+        print(f"error: {error}", file=sys.stderr)
+    if errors:
+        print(
+            f"error: invalid netrc at {path}\n"
+            f"See docker/snippets/uv/.netrc.example, then re-run:\n"
+            f"  python3 docker/snippets/uv/validate_netrc.py {path}",
+            file=sys.stderr,
+        )
+    elif not args.quiet:
+        print(f"ok: {path}")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker/snippets/uv/validate_netrc.py
+++ b/docker/snippets/uv/validate_netrc.py
@@ -48,13 +48,20 @@ def validate(path: Path) -> Tuple[int, List[str]]:
     if not path.is_file():
         return 1, [f"netrc file not found: {path}"]
 
-    text = path.read_text(encoding="utf-8")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return 1, [f"cannot read {path}: {type(exc).__name__}"]
+
     blank_comment_lines = _blank_then_comment_lines(text)
 
     try:
         netrc.netrc(str(path))
     except netrc.NetrcParseError as exc:
-        errors = [f"failed to parse {path}: {exc}"]
+        # Avoid echoing parse tokens (can include password fragments).
+        line = getattr(exc, "lineno", None)
+        loc = f" (line {line})" if line else ""
+        errors = [f"failed to parse {path}{loc}"]
         if blank_comment_lines:
             errors.append(
                 f"likely cause: blank line(s) before #-comment at line(s) "
@@ -94,13 +101,21 @@ def _self_test() -> int:
             "machine a.example login u password p\n\nmachine b.example login u password p\n",
             True,
         ),
+        (
+            "bad_binary",
+            None,  # filled below with non-utf8 bytes
+            False,
+        ),
     ]
     failed = 0
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         for name, content, expect_ok in cases:
             path = tmp_path / name
-            path.write_text(content, encoding="utf-8")
+            if name == "bad_binary":
+                path.write_bytes(b"\xff\xfe machine h login u password p\n")
+            else:
+                path.write_text(content, encoding="utf-8")
             code, errors = validate(path)
             ok = code == 0
             if ok != expect_ok:

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -474,7 +474,17 @@ export DATAHUB_NETRC_PATH=/path/to/.netrc
 ```
 
 See `docker/snippets/uv/.netrc.example` for the full format
-and examples. The file is mounted into the build via a Docker BuildKit secret — it is **never
+and examples. Validate a file with:
+
+```bash
+python3 docker/snippets/uv/validate_netrc.py docker/snippets/uv/.netrc
+```
+
+Gradle runs the same check automatically when a netrc file is present (Docker image builds
+and local `uv` installs). A common failure mode is a blank line before later `#`-comment
+lines — Python's netrc parser then fails and uv reports opaque "Missing credentials" errors.
+
+The file is mounted into the build via a Docker BuildKit secret — it is **never
 written to any image layer** and will not appear in `docker history` output.
 
 :::warning Credentials in URLs

--- a/gradle/docker/python-docker.gradle
+++ b/gradle/docker/python-docker.gradle
@@ -2,11 +2,15 @@
 // Provides netrc secret injection and resolveUvBuildArgs (UV_PROFILE / index URLs).
 // Profile resolution (CLI -P > UV_DOCKER_PROFILE env > gradle.properties) is in settings.gradle.
 
+apply from: "${rootProject.projectDir}/gradle/python/netrc.gradle"
+
 def netrcFile = {
   def path = System.getenv("DATAHUB_NETRC_PATH") ?: "${rootProject.projectDir}/docker/snippets/uv/.netrc"
   def file = new File(path)
   return file.exists() ? file.absolutePath : null
 }()
+
+validateDatahubNetrc(netrcFile)
 
 def uvDockerProfile = gradle.ext['datahub.dependencies.python.uvDockerProfile']
 

--- a/gradle/python/netrc.gradle
+++ b/gradle/python/netrc.gradle
@@ -5,17 +5,24 @@ ext.validateDatahubNetrc = { String path ->
   if (!path) {
     return
   }
+  // Normalize once so cache key and script see the same file (relative NETRC paths
+  // would otherwise resolve against JVM cwd vs project.exec working dir).
+  def file = new File(path)
+  if (!file.exists()) {
+    return
+  }
+  def absolutePath = file.canonicalPath
+
   // Many Python modules apply this script; validate each path once per build.
-  def cacheKey = "datahub.netrc.validated:${new File(path).canonicalPath}"
+  def cacheKey = "datahub.netrc.validated:${absolutePath}"
   if (rootProject.ext.has(cacheKey)) {
     return
   }
-  rootProject.ext.set(cacheKey, true)
 
   def script = "${rootProject.projectDir}/docker/snippets/uv/validate_netrc.py"
   def stderr = new ByteArrayOutputStream()
   def result = project.exec {
-    commandLine 'python3', script, '--quiet', path
+    commandLine 'python3', script, '--quiet', absolutePath
     errorOutput = stderr
     ignoreExitValue = true
   }
@@ -29,7 +36,9 @@ ext.validateDatahubNetrc = { String path ->
   }
   if (result.exitValue != 0) {
     throw new GradleException(
-      "Invalid netrc at ${path}. Fix the file (see docker/snippets/uv/.netrc.example), then run:\n" +
-      "  python3 docker/snippets/uv/validate_netrc.py ${path}")
+      "Invalid netrc at ${absolutePath}. Fix the file (see docker/snippets/uv/.netrc.example), then run:\n" +
+      "  python3 docker/snippets/uv/validate_netrc.py ${absolutePath}")
   }
+  // Only cache successful validation so a failed configure can be retried in-process.
+  rootProject.ext.set(cacheKey, true)
 }

--- a/gradle/python/netrc.gradle
+++ b/gradle/python/netrc.gradle
@@ -1,0 +1,35 @@
+// Shared netrc validation for Python uv installs and Docker builds.
+// Apply: apply from: "${rootProject.projectDir}/gradle/python/netrc.gradle"
+
+ext.validateDatahubNetrc = { String path ->
+  if (!path) {
+    return
+  }
+  // Many Python modules apply this script; validate each path once per build.
+  def cacheKey = "datahub.netrc.validated:${new File(path).canonicalPath}"
+  if (rootProject.ext.has(cacheKey)) {
+    return
+  }
+  rootProject.ext.set(cacheKey, true)
+
+  def script = "${rootProject.projectDir}/docker/snippets/uv/validate_netrc.py"
+  def stderr = new ByteArrayOutputStream()
+  def result = project.exec {
+    commandLine 'python3', script, '--quiet', path
+    errorOutput = stderr
+    ignoreExitValue = true
+  }
+  def errText = stderr.toString().trim()
+  if (errText) {
+    errText.split('\n').each { line ->
+      if (line) {
+        logger.error("[netrc] ${line}")
+      }
+    }
+  }
+  if (result.exitValue != 0) {
+    throw new GradleException(
+      "Invalid netrc at ${path}. Fix the file (see docker/snippets/uv/.netrc.example), then run:\n" +
+      "  python3 docker/snippets/uv/validate_netrc.py ${path}")
+  }
+}

--- a/gradle/python/netrc.gradle
+++ b/gradle/python/netrc.gradle
@@ -5,9 +5,14 @@ ext.validateDatahubNetrc = { String path ->
   if (!path) {
     return
   }
-  // Normalize once so cache key and script see the same file (relative NETRC paths
-  // would otherwise resolve against JVM cwd vs project.exec working dir).
-  def file = new File(path)
+  // Expand ~ (java.io.File does not) and resolve relative paths against the repo
+  // root so cache key + script agree across subprojects / JVM cwd differences.
+  // Missing files are intentionally skipped: mise always exports NETRC even when
+  // docker/snippets/uv/.netrc has not been created yet.
+  def expanded = (path == '~' || path.startsWith('~/') || path.startsWith('~' + File.separator))
+      ? System.getProperty('user.home') + path.substring(1)
+      : path
+  def file = rootProject.file(expanded)
   if (!file.exists()) {
     return
   }

--- a/gradle/python/python-uv.gradle
+++ b/gradle/python/python-uv.gradle
@@ -3,6 +3,8 @@
 // Uses uvInstallProfile from settings.gradle (CLI -P > UV_INSTALL_PROFILE > gradle.properties).
 // Sets UV_CONFIG_FILE, UV_INSTALL_PROFILE, and NETRC on Exec tasks. Rejects profile "custom".
 
+apply from: "${rootProject.projectDir}/gradle/python/netrc.gradle"
+
 def uvInstallProfile = gradle.ext['datahub.dependencies.python.uvInstallProfile']
 def uvConfigPath = gradle.ext['resolveUvProfileFile'](uvInstallProfile)
 
@@ -14,6 +16,8 @@ def netrcPath = {
   def file = new File(path)
   return file.exists() ? file.absolutePath : null
 }()
+
+validateDatahubNetrc(netrcPath ?: System.getenv("NETRC"))
 
 if (uvConfigPath) {
   logger.lifecycle("[python-uv] ${project.path}: UV_CONFIG_FILE=${uvConfigPath} (uvInstallProfile=${uvInstallProfile})")


### PR DESCRIPTION
## Summary

See title. I also felt its super non-obvious that you can't have blank lines (and the error message is esoteric) so I added a quick validator that runs on gradle builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`validate_netrc.py`** so developers can catch `.netrc` files that Python’s `netrc` parser rejects—especially **blank lines before later `#` comments**, which often surfaces as vague uv “Missing credentials” errors. The script parses with `netrc`, flags that layout issue, avoids leaking password fragments in errors, and includes **`--self-test`** / **`--quiet`**.
> 
> **Gradle** now runs the same check via new **`gradle/python/netrc.gradle`** (`validateDatahubNetrc`) from **`python-uv.gradle`** and **`python-docker.gradle`** when a netrc path exists (including `NETRC` for local uv installs). Missing files are skipped; each path is validated once per build.
> 
> **`.netrc.example`** is adjusted to use lone `#` lines instead of blank lines between comment blocks, with a pointer to the validator. **`docs/developers.md`** documents the manual command and the automatic Gradle check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0484af7fd0e63e5e3bce70abf567803a8a8afc86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `.netrc` auth issues by adding a validator and wiring it into Gradle for `uv` installs and Docker builds. Improves error handling to prevent opaque "Missing credentials" and leaks, with clear guidance.

- **Bug Fixes**
  - Added `docker/snippets/uv/validate_netrc.py` to validate `.netrc`, flag blank-line-before-`#`-comment cases, support `DATAHUB_NETRC_PATH`/`NETRC`, `--self-test`/`--quiet`, and harden against non-UTF8 input and token leakage.
  - Integrated validation into Gradle via `gradle/python/netrc.gradle`; used by `python-uv.gradle` and Docker builds, expands `~`, resolves relative paths from the repo root, canonicalizes paths before exec, skips missing NETRC files, validates once per path, caches only after success, and fails fast with guidance.
  - Updated `docker/snippets/uv/.netrc.example` and `docs/developers.md` with a one-line validator command and the known failure mode.

<sup>Written for commit 0484af7fd0e63e5e3bce70abf567803a8a8afc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

