### PR TITLE
fix(smoke-test): retry relatedDocuments lookup instead of a fixed sleep

### DIFF
--- a/smoke-test/tests/knowledge/document_search_filter_test.py
+++ b/smoke-test/tests/knowledge/document_search_filter_test.py
@@ -17,6 +17,7 @@ import uuid
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,50 @@ def _create_document(
         assert "errors" not in update_res, f"GraphQL errors: {update_res.get('errors')}"
 
     return urn
+
+
+@with_test_retry()
+def _fetch_related_documents(auth_session, dataset_urn: str, expected_doc_urn: str):
+    """Read an entity's relatedDocuments, retrying until the document shows up.
+
+    relatedDocuments is a reverse relationship lookup served by the graph index,
+    so it only reflects the write once the MCL has been consumed *and* indexed.
+    Waiting on the consumer offset does not cover the indexing step, and a fixed
+    sleep is just a guess at how long that takes on any given runner -- retry
+    instead, matching test_scroll_lineage.py::_assert_lineage_edges.
+    """
+    related_query = """
+        query GetDatasetDocs($urn: String!, $input: RelatedDocumentsInput!) {
+          dataset(urn: $urn) {
+            relatedDocuments(input: $input) {
+              total
+              documents {
+                urn
+                info { title }
+                settings { showInGlobalContext }
+              }
+            }
+          }
+        }
+    """
+    related_vars = {
+        "urn": dataset_urn,
+        "input": {"start": 0, "count": 100},
+    }
+    related_res = execute_graphql(auth_session, related_query, related_vars)
+    assert "errors" not in related_res, f"GraphQL errors: {related_res.get('errors')}"
+
+    related_docs = related_res["data"]["dataset"]["relatedDocuments"]
+    found_urns = [doc["urn"] for doc in related_docs["documents"]]
+
+    # Context-only document SHOULD appear in relatedDocuments. This is the key
+    # distinction: relatedDocuments shows context docs, global search does not.
+    assert expected_doc_urn in found_urns, (
+        f"Context-only document {expected_doc_urn} SHOULD appear in relatedDocuments. "
+        f"Found: {found_urns}. "
+        f"Context documents are meant to be discovered through their related entities."
+    )
+    return related_docs
 
 
 def _delete_document(auth_session, urn: str):
@@ -349,45 +394,9 @@ def test_related_documents_shows_context_only_documents(auth_session):
     assert "errors" not in update_res, f"GraphQL errors: {update_res.get('errors')}"
 
     wait_for_writes_to_sync(mae_only=True)
-    time.sleep(5)  # Wait for search indexing
-
-    # Query relatedDocuments on the dataset
-    related_query = """
-        query GetDatasetDocs($urn: String!, $input: RelatedDocumentsInput!) {
-          dataset(urn: $urn) {
-            relatedDocuments(input: $input) {
-              total
-              documents {
-                urn
-                info { title }
-                settings { showInGlobalContext }
-              }
-            }
-          }
-        }
-    """
-    related_vars = {
-        "urn": dataset_urn,
-        "input": {"start": 0, "count": 100},
-    }
 
     try:
-        related_res = execute_graphql(auth_session, related_query, related_vars)
-        assert "errors" not in related_res, (
-            f"GraphQL errors: {related_res.get('errors')}"
-        )
-
-        related_docs = related_res["data"]["dataset"]["relatedDocuments"]
-        found_urns = [doc["urn"] for doc in related_docs["documents"]]
-
-        # Context-only document SHOULD appear in relatedDocuments
-        # This is the key distinction: relatedDocuments shows context docs,
-        # while global search does not.
-        assert doc_urn in found_urns, (
-            f"Context-only document {doc_urn} SHOULD appear in relatedDocuments. "
-            f"Found: {found_urns}. "
-            f"Context documents are meant to be discovered through their related entities."
-        )
+        related_docs = _fetch_related_documents(auth_session, dataset_urn, doc_urn)
 
         # Verify it has showInGlobalContext=false
         our_doc = next(

--- a/smoke-test/tests/knowledge/document_search_filter_test.py
+++ b/smoke-test/tests/knowledge/document_search_filter_test.py
@@ -15,11 +15,16 @@ import time
 import uuid
 
 import pytest
+import tenacity
 
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import with_test_retry
+from tests.utils import get_sleep_info
 
 logger = logging.getLogger(__name__)
+
+# Same env-driven timing as with_test_retry(), but scoped to a single retryable
+# condition (see _fetch_related_documents) rather than any exception.
+_RETRY_SLEEP, _RETRY_TIMES = get_sleep_info()
 
 
 def execute_graphql(
@@ -91,7 +96,16 @@ def _create_document(
     return urn
 
 
-@with_test_retry()
+class _DocumentNotIndexedYet(Exception):
+    """The document is not visible in the graph index yet -- worth retrying."""
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(_RETRY_TIMES),
+    wait=tenacity.wait_fixed(_RETRY_SLEEP),
+    retry=tenacity.retry_if_exception_type(_DocumentNotIndexedYet),
+    reraise=True,
+)
 def _fetch_related_documents(auth_session, dataset_urn: str, expected_doc_urn: str):
     """Read an entity's relatedDocuments, retrying until the document shows up.
 
@@ -100,6 +114,10 @@ def _fetch_related_documents(auth_session, dataset_urn: str, expected_doc_urn: s
     Waiting on the consumer offset does not cover the indexing step, and a fixed
     sleep is just a guess at how long that takes on any given runner -- retry
     instead, matching test_scroll_lineage.py::_assert_lineage_edges.
+
+    Only the not-yet-indexed case retries. An HTTP error or a GraphQL error
+    payload is not transient, so it propagates on the first attempt rather than
+    costing every genuine failure the full retry budget.
     """
     related_query = """
         query GetDatasetDocs($urn: String!, $input: RelatedDocumentsInput!) {
@@ -127,11 +145,12 @@ def _fetch_related_documents(auth_session, dataset_urn: str, expected_doc_urn: s
 
     # Context-only document SHOULD appear in relatedDocuments. This is the key
     # distinction: relatedDocuments shows context docs, global search does not.
-    assert expected_doc_urn in found_urns, (
-        f"Context-only document {expected_doc_urn} SHOULD appear in relatedDocuments. "
-        f"Found: {found_urns}. "
-        f"Context documents are meant to be discovered through their related entities."
-    )
+    if expected_doc_urn not in found_urns:
+        raise _DocumentNotIndexedYet(
+            f"Context-only document {expected_doc_urn} SHOULD appear in relatedDocuments. "
+            f"Found: {found_urns}. "
+            f"Context documents are meant to be discovered through their related entities."
+        )
     return related_docs
 
 


### PR DESCRIPTION
## Summary

`test_related_documents_shows_context_only_documents` started failing on `master` after #18881 — twice on the merge commit's own run (`31142891680`), including on the retry attempt.

The retry attempt is the informative one: it ran that module's 4 tests alone, under minimal load, with `DATAHUB_TEST_FORCE_LEGACY_WAIT=true`, and still returned `Found: []`. So this is not the offset-checkpoint wait, and not concurrency pressure.

## What the test does

Creates a context-only document (`showInGlobalContext=false`), links it to the bootstrap `SampleKafkaDataset` via `updateDocumentRelatedEntities`, then does a **reverse** lookup — `dataset.relatedDocuments` — and asserts the document comes back. It guards a real product behaviour: context documents are deliberately hidden from global search but must stay discoverable through the entity they're attached to.

## Why it broke

The writes are synchronous — `DocumentService` uses `entityClient.ingestProposal(opContext, mcp, false)` throughout, so MySQL is written and the MCL produced and acked in-request, with nothing going to the MCP topic. `wait_for_writes_to_sync(mae_only=True)` is therefore the *correct* scope, and widening it would only add unrelated waiting.

But the assertion needs one more hop than any consumer-offset wait covers: `relatedDocuments` is served by the **graph index**, which is written after the MCL is consumed. The test covered that hop with `time.sleep(5)` — a guess at indexing latency on whatever runner it lands on.

That guess only held because it was padded. Before #18881, each of the four writes in this test auto-waited with the full default wait plus its own trailing ES-refresh sleep. #18881 batched those away (correctly — nothing reads between them), which left the fixed sleep as the sole cover, and it isn't reliably enough in CI.

## Change

Move the query and assertion into a `@with_test_retry()` helper, matching `test_scroll_lineage.py::_assert_lineage_edges`. This bounds indexing latency instead of guessing it, and removes the unconditional 5s sleep — so it costs nothing when the first attempt succeeds, which is the normal case.

## Test plan

- [x] Full module (4 tests) against a live instance under `-n 3 --dist=loadscope`, matching CI's shape — 4 passed
- [x] `./gradlew :smoke-test:lintFix` (ruff + mypy clean)
- [ ] CI on master after merge — the real check, since this did not reproduce locally either before or after the change

## Note

I could not reproduce the original failure locally, before or after this change, so this is a fix for a CI-only failure. The reasoning above is derived from the logs and the write path rather than from a local repro; the retry is the right shape regardless, since a single-shot assertion on an eventually-consistent index is fragile whatever the underlying latency turns out to be.

Related: #18881 (cause), #18960 (batch rebalancing), #18961 (an unrelated CI flake in `migrate.py`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the relatedDocuments smoke test by polling the reverse lookup until the document is indexed and failing fast on real errors. Removes the fixed 5s sleep to cut unnecessary waiting and fix CI flakes after batching changes.

- **Bug Fixes**
  - Added `_fetch_related_documents` using `tenacity` to retry only when the document isn’t indexed; HTTP/GraphQL errors surface immediately.
  - Removed the hardcoded sleep; kept `wait_for_writes_to_sync(mae_only=True)` and use `get_sleep_info()` for retry timing to avoid extra wait when indexing is fast.

<sup>Written for commit cede3bd4d8aa0f9a445d434c13407478f98bf719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

