### PR TITLE
perf(dataproducts): Improve some batching in data product batch mutations

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DataProductResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataproduct/DataProductResolverUtils.java
@@ -6,6 +6,8 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.metadata.service.DataProductService;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 /** Utility methods shared across Data Product GraphQL resolvers. */
@@ -27,11 +29,16 @@ public class DataProductResolverUtils {
       @Nonnull final List<String> resources,
       @Nonnull final QueryContext context,
       @Nonnull final DataProductService dataProductService) {
-    for (String resource : resources) {
-      final Urn resourceUrn = UrnUtils.getUrn(resource);
-      if (!dataProductService.verifyEntityExists(context.getOperationContext(), resourceUrn)) {
+    final List<Urn> resourceUrns =
+        resources.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+    final Set<Urn> existingUrns =
+        dataProductService.filterExistingUrns(context.getOperationContext(), resourceUrns);
+
+    for (Urn resourceUrn : resourceUrns) {
+      if (!existingUrns.contains(resourceUrn)) {
         throw new RuntimeException(
-            String.format("Failed to update data products, resource %s does not exist", resource));
+            String.format(
+                "Failed to update data products, resource %s does not exist", resourceUrn));
       }
     }
   }
@@ -66,11 +73,16 @@ public class DataProductResolverUtils {
       @Nonnull final List<String> resources,
       @Nonnull final QueryContext context,
       @Nonnull final DataProductService dataProductService) {
-    for (String resource : resources) {
-      final Urn resourceUrn = UrnUtils.getUrn(resource);
-      if (!dataProductService.verifyEntityExists(context.getOperationContext(), resourceUrn)) {
+    final List<Urn> resourceUrns =
+        resources.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+    final Set<Urn> existingUrns =
+        dataProductService.filterExistingUrns(context.getOperationContext(), resourceUrns);
+
+    for (Urn resourceUrn : resourceUrns) {
+      if (!existingUrns.contains(resourceUrn)) {
         throw new RuntimeException(
-            String.format("Failed to update data products, resource %s does not exist", resource));
+            String.format(
+                "Failed to update data products, resource %s does not exist", resourceUrn));
       }
       if (!DataProductAuthorizationUtils.isAuthorizedToUpdateDataProductsForEntity(
           context, resourceUrn)) {
@@ -92,8 +104,16 @@ public class DataProductResolverUtils {
       @Nonnull final List<String> dataProductUrns,
       @Nonnull final QueryContext context,
       @Nonnull final DataProductService dataProductService) {
-    for (String dataProductUrn : dataProductUrns) {
-      verifyDataProduct(dataProductUrn, context, dataProductService);
+    final List<Urn> urns =
+        dataProductUrns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+    final Set<Urn> existingUrns =
+        dataProductService.filterExistingUrns(context.getOperationContext(), urns);
+
+    for (Urn urn : urns) {
+      if (!existingUrns.contains(urn)) {
+        throw new RuntimeException(
+            String.format("Failed to update data products, data product %s does not exist", urn));
+      }
     }
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchAddToDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchAddToDataProductsResolverTest.java
@@ -11,8 +11,12 @@ import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.BatchSetDataProductsInput;
 import com.linkedin.metadata.service.DataProductService;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -25,13 +29,28 @@ public class BatchAddToDataProductsResolverTest {
   private static final String TEST_DATA_PRODUCT_URN_1 = "urn:li:dataProduct:test-product-1";
   private static final String TEST_DATA_PRODUCT_URN_2 = "urn:li:dataProduct:test-product-2";
 
+  private static void mockExistingUrns(DataProductService mockService, Urn... existingUrns) {
+    final Set<Urn> existing = new HashSet<>(List.of(existingUrns));
+    Mockito.when(mockService.filterExistingUrns(any(), anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream().filter(existing::contains).collect(Collectors.toSet());
+            });
+  }
+
   @Test
   public void testGetSuccessMultipleDataProducts() throws Exception {
     DataProductService mockService = Mockito.mock(DataProductService.class);
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    mockExistingUrns(
+        mockService,
+        UrnUtils.getUrn(TEST_RESOURCE_URN_1),
+        UrnUtils.getUrn(TEST_RESOURCE_URN_2),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_2));
 
     BatchAddToDataProductsResolver resolver =
         new BatchAddToDataProductsResolver(mockService, mockFeatureFlags);
@@ -47,8 +66,8 @@ public class BatchAddToDataProductsResolverTest {
 
     assertTrue(resolver.get(mockEnv).get());
 
-    Mockito.verify(mockService, Mockito.times(4))
-        .verifyEntityExists(any(), any()); // 2 resources + 2 data products
+    Mockito.verify(mockService, Mockito.times(2))
+        .filterExistingUrns(any(), any()); // 1 batched call for resources + 1 for data products
     Mockito.verify(mockService, Mockito.times(2))
         .batchAddToDataProduct(any(), any(Urn.class), anyList()); // 2 data products
   }
@@ -59,7 +78,10 @@ public class BatchAddToDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    mockExistingUrns(
+        mockService,
+        UrnUtils.getUrn(TEST_RESOURCE_URN_1),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1));
 
     BatchAddToDataProductsResolver resolver =
         new BatchAddToDataProductsResolver(mockService, mockFeatureFlags);
@@ -76,7 +98,7 @@ public class BatchAddToDataProductsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     Mockito.verify(mockService, Mockito.times(2))
-        .verifyEntityExists(any(), any()); // 1 resource + 1 data product
+        .filterExistingUrns(any(), any()); // 1 batched call for resources + 1 for data products
     Mockito.verify(mockService, Mockito.times(1))
         .batchAddToDataProduct(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1)), anyList());
   }
@@ -110,8 +132,7 @@ public class BatchAddToDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_RESOURCE_URN_1))))
-        .thenReturn(false);
+    mockExistingUrns(mockService); // Resource does not exist
 
     BatchAddToDataProductsResolver resolver =
         new BatchAddToDataProductsResolver(mockService, mockFeatureFlags);
