### PR TITLE
fix(cli/migrate): skip containers missing subTypes instead of aborting

### DIFF
--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -179,12 +179,7 @@ def _first_sub_type(container: Dict[str, Any]) -> Optional[str]:
     shows up in the env-wide listing without this aspect, so callers must treat
     a missing value as "not a migration candidate" rather than an error.
     """
-    type_names = (
-        container.get("aspects", {})
-        .get("subTypes", {})
-        .get("value", {})
-        .get("typeNames")
-    )
+    type_names = _aspect_value(container, "subTypes").get("typeNames")
     if not type_names:
         return None
     return type_names[0]
@@ -192,12 +187,20 @@ def _first_sub_type(container: Dict[str, Any]) -> Optional[str]:
 
 def _custom_properties(container: Dict[str, Any]) -> Optional[Dict[str, str]]:
     """customProperties from a container's containerProperties aspect, or None."""
-    return (
-        container.get("aspects", {})
-        .get("containerProperties", {})
-        .get("value", {})
-        .get("customProperties")
-    )
+    return _aspect_value(container, "containerProperties").get("customProperties")
+
+
+def _aspect_value(container: Dict[str, Any], aspect_name: str) -> Dict[str, Any]:
+    """The `value` payload of one aspect, or {} if absent or explicitly null.
+
+    `.get(key, {})` is not enough here: these payloads come off the wire, so a
+    key can be present with a null value, and the default only applies when the
+    key is missing. Coalesce at every level so a malformed entry is skipped
+    rather than raising.
+    """
+    aspects = container.get("aspects") or {}
+    aspect = aspects.get(aspect_name) or {}
+    return aspect.get("value") or {}
 
 
 def _migrate_containers(

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -172,6 +172,34 @@ def _run_entity_migration(
     return _run_migration(graph, pairs, options)
 
 
+def _first_sub_type(container: Dict[str, Any]) -> Optional[str]:
+    """First declared subType of a container, or None if it has none.
+
+    A container mid-write (or one whose subTypes aspect was never populated)
+    shows up in the env-wide listing without this aspect, so callers must treat
+    a missing value as "not a migration candidate" rather than an error.
+    """
+    type_names = (
+        container.get("aspects", {})
+        .get("subTypes", {})
+        .get("value", {})
+        .get("typeNames")
+    )
+    if not type_names:
+        return None
+    return type_names[0]
+
+
+def _custom_properties(container: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """customProperties from a container's containerProperties aspect, or None."""
+    return (
+        container.get("aspects", {})
+        .get("containerProperties", {})
+        .get("value", {})
+        .get("customProperties")
+    )
+
+
 def _migrate_containers(
     env: str,
     platform: str,
@@ -194,10 +222,21 @@ def _migrate_containers(
     skipped_count = 0
     try:
         for container in progressbar.progressbar(containers, redirect_stdout=True):
-            subType = container["aspects"]["subTypes"]["value"]["typeNames"][0]
-            customProperties = container["aspects"]["containerProperties"]["value"][
-                "customProperties"
-            ]
+            # _get_containers_for_migration returns every container in the env,
+            # including ones this migration will filter out below. Reading the
+            # aspects defensively keeps an unrelated container -- one still being
+            # written, or one that legitimately has no subTypes -- from aborting
+            # the whole run before should_migrate() ever gets to skip it.
+            subType = _first_sub_type(container)
+            customProperties = _custom_properties(container)
+            if subType is None or customProperties is None:
+                log.debug(
+                    f"{container.get('urn')} is missing subTypes/containerProperties, "
+                    "skipping.. (not a migration candidate)"
+                )
+                skipped_count += 1
+                continue
+
             if not should_migrate(customProperties):
                 log.debug(
                     f"{container['urn']} does not match filter criteria, skipping.. "

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -11,6 +11,7 @@ from datahub.emitter.mce_builder import (
     make_data_platform_urn,
     make_dataplatform_instance_urn,
 )
+from datahub.emitter.mcp_builder import DatabaseKey
 from datahub.metadata.schema_classes import (
     DataPlatformInstanceClass,
     EditableSchemaFieldInfoClass,
@@ -879,22 +880,21 @@ class TestMigrateContainers:
         assert instances[0].instance == make_dataplatform_instance_urn(
             "snowflake", "newinst"
         )
-        # Migration emits to the regenerated destination URN, never the source,
-        # so assert on shape: exactly one destination, and no malformed source
-        # leaked through.
-        emitted_urns = {c.args[0].entityUrn for c in emitter.emit_mcp.call_args_list}
-        assert len(emitted_urns) == 1, (
-            f"expected exactly one destination container, got {emitted_urns}"
+        # Migration emits to the regenerated destination URN, never the source.
+        # Derive the expected destination the same way _migrate_containers does,
+        # so this pins *which* container migrated rather than just how many --
+        # a malformed one migrating by mistake would produce a different guid.
+        expected_key = DatabaseKey.model_validate(
+            migratable["aspects"]["containerProperties"]["value"]["customProperties"]
         )
-        assert emitted_urns.isdisjoint(
-            {
-                "urn:li:container:noaspects",
-                "urn:li:container:nosubtypes",
-                "urn:li:container:emptytypenames",
-                "urn:li:container:noprops",
-                "urn:li:container:goodguid",
-            }
-        ), f"emitted to a source URN rather than the destination: {emitted_urns}"
+        expected_key.instance = "newinst"
+        expected_dst = f"urn:li:container:{expected_key.guid()}"
+
+        emitted_urns = {c.args[0].entityUrn for c in emitter.emit_mcp.call_args_list}
+        assert emitted_urns == {expected_dst}, (
+            f"expected only the valid container to migrate, to {expected_dst}; "
+            f"got {emitted_urns}"
+        )
 
 
 # --- checkpoint / resume ---

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -879,10 +879,22 @@ class TestMigrateContainers:
         assert instances[0].instance == make_dataplatform_instance_urn(
             "snowflake", "newinst"
         )
-        migrated_urns = {c.args[0].entityUrn for c in emitter.emit_mcp.call_args_list}
-        assert migrated_urns == {"urn:li:container:goodguid"}, (
-            f"a malformed container was migrated: {migrated_urns}"
+        # Migration emits to the regenerated destination URN, never the source,
+        # so assert on shape: exactly one destination, and no malformed source
+        # leaked through.
+        emitted_urns = {c.args[0].entityUrn for c in emitter.emit_mcp.call_args_list}
+        assert len(emitted_urns) == 1, (
+            f"expected exactly one destination container, got {emitted_urns}"
         )
+        assert emitted_urns.isdisjoint(
+            {
+                "urn:li:container:noaspects",
+                "urn:li:container:nosubtypes",
+                "urn:li:container:emptytypenames",
+                "urn:li:container:noprops",
+                "urn:li:container:goodguid",
+            }
+        ), f"emitted to a source URN rather than the destination: {emitted_urns}"
 
 
 # --- checkpoint / resume ---

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -865,15 +865,23 @@ class TestMigrateContainers:
             rest_emitter=emitter,
         )
 
-        # The one valid container still migrates.
+        # Exactly one container migrates -- the valid one. Asserting the count,
+        # not just "at least one", is what catches a malformed container being
+        # migrated instead of skipped.
         instances = [
             c.args[0].aspect
             for c in emitter.emit_mcp.call_args_list
             if isinstance(c.args[0].aspect, DataPlatformInstanceClass)
         ]
-        assert instances, "valid container was not migrated"
-        assert instances[-1].instance == make_dataplatform_instance_urn(
+        assert len(instances) == 1, (
+            f"expected only the valid container to migrate, got {len(instances)}"
+        )
+        assert instances[0].instance == make_dataplatform_instance_urn(
             "snowflake", "newinst"
+        )
+        migrated_urns = {c.args[0].entityUrn for c in emitter.emit_mcp.call_args_list}
+        assert migrated_urns == {"urn:li:container:goodguid"}, (
+            f"a malformed container was migrated: {migrated_urns}"
         )
 
 

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -819,20 +819,17 @@ class TestMigrateContainers:
         """
         from datahub.cli.migrate import _migrate_containers
 
+        good_props = {
+            "platform": "snowflake",
+            "instance": "oldinst",
+            "env": "PROD",
+            "database": "db1",
+        }
         migratable = {
             "urn": "urn:li:container:goodguid",
             "aspects": {
                 "subTypes": {"value": {"typeNames": ["Database"]}},
-                "containerProperties": {
-                    "value": {
-                        "customProperties": {
-                            "platform": "snowflake",
-                            "instance": "oldinst",
-                            "env": "PROD",
-                            "database": "db1",
-                        }
-                    }
-                },
+                "containerProperties": {"value": {"customProperties": good_props}},
             },
         }
         mock_get.return_value = [
@@ -884,9 +881,7 @@ class TestMigrateContainers:
         # Derive the expected destination the same way _migrate_containers does,
         # so this pins *which* container migrated rather than just how many --
         # a malformed one migrating by mistake would produce a different guid.
-        expected_key = DatabaseKey.model_validate(
-            migratable["aspects"]["containerProperties"]["value"]["customProperties"]
-        )
+        expected_key = DatabaseKey.model_validate(good_props)
         expected_key.instance = "newinst"
         expected_dst = f"urn:li:container:{expected_key.guid()}"
 

--- a/metadata-ingestion/tests/unit/cli/test_migrate.py
+++ b/metadata-ingestion/tests/unit/cli/test_migrate.py
@@ -804,6 +804,78 @@ class TestMigrateContainers:
         )
         emitter.emit_mcp.assert_not_called()
 
+    @patch("datahub.cli.migrate._process_container_relationships")
+    @patch("datahub.cli.migration_utils.clone_aspect", return_value=[])
+    @patch("datahub.cli.migrate._get_containers_for_migration")
+    def test_skips_containers_missing_aspects(
+        self, mock_get: MagicMock, _mock_clone: MagicMock, _mock_rels: MagicMock
+    ) -> None:
+        """Containers without subTypes/containerProperties are skipped, not fatal.
+
+        The listing covers every container in the env, so it can include ones
+        still being written or ones that never had these aspects. They are not
+        migration candidates, and must not abort the containers that are.
+        """
+        from datahub.cli.migrate import _migrate_containers
+
+        migratable = {
+            "urn": "urn:li:container:goodguid",
+            "aspects": {
+                "subTypes": {"value": {"typeNames": ["Database"]}},
+                "containerProperties": {
+                    "value": {
+                        "customProperties": {
+                            "platform": "snowflake",
+                            "instance": "oldinst",
+                            "env": "PROD",
+                            "database": "db1",
+                        }
+                    }
+                },
+            },
+        }
+        mock_get.return_value = [
+            {"urn": "urn:li:container:noaspects", "aspects": {}},
+            {
+                "urn": "urn:li:container:nosubtypes",
+                "aspects": {"containerProperties": {"value": {"customProperties": {}}}},
+            },
+            {
+                "urn": "urn:li:container:emptytypenames",
+                "aspects": {
+                    "subTypes": {"value": {"typeNames": []}},
+                    "containerProperties": {"value": {"customProperties": {}}},
+                },
+            },
+            {
+                "urn": "urn:li:container:noprops",
+                "aspects": {"subTypes": {"value": {"typeNames": ["Database"]}}},
+            },
+            migratable,
+        ]
+        emitter = MagicMock()
+        _migrate_containers(
+            env="PROD",
+            platform="snowflake",
+            target_instance="newinst",
+            should_migrate=lambda props: True,
+            dry_run=False,
+            hard=False,
+            keep=True,
+            rest_emitter=emitter,
+        )
+
+        # The one valid container still migrates.
+        instances = [
+            c.args[0].aspect
+            for c in emitter.emit_mcp.call_args_list
+            if isinstance(c.args[0].aspect, DataPlatformInstanceClass)
+        ]
+        assert instances, "valid container was not migrated"
+        assert instances[-1].instance == make_dataplatform_instance_urn(
+            "snowflake", "newinst"
+        )
+
 
 # --- checkpoint / resume ---
 


### PR DESCRIPTION
## Summary

`datahub migrate instance2instance` can abort with `KeyError('subTypes')` because of a container it was never going to migrate.

`_migrate_containers` extracts two aspects with hard indexing:

```python
subType = container["aspects"]["subTypes"]["value"]["typeNames"][0]
customProperties = container["aspects"]["containerProperties"]["value"]["customProperties"]
if not should_migrate(customProperties):   # <-- filtering happens *after*
```

But `_get_containers_for_migration(env)` lists **every** container in the environment (`get_urns_by_filter(entity_types=["container"], env=env)`) — the `--platform`/instance filtering is applied afterwards, by `should_migrate`. So a single container lacking `subTypes` raises before the filter can skip it, and takes down the entire run along with every container that *was* a valid candidate.

## How it shows up

Intermittent CI failures in `tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py`:

```
assert 1 == 0
 +  where 1 = <Result KeyError('subTypes')>.exit_code
```

Three tests in that module fail together, the CLI having crashed rather than the assertion being wrong. It is timing-dependent: the smoke suite runs under `pytest-xdist`, so whether some *other* worker happens to have a container mid-write (present in the search index, `subTypes` not yet materialised) decides whether the run survives. It appears and disappears with no change to the migration code, which makes it easy to misattribute to whatever else is in flight.

## Change

Read both aspects defensively via two small helpers and treat a missing value as "not a migration candidate" — skipped and counted, exactly like any other non-matching container. Valid containers in the same listing migrate normally.

The `.get()` chains also cover the genuine case: a container that legitimately has no `subTypes` is simply not migratable, and previously produced a crash rather than a skip.

## Test plan

- [x] New unit test `TestMigrateContainers::test_skips_containers_missing_aspects` feeds the listing four malformed containers (no `aspects`, no `subTypes`, empty `typeNames`, no `containerProperties`) alongside one valid one, and asserts the valid one still migrates
- [x] Existing `TestMigrateContainers` tests unchanged and still assert the normal path
- [x] `ruff check` / `ruff format` clean

Not fixed here, worth noting: the smoke test scans env-wide container state while other tests concurrently create containers, so it is inherently sensitive to cross-test interference. This change removes the crash, but scoping that test's fixture data would be a further improvement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `datahub migrate instance2instance` crashing on containers missing `subTypes` or `containerProperties` by reading aspects defensively and skipping them. Keeps migrations running and stabilizes CI.

- **Bug Fixes**
  - Read aspects via `_first_sub_type`, `_custom_properties`, and `_aspect_value`; treat absent or null payloads as missing and skip.
  - Tightens `test_skips_containers_missing_aspects` to assert exactly one migration and verify the migrated destination URN derived via `DatabaseKey`; also checks the emitted `DataPlatformInstance`.

<sup>Written for commit b89a68106390719f8b315454c18ef93220905229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

