### PR TITLE
perf(smoke-test): weight batches by wall clock, not summed test duration

### DIFF
--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -322,6 +322,37 @@ def _is_global_policy_mutator(item: Item) -> bool:
     return item.get_closest_marker("global_policy_mutator") is not None
 
 
+def phase_aware_module_weight(
+    items: List[Item], test_weights: Dict[str, float], xdist_workers: int
+) -> float:
+    """Estimate a module's contribution to a batch's *wall clock*, not its total
+    test time.
+
+    smoke.sh runs each batch in two pytest invocations: non-mutator tests under
+    xdist (``-n N --dist=loadscope``), then policy mutators serially. A serial
+    minute therefore costs about N times what a parallel minute does.
+
+    Packing batches by raw summed duration ignores that and systematically
+    overloads whichever batch happens to draw the mutator-heavy modules --
+    ``tests/authorization/test_aspect_write_auth.py`` alone is ~7.6 min of
+    strictly serial work. Measured across master runs, the resulting spread was
+    ~1.7x between the slowest and fastest batch even though every batch had an
+    identical summed weight.
+
+    With xdist_workers == 1 this reduces to the plain sum, i.e. the previous
+    behaviour, which is correct because both phases are then serial.
+    """
+    parallel_seconds = 0.0
+    serial_seconds = 0.0
+    for item in items:
+        weight = get_pytest_test_weight(item, test_weights)
+        if _is_global_policy_mutator(item):
+            serial_seconds += weight
+        else:
+            parallel_seconds += weight
+    return parallel_seconds / max(1, xdist_workers) + serial_seconds
+
+
 def _apply_smoke_policy_phase_filter(items: List[Item]) -> None:
     """Keep batch assignment stable across smoke.sh's two pytest invocations.
 
@@ -414,12 +445,20 @@ def pytest_collection_modifyitems(
     module_map = {
         module_path: module_items for module_path, module_items, _ in module_data
     }
+    # Weight by estimated wall clock rather than summed duration -- serial
+    # policy-mutator tests cost xdist_workers times more than parallel ones.
+    xdist_workers = env_vars.get_pytest_xdist_workers()
     weighted_modules = [
-        (module_path, total_weight) for module_path, _, total_weight in module_data
+        (
+            module_path,
+            phase_aware_module_weight(module_items, test_weights, xdist_workers),
+        )
+        for module_path, module_items, _ in module_data
     ]
 
     logger.info(
-        f"Batching {len(items)} tests from {len(weighted_modules)} modules across {batch_count} batches"
+        f"Batching {len(items)} tests from {len(weighted_modules)} modules across "
+        f"{batch_count} batches (xdist_workers={xdist_workers})"
     )
 
     # Apply bin-packing to modules

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -287,16 +287,21 @@ def get_pytest_test_weight(item: Item, test_weights: Dict[str, float]) -> float:
 
 def aggregate_module_weights(
     items: List[Item], test_weights: Dict[str, float]
-) -> List[Tuple[str, List[Item], float]]:
+) -> List[Tuple[str, List[Item], float, float]]:
     """
-    Group test items by module and aggregate their weights.
+    Group test items by module, splitting each module's weight by execution phase.
+
+    smoke.sh runs each batch as two pytest invocations: non-mutator tests under
+    xdist, then policy mutators serially. Those two buckets cost different
+    amounts of wall clock per second of test time, so they are accumulated
+    separately here and combined by the caller, which knows the worker count.
 
     Args:
         items: List of pytest test items
         test_weights: Dictionary mapping test IDs to durations
 
     Returns:
-        List of (module_path, items_in_module, total_weight) tuples
+        List of (module_path, items_in_module, parallel_seconds, serial_seconds)
     """
 
     # Group items by module (file path)
@@ -306,14 +311,21 @@ def aggregate_module_weights(
         module_path = str(item.fspath)
         modules[module_path].append(item)
 
-    # Calculate total weight for each module
+    # Each item's weight is looked up exactly once, here.
     module_data = []
     for module_path, module_items in modules.items():
-        total_weight = 0.0
+        parallel_seconds = 0.0
+        serial_seconds = 0.0
         for item in module_items:
-            total_weight += get_pytest_test_weight(item, test_weights)
+            weight = get_pytest_test_weight(item, test_weights)
+            if _is_global_policy_mutator(item):
+                serial_seconds += weight
+            else:
+                parallel_seconds += weight
 
-        module_data.append((module_path, module_items, total_weight))
+        module_data.append(
+            (module_path, module_items, parallel_seconds, serial_seconds)
+        )
 
     return module_data
 
@@ -323,7 +335,7 @@ def _is_global_policy_mutator(item: Item) -> bool:
 
 
 def phase_aware_module_weight(
-    items: List[Item], test_weights: Dict[str, float], xdist_workers: int
+    parallel_seconds: float, serial_seconds: float, xdist_workers: int
 ) -> float:
     """Estimate a module's contribution to a batch's *wall clock*, not its total
     test time.