@@ -135,11 +156,7 @@ public class BatchAddToDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_RESOURCE_URN_1))))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1))))
-        .thenReturn(false);
+    mockExistingUrns(mockService, UrnUtils.getUrn(TEST_RESOURCE_URN_1)); // Data product missing
 
     BatchAddToDataProductsResolver resolver =
         new BatchAddToDataProductsResolver(mockService, mockFeatureFlags);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchRemoveFromDataProductsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchRemoveFromDataProductsResolverTest.java
@@ -11,8 +11,12 @@ import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.BatchSetDataProductsInput;
 import com.linkedin.metadata.service.DataProductService;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -25,13 +29,28 @@ public class BatchRemoveFromDataProductsResolverTest {
   private static final String TEST_DATA_PRODUCT_URN_1 = "urn:li:dataProduct:test-product-1";
   private static final String TEST_DATA_PRODUCT_URN_2 = "urn:li:dataProduct:test-product-2";
 
+  private static void mockExistingUrns(DataProductService mockService, Urn... existingUrns) {
+    final Set<Urn> existing = new HashSet<>(List.of(existingUrns));
+    Mockito.when(mockService.filterExistingUrns(any(), anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream().filter(existing::contains).collect(Collectors.toSet());
+            });
+  }
+
   @Test
   public void testGetSuccessMultipleDataProducts() throws Exception {
     DataProductService mockService = Mockito.mock(DataProductService.class);
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    mockExistingUrns(
+        mockService,
+        UrnUtils.getUrn(TEST_RESOURCE_URN_1),
+        UrnUtils.getUrn(TEST_RESOURCE_URN_2),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_2));
 
     BatchRemoveFromDataProductsResolver resolver =
         new BatchRemoveFromDataProductsResolver(mockService, mockFeatureFlags);
@@ -47,8 +66,8 @@ public class BatchRemoveFromDataProductsResolverTest {
 
     assertTrue(resolver.get(mockEnv).get());
 
-    Mockito.verify(mockService, Mockito.times(4))
-        .verifyEntityExists(any(), any()); // 2 resources + 2 data products
+    Mockito.verify(mockService, Mockito.times(2))
+        .filterExistingUrns(any(), any()); // 1 batched call for resources + 1 for data products
     Mockito.verify(mockService, Mockito.times(2))
         .batchRemoveFromDataProduct(any(), any(Urn.class), anyList()); // 2 data products
   }
@@ -59,7 +78,10 @@ public class BatchRemoveFromDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), any())).thenReturn(true);
+    mockExistingUrns(
+        mockService,
+        UrnUtils.getUrn(TEST_RESOURCE_URN_1),
+        UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1));
 
     BatchRemoveFromDataProductsResolver resolver =
         new BatchRemoveFromDataProductsResolver(mockService, mockFeatureFlags);
