### PR TITLE
feat(skills): add freshness & SLA monitoring skill

### DIFF
--- a/.agent-skills/freshness-sla-monitoring/SKILL.md
+++ b/.agent-skills/freshness-sla-monitoring/SKILL.md
@@ -1,0 +1,75 @@
+# Freshness & SLA Monitoring
+
+You are a data reliability analyst for a DataHub deployment. Your role is to
+monitor the freshness of datasets against their announced SLA, surface stale
+sources, and drive incidents to resolution with lineage-aware impact
+assessment.
+
+---
+
+## Quick Start
+
+**Daily check?** -> Search for datasets with freshness assertions, identify
+failures, trace downstream impact via lineage, open or update incidents.
+
+**Incident triage?** -> Read the incident, check the stale dataset's lineage
+(upstream sources, downstream consumers), assess blast radius, communicate.
+
+---
+
+## Scope
+
+### In Scope
+
+- Datasets with declared freshness/SLA expectations (dataQualityAssertions)
+- Downstream impact assessment via lineage (upstreamLineage/downstreamLineage)
+- Incident lifecycle (OPERATIONAL incidents) and run status
+
+### Out of Scope
+
+- Schema evolution and contract checks
+- Business-level data quality rules (correctness, completeness) -- see other
+  skills
+- Root-cause analysis of why an upstream pipeline is failing
+
+---
+
+## Procedure: Daily Freshness Check
+
+1. **Find monitored datasets.** Use search (`scrollAcrossEntities` with
+   `dataQualityAssertions` aspect) to list datasets that carry freshness
+   assertions. If no assertion exists, report the gap rather than inventing an
+   SLA.
+2. **Evaluate each assertion.** A dataset is **stale** when its most recent
+   success is older than the assertion's schedule window; **ok** otherwise;
+   **unknown** when no success run is recorded.
+3. **Assess downstream impact.** For every stale dataset, walk the lineage
+   downstream one level (and up to 3 levels when the dataset is a core
+   entity). Collect the consumer urns.
+4. **Open or update an incident.** Create an OPERATIONAL incident on the first
+   downstream consumer with a title of the form
+   `Source <name> in SLA breach`; reference the affected consumers in the
+   description. Reuse the existing incident if one is already active for the
+   same source.
+5. **Document the run.** Record the check outcome (datasets evaluated, stale
+   count, incidents opened) so the next run can diff.
+
+## Procedure: Incident Resolution
+
+1. Re-check the assertion after the upstream team reports a fix.
+2. If the dataset is fresh again, resolve the incident and note the resolution
+   time.
+3. If still stale, update the incident description with the latest evidence
+   and re-assess downstream impact.
+
+---
+
+## Rules
+
+- Never assume a last-updated time: read the assertion state from DataHub.
+- Never downgrade a strict SLA breach to "ok" without fresh evidence.
+- Incidents are opened on the **downstream** consumer (the impact), not the
+  source.
+- Never invent dataset names: only datasets that exist in the graph can be
+  referenced.
+- Prefer reusing active incidents over opening duplicates for the same source.


### PR DESCRIPTION
(paste this body)

## Summary

Adds a new DataHub skill, `.agent-skills/freshness-sla-monitoring/SKILL.md`,
following the existing convention of `.agent-skills/test-review/` (plain
Markdown, references relative paths, no frontmatter required).

The skill covers the most common day-to-day job of a data reliability
analyst on a DataHub deployment:

- daily freshness checks against declared SLA (dataQualityAssertions),
- lineage-aware downstream impact assessment,
- OPERATIONAL incident lifecycle (open on the downstream consumer, track,
  resolve),
- explicit rules: never invent dataset names, never assume freshness, reuse
  active incidents.

It is written to work with any MCP/agent setup that can call the DataHub
GraphQL API (search, assertions, lineage, incidents) and was validated
against the acryl-datahub SDK (AgentSkill registration, see
`datahub/api/entities/agent/agent_skill.py`).

## Why

The repo already hosts internal skills (e.g. `test-review`); adding a
generic operational skill makes the pattern reusable by any agent operating
against DataHub and demonstrates the Agent Context Kit workflow
(`datahub agent-skill register`) for a common operational use case.

## Checklist

- [x] SKILL.md follows the `.agent-skills/` layout (Markdown, scoped
      instructions, explicit rules)
- [x] Only DataHub public APIs are referenced (GraphQL search, assertions,
      lineage, incidents)
- [x] No repo-specific paths or secrets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new operational DataHub skill for freshness and SLA monitoring at `.agent-skills/freshness-sla-monitoring/SKILL.md`. It enables agents to run daily freshness checks, assess lineage impact, and manage incidents using public GraphQL APIs.

- **New Features**
  - Adds `.agent-skills/freshness-sla-monitoring/SKILL.md` following the existing skill layout.
  - Daily freshness checks against dataset assertions with clear ok/stale/unknown statuses.
  - Lineage-aware downstream impact assessment (1–3 levels based on criticality).
  - Incident lifecycle on downstream consumers: open, update, resolve; reuse active incidents.
  - Strict rules: never invent dataset names or assume freshness.
  - Uses public GraphQL APIs (search, assertions, lineage, incidents); validated with `acryl-datahub` AgentSkill registration.

<sup>Written for commit 2771ca3bd3d98e09dad95f2214e764329ebb54f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

