### PR TITLE
feat(looker): emit per-field explore usage (fieldCounts) from System Activity

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
@@ -33,6 +33,7 @@ class LookerField(StrEnum):
     COUNT = "count"
     MODEL = "model"
     VIEW = "view"
+    FIELDS = "fields"
 
 
 class ViewField(StrEnum):
@@ -66,6 +67,9 @@ class QueryViewField(ViewField):
     # LookML view). Together with `query.model` it identifies the explore.
     QUERY_MODEL = f"{LookerView.QUERY}.{LookerField.MODEL}"
     QUERY_VIEW = f"{LookerView.QUERY}.{LookerField.VIEW}"
+    # System Activity's list of fully-qualified `view.field` names each query
+    # referenced.  Returned as a single delimited string (not an array).
+    QUERY_FIELDS = f"{LookerView.QUERY}.{LookerField.FIELDS}"
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -822,12 +822,11 @@ class ExploreStatGenerator(BaseStatGenerator):
 
     @staticmethod
     def _parse_query_fields(raw_fields: object) -> List[str]:
-        result: List[str] = []
-        for token in _QUERY_FIELDS_SPLIT_RE.split(str(raw_fields)):
-            stripped = token.strip()
-            if stripped:
-                result.append(stripped)
-        return result
+        if isinstance(raw_fields, (list, tuple)):
+            tokens = [str(t) for t in raw_fields]
+        else:
+            tokens = _QUERY_FIELDS_SPLIT_RE.split(str(raw_fields))
+        return [t.strip() for t in tokens if t.strip()]
 
     def _augment_entity_timeseries_aspects(
         self, entity_usage_stat: Dict[Tuple[str, str], Any]

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -218,6 +218,7 @@ query_collection: Dict[QueryId, LookerQuery] = {
         ],
         filters={
             QueryViewField.QUERY_VIEW: "NOT NULL",
+            QueryViewField.QUERY_FIELDS: "NOT NULL",
         },
     ),
 }

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -8,7 +8,9 @@ import concurrent.futures
 import dataclasses
 import datetime
 import logging
+import re
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, cast
 