@@ -76,7 +98,7 @@ public class BatchRemoveFromDataProductsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
 
     Mockito.verify(mockService, Mockito.times(2))
-        .verifyEntityExists(any(), any()); // 1 resource + 1 data product
+        .filterExistingUrns(any(), any()); // 1 batched call for resources + 1 for data products
     Mockito.verify(mockService, Mockito.times(1))
         .batchRemoveFromDataProduct(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1)), anyList());
   }
@@ -110,8 +132,7 @@ public class BatchRemoveFromDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_RESOURCE_URN_1))))
-        .thenReturn(false);
+    mockExistingUrns(mockService); // Resource does not exist
 
     BatchRemoveFromDataProductsResolver resolver =
         new BatchRemoveFromDataProductsResolver(mockService, mockFeatureFlags);
@@ -135,11 +156,7 @@ public class BatchRemoveFromDataProductsResolverTest {
     FeatureFlags mockFeatureFlags = Mockito.mock(FeatureFlags.class);
 
     Mockito.when(mockFeatureFlags.isMultipleDataProductsPerAsset()).thenReturn(true);
-    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_RESOURCE_URN_1))))
-        .thenReturn(true);
-    Mockito.when(
-            mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN_1))))
-        .thenReturn(false);
+    mockExistingUrns(mockService, UrnUtils.getUrn(TEST_RESOURCE_URN_1)); // Data product missing
 
     BatchRemoveFromDataProductsResolver resolver =
         new BatchRemoveFromDataProductsResolver(mockService, mockFeatureFlags);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchSetDataProductResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataproduct/BatchSetDataProductResolverTest.java
