### PR TITLE
adding sort functionality to the domains sidebar

### DIFF
--- a/datahub-web-react/src/app/domainV2/__tests__/getDomainsScrollInput.test.tsx
+++ b/datahub-web-react/src/app/domainV2/__tests__/getDomainsScrollInput.test.tsx
@@ -1,12 +1,14 @@
+import { DOMAIN_SIDEBAR_SORT } from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
 import { DOMAIN_COUNT, getDomainsScrollInput } from '@app/domainV2/useScrollDomains';
 import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+import { CREATED_TIME_FIELD_NAME } from '@app/searchV2/utils/constants';
 
 import { EntityType, FilterOperator, SortOrder } from '@types';
 
 describe('getDomainsScrollInput', () => {
     describe('Root domains (parentDomain is null)', () => {
         it('should create correct input for root domains with no scrollId', () => {
-            const result = getDomainsScrollInput(null, null);
+            const result = getDomainsScrollInput({ parentDomain: null, scrollId: null });
 
             expect(result).toEqual({
                 input: {
@@ -40,7 +42,7 @@ describe('getDomainsScrollInput', () => {
 
         it('should create correct input for root domains with scrollId', () => {
             const scrollId = 'test-scroll-id-123';
-            const result = getDomainsScrollInput(null, scrollId);
+            const result = getDomainsScrollInput({ parentDomain: null, scrollId });
 
             expect(result).toEqual({
                 input: {
@@ -77,7 +79,7 @@ describe('getDomainsScrollInput', () => {
         const parentDomainUrn = 'urn:li:domain:parent';
 
         it('should create correct input for child domains with no scrollId', () => {
-            const result = getDomainsScrollInput(parentDomainUrn, null);
+            const result = getDomainsScrollInput({ parentDomain: parentDomainUrn, scrollId: null });
 
             expect(result).toEqual({
                 input: {
@@ -110,7 +112,7 @@ describe('getDomainsScrollInput', () => {
 
         it('should create correct input for child domains with scrollId', () => {
             const scrollId = 'child-scroll-id-456';
-            const result = getDomainsScrollInput(parentDomainUrn, scrollId);
+            const result = getDomainsScrollInput({ parentDomain: parentDomainUrn, scrollId });
 
             expect(result).toEqual({
                 input: {
@@ -144,7 +146,7 @@ describe('getDomainsScrollInput', () => {
 
     describe('Edge cases', () => {
         it('should handle empty string parentDomain as no parent domain', () => {
-            const result = getDomainsScrollInput('', null);
+            const result = getDomainsScrollInput({ parentDomain: '', scrollId: null });
 
             expect(result.input.orFilters).toEqual([
                 {
@@ -160,48 +162,53 @@ describe('getDomainsScrollInput', () => {
         });
 
         it('should handle empty string scrollId', () => {
-            const result = getDomainsScrollInput(null, '');
+            const result = getDomainsScrollInput({ parentDomain: null, scrollId: '' });
 
             expect(result.input.scrollId).toBe('');
-        });
-
-        it('should handle undefined parentDomain same as null', () => {
-            const resultNull = getDomainsScrollInput(null, null);
-            const resultUndefined = getDomainsScrollInput(undefined as any, null);
-
-            expect(resultNull).toEqual(resultUndefined);
         });
     });
 
     describe('Configuration consistency', () => {
         it('should always use the same query string', () => {
-            const result1 = getDomainsScrollInput(null, null);
-            const result2 = getDomainsScrollInput('urn:li:domain:parent', 'scroll-id');
+            const result1 = getDomainsScrollInput({ parentDomain: null, scrollId: null });
+            const result2 = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: 'scroll-id',
+            });
 
             expect(result1.input.query).toBe('*');
             expect(result2.input.query).toBe('*');
         });
 
         it('should always include Domain entity type', () => {
-            const result1 = getDomainsScrollInput(null, null);
-            const result2 = getDomainsScrollInput('urn:li:domain:parent', 'scroll-id');
+            const result1 = getDomainsScrollInput({ parentDomain: null, scrollId: null });
+            const result2 = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: 'scroll-id',
+            });
 
             expect(result1.input.types).toEqual([EntityType.Domain]);
             expect(result2.input.types).toEqual([EntityType.Domain]);
         });
 
         it('should always use the same count', () => {
-            const result1 = getDomainsScrollInput(null, null);
-            const result2 = getDomainsScrollInput('urn:li:domain:parent', 'scroll-id');
+            const result1 = getDomainsScrollInput({ parentDomain: null, scrollId: null });
+            const result2 = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: 'scroll-id',
+            });
 
             expect(result1.input.count).toBe(DOMAIN_COUNT);
             expect(result2.input.count).toBe(DOMAIN_COUNT);
-            expect(result1.input.count).toBe(25); // Verify the constant value
+            expect(result1.input.count).toBe(25);
         });
 
-        it('should always use ascending sort by name', () => {
-            const result1 = getDomainsScrollInput(null, null);
-            const result2 = getDomainsScrollInput('urn:li:domain:parent', 'scroll-id');
+        it('should default to ascending sort by name', () => {
+            const result1 = getDomainsScrollInput({ parentDomain: null, scrollId: null });
+            const result2 = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: 'scroll-id',
+            });
 
             const expectedSortInput = {
                 sortCriteria: [
@@ -217,30 +224,66 @@ describe('getDomainsScrollInput', () => {
         });
 
         it('should always skip cache', () => {
-            const result1 = getDomainsScrollInput(null, null);
-            const result2 = getDomainsScrollInput('urn:li:domain:parent', 'scroll-id');
+            const result1 = getDomainsScrollInput({ parentDomain: null, scrollId: null });
+            const result2 = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: 'scroll-id',
+            });
 
             expect(result1.input.searchFlags).toEqual({ skipCache: true });
             expect(result2.input.searchFlags).toEqual({ skipCache: true });
         });
     });
 
+    describe('Sort options', () => {
+        it('applies name descending when requested', () => {
+            const result = getDomainsScrollInput({
+                parentDomain: null,
+                scrollId: null,
+                sort: DOMAIN_SIDEBAR_SORT.NAME_DESC,
+            });
+
+            expect(result.input.sortInput).toEqual({
+                sortCriteria: [{ field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Descending }],
+            });
+        });
+
+        it('applies created descending when requested', () => {
+            const result = getDomainsScrollInput({
+                parentDomain: null,
+                scrollId: null,
+                sort: DOMAIN_SIDEBAR_SORT.CREATED_DESC,
+            });
+
+            expect(result.input.sortInput).toEqual({
+                sortCriteria: [{ field: CREATED_TIME_FIELD_NAME, sortOrder: SortOrder.Descending }],
+            });
+        });
+    });
+
     describe('Owner filter', () => {
         it('omits the owners clause when selectedOwnerUrns is undefined / null / empty', () => {
-            // The "no filter" cases should produce the same orFilters shape as
-            // calling without the third argument at all.
-            const baseline = getDomainsScrollInput(null, null).input.orFilters;
+            const baseline = getDomainsScrollInput({ parentDomain: null, scrollId: null }).input.orFilters;
 
-            expect(getDomainsScrollInput(null, null, undefined).input.orFilters).toEqual(baseline);
-            expect(getDomainsScrollInput(null, null, null).input.orFilters).toEqual(baseline);
-            expect(getDomainsScrollInput(null, null, []).input.orFilters).toEqual(baseline);
+            expect(
+                getDomainsScrollInput({ parentDomain: null, scrollId: null, selectedOwnerUrns: undefined }).input
+                    .orFilters,
+            ).toEqual(baseline);
+            expect(
+                getDomainsScrollInput({ parentDomain: null, scrollId: null, selectedOwnerUrns: null }).input.orFilters,
+            ).toEqual(baseline);
+            expect(
+                getDomainsScrollInput({ parentDomain: null, scrollId: null, selectedOwnerUrns: [] }).input.orFilters,
+            ).toEqual(baseline);
         });
 
         it('ANDs the owners clause with the root-domain scope', () => {
-            const result = getDomainsScrollInput(null, null, ['urn:li:corpuser:jane', 'urn:li:corpuser:john']);
+            const result = getDomainsScrollInput({
+                parentDomain: null,
+                scrollId: null,
+                selectedOwnerUrns: ['urn:li:corpuser:jane', 'urn:li:corpuser:john'],
+            });
 
-            // Single AND clause carrying BOTH the parent scope and the owner
-            // selection — server returns root domains that match both.
             expect(result.input.orFilters).toEqual([
                 {
                     and: [
@@ -252,7 +295,11 @@ describe('getDomainsScrollInput', () => {
         });
 
         it('ANDs the owners clause with the child-domain scope', () => {
-            const result = getDomainsScrollInput('urn:li:domain:parent', null, ['urn:li:corpuser:jane']);
+            const result = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: null,
+                selectedOwnerUrns: ['urn:li:corpuser:jane'],
+            });
 
             expect(result.input.orFilters).toEqual([
                 {
@@ -267,25 +314,33 @@ describe('getDomainsScrollInput', () => {
 
     describe('ignoreParentScope (flat-list mode)', () => {
         it('drops the parentDomain clause entirely so the query spans every depth', () => {
-            // This is the bug-fix John flagged: the sidebar's flat-list mode
-            // (active when an owner filter is selected) must NOT pin the
-            // query to root domains, or matching subdomains would silently
-            // disappear from the results.
-            const result = getDomainsScrollInput(null, null, ['urn:li:corpuser:jane'], true);
+            const result = getDomainsScrollInput({
+                parentDomain: null,
+                scrollId: null,
+                selectedOwnerUrns: ['urn:li:corpuser:jane'],
+                ignoreParentScope: true,
+            });
 
             expect(result.input.orFilters).toEqual([{ and: [{ field: 'owners', values: ['urn:li:corpuser:jane'] }] }]);
         });
 
         it('drops the parentDomain clause even when a parentDomain argument is supplied', () => {
-            // `ignoreParentScope` wins over the parentDomain argument — the
-            // caller is explicitly opting into a global query.
-            const result = getDomainsScrollInput('urn:li:domain:parent', null, ['urn:li:corpuser:jane'], true);
+            const result = getDomainsScrollInput({
+                parentDomain: 'urn:li:domain:parent',
+                scrollId: null,
+                selectedOwnerUrns: ['urn:li:corpuser:jane'],
+                ignoreParentScope: true,
+            });
 
             expect(result.input.orFilters).toEqual([{ and: [{ field: 'owners', values: ['urn:li:corpuser:jane'] }] }]);
         });
 
         it('produces an empty AND clause when no filters apply (server treats this as "no filter")', () => {
-            const result = getDomainsScrollInput(null, null, undefined, true);
+            const result = getDomainsScrollInput({
+                parentDomain: null,
+                scrollId: null,
+                ignoreParentScope: true,
+            });
 
             expect(result.input.orFilters).toEqual([{ and: [] }]);
         });

--- a/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Tooltip } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
@@ -41,8 +41,22 @@ function ManageDomainsSidebarInner() {
     const [isCreatingDomain, setIsCreatingDomain] = useState(false);
     const { selectedOwnerUrns, setSelectedOwnerUrns, availableOwners, sortSelection, setSortSelection } =
         useDomainSidebarFilters();
+    const isFirstSortEffectRef = useRef(true);
 
     const isHomeSelected = matchPath(location.pathname, { path: PageRoutes.DOMAINS, exact: true }) !== null;
+
+    // Sort reloads the scroll stream from page 1 — pin the browse list at the top
+    // so results don't land off-screen after the user had scrolled down (Documents).
+    useEffect(() => {
+        if (isFirstSortEffectRef.current) {
+            isFirstSortEffectRef.current = false;
+            return;
+        }
+        const treeScroll = document.querySelector('[data-testid="hierarchical-browse-tree-scroll"]');
+        if (treeScroll instanceof HTMLElement) {
+            treeScroll.scrollTop = 0;
+        }
+    }, [sortSelection]);
 
     const unhideSidebar = useCallback(() => {
         setIsClosed(false);

--- a/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
@@ -15,9 +15,14 @@ import {
     DomainSidebarFiltersProvider,
     useDomainSidebarFilters,
 } from '@app/domainV2/nestedDomains/domainSidebarFilters/DomainSidebarFiltersContext';
+import {
+    DOMAIN_SIDEBAR_SORT,
+    DomainSidebarSortValue,
+} from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
 import HierarchicalBrowseSidebar from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar';
 import { SidebarCreateButton } from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/HierarchicalBrowseSidebar.components';
 import SidebarHomeNavLink from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarHomeNavLink';
+import SidebarSortSelect from '@app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarSortSelect';
 import { PageRoutes } from '@conf/Global';
 
 import { EntityType } from '@types';
@@ -30,10 +35,12 @@ const OwnerOptionRow = styled.span`
 
 function ManageDomainsSidebarInner() {
     const { t } = useTranslation('governance.domain');
+    const { t: tm } = useTranslation('misc');
     const location = useLocation();
     const [isClosed, setIsClosed] = useState(false);
     const [isCreatingDomain, setIsCreatingDomain] = useState(false);
-    const { selectedOwnerUrns, setSelectedOwnerUrns, availableOwners } = useDomainSidebarFilters();
+    const { selectedOwnerUrns, setSelectedOwnerUrns, availableOwners, sortSelection, setSortSelection } =
+        useDomainSidebarFilters();
 
     const isHomeSelected = matchPath(location.pathname, { path: PageRoutes.DOMAINS, exact: true }) !== null;
 
@@ -51,6 +58,15 @@ function ManageDomainsSidebarInner() {
         [availableOwners],
     );
 
+    const sortOptions = useMemo(
+        () => [
+            { value: DOMAIN_SIDEBAR_SORT.NAME_ASC, label: tm('sidebarSort.nameAtoZ') },
+            { value: DOMAIN_SIDEBAR_SORT.NAME_DESC, label: tm('sidebarSort.nameZtoA') },
+            { value: DOMAIN_SIDEBAR_SORT.CREATED_DESC, label: tm('sidebarSort.created') },
+        ],
+        [tm],
+    );
+
     const headerActions = (
         <Tooltip showArrow={false} title={t('sidebar.createTooltip')} placement="right">
             <SidebarCreateButton
@@ -64,7 +80,9 @@ function ManageDomainsSidebarInner() {
         </Tooltip>
     );
 
-    const ownerFilter = (
+    // Domains only support Owners (no tags/terms on the Domain entity). One
+    // filter → no "+ Filter" menu.
+    const filters = (
         <SimpleSelect
             size="sm"
             width="fit-content"
@@ -108,7 +126,15 @@ function ManageDomainsSidebarInner() {
                 headerActions={headerActions}
                 id="browse-v2"
                 search={<DomainSearch />}
-                filters={ownerFilter}
+                sort={
+                    <SidebarSortSelect
+                        options={sortOptions}
+                        value={sortSelection}
+                        onChange={(next) => setSortSelection(next as DomainSidebarSortValue)}
+                        dataTestId="domain-sidebar-sort"
+                    />
+                }
+                filters={filters}
                 homeNav={
                     <SidebarHomeNavLink
                         to={PageRoutes.DOMAINS}
@@ -122,10 +148,10 @@ function ManageDomainsSidebarInner() {
                     isCollapsed ? (
                         <>
                             <DomainSearch isCollapsed unhideSidebar={unhideSidebar} />
-                            <DomainNavigator isCollapsed variant="sidebar" includeHome />
+                            <DomainNavigator key={sortSelection} isCollapsed variant="sidebar" includeHome />
                         </>
                     ) : (
-                        <DomainNavigator variant="sidebar" includeHome={false} />
+                        <DomainNavigator key={sortSelection} variant="sidebar" includeHome={false} />
                     )
                 }
             </HierarchicalBrowseSidebar>

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNavigator.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNavigator.tsx
@@ -58,7 +58,7 @@ function DomainNavigatorInner({
 }: Props) {
     const { t } = useTranslation('governance.domain');
     const { t: tm } = useTranslation('misc');
-    const { selectedOwnerUrns, setAvailableOwners } = useDomainSidebarFilters();
+    const { selectedOwnerUrns, setAvailableOwners, sortSelection } = useDomainSidebarFilters();
     const expansion = useTreeExpansionRegistry();
     const isSidebar = variant === 'sidebar';
 
@@ -76,6 +76,7 @@ function DomainNavigatorInner({
     const { domains, hasInitialized, loading, error, scrollRef } = useScrollDomains({
         selectedOwnerUrns: isSidebar ? selectedOwnerUrns : undefined,
         ignoreParentScope: isFiltering,
+        sort: isSidebar ? sortSelection : undefined,
     });
 
     // Dropdown options come from a dedicated aggregation query that covers

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
@@ -169,16 +169,17 @@ export default function DomainNode({
     const expansion = useTreeExpansionRegistry();
     const isInSelectMode = !!selectDomainOverride;
     const isSidebarVariant = variant === 'sidebar';
-    // Propagate the sidebar's owner selection down into every level of the
-    // tree so child-domain scrolls are filtered server-side too (mirrors how
+    // Propagate the sidebar's owner / sort selection down into every level of the
+    // tree so child-domain scrolls stay consistent with the root (mirrors how
     // the root scroll is filtered in `DomainNavigator`). Picker variants
     // intentionally don't inherit the sidebar filter — they have their own
     // scope. Returns noop defaults outside the sidebar provider tree.
-    const { selectedOwnerUrns } = useDomainSidebarFilters();
+    const { selectedOwnerUrns, sortSelection } = useDomainSidebarFilters();
     const { domains, loading, scrollRef } = useScrollDomains({
         parentDomain: domain.urn,
         skip: !isOpen || shouldHideDomain,
         selectedOwnerUrns: isSidebarVariant ? selectedOwnerUrns : undefined,
+        sort: isSidebarVariant ? sortSelection : undefined,
     });
     const isOnEntityPage = entityData && entityData.urn === domain.urn;
     const displayName = entityRegistry.getDisplayName(domain.type, isOnEntityPage ? entityData : domain);

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/DomainSidebarFiltersContext.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/DomainSidebarFiltersContext.tsx
@@ -1,6 +1,10 @@
 import React, { createContext, useContext, useMemo, useState } from 'react';
 
 import { DomainOwnerInfo } from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarFilters.utils';
+import {
+    DEFAULT_DOMAIN_SIDEBAR_SORT,
+    DomainSidebarSortValue,
+} from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
 
 interface DomainSidebarFiltersContextValue {
     /** URNs of owners the user has selected from the multi-select. Empty = no filter. */
@@ -8,12 +12,14 @@ interface DomainSidebarFiltersContextValue {
     setSelectedOwnerUrns: (urns: string[]) => void;
     /**
      * Distinct owners that exist anywhere in the server-side domain index,
-     * sourced from the `owners` facet aggregations on the root scroll query.
-     * Populated by `DomainNavigator` whenever the server returns a new set of
-     * facets; the dropdown reads it directly.
+     * sourced from the `owners` facet aggregations.
+     * Populated by `DomainNavigator`; the dropdown reads it directly.
      */
     availableOwners: DomainOwnerInfo[];
     setAvailableOwners: (owners: DomainOwnerInfo[]) => void;
+    /** Server-side sort for browse / filtered scroll queries. */
+    sortSelection: DomainSidebarSortValue;
+    setSortSelection: (sort: DomainSidebarSortValue) => void;
 }
 
 // Noop defaults (rather than a throw-on-missing-provider hook like
@@ -28,11 +34,14 @@ const DomainSidebarFiltersContext = createContext<DomainSidebarFiltersContextVal
     setSelectedOwnerUrns: () => {},
     availableOwners: [],
     setAvailableOwners: () => {},
+    sortSelection: DEFAULT_DOMAIN_SIDEBAR_SORT,
+    setSortSelection: () => {},
 });
 
 export function DomainSidebarFiltersProvider({ children }: { children: React.ReactNode }) {
     const [selectedOwnerUrns, setSelectedOwnerUrns] = useState<string[]>([]);
     const [availableOwners, setAvailableOwners] = useState<DomainOwnerInfo[]>([]);
+    const [sortSelection, setSortSelection] = useState<DomainSidebarSortValue>(DEFAULT_DOMAIN_SIDEBAR_SORT);
 
     const value = useMemo<DomainSidebarFiltersContextValue>(
         () => ({
@@ -40,8 +49,10 @@ export function DomainSidebarFiltersProvider({ children }: { children: React.Rea
             setSelectedOwnerUrns,
             availableOwners,
             setAvailableOwners,
+            sortSelection,
+            setSortSelection,
         }),
-        [selectedOwnerUrns, availableOwners],
+        [selectedOwnerUrns, availableOwners, sortSelection],
     );
 
     return <DomainSidebarFiltersContext.Provider value={value}>{children}</DomainSidebarFiltersContext.Provider>;

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/DomainSidebarFiltersContext.test.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/DomainSidebarFiltersContext.test.tsx
@@ -7,6 +7,10 @@ import {
     useDomainSidebarFilters,
 } from '@app/domainV2/nestedDomains/domainSidebarFilters/DomainSidebarFiltersContext';
 import { DomainOwnerInfo } from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarFilters.utils';
+import {
+    DEFAULT_DOMAIN_SIDEBAR_SORT,
+    DOMAIN_SIDEBAR_SORT,
+} from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
 
 import { EntityType } from '@types';
 
@@ -25,22 +29,23 @@ function makeOwnerInfo(overrides: Partial<DomainOwnerInfo> = {}): DomainOwnerInf
 
 describe('DomainSidebarFiltersContext', () => {
     describe('defaults', () => {
-        it('initializes both selection and available owners to empty', () => {
+        it('initializes selection, available owners, and sort defaults', () => {
             const { result } = renderHook(() => useDomainSidebarFilters(), { wrapper });
 
             expect(result.current.selectedOwnerUrns).toEqual([]);
             expect(result.current.availableOwners).toEqual([]);
+            expect(result.current.sortSelection).toBe(DEFAULT_DOMAIN_SIDEBAR_SORT);
         });
 
         it('returns noop defaults when used outside a provider (used by picker variants)', () => {
-            // Important: DomainNode is rendered inside pickers without a
-            // provider; calling useDomainSidebarFilters() there must NOT throw.
             const { result } = renderHook(() => useDomainSidebarFilters());
 
             expect(result.current.selectedOwnerUrns).toEqual([]);
             expect(result.current.availableOwners).toEqual([]);
+            expect(result.current.sortSelection).toBe(DEFAULT_DOMAIN_SIDEBAR_SORT);
             expect(() => result.current.setSelectedOwnerUrns(['x'])).not.toThrow();
             expect(() => result.current.setAvailableOwners([makeOwnerInfo()])).not.toThrow();
+            expect(() => result.current.setSortSelection(DOMAIN_SIDEBAR_SORT.NAME_DESC)).not.toThrow();
         });
     });
 
@@ -56,7 +61,7 @@ describe('DomainSidebarFiltersContext', () => {
     });
 
     describe('setAvailableOwners', () => {
-        it('replaces the available-owners list wholesale (mirrors how facets re-arrive on every server response)', () => {
+        it('replaces the available-owners list wholesale', () => {
             const { result } = renderHook(() => useDomainSidebarFilters(), { wrapper });
 
             const first = [makeOwnerInfo({ urn: 'urn:li:corpuser:jane' })];
@@ -78,10 +83,18 @@ describe('DomainSidebarFiltersContext', () => {
             act(() => result.current.setSelectedOwnerUrns(['urn:li:corpuser:jane']));
             act(() => result.current.setAvailableOwners([makeOwnerInfo({ urn: 'urn:li:corpuser:john' })]));
 
-            // Selection survives even when the available list no longer
-            // contains the selected URN — the dropdown is responsible for
-            // showing/handling stale chips, not the context.
             expect(result.current.selectedOwnerUrns).toEqual(['urn:li:corpuser:jane']);
+        });
+    });
+
+    describe('sort', () => {
+        it('updates sort independently of owner selection', () => {
+            const { result } = renderHook(() => useDomainSidebarFilters(), { wrapper });
+
+            act(() => result.current.setSortSelection(DOMAIN_SIDEBAR_SORT.NAME_DESC));
+
+            expect(result.current.sortSelection).toBe(DOMAIN_SIDEBAR_SORT.NAME_DESC);
+            expect(result.current.selectedOwnerUrns).toEqual([]);
         });
     });
 });

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/domainSidebarSort.test.ts
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/domainSidebarSort.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_DOMAIN_SIDEBAR_SORT,
+    DOMAIN_SIDEBAR_SORT,
+    domainSidebarSortToCriterion,
+} from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
+import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+import { CREATED_TIME_FIELD_NAME } from '@app/searchV2/utils/constants';
+
+import { SortOrder } from '@types';
+
+describe('domainSidebarSortToCriterion', () => {
+    it('maps name and created selections to search sortCriterion', () => {
+        expect(domainSidebarSortToCriterion(DOMAIN_SIDEBAR_SORT.NAME_ASC)).toEqual({
+            field: ENTITY_NAME_FIELD,
+            sortOrder: SortOrder.Ascending,
+        });
+        expect(domainSidebarSortToCriterion(DOMAIN_SIDEBAR_SORT.NAME_DESC)).toEqual({
+            field: ENTITY_NAME_FIELD,
+            sortOrder: SortOrder.Descending,
+        });
+        expect(domainSidebarSortToCriterion(DOMAIN_SIDEBAR_SORT.CREATED_DESC)).toEqual({
+            field: CREATED_TIME_FIELD_NAME,
+            sortOrder: SortOrder.Descending,
+        });
+    });
+
+    it('defaults to name ascending', () => {
+        expect(DEFAULT_DOMAIN_SIDEBAR_SORT).toBe(DOMAIN_SIDEBAR_SORT.NAME_ASC);
+    });
+});

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/domainSidebarSort.test.ts
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/__tests__/domainSidebarSort.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-    DEFAULT_DOMAIN_SIDEBAR_SORT,
     DOMAIN_SIDEBAR_SORT,
     domainSidebarSortToCriterion,
 } from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
@@ -24,9 +23,5 @@ describe('domainSidebarSortToCriterion', () => {
             field: CREATED_TIME_FIELD_NAME,
             sortOrder: SortOrder.Descending,
         });
-    });
-
-    it('defaults to name ascending', () => {
-        expect(DEFAULT_DOMAIN_SIDEBAR_SORT).toBe(DOMAIN_SIDEBAR_SORT.NAME_ASC);
     });
 });

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort.ts
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort.ts
@@ -1,0 +1,36 @@
+import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
+import { CREATED_TIME_FIELD_NAME } from '@app/searchV2/utils/constants';
+
+import { SortCriterion, SortOrder } from '@types';
+
+/** Domain sidebar sort option values (also used as menu keys). */
+export const DOMAIN_SIDEBAR_SORT = {
+    NAME_ASC: 'name_asc',
+    NAME_DESC: 'name_desc',
+    CREATED_DESC: 'created_desc',
+} as const;
+
+export type DomainSidebarSortValue = (typeof DOMAIN_SIDEBAR_SORT)[keyof typeof DOMAIN_SIDEBAR_SORT];
+
+/** Preserve historical tree order (name A–Z) as the default. */
+export const DEFAULT_DOMAIN_SIDEBAR_SORT: DomainSidebarSortValue = DOMAIN_SIDEBAR_SORT.NAME_ASC;
+
+/**
+ * Domains index `_entityName` and `createdTime` (searchLabel createdAt) on
+ * DomainProperties — there is no searchable lastModifiedAt.
+ * Pass via scrollAcrossEntities sortInput — never reorder client-side.
+ */
+export function domainSidebarSortToCriterion(sort: DomainSidebarSortValue): SortCriterion {
+    switch (sort) {
+        case DOMAIN_SIDEBAR_SORT.NAME_ASC:
+            return { field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Ascending };
+        case DOMAIN_SIDEBAR_SORT.NAME_DESC:
+            return { field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Descending };
+        case DOMAIN_SIDEBAR_SORT.CREATED_DESC:
+            return { field: CREATED_TIME_FIELD_NAME, sortOrder: SortOrder.Descending };
+        default: {
+            const exhaustiveCheck: never = sort;
+            throw new Error(`Unhandled domain sidebar sort: ${exhaustiveCheck}`);
+        }
+    }
+}

--- a/datahub-web-react/src/app/domainV2/useScrollDomains.ts
+++ b/datahub-web-react/src/app/domainV2/useScrollDomains.ts
@@ -1,26 +1,39 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
+import {
+    DEFAULT_DOMAIN_SIDEBAR_SORT,
+    DomainSidebarSortValue,
+    domainSidebarSortToCriterion,
+} from '@app/domainV2/nestedDomains/domainSidebarFilters/domainSidebarSort';
 import useManageDomains from '@app/domainV2/useManageDomains';
-import { ENTITY_NAME_FIELD } from '@app/searchV2/context/constants';
 import { OWNERS_FILTER_NAME } from '@app/searchV2/utils/constants';
 
 import { ListDomainFragment } from '@graphql/domain.generated';
 import { useScrollAcrossEntitiesQuery } from '@graphql/search.generated';
-import { EntityType, FacetFilterInput, FilterOperator, SortOrder } from '@types';
+import { EntityType, FacetFilterInput, FilterOperator } from '@types';
 
 export const DOMAIN_COUNT = 25;
 
-export function getDomainsScrollInput(
-    parentDomain: string | null,
-    scrollId: string | null,
-    selectedOwnerUrns?: ReadonlyArray<string> | null,
-    ignoreParentScope?: boolean,
-) {
+export type DomainsScrollInputParams = {
+    parentDomain: string | null;
+    scrollId: string | null;
+    selectedOwnerUrns?: ReadonlyArray<string> | null;
+    ignoreParentScope?: boolean;
+    sort?: DomainSidebarSortValue;
+};
+
+export function getDomainsScrollInput({
+    parentDomain,
+    scrollId,
+    selectedOwnerUrns,
+    ignoreParentScope,
+    sort = DEFAULT_DOMAIN_SIDEBAR_SORT,
+}: DomainsScrollInputParams) {
     const filters: FacetFilterInput[] = [];
     // `ignoreParentScope` switches the query from "domains at this level of
     // the hierarchy" to "domains anywhere in the index" — used by the
-    // sidebar's flat-list mode when an owner filter is active, so we don't
+    // sidebar's flat-list mode when a filter is active, so we don't
     // miss matching subdomains whose parents don't match the filter.
     if (!ignoreParentScope) {
         const parentFilter: FacetFilterInput = parentDomain
@@ -46,7 +59,7 @@ export function getDomainsScrollInput(
             orFilters: [{ and: filters }],
             count: DOMAIN_COUNT,
             sortInput: {
-                sortCriteria: [{ field: ENTITY_NAME_FIELD, sortOrder: SortOrder.Ascending }],
+                sortCriteria: [domainSidebarSortToCriterion(sort)],
             },
             searchFlags: { skipCache: true },
         },
@@ -66,27 +79,29 @@ interface Props {
     /**
      * When true, drop the `parentDomain` clause from the scroll query so the
      * result set spans every domain at every depth. Used by the sidebar's
-     * flat-list "filter results" mode — without this, an owner filter would
+     * flat-list "filter results" mode — without this, a filter would
      * be ANDed with `parentDomain NOT EXISTS` and silently exclude matching
      * subdomains whose parents don't match the filter (the bug John flagged
      * in PR #18088 review).
      */
     ignoreParentScope?: boolean;
+    /** Server-side sort for this scroll stream. Defaults to name A–Z. */
+    sort?: DomainSidebarSortValue;
 }
 
-export default function useScrollDomains({ parentDomain, skip, selectedOwnerUrns, ignoreParentScope }: Props) {
+export default function useScrollDomains({
+    parentDomain,
+    skip,
+    selectedOwnerUrns,
+    ignoreParentScope,
+    sort = DEFAULT_DOMAIN_SIDEBAR_SORT,
+}: Props) {
     const [hasInitialized, setHasInitialized] = useState(false);
     const [data, setData] = useState<ListDomainFragment[]>([]);
     const [dataUrnsSet, setDataUrnsSet] = useState<Set<string>>(new Set());
     const [scrollId, setScrollId] = useState<string | null>(null);
 
-    // Reset the in-memory accumulator whenever the *filter scope* changes
-    // (parent domain or owner selection). Without this, switching the owner
-    // filter from Alice to Bob would leave Alice's already-fetched domains
-    // stuck in `data` because the URN-dedup guard would silently drop the
-    // newly-fetched Bob domains as "already seen" without ever flushing
-    // Alice's. Memoize the owner-filter key on a sorted join so reference
-    // identity (Apollo refetches) doesn't trip the reset.
+    // Reset the in-memory accumulator whenever the *filter / sort scope* changes.
     const ownerKey = useMemo(
         () => (selectedOwnerUrns ? [...selectedOwnerUrns].sort().join(',') : ''),
         [selectedOwnerUrns],
@@ -96,7 +111,7 @@ export default function useScrollDomains({ parentDomain, skip, selectedOwnerUrns
         setDataUrnsSet(new Set());
         setScrollId(null);
         setHasInitialized(false);
-    }, [parentDomain, ownerKey, ignoreParentScope]);
+    }, [parentDomain, ownerKey, ignoreParentScope, sort]);
 
     const {
         data: scrollData,
@@ -105,7 +120,13 @@ export default function useScrollDomains({ parentDomain, skip, selectedOwnerUrns
         refetch,
     } = useScrollAcrossEntitiesQuery({
         variables: {
-            ...getDomainsScrollInput(parentDomain || null, scrollId, selectedOwnerUrns, ignoreParentScope),
+            ...getDomainsScrollInput({
+                parentDomain: parentDomain || null,
+                scrollId,
+                selectedOwnerUrns,
+                ignoreParentScope,
+                sort,
+            }),
         },
         skip,
         notifyOnNetworkStatusChange: true,

--- a/datahub-web-react/src/i18n/locales/en/misc.json
+++ b/datahub-web-react/src/i18n/locales/en/misc.json
@@ -88,6 +88,7 @@
     "sidebarSort.nameAtoZ": "Name A to Z",
     "sidebarSort.nameZtoA": "Name Z to A",
     "sidebarSort.lastModified": "Last modified",
+    "sidebarSort.created": "Recently created",
     "sidebarAddFilter.label": "Filter",
     "context.import.back": "Back",
     "context.import.buttonTooltip": "Import Documents",


### PR DESCRIPTION
Before:
<img width="1840" height="1196" alt="Screenshot 2026-08-06 at 12 22 12 PM" src="https://github.com/user-attachments/assets/704102f1-df2a-4ae2-a538-77ba9c1e9831" />
After:
<img width="1840" height="1196" alt="Screenshot 2026-08-06 at 12 21 21 PM" src="https://github.com/user-attachments/assets/5ba377b9-1673-49a0-bb8c-ea065007d21d" />
<img width="1840" height="1196" alt="Screenshot 2026-08-06 at 12 21 25 PM" src="https://github.com/user-attachments/assets/ab71f6e8-57cc-4d52-a402-e18f1802fa3c" />
<img width="1840" height="1196" alt="Screenshot 2026-08-06 at 12 21 22 PM" src="https://github.com/user-attachments/assets/354300cb-33bf-4f15-9382-245ca58ccb39" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side sorting to the Domains sidebar (Name A–Z, Name Z–A, Recently created). Sorting applies to root and child lists, and the list scrolls to the top on sort changes to keep results visible.

- **New Features**
  - Added a sort dropdown in the Domains sidebar using `SidebarSortSelect`.
  - Persisted sort selection in `DomainSidebarFiltersContext` with `DEFAULT_DOMAIN_SIDEBAR_SORT` (Name A–Z).
  - Mapped sort selections to search `sortInput` via `domainSidebarSortToCriterion` (no client-side reordering).
  - Applied sort to root and child scrolls in `DomainNavigator` and `DomainNode`.
  - Added tests for sort mapping and updated scroll input tests; added i18n label `misc.sidebarSort.created`.

- **Bug Fixes**
  - Reset browse tree scroll position to top on sort change to prevent results from appearing off-screen.

<sup>Written for commit a3b9a8e78306be5217e0287b97a131ffabe2b161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