@@ -40,6 +42,7 @@ from datahub.metadata.schema_classes import (
     ChartUserUsageCountsClass,
     DashboardUsageStatisticsClass,
     DashboardUserUsageCountsClass,
+    DatasetFieldUsageCountsClass,
     DatasetUsageStatisticsClass,
     DatasetUserUsageCountsClass,
     TimeWindowSizeClass,
@@ -48,6 +51,11 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities.lossy_collections import LossySet
 
 logger = logging.getLogger(__name__)
+
+# System Activity returns `query.fields` as a single string joining
+# the referenced `view.field` names.  Looker has used both comma and
+# newline separators across versions, so we split on either.
+_QUERY_FIELDS_SPLIT_RE = re.compile(r"[,\n]")
 
 
 @dataclass
@@ -119,6 +127,7 @@ class QueryId(StrEnum):
     LOOK_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_look"
     EXPLORE_PER_DAY_USAGE_STAT = "counts_per_day_per_explore"
     EXPLORE_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_explore"
+    EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT = "counts_per_day_per_field_per_explore"
 
 
 query_collection: Dict[QueryId, LookerQuery] = {
@@ -189,6 +198,23 @@ query_collection: Dict[QueryId, LookerQuery] = {
             QueryViewField.QUERY_MODEL,
             QueryViewField.QUERY_VIEW,
             UserViewField.USER_ID,
+        ],
+        filters={
+            QueryViewField.QUERY_VIEW: "NOT NULL",
+        },
+    ),
+    # Kept separate from the per-day explore query: adding query.fields would
+    # fragment the (model, view, date) grouping that feeds totalSqlQueries.
+    # Rows here are exploded client-side into per-field counts.
+    QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: LookerQuery(
+        model=LookerModel.SYSTEM_ACTIVITY,
+        explore=LookerExplore.HISTORY,
+        fields=[
+            HistoryViewField.HISTORY_CREATED_DATE,
+            HistoryViewField.HISTORY_COUNT,
+            QueryViewField.QUERY_MODEL,
+            QueryViewField.QUERY_VIEW,
+            QueryViewField.QUERY_FIELDS,
         ],
         filters={
             QueryViewField.QUERY_VIEW: "NOT NULL",
@@ -418,6 +444,14 @@ class BaseStatGenerator(ABC):
         """
         return True
 
+    def _augment_entity_timeseries_aspects(
+        self, entity_usage_stat: Dict[Tuple[str, str], Any]
+    ) -> None:
+        """Hook for subclasses to enrich per-day entity aspects with extra
+        signals (keyed by the same ``get_entity_stat_key`` tuple).  No-op by
+        default so dashboards/looks are unaffected."""
+        return
+
     def generate_usage_stat_mcps(self) -> Iterable[MetadataChangeProposalWrapper]:
         # No looker entities available to process stat generation
         if len(self.looker_models) == 0:
@@ -439,6 +473,10 @@ class BaseStatGenerator(ABC):
         entity_usage_stat: Dict[Tuple[str, str], Any] = (
             self._process_entity_timeseries_rows(entity_rows)
         )  # Any type to pass mypy unbound Aspect type error
+
+        # Optional per-entity enrichment (e.g. explore field-usage counts).
+        # Default no-op; subclasses override to run extra queries.
+        self._augment_entity_timeseries_aspects(entity_usage_stat)
 
         user_wise_query_with_filters: LookerQuery = self._append_filters(
             self.get_entity_user_timeseries_query()
@@ -780,6 +818,49 @@ class ExploreStatGenerator(BaseStatGenerator):
             uniqueUserCount=0,
             userCounts=[],
         )
+
+    @staticmethod
+    def _parse_query_fields(raw_fields: object) -> List[str]:
+        result: List[str] = []
+        for token in _QUERY_FIELDS_SPLIT_RE.split(str(raw_fields)):
+            stripped = token.strip()
+            if stripped:
+                result.append(stripped)
+        return result
+
+    def _augment_entity_timeseries_aspects(
+        self, entity_usage_stat: Dict[Tuple[str, str], Any]
+    ) -> None:
+        """Attach per-field usage (``query.fields``) to each per-day explore
+        aspect.  Each System Activity row is one ``(date, model, explore,
+        field-set)`` bucket with its execution count.  We explode each
+        field-set and sum the row's count into every field it names."""
+        field_query_with_filters: LookerQuery = self._append_filters(
+            query_collection[QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT]
+        )
+        # _execute_query handles exceptions internally and returns [] on failure.
+        field_rows = self._execute_query(field_query_with_filters, "field_query")
+
+        per_key_counts: Dict[Tuple[str, str], Dict[str, int]] = defaultdict(
+            lambda: defaultdict(int)
+        )
+        for row in field_rows:
+            raw_fields = row.get(QueryViewField.QUERY_FIELDS)
+            if not raw_fields:
+                continue
+            key = self.get_entity_stat_key(row)
+            count = row[HistoryViewField.HISTORY_COUNT]
+            for field_name in self._parse_query_fields(raw_fields):
+                per_key_counts[key][field_name] += count
+
+        for key, field_counts in per_key_counts.items():
+            aspect = entity_usage_stat.get(key)
+            if aspect is None:
+                continue
+            aspect.fieldCounts = [
+                DatasetFieldUsageCountsClass(fieldPath=field_name, count=count)
+                for field_name, count in sorted(field_counts.items())
+            ]
 
     def append_user_stat(
         self, entity_stat_aspect: Aspect, user: LookerUser, row: Dict

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -690,10 +690,12 @@ def side_effect_query_inline(
                 },
             ]
         ),
-        # Explore-level usage is unit-tested in tests/unit/looker/test_looker_usage.py;
-        # here we just return empty so the dashboard/look goldens are unaffected.
+        # Explore-level usage (incl. per-field query.fields) is unit-tested in
+        # tests/unit/looker/test_looker_usage.py; return empty here so the
+        # dashboard/look goldens are unaffected.
         looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT: json.dumps([]),
         looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: json.dumps([]),
+        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: json.dumps([]),
     }
 
     if query_id_vs_response.get(query_type) is None:

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -47,6 +47,18 @@ def test_explore_usage_queries_target_system_activity_query_view():
     assert UserViewField.USER_ID not in per_day.fields
     assert UserViewField.USER_ID in per_user.fields
 
+    # The per-field query is separate (adding query.fields to the per-day query
+    # would fragment the (model, view, date) grouping) and carries query.fields.
+    per_field = looker_usage.query_collection[
+        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT
+    ]
+    assert per_field.model == LookerModel.SYSTEM_ACTIVITY
+    assert QueryViewField.QUERY_FIELDS in per_field.fields
+    assert QueryViewField.QUERY_MODEL in per_field.fields
+    assert QueryViewField.QUERY_VIEW in per_field.fields
+    assert UserViewField.USER_ID not in per_field.fields
+    assert QueryViewField.QUERY_FIELDS not in per_day.fields
+
 
 def test_explore_stat_generator_builds_explore_dataset_urn():
     generator = looker_usage.create_explore_stat_generator(
@@ -77,6 +89,24 @@ def test_explore_stat_generator_emits_usage_stats():
             HistoryViewField.HISTORY_COUNT: 30,
         }
     ]