@@ -1,0 +1,157 @@
+package com.linkedin.datahub.graphql.resolvers.dataproduct;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.BatchSetDataProductInput;
+import com.linkedin.domain.Domains;
+import com.linkedin.metadata.service.DataProductService;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class BatchSetDataProductResolverTest {
+
+  private static final String TEST_RESOURCE_URN_1 =
+      "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+  private static final String TEST_RESOURCE_URN_2 =
+      "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test-2,PROD)";
+  private static final String TEST_DATA_PRODUCT_URN = "urn:li:dataProduct:test-product";
+  private static final String TEST_DOMAIN_URN = "urn:li:domain:test-domain";
+
+  private static void mockExistingUrns(DataProductService mockService, Urn... existingUrns) {
+    final Set<Urn> existing = new HashSet<>(List.of(existingUrns));
+    Mockito.when(mockService.filterExistingUrns(any(), anyCollection()))
+        .thenAnswer(
+            invocation -> {
+              Collection<Urn> requestedUrns = invocation.getArgument(1);
+              return requestedUrns.stream().filter(existing::contains).collect(Collectors.toSet());
+            });
+  }
+
+  private static void mockDataProductDomain(DataProductService mockService) {
+    Mockito.when(mockService.getDataProductDomains(any(), any()))
+        .thenReturn(new Domains().setDomains(new UrnArray(UrnUtils.getUrn(TEST_DOMAIN_URN))));
+  }
+
+  @Test
+  public void testGetSuccessWithDataProductUrn() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    mockExistingUrns(
+        mockService, UrnUtils.getUrn(TEST_RESOURCE_URN_1), UrnUtils.getUrn(TEST_RESOURCE_URN_2));
+    mockDataProductDomain(mockService);
+    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN))))
+        .thenReturn(true);
+
+    BatchSetDataProductResolver resolver = new BatchSetDataProductResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchSetDataProductInput input =
+        new BatchSetDataProductInput(
+            TEST_DATA_PRODUCT_URN, List.of(TEST_RESOURCE_URN_1, TEST_RESOURCE_URN_2));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertTrue(resolver.get(mockEnv).get());
+
+    Mockito.verify(mockService, Mockito.times(1))
+        .batchSetDataProduct(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN)), anyList());
+  }
+
+  @Test
+  public void testGetSuccessWithoutDataProductUrn() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    mockExistingUrns(mockService, UrnUtils.getUrn(TEST_RESOURCE_URN_1));
+
+    BatchSetDataProductResolver resolver = new BatchSetDataProductResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchSetDataProductInput input =
+        new BatchSetDataProductInput(null, List.of(TEST_RESOURCE_URN_1));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertTrue(resolver.get(mockEnv).get());
+
+    Mockito.verify(mockService, Mockito.times(1)).batchUnsetDataProduct(any(), anyList());
+  }
+
+  @Test
+  public void testGetFailureResourceDoesNotExistWithDataProductUrn() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    mockExistingUrns(mockService); // Resource does not exist
+    mockDataProductDomain(mockService);
+    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN))))
+        .thenReturn(true);
+
+    BatchSetDataProductResolver resolver = new BatchSetDataProductResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchSetDataProductInput input =
+        new BatchSetDataProductInput(TEST_DATA_PRODUCT_URN, List.of(TEST_RESOURCE_URN_1));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).batchSetDataProduct(any(), any(), any());
+  }
+
+  @Test
+  public void testGetFailureResourceDoesNotExistWithoutDataProductUrn() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    mockExistingUrns(mockService); // Resource does not exist
+
+    BatchSetDataProductResolver resolver = new BatchSetDataProductResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchSetDataProductInput input =
+        new BatchSetDataProductInput(null, List.of(TEST_RESOURCE_URN_1));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).batchUnsetDataProduct(any(), any());
+  }
+
+  @Test
+  public void testGetFailureUnauthorizedProductSideMembershipChange() throws Exception {
+    DataProductService mockService = Mockito.mock(DataProductService.class);
+    mockExistingUrns(mockService, UrnUtils.getUrn(TEST_RESOURCE_URN_1));
+    Mockito.when(mockService.verifyEntityExists(any(), eq(UrnUtils.getUrn(TEST_DATA_PRODUCT_URN))))
+        .thenReturn(true);
+    // No domains associated with the data product, so no domain grants MANAGE_DATA_PRODUCTS.
+    Mockito.when(mockService.getDataProductDomains(any(), any())).thenReturn(new Domains());
+
+    BatchSetDataProductResolver resolver = new BatchSetDataProductResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchSetDataProductInput input =
+        new BatchSetDataProductInput(TEST_DATA_PRODUCT_URN, List.of(TEST_RESOURCE_URN_1));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).batchSetDataProduct(any(), any(), any());
+  }
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/DataProductService.java
@@ -25,6 +25,8 @@ import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -585,6 +587,19 @@ public class DataProductService {
     } catch (Exception e) {
       throw new RuntimeException(
           String.format("Failed to determine if entity with urn %s exists", entityUrn), e);
+    }
+  }
+
+  public Set<Urn> filterExistingUrns(
+      @Nonnull OperationContext opContext, @Nonnull Collection<Urn> entityUrns) {
+    if (entityUrns.isEmpty()) {
+      return Collections.emptySet();
+    }
+    try {
+      return _entityClient.filterExistingUrns(opContext, entityUrns);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("Failed to determine which entities exist among %s", entityUrns), e);
     }
   }
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/DataProductServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/DataProductServiceTest.java
@@ -378,4 +378,28 @@ public class DataProductServiceTest {
     assertFalse(result);
     verify(mockClient, times(1)).exists(any(OperationContext.class), eq(TEST_RESOURCE_URN_1));
   }