@@ -342,14 +354,6 @@ def phase_aware_module_weight(
     With xdist_workers == 1 this reduces to the plain sum, i.e. the previous
     behaviour, which is correct because both phases are then serial.
     """
-    parallel_seconds = 0.0
-    serial_seconds = 0.0
-    for item in items:
-        weight = get_pytest_test_weight(item, test_weights)
-        if _is_global_policy_mutator(item):
-            serial_seconds += weight
-        else:
-            parallel_seconds += weight
     return parallel_seconds / max(1, xdist_workers) + serial_seconds
 
 
@@ -443,7 +447,7 @@ def pytest_collection_modifyitems(
     # Create weighted tuples for bin-packing: (module_path, weight)
     # We'll also keep track of the items for each module
     module_map = {
-        module_path: module_items for module_path, module_items, _ in module_data
+        module_path: module_items for module_path, module_items, _, _ in module_data
     }
     # Weight by estimated wall clock rather than summed duration -- serial
     # policy-mutator tests cost xdist_workers times more than parallel ones.
@@ -451,9 +455,9 @@ def pytest_collection_modifyitems(
     weighted_modules = [
         (
             module_path,
-            phase_aware_module_weight(module_items, test_weights, xdist_workers),
+            phase_aware_module_weight(parallel_seconds, serial_seconds, xdist_workers),
         )
-        for module_path, module_items, _ in module_data
+        for module_path, _, parallel_seconds, serial_seconds in module_data
     ]
 
     logger.info(

--- a/smoke-test/pytest_test_weights.json
+++ b/smoke-test/pytest_test_weights.json
@@ -1,2438 +1,34 @@
 [
   {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_related_entities",
-    "duration": "197.243s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_01_soft_delete",
-    "duration": "188.245s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_regular_user_active_identities",
-    "duration": "170.799s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_session_user_dual_group_types_labeled_correctly",
-    "duration": "170.060s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_secret",
-    "duration": "145.774s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_list_and_revoke_tokens",
-    "duration": "124.199s"
-  },
-  {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_update_schemafield",
-    "duration": "120.158s"
-  },
-  {
-    "testId": "tests.metrics.test_metrics::test_usage_aggregation_micrometer_export",
-    "duration": "118.106s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationGraphqlOutputDedup::test_usage_aggregation_graphql_output_bytes_not_double_counted",
-    "duration": "112.291s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_document_settings",
-    "duration": "105.206s"
-  },
-  {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_across_entities_filters_documents",
-    "duration": "100.157s"
-  },
-  {
-    "testId": "test_e2e::test_gms_get_user",
-    "duration": "99.733s"
-  },
-  {
-    "testId": "tests.timeseries.test_dataset_profiles_graphql::test_dataset_profiles_graphql",
-    "duration": "96.117s"
-  },
-  {
-    "testId": "tests.openapi.test_openapi::test_openapi",
-    "duration": "95.824s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_service_account_default_view",
-    "duration": "94.113s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_search_history.TestDocumentSearchAndHistory::test_change_history",
-    "duration": "91.453s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_search_history.TestDocumentSearchAndHistory::test_search_documents_with_filters",
-    "duration": "90.710s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_hidden_stage_excludes_from_search",
-    "duration": "90.144s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_large_fanout",
-    "duration": "89.945s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_parent_documents_hierarchy",
-    "duration": "87.808s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_audit_token_events",
-    "duration": "86.080s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_ingestion_execution_request",
-    "duration": "85.766s"
-  },
-  {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_filters_hidden_context_documents",
-    "duration": "85.132s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_02_suspend",
-    "duration": "84.781s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_set_lifecycle_stage_mutation",
-    "duration": "82.793s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_move_document",
-    "duration": "79.781s"
-  },
-  {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history",
-    "duration": "78.626s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_search_ownership_filtering",
-    "duration": "77.989s"
-  },
-  {
-    "testId": "tests.metrics.test_queue_ingest_usage::test_queue_ingest_metadata_ingest_metric_on_mce",
-    "duration": "74.435s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_ownership_changes",
-    "duration": "71.791s"
-  },
-  {
-    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[100-50]",
-    "duration": "70.023s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_overwritten_async_write",
-    "duration": "69.813s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_sync_move_reflects_in_parent_domains",
-    "duration": "69.541s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_failed_login_events",
-    "duration": "67.451s"
-  },
-  {
-    "testId": "tests.tokens.session_access_token_test::test_03_hard_delete",
-    "duration": "66.323s"
-  },
-  {
-    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[10-20]",
-    "duration": "65.617s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_manage_tokens_generated_by_other_user",
-    "duration": "65.215s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_from_group_role_can_create_and_manage_secret",
-    "duration": "65.158s"
-  },
-  {
-    "testId": "tests.knowledge.document_search_filter_test::test_related_documents_shows_context_only_documents",
-    "duration": "64.753s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_configured_admin_actor_class",
-    "duration": "63.735s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_user_events",
-    "duration": "63.311s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_returns_scrollid",
-    "duration": "61.631s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_missing_elasticsearch_async_write",
-    "duration": "60.338s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_noop_with_fmcp_async_write",
-    "duration": "60.222s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_visible_stage_remains_in_search",
-    "duration": "60.182s"
-  },
-  {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag",
-    "duration": "60.139s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_datasets",
-    "duration": "59.818s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_pagination_no_duplicates",
-    "duration": "59.791s"
-  },
-  {
-    "testId": "tests.containers.containers_test::test_update_container",
-    "duration": "59.706s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_status",
-    "duration": "59.659s"
-  },
-  {
-    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_no_scrollid_on_last_page",
-    "duration": "58.487s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_structured_properties",
-    "duration": "58.476s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_and_revoke_tokens_for_other_user",
-    "duration": "56.840s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_secrets",
-    "duration": "56.365s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_parent_domains_hierarchy",
-    "duration": "55.892s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_immediately_after_add_second_member",
-    "duration": "55.707s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_noop_async_write",
-    "duration": "54.845s"
-  },
-  {
-    "testId": "tests.domains.domains_test::test_create_list_get_domain",
-    "duration": "54.678s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_after_native_add",
-    "duration": "54.239s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_not_generate_tokens_for_others",
-    "duration": "54.149s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_create_list_get_delete_service_account",
-    "duration": "53.616s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_patch",
-    "duration": "53.224s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_ownership_changes",
-    "duration": "51.897s"
-  },
-  {
-    "testId": "tests.cli.delete_cmd.test_timeseries_delete::test_timeseries_delete",
-    "duration": "50.062s"
-  },
-  {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_term",
-    "duration": "50.045s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_context_documents_for_dataset",
-    "duration": "50.035s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_6",
-    "duration": "49.928s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_create_access_token_for_service_account",
-    "duration": "49.898s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_ownership_changes",
-    "duration": "49.861s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_cycles",
-    "duration": "49.655s"
-  },
-  {
-    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag_to_chart",
-    "duration": "49.649s"
-  },
-  {
-    "testId": "test_e2e::test_add_remove_members_from_group",
-    "duration": "48.292s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_fresh_admin_session_login",
-    "duration": "47.481s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_delete",
-    "duration": "47.222s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_target",
-    "duration": "46.367s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_graphql_output_bytes",
-    "duration": "45.428s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_search_output_bytes",
-    "duration": "44.847s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_pat_authenticated_traffic",
-    "duration": "44.582s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_ingestion_source",
-    "duration": "44.494s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_allowed_with_edit_entity_on_target_and_parent",
-    "duration": "44.034s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_ownership_changes",
-    "duration": "43.734s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_successful_async_write",
-    "duration": "43.635s"
-  },
-  {
-    "testId": "tests.read_only.test_search::test_openapi_v3_entity",
-    "duration": "41.974s"
-  },
-  {
-    "testId": "tests.database.test_database::test_mysql_deadlock_gap_locking",
-    "duration": "41.853s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_search",
-    "duration": "41.812s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_structured_property_changes",
-    "duration": "41.769s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_policy_events",
-    "duration": "41.553s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string",
-    "duration": "40.571s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_sync_reparent_reflects_in_parent_nodes",
-    "duration": "40.492s"
-  },
-  {
-    "testId": "tests.incidents.incidents_test::test_raise_resolve_incident",
-    "duration": "40.463s"
-  },
-  {
-    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_1",
-    "duration": "40.404s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_list_service_accounts_with_query",
-    "duration": "40.385s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_subtype",
-    "duration": "40.356s"
-  },
-  {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_upsert_institutional_memory",
-    "duration": "40.286s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_authenticated_non_admin_user_returns_403",
-    "duration": "40.140s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_via_dataset_policies_only",
-    "duration": "40.047s"
-  },
-  {
-    "testId": "tests.read_only.test_search::test_search_works",
-    "duration": "40.042s"
-  },
-  {
-    "testId": "tests.domains.domains_test::test_set_unset_domain",
-    "duration": "40.010s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_with_mixed_dataset_and_field_grants",
-    "duration": "39.987s"
-  },
-  {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_with_time_range",
-    "duration": "39.981s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_edit_entity_on_data_product",
-    "duration": "39.957s"
-  },
-  {
-    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_empty",
-    "duration": "39.873s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_contents",
-    "duration": "39.792s"
-  },
-  {
-    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_shows_owned_unpublished",
-    "duration": "39.700s"
-  },
-  {
-    "testId": "tests.dataproduct.test_dataproduct::test_create_data_product",
-    "duration": "39.404s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_admin_active_identities",
-    "duration": "38.787s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_list",
-    "duration": "38.293s"
-  },
-  {
-    "testId": "tests.policies.test_policies::test_frontend_policy_operations",
-    "duration": "37.672s"
-  },
-  {
-    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_all_fields",
-    "duration": "37.662s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_admin_actor_class_and_tags",
-    "duration": "36.466s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_assertion_info_patch_preserves_note",
-    "duration": "35.778s"
-  },
-  {
-    "testId": "tests.browse.browse_test::test_get_browse_paths",
-    "duration": "34.809s"
-  },
-  {
-    "testId": "tests.domains.domains_test::test_delete_parent_domain_immediately_after_child_deletion",
-    "duration": "33.816s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_login_events",
-    "duration": "33.660s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_all",
-    "duration": "31.104s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_create_document_with_owners",
-    "duration": "30.880s"
-  },
-  {
-    "testId": "tests.views.views_test::test_create_list_delete_personal_view",
-    "duration": "30.752s"
+    "testId": "test_authentication_e2e::test_actuator_prometheus_no_auth",
+    "duration": "0.076s"
   },
   {
     "testId": "test_authentication_e2e::test_admin_endpoints_require_privileges",
-    "duration": "30.489s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_tag_changes",
-    "duration": "30.369s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_revoke_personal_access_tokens",
-    "duration": "30.329s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_mcp_fail_aspect_async_write",
-    "duration": "30.319s"
-  },
-  {
-    "testId": "tests.delete.delete_test::test_delete_reference",
-    "duration": "30.285s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_domain_changes",
-    "duration": "30.281s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_remove_from_data_products_allowed_with_asset_side_privilege_only",
-    "duration": "30.267s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_passwords_and_connection_strings_with_special_chars",
-    "duration": "30.247s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_unset_data_product_allowed_with_asset_side_privilege_only",
-    "duration": "30.233s"
-  },
-  {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_add_institutional_memory",
-    "duration": "30.232s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_domain_changes",
-    "duration": "30.189s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_structured_property_changes",
-    "duration": "30.181s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_get_document",
-    "duration": "30.173s"
-  },
-  {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_update_institutional_memory",
-    "duration": "30.096s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_read_mutation",
-    "duration": "30.090s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_glossary",
-    "duration": "30.067s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_tags",
-    "duration": "30.036s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_glossary_term_changes",
-    "duration": "29.983s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_documentation",
-    "duration": "29.902s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_application_changes",
-    "duration": "29.896s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_tag_changes",
-    "duration": "29.848s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_structured_property_changes",
-    "duration": "29.807s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_domain_changes",
-    "duration": "29.791s"
-  },
-  {
-    "testId": "tests.trace.test_api_trace::test_timeseries_async_write",
-    "duration": "29.776s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_asset_membership_changes",
-    "duration": "29.763s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_role",
-    "duration": "29.746s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_search_documents",
-    "duration": "29.679s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_related_terms_changes",
-    "duration": "29.678s"
-  },
-  {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_remove_institutional_memory",
-    "duration": "29.650s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_ownership",
-    "duration": "29.572s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_search_filter_validation",
-    "duration": "29.526s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_ingestion_source_events",
-    "duration": "29.291s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[role_query.py]",
-    "duration": "28.376s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Dataset]",
-    "duration": "28.265s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_application_changes",
-    "duration": "28.183s"
-  },
-  {
-    "testId": "test_rapid::test_ingestion_via_rest_rapid",
-    "duration": "28.078s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_glossary_term_changes",
-    "duration": "27.870s"
-  },
-  {
-    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_create_list_revoke_tokens",
-    "duration": "27.861s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_schema_changes",
-    "duration": "27.775s"
-  },
-  {
-    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_json_credentials_with_newlines_and_slashes",
-    "duration": "27.703s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_documentation_changes",
-    "duration": "27.197s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_application_changes",
-    "duration": "27.125s"
-  },
-  {
-    "testId": "tests.cli.ingest_cmd.test_timeseries_rollback::test_timeseries_rollback",
-    "duration": "26.774s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "26.691s"
-  },
-  {
-    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_create_document",
-    "duration": "26.474s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_wildcard_returns_json",
-    "duration": "26.300s"
-  },
-  {
-    "testId": "tests.audit_events.audit_events_test::test_policy_create_delete",
-    "duration": "26.246s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_bidirectional",
-    "duration": "26.227s"
-  },
-  {
-    "testId": "tests.assertions.custom_assertions_test::test_create_update_delete_dataset_custom_assertion",
-    "duration": "26.065s"
-  },
-  {
-    "testId": "tests.views.views_test::test_update_global_view",
-    "duration": "25.737s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_dataset",
-    "duration": "25.612s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_dashboards",
-    "duration": "25.284s"
-  },
-  {
-    "testId": "tests.read_only.test_lineage_apis::test_scroll_across_lineage_api",
-    "duration": "25.114s"
-  },
-  {
-    "testId": "tests.timeline.timeline_test::test_schema",
-    "duration": "25.082s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_deep_hierarchy_within_bundled_max_depth",
-    "duration": "24.907s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_basic",
-    "duration": "24.623s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_returns_snowflake_datasets",
-    "duration": "24.173s"
-  },
-  {
-    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_read_and_search",
-    "duration": "24.088s"
-  },
-  {
-    "testId": "tests.timeseries.test_stats_summary_graphql::test_dashboard_stats_summary",
-    "duration": "24.031s"
-  },
-  {
-    "testId": "tests.institutional_memory.institutional_memory_test::test_get_institutional_memory",
-    "duration": "24.007s"
-  },
-  {
-    "testId": "tests.views.views_test::test_create_list_delete_global_view",
-    "duration": "23.555s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "22.998s"
-  },
-  {
-    "testId": "tests.graph.test_graph_client::test_graph_relationships",
-    "duration": "22.073s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_offset_returns_different_results",
-    "duration": "21.730s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_parent_containers_hierarchy",
-    "duration": "21.691s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "21.071s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_membership_relationships_idempotent_for_session_user",
-    "duration": "20.929s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_manage_data_products_on_domain",
-    "duration": "20.524s"
-  },
-  {
-    "testId": "test_e2e::test_update_corp_group_description",
-    "duration": "20.455s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_physical_dataset",
-    "duration": "20.428s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_reader_role",
-    "duration": "20.325s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_QUERY_DATASET]",
-    "duration": "20.324s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_schema_field",
-    "duration": "20.307s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "20.297s"
-  },
-  {
-    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_with_lineage",
-    "duration": "20.212s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_parent_nodes_hierarchy",
-    "duration": "20.197s"
-  },
-  {
-    "testId": "tests.data_process_instance.test_data_process_instance::test_search_dpi",
-    "duration": "20.180s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_policies",
-    "duration": "20.160s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_duplicate_user",
-    "duration": "20.120s"
-  },
-  {
-    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_partial_fields",
-    "duration": "20.119s"
+    "duration": "25.087s"
   },
   {
     "testId": "test_authentication_e2e::test_api_token_authentication",
-    "duration": "20.012s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double",
-    "duration": "19.991s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_parent",
-    "duration": "19.983s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_with_manage_data_products_on_domain",
-    "duration": "19.982s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_admin_role",
-    "duration": "19.975s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_add_to_data_products_allowed_with_asset_side_privilege_only",
-    "duration": "19.966s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_cross_domain_with_manage_on_product_domain",
-    "duration": "19.959s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_denied_with_asset_side_privilege_only",
-    "duration": "19.938s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_documentation_changes",
-    "duration": "19.934s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_id_different_from_email",
-    "duration": "19.890s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_explicit_id",
-    "duration": "19.878s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_structured_property_changes",
-    "duration": "19.851s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double_multiple",
-    "duration": "19.843s"
-  },
-  {
-    "testId": "tests.test_kafka_default_sink::test_default_sink_ingests_end_to_end[kafka-datahub-kafka]",
-    "duration": "19.785s"
-  },
-  {
-    "testId": "tests.read_only.test_lineage_apis::test_search_across_lineage_api",
-    "duration": "19.724s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_documentation_changes",
-    "duration": "19.608s"
-  },
-  {
-    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_ingestion_source",
-    "duration": "19.590s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_session_vs_token_authentication",
-    "duration": "19.517s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string_allowed_values",
-    "duration": "19.325s"
-  },
-  {
-    "testId": "tests.test_kafka_default_sink::test_default_sink_ingests_end_to_end[rest-datahub-rest]",
-    "duration": "18.694s"
-  },
-  {
-    "testId": "tests.incidents.incidents_test::test_list_dataset_incidents",
-    "duration": "18.610s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_all_edges_around_urn",
-    "duration": "17.904s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_text_exits_cleanly",
-    "duration": "17.876s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dataset_returns_only_datasets",
-    "duration": "17.825s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_basic",
-    "duration": "17.770s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_cross_service_authentication_consistency",
-    "duration": "17.508s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_JOB_DATASET]",
-    "duration": "17.383s"
-  },
-  {
-    "testId": "test_e2e::test_update_corp_group_properties",
-    "duration": "17.377s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_relationships_direct_children",
-    "duration": "16.890s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_rest_v2_unauthorized_user_is_denied",
-    "duration": "16.633s"
-  },
-  {
-    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_list_lifecycle_stages_includes_ingested",
-    "duration": "16.538s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_valid_token",
-    "duration": "16.267s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_me_query",
-    "duration": "16.029s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_editor_role",
-    "duration": "15.610s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_with_asset_side_privilege_only",
-    "duration": "15.320s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_gms_get_latest_assertions_results_by_partition",
-    "duration": "15.284s"
-  },
-  {
-    "testId": "test_e2e::test_remove_user",
-    "duration": "14.306s"
-  },
-  {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_elasticsearch",
-    "duration": "14.303s"
-  },
-  {
-    "testId": "tests.graph.test_graph_client::test_get_aspect_v2",
-    "duration": "14.095s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_from_datahub",
-    "duration": "14.038s"
-  },
-  {
-    "testId": "tests.containers.containers_test::test_get_full_container",
-    "duration": "13.460s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_search",
-    "duration": "12.454s"
-  },
-  {
-    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary",
-    "duration": "12.008s"
-  },
-  {
-    "testId": "tests.schema_fields.test_schemafields::test_schema_field_gql_mapper_for_charts",
-    "duration": "12.004s"
-  },
-  {
-    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_async",
-    "duration": "11.412s"
-  },
-  {
-    "testId": "tests.search.test_lineage_search_index_fields::test_upstream_dataset_search_index_fields",
-    "duration": "11.271s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_load_bootstrap_via_cli",
-    "duration": "11.203s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_describe_filter_subcommand",
-    "duration": "11.128s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_many_versions",
-    "duration": "10.972s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_by_resource_type",
-    "duration": "10.468s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_definition_evolution",
-    "duration": "10.447s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_get_nonexistent_service_account",
-    "duration": "10.349s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_top_searches_chart",
-    "duration": "10.346s"
-  },
-  {
-    "testId": "tests.service_accounts.test_service_accounts::test_delete_nonexistent_service_account",
-    "duration": "10.334s"
-  },
-  {
-    "testId": "tests.ml_models.test_ml_models::test_create_ml_models",
-    "duration": "10.305s"
-  },
-  {
-    "testId": "tests.read_only.test_dataproduct::test_dataproduct_search_works",
-    "duration": "10.287s"
-  },
-  {
-    "testId": "tests.cli.user_groups_cmd.test_user_cmd::test_user_upsert",
-    "duration": "10.276s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_all_categories",
-    "duration": "10.264s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
-    "duration": "10.256s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_glossary_terms",
-    "duration": "10.238s"
-  },
-  {
-    "testId": "tests.test_kafka_default_sink::test_pgqueue_sink_ingests_end_to_end",
-    "duration": "10.234s"
-  },
-  {
-    "testId": "test_e2e::test_create_group",
-    "duration": "10.188s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_documentation_changes",
-    "duration": "10.151s"
-  },
-  {
-    "testId": "tests.cli.user_groups_cmd.test_group_cmd::test_group_upsert",
-    "duration": "10.010s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_validation",
-    "duration": "9.964s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_complex_queries",
-    "duration": "9.938s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_via_frontend_uses_gzip",
-    "duration": "9.913s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_restli_endpoints_with_valid_auth",
-    "duration": "9.906s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_validation",
-    "duration": "9.901s"
-  },
-  {
-    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary_out_of_window_only",
-    "duration": "9.861s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_dataset_yaml_loader",
-    "duration": "9.826s"
-  },
-  {
-    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_without_lineage",
-    "duration": "9.741s"
-  },
-  {
-    "testId": "tests.read_only.test_ingestion_list::test_policies_are_accessible",
-    "duration": "9.740s"
-  },
-  {
-    "testId": "test_e2e::test_ingest_with_system_metadata",
-    "duration": "9.735s"
-  },
-  {
-    "testId": "tests.read_only.test_analytics::test_highlights_is_accessible",
-    "duration": "9.724s"
-  },
-  {
-    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_to_datahub",
-    "duration": "9.700s"
-  },
-  {
-    "testId": "test_e2e::test_remove_group",
-    "duration": "9.671s"
-  },
-  {
-    "testId": "test_e2e::test_gms_search_dataset[covid-1]",
-    "duration": "9.407s"
-  },
-  {
-    "testId": "tests.containers.containers_test::test_get_parent_container",
-    "duration": "9.296s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_projection_reduces_payload",
-    "duration": "9.116s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_all_categories",
-    "duration": "8.534s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_analytics_charts_have_data",
-    "duration": "8.279s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
-    "duration": "8.183s"
-  },
-  {
-    "testId": "test_e2e::test_generate_personal_access_token",
-    "duration": "8.095s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_across_entities[covid-1]",
-    "duration": "7.800s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_weekly_active_users_chart",
-    "duration": "7.785s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_timeline_structure",
-    "duration": "7.783s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_urn_secondary_key",
-    "duration": "7.767s"
-  },
-  {
-    "testId": "tests.read_only.test_analytics::test_analytics_chart_is_accessible",
-    "duration": "7.266s"
+    "duration": "19.947s"
   },
   {
     "testId": "test_authentication_e2e::test_authentication_behavior_summary",
-    "duration": "7.216s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_datasets[sample-3]",
-    "duration": "7.186s"
-  },
-  {
-    "testId": "test_e2e::test_ingest_with_blank_system_metadata",
-    "duration": "7.185s"
-  },
-  {
-    "testId": "test_e2e::test_list_users",
-    "duration": "7.184s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_app_config",
-    "duration": "7.152s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_user_info",
-    "duration": "7.136s"
-  },
-  {
-    "testId": "test_e2e::test_list_groups",
-    "duration": "6.671s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_in_list",
-    "duration": "6.667s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_simple_query_passes_through",
-    "duration": "6.428s"
-  },
-  {
-    "testId": "test_e2e::test_gms_search_across_entities[covid-1]",
-    "duration": "6.428s"
-  },
-  {
-    "testId": "test_e2e::test_gms_usage_fetch",
-    "duration": "6.199s"
-  },
-  {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_kafka",
-    "duration": "6.175s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[graph_client]",
-    "duration": "6.011s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[graph_client]",
-    "duration": "5.779s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_tab_views_by_entity_type_chart",
-    "duration": "5.763s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_across_entities[-1]",
-    "duration": "5.707s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[graph_client]",
-    "duration": "5.479s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[application_create.py]",
-    "duration": "5.395s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_table_level_lineage",
-    "duration": "5.310s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_read_write",
-    "duration": "5.218s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_agent_context_flag_exits_zero",
-    "duration": "5.168s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_datasets[covid-1]",
-    "duration": "5.157s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_datasets[-1]",
-    "duration": "5.150s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_entity_type_filter_narrows_results",
-    "duration": "5.070s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[101-Suite.B]",
-    "duration": "4.934s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_gms_service_sets_gms_and_global_vars",
-    "duration": "4.825s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_writes_n_entities_and_records_dual_write_urns",
-    "duration": "4.825s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_health_endpoint_no_auth",
-    "duration": "4.821s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_started",
-    "duration": "4.815s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_no_es_client_returns_no_failures",
-    "duration": "4.804s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_passes_when_three_backfill_aliases_all_completed",
-    "duration": "4.784s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_semantic_section_has_expected_keys",
-    "duration": "4.681s"
-  },
-  {
-    "testId": "test_e2e::test_home_page_recommendations",
-    "duration": "4.662s"
-  },
-  {
-    "testId": "test_e2e::test_ingest_without_system_metadata",
-    "duration": "4.572s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_all_categories",
-    "duration": "4.438s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_all_categories",
-    "duration": "4.360s"
-  },
-  {
-    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary_duplicate_urn_in_request",
-    "duration": "4.326s"
-  },
-  {
-    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_hidden_without_subject_view",
-    "duration": "4.285s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_search_across_entities[sample-3]",
-    "duration": "4.179s"
-  },
-  {
-    "testId": "test_e2e::test_gms_search_across_entities[sample-3]",
-    "duration": "4.163s"
-  },
-  {
-    "testId": "tests.analytics.test_analytics::test_top_viewed_datasets_chart",
-    "duration": "4.144s"
-  },
-  {
-    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_without_privilege",
-    "duration": "4.135s"
-  },
-  {
-    "testId": "test_e2e::test_frontend_browse_datasets",
-    "duration": "4.104s"
-  },
-  {
-    "testId": "tests.read_only.test_policies::test_policies_are_accessible",
-    "duration": "4.101s"
-  },
-  {
-    "testId": "tests.read_only.test_analytics::test_metadata_analytics_chart_is_accessible",
-    "duration": "4.092s"
-  },
-  {
-    "testId": "test_e2e::test_gms_search_dataset[sample-3]",
-    "duration": "4.080s"
-  },
-  {
-    "testId": "test_e2e::test_search_results_recommendations",
-    "duration": "4.080s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_authorized_user_succeeds",
-    "duration": "4.046s"
-  },
-  {
-    "testId": "tests.semantic.test_current_offset_api::test_poll_with_retrieved_offset",
-    "duration": "4.017s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_dual_write_timeout_does_not_hang_on_quiet_log_stream",
-    "duration": "3.003s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[data_process_instance_create_simple.py]",
-    "duration": "2.908s"
-  },
-  {
-    "testId": "tests.semantic.test_current_offset_api::test_offset_behavior_without_lookback",
-    "duration": "2.415s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_unload_bootstrap_via_cli",
-    "duration": "2.181s"
-  },
-  {
-    "testId": "tests.semantic.test_current_offset_api::test_get_current_offset_no_params",
-    "duration": "2.013s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties",
-    "duration": "1.523s"
-  },
-  {
-    "testId": "tests.test_stateful_ingestion::test_stateful_ingestion",
-    "duration": "1.511s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_watchdog_terminates_silent_child_and_marks_timeout",
-    "duration": "1.003s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_alphanumeric",
-    "duration": "0.854s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[graph_client]",
-    "duration": "0.811s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_freshness.py]",
-    "duration": "0.803s"
-  },
-  {
-    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_async",
-    "duration": "0.710s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_new_latest",
-    "duration": "0.647s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[openapi_graph_client]",
-    "duration": "0.641s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_volume_rows.py]",
-    "duration": "0.631s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create.py]",
-    "duration": "0.572s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[ermodelrelationship_create_basic.py]",
-    "duration": "0.565s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dataproduct_create.py]",
-    "duration": "0.548s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_schema.py]",
-    "duration": "0.541s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[graph_client]",
-    "duration": "0.537s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[structured_property_create_basic.py]",
-    "duration": "0.536s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[openapi_graph_client]",
-    "duration": "0.533s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_relative_path_resolution",
-    "duration": "0.530s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[graph_client]",
-    "duration": "0.501s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_database.py]",
-    "duration": "0.489s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpuser_create_basic.py]",
-    "duration": "0.481s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[openapi_graph_client]",
-    "duration": "0.480s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[chart_create_simple.py]",
-    "duration": "0.468s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[datajob_create_basic.py]",
-    "duration": "0.468s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[graph_client]",
-    "duration": "0.467s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_node_create.py]",
-    "duration": "0.465s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_comma_or_logic_returns_union",
-    "duration": "0.457s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_create.py]",
-    "duration": "0.454s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dashboard_create_simple.py]",
-    "duration": "0.454s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_not_latest",
-    "duration": "0.453s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_field_uniqueness.py]",
-    "duration": "0.450s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[openapi_graph_client]",
-    "duration": "0.449s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_query_rest_api.py]",
-    "duration": "0.439s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dataset_create_with_structured_properties.py]",
-    "duration": "0.438s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[graph_client]",
-    "duration": "0.415s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_limit_respected",
-    "duration": "0.414s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[graph_client]",
-    "duration": "0.414s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[dataflow_create.py]",
-    "duration": "0.413s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_schema.py]",
-    "duration": "0.412s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_create.py]",
-    "duration": "0.412s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_urns_only_format",
-    "duration": "0.411s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_group_create.py]",
-    "duration": "0.411s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_describe_me_returns_operation_details",
-    "duration": "0.404s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create_simple.py]",
-    "duration": "0.403s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[datacontract_create_basic.py]",
-    "duration": "0.401s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[search_filter_by_domain.py]",
-    "duration": "0.401s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_create.py]",
-    "duration": "0.400s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_minimal_projection",
-    "duration": "0.400s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_chart_returns_only_charts",
-    "duration": "0.398s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_platform_eq",
-    "duration": "0.397s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create.py]",
-    "duration": "0.390s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[graph_client]",
-    "duration": "0.390s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_create.py]",
-    "duration": "0.389s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[openapi_graph_client]",
-    "duration": "0.388s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[openapi_graph_client]",
-    "duration": "0.386s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[graph_client]",
-    "duration": "0.382s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[openapi_graph_client]",
-    "duration": "0.381s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[openapi_graph_client]",
-    "duration": "0.379s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[tag_create_basic.py]",
-    "duration": "0.377s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_sql_metric.py]",
-    "duration": "0.373s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[openapi_graph_client]",
-    "duration": "0.368s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[openapi_graph_client]",
-    "duration": "0.361s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_total_is_consistent_across_pages",
-    "duration": "0.359s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_create.py]",
-    "duration": "0.357s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[openapi_graph_client]",
-    "duration": "0.356s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[graph_client]",
-    "duration": "0.350s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[openapi_graph_client]",
-    "duration": "0.346s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create.py]",
-    "duration": "0.344s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlprimarykey_create.py]",
-    "duration": "0.344s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[query_create.py]",
-    "duration": "0.344s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_deployment_create.py]",
-    "duration": "0.343s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[notebook_create.py]",
-    "duration": "0.343s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[ownership_type_create_custom.py]",
-    "duration": "0.343s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[openapi_graph_client]",
-    "duration": "0.339s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[data_platform_create.py]",
-    "duration": "0.337s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_table_create.py]",
-    "duration": "0.337s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[platform_instance_create.py]",
-    "duration": "0.336s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[role_create.py]",
-    "duration": "0.332s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_pagination",
-    "duration": "0.331s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage_from_schema_field",
-    "duration": "0.331s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create_nested.py]",
-    "duration": "0.326s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[openapi_graph_client]",
-    "duration": "0.322s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_list_operations",
-    "duration": "0.320s"
-  },
-  {
-    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_sync",
-    "duration": "0.311s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[graph_client]",
-    "duration": "0.308s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[graph_client]",
-    "duration": "0.307s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[openapi_graph_client]",
-    "duration": "0.307s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_list_operations_returns_real_schema",
-    "duration": "0.306s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_multiple_filters_are_anded",
-    "duration": "0.305s"
-  },
-  {
-    "testId": "test_e2e::test_native_user_endpoints",
-    "duration": "0.304s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_bigquery_returns_bigquery_datasets",
-    "duration": "0.297s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_and_narrows_results",
-    "duration": "0.288s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[openapi_graph_client]",
-    "duration": "0.288s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_execute_me_query_returns_current_user",
-    "duration": "0.283s"
-  },
-  {
-    "testId": "tests.graph.test_graph_client::test_get_entity_aspect_specs",
-    "duration": "0.279s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_downstream_of_upstream_node",
-    "duration": "0.275s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[openapi_graph_client]",
-    "duration": "0.270s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[graph_client]",
-    "duration": "0.263s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[openapi_graph_client]",
-    "duration": "0.262s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[graph_client]",
-    "duration": "0.260s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_feature_directions",
-    "duration": "0.258s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_endpoint_separation",
-    "duration": "0.256s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_facets_only",
-    "duration": "0.255s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[openapi_graph_client]",
-    "duration": "0.255s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[openapi_graph_client]",
-    "duration": "0.250s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_operation_resolves_via_introspection",
-    "duration": "0.249s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[openapi_graph_client]",
-    "duration": "0.245s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[openapi_graph_client]",
-    "duration": "0.245s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[openapi_graph_client]",
-    "duration": "0.242s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_properties_structure",
-    "duration": "0.241s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_projection_reduces_payload",
-    "duration": "0.239s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[graph_client]",
-    "duration": "0.236s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_schema_introspection",
-    "duration": "0.235s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[graph_client]",
-    "duration": "0.235s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[graph_client]",
-    "duration": "0.234s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[graph_client]",
-    "duration": "0.224s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[openapi_graph_client]",
-    "duration": "0.222s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[application_query_rest_api.py]",
-    "duration": "0.220s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_json_result_structure",
-    "duration": "0.219s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_patch_multiple_new_fields_merges_with_existing[graph_client]",
-    "duration": "0.217s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_complex_filters_json_and",
-    "duration": "0.214s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_parallel_slicing",
-    "duration": "0.212s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_produces_source_is_upstream",
-    "duration": "0.210s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[graph_client]",
-    "duration": "0.210s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[openapi_graph_client]",
-    "duration": "0.210s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[openapi_graph_client]",
-    "duration": "0.209s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[graph_client]",
-    "duration": "0.208s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_patch_multiple_new_fields_merges_with_existing[openapi_graph_client]",
-    "duration": "0.205s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_datajob_directions",
-    "duration": "0.203s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[graph_client]",
-    "duration": "0.202s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[graph_client]",
-    "duration": "0.199s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[openapi_graph_client]",
-    "duration": "0.199s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[graph_client]",
-    "duration": "0.196s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[graph_client]",
-    "duration": "0.194s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[graph_client]",
-    "duration": "0.191s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tag_patch_on_new_field_preserves_fieldpath[openapi_graph_client]",
-    "duration": "0.183s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[openapi_graph_client]",
-    "duration": "0.183s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_query_from_file",
-    "duration": "0.180s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[graph_client]",
-    "duration": "0.176s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_table_format",
-    "duration": "0.174s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tag_patch_on_new_field_preserves_fieldpath[graph_client]",
-    "duration": "0.174s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_corpuser_returns_only_corpusers",
-    "duration": "0.171s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[graph_client]",
-    "duration": "0.169s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[openapi_graph_client]",
-    "duration": "0.165s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[graph_client]",
-    "duration": "0.164s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[openapi_graph_client]",
-    "duration": "0.163s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_empty_returns_all_aspects",
-    "duration": "0.157s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[openapi_graph_client]",
-    "duration": "0.155s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[graph_client]",
-    "duration": "0.154s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dashboard_returns_only_dashboards",
-    "duration": "0.152s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_main_endpoint",
-    "duration": "0.145s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_excludes_bigquery",
-    "duration": "0.142s"
-  },
-  {
-    "testId": "tests.restli.restli_test::test_gms_delete_mcp",
-    "duration": "0.141s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_term_patch_on_new_field_preserves_fieldpath[graph_client]",
-    "duration": "0.141s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_query_rest_api.py]",
-    "duration": "0.136s"
-  },
-  {
-    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[openapi_graph_client]",
-    "duration": "0.135s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_spring_components_endpoint",
-    "duration": "0.131s"
-  },
-  {
-    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[graph_client]",
-    "duration": "0.130s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_term_patch_on_new_field_preserves_fieldpath[openapi_graph_client]",
-    "duration": "0.129s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_properties_endpoint",
-    "duration": "0.122s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_config_progressive_disclosure",
-    "duration": "0.114s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_keyword_connected",
-    "duration": "0.112s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_simple_properties_endpoint",
-    "duration": "0.112s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_search_query_with_known_entity_types",
-    "duration": "0.110s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_json_structure",
-    "duration": "0.107s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_filter_is_applied",
-    "duration": "0.106s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_dataset_properties_projection",
-    "duration": "0.106s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_facets_always_present",
-    "duration": "0.105s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_minimal_projection_urn_only",
-    "duration": "0.101s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_relationship_types_filter",
-    "duration": "0.099s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_sensitive_data_redaction",
-    "duration": "0.097s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_pagination",
-    "duration": "0.092s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_spring_components_structure",
-    "duration": "0.091s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_pending_urns_on_timeout",
-    "duration": "0.090s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_actuator_prometheus_no_auth",
-    "duration": "0.090s"
-  },
-  {
-    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_query.py]",
-    "duration": "0.088s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_no_urns_returns_lineage_edges",
-    "duration": "0.086s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_platform_fields_fragment_projection",
-    "duration": "0.085s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_filtered_column_level_lineage",
-    "duration": "0.084s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_schema_discovery",
-    "duration": "0.082s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_simple_query_execution",
-    "duration": "0.079s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_sort_criteria",
-    "duration": "0.077s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_query",
-    "duration": "0.072s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_json_output_format",
-    "duration": "0.070s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_entity_type",
-    "duration": "0.070s"
-  },
-  {
-    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage",
-    "duration": "0.069s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_multiple_entity_types",
-    "duration": "0.067s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_schema_cached_across_calls",
-    "duration": "0.065s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_raw_query_returns_json",
-    "duration": "0.064s"
-  },
-  {
-    "testId": "tests.restli.restli_test::test_gms_ignore_unknown_dashboard_info",
-    "duration": "0.057s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_file_path_handling",
-    "duration": "0.053s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_shows_compiled_filter",
-    "duration": "0.052s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_relative_path_handling",
-    "duration": "0.052s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestUnknownTC::test_unknown_catchup_tc_returns_skip",
-    "duration": "0.050s"
-  },
-  {
-    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_visible_with_edit_queries_on_subject",
-    "duration": "0.049s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_system_metadata",
-    "duration": "0.049s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestUnknownTc::test_unknown_tc_returns_skip",
-    "duration": "0.048s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_still_works",
-    "duration": "0.048s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsAbsentServices::test_only_recreates_present_services",
-    "duration": "0.046s"
-  },
-  {
-    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_sync",
-    "duration": "0.044s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_query_with_variables_and_operation_name",
-    "duration": "0.042s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_with_projection_shows_query",
-    "duration": "0.041s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_multiple_unknown_fragments_and_fields",
-    "duration": "0.041s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenOptOut::test_token_refresh_skipped_when_disabled",
-    "duration": "0.041s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_nonexistent_type_fragment_stripped",
-    "duration": "0.040s"
-  },
-  {
-    "testId": "tests.read_only.test_services_up::test_gms_config_accessible",
-    "duration": "0.040s"
-  },
-  {
-    "testId": "tests.semantic.test_event_driven_docs.TestEventDrivenDocumentIngestion::test_event_driven_document_update",
-    "duration": "0.040s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_error_handling",
-    "duration": "0.038s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_none_returns_urns_only",
-    "duration": "0.038s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_unknown_field_on_known_type_stripped",
-    "duration": "0.036s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_pagination",
-    "duration": "0.035s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
-    "duration": "0.034s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_destination_urns_and_filter_equivalent",
-    "duration": "0.033s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_single_returns_only_that_aspect",
-    "duration": "0.032s"
-  },
-  {
-    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_with_bad_field_fails",
-    "duration": "0.031s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_source_urns_and_filter_equivalent",
-    "duration": "0.031s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestListTasks::test_flattens_nodes_and_attaches_task_id",
-    "duration": "0.030s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestAllChecksPass::test_passes_when_stack_up_token_set_and_env_correct",
-    "duration": "0.030s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_gms_get_assertion_info",
-    "duration": "0.029s"
-  },
-  {
-    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Domain]",
-    "duration": "0.029s"
-  },
-  {
-    "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
-    "duration": "0.028s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_downstream",
-    "duration": "0.028s"
-  },
-  {
-    "testId": "tests.semantic.test_semantic_search.TestSemanticSearchWithIngestion::test_end_to_end_ingestion_and_semantic_search",
-    "duration": "0.025s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset",
-    "duration": "0.024s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_offline",
-    "duration": "0.024s"
-  },
-  {
-    "testId": "tests.graph.test_graph_client::test_get_entities_v3",
-    "duration": "0.024s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestFromEnvCredentials::test_mysql_credentials_from_env",
-    "duration": "0.024s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_json_file_detection",
-    "duration": "0.023s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenDisabled::test_skips_when_prepare_old_stack_false",
-    "duration": "0.022s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_consumes",
-    "duration": "0.022s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_urns",
-    "duration": "0.021s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenTagIsDefault::test_skips_when_old_image_tag_is_debug",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_non_existent",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_incoming",
-    "duration": "0.020s"
-  },
-  {
-    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset_field",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestNoRestartWhenAlreadyOnOld::test_passes_without_restart_when_image_matches",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "test_e2e::test_gms_batch_get_v2",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_urns",
-    "duration": "0.019s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_derived_from",
-    "duration": "0.018s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_edge_filter",
-    "duration": "0.018s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_outgoing",
-    "duration": "0.018s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHappyPath::test_captures_secrets_wipes_redeploys_and_waits_for_health",
-    "duration": "0.017s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_types",
-    "duration": "0.017s"
-  },
-  {
-    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_types",
-    "duration": "0.017s"
-  },
-  {
-    "testId": "test_system_info::test_system_info_unauthorized_access_returns_403",
-    "duration": "0.016s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/public-iceberg/health]",
-    "duration": "0.016s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_no_args_exits_with_usage_code",
-    "duration": "0.015s"
-  },
-  {
-    "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
-    "duration": "0.015s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_no_auth",
-    "duration": "0.014s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_partial_drain_resolves_on_retry",
-    "duration": "0.013s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_force_nuke_overrides_skip",
-    "duration": "0.013s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_graphql_endpoint_invalid_token",
-    "duration": "0.013s"
-  },
-  {
-    "testId": "tests.telemetry.telemetry_test::test_no_client_id",
-    "duration": "0.011s"
-  },
-  {
-    "testId": "tests.telemetry.telemetry_test::test_no_telemetry_client_id",
-    "duration": "0.011s"
+    "duration": "8.378s"
   },
   {
     "testId": "test_authentication_e2e::test_authentication_priority_and_fallback",
-    "duration": "0.011s"
+    "duration": "0.016s"
   },
   {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_endpoint_is_active",
-    "duration": "0.010s"
+    "testId": "test_authentication_e2e::test_config_progressive_disclosure",
+    "duration": "0.057s"
   },
   {
-    "testId": "tests.pgqueue.test_messaging_operations::test_mcp_consumer_lag_detailed",
-    "duration": "0.010s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/schema-registry/subjects]",
-    "duration": "0.010s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_skips_when_no_failures",
-    "duration": "0.009s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_phase_failure",
-    "duration": "0.009s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_messaging_transport_reports_pgqueue",
-    "duration": "0.009s"
-  },
-  {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_single_lookup",
-    "duration": "0.008s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_versioned_consumer_lag_detailed",
-    "duration": "0.008s"
+    "testId": "test_authentication_e2e::test_cross_service_authentication_consistency",
+    "duration": "11.518s"
   },
   {
     "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/config/search/export]",
-    "duration": "0.008s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_reader_writer_events_dump_observations_and_writes",
-    "duration": "0.007s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_continues_on_per_artifact_failure",
-    "duration": "0.007s"
-  },
-  {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_pgqueue",
-    "duration": "0.007s"
-  },
-  {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_unknown_name_returns_404",
-    "duration": "0.007s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_health_endpoint_with_invalid_token",
     "duration": "0.007s"
   },
   {
@@ -2440,75 +36,59 @@
     "duration": "0.007s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer]",
+    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/public-iceberg/health]",
+    "duration": "0.018s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_excluded_paths_no_auth[/schema-registry/subjects]",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_invalid_token",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_no_auth",
+    "duration": "0.013s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_valid_token",
+    "duration": "7.312s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_graphql_endpoint_via_frontend_uses_gzip",
+    "duration": "9.983s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_health_endpoint_no_auth",
+    "duration": "2.771s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_health_endpoint_with_invalid_token",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Basic dXNlcjpwYXNz]",
     "duration": "0.007s"
   },
   {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_invokes_gradle_bootjar_when_repo_root_found",
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer ]",
     "duration": "0.006s"
   },
   {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_upgrade_result_includes_blocking_and_nonblocking",
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer]",
+    "duration": "0.009s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[InvalidPrefix token]",
     "duration": "0.006s"
   },
   {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_no_reindex_needed_still_passes",
-    "duration": "0.006s"
+    "testId": "test_authentication_e2e::test_malformed_auth_headers[bearer invalid-token]",
+    "duration": "0.008s"
   },
   {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_contain_stable_keys",
-    "duration": "0.006s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_list_registered_consumers",
-    "duration": "0.006s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_scenario_failure",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_non_tty_help_includes_agent_context",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_timeout_kills_process_and_returns_failed",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_records_alias_swaps_and_indices_state",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_accessible_without_auth",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_timeseries_consumer_lag_detailed",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_consumer_registration_lifecycle",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.search.test_search_projection.TestSearchProjection::test_default_query_no_projection",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_old_index_missing_doc_emits_warning",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_passes_explicit_nonblocking_extra_args_to_run_upgrade_job",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_captures_upgrade_nonblocking_result_on_completion",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/openapi/v2/entity/dataset-GET]",
+    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/aspects?action=getAspect-GET]",
     "duration": "0.005s"
   },
   {
@@ -2516,115 +96,11 @@
     "duration": "0.005s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[bearer invalid-token]",
+    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/openapi/operations/throttle/requests-GET]",
     "duration": "0.005s"
   },
   {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Basic dXNlcjpwYXNz]",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[InvalidPrefix token]",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_malformed_auth_headers[Bearer ]",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_parsed_json",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_on_malformed_json",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_es_failure_marks_phase_failed_but_does_not_crash",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_info",
-    "duration": "0.005s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_limit_exit_code_2",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_conflicting_filters_exit_code_2",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_runs_gradle_from_repo_root_cwd",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_mixpanel",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_yaml_load_with_bad_entity_type",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_passes_new_image_tag_via_compose_env",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_nonzero_exit_marks_failed",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_signing_key_missing",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[201-Suite.D]",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestMutatesConfigTags::test_run_sets_config_image_tags",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.pgqueue.test_messaging_operations::test_reset_stuck_ahead_consumer_offsets",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_ingest_failure_fails_phase",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestMissingLocalCommonEnv::test_skips_authz_env_when_not_set",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestPartialSecretCapture::test_partial_capture_filled_from_secrets_file",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_fails_when_count_decreases",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_fails_when_index_missing_at_t1",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_skips_when_t0_missing",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_compose_env_includes_token_service_keys",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_capture_result_skipped_when_mysql_returns_none",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/entities?action=search-POST]",
+    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/openapi/v2/entity/dataset-GET]",
     "duration": "0.004s"
   },
   {
@@ -2632,459 +108,2583 @@
     "duration": "0.004s"
   },
   {
-    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/openapi/v2/entity/dataset-GET]",
+    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/entities?action=search-POST]",
     "duration": "0.004s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/aspects?action=getAspect-GET]",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_invalid_token[/openapi/operations/throttle/requests-GET]",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_csv_with_header_and_rows",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_list",
-    "duration": "0.004s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_password_flag",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_id_or_flag",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_cache_metrics_when_isolated",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_projection_exit_code_2",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_list_filters_subcommand",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_idempotent_within_process",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_raises_runtime_error_on_gradle_failure",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_skips_when_repo_root_not_found",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_skips_when_snapshot_missing",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestSeedIsNoop::test_seed_returns_empty",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_env_var_wins_over_datahubenv",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_reads_n_seeded_entities_and_records_probes",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_help",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_deadline_hits_mid_stream_kills_process",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_compose_env_includes_token_service_keys",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_includes_g20a_reindex_flags",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_still_includes_token_keys",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_default_new_image_tag_is_debug",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_alias_swap_failure_in_log_marks_failed",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_both_keys_empty_string",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestRecreatesWhenMismatched::test_recreates_all_services_when_running_debug",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPartialMismatch::test_recreates_only_mismatched_services",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestHealthCheckTimeout::test_returns_failed_when_health_check_times_out",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[109-Suite.B]",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_writes_refreshed_token_to_config",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_subprocess_returns_nonzero",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_nuke_failure_propagates",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_cache_miss_log_names_missing_image",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_uses_persistent_worktree",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestShaResolution::test_resolves_short_sha_from_git_ref",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestCacheMissBuildsBothSides::test_cache_miss_builds_both_sides",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_all_urns_present_immediately",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_mysql_missing_one_urn_fails_phase",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_partial_ingest_records_partial_gap_urns_on_failure",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_seeds_io_pool_via_rest_not_mysql",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHealthCheckFailure::test_fails_when_gms_does_not_come_back",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_zdu_reindex_flags_NOT_in_compose_env",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_new_index_missing_doc_emits_warning",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_token_check_skipped_when_refresh_on",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_missing_field_emits_fail",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_fails_when_expected_in_place_update_missing",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_dataset_entity_type_uses_dataset_alias",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_unknown_entity_type_emits_fail",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_skips_when_expected_unset",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_all_invariants_satisfied_returns_no_failures",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestSeedIsNoop::test_seed_returns_empty_list",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_cursor_heartbeat",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/openapi/v1/system-info-GET]",
-    "duration": "0.003s"
   },
   {
     "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/openapi/operations/throttle/requests-GET]",
     "duration": "0.003s"
   },
   {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_int_when_present",
+    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/openapi/v1/system-info-GET]",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_protected_endpoints_no_auth[/openapi/v2/entity/dataset-GET]",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_restli_endpoints_with_valid_auth",
+    "duration": "10.001s"
+  },
+  {
+    "testId": "test_authentication_e2e::test_session_vs_token_authentication",
+    "duration": "19.956s"
+  },
+  {
+    "testId": "test_e2e::test_add_remove_members_from_group",
+    "duration": "48.287s"
+  },
+  {
+    "testId": "test_e2e::test_create_group",
+    "duration": "11.600s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_app_config",
+    "duration": "8.356s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_auth",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_browse_datasets",
+    "duration": "10.090s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
+    "duration": "10.048s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_datasets[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
+    "duration": "9.202s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_me_query",
+    "duration": "9.928s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_across_entities[-1]",
+    "duration": "9.969s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_across_entities[covid-1]",
+    "duration": "9.987s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_across_entities[sample-3]",
+    "duration": "10.093s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_datasets[-1]",
+    "duration": "9.960s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_datasets[covid-1]",
+    "duration": "9.966s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_search_datasets[sample-3]",
+    "duration": "9.938s"
+  },
+  {
+    "testId": "test_e2e::test_frontend_user_info",
+    "duration": "5.719s"
+  },
+  {
+    "testId": "test_e2e::test_generate_personal_access_token",
+    "duration": "3.115s"
+  },
+  {
+    "testId": "test_e2e::test_gms_batch_get_v2",
+    "duration": "0.017s"
+  },
+  {
+    "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:bigquery-bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times-PROD]",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "test_e2e::test_gms_get_dataset[urn:li:dataPlatform:kafka-SampleKafkaDataset-PROD]",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "test_e2e::test_gms_get_user",
+    "duration": "74.326s"
+  },
+  {
+    "testId": "test_e2e::test_gms_search_across_entities[covid-1]",
+    "duration": "9.938s"
+  },
+  {
+    "testId": "test_e2e::test_gms_search_across_entities[sample-3]",
+    "duration": "9.908s"
+  },
+  {
+    "testId": "test_e2e::test_gms_search_dataset[covid-1]",
+    "duration": "9.930s"
+  },
+  {
+    "testId": "test_e2e::test_gms_search_dataset[sample-3]",
+    "duration": "10.105s"
+  },
+  {
+    "testId": "test_e2e::test_gms_usage_fetch",
+    "duration": "10.046s"
+  },
+  {
+    "testId": "test_e2e::test_home_page_recommendations",
+    "duration": "2.140s"
+  },
+  {
+    "testId": "test_e2e::test_ingest_with_blank_system_metadata",
+    "duration": "1.597s"
+  },
+  {
+    "testId": "test_e2e::test_ingest_with_system_metadata",
+    "duration": "10.084s"
+  },
+  {
+    "testId": "test_e2e::test_ingest_without_system_metadata",
+    "duration": "4.942s"
+  },
+  {
+    "testId": "test_e2e::test_list_groups",
+    "duration": "1.613s"
+  },
+  {
+    "testId": "test_e2e::test_list_users",
+    "duration": "10.134s"
+  },
+  {
+    "testId": "test_e2e::test_native_user_endpoints",
+    "duration": "0.233s"
+  },
+  {
+    "testId": "test_e2e::test_remove_group",
+    "duration": "19.868s"
+  },
+  {
+    "testId": "test_e2e::test_remove_user",
+    "duration": "20.007s"
+  },
+  {
+    "testId": "test_e2e::test_search_results_recommendations",
+    "duration": "1.607s"
+  },
+  {
+    "testId": "test_e2e::test_update_corp_group_description",
+    "duration": "30.200s"
+  },
+  {
+    "testId": "test_e2e::test_update_corp_group_properties",
+    "duration": "29.966s"
+  },
+  {
+    "testId": "test_rapid::test_ingestion_via_rest_rapid",
+    "duration": "21.678s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_authenticated_non_admin_user_returns_403",
+    "duration": "25.915s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_endpoint_separation",
+    "duration": "0.276s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_main_endpoint",
+    "duration": "2.917s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_properties_endpoint",
+    "duration": "0.101s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_properties_structure",
+    "duration": "0.175s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_sensitive_data_redaction",
+    "duration": "0.126s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_simple_properties_endpoint",
+    "duration": "0.147s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_spring_components_endpoint",
+    "duration": "0.108s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_spring_components_structure",
+    "duration": "0.084s"
+  },
+  {
+    "testId": "test_system_info::test_system_info_unauthorized_access_returns_403",
+    "duration": "0.029s"
+  },
+  {
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_cycles",
+    "duration": "44.991s"
+  },
+  {
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_1",
+    "duration": "40.300s"
+  },
+  {
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_depth_6",
+    "duration": "50.027s"
+  },
+  {
+    "testId": "tests.actions.doc_propagation.test_propagation::test_col_col_propagation_large_fanout",
+    "duration": "88.125s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_analytics_charts_have_data",
+    "duration": "12.636s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_tab_views_by_entity_type_chart",
+    "duration": "10.059s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_top_searches_chart",
+    "duration": "10.046s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_top_viewed_datasets_chart",
+    "duration": "9.928s"
+  },
+  {
+    "testId": "tests.analytics.test_analytics::test_weekly_active_users_chart",
+    "duration": "9.946s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_assertion_info_patch_preserves_note",
+    "duration": "29.212s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_gms_get_assertion_info",
+    "duration": "0.008s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_gms_get_assertions_on_dataset_field",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.assertions.assertions_test::test_gms_get_latest_assertions_results_by_partition",
+    "duration": "14.470s"
+  },
+  {
+    "testId": "tests.assertions.custom_assertions_test::test_create_update_delete_dataset_custom_assertion",
+    "duration": "25.594s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_audit_token_events",
+    "duration": "84.590s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_failed_login_events",
+    "duration": "56.558s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_ingestion_source_events",
+    "duration": "34.813s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_login_events",
+    "duration": "44.928s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_policy_create_delete",
+    "duration": "40.918s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_policy_events",
+    "duration": "38.538s"
+  },
+  {
+    "testId": "tests.audit_events.audit_events_test::test_user_events",
+    "duration": "55.886s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_add_to_data_products_allowed_with_asset_side_privilege_only",
+    "duration": "20.059s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_remove_from_data_products_allowed_with_asset_side_privilege_only",
+    "duration": "29.934s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_cross_domain_with_manage_on_product_domain",
+    "duration": "19.902s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_allowed_with_manage_data_products_on_domain",
+    "duration": "19.900s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_set_data_product_denied_with_asset_side_privilege_only",
+    "duration": "20.032s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_batch_unset_data_product_allowed_with_asset_side_privilege_only",
+    "duration": "30.080s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_allowed_with_edit_entity_on_target_and_parent",
+    "duration": "41.444s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_parent",
+    "duration": "20.028s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_denied_without_edit_entity_on_target",
+    "duration": "37.498s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_via_dataset_policies_only",
+    "duration": "40.035s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_allowed_with_mixed_dataset_and_field_grants",
+    "duration": "40.108s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_logical_dataset",
+    "duration": "18.416s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_set_logical_parent_schema_field_denied_without_edit_entity_on_physical_dataset",
+    "duration": "19.977s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_edit_entity_on_data_product",
+    "duration": "40.227s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_allowed_with_manage_data_products_on_domain",
+    "duration": "19.940s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_with_asset_side_privilege_only",
+    "duration": "18.491s"
+  },
+  {
+    "testId": "tests.authorization.test_aspect_write_auth::test_update_data_product_name_denied_without_privilege",
+    "duration": "1.621s"
+  },
+  {
+    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_hidden_without_subject_view",
+    "duration": "2.173s"
+  },
+  {
+    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_visible_with_edit_queries_on_subject",
+    "duration": "0.032s"
+  },
+  {
+    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_visible_with_subject_view",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.browse.browse_test::test_get_browse_paths",
+    "duration": "5.554s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_bidirectional",
+    "duration": "30.069s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_from_datahub",
+    "duration": "19.911s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_to_datahub",
+    "duration": "10.124s"
+  },
+  {
+    "testId": "tests.cli.dataset_cmd.test_dataset_command::test_dataset_sync_validation",
+    "duration": "9.941s"
+  },
+  {
+    "testId": "tests.cli.delete_cmd.test_timeseries_delete::test_timeseries_delete",
+    "duration": "49.447s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_agent_context_flag_exits_zero",
+    "duration": "2.978s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_describe_me_returns_operation_details",
+    "duration": "0.106s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_operation_resolves_via_introspection",
+    "duration": "0.449s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_dry_run_with_raw_query_returns_json",
+    "duration": "0.081s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_execute_me_query_returns_current_user",
+    "duration": "0.096s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_list_operations_returns_real_schema",
+    "duration": "0.104s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_no_args_exits_with_usage_code",
+    "duration": "0.009s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestAgentFriendlyFeatures::test_non_tty_help_includes_agent_context",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_json_file_detection",
+    "duration": "0.014s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIFileHandling::test_relative_path_resolution",
+    "duration": "0.140s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_error_handling",
+    "duration": "0.031s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_json_output_format",
+    "duration": "0.052s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_list_operations",
+    "duration": "0.127s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_query_from_file",
+    "duration": "0.051s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_schema_introspection",
+    "duration": "0.169s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIIntegration::test_graphql_simple_query_execution",
+    "duration": "0.051s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_file_path_handling",
+    "duration": "0.042s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_help",
     "duration": "0.003s"
   },
   {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_on_malformed_json",
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_relative_path_handling",
+    "duration": "0.040s"
+  },
+  {
+    "testId": "tests.cli.graphql_cmd.test_graphql_cli_smoke.TestGraphQLCLIStandalone::test_graphql_schema_discovery",
+    "duration": "0.080s"
+  },
+  {
+    "testId": "tests.cli.ingest_cmd.test_timeseries_rollback::test_timeseries_rollback",
+    "duration": "24.321s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_instance2instance_smoke::test_incoming_references_are_rewritten",
+    "duration": "23.277s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_instance2instance_smoke::test_instance2instance_rewrites_lineage_and_migrates_aspects",
+    "duration": "26.784s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_instance2instance_smoke::test_merge_mode_carries_and_rewrites_fine_grained_lineage",
+    "duration": "56.879s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_scenarios_smoke::test_assertion_reference_is_rewritten",
+    "duration": "40.037s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_scenarios_smoke::test_container_migration_regenerates_instance",
+    "duration": "39.857s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_scenarios_smoke::test_dataplatform2instance_assigns_instance_and_carries_aspects",
+    "duration": "32.349s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_scenarios_smoke::test_preserve_leaves_existing_target_untouched",
+    "duration": "30.018s"
+  },
+  {
+    "testId": "tests.cli.migrate_cmd.test_migrate_scenarios_smoke::test_urns_mapping_full_scenario",
+    "duration": "40.001s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_facets_only",
+    "duration": "0.227s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_json_result_structure",
+    "duration": "0.235s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_limit_respected",
+    "duration": "0.297s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_table_format",
+    "duration": "0.131s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_urns_only_format",
+    "duration": "0.218s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchBasic::test_wildcard_returns_json",
+    "duration": "16.400s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_json_structure",
+    "duration": "0.130s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_keyword_connected",
+    "duration": "0.108s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_semantic_section_has_expected_keys",
+    "duration": "5.632s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDiagnose::test_diagnose_text_exits_cleanly",
+    "duration": "20.176s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_offline",
+    "duration": "0.038s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_shows_compiled_filter",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchDryRun::test_dry_run_with_projection_shows_query",
+    "duration": "0.021s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_conflicting_filters_exit_code_2",
     "duration": "0.003s"
   },
   {
-    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_first_match",
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_describe_filter_subcommand",
+    "duration": "7.280s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_limit_exit_code_2",
     "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_malformed_metadata",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_missing",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_metadata_is_non_dict_json",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_groups_by_schema_version_with_pymysql_string_keys",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_returns_empty_when_no_rows",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_only_header_when_no_rows",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_prepends_live_project_prefix_to_short_volume_names",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_dataclass",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_attribution_patch[graph_client]",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_wrong_audience_is_rejected",
-    "duration": "0.003s"
-  },
-  {
-    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_both_id_and_flag",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_cache_metrics_when_isolated",
-    "duration": "0.002s"
   },
   {
     "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_offset_exit_code_2",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_invalid_projection_exit_code_2",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_opt_out_via_env_var_skips_gradle",
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchErrorHandling::test_list_filters_subcommand",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_passes_when_all_urns_at_target",
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_comma_or_logic_returns_union",
+    "duration": "0.327s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_complex_filters_json_and",
+    "duration": "0.097s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFilterCombinations::test_multiple_filters_are_anded",
+    "duration": "0.261s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_entity_type_filter_narrows_results",
+    "duration": "1.821s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_chart_returns_only_charts",
+    "duration": "0.324s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_corpuser_returns_only_corpusers",
+    "duration": "0.199s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dashboard_returns_only_dashboards",
+    "duration": "0.107s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByEntityType::test_filter_dataset_returns_only_datasets",
+    "duration": "20.245s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_bigquery_returns_bigquery_datasets",
+    "duration": "0.327s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_excludes_bigquery",
+    "duration": "0.109s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchFiltersByPlatform::test_filter_snowflake_returns_snowflake_datasets",
+    "duration": "12.223s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_offset_returns_different_results",
+    "duration": "11.261s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchPagination::test_total_is_consistent_across_pages",
+    "duration": "1.267s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_minimal_projection_urn_only",
+    "duration": "5.138s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchProjectionLive::test_projection_reduces_payload",
+    "duration": "1.683s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_and_narrows_results",
+    "duration": "0.153s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_in_list",
+    "duration": "1.896s"
+  },
+  {
+    "testId": "tests.cli.search_cmd.test_search_cmd.TestSearchWhereFilter::test_where_platform_eq",
+    "duration": "0.292s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_duplicate_user",
+    "duration": "20.026s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_id_different_from_email",
+    "duration": "14.373s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_admin_role",
+    "duration": "20.033s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_both_id_and_flag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_editor_role",
+    "duration": "19.934s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_explicit_id",
+    "duration": "11.296s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_with_reader_role",
+    "duration": "20.087s"
+  },
+  {
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_id_or_flag",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_fails_when_any_urn_below_target",
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_password_flag",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_fails_when_urn_missing_schema_version",
+    "testId": "tests.cli.user_cmd.test_user_add::test_user_add_without_role",
+    "duration": "19.904s"
+  },
+  {
+    "testId": "tests.cli.user_groups_cmd.test_group_cmd::test_group_upsert",
+    "duration": "9.070s"
+  },
+  {
+    "testId": "tests.cli.user_groups_cmd.test_user_cmd::test_user_upsert",
+    "duration": "11.130s"
+  },
+  {
+    "testId": "tests.containers.container_entities_batching_test::test_container_entities_counts_are_batched_and_correct",
+    "duration": "19.197s"
+  },
+  {
+    "testId": "tests.containers.container_entities_batching_test::test_container_entities_counts_correct_across_chunk_boundary",
+    "duration": "10.082s"
+  },
+  {
+    "testId": "tests.containers.container_entities_batching_test::test_container_entities_direct_path_matches_batched_total",
+    "duration": "1.578s"
+  },
+  {
+    "testId": "tests.containers.container_entities_batching_test::test_container_entities_filters_are_applied",
+    "duration": "1.595s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_get_full_container",
+    "duration": "19.053s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_get_parent_container",
+    "duration": "9.931s"
+  },
+  {
+    "testId": "tests.containers.containers_test::test_update_container",
+    "duration": "19.973s"
+  },
+  {
+    "testId": "tests.data_process_instance.test_data_process_instance::test_search_dpi",
+    "duration": "9.861s"
+  },
+  {
+    "testId": "tests.database.test_database::test_mysql_deadlock_gap_locking",
+    "duration": "28.366s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_info",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_skips_when_expected_schema_version_unset",
+    "testId": "tests.datapack.test_datapack_smoke.TestDatapackCLI::test_datapack_list",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC503ConcurrentWrites::test_passes_when_all_writes_passed",
+    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_load_bootstrap_via_cli",
+    "duration": "11.111s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestDemoDataBootstrap::test_unload_bootstrap_via_cli",
+    "duration": "2.639s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_dashboards",
+    "duration": "9.881s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_datasets",
+    "duration": "26.368s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_glossary_terms",
+    "duration": "10.079s"
+  },
+  {
+    "testId": "tests.datapack.test_datapack_smoke.TestShowcaseData::test_showcase_has_structured_properties",
+    "duration": "58.117s"
+  },
+  {
+    "testId": "tests.dataproduct.test_dataproduct::test_create_data_product",
+    "duration": "38.626s"
+  },
+  {
+    "testId": "tests.delete.delete_test::test_delete_reference",
+    "duration": "37.974s"
+  },
+  {
+    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_all_fields",
+    "duration": "27.078s"
+  },
+  {
+    "testId": "tests.deprecation.deprecation_test::test_update_deprecation_partial_fields",
+    "duration": "10.774s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_single_lookup",
+    "duration": "0.010s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flag_unknown_name_returns_404",
+    "duration": "0.010s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_accessible_without_auth",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_contain_stable_keys",
+    "duration": "0.010s"
+  },
+  {
+    "testId": "tests.dev_tooling.test_dev_tooling::test_dev_feature_flags_endpoint_is_active",
+    "duration": "0.010s"
+  },
+  {
+    "testId": "tests.domains.domain_entities_batching_test::test_domain_entities_counts_are_batched_and_correct",
+    "duration": "20.040s"
+  },
+  {
+    "testId": "tests.domains.domains_test::test_create_list_get_domain",
+    "duration": "18.398s"
+  },
+  {
+    "testId": "tests.domains.domains_test::test_delete_parent_domain_immediately_after_child_deletion",
+    "duration": "24.988s"
+  },
+  {
+    "testId": "tests.domains.domains_test::test_set_unset_domain",
+    "duration": "25.843s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_parent_containers_hierarchy",
+    "duration": "19.111s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_container_relationships_direct_children",
+    "duration": "20.056s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_after_native_add",
+    "duration": "34.264s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_corp_group_incoming_members_immediately_after_add_second_member",
+    "duration": "36.780s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_cache_metrics_when_isolated",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_parent_domains_hierarchy",
+    "duration": "57.544s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_domain_sync_move_reflects_in_parent_domains",
+    "duration": "67.224s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_cache_metrics_when_isolated",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_deep_hierarchy_within_bundled_max_depth",
+    "duration": "11.687s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_parent_nodes_hierarchy",
+    "duration": "20.047s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_glossary_sync_reparent_reflects_in_parent_nodes",
+    "duration": "32.405s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_membership_relationships_idempotent_for_isolated_user",
+    "duration": "129.045s"
+  },
+  {
+    "testId": "tests.entity_graph_cache.test_entity_graph_cache::test_session_user_dual_group_types_labeled_correctly",
+    "duration": "113.960s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_three_versions_unlink_middle_and_latest",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_version",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_many_versions",
+    "duration": "8.123s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties",
+    "duration": "0.545s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_alphanumeric",
+    "duration": "0.473s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_new_latest",
+    "duration": "0.541s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_ingest::test_ingest_version_properties_version_set_not_latest",
+    "duration": "0.321s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_timeline::test_get_timeline_version_set_superset_of_single_entity",
+    "duration": "0.304s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_timeline::test_get_timeline_with_version_set_returns_all_versions",
+    "duration": "0.044s"
+  },
+  {
+    "testId": "tests.entity_versioning.test_versioning_timeline::test_get_timeline_without_version_set",
+    "duration": "9.355s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_and_remove_form",
+    "duration": "102.978s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_form_across_entity_types",
+    "duration": "51.937s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_form_is_idempotent",
+    "duration": "43.127s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_form_rejects_batch_with_missing_entity",
+    "duration": "32.755s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_form_reports_every_missing_entity",
+    "duration": "17.930s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_assign_form_tolerates_duplicate_urns",
+    "duration": "40.052s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_remove_form_never_assigned_is_noop",
+    "duration": "6.345s"
+  },
+  {
+    "testId": "tests.forms.forms_test::test_batch_remove_form_only_affects_named_form",
+    "duration": "52.038s"
+  },
+  {
+    "testId": "tests.glossary.glossary_children_count_test::test_children_count_is_correct_for_a_batch_of_sibling_nodes",
+    "duration": "7.569s"
+  },
+  {
+    "testId": "tests.graph.test_graph_client::test_get_aspect_v2",
+    "duration": "9.957s"
+  },
+  {
+    "testId": "tests.graph.test_graph_client::test_get_entities_v3",
+    "duration": "0.010s"
+  },
+  {
+    "testId": "tests.graph.test_graph_client::test_get_entity_aspect_specs",
+    "duration": "0.211s"
+  },
+  {
+    "testId": "tests.graph.test_graph_client::test_graph_relationships",
+    "duration": "20.028s"
+  },
+  {
+    "testId": "tests.incidents.health_batch_test::test_batched_incident_health",
+    "duration": "11.512s"
+  },
+  {
+    "testId": "tests.incidents.health_batch_test::test_incident_health_survives_soft_deleted_asset",
+    "duration": "58.328s"
+  },
+  {
+    "testId": "tests.incidents.incidents_test::test_list_dataset_incidents",
+    "duration": "18.020s"
+  },
+  {
+    "testId": "tests.incidents.incidents_test::test_raise_resolve_incident",
+    "duration": "31.878s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_add_institutional_memory",
+    "duration": "29.932s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_get_institutional_memory",
+    "duration": "20.207s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_remove_institutional_memory",
+    "duration": "34.200s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_update_institutional_memory",
+    "duration": "30.698s"
+  },
+  {
+    "testId": "tests.institutional_memory.institutional_memory_test::test_upsert_institutional_memory",
+    "duration": "30.059s"
+  },
+  {
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history",
+    "duration": "11.840s"
+  },
+  {
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_empty",
+    "duration": "10.123s"
+  },
+  {
+    "testId": "tests.knowledge.document_change_history_test::test_document_change_history_with_time_range",
+    "duration": "9.880s"
+  },
+  {
+    "testId": "tests.knowledge.document_search_filter_test::test_related_documents_shows_context_only_documents",
+    "duration": "10.498s"
+  },
+  {
+    "testId": "tests.knowledge.document_search_filter_test::test_search_across_entities_filters_documents",
+    "duration": "15.307s"
+  },
+  {
+    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_filters_hidden_context_documents",
+    "duration": "16.761s"
+  },
+  {
+    "testId": "tests.knowledge.document_search_filter_test::test_search_documents_shows_owned_unpublished",
+    "duration": "20.431s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_create_document",
+    "duration": "20.055s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_create_document_with_owners",
+    "duration": "24.947s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_get_document",
+    "duration": "29.953s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_move_document",
+    "duration": "45.028s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_search_documents",
+    "duration": "29.905s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_contents",
+    "duration": "30.005s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_status",
+    "duration": "45.112s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_document_subtype",
+    "duration": "29.938s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_crud.TestDocumentCrudAndMutations::test_update_related_entities",
+    "duration": "30.029s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_context_documents_for_dataset",
+    "duration": "40.041s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_document_settings",
+    "duration": "44.938s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_parent_documents_hierarchy",
+    "duration": "21.866s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_hierarchy_settings.TestDocumentHierarchyAndSettings::test_search_ownership_filtering",
+    "duration": "40.098s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_search_history.TestDocumentSearchAndHistory::test_change_history",
+    "duration": "38.561s"
+  },
+  {
+    "testId": "tests.knowledge.test_document_search_history.TestDocumentSearchAndHistory::test_search_documents_with_filters",
+    "duration": "36.520s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[application_create.py]",
+    "duration": "3.362s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[application_query_rest_api.py]",
+    "duration": "0.143s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_field_uniqueness.py]",
+    "duration": "0.361s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_freshness.py]",
+    "duration": "0.429s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_schema.py]",
+    "duration": "0.373s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_sql_metric.py]",
+    "duration": "0.314s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[assertion_create_volume_rows.py]",
+    "duration": "0.498s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_create.py]",
+    "duration": "0.305s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[business_attribute_query.py]",
+    "duration": "0.086s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[chart_create_simple.py]",
+    "duration": "0.391s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create.py]",
+    "duration": "0.417s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_database.py]",
+    "duration": "0.512s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[container_create_schema.py]",
+    "duration": "0.485s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_create.py]",
+    "duration": "0.420s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpgroup_query_rest_api.py]",
+    "duration": "0.114s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[corpuser_create_basic.py]",
+    "duration": "0.373s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dashboard_create_simple.py]",
+    "duration": "0.407s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[data_platform_create.py]",
+    "duration": "0.291s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[data_process_instance_create_simple.py]",
+    "duration": "2.987s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[datacontract_create_basic.py]",
+    "duration": "0.393s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dataflow_create.py]",
+    "duration": "0.436s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[datajob_create_basic.py]",
+    "duration": "0.465s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dataproduct_create.py]",
+    "duration": "0.510s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[dataset_create_with_structured_properties.py]",
+    "duration": "0.392s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create.py]",
+    "duration": "0.299s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[domain_create_nested.py]",
+    "duration": "0.302s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[ermodelrelationship_create_basic.py]",
+    "duration": "0.471s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_node_create.py]",
+    "duration": "0.412s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create.py]",
+    "duration": "0.359s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[glossary_term_create_simple.py]",
+    "duration": "0.367s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_create.py]",
+    "duration": "0.330s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[incident_query_rest_api.py]",
+    "duration": "0.380s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_create.py]",
+    "duration": "0.311s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlfeature_table_create.py]",
+    "duration": "0.314s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_create.py]",
+    "duration": "0.342s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_deployment_create.py]",
+    "duration": "0.298s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlmodel_group_create.py]",
+    "duration": "0.386s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[mlprimarykey_create.py]",
+    "duration": "0.329s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[notebook_create.py]",
+    "duration": "0.331s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[ownership_type_create_custom.py]",
+    "duration": "0.300s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[platform_instance_create.py]",
+    "duration": "0.284s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[query_create.py]",
+    "duration": "0.295s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[role_create.py]",
+    "duration": "0.275s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[role_query.py]",
+    "duration": "28.348s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[search_filter_by_domain.py]",
+    "duration": "0.338s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[structured_property_create_basic.py]",
+    "duration": "0.455s"
+  },
+  {
+    "testId": "tests.library_examples.test_library_examples::test_library_example[tag_create_basic.py]",
+    "duration": "0.339s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "11.655s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[1-LineageStyle.DATASET_QUERY_DATASET]",
+    "duration": "17.972s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "16.667s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[2-LineageStyle.DATASET_QUERY_DATASET]",
+    "duration": "12.687s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_JOB_DATASET]",
+    "duration": "20.704s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage::test_lineage_via_node[3-LineageStyle.DATASET_QUERY_DATASET]",
+    "duration": "20.492s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage",
+    "duration": "0.199s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_column_level_lineage_from_schema_field",
+    "duration": "0.295s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_filtered_column_level_lineage",
+    "duration": "0.182s"
+  },
+  {
+    "testId": "tests.lineage.test_lineage_sdk::test_table_level_lineage",
+    "duration": "10.337s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_ingestion_execution_request",
+    "duration": "74.963s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_ingestion_source",
+    "duration": "44.242s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_create_list_get_remove_secret",
+    "duration": "125.089s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_json_credentials_with_newlines_and_slashes",
+    "duration": "20.053s"
+  },
+  {
+    "testId": "tests.managed_ingestion.managed_ingestion_test::test_secret_roundtrip_preserves_passwords_and_connection_strings_with_special_chars",
+    "duration": "20.726s"
+  },
+  {
+    "testId": "tests.metrics.test_metrics::test_usage_aggregation_micrometer_export",
+    "duration": "70.749s"
+  },
+  {
+    "testId": "tests.metrics.test_queue_ingest_usage::test_queue_ingest_metadata_ingest_metric_on_mce",
+    "duration": "74.505s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_admin_active_identities",
+    "duration": "4.348s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationActiveIdentities::test_usage_aggregation_regular_user_active_identities",
+    "duration": "112.554s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_admin_actor_class_and_tags",
+    "duration": "59.919s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_configured_admin_actor_class",
+    "duration": "47.116s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_fresh_admin_session_login",
+    "duration": "58.508s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationAdminSessions::test_usage_aggregation_pat_authenticated_traffic",
+    "duration": "60.970s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_graphql_output_bytes",
+    "duration": "59.421s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_read_and_search",
+    "duration": "29.207s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationByteMetrics::test_usage_aggregation_openapi_search_output_bytes",
+    "duration": "60.293s"
+  },
+  {
+    "testId": "tests.metrics.test_usage_aggregation_audit.TestUsageAggregationGraphqlOutputDedup::test_usage_aggregation_graphql_output_bytes_not_double_counted",
+    "duration": "42.825s"
+  },
+  {
+    "testId": "tests.ml_models.test_ml_models::test_create_ml_models",
+    "duration": "15.128s"
+  },
+  {
+    "testId": "tests.oauth.test_oauth_cli_gms::test_ingest_explicit_static_token_wins_over_env_auth",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.oauth.test_oauth_cli_gms::test_version_check_config_fetch_uses_env_auth",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.oauth.test_oauth_cli_gms::test_wrong_audience_is_rejected",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.object_storage.test_object_storage::test_documentation_file_upload_gated_without_presigned_urls",
+    "duration": "9.891s"
+  },
+  {
+    "testId": "tests.object_storage.test_object_storage::test_get_presigned_upload_url_rejects_local_provider",
+    "duration": "19.973s"
+  },
+  {
+    "testId": "tests.object_storage.test_object_storage::test_object_storage_config_exposed_in_system_info",
+    "duration": "0.070s"
+  },
+  {
+    "testId": "tests.openapi.test_openapi::test_openapi",
+    "duration": "91.642s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_elasticsearch",
+    "duration": "20.636s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_kafka",
+    "duration": "10.028s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_mixpanel",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.openapi.v1.test_tracking::test_tracking_api_pgqueue",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_no_scrollid_on_last_page",
+    "duration": "9.968s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_pagination_no_duplicates",
+    "duration": "7.849s"
+  },
+  {
+    "testId": "tests.openapi.v2.test_timeseries_scroll::test_timeseries_scroll_returns_scrollid",
+    "duration": "10.889s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_empty_returns_all_aspects",
+    "duration": "0.218s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_none_returns_urns_only",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_aspects_single_returns_only_that_aspect",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_basic",
+    "duration": "15.530s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_entity_type",
+    "duration": "0.053s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_by_multiple_entity_types",
+    "duration": "0.075s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_filter_is_applied",
+    "duration": "0.026s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_pagination",
+    "duration": "0.059s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_parallel_slicing",
+    "duration": "0.090s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_query",
+    "duration": "0.051s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_sort_criteria",
+    "duration": "0.037s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_entities::test_scroll_entities_with_system_metadata",
+    "duration": "0.027s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_all_edges_around_urn",
+    "duration": "9.752s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_datajob_directions",
+    "duration": "0.130s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_downstream_of_upstream_node",
+    "duration": "0.132s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_feature_directions",
+    "duration": "0.131s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_no_urns_returns_lineage_edges",
+    "duration": "0.053s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_pagination",
+    "duration": "0.195s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_produces_source_is_upstream",
+    "duration": "0.111s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_lineage::test_scroll_lineage_relationship_types_filter",
+    "duration": "0.051s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_basic",
+    "duration": "10.822s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_consumes",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_derived_from",
+    "duration": "0.025s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_by_type_downstream",
+    "duration": "0.037s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_destination_urns_and_filter_equivalent",
+    "duration": "0.039s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_pagination",
+    "duration": "0.038s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_source_urns_and_filter_equivalent",
+    "duration": "0.036s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_types",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_destination_urns",
+    "duration": "0.020s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_incoming",
+    "duration": "0.023s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_direction_outgoing",
+    "duration": "0.021s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_edge_filter",
+    "duration": "0.030s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_types",
+    "duration": "0.018s"
+  },
+  {
+    "testId": "tests.openapi.v3.test_scroll_relationships::test_scroll_relationships_with_source_urns",
+    "duration": "0.019s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[graph_client]",
+    "duration": "0.376s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_custom_properties_patch[openapi_graph_client]",
+    "duration": "0.329s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[graph_client]",
+    "duration": "0.172s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_add_fine_grained_lineage[openapi_graph_client]",
+    "duration": "0.187s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[graph_client]",
+    "duration": "0.247s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_inputoutput_dataset_patch[openapi_graph_client]",
+    "duration": "0.264s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[graph_client]",
+    "duration": "0.304s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_multiple_inputoutput_dataset_patch[openapi_graph_client]",
+    "duration": "0.161s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[graph_client]",
+    "duration": "3.397s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_ownership_patch[openapi_graph_client]",
+    "duration": "0.357s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[graph_client]",
+    "duration": "0.173s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_set_fine_grained_lineages[openapi_graph_client]",
+    "duration": "0.173s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[graph_client]",
+    "duration": "0.524s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_datajob_tags_patch[openapi_graph_client]",
+    "duration": "0.367s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[graph_client]",
+    "duration": "0.407s"
+  },
+  {
+    "testId": "tests.patch.test_datajob_patches::test_dataset_terms_patch[openapi_graph_client]",
+    "duration": "0.419s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[graph_client]",
+    "duration": "0.187s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_add_attributed_tag_is_idempotent[openapi_graph_client]",
+    "duration": "0.160s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[graph_client]",
+    "duration": "0.241s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_attributed_duplicates_survive_unrelated_tag_patch[openapi_graph_client]",
+    "duration": "0.242s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[graph_client]",
+    "duration": "0.233s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_attribution_based_tag_patch[openapi_graph_client]",
+    "duration": "0.272s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[graph_client]",
+    "duration": "0.289s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_custom_properties_patch[openapi_graph_client]",
+    "duration": "0.317s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[graph_client]",
+    "duration": "0.204s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_add_fine_grained_lineage[openapi_graph_client]",
+    "duration": "0.179s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[graph_client]",
+    "duration": "3.588s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_ownership_patch[openapi_graph_client]",
+    "duration": "0.545s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[graph_client]",
+    "duration": "0.217s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_set_fine_grained_lineages[openapi_graph_client]",
+    "duration": "0.310s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[graph_client]",
+    "duration": "0.547s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_tags_patch[openapi_graph_client]",
+    "duration": "0.732s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[graph_client]",
+    "duration": "0.400s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_terms_patch[openapi_graph_client]",
+    "duration": "0.331s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[graph_client]",
+    "duration": "0.325s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_dataset_upstream_lineage_patch[openapi_graph_client]",
+    "duration": "0.332s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[graph_client]",
+    "duration": "0.123s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_documentation_patch[openapi_graph_client]",
+    "duration": "0.162s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_patch_multiple_new_fields_merges_with_existing[graph_client]",
+    "duration": "0.206s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_patch_multiple_new_fields_merges_with_existing[openapi_graph_client]",
+    "duration": "0.201s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tag_patch_on_new_field_preserves_fieldpath[graph_client]",
+    "duration": "0.246s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tag_patch_on_new_field_preserves_fieldpath[openapi_graph_client]",
+    "duration": "0.165s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tags_attribution_patch[graph_client]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[graph_client]",
+    "duration": "0.469s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_tags_patch[openapi_graph_client]",
+    "duration": "0.360s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_term_patch_on_new_field_preserves_fieldpath[graph_client]",
+    "duration": "0.176s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_term_patch_on_new_field_preserves_fieldpath[openapi_graph_client]",
+    "duration": "0.135s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[graph_client]",
+    "duration": "0.386s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_field_terms_patch[openapi_graph_client]",
+    "duration": "0.413s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[graph_client]",
+    "duration": "0.287s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_ownership_multi_type_urn_patch[openapi_graph_client]",
+    "duration": "0.215s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[graph_client]",
+    "duration": "0.145s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_all_documentation[openapi_graph_client]",
+    "duration": "0.154s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[graph_client]",
+    "duration": "0.217s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_remove_without_attribution_deletes_all_entries[openapi_graph_client]",
+    "duration": "0.155s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[graph_client]",
+    "duration": "0.222s"
+  },
+  {
+    "testId": "tests.patch.test_dataset_patches::test_unattributed_and_attributed_tag_coexist[openapi_graph_client]",
+    "duration": "0.253s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[graph_client]",
+    "duration": "0.390s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_patch_updates_domains[openapi_graph_client]",
+    "duration": "0.363s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[graph_client]",
+    "duration": "0.232s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domain_associations_upsert_updates_domains[openapi_graph_client]",
+    "duration": "0.256s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[graph_client]",
+    "duration": "3.537s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_add_remove_via_domains_updates_domain_associations[openapi_graph_client]",
+    "duration": "0.663s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[graph_client]",
+    "duration": "0.139s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_propagated_domains_ordered_after_manual[openapi_graph_client]",
+    "duration": "0.108s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[graph_client]",
+    "duration": "0.245s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_associations_updates_domains[openapi_graph_client]",
+    "duration": "0.216s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[graph_client]",
+    "duration": "0.206s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_read_modify_write_domains_updates_associations[openapi_graph_client]",
+    "duration": "0.190s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[graph_client]",
+    "duration": "0.205s"
+  },
+  {
+    "testId": "tests.patch.test_domain_patches::test_updating_both_domains_and_domain_associations_errors[openapi_graph_client]",
+    "duration": "0.182s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_consumer_registration_lifecycle",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_list_registered_consumers",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_timeseries_consumer_lag_detailed",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcl_versioned_consumer_lag_detailed",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_mcp_consumer_lag_detailed",
+    "duration": "0.006s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_messaging_transport_reports_pgqueue",
+    "duration": "0.006s"
+  },
+  {
+    "testId": "tests.pgqueue.test_messaging_operations::test_reset_stuck_ahead_consumer_offsets",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_by_resource_type",
+    "duration": "10.090s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_listing_complex_queries",
+    "duration": "9.866s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_non_existent",
+    "duration": "0.021s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_read_write",
+    "duration": "10.625s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_search",
+    "duration": "9.934s"
+  },
+  {
+    "testId": "tests.platform_resources.test_platform_resource::test_platform_resource_urn_secondary_key",
+    "duration": "10.112s"
+  },
+  {
+    "testId": "tests.policies.test_policies::test_frontend_policy_operations",
+    "duration": "39.979s"
+  },
+  {
+    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[10-20]",
+    "duration": "50.106s"
+  },
+  {
+    "testId": "tests.policies.test_policy_eval_perf::test_domains_page_perf_with_domain_scoped_policies[100-50]",
+    "duration": "59.992s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_from_group_role_can_create_and_manage_secret",
+    "duration": "50.010s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_ingestion_source",
+    "duration": "27.607s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_policies",
+    "duration": "19.071s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_manage_secrets",
+    "duration": "41.650s"
+  },
+  {
+    "testId": "tests.privileges.test_privileges::test_privilege_to_create_and_revoke_personal_access_tokens",
+    "duration": "20.838s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_multiple_unknown_fragments_and_fields",
+    "duration": "0.040s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_nonexistent_type_fragment_stripped",
+    "duration": "0.036s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_query_with_variables_and_operation_name",
+    "duration": "0.033s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_schema_cached_across_calls",
+    "duration": "0.072s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_search_query_with_known_entity_types",
+    "duration": "0.077s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_simple_query_passes_through",
+    "duration": "1.399s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_still_works",
+    "duration": "0.030s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_strip_false_with_bad_field_fails",
+    "duration": "0.029s"
+  },
+  {
+    "testId": "tests.query_projection.test_query_projection_smoke::test_unknown_field_on_known_type_stripped",
+    "duration": "0.039s"
+  },
+  {
+    "testId": "tests.read_only.test_analytics::test_analytics_chart_is_accessible",
+    "duration": "1.667s"
+  },
+  {
+    "testId": "tests.read_only.test_analytics::test_highlights_is_accessible",
+    "duration": "7.574s"
+  },
+  {
+    "testId": "tests.read_only.test_analytics::test_metadata_analytics_chart_is_accessible",
+    "duration": "8.299s"
+  },
+  {
+    "testId": "tests.read_only.test_dataproduct::test_dataproduct_search_works",
+    "duration": "19.313s"
+  },
+  {
+    "testId": "tests.read_only.test_ingestion_list::test_policies_are_accessible",
+    "duration": "10.031s"
+  },
+  {
+    "testId": "tests.read_only.test_lineage_apis::test_scroll_across_lineage_api",
+    "duration": "9.867s"
+  },
+  {
+    "testId": "tests.read_only.test_lineage_apis::test_search_across_lineage_api",
+    "duration": "15.905s"
+  },
+  {
+    "testId": "tests.read_only.test_policies::test_policies_are_accessible",
+    "duration": "1.587s"
+  },
+  {
+    "testId": "tests.read_only.test_search::test_openapi_v3_entity",
+    "duration": "71.266s"
+  },
+  {
+    "testId": "tests.read_only.test_search::test_search_works",
+    "duration": "22.944s"
+  },
+  {
+    "testId": "tests.read_only.test_services_up::test_gms_config_accessible",
+    "duration": "0.036s"
+  },
+  {
+    "testId": "tests.restli.restli_test::test_gms_delete_mcp",
+    "duration": "0.136s"
+  },
+  {
+    "testId": "tests.restli.restli_test::test_gms_ignore_unknown_dashboard_info",
+    "duration": "0.051s"
+  },
+  {
+    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_async",
+    "duration": "9.772s"
+  },
+  {
+    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_async",
+    "duration": "0.419s"
+  },
+  {
+    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_exception_sync",
+    "duration": "0.031s"
+  },
+  {
+    "testId": "tests.restli.test_restli_batch_ingestion::test_restli_batch_ingestion_sync",
+    "duration": "0.240s"
+  },
+  {
+    "testId": "tests.schema_fields.test_schemafields::test_schema_field_gql_mapper_for_charts",
+    "duration": "8.627s"
+  },
+  {
+    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_with_lineage",
+    "duration": "16.482s"
+  },
+  {
+    "testId": "tests.search.test_lineage_search_index_fields::test_lineage_search_index_fields_without_lineage",
+    "duration": "8.618s"
+  },
+  {
+    "testId": "tests.search.test_lineage_search_index_fields::test_upstream_dataset_search_index_fields",
+    "duration": "1.615s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_dataset_properties_projection",
+    "duration": "0.081s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_default_query_no_projection",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_finds_root_with_settings_gradle_and_gradlew",
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_facets_always_present",
+    "duration": "0.254s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_minimal_projection",
+    "duration": "0.124s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_platform_fields_fragment_projection",
+    "duration": "0.062s"
+  },
+  {
+    "testId": "tests.search.test_search_projection.TestSearchProjection::test_projection_reduces_payload",
+    "duration": "0.138s"
+  },
+  {
+    "testId": "tests.semantic.test_config_fingerprint.TestConfigFingerprint::test_chunking_max_characters_change_triggers_reprocessing",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.semantic.test_current_offset_api::test_get_current_offset_no_params",
+    "duration": "2.013s"
+  },
+  {
+    "testId": "tests.semantic.test_current_offset_api::test_offset_behavior_without_lookback",
+    "duration": "1.898s"
+  },
+  {
+    "testId": "tests.semantic.test_current_offset_api::test_poll_with_retrieved_offset",
+    "duration": "4.012s"
+  },
+  {
+    "testId": "tests.semantic.test_event_driven_docs.TestEventDrivenDocumentIngestion::test_event_driven_document_update",
+    "duration": "0.050s"
+  },
+  {
+    "testId": "tests.semantic.test_event_mode_fallback.TestEventModeFallback::test_bootstrap_flow_first_run_captures_offset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.semantic.test_event_mode_fallback.TestEventModeFallback::test_fallback_when_no_offsets_first_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.semantic.test_event_mode_fallback.TestEventModeFallback::test_successful_event_mode_with_lookback",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.semantic.test_local_embedding_provider.TestLocalEmbeddingProvider::test_embedding_provider_type_is_local",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.semantic.test_local_embedding_provider.TestLocalEmbeddingProvider::test_local_embedding_server_reachable",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.semantic.test_semantic_search.TestSemanticSearchWithIngestion::test_end_to_end_ingestion_and_semantic_search",
+    "duration": "0.037s"
+  },
+  {
+    "testId": "tests.semantic.test_source_type_filtering.TestSourceTypeFiltering::test_empty_platform_filter_explicit",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_returns_none_when_no_root_found",
+    "testId": "tests.semantic.test_source_type_filtering.TestSourceTypeFiltering::test_wildcard_filter_processes_all",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_create_access_token_for_service_account",
+    "duration": "49.947s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_create_list_get_delete_service_account",
+    "duration": "59.386s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_delete_nonexistent_service_account",
+    "duration": "10.061s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_get_nonexistent_service_account",
+    "duration": "9.973s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_list_service_accounts_with_query",
+    "duration": "24.987s"
+  },
+  {
+    "testId": "tests.service_accounts.test_service_accounts::test_service_account_default_view",
+    "duration": "84.950s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_draft_stage_hidden_from_owner_in_doc_search",
+    "duration": "39.911s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_hidden_stage_excludes_from_cross_entity_search",
+    "duration": "62.252s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_hidden_stage_visible_to_owner_in_doc_search",
+    "duration": "37.740s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_list_lifecycle_stages_includes_ingested",
+    "duration": "10.841s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_set_lifecycle_stage_mutation",
+    "duration": "48.378s"
+  },
+  {
+    "testId": "tests.status.test_lifecycle_state.TestLifecycleStageAPIs::test_visible_stage_remains_in_search",
+    "duration": "60.093s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_delete",
+    "duration": "41.606s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_patch",
+    "duration": "49.875s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_read_mutation",
+    "duration": "29.983s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_search_filter_validation",
+    "duration": "30.096s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_structured_property_soft_delete_validation",
+    "duration": "9.950s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_dataset_yaml_loader",
+    "duration": "10.012s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_list",
+    "duration": "38.298s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_properties_yaml_load_with_bad_entity_type",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_definition_evolution",
+    "duration": "9.973s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double",
+    "duration": "19.973s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_double_multiple",
+    "duration": "20.003s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_schema_field",
+    "duration": "20.073s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_search",
+    "duration": "40.095s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string",
+    "duration": "35.493s"
+  },
+  {
+    "testId": "tests.structured_properties.test_structured_properties::test_structured_property_string_allowed_values",
+    "duration": "19.977s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag",
+    "duration": "59.160s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_tag_to_chart",
+    "duration": "50.084s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_add_term",
+    "duration": "49.958s"
+  },
+  {
+    "testId": "tests.tags_and_terms.tags_and_terms_test::test_update_schemafield",
+    "duration": "129.954s"
+  },
+  {
+    "testId": "tests.telemetry.telemetry_test::test_no_client_id",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.telemetry.telemetry_test::test_no_telemetry_client_id",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.test_kafka_default_sink::test_default_sink_ingests_end_to_end[kafka-datahub-kafka]",
+    "duration": "17.472s"
+  },
+  {
+    "testId": "tests.test_kafka_default_sink::test_default_sink_ingests_end_to_end[rest-datahub-rest]",
+    "duration": "24.035s"
+  },
+  {
+    "testId": "tests.test_kafka_default_sink::test_pgqueue_sink_ingests_end_to_end",
+    "duration": "5.706s"
+  },
+  {
+    "testId": "tests.test_stateful_ingestion::test_stateful_ingestion",
+    "duration": "0.694s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_authorized_user_succeeds",
+    "duration": "1.571s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_rest_v2_unauthorized_user_is_denied",
+    "duration": "18.459s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Dataset]",
+    "duration": "29.237s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_auth_test::test_get_timeline_unauthorized_user_is_denied[Domain]",
+    "duration": "0.029s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_all_categories",
+    "duration": "9.948s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_application_changes",
+    "duration": "29.209s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_asset_membership_changes",
+    "duration": "35.102s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_documentation_changes",
+    "duration": "20.111s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_domain_changes",
+    "duration": "30.046s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_glossary_term_changes",
+    "duration": "29.983s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_ownership_changes",
+    "duration": "57.322s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_structured_property_changes",
+    "duration": "30.813s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_tag_changes",
+    "duration": "29.966s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDataProductTimeline::test_data_product_timeline_structure",
+    "duration": "15.364s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_all_categories",
+    "duration": "10.434s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_application_changes",
+    "duration": "28.663s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_documentation_changes",
+    "duration": "30.035s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_domain_changes",
+    "duration": "29.952s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_glossary_term_changes",
+    "duration": "40.104s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_ownership_changes",
+    "duration": "50.776s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_schema_changes",
+    "duration": "29.847s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_structured_property_changes",
+    "duration": "46.439s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDatasetTimeline::test_dataset_tag_changes",
+    "duration": "30.037s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_all_categories",
+    "duration": "6.105s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_documentation_changes",
+    "duration": "18.544s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_ownership_changes",
+    "duration": "56.401s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestDomainTimeline::test_domain_structured_property_changes",
+    "duration": "26.371s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_all_categories",
+    "duration": "4.944s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_application_changes",
+    "duration": "23.595s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_documentation_changes",
+    "duration": "25.084s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_domain_changes",
+    "duration": "26.368s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_ownership_changes",
+    "duration": "49.024s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_related_terms_changes",
+    "duration": "21.319s"
+  },
+  {
+    "testId": "tests.timeline.timeline_change_history_test.TestGlossaryTermTimeline::test_glossary_term_structured_property_changes",
+    "duration": "30.005s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_all",
+    "duration": "34.467s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_documentation",
+    "duration": "29.949s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_glossary",
+    "duration": "30.216s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_ownership",
+    "duration": "30.050s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_schema",
+    "duration": "29.840s"
+  },
+  {
+    "testId": "tests.timeline.timeline_test::test_tags",
+    "duration": "29.868s"
+  },
+  {
+    "testId": "tests.timeseries.test_dataset_profiles_graphql::test_dataset_profiles_graphql",
+    "duration": "95.461s"
+  },
+  {
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dashboard_stats_summary",
+    "duration": "19.871s"
+  },
+  {
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary",
+    "duration": "10.088s"
+  },
+  {
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary_duplicate_urn_in_request",
+    "duration": "10.210s"
+  },
+  {
+    "testId": "tests.timeseries.test_stats_summary_graphql::test_dataset_stats_summary_out_of_window_only",
+    "duration": "9.986s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_and_revoke_tokens_for_other_user",
+    "duration": "69.239s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_create_list_and_revoke_tokens",
+    "duration": "100.755s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_admin_can_manage_tokens_generated_by_other_user",
+    "duration": "60.636s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_create_list_revoke_tokens",
+    "duration": "30.161s"
+  },
+  {
+    "testId": "tests.tokens.revokable_access_token_test::test_non_admin_can_not_generate_tokens_for_others",
+    "duration": "42.122s"
+  },
+  {
+    "testId": "tests.tokens.session_access_token_test::test_01_soft_delete",
+    "duration": "80.823s"
+  },
+  {
+    "testId": "tests.tokens.session_access_token_test::test_02_suspend",
+    "duration": "85.925s"
+  },
+  {
+    "testId": "tests.tokens.session_access_token_test::test_03_hard_delete",
+    "duration": "60.746s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_mcp_fail_aspect_async_write",
+    "duration": "18.385s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_missing_elasticsearch_async_write",
+    "duration": "48.336s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_noop_async_write",
+    "duration": "39.967s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_noop_with_fmcp_async_write",
+    "duration": "49.924s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_overwritten_async_write",
+    "duration": "61.742s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_successful_async_write",
+    "duration": "29.683s"
+  },
+  {
+    "testId": "tests.trace.test_api_trace::test_timeseries_async_write",
+    "duration": "30.025s"
+  },
+  {
+    "testId": "tests.views.views_test::test_create_list_delete_global_view",
+    "duration": "45.100s"
+  },
+  {
+    "testId": "tests.views.views_test::test_create_list_delete_personal_view",
+    "duration": "40.716s"
+  },
+  {
+    "testId": "tests.views.views_test::test_update_global_view",
+    "duration": "0.107s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestCacheHit::test_cache_hit_skips_build_and_returns_passed",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissBuildsBothSides::test_cache_miss_builds_both_sides",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_falls_back_to_datahubenv_when_env_unset",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_cache_miss_log_names_missing_image",
+    "duration": "0.003s"
   },
   {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_neither_source_present",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_datahubenv_has_no_token_line",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_token_value_is_empty",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_strips_whitespace_from_token",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_from_env_picks_up_datahubenv_token",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_report_path_default_is_absolute",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_paths_are_invariant_to_cwd",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_writes_n_fresh_entities_and_verifies_persisted_version",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_read_probe_records_mismatch_without_failing_phase",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_write_probe_records_error_when_ingest_fails",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_no_seeded_entities_skips_read_probes",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPassthroughEnvForwarded::test_recreate_calls_include_token_service_secrets",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[206-Suite.D]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[301-Suite.N]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[323-Suite.N]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[328-Suite.N]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[403-Suite.C]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[-1]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[100]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[110]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[200]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[404]",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_passes_on_good_capture",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_killed_too_late",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_state_at_kill_wrong",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_resume_log_not_observed",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_final_count_wrong",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_skips_when_capture_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_with_too_few_advances",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_state_not_succeeded",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_env_dict_when_all_dirs_present",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestLoadScenarios::test_load_returns_full_suite_a",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_existing_worktree_synced_to_ref",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_dirty_worktree_refuses_to_clobber",
+    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_first_missing_image_returns_first_missing_ref",
     "duration": "0.002s"
   },
   {
@@ -3092,68 +2692,96 @@
     "duration": "0.002s"
   },
   {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_dirty_worktree_refuses_to_clobber",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_existing_worktree_synced_to_ref",
+    "duration": "0.005s"
+  },
+  {
     "testId": "tests.zdu.framework.test_build_images.TestEnsureWorktree::test_new_worktree_uses_resolved_sha_not_head_string",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_cli_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_datahubenv_has_no_token_after_init",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_load_scenarios_includes_6_suite_d_scenarios",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_suite_d_scenarios_use_catch_up_scenario_type",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_new_artifact_falls_back_to_rest_tag",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_old_artifact_also_falls_back",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_custom_rest_tag_via_constructor",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_build_failure_propagates",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_token_refresh_failure_is_best_effort",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestKnownFailuresSet::test_known_failure_skip_reason_matches_dict",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_does_not_remove_worktree",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_build_images.TestGradleTagPropertyName::test_build_new_passes_ptag_flag",
+    "duration": "0.003s"
   },
   {
     "testId": "tests.zdu.framework.test_build_images.TestGradleTagPropertyName::test_build_old_passes_ptag_flag",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_build_images.TestGradleTagPropertyName::test_build_new_passes_ptag_flag",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestPostBuildImageVerification::test_raises_when_image_not_in_daemon_after_build",
+    "testId": "tests.zdu.framework.test_build_images.TestMutatesConfigTags::test_run_sets_config_image_tags",
     "duration": "0.002s"
   },
   {
     "testId": "tests.zdu.framework.test_build_images.TestPostBuildImageVerification::test_passes_when_image_present_after_build",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestPostBuildImageVerification::test_raises_when_image_not_in_daemon_after_build",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestRaisesOnGradleFailure::test_gradle_nonzero_returncode_raises",
     "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestShaResolution::test_resolves_short_sha_from_git_ref",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestSkipsWhenDisabled::test_skips_when_build_images_false",
+    "duration": "0.017s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_does_not_remove_worktree",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_build_images.TestWorktreeLifecycle::test_build_old_uses_persistent_worktree",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestSeedIsNoop::test_seed_returns_empty_list",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_no_catch_up_windows_passes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_window_with_t0_ge_t1_returns_skip",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_window_with_t0_lt_t1_passes_when_gap_urns_absent",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_blocking_with_indices_skips_invariant",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_empty_blocking_indices_with_empty_nonblocking_passes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_nonblocking_captured_windows_when_blocking_empty_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestUnknownTC::test_unknown_catchup_tc_returns_skip",
+    "duration": "0.015s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_catchup_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "duration": "0.012s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestDigestFallsBackToRestTag::test_digest_pre_test_image_uses_rest_tag",
+    "duration": "0.025s"
   },
   {
     "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckLogging::test_success_logs_health_confirmation",
@@ -3164,24 +2792,8 @@
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_build_images.TestSkipsWhenDisabled::test_skips_when_build_images_false",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestCacheHit::test_cache_hit_skips_build_and_returns_passed",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_build_images.TestRaisesOnGradleFailure::test_gradle_nonzero_returncode_raises",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_cleanup.TestSkipsWhenNoSnapshot::test_skips_when_prepare_old_stack_is_none",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_cleanup.TestDigestFallsBackToRestTag::test_digest_pre_test_image_uses_rest_tag",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckTimeout::test_fails_when_gms_does_not_come_back_healthy",
+    "duration": "0.001s"
   },
   {
     "testId": "tests.zdu.framework.test_cleanup.TestNoOpWhenAlreadyOnOriginal::test_passes_without_recreate_when_gms_already_on_original_tag",
@@ -3189,26 +2801,306 @@
   },
   {
     "testId": "tests.zdu.framework.test_cleanup.TestRestoresWhenMismatched::test_recreates_with_original_tag_and_full_passthrough",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestSkipsWhenNoSnapshot::test_skips_when_prepare_old_stack_is_none",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_cleanup.TestHealthCheckTimeout::test_fails_when_gms_does_not_come_back_healthy",
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_custom_rest_tag_via_constructor",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_new_artifact_falls_back_to_rest_tag",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestDefaultAllSubStepsRun::test_all_three_sub_steps_called",
+    "testId": "tests.zdu.framework.test_cleanup.TestZduArtifactFallsBackToRestTag::test_pretest_zdu_old_artifact_also_falls_back",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_no_env_var_means_cleanup_not_skipped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_skip_cleanup_env_var_appends_to_skip_phases",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_build_dir_default_is_absolute",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_build_dir_default_lives_under_repo_root",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_paths_are_invariant_to_cwd",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_report_path_default_is_absolute",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_report_path_default_lives_under_repo_root",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_env_var_wins_over_datahubenv",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_setup_old_stack.TestCleanBuildOptOut::test_nuke_skipped_when_clean_build_false",
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_falls_back_to_datahubenv_when_env_unset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_from_env_picks_up_datahubenv_token",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_datahubenv_has_no_token_line",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_es_client",
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_neither_source_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_returns_none_when_token_value_is_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestResolveGmsToken::test_strips_whitespace_from_token",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_default_is_enabled",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_explicit_false_disables",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_explicit_zero_disables",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_unrecognized_value_keeps_default",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_prepends_live_project_prefix_to_short_volume_names",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_scenarios_have_known_alias",
+    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_underscore_in_short_name_is_NOT_treated_as_qualified",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_compose_config_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_name_field_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_output_is_not_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_returns_name_from_compose_config_json",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_empty_string_on_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_stdout_from_docker_compose_logs",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_failed_up_d_raises",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_logs_recreate_duration_before_wait_healthy",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_no_compose_env_does_not_pass_env_kwarg",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_runs_compose_up_d_with_compose_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_wait_healthy_logs_duration_on_success",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_does_not_become_dash_e_flag",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_none_does_not_override_parent_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_sets_subprocess_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_env_overrides_become_dash_e_flags",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_extra_args_appended_after_service",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_aliases_returns_text_body",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_indices_returns_text_body",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_returns_empty_string_on_error",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_404_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_returns_index_keys",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_404_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_doc_id_with_special_chars_is_double_encoded",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_returns_source",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_404_returns_zero",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_returns_count",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_404_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_returns_mappings_inner_dict",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_empty_when_no_match",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_filters_by_prefix",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestListTasks::test_flattens_nodes_and_attaches_task_id",
+    "duration": "0.016s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_finds_urn_in_results",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_missing_urn_returns_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_continues_on_per_artifact_failure",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_reader_writer_events_dump_observations_and_writes",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_skips_when_no_failures",
+    "duration": "2.760s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_upgrade_result_includes_blocking_and_nonblocking",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_phase_failure",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_failure_bundle.TestFailureBundleWriter::test_writes_bundle_on_scenario_failure",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_paths_have_trailing_slash",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_rejects_invalid_side",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_env_dict_when_all_dirs_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_any_mount_source_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_worktree_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_ingest_failure_fails_phase_with_partial_dual_write_urns",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_mysql_missing_one_urn_fails_phase",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_degenerate_single_image_case_skips_index_distinction",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_new_index_missing_doc_emits_warning",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_no_upgrade_blocking_state_skips_index_checks_entirely",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_old_index_missing_doc_emits_warning",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_writes_n_entities_and_records_dual_write_urns",
     "duration": "0.002s"
   },
   {
@@ -3216,11 +3108,19 @@
     "duration": "0.002s"
   },
   {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_ingest_failure_fails_phase",
+    "duration": "0.005s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_mysql_missing_one_urn_fails_phase",
+    "duration": "0.003s"
+  },
+  {
     "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_mysql_missing_records_full_ingested_list_on_failure",
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseHappyPath::test_writes_n_entities_and_records_gap_urns",
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseFailures::test_partial_ingest_records_partial_gap_urns_on_failure",
     "duration": "0.002s"
   },
   {
@@ -3232,339 +3132,39 @@
     "duration": "0.002s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestRefreshTokenEnvVar::test_opt_out",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_inject_traffic_pre.TestInjectTrafficPrePhaseHappyPath::test_writes_n_entities_and_records_gap_urns",
+    "duration": "0.003s"
   },
   {
-    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_io_pool_seed_aspect_is_embed",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestSeedIsNoop::test_seed_returns_empty",
+    "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_registers_test_platform_via_ingest_mcp",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_fails_when_any_urn_below_target",
+    "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenCleanBuildDisabled::test_skipped_when_clean_build_false",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_fails_when_urn_missing_schema_version",
+    "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenOldTagIsDebug::test_skipped_when_old_tag_is_debug",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_passes_when_all_urns_at_target",
+    "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_degenerate_single_image_case_skips_index_distinction",
-    "duration": "0.002s"
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_skips_when_expected_schema_version_unset",
+    "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseHappyPath::test_no_upgrade_blocking_state_skips_index_checks_entirely",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_returns_source",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_404_returns_none",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestGetDoc::test_doc_id_with_special_chars_is_double_encoded",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_recreates_services_in_order",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_no_dual_write_log_lines_yields_empty_dict",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_collapsed_debug_profile_tails_gms_when_mae_absent",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_both_services_present_first_timestamp_wins",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_returns_index_keys",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_recreate_service_failure_aborts_phase",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_none",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_empty_string",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_set_to_empty_env",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_filters_by_prefix",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestGmsUnreachable::test_fails_when_health_endpoint_unreachable",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_no_opted_in_scenarios_returns_no_failures",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_passes_at_boundary",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_fails_when_fewer_than_min",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_fails_when_any_backfill_alias_incomplete",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_skips_when_raw_empty",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_all_fields_present_returns_no_failures",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_skips_when_min_count_unset",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_passes_when_expected_in_place_update_observed",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_doc_not_found_emits_fail",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_fails_when_index_also_reindexed_with_swap",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_passes_when_swap_is_for_different_index",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_skips_when_phase4_did_not_run",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_es_client_exception_emits_fail",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_passes_when_all_phase6_indices_skipped",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_passes_when_phase6_index_absent_from_rerun",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_fails_when_rerun_produces_new_real_reindex",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_fails_when_rerun_exit_code_nonzero",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_alias_missing_next_index_name_fails",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_skips_when_phase6_baseline_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_dual_write_disabled_for_unknown_index_fails",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_rolling_restart_missing_dual_write_start_time_fails",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_passes_when_observed_matches_expected",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_fails_when_expected_reindex_is_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_fails_when_unexpected_reindex_observed",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_skips_when_expected_set_is_none",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_no_runtime_migration_returns_no_failures",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_all_passed_probes_returns_no_failures",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_failed_read_probes_emit_one_fail",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_both_modes_failing_emits_two_separate_fails",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_passes_when_all_required_keys_present",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_fails_when_required_keys_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_skips_when_raw_empty",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_no_catch_up_windows_passes",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_failed",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_batch_gms",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_field_absent",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_metadata_is_null",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_no_row",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_systemmetadata_is_json_null",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_runs_compose_up_d_with_compose_env",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_no_compose_env_does_not_pass_env_kwarg",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_logs_recreate_duration_before_wait_healthy",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_failed_up_d_raises",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_none_when_no_match",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_non_dict_payload",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_unparseable_string_falls_through_to_none",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_inserts_row_with_default_systemmetadata",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_explicit_systemmetadata_passed_through",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_commits_after_execute",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_aspect_query_failure_does_not_drop_other_aspects",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_index_doc_count_failure_does_not_drop_other_indices",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_no_upgrade_id_means_no_check",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_present_sets_flag_true",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_absent_sets_flag_false",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_dual_write_disabled_line",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_stdout_from_docker_compose_logs",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetServiceLogs::test_returns_empty_string_on_failure",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestDownAndWipeVolumeQualification::test_underscore_in_short_name_is_NOT_treated_as_qualified",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_none_when_missing",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseHappyPath::test_captures_aliases_doc_counts_and_aspects",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_env_auth_resolves_client_config",
-    "duration": "0.002s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC502ReadsMonotonicPerUrn::test_passes_when_each_urn_monotonic",
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC501WritesPersistAtTarget::test_skips_when_snapshot_missing",
     "duration": "0.001s"
   },
   {
     "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC502ReadsMonotonicPerUrn::test_fails_on_version_regression",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC502ReadsMonotonicPerUrn::test_passes_when_each_urn_monotonic",
     "duration": "0.001s"
   },
   {
@@ -3584,7 +3184,611 @@
     "duration": "0.001s"
   },
   {
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC503ConcurrentWrites::test_passes_when_all_writes_passed",
+    "duration": "0.001s"
+  },
+  {
     "testId": "tests.zdu.framework.test_live_traffic_executor.TestTC503ConcurrentWrites::test_skips_when_no_io_writes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestUnknownTc::test_unknown_tc_returns_skip",
+    "duration": "0.016s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_live_traffic_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "duration": "0.015s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_catch_up_window_line",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_dual_write_disabled_line",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_malformed_window_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_unrelated_line_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_no_match_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_batch_gms",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_completed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_cursor_heartbeat",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_started",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_unrelated_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_with_namespaced_entity",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_failed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_alias_swap_failed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_alias_swapped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_already_completed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_already_dual_write_disabled",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_empty_source_swap",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_no_indices_require_reindex",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_resuming_polling",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_unrelated_returns_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_skipped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_parse_started",
+    "duration": "2.838s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_log_monitor::test_upgrade_pattern_not_matched_by_gms",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_groups_by_schema_version_with_pymysql_string_keys",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_returns_empty_when_no_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestCountAspectsBySchemaVersion::test_unparseable_string_falls_through_to_none",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_csv_with_header_and_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestDumpZduAspectsCsv::test_returns_only_header_when_no_rows",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_first_match",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_returns_none_when_no_match",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_malformed_metadata",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFindUpgradeResultWithField::test_skips_non_dict_payload",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestFromEnvCredentials::test_mysql_credentials_from_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_dataclass",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetAspectRaw::test_returns_none_when_missing",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_int_when_present",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_on_malformed_json",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_field_absent",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_metadata_is_null",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_no_row",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetSchemaVersion::test_returns_none_when_systemmetadata_is_json_null",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_on_malformed_json",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_metadata_is_non_dict_json",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_none_when_missing",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestGetUpgradeResult::test_returns_parsed_json",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_commits_after_execute",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_explicit_systemmetadata_passed_through",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_mysql_client.TestUpsertAspectRaw::test_inserts_row_with_default_systemmetadata",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_default_is_on",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_force_nuke_overrides_skip",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_skip_nuke_opts_out",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHappyPath::test_captures_secrets_wipes_redeploys_and_waits_for_health",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestHealthCheckFailure::test_fails_when_gms_does_not_come_back",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestMissingLocalCommonEnv::test_skips_authz_env_when_not_set",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestPartialSecretCapture::test_partial_capture_filled_from_secrets_file",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestRefreshTokenEnvVar::test_default_is_on",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestRefreshTokenEnvVar::test_opt_out",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenCleanBuildDisabled::test_skipped_when_clean_build_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestSkipsWhenOldTagIsDebug::test_skipped_when_old_tag_is_debug",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestParseFlatIndicesState::test_skips_top_level_keys_without_dots",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestParseFlatIndicesState::test_unflattens_real_stack_shape",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestSeedIsNoop::test_seed_returns_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_fails_when_expected_reindex_is_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_fails_when_unexpected_reindex_observed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_passes_when_observed_matches_expected",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_skips_when_expected_set_is_none",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_skips_when_phase4_did_not_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_fails_when_unexpected_index_reindexed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_passes_when_only_expected_indices_reindexed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_skips_when_tc101_not_in_scenario_list",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_fails_when_expected_in_place_update_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_fails_when_index_also_reindexed_with_swap",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_passes_when_expected_in_place_update_observed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_passes_when_swap_is_for_different_index",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_skips_when_expected_unset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC103SettingsOnlyUpdate::test_skips_when_phase4_did_not_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_cross_check_fails_when_raw_contradicts",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_fails_when_all_swaps_are_real_reindexes",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_passes_when_empty_source_swap_present",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_fails_when_any_backfill_alias_incomplete",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_fails_when_fewer_than_min",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_passes_at_boundary",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_passes_when_three_backfill_aliases_all_completed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_skips_when_min_count_unset",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC105MultiIndexAllReindex::test_skips_when_raw_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_fails_when_only_noops",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_fails_when_only_real_reindexes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_passes_when_both_real_and_noop_observed",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_fails_when_required_keys_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_passes_when_all_required_keys_present",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_skips_when_raw_empty",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_taskid_not_required",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_fails_when_rerun_exit_code_nonzero",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_fails_when_rerun_produces_new_real_reindex",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_passes_when_all_phase6_indices_skipped",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_passes_when_phase6_index_absent_from_rerun",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_skips_when_phase6_baseline_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_skips_when_rerun_phase_did_not_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_fails_when_count_decreases",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_fails_when_index_missing_at_t1",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_passes_when_all_counts_match",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_passes_when_count_increases",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_skips_when_t0_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_skips_when_t1_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestUnknownTC::test_unknown_tc_returns_skip",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAllChecksPass::test_passes_when_stack_up_token_set_and_env_correct",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_does_not_exist",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_missing_bypass_keys",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_set_to_empty_env",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_unset",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_both_defaults_on_only_authz_env_checked",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_gms_check_skipped_when_clean_build_on",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_token_check_skipped_when_refresh_on",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestGmsUnreachable::test_fails_when_health_endpoint_unreachable",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestMultipleFailuresReportedTogether::test_all_failures_collected_in_single_run",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_empty_string",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_preflight.TestTokenMissing::test_fails_when_token_none",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_both_keys_empty_string",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestFailFastOnMissingPassthrough::test_fails_when_signing_key_missing",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestHealthCheckTimeout::test_returns_failed_when_health_check_times_out",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestNoRestartWhenAlreadyOnOld::test_passes_without_restart_when_image_matches",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPartialMismatch::test_recreates_only_mismatched_services",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestPassthroughEnvForwarded::test_recreate_calls_include_token_service_secrets",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestRecreatesWhenMismatched::test_recreates_all_services_when_running_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsAbsentServices::test_only_recreates_present_services",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenDisabled::test_skips_when_prepare_old_stack_false",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_prepare_old_stack.TestSkipsWhenTagIsDefault::test_skips_when_old_image_tag_is_debug",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_gms_service_sets_gms_and_global_vars",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_mae_service_sets_mae_and_global_vars",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_mce_service_sets_mce_and_global_vars",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_metadata_service_auth_disabled_across_restart",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_unknown_service_falls_back_to_global_only",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_zdu_reindex_flags_NOT_in_compose_env",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_both_services_present_first_timestamp_wins",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_collapsed_debug_profile_tails_gms_when_mae_absent",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_no_mae_no_gms_present_logs_warning_and_returns_empty",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_health_timeout_propagates",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_recreate_service_failure_aborts_phase",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_dual_write_timeout_does_not_hang_on_quiet_log_stream",
+    "duration": "3.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_no_dual_write_log_lines_yields_empty_dict",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseHappyPath::test_recreates_services_in_order",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_no_seeded_entities_skips_read_probes",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_read_probe_records_mismatch_without_failing_phase",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_reads_n_seeded_entities_and_records_probes",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_write_probe_records_error_when_ingest_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_runtime_migration.TestRuntimeMigrationPhase::test_writes_n_fresh_entities_and_verifies_persisted_version",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_executor::test_double_register_raises",
     "duration": "0.001s"
   },
   {
@@ -3596,143 +3800,11 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_scenario_executor::test_double_register_raises",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.authorization.test_query_entity_read_auth::test_query_entity_visible_with_subject_view",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_report_path_default_lives_under_repo_root",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_build_dir_default_is_absolute",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestOutputPathsAreRepoRootRelative::test_build_dir_default_lives_under_repo_root",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_three_versions_unlink_middle_and_latest",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_default_is_enabled",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_explicit_zero_disables",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_explicit_false_disables",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_config.TestUrnSyncEnabledEnvBinding::test_unrecognized_value_keeps_default",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_full_payload",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_missing_fields_default_to_none_or_zero",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_empty_payload_returns_empty_list",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_non_dict_alias_value_skipped",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[324-Suite.N]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[401-Suite.C]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[0]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[207]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[300]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[332]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[400]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[999]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_skips_when_capture_missing",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_killed_too_early",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_cursor_missing",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_final_upgrade_state_wrong",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_passes_when_gaps_respect_delay",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_gaps_too_small",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_final_count_wrong",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_passes_on_good_capture",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_skips_when_capture_missing",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_v1_not_fully_migrated",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_v4_rows_touched",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_state_not_succeeded",
-    "duration": "0.001s"
-  },
-  {
     "testId": "tests.zdu.framework.test_scenario_loader.TestAllSuites::test_load_scenarios_returns_combined_list",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestAllSuites::test_suite_b_count",
     "duration": "0.001s"
   },
   {
@@ -3744,27 +3816,23 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestAllSuites::test_suite_b_count",
-    "duration": "0.001s"
-  },
-  {
     "testId": "tests.zdu.framework.test_scenario_loader.TestAllSuites::test_total_scenarios_is_sum_of_suites",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_worktree_missing",
+    "testId": "tests.zdu.framework.test_scenario_loader.TestExecutorValidateTakesCtxAndFiltersByTc::test_validates_only_tc_specific_urns",
+    "duration": "0.028s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestKnownFailuresSet::test_expected_to_fail_matches_known_failures_dict",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_returns_none_when_any_mount_source_missing",
+    "testId": "tests.zdu.framework.test_scenario_loader.TestKnownFailuresSet::test_known_failure_skip_reason_matches_dict",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_rejects_invalid_side",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_host_mounts.TestWorktreeMountEnv::test_paths_have_trailing_slash",
+    "testId": "tests.zdu.framework.test_scenario_loader.TestLoadScenarios::test_load_returns_full_suite_a",
     "duration": "0.001s"
   },
   {
@@ -3784,6 +3852,10 @@
     "duration": "0.001s"
   },
   {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestScenarioFields::test_tc20_read_path_in_memory",
+    "duration": "0.001s"
+  },
+  {
     "testId": "tests.zdu.framework.test_scenario_loader.TestScenarioFields::test_tc4_embed_dashboard_multi_hop",
     "duration": "0.001s"
   },
@@ -3792,11 +3864,95 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestScenarioFields::test_tc20_read_path_in_memory",
+    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_dev_stack_skip_scenarios_have_skip_reason",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_returns_env_when_all_keys_present",
+    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_load_scenarios_includes_6_suite_d_scenarios",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_suite_d_scenarios_use_catch_up_scenario_type",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_registers_test_platform_via_ingest_mcp",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_swallows_ingest_failure",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_io_pool_seed_aspect_is_embed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestSeedIOPoolViaRest::test_seeds_io_pool_via_rest_not_mysql",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_partial_drain_resolves_on_retry",
+    "duration": "0.011s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_all_urns_present_immediately",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_es_client",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_empty_when_no_scenarios_have_known_alias",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_seed.TestWaitForESDrain::test_returns_pending_urns_on_timeout",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestCleanBuildOptOut::test_nuke_skipped_when_clean_build_false",
+    "duration": "0.030s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestDefaultAllSubStepsRun::test_all_three_sub_steps_called",
+    "duration": "0.038s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_build_failure_propagates",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_nuke_failure_propagates",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestFailurePropagation::test_token_refresh_failure_is_best_effort",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenOptOut::test_token_refresh_skipped_when_disabled",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_cli_missing",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_datahubenv_has_no_token_after_init",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_fails_when_subprocess_returns_nonzero",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_setup_old_stack.TestRefreshTokenSubprocess::test_writes_refreshed_token_to_config",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_passes_purpose_into_log_message",
     "duration": "0.001s"
   },
   {
@@ -3804,27 +3960,43 @@
     "duration": "0.001s"
   },
   {
+    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_returns_env_when_all_keys_present",
+    "duration": "0.001s"
+  },
+  {
     "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_warns_on_partial_keys_but_still_returns_what_was_captured",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_es_failure_marks_phase_failed_but_does_not_crash",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_aspect_query_failure_does_not_drop_other_aspects",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseDefensiveErrors::test_one_index_doc_count_failure_does_not_drop_other_indices",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseHappyPath::test_captures_aliases_doc_counts_and_aspects",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_no_upgrade_id_means_no_check",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_absent_sets_flag_false",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_shared.TestReadTokenPassthrough::test_passes_purpose_into_log_message",
-    "duration": "0.001s"
+    "testId": "tests.zdu.framework.test_snapshot_t0.TestSnapshotT0PhaseUpgradeResultCheck::test_upgrade_id_present_sets_flag_true",
+    "duration": "0.002s"
   },
   {
-    "testId": "test_e2e::test_frontend_auth",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestSuiteD::test_dev_stack_skip_scenarios_have_skip_reason",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC27NoMutatorsNoop::test_tc27_passes_when_chain_was_empty",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestTC27NoMutatorsNoop::test_tc27_skips_when_chain_had_mutators",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteEnum::test_all_codified_suites_present",
     "duration": "0.001s"
   },
   {
@@ -3832,31 +4004,87 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_suite.TestSuiteEnum::test_all_codified_suites_present",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[101-Suite.B]",
+    "duration": "2.758s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[109-Suite.B]",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[201-Suite.D]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestKnownFailuresSet::test_expected_to_fail_matches_known_failures_dict",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[206-Suite.D]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_build_images.TestCacheMissLogIsDiagnostic::test_first_missing_image_returns_first_missing_ref",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[301-Suite.N]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_skip_cleanup_env_var_appends_to_skip_phases",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[323-Suite.N]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_cleanup.TestZduSkipCleanupEnvVar::test_no_env_var_means_cleanup_not_skipped",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[324-Suite.N]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[328-Suite.N]",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_sweep_executor.TestUnknownTC::test_unknown_tc_returns_skip",
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[401-Suite.C]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_known_ranges[403-Suite.C]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[-1]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[0]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[100]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[110]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[200]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[207]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[300]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[332]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[400]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[404]",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_suite.TestSuiteForTc::test_unknown_returns_none[999]",
     "duration": "0.001s"
   },
   {
@@ -3864,155 +4092,223 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_scenario_loader.TestExecutorValidateTakesCtxAndFiltersByTc::test_validates_only_tc_specific_urns",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC27NoMutatorsNoop::test_tc27_passes_when_chain_was_empty",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC27NoMutatorsNoop::test_tc27_skips_when_chain_had_mutators",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_cursor_missing",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_attribution_patch[graph_client]",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_final_count_wrong",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestRefreshTokenEnvVar::test_default_is_on",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_final_upgrade_state_wrong",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_seed.TestRegisterReferencedPlatforms::test_swallows_ingest_failure",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_killed_too_early",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_killed_too_late",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_default_is_on",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_resume_log_not_observed",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_nuke_and_redeploy.TestCleanBuildEnvVars::test_skip_nuke_opts_out",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_fails_when_state_at_kill_wrong",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_passes_on_good_capture",
+    "duration": "2.821s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC324CursorResumability::test_skips_when_capture_missing",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_mae_service_sets_mae_and_global_vars",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_final_count_wrong",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_mce_service_sets_mce_and_global_vars",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_gaps_too_small",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_unknown_service_falls_back_to_global_only",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_when_state_not_succeeded",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestComposeEnvForService::test_metadata_service_auth_disabled_across_restart",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_fails_with_too_few_advances",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_indices_returns_text_body",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_passes_when_gaps_respect_delay",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_aliases_returns_text_body",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC325BatchDelay::test_skips_when_capture_missing",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestCatEndpoints::test_cat_returns_empty_string_on_error",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_state_not_succeeded",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestDualWriteTailG20d::test_no_mae_no_gms_present_logs_warning_and_returns_empty",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_v1_not_fully_migrated",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_gms_check_skipped_when_clean_build_on",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_fails_when_v4_rows_touched",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_preflight.TestConditionalSkipping::test_both_defaults_on_only_authz_env_checked",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_passes_on_good_capture",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestGetAliasTargets::test_404_returns_empty",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestTC326SkipAlreadyMigrated::test_skips_when_capture_missing",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_returns_count",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestUnknownTC::test_unknown_tc_returns_skip",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestGetDocCount::test_404_returns_zero",
+    "testId": "tests.zdu.framework.test_sweep_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
+    "duration": "0.023s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_empty_payload_returns_empty_list",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_finds_urn_in_results",
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_full_payload",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestSearchForEntity::test_missing_urn_returns_false",
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_missing_fields_default_to_none_or_zero",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_returns_mappings_inner_dict",
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestParseIndicesState::test_non_dict_alias_value_skipped",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestGetMappings::test_404_returns_empty",
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_compose_env_includes_token_service_keys",
+    "duration": "0.007s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_includes_g20a_reindex_flags",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestTokenServiceSecretsInComposeEnv::test_env_overrides_still_includes_token_keys",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_alias_swap_failure_in_log_marks_failed",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseFailures::test_nonzero_exit_marks_failed",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_no_reindex_needed_still_passes",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseHappyPath::test_records_alias_swaps_and_indices_state",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_default_new_image_tag_is_debug",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseImageTag::test_passes_new_image_tag_via_compose_env",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_deadline_hits_mid_stream_kills_process",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_timeout_kills_process_and_returns_failed",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_blocking.TestUpgradeBlockingPhaseTimeout::test_watchdog_terminates_silent_child_and_marks_timeout",
+    "duration": "1.034s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_idempotent_within_process",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_rolling_restart.TestRollingRestartPhaseFailures::test_health_timeout_propagates",
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_invokes_gradle_bootjar_when_repo_root_found",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_opt_out_via_env_var_skips_gradle",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvUnset::test_fails_when_local_common_env_unset",
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_raises_runtime_error_on_gradle_failure",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_does_not_exist",
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_runs_gradle_from_repo_root_cwd",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestEnsureUpgradeJarFresh::test_skips_when_repo_root_not_found",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_preflight.TestAuthzBypassEnvFileBroken::test_fails_when_env_file_missing_bypass_keys",
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_finds_root_with_settings_gradle_and_gradlew",
+    "duration": "0.002s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_jar_freshness.TestFindRepoRoot::test_returns_none_when_no_root_found",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_mysql_missing_one_urn_fails_phase",
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_capture_result_skipped_when_mysql_returns_none",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_captures_upgrade_nonblocking_result_on_completion",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_compose_env_includes_token_service_keys",
+    "duration": "0.003s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_upgrade_nonblocking.TestUpgradeNonBlockingPhase::test_passes_explicit_nonblocking_extra_args_to_run_upgrade_job",
+    "duration": "0.004s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_alias_missing_next_index_name_fails",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_inject_traffic_dual.TestInjectTrafficDualPhaseFailures::test_ingest_failure_fails_phase_with_partial_dual_write_urns",
+    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_all_invariants_satisfied_returns_no_failures",
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_es_client.TestListIndices::test_empty_when_no_match",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_preflight.TestMultipleFailuresReportedTogether::test_all_failures_collected_in_single_run",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_oauth_authenticated_call_succeeds",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_ingest_explicit_static_token_wins_over_env_auth",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_passes_when_all_counts_match",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_passes_when_count_increases",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC109DocCountPreservation::test_skips_when_t1_missing",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC108ReRunAfterCompleted::test_skips_when_rerun_phase_did_not_run",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_no_rolling_restart_skips_dual_write_start_time_check",
+    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_dual_write_disabled_for_unknown_index_fails",
     "duration": "0.001s"
   },
   {
@@ -4020,7 +4316,55 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC101InputDrivenReindex::test_skips_when_phase4_did_not_run",
+    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_no_rolling_restart_skips_dual_write_start_time_check",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckDualWriteState::test_rolling_restart_missing_dual_write_start_time_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_all_fields_present_returns_no_failures",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_dataset_entity_type_uses_dataset_alias",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_doc_not_found_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_es_client_exception_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_missing_field_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_no_es_client_returns_no_failures",
+    "duration": "2.821s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_no_opted_in_scenarios_returns_no_failures",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckEsFieldPresence::test_unknown_entity_type_emits_fail",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_all_passed_probes_returns_no_failures",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_both_modes_failing_emits_two_separate_fails",
+    "duration": "0.001s"
+  },
+  {
+    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_failed_read_probes_emit_one_fail",
     "duration": "0.001s"
   },
   {
@@ -4028,275 +4372,7 @@
     "duration": "0.001s"
   },
   {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC107StateShape::test_taskid_not_required",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_passes_when_empty_source_swap_present",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_fails_when_all_swaps_are_real_reindexes",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC104EmptySourceNoop::test_cross_check_fails_when_raw_contradicts",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_passes_when_both_real_and_noop_observed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_fails_when_only_real_reindexes",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC106MixedReindex::test_fails_when_only_noops",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_window_with_t0_lt_t1_passes_when_gap_urns_absent",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC303T0GeT1Noop::test_window_with_t0_ge_t1_returns_skip",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_empty_blocking_indices_with_empty_nonblocking_passes",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_nonblocking_captured_windows_when_blocking_empty_fails",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_catchup_executor.TestTC304NoPhase1Noop::test_blocking_with_indices_skips_invariant",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestParseFlatIndicesState::test_unflattens_real_stack_shape",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestParseFlatIndicesState::test_skips_top_level_keys_without_dots",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_passes_when_only_expected_indices_reindexed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_fails_when_unexpected_index_reindexed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestTC102UnchangedIndices::test_skips_when_tc101_not_in_scenario_list",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestSeedIsNoop::test_seed_returns_empty",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestXfailDispatch::test_expected_to_fail_returns_xfail_with_skip_reason",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_phase1_reindex_executor.TestUnknownTC::test_unknown_tc_returns_skip",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_completed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_skipped",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_no_match_returns_none",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_upgrade_pattern_not_matched_by_gms",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_no_indices_require_reindex",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_already_completed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_already_dual_write_disabled",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_resuming_polling",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_alias_swapped",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_empty_source_swap",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_alias_swap_failed",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_phase1_unrelated_returns_none",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_started",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_with_namespaced_entity",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor::test_parse_dual_write_unrelated_returns_none",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_env_overrides_become_dash_e_flags",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_extra_args_appended_after_service",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_sets_subprocess_env",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_does_not_become_dash_e_flag",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRunUpgradeJob::test_compose_env_none_does_not_override_parent_env",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestRecreateService::test_wait_healthy_logs_duration_on_success",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_returns_name_from_compose_config_json",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_compose_config_fails",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_output_is_not_json",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_docker_compose.TestGetProjectName::test_raises_when_name_field_missing",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_catch_up_window_line",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_unrelated_line_returns_none",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.framework.test_log_monitor.TestParseNonBlockingLine::test_malformed_window_returns_none",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_version",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_three_versions",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_three_versions_unlink_all",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.entity_versioning.test_versioning::test_link_unlink_three_versions_unlink_and_relink",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_stateful_ingestion.TestStatefulIngestion::test_first_run_processes_all_documents",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_stateful_ingestion.TestStatefulIngestion::test_force_reprocess_overrides_incremental",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_stateful_ingestion.TestStatefulIngestion::test_state_persistence_across_runs",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.test_zdu_upgrade::test_seed_phase",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.zdu.test_zdu_upgrade::test_upgrade_nonblocking_phase",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_tags_attribution_patch[openapi_graph_client]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.patch.test_dataset_patches::test_field_terms_attribution_patch[openapi_graph_client]",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_source_type_filtering.TestSourceTypeFiltering::test_default_behavior_processes_only_native",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_source_type_filtering.TestSourceTypeFiltering::test_wildcard_filter_processes_all",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_unauthenticated_request_is_rejected",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_ingest_default_sink_uses_env_auth",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_ingest_explicit_credentialless_sink_inherits_env_auth",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.oauth.test_oauth_cli_gms::test_connector_graph_client_from_recipe_datahub_api",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_local_embedding_provider.TestLocalEmbeddingProvider::test_local_embedding_server_reachable",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_local_embedding_provider.TestLocalEmbeddingProvider::test_embedding_provider_type_is_local",
-    "duration": "0.001s"
-  },
-  {
-    "testId": "tests.semantic.test_local_embedding_provider.TestLocalEmbeddingProvider::test_local_embeddings_generated_with_correct_model_key",
+    "testId": "tests.zdu.framework.test_validation.TestCheckRuntimeMigrationProbes::test_no_runtime_migration_returns_no_failures",
     "duration": "0.001s"
   }
 ]

--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -2,6 +2,7 @@
 # ABOUTME: All environment variable reads should go through this module for discoverability and maintainability.
 
 import os
+import re
 from typing import Optional
 
 # ============================================================================
@@ -137,6 +138,10 @@ def get_postgres_password() -> str:
 # ============================================================================
 
 
+# Same gate smoke.sh uses to decide whether to pass -n to pytest.
+_XDIST_WORKERS_PATTERN = re.compile(r"^[1-9][0-9]*$")
+
+
 def get_batch_count() -> int:
     """Number of test batches for parallel execution."""
     return int(os.getenv("BATCH_COUNT", "1"))
@@ -150,14 +155,20 @@ def get_batch_number() -> int:
 def get_pytest_xdist_workers() -> int:
     """pytest-xdist worker count used for a batch's parallel phase.
 
-    smoke.sh passes ``-n $PYTEST_XDIST_WORKERS`` when this is a positive
-    integer, so batch weighting uses it to tell parallel work from serial.
-    Anything unset or malformed means no xdist, i.e. one worker.
+    Deliberately mirrors smoke.sh's gate byte for byte::
+
+        if [[ "${PYTEST_XDIST_WORKERS:-0}" =~ ^[1-9][0-9]*$ ]]; then
+
+    smoke.sh is what decides whether ``-n`` is actually passed, so anything this
+    accepts that the shell rejects would have batch weighting assume parallelism
+    that never happens. That rules out surrounding whitespace and leading zeros
+    (``" 3 "``, ``"03"``), which the shell will not match, and non-ASCII digits
+    like ``"²"``, for which ``str.isdigit()`` is True but ``int()`` raises.
+    Anything unset or not matching means no xdist, i.e. one worker.
     """
-    raw = os.getenv("PYTEST_XDIST_WORKERS", "").strip()
-    if not raw.isdigit():
+    if not _XDIST_WORKERS_PATTERN.match(os.getenv("PYTEST_XDIST_WORKERS", "")):
         return 1
-    return max(1, int(raw))
+    return int(os.environ["PYTEST_XDIST_WORKERS"])
 
 
 def get_test_strategy() -> Optional[str]:

--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -138,8 +138,10 @@ def get_postgres_password() -> str:
 # ============================================================================
 
 
-# Same gate smoke.sh uses to decide whether to pass -n to pytest.
-_XDIST_WORKERS_PATTERN = re.compile(r"^[1-9][0-9]*$")
+# Same gate smoke.sh uses to decide whether to pass -n to pytest. Matched with
+# fullmatch, not $: Python's $ also matches just before a trailing newline, so
+# "3\n" would pass here while bash's =~ ^[1-9][0-9]*$ rejects it.
+_XDIST_WORKERS_PATTERN = re.compile(r"[1-9][0-9]*")
 
 
 def get_batch_count() -> int:
@@ -163,10 +165,11 @@ def get_pytest_xdist_workers() -> int:
     accepts that the shell rejects would have batch weighting assume parallelism
     that never happens. That rules out surrounding whitespace and leading zeros
     (``" 3 "``, ``"03"``), which the shell will not match, and non-ASCII digits
-    like ``"²"``, for which ``str.isdigit()`` is True but ``int()`` raises.
+    like ``"²"``, for which ``str.isdigit()`` is True but ``int()`` raises, and
+    a trailing newline (``"3\n"``), which Python's ``$`` would otherwise accept.
     Anything unset or not matching means no xdist, i.e. one worker.
     """
-    if not _XDIST_WORKERS_PATTERN.match(os.getenv("PYTEST_XDIST_WORKERS", "")):
+    if not _XDIST_WORKERS_PATTERN.fullmatch(os.getenv("PYTEST_XDIST_WORKERS", "")):
         return 1
     return int(os.environ["PYTEST_XDIST_WORKERS"])
 

--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -147,6 +147,19 @@ def get_batch_number() -> int:
     return int(os.getenv("BATCH_NUMBER", "0"))
 
 
+def get_pytest_xdist_workers() -> int:
+    """pytest-xdist worker count used for a batch's parallel phase.
+
+    smoke.sh passes ``-n $PYTEST_XDIST_WORKERS`` when this is a positive
+    integer, so batch weighting uses it to tell parallel work from serial.
+    Anything unset or malformed means no xdist, i.e. one worker.
+    """
+    raw = os.getenv("PYTEST_XDIST_WORKERS", "").strip()
+    if not raw.isdigit():
+        return 1
+    return max(1, int(raw))
+
+
 def get_test_strategy() -> Optional[str]:
     """Test execution strategy (e.g., 'cypress')."""
     return os.getenv("TEST_STRATEGY")


### PR DESCRIPTION
## Summary

Pytest smoke batches run in parallel, so wall clock is set by the **slowest** batch. Measured on `master` after #18881, pytest time per batch ranges 6.4m → 14.4m — a **2.25x spread**, with phase 1 alone at **3.56x**.

Two independent causes, both fixed here. Neither is sufficient alone.

### 1. The cost model ignored that half the work is serial

`smoke.sh` runs each batch as two pytest invocations: non-mutator tests under xdist (`-n N --dist=loadscope`), then policy mutators **serially**. A serial minute therefore costs ~N times a parallel one — but `bin_pack_tasks` balanced raw summed duration, which prices them identically.

Measured, not theorised: batch 0 spends 4.4 of its 13.9 pytest minutes in the serial phase; batch 1 spends 7.3 of 11.3. Batch weight is now `parallel_seconds / xdist_workers + serial_seconds`.

### 2. The weights were 18% stale, concentrated where it mattered most

The committed weights predate #18881, which removed redundant per-write waits. On the 1054 tests in both sets the new medians are **18% lower** — independently consistent with the ~17% CI wall-clock drop measured on `master` after that merge.

The staleness was not evenly spread:

| test | old | new |
|---|---|---|
| `test_document_crud::test_update_related_entities` | 197s | **30s** |
| `session_access_token_test::test_01_soft_delete` | 188s | **81s** |
| `document_search_filter_test::test_search_across_entities...` | 100s | **15s** |
| `test_document_hierarchy_settings::test_search_ownership...` | 105s | **45s** |

The packer believed the document tests were among the most expensive in the suite when they are now among the cheapest. **This is why the algorithm looked correct while the result was not** — fed these weights, the packer predicted every batch was *equal* while reality was 2.25x apart. No amount of packing sophistication fixes wrong input, which is why both halves are needed.

## Expected effect

| weights | packing | predicted max | spread |
|---|---|---|---|
| old | sum (today) | 15.4m | 1.75x |
| old | phase-aware only | 10.2m | 1.00x |
| new | sum only | 12.9m | 1.61x |
| **new** | **phase-aware (this PR)** | **9.9m** | **1.07x** |

~14.4m → ~9.9m of pytest time, roughly **4.5 min off every CI run**.

## Reviewing this

Three files, but only two are hand-written:

- `smoke-test/conftest.py` — the cost model (~40 lines)
- `smoke-test/tests/utilities/env_vars.py` — `get_pytest_xdist_workers()`, mirroring `smoke.sh`'s `^[1-9][0-9]*$` gate byte for byte so the two can't disagree about whether xdist is on
- `smoke-test/pytest_test_weights.json` — **generated**, safe to skim. Produced by `.github/scripts/generate_test_weights.py` (the same script the weekly workflow runs) over junit artifacts from two post-#18881 runs: `31147828186` (all 7 batches green) and `31142891680` (`master`'s 6 healthy batches). The whole file moves because the generator now sorts alphabetically while the committed file predates that and was duration-sorted.

The scheduled weekly refresh could not produce these weights: `master` has had exactly one run since the merge and it was red, so the workflow would have sampled pre-#18881 durations and made things worse.

## Safety

- **No behaviour change without xdist.** With `PYTEST_XDIST_WORKERS` unset the formula collapses to the plain sum — the previous behaviour, and correct, since both phases are then serial.
- **`bin_pack_tasks` is untouched**, as `tests/cypress/integration_test.py` shares it. Only the weight handed to it changes.
- Collected all 7 batches with and without xdist: all 1122 tests accounted for in both configurations.

## Caveats

- The predicted spreads come from a model that previously said "1.00x" while reality was 2.25x, so treat 1.07x as directional. The weights are measured from real runs and are the trustworthy half.
- Two sample runs rather than the workflow's usual three, so medians are noisier. The weekly job will supersede them with a wider sample.
- `tests/entity_graph_cache` remains the binding floor: `--dist=loadscope` pins a module to one worker, so no packing can go below the heaviest single module. Splitting it, and the ~6-7 min of fixed per-batch overhead, are the next levers.

## Test plan

- [x] Simulated old vs new packing through the real `bin_pack_tasks` against both weight sets
- [x] Collected all 7 batches with `PYTEST_XDIST_WORKERS=3` and unset — no test loss, no-xdist behaviour unchanged
- [x] Verified the xdist parser agrees with `smoke.sh` on `' 3 '`, `'03'`, `'0'`, `'3'`, `'12'`, `'²'`, `'x'`, `''`, `'-1'`, unset
- [x] `./gradlew :smoke-test:lintFix` (ruff + mypy clean)
- [ ] CI: confirm the observed per-batch spread narrows and the slowest batch drops