+    # Two field-set buckets for the same (explore, day): orders.count appears in
+    # both, so its per-field count sums across rows (18 + 12 = 30).
+    field_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            QueryViewField.QUERY_FIELDS: "orders.count,orders.created_date",
+            HistoryViewField.HISTORY_COUNT: 18,
+        },
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            QueryViewField.QUERY_FIELDS: "orders.count",
+            HistoryViewField.HISTORY_COUNT: 12,
+        },
+    ]
     user_rows = [
         {
             QueryViewField.QUERY_MODEL: "sales",
@@ -95,8 +125,9 @@ def test_explore_stat_generator_emits_usage_stats():
     ]
 
     mock_api = mock.MagicMock()
-    # entity query is executed first, then the per-user query.
-    mock_api.execute_query.side_effect = [entity_rows, user_rows]
+    # Execution order: entity query, then the per-field query (from the augment
+    # hook), then the per-user query.
+    mock_api.execute_query.side_effect = [entity_rows, field_rows, user_rows]
 
     def fake_user(user_id: int) -> mock.MagicMock:
         user = mock.MagicMock()
@@ -129,6 +160,28 @@ def test_explore_stat_generator_emits_usage_stats():
     assert {uc.count for uc in aspect.userCounts} == {20, 10}
     entity_urn = mcps[0].entityUrn
     assert entity_urn is not None and "sales.explore.orders" in entity_urn
+
+    # query.fields is exploded and summed into per-field usage counts.
+    assert aspect.fieldCounts is not None
+    field_counts = {fc.fieldPath: fc.count for fc in aspect.fieldCounts}
+    assert field_counts == {"orders.count": 30, "orders.created_date": 18}
+
+
+def test_parse_query_fields_handles_delimiters_and_blanks():
+    parse = looker_usage.ExploreStatGenerator._parse_query_fields
+    assert parse("orders.count,orders.created_date") == [
+        "orders.count",
+        "orders.created_date",
+    ]
+    assert parse("orders.count\norders.created_date") == [
+        "orders.count",
+        "orders.created_date",
+    ]
+    assert parse(" orders.count , ,\n orders.state ") == [
+        "orders.count",
+        "orders.state",
+    ]
+    assert parse("") == []
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():
@@ -183,7 +236,8 @@ def test_explore_stat_generator_skips_unresolved_users():
     ]
 
     mock_api = mock.MagicMock()
-    mock_api.execute_query.side_effect = [entity_rows, user_rows]
+    # entity query, per-field query, per-user query — all after the first are empty.
+    mock_api.execute_query.side_effect = [entity_rows, [], user_rows]
 
     def fake_user(user_id: int) -> mock.MagicMock:
         user = mock.MagicMock()
@@ -240,7 +294,8 @@ def test_explore_stat_generator_reports_non_ingested_explore_as_skipped():
     ]
 
     mock_api = mock.MagicMock()
-    mock_api.execute_query.side_effect = [entity_rows, []]
+    # entity query, per-field query, per-user query — all after the first are empty.
+    mock_api.execute_query.side_effect = [entity_rows, [], []]
 
     report = LookerDashboardSourceReport()
     generator = looker_usage.create_explore_stat_generator(

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -182,6 +182,12 @@ def test_parse_query_fields_handles_delimiters_and_blanks():
         "orders.state",
     ]
     assert parse("") == []
+    # Some Looker versions / result formats return a JSON array instead of a
+    # delimited string; the parser must handle both.
+    assert parse(["orders.count", "orders.created_date"]) == [
+        "orders.count",
+        "orders.created_date",
+    ]
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():


### PR DESCRIPTION
## Summary

Populate the existing but unused `DatasetUsageStatistics.fieldCounts` field for Looker explore datasets by extracting per-field query references from System Activity's `query.fields` column.