+
+  @Test
+  public void testFilterExistingUrns() throws Exception {
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
+    final GraphClient mockGraphClient = mock(GraphClient.class);
+    final DataProductService service = new DataProductService(mockClient, mockGraphClient);
+
+    when(mockClient.filterExistingUrns(
+            eq(opContext), eq(ImmutableList.of(TEST_RESOURCE_URN_1, TEST_RESOURCE_URN_2))))
+        .thenReturn(ImmutableSet.of(TEST_RESOURCE_URN_1));
+
+    assertEquals(
+        service.filterExistingUrns(
+            opContext, ImmutableList.of(TEST_RESOURCE_URN_1, TEST_RESOURCE_URN_2)),
+        ImmutableSet.of(TEST_RESOURCE_URN_1));
+
+    assertEquals(service.filterExistingUrns(opContext, List.of()), ImmutableSet.of());
+
+    when(mockClient.filterExistingUrns(eq(opContext), eq(ImmutableList.of(TEST_DATA_PRODUCT_URN))))
+        .thenThrow(new RuntimeException("Client error"));
+    assertThrows(
+        RuntimeException.class,
+        () -> service.filterExistingUrns(opContext, ImmutableList.of(TEST_DATA_PRODUCT_URN)));
+  }
 }

--- a/smoke-test/tests/dataproduct/test_dataproduct.py
+++ b/smoke-test/tests/dataproduct/test_dataproduct.py
@@ -7,17 +7,29 @@ from typing import List
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
-from datahub.emitter.mce_builder import datahub_guid, make_dataset_urn
+from datahub.emitter.mce_builder import (
+    datahub_guid,
+    make_chart_urn,
+    make_container_urn,
+    make_dashboard_urn,
+    make_dataset_urn,
+    make_ml_model_urn,
+)
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
 from datahub.ingestion.api.sink import NoopWriteCallback
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.sink.file import FileSink, FileSinkConfig
 from datahub.metadata.schema_classes import (
+    ChangeAuditStampsClass,
+    ChartInfoClass,
+    ContainerPropertiesClass,
+    DashboardInfoClass,
     DataProductPropertiesClass,
     DatasetPropertiesClass,
     DomainPropertiesClass,
     DomainsClass,
+    MLModelPropertiesClass,
 )
 from datahub.utilities.urns.urn import Urn
 from tests.utils import wait_for_writes_to_sync, with_test_retry
@@ -30,6 +42,28 @@ dataset_urns = [
     make_dataset_urn("snowflake", f"table_foo_{i}")
     for i in range(start_index, start_index + 10)
 ]
+
+# One asset of each type, used to exercise the batch data product mutations
+# with a heterogeneous set of resources rather than only datasets.
+heterogeneous_asset_urns = [
+    make_dataset_urn("snowflake", f"table_batch_{start_index}"),
+    make_dashboard_urn("looker", f"dashboard_batch_{start_index}"),
+    make_chart_urn("looker", f"chart_batch_{start_index}"),
+    make_container_urn(datahub_guid({"name": f"container_batch_{start_index}"})),
+    make_ml_model_urn("sagemaker", f"model_batch_{start_index}", "PROD"),
+]
+
+BATCH_ADD_TO_DATA_PRODUCTS_QUERY = """
+mutation batchAddToDataProducts($dataProductUrns: [String!]!, $resourceUrns: [String!]!) {
+  batchAddToDataProducts(input: { dataProductUrns: $dataProductUrns, resourceUrns: $resourceUrns })
+}
+"""
+
+BATCH_REMOVE_FROM_DATA_PRODUCTS_QUERY = """
+mutation batchRemoveFromDataProducts($dataProductUrns: [String!]!, $resourceUrns: [String!]!) {
+  batchRemoveFromDataProducts(input: { dataProductUrns: $dataProductUrns, resourceUrns: $resourceUrns })
+}
+"""
 
 
 class FileEmitter:
