### PR TITLE
feat(ci): add base_branch to workflow metrics for PR triggers

### DIFF
--- a/.github/scripts/test/test_workflow_metrics.py
+++ b/.github/scripts/test/test_workflow_metrics.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from utils.github.workflow_metrics import JobMetrics
+from utils.github.workflow_metrics import JobMetrics, WorkflowMetrics
 
 
 def test_parse_matrix_normal_job():
@@ -29,3 +29,57 @@ def test_parse_matrix_reusable_workflow_dynamic_inner_name():
     assert JobMetrics._parse_matrix(
         "Playwright E2E Tests (5, 5) / Playwright E2E Tests (Shard 5/5)"
     ) == ("Playwright E2E Tests", ["5", "5"])
+
+
+def test_workflow_metrics_base_branch_from_pull_request():
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "pull_request",
+            "actor": {"login": "alice"},
+            "triggering_actor": {"login": "alice"},
+            "pull_requests": [
+                {
+                    "number": 42,
+                    "url": "https://api.github.com/repos/org/repo/pulls/42",
+                    "base": {"ref": "main"},
+                }
+            ],
+            "head_branch": "feature/foo",
+            "head_sha": "abc123",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=99,
+        attempt=1,
+        rerun_type="initial",
+    )
+    assert metrics.base_branch == "main"
+    assert metrics.pull_request_number == 42
+
+
+def test_workflow_metrics_base_branch_absent_without_pull_request():
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "push",
+            "actor": {"login": "alice"},
+            "triggering_actor": {"login": "alice"},
+            "pull_requests": [],
+            "head_branch": "main",
+            "head_sha": "abc123",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=99,
+        attempt=1,
+        rerun_type="initial",
+    )
+    assert metrics.base_branch is None
+    assert metrics.pull_request_number is None

--- a/.github/scripts/test/test_workflow_metrics.py
+++ b/.github/scripts/test/test_workflow_metrics.py
@@ -61,6 +61,35 @@ def test_workflow_metrics_base_branch_from_pull_request():
     assert metrics.pull_request_number == 42
 
 
+def test_workflow_metrics_base_branch_from_pull_request_target():
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "pull_request_target",
+            "actor": {"login": "alice"},
+            "triggering_actor": {"login": "alice"},
+            "pull_requests": [
+                {
+                    "number": 42,
+                    "url": "https://api.github.com/repos/org/repo/pulls/42",
+                    "base": {"ref": "main"},
+                }
+            ],
+            "head_branch": "feature/foo",
+            "head_sha": "abc123",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=99,
+        attempt=1,
+        rerun_type="initial",
+    )
+    assert metrics.base_branch == "main"
+
+
 def test_workflow_metrics_base_branch_absent_without_pull_request():
     metrics = WorkflowMetrics.from_api(
         {
@@ -83,3 +112,34 @@ def test_workflow_metrics_base_branch_absent_without_pull_request():
     )
     assert metrics.base_branch is None
     assert metrics.pull_request_number is None
+
+
+def test_workflow_metrics_base_branch_ignored_for_non_pull_request_event():
+    # GitHub may associate an open PR with a push run; base_branch stays null.
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "push",
+            "actor": {"login": "alice"},
+            "triggering_actor": {"login": "alice"},
+            "pull_requests": [
+                {
+                    "number": 42,
+                    "url": "https://api.github.com/repos/org/repo/pulls/42",
+                    "base": {"ref": "main"},
+                }
+            ],
+            "head_branch": "feature/foo",
+            "head_sha": "abc123",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=99,
+        attempt=1,
+        rerun_type="initial",
+    )
+    assert metrics.base_branch is None
+    assert metrics.pull_request_number == 42

--- a/.github/scripts/utils/github/workflow_metrics.py
+++ b/.github/scripts/utils/github/workflow_metrics.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass
 from typing import Any
 from utils.datetime_utils import parse_dt, duration_seconds
 
+# Events where pull_requests[].base.ref is a meaningful PR base branch.
+_PR_TRIGGER_EVENTS = frozenset({"pull_request", "pull_request_target"})
+
 
 @dataclass
 class StepMetrics:
@@ -121,20 +124,26 @@ class WorkflowMetrics:
     ) -> "WorkflowMetrics":
         run_started = parse_dt(data.get("run_started_at"))
         run_completed = parse_dt(data.get("updated_at"))
-        # pull_requests is populated only when the triggering event is pull_request
+        trigger_event = data.get("event")
         pr = (data.get("pull_requests") or [None])[0]
         actor_obj: dict[str, Any] = data.get("actor") or {}
         triggering_actor_obj: dict[str, Any] = data.get("triggering_actor") or {}
+        # PR-trigger-only: GitHub can associate open PRs with push/etc. runs too
+        base_branch = (
+            (pr.get("base") or {}).get("ref")
+            if pr and trigger_event in _PR_TRIGGER_EVENTS
+            else None
+        )
         return cls(
             id=data.get("workflow_id"),
             name=data.get("name"),
             run_id=run_id,
-            trigger_event=data.get("event"),
+            trigger_event=trigger_event,
             actor=actor_obj.get("login"),
             triggering_actor=triggering_actor_obj.get("login"),
             pull_request_number=pr.get("number") if pr else None,
             pull_request_url=pr.get("url") if pr else None,
-            base_branch=(pr.get("base") or {}).get("ref") if pr else None,
+            base_branch=base_branch,
             head_branch=data.get("head_branch"),
             head_sha=data.get("head_sha"),
             conclusion=data.get("conclusion"),

--- a/.github/scripts/utils/github/workflow_metrics.py
+++ b/.github/scripts/utils/github/workflow_metrics.py
@@ -101,6 +101,7 @@ class WorkflowMetrics:
     triggering_actor: str | None
     pull_request_number: int | None
     pull_request_url: str | None
+    base_branch: str | None
     head_branch: str | None
     head_sha: str | None
     conclusion: str | None
@@ -133,6 +134,7 @@ class WorkflowMetrics:
             triggering_actor=triggering_actor_obj.get("login"),
             pull_request_number=pr.get("number") if pr else None,
             pull_request_url=pr.get("url") if pr else None,
+            base_branch=(pr.get("base") or {}).get("ref") if pr else None,
             head_branch=data.get("head_branch"),
             head_sha=data.get("head_sha"),
             conclusion=data.get("conclusion"),

--- a/.github/scripts/utils/posthog/ci_reporter.py
+++ b/.github/scripts/utils/posthog/ci_reporter.py
@@ -67,6 +67,7 @@ class PostHogCIReporter:
             "triggering_actor": w.get("triggering_actor"),
             "pull_request_number": w.get("pull_request_number"),
             "pull_request_url": w.get("pull_request_url"),
+            "base_branch": w.get("base_branch"),
             "head_branch": w.get("head_branch"),
             "head_sha": w.get("head_sha"),
             "conclusion": w.get("conclusion"),


### PR DESCRIPTION
## Summary
- Add `base_branch` to workflow metrics collected from GitHub Actions, set from `pull_requests[].base.ref` for pull_request triggers only
- Include the property in PostHog CI events (`ci_step_completed`, `ci_job_completed`, `ci_workflow_run_completed`)
- Cover PR and non-PR cases in unit tests

## Test plan
- [x] `pytest .github/scripts/test/test_workflow_metrics.py`
- [ ] Confirm a PR-triggered workflow run publishes `base_branch` to PostHog
- [ ] Confirm a push/schedule run leaves `base_branch` unset/null


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `base_branch` to workflow metrics for PR-triggered runs (including `pull_request_target`) and forward it to PostHog CI events to improve branch analytics. For other events, the field stays unset, even if GitHub associates a PR.

- **New Features**
  - Populate `base_branch` from `pull_requests[].base.ref` for `pull_request` and `pull_request_target`; ignore for push/schedule.
  - Include `base_branch` in `ci_step_completed`, `ci_job_completed`, and `ci_workflow_run_completed`.
  - Add unit tests for PR, PR target, non-PR runs, and push runs with associated PRs.

<sup>Written for commit 64c2e0b1ae30dc1c26ac7f73b32e28c43a09e5a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