## Motivation

The `DatasetUsageStatisticsClass` model already defines a `fieldCounts` field for per-field usage granularity, but the Looker explore usage pipeline never populated it — it only emitted `totalSqlQueries` and `userCounts`. This means there was no visibility into which specific explore fields (dimensions/measures) are actually queried by users. Surfacing per-field counts enables downstream consumers to identify heavily-used vs. dead fields within an explore.

## Changes Overview

**New capabilities:**
- Looker explore datasets now emit `fieldCounts` on each per-day `DatasetUsageStatistics` aspect, reporting how many query executions referenced each field that day

**Query model (`looker_query_model.py`):**
- Added `LookerField.FIELDS` and `QueryViewField.QUERY_FIELDS` enum values to represent the System Activity `query.fields` column

**Usage pipeline (`looker_usage.py`):**
- New `EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT` query in the query collection
- New `_augment_entity_timeseries_aspects` template-method hook on `BaseStatGenerator` (no-op by default, dashboards/looks unaffected)
- `ExploreStatGenerator` overrides the hook to fetch, explode, and aggregate field-level counts

## Architecture / Design Notes

**Separate query by design.** The per-field query is intentionally kept separate from the existing per-day explore query (`EXPLORE_PER_DAY_USAGE_STAT`). Adding `query.fields` to the per-day query would fragment the `(model, view, date)` grouping that feeds `totalSqlQueries` — each unique field-set would produce its own row, requiring a client-side re-aggregation to recover the total. Keeping the queries separate avoids this.

**Explode-and-sum aggregation.** Looker's System Activity returns `query.fields` as a single delimited string (e.g. `"orders.count,orders.created_date"`), not an array. Each row represents a `(date, model, explore, field-set, count)` bucket. If a field appears in multiple field-set buckets, its counts are summed. Handles both comma and newline delimiters (Looker has used both across versions).

**Template-method hook.** The enrichment runs between entity-stat and user-stat processing via a hook on `BaseStatGenerator`, avoiding the need to duplicate the entire `generate_usage_stat_mcps` orchestration method. Only `ExploreStatGenerator` overrides it; dashboards and looks are unaffected.

**Graceful degradation.** If the per-field query fails, `_execute_query` returns `[]` internally and field counts are simply omitted — the rest of the pipeline is unaffected.

## Testing

- **Unit tests** (`test_looker_usage.py`):
  - Query-shape assertions verify the new query targets System Activity with the right fields
  - End-to-end stat generation test with two field-set buckets validates the explode-and-sum logic (`orders.count` appears in both → summed count of 30)
  - Dedicated delimiter/whitespace parsing test covers comma, newline, mixed, and empty inputs
  - Existing tests updated to account for the new query in the execution order
- **Integration tests** (`test_looker.py`): New query ID mocked to return `[]` so dashboard/look goldens are unaffected
- **Live ingestion**: Ran against the Acryl Looker instance with a file sink — no errors, no warnings. The test instance has no System Activity history, so 0 explore usage MCPs were emitted (correct behavior). Prior connector-test output from an instance with System Activity data confirms 59 explore usage MCPs are produced.

## Impact Assessment

- **Affected components:** Looker source connector only (`looker_usage.py`, `looker_query_model.py`)
- **Breaking changes:** None — `fieldCounts` was already in the model but unpopulated; this only adds data
- **Performance:** One additional System Activity API call per ingestion run (bounded by the same date-range filter as existing queries)
- **Risk level:** Low — additive-only change, no existing behavior modified, graceful degradation on failure


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit per-field usage for Looker explores by populating `DatasetUsageStatistics.fieldCounts` from System Activity `query.fields`. Adds a dedicated query and enrichment step in the explore usage pipeline.

- **New Features**
  - Added `EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT` for per-day field usage; kept separate to avoid fragmenting `(model, view, date)` totals.
  - `_augment_entity_timeseries_aspects` in `ExploreStatGenerator` explodes `query.fields` (comma/newline or array), sums per day, and fills `fieldCounts`.

- **Bug Fixes**
  - Filter out null `query.fields` server-side in the per-field query to skip empty rows.
  - Handle `query.fields` returned as a list/tuple to avoid emitting invalid `fieldPath`s.

<sup>Written for commit bd28f0dedb4b09f669831c8421358e04250aa4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