@@ -69,8 +103,49 @@ def create_test_data(filename: str):
         for dataset_urn in dataset_urns
     ]
 
+    (
+        heterogeneous_dataset_urn,
+        dashboard_urn,
+        chart_urn,
+        container_urn,
+        ml_model_urn,
+    ) = heterogeneous_asset_urns
+    heterogeneous_asset_mcps = [
+        MetadataChangeProposalWrapper(
+            entityUrn=heterogeneous_dataset_urn,
+            aspect=DatasetPropertiesClass(
+                name=f"Test Dataset ({heterogeneous_dataset_urn})",
+                description=heterogeneous_dataset_urn,
+            ),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=dashboard_urn,
+            aspect=DashboardInfoClass(
+                title="Test Dashboard",
+                description=dashboard_urn,
+                lastModified=ChangeAuditStampsClass(),
+            ),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=chart_urn,
+            aspect=ChartInfoClass(
+                title="Test Chart",
+                description=chart_urn,
+                lastModified=ChangeAuditStampsClass(),
+            ),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=container_urn,
+            aspect=ContainerPropertiesClass(name="Test Container"),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=ml_model_urn,
+            aspect=MLModelPropertiesClass(name="Test ML Model"),
+        ),
+    ]
+
     file_emitter = FileEmitter(filename)
-    for mcps in [domain_mcp] + dataset_mcps:
+    for mcps in [domain_mcp] + dataset_mcps + heterogeneous_asset_mcps:
         file_emitter.emit(mcps)
 
     file_emitter.close()
@@ -237,3 +312,95 @@ def test_create_data_product(graph_client, ingest_cleanup_data):
     assert set(urns_missing) == set(dataset_urns), (
         f"All dataset urns should no longer have a DataProductContains relationship to the data product {data_product_urn}"
     )
