### PR TITLE
fix(search): use aggregation entity's valueType for structured-property bucket display names

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/__tests__/utils.test.tsx
@@ -346,6 +346,85 @@ describe('useLoadAggregationOptions', () => {
         expect(result.current.options.map((opt) => opt.value)).toEqual(['snowflake', 'redshift']);
     });
 
+    it('formats structured-property values using the aggregation facet entity valueType', () => {
+        const structuredPropField: FilterField = {
+            field: 'structuredProperties.io.acryl.privacy.retentionTime',
+            displayName: 'Retention Time',
+            type: FieldType.TEXT,
+            // No entity on the field itself: the definition must come from the facet.
+        };
+        const mockAggregationData = {
+            aggregateAcrossEntities: {
+                facets: [
+                    {
+                        field: structuredPropField.field,
+                        entity: {
+                            __typename: 'StructuredPropertyEntity',
+                            urn: 'urn:li:structuredProperty:io.acryl.privacy.retentionTime',
+                            definition: {
+                                valueType: { urn: 'urn:li:dataType:datahub.number' },
+                            },
+                        },
+                        aggregations: [{ value: '42000.0', count: 3, entity: null }],
+                    },
+                ],
+            },
+        };
+
+        (useAggregateAcrossEntitiesQuery as any).mockReturnValue({
+            data: mockAggregationData,
+            loading: false,
+        });
+
+        const { result } = renderHook(() =>
+            useLoadAggregationOptions({
+                field: structuredPropField,
+                visible: true,
+                includeCounts: true,
+            }),
+        );
+
+        // Raw Elasticsearch double renders as the formatted number, not "42000.0".
+        expect(result.current.options).toHaveLength(1);
+        expect(result.current.options[0].displayName).toEqual('42000');
+    });
+
+    it('falls back to the raw structured-property value when the facet carries no entity', () => {
+        const structuredPropField: FilterField = {
+            field: 'structuredProperties.io.acryl.privacy.retentionTime',
+            displayName: 'Retention Time',
+            type: FieldType.TEXT,
+        };
+        const mockAggregationData = {
+            aggregateAcrossEntities: {
+                facets: [
+                    {
+                        field: structuredPropField.field,
+                        entity: null,
+                        aggregations: [{ value: '42000.0', count: 3, entity: null }],
+                    },
+                ],
+            },
+        };
+
+        (useAggregateAcrossEntitiesQuery as any).mockReturnValue({
+            data: mockAggregationData,
+            loading: false,
+        });
+
+        const { result } = renderHook(() =>
+            useLoadAggregationOptions({
+                field: structuredPropField,
+                visible: true,
+                includeCounts: true,
+            }),
+        );
+
+        // Without a definition the value type is unknown, so the raw value renders verbatim.
+        expect(result.current.options).toHaveLength(1);
+        expect(result.current.options[0].displayName).toEqual('42000.0');
+    });
+
     it('should handle missing facet data', () => {
         const mockAggregationData = {
             aggregateAcrossEntities: {

--- a/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/utils.tsx
@@ -123,6 +123,18 @@ export const useLoadAggregationOptions = ({
     }
 
     const requestedAgg = data?.aggregateAcrossEntities?.facets?.find((facet: any) => facet.field === field.field);
+
+    // The aggregation facet's entity carries the structured-property definition (incl. valueType),
+    // which getStructuredPropFilterDisplayName needs to format numbers and dates. Prefer it over
+    // field.entity, which doesn't carry the definition in every dropdown path — without it, number
+    // buckets render as the raw double (e.g. "42000.0") and dates as raw epochs in the selector,
+    // inconsistent with how the selected-filter chip renders the same value.
+    const structuredPropEntity =
+        requestedAgg?.entity?.__typename === 'StructuredPropertyEntity'
+            ? (requestedAgg.entity as StructuredPropertyEntity)
+            : undefined;
+    const propertyEntity = structuredPropEntity ?? field.entity;
+
     // Filter out options with no count only if removeOptionsWithNoCount otherwise do not filter
     const filteredOptions = requestedAgg?.aggregations?.filter((agg) =>
         removeOptionsWithNoCount ? !!agg.count : true,
@@ -133,15 +145,11 @@ export const useLoadAggregationOptions = ({
             entity: aggregation.entity,
             icon: field.icon,
             count: includeCounts ? aggregation.count : undefined,
-            displayName: getStructuredPropFilterDisplayName(field.field, aggregation.value, field.entity),
+            displayName: getStructuredPropFilterDisplayName(field.field, aggregation.value, propertyEntity),
         };
     });
     // For structured property fields with allowedValues, surface every allowed value even if it
     // has no indexed documents yet — so the full set of filterable choices is always visible.
-    const structuredPropEntity =
-        requestedAgg?.entity?.__typename === 'StructuredPropertyEntity'
-            ? (requestedAgg.entity as StructuredPropertyEntity)
-            : undefined;
     const allowedValuesFromDefinition = structuredPropEntity?.definition?.allowedValues;
     if (allowedValuesFromDefinition?.length) {
         return {
@@ -149,7 +157,7 @@ export const useLoadAggregationOptions = ({
                 value: rawValue,
                 icon: field.icon,
                 count: includeCounts ? 0 : undefined,
-                displayName: getStructuredPropFilterDisplayName(field.field, rawValue, field.entity),
+                displayName: getStructuredPropFilterDisplayName(field.field, rawValue, propertyEntity),
             })),
             loading,
         };
@@ -211,8 +219,16 @@ export const useLoadSearchOptions = (field: EntityFilterField, query?: string, s
 };
 
 /**
- * Hook used to filter selector options by a raw search query string. This uses the name of the filter value
- * to match against the search query.
+ * Hook used to filter selector options by a raw search query string. Matches against the option's
+ * human-readable form only — the entity display name for urn-typed options, or the formatted display
+ * name otherwise.
+ *
+ * We deliberately do NOT match the raw underlying value. The raw value is only ever the interesting
+ * thing to search when it equals the human-readable form (strings, numbers), and in those cases the
+ * display name already covers it. When they differ — a urn behind an entity option, or an epoch behind
+ * a date option — the raw value is noise no user would type, so matching it only produces spurious
+ * hits. (This relies on getStructuredPropFilterDisplayName rendering the real value; previously a
+ * parseFloat bug corrupted numeric-looking strings to "Infinity", which is fixed separately.)
  */
 export const useFilterOptionsBySearchQuery = (
     options: FilterValueOption[],


### PR DESCRIPTION
### Summary

The search-filter "More Filters" dropdown for a NUMBER-typed structured property renders raw
Elasticsearch aggregation bucket values (e.g. `"42000.0"`) instead of the formatted display value
(`42000`) used everywhere else the property's value is shown. This PR fixes that.

### Test plan

- [x] Manual: created a NUMBER-typed structured property (`numeric_metric`, "Numeric Metric",
      `showInSearchFilters: true`) and 3 test datasets with distinct values (`42000.0`, `15750.5`,
      `999.0`). Opened the search sidebar's "More Filters" → Numeric Metric dropdown — bucket
      values render as `42000`, `15750.5`, `999` (formatted), not the raw ES doubles
      (`"42000.0"`, etc.) that showed before this fix.
- [X] Selecting one of those values as a filter — confirm the selected-filter chip shows the same
      formatted value the dropdown did (not yet re-verified after the latest change; flagging as
      a follow-up check before merge)

---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the search "More Filters" dropdown to format structured-property bucket values by using the aggregation facet's `StructuredPropertyEntity` (with valueType). Values like 42000 and dates now match the selected-filter chip and other views instead of showing raw ES values (e.g. "42000.0").

- Prefer the aggregation facet's entity for formatting and fall back to `field.entity`. Applies to both bucket values and `allowedValues`.
- Adds tests to pin formatting via the facet entity's valueType and the fallback behavior when no facet entity is present.

<sup>Written for commit b546cc8cd920bc4930a22ef6fdda755f23564d2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