+
+
+def create_data_product(graph_client, name: str) -> str:
+    domain_urn = Urn("domain", [datahub_guid({"name": "Marketing"})])
+    result = graph_client.execute_graphql(
+        get_gql_query("tests/dataproduct/queries/add_dataproduct.graphql"),
+        {"domainUrn": str(domain_urn), "name": name, "description": "Test Description"},
+    )
+    assert "createDataProduct" in result
+    return result["createDataProduct"]["urn"]
+
+
+def delete_data_product(graph_client, data_product_urn: str) -> None:
+    graph_client.execute_graphql(
+        get_gql_query("tests/dataproduct/queries/delete_dataproduct.graphql"),
+        {"urn": data_product_urn},
+    )
+
+
+def get_data_product_asset_urns(graph_client, data_product_urn: str) -> set:
+    data_product_props = graph_client.get_aspect(
+        data_product_urn, DataProductPropertiesClass
+    )
+    assert data_product_props is not None
+    if data_product_props.assets is None:
+        return set()
+    return {asset.destinationUrn for asset in data_product_props.assets}
+
+
+@with_test_retry()
+def test_batch_add_to_data_products(graph_client, ingest_cleanup_data):
+    data_product_urn_1 = create_data_product(
+        graph_client, "Test Batch Add Data Product 1"
+    )
+    data_product_urn_2 = create_data_product(
+        graph_client, "Test Batch Add Data Product 2"
+    )
+    try:
+        result = graph_client.execute_graphql(
+            BATCH_ADD_TO_DATA_PRODUCTS_QUERY,
+            {
+                "dataProductUrns": [data_product_urn_1, data_product_urn_2],
+                "resourceUrns": heterogeneous_asset_urns,
+            },
+        )
+        assert result["batchAddToDataProducts"] is True
+
+        wait_for_writes_to_sync()
+
+        assert get_data_product_asset_urns(graph_client, data_product_urn_1) == set(
+            heterogeneous_asset_urns
+        )
+        assert get_data_product_asset_urns(graph_client, data_product_urn_2) == set(
+            heterogeneous_asset_urns
+        )
+    finally:
+        delete_data_product(graph_client, data_product_urn_1)
+        delete_data_product(graph_client, data_product_urn_2)
+
+
+@with_test_retry()
+def test_batch_remove_from_data_products(graph_client, ingest_cleanup_data):
+    data_product_urn = create_data_product(
+        graph_client, "Test Batch Remove Data Product"
+    )
+    try:
+        graph_client.execute_graphql(
+            get_gql_query("tests/dataproduct/queries/setassets_dataproduct.graphql"),
+            {
+                "dataProductUrn": data_product_urn,
+                "resourceUrns": heterogeneous_asset_urns,
+            },
+        )
+        wait_for_writes_to_sync()
+        assert get_data_product_asset_urns(graph_client, data_product_urn) == set(
+            heterogeneous_asset_urns
+        )
+
+        result = graph_client.execute_graphql(
+            BATCH_REMOVE_FROM_DATA_PRODUCTS_QUERY,
+            {
+                "dataProductUrns": [data_product_urn],
+                "resourceUrns": heterogeneous_asset_urns,
+            },
+        )
+        assert result["batchRemoveFromDataProducts"] is True
+
+        wait_for_writes_to_sync()
+
+        assert get_data_product_asset_urns(graph_client, data_product_urn) == set()
+    finally:
+        delete_data_product(graph_client, data_product_urn)


### PR DESCRIPTION
## Summary
All four data product operations that add asset associations in batches (batchSet, batchUnset, batchAddTo, batchRemoveFrom) require an existence check for assets before they proceed. This existence check currently is a simple for-loop that checks every asset one by one leading to a query count linearly proportional to asset count. This PR batches the existence check into a single check.

With this change, pre-ingestion read queries (excluding authn/authz) required to add N associations to M data products reduce from `M + N` to `M + 1`

Some notes:
 - There is potential to also improve batching along the `M` dimension but this would not be very useful given data product count per asset is very bounded.
 - Testing locally, even with N=200, I did not find any statistically significant performance improvement in E2E latency of the batch mutation APIs, likely because MySQL round trip costs in a local setup are negligible and write costs outweighs read costs.

## Changes
 - `DataProductResolverUtils`:  Now uses a batched check for existence

## Test Plan
- Added/updated unit tests
- Added some missing smoke test coverage for batchAddToDataProducts/batchRemoveFromDataProducts
- Manually verified via MySQL logs that these operations now generate fewer queries

## Breaking Changes
None

## Checklist

- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Linked related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batched existence checks for assets and data products in `batchSet`, `batchUnset`, `batchAddTo`, and `batchRemoveFrom` mutations. This reduces pre-ingestion read queries from M+N to M+1 and lowers DB load.

- **Refactors**
  - Added `filterExistingUrns` to `DataProductService` and updated `DataProductResolverUtils` to batch resource and data product validation.
  - Updated resolver tests to assert two batched checks per request and added unit tests for `BatchSetDataProductResolver` (set/unset and unauthorized cases) and `filterExistingUrns`.
  - Added smoke tests for `batchAddToDataProducts`/`batchRemoveFromDataProducts` using heterogeneous assets (dataset, dashboard, chart, container, ML model).

<sup>Written for commit 6ff41d2884103ac971aea8381f471c3bfeadfc27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

