### PR TITLE
fix(masking): install-once filter, registry scoping without teardown

### DIFF
--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -5,7 +5,7 @@ import os
 import sys
 import textwrap
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, NoReturn, Optional
 
 if TYPE_CHECKING:
     from datahub.ingestion.recording.recorder import IngestionRecorder
@@ -24,7 +24,7 @@ from datahub.ingestion.graph.client import get_default_graph
 from datahub.ingestion.graph.config import ClientMode
 from datahub.ingestion.run.connection import ConnectionManager
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.masking.bootstrap import initialize_secret_masking
+from datahub.masking.bootstrap import initialize_secret_masking, shutdown_secret_masking
 from datahub.telemetry import telemetry
 from datahub.upgrade import upgrade
 from datahub.utilities.ingest_utils import deploy_source_vars
@@ -180,8 +180,18 @@ def run(
 ) -> None:
     """Ingest metadata into DataHub."""
 
-    # Initialize secret masking (before any logging)
-    initialize_secret_masking()
+    # Initialize secret masking (before any logging). Fail-loud: never
+    # proceed with secrets unmasked; show a clean click error instead of a
+    # raw traceback.
+    try:
+        initialize_secret_masking()
+    except RuntimeError as e:
+        click.echo(
+            f"Failed to initialize secret masking: {e}. Aborting to avoid "
+            "exposing secrets in logs.",
+            err=True,
+        )
+        sys.exit(1)
 
     def run_pipeline_to_completion(pipeline: Pipeline) -> int:
         logger.info("Starting metadata ingestion")
@@ -205,6 +215,12 @@ def run(
     # main function begins
     logger.info("DataHub CLI version: %s", nice_version_name())
 
+    # Non-exception exits shut the masking scope down; exception paths keep it
+    # so the top-level handler in entrypoints.py formats the traceback masked.
+    def _exit(code: int) -> NoReturn:
+        shutdown_secret_masking()
+        sys.exit(code)
+
     pipeline_config = load_config_file(
         config,
         squirrel_original_config=True,
@@ -217,7 +233,7 @@ def run(
     raw_pipeline_config = pipeline_config.pop("__raw_config")
 
     if test_source_connection:
-        sys.exit(_test_source_connection(report_to, pipeline_config))
+        _exit(_test_source_connection(report_to, pipeline_config))
 
     if no_default_report:
         # The default is "datahub" reporting. The extra flag will disable it.
@@ -256,6 +272,9 @@ def run(
     else:
         ret = create_and_run_pipeline()
 
+    # Non-exception exits shut the masking scope down; exception paths keep it
+    # so the top-level handler in entrypoints.py formats the traceback masked.
+    shutdown_secret_masking()
     if ret:
         sys.exit(ret)
     # don't raise SystemExit if there's no error

--- a/metadata-ingestion/src/datahub/masking/__init__.py
+++ b/metadata-ingestion/src/datahub/masking/__init__.py
@@ -10,10 +10,14 @@ __all__ = [
     "SecretRegistry",
     "is_masking_enabled",
     "initialize_secret_masking",
+    "shutdown_secret_masking",
     "get_masking_safe_logger",
 ]
 
-from datahub.masking.bootstrap import initialize_secret_masking
+from datahub.masking.bootstrap import (
+    initialize_secret_masking,
+    shutdown_secret_masking,
+)
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.masking_filter import (
     SecretMaskingFilter,

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -1,17 +1,4 @@
-"""
-Bootstrap module for secret masking initialization.
-
-Architecture:
-    This module sets up the masking infrastructure (logging filter + exception hook).
-    Secret discovery is separated and happens automatically at point-of-read:
-    - Config loaders register secrets during ${VAR} expansion
-    - Pydantic models register SecretStr fields during validation
-
-    This separation means:
-    - Infrastructure setup is context-independent
-    - Components own their secret registration
-    - Errors surface at point-of-read (not during bootstrap)
-"""
+"""Bootstrap for the secret-masking infrastructure."""
 
 import logging
 import sys
@@ -20,171 +7,128 @@ import traceback
 from typing import Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
-from datahub.masking.masking_filter import (
-    SecretMaskingFilter,
-    install_masking_filter,
-    uninstall_masking_filter,
-)
-from datahub.masking.secret_registry import SecretRegistry
+from datahub.masking.masking_filter import install_masking_filter
+from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
 
 logger = get_masking_safe_logger(__name__)
 
-# Bootstrap state tracking
 _bootstrap_completed = False
 _bootstrap_error: Optional[Exception] = None
-_original_excepthook = None  # Track original exception hook for restoration
-_bootstrap_lock = threading.Lock()  # Thread safety for concurrent initialization
+_original_excepthook = None
+_disabled_warned = False
+_bootstrap_lock = threading.Lock()
+
+MASKING_ERROR_NOTE = "[masking failed; traceback suppressed for security]"
 
 
 def is_bootstrapped() -> bool:
-    """Check if secret masking bootstrap has completed."""
+    """True once the filter + excepthook + stream wrappers are installed."""
     return _bootstrap_completed
 
 
 def get_bootstrap_error() -> Optional[Exception]:
-    """Get bootstrap error if bootstrap failed."""
+    """Return the last install error, or None if install succeeded."""
     return _bootstrap_error
 
 
-def _install_exception_hook(registry: SecretRegistry) -> None:
-    """Install custom exception hook to mask secrets."""
-    global _original_excepthook
+def reset_bootstrap_state() -> None:
+    # Test-only: clear the bootstrap latch and warn-once flags. Also call
+    # SecretRegistry.reset_instance(); a stranded latch keeps the filter bound
+    # to a dead singleton.
+    global _bootstrap_completed, _bootstrap_error, _disabled_warned
+    with _bootstrap_lock:
+        _bootstrap_completed = False
+        _bootstrap_error = None
+        _disabled_warned = False
 
-    # Store original exception hook for later restoration
+
+def _install_exception_hook(masking_filter) -> None:
+    # Process-lifetime excepthook; on masking failure print only the class
+    # name plus a note, never the raw traceback (fail-closed).
+    global _original_excepthook
     if _original_excepthook is None:
         _original_excepthook = sys.excepthook
 
-    original_excepthook = _original_excepthook
-
-    masking_filter = SecretMaskingFilter(registry)
-
-    def masking_excepthook(exc_type, exc_value, exc_traceback):
-        """Custom exception hook that masks secrets in exception messages."""
+    def masking_excepthook(exc_type, exc_value, exc_traceback) -> None:
         try:
-            # Format the exception to a string
-            tb_lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
-            tb_text = "".join(tb_lines)
+            tb_text = "".join(
+                traceback.format_exception(exc_type, exc_value, exc_traceback)
+            )
+            masked = masking_filter.mask_text(tb_text)
+            sys.stderr.write(masked)
+        except Exception:
+            sys.stderr.write(f"{exc_type.__name__}: {MASKING_ERROR_NOTE}\n")
 
-            # Mask secrets in the formatted traceback
-            masked_tb_text = masking_filter.mask_text(tb_text)
-
-            # Write masked traceback to stderr
-            sys.stderr.write(masked_tb_text)
-        except Exception as e:
-            # If masking fails, fall back to original exception hook
-            logger.error(f"Failed to mask exception: {e}")
-            original_excepthook(exc_type, exc_value, exc_traceback)
-
-    # Install the custom hook
     sys.excepthook = masking_excepthook
-    logger.debug("Installed custom exception hook for secret masking")
+    logger.debug("Installed masking exception hook")
 
 
 def initialize_secret_masking(
     max_message_size: int = 5000,
     force: bool = False,
-) -> None:
-    """
-    Initialize secret masking infrastructure (logging filter + exception hook).
-
-    Secrets register automatically at point-of-read.
-    """
-    global _bootstrap_completed, _bootstrap_error
-
-    # Check if masking is disabled via environment variable
-    from datahub.masking.secret_registry import is_masking_enabled
+) -> Optional[str]:
+    # Install masking and open a per-execution secret scope. Returns the
+    # execution token, or None if masking is disabled. Raises RuntimeError
+    # if masking is enabled but install failed (fail-loud). ``force`` is
+    # accepted and ignored — kept for backward compatibility.
+    global _bootstrap_completed, _bootstrap_error, _disabled_warned
 
     if not is_masking_enabled():
-        logger.warning(
-            "Secret masking is DISABLED via DATAHUB_DISABLE_SECRET_MASKING environment variable. "
-            "Sensitive information will be exposed in logs. Only use this for debugging!"
-        )
-        _bootstrap_completed = True  # Mark as completed to avoid repeated warnings
-        return
-
-    # Thread-safe initialization: acquire lock for entire operation
-    with _bootstrap_lock:
-        # Prevent double initialization
-        if _bootstrap_completed and not force:
-            logger.debug("Secret masking already initialized")
-            return
-
-        try:
-            logger.info("Initializing secret masking infrastructure")
-
-            # Get registry
-            registry = SecretRegistry.get_instance()
-
-            # Install logging filter + stdout wrapper
-            install_masking_filter(
-                secret_registry=registry,
-                max_message_size=max_message_size,
-                install_stdout_wrapper=True,
+        if not _disabled_warned:
+            logger.warning(
+                "Secret masking is DISABLED via "
+                "DATAHUB_DISABLE_SECRET_MASKING. Sensitive information will "
+                "be exposed in logs. Only use this for debugging."
             )
+            _disabled_warned = True
+        return None
 
-            # Install custom exception hook to mask unhandled exceptions
-            _install_exception_hook(registry)
-
-            # Configure warnings to use logging
-            logging.captureWarnings(True)
-
-            # Disable HTTP debug output (prevent deadlock)
+    registry = SecretRegistry.get_instance()
+    with _bootstrap_lock:
+        if not _bootstrap_completed:
             try:
+                logger.info("Initializing secret masking infrastructure")
+                installed = install_masking_filter(
+                    secret_registry=registry,
+                    max_message_size=max_message_size,
+                    install_stdout_wrapper=True,
+                )
+                _install_exception_hook(installed)
+                logging.captureWarnings(True)
                 import http.client
 
                 http.client.HTTPConnection.debuglevel = 0
-            except Exception:
-                pass
-
-            # Set HTTP-related loggers to INFO (not DEBUG)
-            for logger_name in [
-                "urllib3",
-                "urllib3.connectionpool",
-                "urllib3.util.retry",
-                "requests",
-            ]:
-                try:
+                for logger_name in [
+                    "urllib3",
+                    "urllib3.connectionpool",
+                    "urllib3.util.retry",
+                    "requests",
+                ]:
                     logging.getLogger(logger_name).setLevel(logging.INFO)
-                except Exception:
-                    pass
+                _bootstrap_completed = True
+                _bootstrap_error = None
+                logger.info(
+                    "Secret masking infrastructure initialized; secrets "
+                    "will be registered automatically as they are loaded."
+                )
+            except Exception as e:
+                _bootstrap_error = e
+                logger.critical(
+                    "Failed to initialize secret masking: %s. Secrets may "
+                    "reach logs unmasked.",
+                    e,
+                    exc_info=True,
+                )
+                raise RuntimeError(f"Secret masking installation failed: {e}") from e
+        else:
+            # Re-scan handlers and rebind to the current registry: handlers
+            # added while the wrap was inert carry no filter.
+            install_masking_filter(secret_registry=registry)
+        return registry.begin_execution()
 
-            _bootstrap_completed = True
-            _bootstrap_error = None
-            logger.info(
-                "Secret masking infrastructure initialized successfully. "
-                "Secrets will be registered automatically as they are loaded."
-            )
 
-        except Exception as e:
-            _bootstrap_error = e
-            logger.error(f"Failed to initialize secret masking: {e}", exc_info=True)
-            # Don't raise - graceful degradation
-
-
-def shutdown_secret_masking() -> None:
-    """Shutdown secret masking system."""
-    global _bootstrap_completed, _bootstrap_error, _original_excepthook
-
-    try:
-        uninstall_masking_filter()
-
-        # Restore original exception hook
-        if _original_excepthook is not None:
-            sys.excepthook = _original_excepthook
-            _original_excepthook = None
-
-        # Clear registry
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-
-        # Reset masking-safe loggers to restore normal logging
-        from datahub.masking.logging_utils import reset_masking_safe_loggers
-
-        reset_masking_safe_loggers()
-
-        _bootstrap_completed = False
-        _bootstrap_error = None
-
-        logger.info("Secret masking shutdown completed")
-    except Exception as e:
-        logger.error(f"Error during secret masking shutdown: {e}")
+def shutdown_secret_masking(execution_id: Optional[str] = None) -> None:
+    # End this execution's masking scope. No logging teardown, no excepthook
+    # restore, no latch clearing — the filter installs once and is never
+    # uninstalled in production.
+    SecretRegistry.get_instance().end_execution(execution_id)

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -4,10 +4,11 @@ import logging
 import sys
 import threading
 import traceback
+from types import TracebackType
 from typing import Optional
 
 from datahub.masking.logging_utils import get_masking_safe_logger
-from datahub.masking.masking_filter import install_masking_filter
+from datahub.masking.masking_filter import SecretMaskingFilter, install_masking_filter
 from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
 
 logger = get_masking_safe_logger(__name__)
@@ -42,14 +43,18 @@ def reset_bootstrap_state() -> None:
         _disabled_warned = False
 
 
-def _install_exception_hook(masking_filter) -> None:
+def _install_exception_hook(masking_filter: SecretMaskingFilter) -> None:
     # Process-lifetime excepthook; on masking failure print only the class
     # name plus a note, never the raw traceback (fail-closed).
     global _original_excepthook
     if _original_excepthook is None:
         _original_excepthook = sys.excepthook
 
-    def masking_excepthook(exc_type, exc_value, exc_traceback) -> None:
+    def masking_excepthook(
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        exc_traceback: Optional[TracebackType],
+    ) -> None:
         try:
             tb_text = "".join(
                 traceback.format_exception(exc_type, exc_value, exc_traceback)

--- a/metadata-ingestion/src/datahub/masking/constants.py
+++ b/metadata-ingestion/src/datahub/masking/constants.py
@@ -1,0 +1,10 @@
+"""Shared constants for the secret-masking framework.
+
+``REDACTED_FORMAT`` lives here so both ``secret_registry`` (validation at
+registration time) and ``masking_filter`` (the masking callback) reference
+one definition. A duplicate would let them drift and re-open the route-A
+hole (a marker-shaped value passing registration because the registry's
+format string differs from the filter's).
+"""
+
+REDACTED_FORMAT = "***REDACTED:{name}***"

--- a/metadata-ingestion/src/datahub/masking/logging_utils.py
+++ b/metadata-ingestion/src/datahub/masking/logging_utils.py
@@ -8,9 +8,13 @@ preventing re-entrancy deadlocks by writing directly to the original stderr.
 import logging
 import sys
 
-# Capture original stderr BEFORE any masking initialization
-# This ensures masking-safe loggers write to unwrapped stderr
-_original_stderr = sys.stderr
+# Capture the *real* stderr (not a proxy). Under celery, ``redirect_stdouts_to_logger``
+# replaces ``sys.stderr`` with a ``LoggingProxy`` that re-enters logging; the masking
+# package is typically imported at task time, *after* that redirect has run, so
+# ``sys.stderr`` at import time is already the proxy. ``sys.__stderr__`` is the
+# original stream and is not affected by the redirect. May be ``None`` under
+# pythonw/embedded interpreters; fall back to ``sys.stderr`` then.
+_original_stderr = sys.__stderr__ if sys.__stderr__ is not None else sys.stderr
 
 
 def get_masking_safe_logger(name: str) -> logging.Logger:
@@ -35,18 +39,3 @@ def get_masking_safe_logger(name: str) -> logging.Logger:
         logger.propagate = False
 
     return logger
-
-
-def reset_masking_safe_loggers() -> None:
-    """Reset all masking-safe loggers to allow normal logging."""
-    # Get all loggers under the masking namespace
-    masking_namespace = "datahub.masking"
-
-    for name in list(logging.Logger.manager.loggerDict.keys()):
-        if name.startswith(masking_namespace):
-            logger = logging.getLogger(name)
-            # Remove all handlers
-            for handler in logger.handlers[:]:
-                logger.removeHandler(handler)
-            # Reset propagate flag to allow normal logging
-            logger.propagate = True

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -6,7 +6,7 @@ import re
 import sys
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, TextIO, Tuple
+from typing import Any, Dict, Iterable, List, Optional, TextIO, Tuple
 
 from datahub.masking.constants import REDACTED_FORMAT
 from datahub.masking.logging_utils import get_masking_safe_logger
@@ -500,7 +500,7 @@ class StreamMaskingWrapper:
         except (ValueError, OSError):
             pass
 
-    def writelines(self, lines) -> None:
+    def writelines(self, lines: Iterable[str]) -> None:
         for line in lines:
             self.write(line)
 

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -1,39 +1,100 @@
-"""
-Logging filter for masking secrets in log messages and streams.
+"""Logging filter that masks registered secrets in log records and streams."""
 
-This module provides a Python logging.Filter that automatically masks
-registered secrets in all log output. Secrets are replaced with
-***REDACTED:VARIABLE_NAME*** for debugging while preventing leaks.
-
-Key Features:
-- Automatic masking of messages, arguments, and exceptions
-- Deferred pattern rebuild (only during masking, not registration)
-- Circuit breaker for graceful degradation
-- Message truncation (5KB default) for performance
-- Stream wrappers for stdout/stderr coverage
-
-Performance:
-- Pattern rebuilt only when needed during masking operations
-- Lock-free masking with COW snapshots
-- Truncation before masking avoids regex on huge strings
-- Performance warnings at 100/500 secrets
-"""
-
+import io
 import logging
 import re
 import sys
 import threading
-from typing import Any, Dict, Optional, TextIO, Tuple
+import uuid
+from typing import Any, Dict, List, Optional, TextIO, Tuple
 
+from datahub.masking.constants import REDACTED_FORMAT
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.secret_registry import SecretRegistry
 
 logger = get_masking_safe_logger(__name__)
 
-# Constants
-REDACTED_FORMAT = "***REDACTED:{name}***"
+REDACTED_MASKING_NAMESPACE = "datahub.masking."
 MASKING_ERROR_MESSAGE = "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]"
-CIRCUIT_OPEN_MESSAGE = "[REDACTED: Masking Circuit Open]"
+
+# Derive the marker prefix/suffix from REDACTED_FORMAT so the generic
+# fallback regex tracks the constant, not a hardcoded copy.
+_MARKER_PREFIX = REDACTED_FORMAT.split("{", 1)[0]
+_MARKER_SUFFIX = REDACTED_FORMAT.rsplit("}", 1)[1]
+_GENERIC_MARKER_RE = (
+    re.escape(_MARKER_PREFIX) + r"[^*]{0,256}?" + re.escape(_MARKER_SUFFIX)
+)
+
+# Idempotency token stamped onto records after masking. A random string
+# (not object()) so structured formatters that serialize record.__dict__ emit
+# a valid line; compared by value so the guard survives cross-thread
+# QueueHandler/QueueListener within a process. Randomness prevents forging
+# extra={'_datahub_masked': ...} to disable masking for a record.
+_MASKED = f"_datahub_masked_{uuid.uuid4().hex}"
+
+# LogRecord standard attributes. Extras (extra={...}) are everything not in
+# this set; we mask those recursively. _datahub_masked is included so the
+# extras loop skips the idempotency token.
+_STANDARD_RECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "process",
+        "processName",
+        "taskName",
+        "message",
+        "asctime",
+        "_datahub_masked",
+    }
+)
+
+# The single installed filter instance. The addHandler wrap reads this; when
+# None (disarmed) the wrap is inert.
+_installed_filter: Optional["SecretMaskingFilter"] = None
+
+# Whether the addHandler wrap has been installed. Installed once at first
+# install_masking_filter call and never removed.
+_addhandler_wrap_installed = False
+_original_add_handler = logging.Logger.addHandler
+
+
+def _is_masking_namespace_name(name: str) -> bool:
+    """True for loggers in the masking framework's own namespace."""
+    return name == "datahub.masking" or name.startswith(REDACTED_MASKING_NAMESPACE)
+
+
+def _patched_add_handler(self: logging.Logger, hdlr: logging.Handler) -> None:
+    # Call the original first so the handler is attached even if masking
+    # is not armed; then attach the shared filter if it is.
+    _original_add_handler(self, hdlr)
+    f = _installed_filter
+    if f is not None and f not in hdlr.filters:
+        hdlr.addFilter(f)
+
+
+def _install_addhandler_wrap() -> None:
+    """Install the Logger.addHandler wrap once. Idempotent."""
+    global _addhandler_wrap_installed
+    if _addhandler_wrap_installed:
+        return
+    logging.Logger.addHandler = _patched_add_handler  # type: ignore[assignment]
+    _addhandler_wrap_installed = True
 
 
 class SecretMaskingFilter(logging.Filter):
@@ -43,453 +104,460 @@ class SecretMaskingFilter(logging.Filter):
         self,
         secret_registry: Optional[SecretRegistry] = None,
         max_message_size: int = 5000,
-    ):
-        """Initialize the masking filter."""
+    ) -> None:
         super().__init__()
-
         self._registry = secret_registry or SecretRegistry.get_instance()
         self._max_message_size = max_message_size
-
-        # Thread safety: RLock for pattern access
-        self._pattern_lock = threading.RLock()
-
-        # Pattern state (immutable references - copy-on-write)
+        self._pattern_lock = threading.Lock()
         self._pattern: Optional[re.Pattern] = None
         self._replacements: Dict[str, str] = {}
         self._last_version: int = 0
+        # max(longest expanded value, longest exact marker). The marker term
+        # stays even after markers are deduped per name; dropping it would
+        # narrow the pre-cut and let a cut land inside a marker.
+        self._longest_pattern_length: int = 0
+        self._rebuild_warned = False
+        self._build_failure_warned = False
 
-        # Circuit breaker to prevent cascading failures
-        self._failure_count = 0
-        self._max_failures = 10
-        self._circuit_open = False
+    # --- Pattern cache ----------------------------------------------------
 
-    def _check_and_rebuild_pattern(self) -> None:
-        """Check if pattern needs rebuilding and rebuild if necessary."""
-        MAX_REBUILD_ATTEMPTS = 10  # Prevent infinite loops
+    def _build_pattern(
+        self, expanded: Dict[str, str]
+    ) -> Tuple[re.Pattern, Dict[str, str], int]:
+        """Compile the masking pattern from expanded keys -> names.
 
-        # Track last successfully built pattern for emergency fallback
-        last_built_pattern: Optional[re.Pattern] = None
-        last_built_replacements: Dict[str, str] = {}
-        last_built_version: int = 0
+        Ordering is load-bearing: marker alternatives first, then values
+        longest-first, then the generic marker fallback. With first-match
+        alternation, a short secret that is a prefix of a longer one would
+        win at the same position if listed first, leaking the longer secret's
+        tail. Markers first makes mask_text idempotent on already-masked text
+        (the marker alternative wins and passes through untouched). The
+        generic fallback protects dropped-execution markers whose names are
+        gone from the registry.
+        """
+        # Per-name markers (deduplicated): expanded keys share a name, so
+        # per-key markers would multiply the alternation ~4x for nothing.
+        names = list(dict.fromkeys(expanded.values()))
+        marker_alts = [
+            f"(?P<m{i}>{re.escape(REDACTED_FORMAT.format(name=n))})"
+            for i, n in enumerate(names)
+        ]
+        # Value alternatives longest-first; re.escape ensures metacharacters
+        # are matched literally.
+        sorted_items = sorted(expanded.items(), key=lambda x: len(x[0]), reverse=True)
+        value_alts = [
+            f"(?P<v{i}>{re.escape(v)})" for i, (v, _) in enumerate(sorted_items)
+        ]
+        generic = [rf"(?P<g>{_GENERIC_MARKER_RE})"]
+        pattern_str = "|".join(marker_alts + value_alts + generic)
+        new_pattern = re.compile(pattern_str)
+        new_replacements = {v: n for v, n in sorted_items}
+        longest_value = len(sorted_items[0][0]) if sorted_items else 0
+        longest_marker = max(
+            (len(REDACTED_FORMAT.format(name=n)) for n in names),
+            default=0,
+        )
+        new_longest = max(longest_value, longest_marker)
+        return new_pattern, new_replacements, new_longest
 
-        for attempt in range(MAX_REBUILD_ATTEMPTS):
-            # Quick check WITHOUT lock (fast path)
-            current_version = self._registry.get_version()
+    def _replace_match(self, match: re.Match, replacements: Dict[str, str]) -> str:
+        # Dispatch on which alternative won (lastgroup), not the matched
+        # text: a marker-shaped value is the same string as its marker, so
+        # text-based dispatch would oscillate.
+        last = match.lastgroup
+        if last is not None and not last.startswith("v"):
+            return match.group(0)
+        return REDACTED_FORMAT.format(name=replacements.get(match.group(0), "UNKNOWN"))
 
-            with self._pattern_lock:
-                if current_version == self._last_version:
-                    return  # Pattern is up to date
+    def _get_pattern(
+        self,
+    ) -> Tuple[Optional[re.Pattern], Dict[str, str], int, bool]:
+        """Return (pattern, replacements, longest, ok).
 
-            # Build pattern OUTSIDE lock (expensive operations)
-            secrets = self._registry.get_all_secrets()
-
-            if not secrets:
-                with self._pattern_lock:
-                    self._pattern = None
-                    self._replacements = {}
-                    self._last_version = current_version
-                return
-
-            # Sort by length (longest first) - NOT under lock
-            sorted_secrets = sorted(
-                secrets.items(), key=lambda x: len(x[0]), reverse=True
-            )
-
-            # Build pattern - NOT under lock
-            # CRITICAL: re.escape() ensures secrets with regex metacharacters
-            # (e.g., ".*", "a+b", "test|prod") are matched literally, not as regex
-            escaped_values = [re.escape(value) for value, _ in sorted_secrets]
-            pattern_str = "|".join(escaped_values)
-
-            # Compile regex - NOT under lock (this is the expensive part!)
-            try:
-                new_pattern = re.compile(pattern_str)
-                new_replacements = {value: name for value, name in sorted_secrets}
-
-                # Save this for emergency fallback
-                last_built_pattern = new_pattern
-                last_built_replacements = new_replacements
-                last_built_version = current_version
-            except Exception as e:
-                logger.error(f"Failed to compile masking pattern: {e}")
-                return  # Keep using old pattern
-
-            # Warn about performance impact with large secret counts
-            secret_count = len(secrets)
-            if secret_count > 500:
-                logger.warning(
-                    f"Very large secret count ({secret_count})! "
-                    f"This may impact masking performance. "
-                    f"Consider using Aho-Corasick algorithm for better performance."
-                )
-            elif secret_count >= 100:
-                logger.warning(
-                    f"Large number of secrets registered ({secret_count}). "
-                    f"This may impact masking performance."
-                )
-
-            # Atomic swap under lock (fast!)
-            with self._pattern_lock:
-                # Check version again - secrets might have changed while building
-                registry_version = self._registry.get_version()
-
-                if registry_version == current_version:
-                    # Version is stable, safe to swap in the new pattern
-                    self._pattern = new_pattern
-                    self._replacements = new_replacements
-                    self._last_version = current_version
-
-                    if attempt > 0:
-                        logger.debug(
-                            f"Rebuilt masking pattern with {secret_count} secrets "
-                            f"(version {current_version}) after {attempt + 1} attempts"
-                        )
-                    else:
-                        logger.debug(
-                            f"Rebuilt masking pattern with {secret_count} secrets "
-                            f"(version {current_version})"
-                        )
-                    return  # Success!
-
-                # Version changed during build, loop will retry
-                logger.debug(
-                    f"Pattern version changed during build "
-                    f"(expected {current_version}, got {registry_version}). "
-                    f"Retrying... (attempt {attempt + 1}/{MAX_REBUILD_ATTEMPTS})"
-                )
-                # Continue to next iteration of the loop
-
-        # If we get here, we failed after MAX_REBUILD_ATTEMPTS
-        # Emergency fallback: Use the last pattern we built if we have no pattern at all
-        # Better to have a slightly stale pattern than no masking at all
+        ``ok`` is False only when secrets exist but no pattern was ever built
+        and the latest rebuild attempt failed — the caller must return
+        MASKING_ERROR_MESSAGE in that case. When the registry is empty,
+        ``pattern`` is None and ``ok`` is True (return text unchanged).
+        """
+        version = self._registry.get_version()
         with self._pattern_lock:
-            if self._pattern is None and last_built_pattern is not None:
-                self._pattern = last_built_pattern
-                self._replacements = last_built_replacements
-                self._last_version = last_built_version
-                logger.warning(
-                    f"Emergency fallback: Using potentially stale pattern (version {last_built_version}) "
-                    f"because no pattern was previously available and registry is changing too rapidly."
+            if version == self._last_version:
+                return (
+                    self._pattern,
+                    self._replacements,
+                    self._longest_pattern_length,
+                    True,
                 )
-            else:
-                logger.error(
-                    f"CRITICAL: Failed to rebuild masking pattern after {MAX_REBUILD_ATTEMPTS} attempts. "
-                    f"Secrets are being modified too rapidly. "
-                    f"Continuing with potentially stale pattern (version {self._last_version}). "
-                    f"Some newly added secrets may not be masked until rate of changes decreases."
-                )
-        # Keep using the old pattern rather than crashing - graceful degradation
+        # Stale: snapshot and rebuild outside the lock.
+        snap_version, expanded = self._registry.snapshot()
+        if not expanded:
+            with self._pattern_lock:
+                self._pattern = None
+                self._replacements = {}
+                self._longest_pattern_length = 0
+                self._last_version = snap_version
+                self._rebuild_warned = False
+                self._build_failure_warned = False
+            return None, {}, 0, True
+        try:
+            new_pattern, new_replacements, new_longest = self._build_pattern(expanded)
+        except Exception as e:
+            # Keep previous pattern if we have one; log once.
+            with self._pattern_lock:
+                if self._pattern is not None:
+                    if not self._rebuild_warned:
+                        logger.warning(
+                            "Masking pattern rebuild failed; keeping previous "
+                            "pattern: %r",
+                            e,
+                        )
+                        self._rebuild_warned = True
+                    return (
+                        self._pattern,
+                        self._replacements,
+                        self._longest_pattern_length,
+                        True,
+                    )
+                # No previous pattern while secrets exist: fail closed.
+                if not self._build_failure_warned:
+                    logger.critical(
+                        "Masking pattern rebuild failed with no previous "
+                        "pattern while secrets exist; returning "
+                        "MASKING_ERROR_MESSAGE: %r",
+                        e,
+                    )
+                    self._build_failure_warned = True
+                return None, {}, 0, False
+        with self._pattern_lock:
+            self._pattern = new_pattern
+            self._replacements = new_replacements
+            self._longest_pattern_length = new_longest
+            self._last_version = snap_version
+            self._rebuild_warned = False
+            self._build_failure_warned = False
+        return new_pattern, new_replacements, new_longest, True
+
+    # --- Masking ----------------------------------------------------------
 
     def mask_text(self, text: str) -> str:
-        """Mask secrets in text string.
+        """Mask secrets in ``text``. Idempotent on already-masked text.
 
-        Public API for masking arbitrary text content. Thread-safe and includes
-        automatic pattern rebuilding, circuit breaker protection, and error handling.
-
-        Args:
-            text: Text content to mask
-
-        Returns:
-            Text with secrets replaced by ***REDACTED:VARIABLE_NAME***
+        Returns the text unchanged when the registry is empty; returns
+        MASKING_ERROR_MESSAGE when secrets exist but no pattern was ever
+        built and the rebuild failed. Public API — never truncates.
         """
         if not isinstance(text, str) or not text:
             return text
-
-        # Get pattern snapshot (no lock during masking!)
-        with self._pattern_lock:
-            self._check_and_rebuild_pattern()
-            pattern = self._pattern
-            replacements = self._replacements  # No .copy() needed!
-
-        # Pattern might be None if no secrets registered
+        pattern, replacements, longest, ok = self._get_pattern()
+        if not ok:
+            return MASKING_ERROR_MESSAGE
         if pattern is None:
             return text
-
-        # Circuit breaker - if too many failures, stop trying
-        if self._circuit_open:
-            return CIRCUIT_OPEN_MESSAGE
-
-        # Mask secrets (outside lock - safe because immutable references)
         try:
-            # Use callback to include variable name in masked output
-            def replace_with_variable_name(match):
-                """Replace matched secret with variable name."""
-                secret_value = match.group(0)
-                # Look up variable name (O(1) dict access)
-                variable_name = replacements.get(secret_value, "UNKNOWN")
-                # Return formatted mask
-                return REDACTED_FORMAT.format(name=variable_name)
+            return pattern.sub(lambda m: self._replace_match(m, replacements), text)
+        except Exception:
+            return MASKING_ERROR_MESSAGE
 
-            masked = pattern.sub(replace_with_variable_name, text)
+    _MAX_EXTRA_DEPTH = 10
 
-            # Success - reset failure count
-            if self._failure_count > 0:
-                self._failure_count = 0
+    def _mask_value_recursive(
+        self, value: Any, _depth: int = 0, _seen: Optional[set] = None
+    ) -> Any:
+        """Recursively mask string leaves in a container value.
 
-            return masked
-
-        except KeyError as e:
-            self._failure_count += 1
-            logger.error(
-                f"CRITICAL: Secret masking failed due to replacement error "
-                f"(failure {self._failure_count}/{self._max_failures}). "
-                f"Message redacted for safety. Error: {e}"
-            )
-            if self._failure_count >= self._max_failures:
-                self._circuit_open = True
-                logger.critical(
-                    "CRITICAL: Masking circuit breaker OPEN. All messages will be redacted."
-                )
-            return "[REDACTED: Masking Replacement Error]"
-
-        except re.error as e:
-            self._failure_count += 1
-            logger.error(
-                f"CRITICAL: Secret masking failed due to regex error "
-                f"(failure {self._failure_count}/{self._max_failures}). "
-                f"Message redacted for safety. Error: {e}"
-            )
-            if self._failure_count >= self._max_failures:
-                self._circuit_open = True
-                logger.critical(
-                    "CRITICAL: Masking circuit breaker OPEN. All messages will be redacted."
-                )
-            return "[REDACTED: Masking Regex Error]"
-
-        except MemoryError:
-            self._failure_count += 1
-            logger.error(
-                f"CRITICAL: Secret masking failed due to memory error "
-                f"(failure {self._failure_count}/{self._max_failures}). "
-                f"Message redacted for safety."
-            )
-            if self._failure_count >= self._max_failures:
-                self._circuit_open = True
-                logger.critical(
-                    "CRITICAL: Masking circuit breaker OPEN. All messages will be redacted."
-                )
-            return "[REDACTED: Masking Memory Error]"
-
-        except Exception as e:
-            self._failure_count += 1
-            logger.error(
-                f"CRITICAL: Secret masking failed with unexpected error "
-                f"(failure {self._failure_count}/{self._max_failures}). "
-                f"Message redacted for safety. Error type: {type(e).__name__}"
-            )
-            if self._failure_count >= self._max_failures:
-                self._circuit_open = True
-                logger.critical(
-                    "CRITICAL: Masking circuit breaker OPEN. All messages will be redacted."
-                )
-            return "[REDACTED: Masking Error]"
+        Containers are copied, not mutated in place. A depth cap and cycle
+        guard bound the recursion; beyond them a placeholder is returned
+        (never the raw subtree). Containers rebuild with their own type; if
+        reconstruction raises, the container becomes MASKING_ERROR_MESSAGE.
+        """
+        if _depth >= self._MAX_EXTRA_DEPTH:
+            return "<not masked: depth limit>"
+        if isinstance(value, str):
+            return self.mask_text(value)
+        if isinstance(value, dict):
+            if _seen is None:
+                _seen = set()
+            if id(value) in _seen:
+                return "<not masked: cycle>"
+            _seen.add(id(value))
+            try:
+                return {
+                    k: self._mask_value_recursive(v, _depth + 1, _seen)
+                    for k, v in value.items()
+                }
+            finally:
+                _seen.discard(id(value))
+        if isinstance(value, (list, tuple, set, frozenset)):
+            if _seen is None:
+                _seen = set()
+            if id(value) in _seen:
+                return "<not masked: cycle>"
+            _seen.add(id(value))
+            try:
+                masked = [
+                    self._mask_value_recursive(v, _depth + 1, _seen) for v in value
+                ]
+            finally:
+                _seen.discard(id(value))
+            try:
+                if hasattr(value, "_fields"):
+                    return type(value)(*masked)
+                return type(value)(masked)
+            except Exception:
+                return MASKING_ERROR_MESSAGE
+        return value
 
     def _mask_args(self, args: Any) -> Any:
-        """Mask secrets in log arguments."""
         if not args:
             return args
+        return self._mask_value_recursive(args)
 
-        try:
-            if isinstance(args, dict):
-                return {
-                    k: self.mask_text(v) if isinstance(v, str) else v
-                    for k, v in args.items()
-                }
-            elif isinstance(args, tuple):
-                return tuple(
-                    self.mask_text(arg) if isinstance(arg, str) else arg for arg in args
-                )
-            else:
-                return args
-        except Exception as e:
-            # Fail-secure: never return unmasked args on error
-            logger.error(f"CRITICAL: Secret masking failed in args: {e}", exc_info=True)
-            return (MASKING_ERROR_MESSAGE,)
-
-    def _mask_exception(self, exc_info: Optional[Tuple]) -> Optional[Tuple]:
-        """Mask secrets in exception information."""
+    def _materialize_exc_text(self, exc_info: Tuple) -> Optional[str]:
+        # exc_info is left untouched so handler-based error reporters keep
+        # the real exception; we only materialize text for masking.
         if not exc_info:
-            return exc_info
+            return None
+        return logging.Formatter().formatException(exc_info)
 
-        try:
-            exc_type, exc_value, exc_traceback = exc_info
+    def _strip_severed_tail(self, kept: str, keys: Any, longest: int) -> str:
+        # Runs on MASKED text: every complete occurrence is already a marker,
+        # so a tail matching a key prefix is a severed fragment. Remove the
+        # longest such suffix (len >= 3, < key) that is a proper prefix of any
+        # expanded key.
+        for L in range(min(longest, len(kept)), 2, -1):
+            for key in keys:
+                if len(key) > L and kept.endswith(key[:L]):
+                    return kept[:-L]
+        return kept
 
-            # Mask exception message/args
-            if exc_value and hasattr(exc_value, "args") and exc_value.args:
-                masked_args = tuple(
-                    self.mask_text(arg) if isinstance(arg, str) else arg
-                    for arg in exc_value.args
+    def _mask_bounded(
+        self, text: str, budget: int, original_len: Optional[int] = None
+    ) -> str:
+        # Pre-cut to budget + longest under one snapshot, mask, then strip any
+        # severed fragment from the masked tail, then final-cut to budget.
+        # Stripping after masking is load-bearing: a secret prefix with a
+        # self-overlapping border can match a coincidental overlap longer than
+        # the real fragment before masking, severing a complete occurrence.
+        pattern, replacements, longest, ok = self._get_pattern()
+        if not ok:
+            return MASKING_ERROR_MESSAGE
+        pre_cut = False
+        if len(text) > budget + longest:
+            kept = text[: budget + longest]
+            pre_cut = True
+        else:
+            kept = text
+        if pattern is None:
+            masked = kept
+        else:
+            try:
+                masked = pattern.sub(
+                    lambda m: self._replace_match(m, replacements), kept
                 )
-                # Create new exception instance with masked args
-                exc_value = type(exc_value)(*masked_args)
-
-            return (exc_type, exc_value, exc_traceback)
-
-        except Exception as e:
-            # Fail-secure: never return unmasked exception on error
-            logger.error(
-                f"CRITICAL: Secret masking failed in exception: {e}", exc_info=True
+            except Exception:
+                return MASKING_ERROR_MESSAGE
+        if pre_cut and pattern is not None:
+            masked = self._strip_severed_tail(masked, replacements.keys(), longest)
+        if pre_cut or len(masked) > budget:
+            base = original_len if original_len is not None else len(text)
+            truncated_bytes = max(0, base - budget)
+            masked = (
+                f"{masked[:budget]}\n"
+                f"... [{truncated_bytes} bytes truncated for performance]"
             )
-            # Return a sanitized exception
-            return (
-                RuntimeError,
-                RuntimeError(MASKING_ERROR_MESSAGE),
-                None,
-            )
+        return masked
 
-    def _truncate_message(self, message: str) -> str:
-        """Truncate large messages before masking."""
-        if not isinstance(message, str):
-            return message
+    def _mask_record_msg(self, record: logging.LogRecord) -> None:
+        if isinstance(record.msg, str):
+            if record.args:
+                # Format string: mask but skip truncation — truncating a
+                # format string can sever a %s placeholder.
+                record.msg = self.mask_text(record.msg)
+            else:
+                original_len = len(record.msg)
+                record.msg = self._mask_bounded(
+                    record.msg, self._max_message_size, original_len
+                )
+        elif isinstance(record.msg, (dict, list, tuple, set, frozenset)):
+            record.msg = self._mask_value_recursive(record.msg)
+        elif record.msg is not None:
+            plain = str(record.msg)
+            masked = self.mask_text(plain)
+            if masked != plain:
+                record.msg = masked
 
-        if len(message) <= self._max_message_size:
-            return message
+    def _mask_extras(self, record: logging.LogRecord) -> None:
+        """Mask non-standard record attributes (extra={...}) per field.
 
-        # Truncate with informative suffix
-        truncated_bytes = len(message) - self._max_message_size
-        return (
-            f"{message[: self._max_message_size]}\n"
-            f"... [{truncated_bytes} bytes truncated for performance]"
-        )
+        One field that raises becomes MASKING_ERROR_MESSAGE while the rest
+        are still masked. The caller's containers are not mutated in place —
+        masked copies are assigned.
+        """
+        for key, value in list(record.__dict__.items()):
+            if key in _STANDARD_RECORD_ATTRS:
+                continue
+            if isinstance(value, (str, dict, list, tuple, set, frozenset)):
+                try:
+                    record.__dict__[key] = self._mask_value_recursive(value)
+                except Exception:
+                    record.__dict__[key] = MASKING_ERROR_MESSAGE
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Filter and mask a log record."""
-        # Check if masking is disabled for debugging
-        from datahub.masking.secret_registry import is_masking_enabled
+        """Mask secrets in a log record. Always returns True.
 
-        if not is_masking_enabled():
-            return True  # Skip all masking and truncation for debugging
-
+        Fail-closed per field: each step runs in its own try; a field that
+        raises is substituted with MASKING_ERROR_MESSAGE and the next step
+        still runs. The idempotency sentinel is set in finally so it guards
+        the failure path. An outer boundary catches anything that escapes the
+        per-step tries and substitutes MASKING_ERROR_MESSAGE for the whole
+        record.
+        """
+        if _is_masking_namespace_name(record.name):
+            return True
+        if getattr(record, "_datahub_masked", None) == _MASKED:
+            return True
         try:
-            # 1. Truncate large messages BEFORE masking (performance optimization)
-            #    This is intentional: truncating first avoids regex on huge strings
-            #    Security: Truncation removes end of message, so secrets at end
-            #    are removed entirely (not just masked), which is acceptable
-            if isinstance(record.msg, str):
-                record.msg = self._truncate_message(record.msg)
-
-            # 2. Mask the log message (after truncation for performance)
-            if isinstance(record.msg, str):
-                record.msg = self.mask_text(record.msg)
-
-            # 3. Mask arguments (for formatting)
-            if record.args:
-                record.args = self._mask_args(record.args)
-
-            # 4. Mask pre-formatted message if it exists
-            if hasattr(record, "message") and record.message:
-                record.message = self.mask_text(record.message)
-
-            # 5. Mask exception information
-            if record.exc_info:
-                record.exc_info = self._mask_exception(record.exc_info)
-
-            # 6. Mask formatted exception text if it exists
-            if record.exc_text:
-                record.exc_text = self.mask_text(record.exc_text)
-
-            # 7. Mask stack_info if present (Python 3.2+)
-            if hasattr(record, "stack_info") and record.stack_info:
-                record.stack_info = self.mask_text(record.stack_info)
-
-        except Exception as e:
-            # NEVER let masking break logging
             try:
-                sys.stderr.write(f"WARNING: Secret masking filter failed: {e}\n")
-                sys.stderr.flush()
+                self._mask_record_msg(record)
             except Exception:
-                pass  # Even error reporting failed, continue silently
-
-        return True  # Always let record through
+                record.msg = MASKING_ERROR_MESSAGE
+            try:
+                if record.args:
+                    record.args = self._mask_args(record.args)
+            except Exception:
+                record.args = (MASKING_ERROR_MESSAGE,)
+            try:
+                if hasattr(record, "message") and record.message:
+                    record.message = self.mask_text(record.message)
+            except Exception:
+                record.message = MASKING_ERROR_MESSAGE
+            try:
+                if record.exc_info and not record.exc_text:
+                    record.exc_text = self._materialize_exc_text(record.exc_info)
+            except Exception:
+                record.exc_text = MASKING_ERROR_MESSAGE
+            try:
+                if record.exc_text:
+                    record.exc_text = self._mask_bounded(
+                        record.exc_text,
+                        2 * self._max_message_size,
+                        len(record.exc_text),
+                    )
+            except Exception:
+                record.exc_text = MASKING_ERROR_MESSAGE
+            try:
+                if hasattr(record, "stack_info") and record.stack_info:
+                    record.stack_info = self.mask_text(record.stack_info)
+            except Exception:
+                record.stack_info = MASKING_ERROR_MESSAGE
+            try:
+                self._mask_extras(record)
+            except Exception:
+                # _mask_extras already masks per-field; reaching here means
+                # the whole loop raised. Substitute a marker key to fail
+                # closed without leaving extras unmasked.
+                record.__dict__["_masking_error"] = MASKING_ERROR_MESSAGE
+        except Exception:
+            # Outer boundary: never let masking break logging. Clearing
+            # exc_info here is deliberate — on the failure path nothing
+            # guarantees it was masked.
+            record.msg = MASKING_ERROR_MESSAGE
+            record.args = ()
+            record.exc_info = None
+            record.exc_text = None
+        finally:
+            record._datahub_masked = _MASKED
+        return True
 
 
 class StreamMaskingWrapper:
-    """Lightweight wrapper for stdout/stderr that masks secrets."""
+    """Wraps stdout/stderr to mask secrets in raw writes."""
 
-    def __init__(self, original_stream: TextIO, masking_filter: SecretMaskingFilter):
-        """Initialize stream wrapper."""
+    def __init__(
+        self, original_stream: TextIO, masking_filter: "SecretMaskingFilter"
+    ) -> None:
         self._original = original_stream
         self._filter = masking_filter
 
     def write(self, text: str) -> int:
-        """Write text to stream with secrets masked."""
-        # Type validation - text streams require strings
         if not isinstance(text, str):
             raise TypeError(f"write() argument must be str, not {type(text).__name__}")
-
         try:
-            # Mask text (filter handles locking internally)
             masked = self._filter.mask_text(text)
-
-            # Write WITHOUT holding any locks (prevents deadlock)
             self._original.write(masked)
-
-            # Return length of MASKED text (contract compliance)
             return len(masked)
-
-        except TypeError:
-            # Re-raise type errors
-            raise
-
         except Exception:
-            # Graceful degradation for masking failures
             try:
-                self._original.write(text)
-                return len(text)
+                self._original.write(MASKING_ERROR_MESSAGE + "\n")
+                return len(MASKING_ERROR_MESSAGE) + 1
             except Exception:
                 return 0
 
-    def flush(self):
-        """Flush the underlying stream."""
+    def flush(self) -> None:
         try:
             if hasattr(self._original, "flush"):
                 self._original.flush()
-        except Exception:
+        except (ValueError, OSError):
             pass
 
-    def __getattr__(self, name):
-        """Delegate all other attributes to original stream."""
+    def writelines(self, lines) -> None:
+        for line in lines:
+            self.write(line)
+
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._original, name)
 
 
-def _update_existing_handlers() -> None:
-    """Update all existing logging handlers to use wrapped streams."""
-    updated_count = 0
+def _is_real_stream(stream: object) -> bool:
+    # Refuse to wrap proxies (e.g. Celery's LoggingProxy) — wrapping one
+    # re-enters logging and silently drops writes; under a proxy, raw
+    # writes already flow through masked handlers.
+    try:
+        stream.fileno()  # type: ignore[attr-defined]
+        return True
+    except (io.UnsupportedOperation, OSError, ValueError, AttributeError):
+        return False
 
-    # Get all loggers (including root and all named loggers)
-    all_loggers = [logging.getLogger()] + [
-        logging.getLogger(name) for name in logging.root.manager.loggerDict
+
+def _all_logger_handler_pairs() -> List[Tuple[logging.Logger, logging.Handler]]:
+    """Snapshot (logger, handler) pairs for the root logger and every
+    named logger. PlaceHolder entries in loggerDict are skipped."""
+    root = logging.getLogger()
+    pairs: List[Tuple[logging.Logger, logging.Handler]] = [
+        (root, h) for h in list(root.handlers)
     ]
+    for _name, obj in list(logging.root.manager.loggerDict.items()):
+        if isinstance(obj, logging.Logger):
+            for h in list(obj.handlers):
+                pairs.append((obj, h))
+    return pairs
 
-    for log in all_loggers:
-        if not isinstance(log, logging.Logger):
-            # Skip PlaceHolder objects in logger dict
+
+def _attach_filter_to_handlers(masking_filter: "SecretMaskingFilter") -> None:
+    """Attach the shared filter to every handler on every logger, skipping
+    handlers in the masking namespace and handlers that already carry this
+    filter instance (identity check, not isinstance)."""
+    added = 0
+    for log, handler in _all_logger_handler_pairs():
+        if _is_masking_namespace_name(log.name):
             continue
+        if masking_filter in handler.filters:
+            continue
+        handler.addFilter(masking_filter)
+        added += 1
+    if added:
+        logger.debug("Attached SecretMaskingFilter to %d handler(s)", added)
 
-        for handler in log.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                # Check if handler is using an unwrapped stream
-                if hasattr(handler, "stream"):
-                    stream = handler.stream
 
-                    # If handler's stream is the original unwrapped stdout/stderr,
-                    # update it to use our wrapped version
-                    if not isinstance(stream, StreamMaskingWrapper):
-                        # Check if this is stdout or stderr by comparing the underlying file
-                        try:
-                            if hasattr(stream, "name"):
-                                if stream.name == "<stderr>":
-                                    handler.setStream(sys.stderr)
-                                    updated_count += 1
-                                elif stream.name == "<stdout>":
-                                    handler.setStream(sys.stdout)
-                                    updated_count += 1
-                        except Exception:
-                            # If we can't determine the stream, skip it
-                            pass
-
-    if updated_count > 0:
-        logger.debug(f"Updated {updated_count} logging handlers to use wrapped streams")
+def _wrap_std_streams(masking_filter: "SecretMaskingFilter") -> None:
+    """Wrap sys.stdout/stderr with StreamMaskingWrapper if they are real
+    OS-backed streams and not already wrapped. Idempotent."""
+    if not isinstance(sys.stdout, StreamMaskingWrapper) and _is_real_stream(sys.stdout):
+        sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
+        logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
+    if not isinstance(sys.stderr, StreamMaskingWrapper) and _is_real_stream(sys.stderr):
+        sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
+        logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
 
 
 def install_masking_filter(
@@ -497,59 +565,65 @@ def install_masking_filter(
     max_message_size: int = 5000,
     install_stdout_wrapper: bool = True,
 ) -> SecretMaskingFilter:
-    """Install secret masking filter on root logger and optionally wrap stdout/stderr."""
-    # Create filter
+    # Install the shared filter on all logger handlers, install the
+    # addHandler wrap so later handlers are covered, and optionally wrap
+    # stdout/stderr. Re-invocation re-scans handlers (closes the interval
+    # where the wrap was inert); max_message_size is ignored on re-invocation
+    # (first install wins); install_stdout_wrapper=True on refresh does wrap.
+    global _installed_filter
+    if _installed_filter is not None:
+        # Already installed: re-scan handlers, rebind registry if a different
+        # one was passed, honour install_stdout_wrapper on refresh.
+        _attach_filter_to_handlers(_installed_filter)
+        if (
+            secret_registry is not None
+            and secret_registry is not _installed_filter._registry
+        ):
+            logger.debug("Rebinding SecretMaskingFilter registry on repeat install")
+            _installed_filter._registry = secret_registry  # type: ignore[attr-defined]
+            with _installed_filter._pattern_lock:  # type: ignore[attr-defined]
+                _installed_filter._last_version = -1  # type: ignore[attr-defined]
+                _installed_filter._pattern = None  # type: ignore[attr-defined]
+                _installed_filter._replacements = {}  # type: ignore[attr-defined]
+        if install_stdout_wrapper:
+            _wrap_std_streams(_installed_filter)
+        return _installed_filter
+
     masking_filter = SecretMaskingFilter(
         secret_registry=secret_registry, max_message_size=max_message_size
     )
-
-    # Install on root logger (affects all loggers)
-    root_logger = logging.getLogger()
-
-    # Check if already installed (avoid duplicates)
-    existing_filters = [
-        f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)
-    ]
-
-    if existing_filters:
-        logger.debug("SecretMaskingFilter already installed on root logger")
-        return existing_filters[0]
-
-    root_logger.addFilter(masking_filter)
-    logger.info("Installed SecretMaskingFilter on root logger")
-
-    # Optionally install stdout/stderr wrapper as backup
+    _installed_filter = masking_filter
+    _install_addhandler_wrap()
+    _attach_filter_to_handlers(masking_filter)
+    logger.info("Installed SecretMaskingFilter on logger handlers")
     if install_stdout_wrapper:
-        if not isinstance(sys.stdout, StreamMaskingWrapper):
-            sys.stdout = StreamMaskingWrapper(sys.stdout, masking_filter)
-            logger.debug("Wrapped sys.stdout with StreamMaskingWrapper")
-
-        if not isinstance(sys.stderr, StreamMaskingWrapper):
-            sys.stderr = StreamMaskingWrapper(sys.stderr, masking_filter)
-            logger.debug("Wrapped sys.stderr with StreamMaskingWrapper")
-
-        # Update all existing logging handlers to use wrapped streams
-        # Handlers created before masking was initialized will have cached
-        # references to the original unwrapped stderr/stdout
-        _update_existing_handlers()
-
+        _wrap_std_streams(masking_filter)
     return masking_filter
 
 
 def uninstall_masking_filter() -> None:
-    """Remove secret masking filter from root logger."""
-    root_logger = logging.getLogger()
-
-    # Remove filters
-    root_logger.filters = [
-        f for f in root_logger.filters if not isinstance(f, SecretMaskingFilter)
-    ]
-
-    # Unwrap stdout/stderr
+    # Test-only teardown; production never uninstalls. Raises off the main
+    # thread or while live execution scopes exist.
+    global _installed_filter
+    if threading.current_thread() is not threading.main_thread():
+        raise RuntimeError(
+            "uninstall_masking_filter() must be called on the main thread"
+        )
+    registry = SecretRegistry.get_instance()
+    if registry.has_active_executions():
+        raise RuntimeError(
+            "uninstall_masking_filter() called while execution scopes are "
+            "still active; ending one execution can never unmask another"
+        )
+    if _installed_filter is None:
+        return
+    f = _installed_filter
+    _installed_filter = None
+    for _log, handler in _all_logger_handler_pairs():
+        while f in handler.filters:
+            handler.removeFilter(f)
     if isinstance(sys.stdout, StreamMaskingWrapper):
         sys.stdout = sys.stdout._original
-
     if isinstance(sys.stderr, StreamMaskingWrapper):
         sys.stderr = sys.stderr._original
-
     logger.info("Uninstalled SecretMaskingFilter")

--- a/metadata-ingestion/src/datahub/masking/secret_registry.py
+++ b/metadata-ingestion/src/datahub/masking/secret_registry.py
@@ -1,48 +1,94 @@
+"""Thread-safe registry for secrets, scoped per execution.
+
+Secrets are grouped by the execution that registered them so overlapping
+in-process executions don't interfere: one execution ending drops only its
+own secrets. The masking filter always sees the union of all groups (via
+``snapshot``), so masking is process-global and always-on; it can over-mask
+during overlap (safe) but never under-mask.
+
+Registration stores raw values only — no key expansion, no pattern work.
+``snapshot`` expands keys (raw + repr + URL-quoted + JSON-escaped) on demand
+from the union of all groups, so the regex carries the working set of the
+concurrent executions, not the process-lifetime union.
 """
-Thread-safe registry for managing secrets used in masking.
 
-This module provides a singleton registry for storing and managing secrets.
-Secrets are automatically registered from ConfigModel fields and environment
-variables, then used by logging filters to mask sensitive data.
-
-"""
-
+import json
 import os
 import threading
-from typing import Dict, Optional
+import uuid
+from contextvars import ContextVar
+from typing import Dict, Optional, Tuple
 
+from datahub.masking.constants import REDACTED_FORMAT
 from datahub.masking.logging_utils import get_masking_safe_logger
 
 logger = get_masking_safe_logger(__name__)
 
+# Marker prefix used to refuse previously-redacted values pasted back into a
+# recipe. Derived from REDACTED_FORMAT so the registry and the filter share
+# one definition — a second hardcoded copy would let them drift.
+_MARKER_PREFIX = REDACTED_FORMAT.split("{", 1)[0]
+
+# Secrets registered outside any execution scope land here. Dropped when no
+# real executions remain active, so the catch-all does not grow unbounded in a
+# long-lived worker.
+_GLOBAL_GROUP = "__global__"
+
+# Identifies the execution owning the ambient context's scope. Set by
+# begin_execution, read by register_secret when no explicit exec_id is passed,
+# cleared by end_execution when it ends the ambient scope.
+_current_exec: ContextVar[Optional[str]] = ContextVar("masking_exec_id", default=None)
+
 
 def is_masking_enabled() -> bool:
-    """Check if masking is enabled."""
-    return os.getenv("DATAHUB_DISABLE_SECRET_MASKING", "").lower() not in (
-        "true",
-        "1",
+    """True unless DATAHUB_DISABLE_SECRET_MASKING is set to a truthy value."""
+    return os.getenv("DATAHUB_DISABLE_SECRET_MASKING", "").lower() not in ("true", "1")
+
+
+def _expand_keys(raw_value: str) -> Dict[str, None]:
+    """All string forms of a secret that should be masked.
+
+    Besides the raw value, covers repr-escaped forms, SQLAlchemy-style URL
+    encoding of ``:@/``, and JSON-escaped forms (the inner content of
+    ``json.dumps(v)``). The JSON form matters for the stdout/stderr wrapper
+    path and for JSON formatters that serialize before the filter sees the
+    record.
+    """
+    keys: Dict[str, None] = {raw_value: None}
+    if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
+        repr_value = repr(raw_value)[1:-1]
+        if repr_value != raw_value:
+            keys[repr_value] = None
+    sqlalchemy_encoded = (
+        raw_value.replace(":", "%3A").replace("@", "%40").replace("/", "%2F")
     )
+    if sqlalchemy_encoded != raw_value:
+        keys[sqlalchemy_encoded] = None
+    json_inner = json.dumps(raw_value)[1:-1]
+    if json_inner != raw_value:
+        keys[json_inner] = None
+    return keys
 
 
 class SecretRegistry:
-    """Thread-safe registry for secrets."""
+    """Thread-safe registry for secrets, scoped per execution."""
 
     _instance: Optional["SecretRegistry"] = None
-    _lock = threading.RLock()
+    _lock = threading.Lock()
 
-    MAX_SECRETS = 10000
+    # Upper bound on raw secret count; the regex carries ~4x MAX_SECRETS
+    # value alternatives plus per-name markers.
+    MAX_SECRETS = 2500
 
-    def __init__(self):
-        self._secrets: Dict[str, str] = {}  # value -> name mapping
-        self._name_to_value: Dict[
-            str, str
-        ] = {}  # name -> value mapping (reverse index)
-        self._version = 0
-        self._registry_lock = threading.RLock()
+    def __init__(self) -> None:
+        self._groups: Dict[str, Dict[str, str]] = {}
+        self._version: int = 0
+        self._registry_lock = threading.Lock()
+        self._capacity_warned = False
+        self._global_fallthrough_warned = False
 
     @classmethod
     def get_instance(cls) -> "SecretRegistry":
-        """Get singleton instance (thread-safe)."""
         with cls._lock:
             if cls._instance is None:
                 cls._instance = cls()
@@ -50,167 +96,244 @@ class SecretRegistry:
 
     @classmethod
     def reset_instance(cls) -> None:
-        """Reset singleton instance."""
+        """Reset the singleton (test-only)."""
         with cls._lock:
             cls._instance = None
+        _current_exec.set(None)
 
-    def register_secret(self, variable_name: str, raw_value: str) -> None:
-        """Register a secret for masking."""
-        if not raw_value or not isinstance(raw_value, str):
+    # --- Execution scoping ------------------------------------------------
+
+    def begin_execution(self) -> str:
+        """Open a new secret scope and return its token.
+
+        Each call opens a distinct scope; two calls on the same context
+        return different tokens and own different groups, so ending one
+        never drops another's secrets. The ambient contextvar is set under
+        ``_registry_lock`` so the contextvar and the ``_groups`` entry
+        publish atomically w.r.t. a concurrent ``register_secret``.
+        """
+        exec_id = uuid.uuid4().hex
+        with self._registry_lock:
+            self._groups[exec_id] = {}
+            _current_exec.set(exec_id)
+            self._global_fallthrough_warned = False
+            self._capacity_warned = False
+        return exec_id
+
+    def end_execution(self, execution_id: Optional[str] = None) -> None:
+        # Drop an execution's secrets. With an explicit token, drops that
+        # group (cross-thread); without it, drops the ambient scope. A dead
+        # id is a no-op. When the last real scope ends, __global__ is dropped
+        # too. A completely no-op call changes neither groups nor version.
+        ambient = _current_exec.get()
+        if execution_id is None:
+            execution_id = ambient
+        if ambient is not None and execution_id == ambient:
+            _current_exec.set(None)
+        with self._registry_lock:
+            popped = self._groups.pop(execution_id, None) if execution_id else None
+            if popped is not None:
+                if not any(g != _GLOBAL_GROUP for g in self._groups):
+                    self._groups.pop(_GLOBAL_GROUP, None)
+                self._version += 1
+            has_live = any(g != _GLOBAL_GROUP for g in self._groups) or any(
+                self._groups.values()
+            )
+        if popped is not None:
             return
+        if has_live:
+            logger.warning(
+                "end_execution resolved to no group but the registry still "
+                "holds live executions or secrets; a scope may be leaking"
+            )
+        else:
+            logger.debug("end_execution called with no scope to drop")
 
+    # --- Registration -----------------------------------------------------
+
+    def _admit(
+        self,
+        variable_name: str,
+        raw_value: str,
+        group: Dict[str, str],
+    ) -> bool:
+        """Validate and store one secret in ``group``. Returns True if stored.
+
+        Single validation path shared by ``register_secret`` and
+        ``register_secrets_batch``. Stores the raw value (no expansion) and
+        bumps ``_version`` once per call (the batch path bumps once for the
+        whole batch, outside this helper).
+        """
+        if not isinstance(raw_value, str) or not raw_value:
+            return False
         if len(raw_value) < 3:
-            return
-
-        # Fast path: check without lock
-        if raw_value in self._secrets:
-            return
-
-        with self._registry_lock:
-            # Copy-on-write
-            new_secrets = self._secrets.copy()
-            new_name_to_value = self._name_to_value.copy()
-
-            # Double-check after acquiring lock
-            if raw_value in new_secrets:
-                return
-
-            # Check memory limit
-            if len(new_secrets) >= self.MAX_SECRETS:
+            logger.warning(
+                "Refusing to register secret %s: value is below the "
+                "3-character minimum floor (%d chars).",
+                variable_name,
+                len(raw_value),
+            )
+            return False
+        if _MARKER_PREFIX in raw_value:
+            # Refusal is fail-open for this one secret: the value will NOT be
+            # masked in logs. State that plainly so an operator sees it.
+            logger.warning(
+                "Refusing to register secret %s: value contains the "
+                "redaction marker prefix %r. This value will NOT be masked "
+                "in logs; it looks like previously-redacted output pasted "
+                "back into a recipe. Rename the variable or change the value.",
+                variable_name,
+                _MARKER_PREFIX,
+            )
+            return False
+        if raw_value in group:
+            return False
+        # Capacity is on raw secret count, not expanded keys.
+        total = sum(len(g) for g in self._groups.values())
+        if total >= self.MAX_SECRETS:
+            if not self._capacity_warned:
                 logger.warning(
-                    f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                    f"Skipping registration of {variable_name}"
+                    "Secret registry at capacity (%d raw secrets). "
+                    "Skipping registration of %s; this value will NOT be "
+                    "masked in logs.",
+                    self.MAX_SECRETS,
+                    variable_name,
                 )
-                return
+                self._capacity_warned = True
+            return False
+        group[raw_value] = variable_name
+        return True
 
-            new_secrets[raw_value] = variable_name
-            new_name_to_value[variable_name] = raw_value
+    def _resolve_group(self, exec_id: Optional[str]) -> Dict[str, str]:
+        """Return the group for ``exec_id`` (or the ambient/global fallback).
 
-            # Register repr() version if secret contains escape sequences
-            if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
-                repr_value = repr(raw_value)[1:-1]
-                if repr_value != raw_value and repr_value not in new_secrets:
-                    new_secrets[repr_value] = variable_name
-
-            # Register SQLAlchemy-style URL encoding (only encodes :@/)
-            # This matches how SQLAlchemy.URL.__str__() renders passwords
-            sqlalchemy_encoded = (
-                raw_value.replace(":", "%3A").replace("@", "%40").replace("/", "%2F")
+        An unknown explicit exec_id falls through to ``__global__`` (dead
+        groups are not revived). When the fall-through lands in
+        ``__global__`` while live execution scopes exist, warn once per
+        execution — the flag is reset by ``begin_execution`` and ``clear``.
+        """
+        if exec_id is not None:
+            group = self._groups.get(exec_id)
+            if group is not None:
+                return group
+            # Unknown explicit id: fall through to __global__ without reviving.
+            active = [g for g in self._groups if g != _GLOBAL_GROUP]
+            if active and not self._global_fallthrough_warned:
+                self._global_fallthrough_warned = True
+                logger.warning(
+                    "Secret registered under an unknown execution id while "
+                    "live scope(s) are active; landing in __global__. If the "
+                    "id is stale the secret outlives its intended scope.",
+                )
+            return self._groups.setdefault(_GLOBAL_GROUP, {})
+        ambient = _current_exec.get()
+        if ambient is not None and ambient in self._groups:
+            return self._groups[ambient]
+        global_group = self._groups.setdefault(_GLOBAL_GROUP, {})
+        active = [g for g in self._groups if g != _GLOBAL_GROUP]
+        if active and not self._global_fallthrough_warned:
+            self._global_fallthrough_warned = True
+            logger.warning(
+                "Secret registered outside any execution scope while %d "
+                "execution scope(s) are active; landing in __global__. If "
+                "the ambient contextvar does not propagate from "
+                "begin_execution to the registration sites, all secrets "
+                "pool in __global__ and per-execution scoping does nothing.",
+                len(active),
             )
-            if (
-                sqlalchemy_encoded != raw_value
-                and sqlalchemy_encoded not in new_secrets
-            ):
-                new_secrets[sqlalchemy_encoded] = variable_name
+        return global_group
 
-            self._secrets = new_secrets
-            self._name_to_value = new_name_to_value
-            self._version += 1
+    def register_secret(
+        self,
+        variable_name: str,
+        raw_value: str,
+        exec_id: Optional[str] = None,
+    ) -> None:
+        """Register a secret for masking.
 
-            logger.debug(
-                f"Registered secret: {variable_name[:8]}*** (version {self._version})"
-            )
-
-    def register_secrets_batch(self, secrets: Dict[str, str]) -> None:
-        """Register multiple secrets atomically."""
-        if not secrets:
-            return
-
-        # Pre-validate all secrets
-        valid_secrets = {
-            name: value
-            for name, value in secrets.items()
-            if value and isinstance(value, str) and len(value) >= 3
-        }
-
-        if not valid_secrets:
-            return
-
-        # Check fast path - if all secrets already registered, skip
-        all_present = all(value in self._secrets for value in valid_secrets.values())
-        if all_present:
-            return
-
-        # Slow path - batch register
+        With ``exec_id`` (the token from ``begin_execution``), the secret
+        lands in that scope — this is how a worker thread registers into a
+        parent execution's scope, since ContextVars do not cross thread
+        boundaries. Without ``exec_id``, the secret lands in the ambient
+        context's scope, or ``__global__`` if the ambient context opened no
+        scope.
+        """
         with self._registry_lock:
-            # Copy-on-write
-            new_secrets = self._secrets.copy()
-            new_name_to_value = self._name_to_value.copy()
-
-            added_count = 0
-            for variable_name, raw_value in valid_secrets.items():
-                # Skip if already registered
-                if raw_value in new_secrets:
-                    continue
-
-                # Check memory limit
-                if len(new_secrets) >= self.MAX_SECRETS:
-                    logger.warning(
-                        f"Secret registry at capacity ({self.MAX_SECRETS}). "
-                        f"Skipping registration of {variable_name}"
-                    )
-                    break
-
-                # Register main value
-                new_secrets[raw_value] = variable_name
-                new_name_to_value[variable_name] = raw_value
-                added_count += 1
-
-                # Register repr version if needed
-                if any(c in raw_value for c in ["\n", "\r", "\t", "\\", '"', "'"]):
-                    repr_value = repr(raw_value)[1:-1]
-                    if repr_value != raw_value and repr_value not in new_secrets:
-                        new_secrets[repr_value] = variable_name
-
-                # Register SQLAlchemy-style URL encoding (only encodes :@/)
-                sqlalchemy_encoded = (
-                    raw_value.replace(":", "%3A")
-                    .replace("@", "%40")
-                    .replace("/", "%2F")
-                )
-                if (
-                    sqlalchemy_encoded != raw_value
-                    and sqlalchemy_encoded not in new_secrets
-                ):
-                    new_secrets[sqlalchemy_encoded] = variable_name
-
-            if added_count > 0:
-                # Atomic swaps - single version increment for entire batch
-                self._secrets = new_secrets
-                self._name_to_value = new_name_to_value
+            group = self._resolve_group(exec_id)
+            if self._admit(variable_name, raw_value, group):
                 self._version += 1
 
-                logger.debug(
-                    f"Batch registered {added_count} secrets (version {self._version})"
-                )
-
-    def get_all_secrets(self) -> Dict[str, str]:
-        """Get all registered secrets."""
+    def register_secrets_batch(
+        self,
+        secrets: Dict[str, str],
+        exec_id: Optional[str] = None,
+    ) -> None:
+        """Register multiple secrets atomically under one execution scope."""
+        if not secrets:
+            return
         with self._registry_lock:
-            return self._secrets.copy()
+            group = self._resolve_group(exec_id)
+            admitted = False
+            for name, value in secrets.items():
+                if self._admit(name, value, group):
+                    admitted = True
+            if admitted:
+                self._version += 1
+
+    # --- Reads -------------------------------------------------------------
+
+    def snapshot(self) -> Tuple[int, Dict[str, str]]:
+        # Return (version, expanded_key -> name) for the union of groups.
+        # Deep-copy under the lock, expand outside it so concurrent mask_text
+        # isn't blocked on O(N) string work. First registration wins a name.
+        with self._registry_lock:
+            version = self._version
+            groups_copy = {k: dict(v) for k, v in self._groups.items()}
+        expanded: Dict[str, str] = {}
+        for group in groups_copy.values():
+            for raw_value, name in group.items():
+                for key in _expand_keys(raw_value):
+                    expanded.setdefault(key, name)
+        return version, expanded
 
     def get_version(self) -> int:
-        """Get current version."""
-        with self._registry_lock:
-            return self._version
+        # Int read is atomic under the GIL; bumps happen under _registry_lock.
+        return self._version
 
     def get_count(self) -> int:
-        """Get number of registered secrets."""
-        return len(self._secrets)
-
-    def clear(self) -> None:
-        """Clear all secrets."""
+        """Number of raw secrets currently registered (the union)."""
         with self._registry_lock:
-            self._secrets = {}
-            self._name_to_value = {}
-            self._version += 1
-            logger.debug("Cleared all secrets from registry")
+            return sum(len(g) for g in self._groups.values())
+
+    def has_active_executions(self) -> bool:
+        """True if any per-execution scope is currently open.
+
+        ``__global__`` (the catch-all for ambient registrations with no
+        exec_id) does not count as an active execution — it is the residual
+        bucket, not a scope.
+        """
+        with self._registry_lock:
+            return any(g != _GLOBAL_GROUP for g in self._groups)
 
     def has_secret(self, variable_name: str) -> bool:
-        """Check if secret is registered."""
+        """True if a secret was registered under ``variable_name``."""
         with self._registry_lock:
-            return variable_name in self._name_to_value
+            return any(variable_name in g.values() for g in self._groups.values())
 
     def get_secret_value(self, variable_name: str) -> Optional[str]:
-        """Get secret value by name."""
-        return self._name_to_value.get(variable_name)
+        """Return the raw value for ``variable_name`` (first-wins across scopes)."""
+        with self._registry_lock:
+            for group in self._groups.values():
+                for raw_value, name in group.items():
+                    if name == variable_name:
+                        return raw_value
+            return None
+
+    def clear(self) -> None:
+        """Drop all secrets from all executions (primarily for tests)."""
+        with self._registry_lock:
+            self._groups = {}
+            self._version += 1
+            self._capacity_warned = False
+            self._global_fallthrough_warned = False
+        _current_exec.set(None)

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -383,3 +383,24 @@ def pytest_collection_modifyitems(
         if target_batch is None or batch_index == target_batch:
             kept.append(item)
     items[:] = kept
+
+
+@pytest.fixture(autouse=True)
+def _reset_secret_masking():
+    yield
+    from datahub.masking.bootstrap import is_bootstrapped, reset_bootstrap_state
+    from datahub.masking.secret_registry import SecretRegistry
+
+    registry = SecretRegistry.get_instance()
+    if (
+        not is_bootstrapped()
+        and registry.get_count() == 0
+        and not registry.has_active_executions()
+    ):
+        return
+    leaked = registry.has_active_executions()
+    SecretRegistry.reset_instance()
+    reset_bootstrap_state()
+    assert not leaked, (
+        "test leaked a live masking execution scope (missing shutdown_secret_masking)"
+    )

--- a/metadata-ingestion/tests/integration/test_masking_integration.py
+++ b/metadata-ingestion/tests/integration/test_masking_integration.py
@@ -43,12 +43,15 @@ def capture_masked_logs(
             logger.info("Secret: my_secret")
             assert "my_secret" not in output.getvalue()
     """
-    # Get masking filter from root logger
+    # Get the shared masking filter from root logger's handlers.
     root_logger = logging.getLogger()
     masking_filter = None
-    for f in root_logger.filters:
-        if isinstance(f, SecretMaskingFilter):
-            masking_filter = f
+    for h in root_logger.handlers:
+        for f in h.filters:
+            if isinstance(f, SecretMaskingFilter):
+                masking_filter = f
+                break
+        if masking_filter is not None:
             break
 
     if masking_filter is None:
@@ -87,9 +90,14 @@ class TestBootstrapIntegration:
     def test_basic_initialization(self):
         initialize_secret_masking()
 
-        # Check that filter is installed
+        # Check that filter is installed on root handlers
         root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
+        filters = [
+            f
+            for h in root_logger.handlers
+            for f in h.filters
+            if isinstance(f, SecretMaskingFilter)
+        ]
         assert len(filters) > 0
 
     def test_manual_secret_registration(self):
@@ -100,7 +108,7 @@ class TestBootstrapIntegration:
         registry.register_secret("TEST_PASSWORD", "my_test_secret_123")
 
         # Check that secret was registered
-        secrets = registry.get_all_secrets()
+        secrets = registry.snapshot()[1]
         assert "my_test_secret_123" in secrets
         assert secrets["my_test_secret_123"] == "TEST_PASSWORD"
 
@@ -329,12 +337,11 @@ class TestDoubleInitialization:
         # Second initialization (should be no-op)
         initialize_secret_masking()
 
-        # Check that only one filter is installed
+        # Check that only one filter is installed per handler
         root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-
-        # Should only have one filter (not duplicated)
-        assert len(filters) == 1
+        for h in root_logger.handlers:
+            filters = [f for f in h.filters if isinstance(f, SecretMaskingFilter)]
+            assert len(filters) == 1
 
     def test_force_reinitialization(self):
         # First initialization

--- a/metadata-ingestion/tests/performance/test_masking_perf.py
+++ b/metadata-ingestion/tests/performance/test_masking_perf.py
@@ -59,7 +59,7 @@ class TestMaskTextPerformance:
             (200, 20_000),
         ],
     )
-    def test_mask_text_ceiling(self, n_secrets: int, text_chars: int):
+    def test_mask_text_ceiling(self, n_secrets: int, text_chars: int) -> None:
         f = _make_filter(n_secrets)
         text = _make_text(text_chars, n_secrets)
         ms = _measure_ms(f, text)

--- a/metadata-ingestion/tests/performance/test_masking_perf.py
+++ b/metadata-ingestion/tests/performance/test_masking_perf.py
@@ -1,0 +1,70 @@
+"""Performance benchmark for SecretMaskingFilter.mask_text.
+
+Run via the testPerformance gradle task (scans tests/performance with -m 'perf'):
+
+    ../gradlew :metadata-ingestion:testPerformance
+
+Only the typical case (<=20 secrets, <=1 KB text) is gated (must stay under
+~1 ms per mask). The other rows document ceilings via print and never gate.
+"""
+
+import time
+
+import pytest
+
+from datahub.masking.masking_filter import SecretMaskingFilter
+from datahub.masking.secret_registry import SecretRegistry
+
+TYPICAL_CASE_MAX_MS = 1.0
+
+
+def _make_filter(n_secrets: int) -> SecretMaskingFilter:
+    reg = SecretRegistry()
+    reg.clear()
+    for i in range(n_secrets):
+        reg.register_secret(f"SECRET_{i}", f"secret_value_{i:04d}_xxxx")
+    return SecretMaskingFilter(reg)
+
+
+def _make_text(size_chars: int, n_secrets: int) -> str:
+    body = "x" * max(0, size_chars - 200)
+    snippets = []
+    for i in range(min(5, n_secrets)):
+        snippets.append(f"leak secret_value_{i:04d}_xxxx here")
+    return body + " ".join(snippets)
+
+
+def _measure_ms(f: SecretMaskingFilter, text: str, iterations: int = 50) -> float:
+    f.mask_text(text)  # warm up pattern build
+    start = time.perf_counter()
+    for _ in range(iterations):
+        f.mask_text(text)
+    end = time.perf_counter()
+    return (end - start) / iterations * 1000.0
+
+
+@pytest.mark.perf
+class TestMaskTextPerformance:
+    @pytest.mark.parametrize(
+        "n_secrets,text_chars",
+        [
+            (20, 100),  # typical case — gating row
+            (20, 5_000),
+            (50, 5_000),
+            (100, 5_000),
+            (200, 5_000),
+            (50, 10_000),
+            (50, 20_000),
+            (100, 10_000),
+            (200, 20_000),
+        ],
+    )
+    def test_mask_text_ceiling(self, n_secrets: int, text_chars: int):
+        f = _make_filter(n_secrets)
+        text = _make_text(text_chars, n_secrets)
+        ms = _measure_ms(f, text)
+        print(f"mask_text: secrets={n_secrets} text={text_chars} -> {ms:.3f} ms/mask")
+        if n_secrets <= 20 and text_chars <= 1_000:
+            assert ms < TYPICAL_CASE_MAX_MS, (
+                f"typical case regression: {ms:.3f} ms > {TYPICAL_CASE_MAX_MS} ms"
+            )

--- a/metadata-ingestion/tests/unit/api/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/api/test_pipeline.py
@@ -28,6 +28,8 @@ from datahub.ingestion.run.pipeline import (
 )
 from datahub.ingestion.sink.datahub_kafka import DatahubKafkaSink
 from datahub.ingestion.sink.datahub_rest import DatahubRestSink
+from datahub.masking import shutdown_secret_masking
+from datahub.masking.secret_registry import SecretRegistry
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import SystemMetadata
 from datahub.metadata.schema_classes import (
     DatasetPropertiesClass,
@@ -793,6 +795,87 @@ sink:
             # Verify the graph has been stored in the pipeline context
             assert pipeline.ctx.graph is mock_graph
 
+    def test_cli_success_path_masks_registered_secret(self, tmp_path):
+        # Success path: a source registers a secret and logs the raw value
+        # through a FileHandler; the log file carries the marker, not the
+        # raw value, and no live scope remains after the command returns.
+        log_file: pathlib.Path = tmp_path / "mask.log"
+        config_file: pathlib.Path = tmp_path / "test.yml"
+        config_file.write_text(
+            f"""
+---
+run_id: pipeline_test
+source:
+    type: tests.unit.api.test_pipeline.FakeSourceWithSecret
+    config: {{log_path: {log_file}}}
+sink:
+    type: console
+"""
+        )
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}"],
+            tmp_path=tmp_path,
+            check_result=False,
+        )
+        logged = log_file.read_text()
+        assert "***REDACTED:TOK***" in logged, logged
+        assert "tok-secret-value-12345" not in logged, logged
+        assert not SecretRegistry.get_instance().has_active_executions()
+
+    def test_cli_error_path_keeps_scope_for_masked_traceback(self, tmp_path):
+        # Error path: a source registers a secret then raises in create()
+        # so the exception escapes run() to entrypoints. The scope is
+        # deliberately NOT dropped on that path so the top-level handler
+        # formats the traceback masked; the registry still holds the
+        # secret after the command returns.
+        config_file: pathlib.Path = tmp_path / "test.yml"
+        config_file.write_text(
+            """
+---
+run_id: pipeline_test
+source:
+    type: tests.unit.api.test_pipeline.FakeSourceRaisesAfterSecret
+    config: {}
+sink:
+    type: console
+"""
+        )
+        try:
+            res = run_datahub_cmd(
+                ["ingest", "-c", f"{config_file}"],
+                tmp_path=tmp_path,
+                check_result=False,
+            )
+            # Scope kept on error so the traceback is formatted masked.
+            assert SecretRegistry.get_instance().has_secret("TOK")
+            assert SecretRegistry.get_instance().has_active_executions()
+            # The raw secret must not appear in the captured output.
+            assert "tok-secret-value-12345" not in (res.output or "")
+        finally:
+            shutdown_secret_masking()
+
+    def test_cli_test_source_connection_drops_scope(self, tmp_path):
+        # The other non-exception exit (--test-source-connection) must drop
+        # the scope before exiting.
+        config_file: pathlib.Path = tmp_path / "test.yml"
+        config_file.write_text(
+            f"""
+---
+run_id: pipeline_test
+source:
+    type: tests.unit.api.test_pipeline.FakeSourceWithSecret
+    config: {{log_path: {tmp_path / "mask.log"}}}
+sink:
+    type: console
+"""
+        )
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}", "--test-source-connection"],
+            tmp_path=tmp_path,
+            check_result=False,
+        )
+        assert not SecretRegistry.get_instance().has_active_executions()
+
 
 class AddStatusRemovedTransformer(Transformer):
     @classmethod
@@ -855,6 +938,51 @@ class FakeSourceWithFailures(FakeSource):
 
     def get_report(self) -> SourceReport:
         return self.source_report
+
+
+@platform_name("fake")
+class FakeSourceWithSecret(FakeSource):
+    SECRET_VALUE = "tok-secret-value-12345"
+
+    def __init__(self, ctx: PipelineContext, log_path: str):
+        super().__init__(ctx)
+        self._log_path = log_path
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "FakeSourceWithSecret":
+        return cls(ctx, log_path=config_dict["log_path"])
+
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        SecretRegistry.get_instance().register_secret("TOK", self.SECRET_VALUE)
+        # Log the raw value through a FileHandler so the masking filter
+        # (attached by the addHandler wrap) proves end-to-end masking.
+        logger = logging.getLogger("test.pipeline.secret")
+        handler = logging.FileHandler(self._log_path)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        logger.warning("using token=%s", self.SECRET_VALUE)
+        logger.removeHandler(handler)
+        handler.close()
+        return self.work_units
+
+    def test_connection(self) -> None:
+        SecretRegistry.get_instance().register_secret("TOK", self.SECRET_VALUE)
+
+
+@platform_name("fake")
+class FakeSourceRaisesAfterSecret(FakeSource):
+    SECRET_VALUE = "tok-secret-value-12345"
+
+    @classmethod
+    def create(
+        cls, config_dict: dict, ctx: PipelineContext
+    ) -> "FakeSourceRaisesAfterSecret":
+        # Register then raise in create() so the exception propagates past
+        # run() to entrypoints (the pipeline swallows source exceptions in
+        # get_workunits, so the scope-keeping error path needs an exception
+        # that escapes run()).
+        SecretRegistry.get_instance().register_secret("TOK", cls.SECRET_VALUE)
+        raise RuntimeError(f"boom with {cls.SECRET_VALUE}")
 
 
 def get_initial_mce() -> MetadataChangeEventClass:

--- a/metadata-ingestion/tests/unit/config/test_nested_secrets.py
+++ b/metadata-ingestion/tests/unit/config/test_nested_secrets.py
@@ -104,7 +104,8 @@ class TestNestedSecretRegistration:
             == "nested-secret-456"
         )
         # The secret VALUE is in the registry and will be masked
-        assert "nested-secret-456" in registry._secrets
+        _ver, snap = registry.snapshot()
+        assert "nested-secret-456" in snap
 
     def test_multiple_levels_of_nesting(self):
         _config = MiddleConfig.model_validate(

--- a/metadata-ingestion/tests/unit/test_bootstrap.py
+++ b/metadata-ingestion/tests/unit/test_bootstrap.py
@@ -1,435 +1,323 @@
-"""
-Tests for secret masking bootstrap functionality.
+"""Tests for the bootstrap lifecycle — invariants 11 and scope halves of 3."""
 
-Note: These tests mock filter installation because bootstrap only sets up
-infrastructure (logging filter + exception hook). Secret discovery happens
-automatically at point-of-read (config expansion, Pydantic validation).
-"""
-
+import logging
+import os
+import sys
 from unittest.mock import patch
 
+import pytest
 
-class TestBootstrapErrorHandling:
-    """Test bootstrap initialization error handling."""
+from datahub.masking.bootstrap import (
+    get_bootstrap_error,
+    initialize_secret_masking,
+    is_bootstrapped,
+    reset_bootstrap_state,
+    shutdown_secret_masking,
+)
+from datahub.masking.masking_filter import SecretMaskingFilter
+from datahub.masking.secret_registry import SecretRegistry
 
-    def test_bootstrap_error_cleared_on_successful_retry(self):
-        """
-        Verify that _bootstrap_error is cleared when retry succeeds.
 
-        Regression test for bug where _bootstrap_error remained set
-        after successful initialization following a previous failure.
+class TestDisabledMasking:
+    """Invariant 11: with DATAHUB_DISABLE_SECRET_MASKING=true, nothing is
+    installed and exactly one warning is emitted."""
 
-        Bug scenario:
-        1. First initialization fails → _bootstrap_error is set
-        2. Second initialization succeeds → _bootstrap_error should be None
-        3. Without fix: _bootstrap_error still contains old error (misleading)
-        """
-        from datahub.masking.bootstrap import (
-            get_bootstrap_error,
-            initialize_secret_masking,
-            is_bootstrapped,
-            shutdown_secret_masking,
-        )
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
 
+    def teardown_method(self):
+        if "DATAHUB_DISABLE_SECRET_MASKING" in os.environ:
+            del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def test_disabled_returns_none_and_warns_once(self, caplog):
+        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
+        # Capture records from the masking-safe bootstrap logger directly,
+        # since propagate=False keeps caplog from seeing them.
+        bootstrap_logger = logging.getLogger("datahub.masking.bootstrap")
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        cap = _Capture()
+        bootstrap_logger.addHandler(cap)
         try:
-            # Start clean
-            shutdown_secret_masking()
-
-            # First attempt: simulate failure during filter installation
-            with patch(
-                "datahub.masking.bootstrap.install_masking_filter"
-            ) as mock_install:
-                test_exception = Exception("Simulated installation failure")
-                mock_install.side_effect = test_exception
-
-                # Initialize (should fail gracefully)
-                initialize_secret_masking()
-
-                # Verify initialization failed
-                assert not is_bootstrapped(), "Should not be bootstrapped after failure"
-
-                # Verify error was recorded
-                error = get_bootstrap_error()
-                assert error is not None, "Error should be recorded after failure"
-                assert "Simulated installation failure" in str(error), (
-                    "Should record the actual error"
-                )
-
-            # Second attempt: simulate success
-            with patch("datahub.masking.bootstrap.install_masking_filter"):
-                # This time it succeeds (no side_effect)
-                initialize_secret_masking(force=True)
-
-                # Verify initialization succeeded
-                assert is_bootstrapped(), (
-                    "Should be bootstrapped after successful retry"
-                )
-
-                # CRITICAL: Verify error was cleared (this is the bug fix)
-                error = get_bootstrap_error()
-                assert error is None, (
-                    "Error should be None after successful initialization. "
-                    "If this assertion fails, _bootstrap_error is not being cleared on success. "
-                    "Fix: Add '_bootstrap_error = None' after '_bootstrap_completed = True'"
-                )
-
+            token = initialize_secret_masking()
+            assert token is None
+            assert not is_bootstrapped()
+            # First call warns once.
+            first_warnings = [r for r in records if "DISABLED" in r.getMessage()]
+            assert len(first_warnings) == 1
+            # Second call does not warn again.
+            records.clear()
+            initialize_secret_masking()
+            second_warnings = [r for r in records if "DISABLED" in r.getMessage()]
+            assert len(second_warnings) == 0
         finally:
-            # Always cleanup
-            shutdown_secret_masking()
+            bootstrap_logger.removeHandler(cap)
 
-    def test_bootstrap_error_set_on_failure(self):
-        """Verify that _bootstrap_error is set when initialization fails."""
-        from datahub.masking.bootstrap import (
-            get_bootstrap_error,
-            initialize_secret_masking,
-            is_bootstrapped,
-            shutdown_secret_masking,
+    def test_disabled_then_enabled_installs_for_real(self):
+        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
+        initialize_secret_masking()
+        assert not is_bootstrapped()
+        del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
+        token = initialize_secret_masking()
+        assert token is not None
+        assert is_bootstrapped()
+        # A registered secret is masked.
+        SecretRegistry.get_instance().register_secret("PW", "after_secret_value")
+        mf = SecretMaskingFilter(SecretRegistry.get_instance())
+        out = mf.mask_text("leak after_secret_value here")
+        assert "after_secret_value" not in out
+        assert "***REDACTED:PW***" in out
+
+
+class TestInitializeInstallsOnce:
+    """Invariant 11 (positive half): initialize installs the filter once;
+    subsequent calls re-scan handlers and open a new scope each."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def test_initialize_returns_distinct_tokens(self):
+        t1 = initialize_secret_masking()
+        t2 = initialize_secret_masking()
+        assert t1 is not None and t2 is not None
+        assert t1 != t2
+
+    def test_initialize_installs_filter_on_handlers(self):
+        initialize_secret_masking()
+        root = logging.getLogger()
+        assert root.handlers, "root logger should have at least one handler"
+        assert all(
+            any(isinstance(f, SecretMaskingFilter) for f in h.filters)
+            for h in root.handlers
         )
 
-        try:
-            shutdown_secret_masking()
+    def test_force_accepted_and_ignored(self):
+        initialize_secret_masking()
+        initialize_secret_masking(force=True)
+        # Exactly one SecretMaskingFilter per handler (identity check on add).
+        root = logging.getLogger()
+        for h in root.handlers:
+            assert sum(1 for f in h.filters if isinstance(f, SecretMaskingFilter)) == 1
 
-            # Simulate failure during filter installation
-            with patch(
-                "datahub.masking.bootstrap.install_masking_filter"
-            ) as mock_install:
-                test_error = ValueError("Test failure during filter installation")
-                mock_install.side_effect = test_error
-
-                # Initialize (should fail gracefully, not raise)
-                initialize_secret_masking()
-
-                # Verify state
-                assert not is_bootstrapped(), "Should not be bootstrapped after failure"
-
-                error = get_bootstrap_error()
-                assert error is not None, "Error should be recorded"
-                assert isinstance(error, ValueError), (
-                    "Should be the ValueError we raised"
-                )
-                assert "Test failure during filter installation" in str(error)
-
-        finally:
-            shutdown_secret_masking()
-
-    def test_bootstrap_thread_safety(self):
-        """
-        Verify that initialize_secret_masking is thread-safe.
-
-        Test that when multiple threads call initialize_secret_masking()
-        simultaneously, only one thread performs the actual initialization.
-
-        Without the lock, this test would fail because:
-        - Multiple filters would be installed
-        - Streams would be double-wrapped
-        - Initialization would run multiple times
-        """
-        import threading
-        import time
-
-        from datahub.masking.bootstrap import (
-            initialize_secret_masking,
-            shutdown_secret_masking,
-        )
-
-        try:
-            # Start clean
-            shutdown_secret_masking()
-
-            # Track how many times the actual initialization code runs
-            init_counter = {"count": 0}
-            lock = threading.Lock()
-
-            def counting_install(*args, **kwargs):
-                with lock:
-                    init_counter["count"] += 1
-                # Simulate some work
-                time.sleep(0.01)  # Make race condition more likely
-
-            with patch(
-                "datahub.masking.bootstrap.install_masking_filter",
-                counting_install,
+    def test_initialize_failure_raises_and_records_error(self):
+        with patch(
+            "datahub.masking.bootstrap.install_masking_filter",
+            side_effect=RuntimeError("install boom"),
+        ):
+            with pytest.raises(
+                RuntimeError, match="Secret masking installation failed"
             ):
-                # Launch 10 threads that all try to initialize simultaneously
-                num_threads = 10
-                threads = []
-
-                for i in range(num_threads):
-                    t = threading.Thread(
-                        target=initialize_secret_masking, name=f"InitThread-{i}"
-                    )
-                    threads.append(t)
-
-                # Start all threads at roughly the same time
-                for t in threads:
-                    t.start()
-
-                # Wait for all threads to complete
-                for t in threads:
-                    t.join(timeout=5.0)
-                    assert not t.is_alive(), f"Thread {t.name} timed out"
-
-            # Critical assertion: should only initialize ONCE, not 10 times
-            assert init_counter["count"] == 1, (
-                f"Expected initialization to run exactly 1 time, but it ran {init_counter['count']} times. "
-                f"This indicates a race condition - the lock is not working correctly!"
-            )
-
-        finally:
-            shutdown_secret_masking()
-
-    def test_bootstrap_concurrent_with_force(self):
-        """
-        Verify thread safety when force=True is used.
-
-        When force=True, initialization should run even if already completed,
-        but it should still be thread-safe (only one thread at a time).
-        """
-        import threading
-        import time
-
-        from datahub.masking.bootstrap import (
-            initialize_secret_masking,
-            shutdown_secret_masking,
-        )
-
-        try:
-            shutdown_secret_masking()
-
-            # First initialization
-            with patch("datahub.masking.bootstrap.install_masking_filter"):
                 initialize_secret_masking()
+            assert not is_bootstrapped()
+            err = get_bootstrap_error()
+            assert err is not None
+            assert "install boom" in str(err)
 
-            # Track calls with force=True
-            init_counter = {"count": 0}
-            lock = threading.Lock()
 
-            def counting_install(*args, **kwargs):
-                with lock:
-                    init_counter["count"] += 1
-                time.sleep(0.01)
+class TestShutdownDropsScope:
+    """Invariant 3 (scope halves via bootstrap): ending one execution
+    leaves the other's secrets masked and the filter installed."""
 
-            with patch(
-                "datahub.masking.bootstrap.install_masking_filter",
-                counting_install,
-            ):
-                # Launch threads with force=True
-                threads = []
-                for i in range(5):
-                    t = threading.Thread(
-                        target=lambda: initialize_secret_masking(force=True),
-                        name=f"ForceThread-{i}",
-                    )
-                    threads.append(t)
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
 
-                for t in threads:
-                    t.start()
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
 
-                for t in threads:
-                    t.join(timeout=5.0)
+    def test_shutdown_one_leaves_other_masked(self):
+        tok_a = initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("A", "aaa_secret_value")
+        tok_b = initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("B", "bbb_secret_value")
 
-            # With force=True, all threads should initialize (sequentially)
-            # This is expected behavior - force=True bypasses the completion check
-            # The lock ensures they run sequentially, not concurrently
-            assert init_counter["count"] == 5, (
-                f"Expected 5 initializations with force=True, got {init_counter['count']}"
+        shutdown_secret_masking(tok_a)
+        # Filter still installed; B's secret still registered.
+        assert is_bootstrapped()
+        assert SecretRegistry.get_instance().has_secret("B")
+        assert not SecretRegistry.get_instance().has_secret("A")
+
+        # A new mask still masks B.
+        mf = SecretMaskingFilter(SecretRegistry.get_instance())
+        out = mf.mask_text("leak bbb_secret_value here")
+        assert "bbb_secret_value" not in out
+        assert "***REDACTED:B***" in out
+
+        shutdown_secret_masking(tok_b)
+        assert SecretRegistry.get_instance().get_count() == 0
+
+    def test_shutdown_no_scope_is_safe_noop(self):
+        # No initialize called; shutdown is a safe no-op.
+        shutdown_secret_masking()
+        shutdown_secret_masking("nonexistent-token")
+
+    def test_shutdown_does_not_uninstall_filter(self):
+        tok = initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("X", "value_xyz_123456")
+        shutdown_secret_masking(tok)
+        # Filter stays installed on handlers; bootstrap latch stays set.
+        assert is_bootstrapped()
+        root = logging.getLogger()
+        assert all(
+            any(isinstance(f, SecretMaskingFilter) for f in h.filters)
+            for h in root.handlers
+        )
+
+    def test_cross_thread_shutdown_with_token(self):
+        import threading
+
+        tok = initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("A", "aaa_secret_value")
+        assert SecretRegistry.get_instance().get_count() > 0
+
+        def shutdown_from_other_thread():
+            shutdown_secret_masking(tok)
+
+        t = threading.Thread(target=shutdown_from_other_thread)
+        t.start()
+        t.join(5)
+        assert not t.is_alive()
+        assert SecretRegistry.get_instance().get_count() == 0
+
+
+class TestExcepthook:
+    """The excepthook is installed once and masks the traceback; on masking
+    failure it prints only the class name plus a note, never the raw
+    traceback."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def test_excepthook_masks_traceback(self, capsys):
+        initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("PW", "traceback_secret_value")
+        hook = sys.excepthook
+        try:
+            raise ValueError("embed traceback_secret_value in message")
+        except ValueError as e:
+            hook(ValueError, e, e.__traceback__)
+        captured = capsys.readouterr()
+        assert "traceback_secret_value" not in captured.err
+        assert "***REDACTED:PW***" in captured.err
+
+    def test_excepthook_failure_does_not_leak(self, capsys):
+        initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("PW", "leak_in_traceback_value")
+        # Break mask_text so the hook's masking path raises.
+        with patch.object(
+            SecretMaskingFilter,
+            "mask_text",
+            side_effect=RuntimeError("mask boom"),
+        ):
+            hook = sys.excepthook
+            try:
+                raise ValueError("embed leak_in_traceback_value in message")
+            except ValueError as e:
+                hook(ValueError, e, e.__traceback__)
+        captured = capsys.readouterr()
+        # The raw traceback (with the secret) must NOT be written; only the
+        # class name plus a masking-error note.
+        assert "leak_in_traceback_value" not in captured.err
+        assert "ValueError" in captured.err
+
+
+class TestReinitHealsStrandedLatch:
+    """Fix 3: re-init after reset_instance (without reset_bootstrap_state)
+    rebinds the filter to the new registry; the re-scan covers handlers added
+    while the wrap was inert."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        reset_bootstrap_state()
+
+    def test_reinit_after_reset_instance_rebinds_and_masks(self):
+        from io import StringIO
+
+        initialize_secret_masking()
+        reg = SecretRegistry.get_instance()
+        reg.register_secret("PW", "first_secret_value")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        root = logging.getLogger()
+        root.addHandler(h)
+        try:
+            log = logging.getLogger("test.reinit.rebind")
+            log.setLevel(logging.INFO)
+            log.info("leak first_secret_value here")
+            assert "first_secret_value" not in cap.getvalue()
+            assert "***REDACTED:PW***" in cap.getvalue()
+        finally:
+            root.removeHandler(h)
+
+        # reset_instance WITHOUT reset_bootstrap_state strands the latch.
+        SecretRegistry.reset_instance()
+        assert is_bootstrapped()
+        initialize_secret_masking()
+        reg2 = SecretRegistry.get_instance()
+        reg2.register_secret("PW", "second_secret_value")
+        cap2 = StringIO()
+        h2 = logging.StreamHandler(cap2)
+        h2.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(h2)
+        try:
+            log = logging.getLogger("test.reinit.rebind2")
+            log.setLevel(logging.INFO)
+            log.info("leak second_secret_value here")
+            out = cap2.getvalue()
+            assert "second_secret_value" not in out, (
+                f"re-init did not rebind filter; cleartext leaked: {out!r}"
             )
-
+            assert "***REDACTED:PW***" in out
         finally:
-            shutdown_secret_masking()
+            root.removeHandler(h2)
 
+    def test_reinit_re_covers_handler_added_while_inert(self):
+        from io import StringIO
 
-class TestExceptionHookOptimization:
-    """Test exception hook filter reuse optimization."""
-
-    def test_exception_hook_reuses_filter(self):
-        """
-        Verify exception hook reuses filter instance for better performance
-        and proper circuit breaker behavior.
-
-        Critical: If a new filter is created every time, the circuit breaker
-        failure count resets to 0, defeating the circuit breaker mechanism.
-        """
-        from datahub.masking.bootstrap import (
-            _install_exception_hook,
-            shutdown_secret_masking,
-        )
-        from datahub.masking.masking_filter import SecretMaskingFilter
-        from datahub.masking.secret_registry import SecretRegistry
-
-        try:
-            shutdown_secret_masking()
-            registry = SecretRegistry.get_instance()
-            registry.register_secret("TEST_SECRET", "secret123")
-
-            # Track how many filter instances are created
-            filter_instances = []
-            original_init = SecretMaskingFilter.__init__
-
-            def track_init(self, *args, **kwargs):
-                filter_instances.append(self)
-                return original_init(self, *args, **kwargs)
-
-            with patch.object(SecretMaskingFilter, "__init__", track_init):
-                # Install exception hook
-                _install_exception_hook(registry)
-
-                # Verify only ONE filter was created during installation
-                assert len(filter_instances) == 1, (
-                    f"Expected 1 filter instance during installation, got {len(filter_instances)}"
-                )
-
-                initial_count = len(filter_instances)
-
-                # Simulate exception hook being called multiple times
-                # Get the installed hook
-                import sys
-
-                current_hook = sys.excepthook
-
-                # Trigger the hook 5 times
-                for i in range(5):
-                    try:
-                        raise ValueError(f"Test exception {i} with secret123")
-                    except ValueError as e:
-                        # Call the hook directly
-                        current_hook(ValueError, e, e.__traceback__)
-
-                # Verify NO additional filters were created
-                assert len(filter_instances) == initial_count, (
-                    f"Filter instances increased from {initial_count} to {len(filter_instances)}. "
-                    f"Exception hook is creating new filters instead of reusing! "
-                    f"This defeats the circuit breaker mechanism."
-                )
-
-        finally:
-            shutdown_secret_masking()
-
-    def test_exception_hook_circuit_breaker_persistence(self):
-        """
-        Verify that circuit breaker state persists across exception hook calls.
-
-        With filter reuse, failures accumulate and circuit opens.
-        Without filter reuse, failures reset to 0 each time (broken).
-        """
-        import sys
-
-        from datahub.masking.bootstrap import (
-            _install_exception_hook,
-            shutdown_secret_masking,
-        )
-        from datahub.masking.masking_filter import SecretMaskingFilter
-        from datahub.masking.secret_registry import SecretRegistry
-
-        try:
-            shutdown_secret_masking()
-            registry = SecretRegistry.get_instance()
-
-            # Track the filter instance
-            captured_filter = None
-
-            original_init = SecretMaskingFilter.__init__
-
-            def capture_init(self, *args, **kwargs):
-                nonlocal captured_filter
-                result = original_init(self, *args, **kwargs)
-                if captured_filter is None:
-                    captured_filter = self
-                return result
-
-            with patch.object(SecretMaskingFilter, "__init__", capture_init):
-                # Install exception hook
-                _install_exception_hook(registry)
-
-                # Get the filter that was created
-                assert captured_filter is not None, "Filter should have been created"
-
-                # Check initial circuit breaker state
-                assert captured_filter._failure_count == 0, (
-                    "Should start with 0 failures"
-                )
-                assert not captured_filter._circuit_open, "Circuit should be closed"
-
-                # Simulate a masking failure by making mask_text raise exception
-                def failing_mask(text):
-                    captured_filter._failure_count += 1
-                    if captured_filter._failure_count >= captured_filter._max_failures:
-                        captured_filter._circuit_open = True
-                    raise Exception("Simulated masking failure")
-
-                # Patch mask_text to simulate failures
-                with patch.object(captured_filter, "mask_text", failing_mask):
-                    # Get the installed hook
-                    current_hook = sys.excepthook
-
-                    # Trigger exceptions to accumulate failures
-                    for i in range(12):
-                        try:
-                            raise ValueError(f"Test {i}")
-                        except ValueError as e:
-                            try:
-                                current_hook(ValueError, e, e.__traceback__)
-                            except Exception:
-                                pass  # Hook may fail, that's expected
-
-                # Verify failures accumulated (circuit breaker triggered)
-                assert captured_filter._failure_count >= 10, (
-                    f"Expected at least 10 failures to accumulate, got {captured_filter._failure_count}. "
-                    f"This indicates filter is NOT being reused!"
-                )
-
-        finally:
-            shutdown_secret_masking()
-
-    def test_exception_hook_updates_secrets(self):
-        """
-        Verify that reused filter detects and uses newly registered secrets.
-
-        The filter checks version on every call, so even though it's reused,
-        it will pick up new secrets registered after hook installation.
-        """
-        import sys
-
-        from datahub.masking.bootstrap import (
-            _install_exception_hook,
-            shutdown_secret_masking,
-        )
-        from datahub.masking.secret_registry import SecretRegistry
-
-        try:
-            shutdown_secret_masking()
-            registry = SecretRegistry.get_instance()
-
-            # Install hook with one secret
-            registry.register_secret("SECRET1", "value123")
-            _install_exception_hook(registry)
-
-            # Add a new secret AFTER hook installation
-            registry.register_secret("SECRET2", "value456")
-
-            # Get the installed hook
-            current_hook = sys.excepthook
-
-            # Capture what the hook produces
-            masked_output = []
-
-            def capture_hook(exc_type, exc_value, exc_traceback):
-                # Capture the masked exception value
-                if exc_value and hasattr(exc_value, "args"):
-                    masked_output.append(exc_value.args[0] if exc_value.args else "")
-
-            with patch.object(sys, "excepthook", current_hook):
-                # Trigger exception with BOTH secrets
-                try:
-                    raise ValueError("Contains value123 and value456")
-                except ValueError as e:
-                    # Call the masking hook
-                    current_hook(ValueError, e, e.__traceback__)
-
-            # The hook should have masked BOTH secrets even though SECRET2
-            # was added after installation (because filter checks version)
-            # Note: This test verifies the mechanism exists, actual masking
-            # behavior is tested in test_masking_filter.py
-
-        finally:
-            shutdown_secret_masking()
+        initialize_secret_masking()
+        log = logging.getLogger("test.reinit.rescan")
+        log.handlers.clear()
+        log.propagate = True
+        log.setLevel(logging.INFO)
+        # Append a handler bypassing addHandler so the wrap misses it.
+        plain = logging.StreamHandler(StringIO())
+        plain.setFormatter(logging.Formatter("%(message)s"))
+        log.handlers.append(plain)
+        assert not any(isinstance(f, SecretMaskingFilter) for f in plain.filters)
+        # Re-initialize; the scan attaches the filter to plain.
+        initialize_secret_masking()
+        assert any(isinstance(f, SecretMaskingFilter) for f in plain.filters)
+        log.handlers.clear()

--- a/metadata-ingestion/tests/unit/test_exception_hook.py
+++ b/metadata-ingestion/tests/unit/test_exception_hook.py
@@ -159,10 +159,8 @@ class TestExceptionHookMasking:
 
     def test_exception_hook_graceful_failure(self):
         """Test that exception hook fails gracefully if masking fails."""
-        # This test verifies that even if masking fails, the original
-        # exception is still displayed (fail-open for debugging)
-
         # Create an exception with an unusual structure that might cause issues
+
         class WeirdException(Exception):  # type: ignore[misc]
             @property
             def args(self):  # type: ignore[override]
@@ -174,50 +172,6 @@ class TestExceptionHookMasking:
             exc_info = sys.exc_info()
             # Should not raise - hook should handle gracefully
             sys.excepthook(*exc_info)
-
-    def test_shutdown_restores_original_hook(self):
-        """Test that shutdown properly restores the original exception hook."""
-        # Store the current hook before shutdown
-        hook_before_shutdown = sys.excepthook
-
-        # Shutdown
-        shutdown_secret_masking()
-
-        # Hook should be different after shutdown (restored)
-        assert sys.excepthook != hook_before_shutdown
-
-    def test_exception_hook_masking_failure(self):
-        """Test that exception hook handles masking failures gracefully."""
-        import io
-        from contextlib import redirect_stderr
-        from unittest import mock
-
-        captured_stderr = io.StringIO()
-
-        # Mock the masking filter to raise an exception
-        with mock.patch(
-            "datahub.masking.bootstrap.SecretMaskingFilter"
-        ) as mock_filter_class:
-            # Make mask_text raise an exception
-            mock_filter_instance = mock_filter_class.return_value
-            mock_filter_instance.mask_text.side_effect = RuntimeError("Masking failed")
-
-            # Reinitialize with the mocked filter
-            shutdown_secret_masking()
-            initialize_secret_masking(force=True)
-
-            try:
-                raise ValueError("Test exception with secret: MySecretPass123!!")
-            except Exception:
-                exc_info = sys.exc_info()
-                with redirect_stderr(captured_stderr):
-                    # Should fall back to original exception hook
-                    sys.excepthook(*exc_info)
-
-            output = captured_stderr.getvalue()
-            # Original exception should still be displayed
-            assert "ValueError" in output
-            assert "Test exception" in output
 
 
 class TestExceptionHookIntegration:

--- a/metadata-ingestion/tests/unit/test_logging_utils.py
+++ b/metadata-ingestion/tests/unit/test_logging_utils.py
@@ -2,10 +2,7 @@
 
 import logging
 
-from datahub.masking.logging_utils import (
-    get_masking_safe_logger,
-    reset_masking_safe_loggers,
-)
+from datahub.masking.logging_utils import get_masking_safe_logger
 
 
 class TestGetMaskingSafeLogger:
@@ -40,56 +37,3 @@ class TestGetMaskingSafeLogger:
 
         assert logger1 is logger2
         assert handler_count_1 == handler_count_2
-
-
-class TestResetMaskingSafeLoggers:
-    """Test reset_masking_safe_loggers function."""
-
-    def test_reset_clears_masking_logger_handlers(self):
-        """reset_masking_safe_loggers should remove handlers from masking loggers."""
-        # Create a masking-safe logger
-        logger = get_masking_safe_logger("datahub.masking.test_reset")
-
-        assert len(logger.handlers) > 0
-        assert logger.propagate is False
-
-        # Reset
-        reset_masking_safe_loggers()
-
-        # Handlers should be removed
-        assert len(logger.handlers) == 0
-
-    def test_reset_restores_propagate_flag(self):
-        """reset_masking_safe_loggers should restore propagate flag."""
-        # Create a masking-safe logger
-        logger = get_masking_safe_logger("datahub.masking.test_propagate")
-
-        assert logger.propagate is False
-
-        # Reset
-        reset_masking_safe_loggers()
-
-        # Propagate should be restored
-        assert logger.propagate is True
-
-    def test_reset_only_affects_masking_namespace(self):
-        """reset should only affect loggers in datahub.masking namespace."""
-        # Create a logger outside masking namespace
-        other_logger = logging.getLogger("datahub.other.test")
-        other_logger.addHandler(logging.StreamHandler())
-        original_handler_count = len(other_logger.handlers)
-
-        # Create a masking logger
-        masking_logger = get_masking_safe_logger("datahub.masking.test_namespace")
-
-        # Reset
-        reset_masking_safe_loggers()
-
-        # Other logger should not be affected
-        assert len(other_logger.handlers) == original_handler_count
-
-        # Masking logger should be reset
-        assert len(masking_logger.handlers) == 0
-
-        # Clean up
-        other_logger.handlers.clear()

--- a/metadata-ingestion/tests/unit/test_masking_coverage.py
+++ b/metadata-ingestion/tests/unit/test_masking_coverage.py
@@ -229,7 +229,7 @@ class TestHandlerAddedAfterInstall:
         target = _Capture()
 
         # QueueHandler attached to a logger; QueueListener dispatches to target.
-        q = queue.Queue()
+        q: queue.Queue[logging.LogRecord] = queue.Queue()
         qh = QueueHandler(q)
         log = logging.getLogger("test.queuehandler")
         log.handlers.clear()

--- a/metadata-ingestion/tests/unit/test_masking_coverage.py
+++ b/metadata-ingestion/tests/unit/test_masking_coverage.py
@@ -1,261 +1,298 @@
-"""
-Additional tests to increase coverage for masking modules.
-"""
+"""Tests for handler coverage — invariants 1, 2, 12, 17."""
 
 import logging
-import os
+import queue
+import sys
 from io import StringIO
+from logging.handlers import QueueHandler, QueueListener
+from typing import List
 
 import pytest
 
+from datahub.masking import masking_filter
 from datahub.masking.bootstrap import (
     initialize_secret_masking,
     shutdown_secret_masking,
 )
-from datahub.masking.logging_utils import get_masking_safe_logger
-from datahub.masking.masking_filter import SecretMaskingFilter
-from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
+from datahub.masking.masking_filter import (
+    SecretMaskingFilter,
+    install_masking_filter,
+    uninstall_masking_filter,
+)
+from datahub.masking.secret_registry import SecretRegistry
 
 
-def test_masking_module_imports():
-    """Test that all public exports from __init__.py are importable."""
-    # Import from masking module to cover __init__.py
-    import datahub.masking
+class TestChildLoggerPropagation:
+    """Invariant 1: a record logged on a child logger and reaching a root
+    FileHandler via propagation is masked."""
 
-    # Test that all exports are available
-    assert hasattr(datahub.masking, "SecretMaskingFilter")
-    assert hasattr(datahub.masking, "StreamMaskingWrapper")
-    assert hasattr(datahub.masking, "install_masking_filter")
-    assert hasattr(datahub.masking, "uninstall_masking_filter")
-    assert hasattr(datahub.masking, "SecretRegistry")
-    assert hasattr(datahub.masking, "is_masking_enabled")
-    assert hasattr(datahub.masking, "initialize_secret_masking")
-    assert hasattr(datahub.masking, "get_masking_safe_logger")
-
-    # Verify imports work
-    from datahub.masking import (
-        SecretMaskingFilter,
-        SecretRegistry,
-        StreamMaskingWrapper,
-    )
-
-    assert SecretMaskingFilter is not None
-    assert SecretRegistry is not None
-    assert StreamMaskingWrapper is not None
-
-
-class TestSecretRegistryEdgeCases:
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_register_secret_empty_value(self):
-        registry = SecretRegistry.get_instance()
-        registry.register_secret("EMPTY", "")
-        assert registry.get_count() == 0
-
-    def test_register_secret_non_string(self):
-        registry = SecretRegistry.get_instance()
-        registry.register_secret("NUMBER", 123)  # type: ignore
-        assert registry.get_count() == 0
-
-    def test_register_secret_short_value(self):
-        registry = SecretRegistry.get_instance()
-        registry.register_secret("SHORT", "ab")
-        assert registry.get_count() == 0
-
-    def test_register_secret_with_escape_sequences(self):
-        registry = SecretRegistry.get_instance()
-        secret_with_newline = "pass\nword"
-        registry.register_secret("MULTILINE", secret_with_newline)
-
-        # Both original and repr version should be registered
-        assert registry.has_secret("MULTILINE")
-        assert registry.get_count() >= 1
-
-    def test_register_secrets_batch_empty(self):
-        registry = SecretRegistry.get_instance()
-        registry.register_secrets_batch({})
-        assert registry.get_count() == 0
-
-    def test_register_secrets_batch_all_invalid(self):
-        registry = SecretRegistry.get_instance()
-        registry.register_secrets_batch(
-            {
-                "EMPTY": "",
-                "SHORT": "ab",
-                "NONE": None,  # type: ignore
-            }
-        )
-        assert registry.get_count() == 0
-
-    def test_memory_limit_single(self):
-        registry = SecretRegistry.get_instance()
-        original_max = registry.MAX_SECRETS
-        registry.MAX_SECRETS = 5
-
-        # Register 10 secrets, only 5 should be stored
-        for i in range(10):
-            registry.register_secret(f"SECRET_{i}", f"value_{i}")
-
-        assert registry.get_count() <= 5
-        registry.MAX_SECRETS = original_max
-
-    def test_get_secret_value_not_found(self):
-        registry = SecretRegistry.get_instance()
-        assert registry.get_secret_value("NONEXISTENT") is None
-
-    def test_has_secret_not_found(self):
-        registry = SecretRegistry.get_instance()
-        assert not registry.has_secret("NONEXISTENT")
-
-
-class TestMaskingEnabled:
-    def test_is_masking_enabled(self):
-        # Default is enabled
-        assert is_masking_enabled()
-
-        # Disable via env var
-        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
-        assert not is_masking_enabled()
-
-        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "1"
-        assert not is_masking_enabled()
-
-        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "false"
-        assert is_masking_enabled()
-
-        del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
-
-
-class TestLoggingUtils:
-    def test_get_masking_safe_logger(self):
-        logger = get_masking_safe_logger(__name__)
-        assert isinstance(logger, logging.Logger)
-        assert logger.name == __name__
-
-    def test_logger_can_log(self):
-        logger = get_masking_safe_logger("test_logger")
-
-        # Capture log output
-        handler = logging.StreamHandler(StringIO())
-        logger.addHandler(handler)
-
-        logger.info("Test message")
-        logger.debug("Debug message")
-        logger.warning("Warning message")
-
-        logger.removeHandler(handler)
-
-
-class TestMaskingFilterDebugMode:
     def setup_method(self):
         shutdown_secret_masking()
         SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
 
     def teardown_method(self):
         shutdown_secret_masking()
         SecretRegistry.reset_instance()
-        # Ensure env var is cleaned up
-        if "DATAHUB_DISABLE_SECRET_MASKING" in os.environ:
-            del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
+        from datahub.masking.bootstrap import reset_bootstrap_state
 
-    def test_filter_masking_disabled_globally(self):
-        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
+        reset_bootstrap_state()
 
-        registry = SecretRegistry.get_instance()
-        registry.register_secret("DISABLED_SECRET", "disabled_value")
-
-        masking_filter = SecretMaskingFilter(registry)
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Secret: disabled_value",
-            args=(),
-            exc_info=None,
-        )
-
-        result = masking_filter.filter(record)
-        assert result
-        # When masking is disabled, secrets should NOT be masked
-        assert "disabled_value" in record.msg
-
-
-class TestBootstrapEdgeCases:
-    def setup_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def test_initialize_twice(self):
+    def test_child_logger_record_masked_at_root_handler(self, tmp_path):
+        log_file = tmp_path / "out.log"
+        # Install a FileHandler on the root logger.
         initialize_secret_masking()
-        initialize_secret_masking()  # Should be no-op
+        SecretRegistry.get_instance().register_secret("PW", "propagation_secret_value")
 
-        # Only one filter should be installed
-        root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-        assert len(filters) == 1
-
-    def test_initialize_with_force(self):
-        initialize_secret_masking()
-        initialize_secret_masking(force=True)
-
-        # Should still work
-        root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-        assert len(filters) >= 1
-
-    def test_shutdown_when_not_initialized(self):
-        shutdown_secret_masking()  # Should be safe
-
-    def test_shutdown_clears_filters(self):
-        initialize_secret_masking()
-        shutdown_secret_masking()
-
-        root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-        assert len(filters) == 0
-
-    def test_is_bootstrapped(self):
-        from datahub.masking.bootstrap import is_bootstrapped
-
-        shutdown_secret_masking()
-        assert not is_bootstrapped()
-
-        initialize_secret_masking()
-        assert is_bootstrapped()
-
-        shutdown_secret_masking()
-        assert not is_bootstrapped()
-
-    def test_get_bootstrap_error(self):
-        from datahub.masking.bootstrap import get_bootstrap_error
-
-        shutdown_secret_masking()
-        assert get_bootstrap_error() is None
-
-    def test_initialize_with_disabled_masking(self):
-        """Test initialization when masking is disabled."""
-        from datahub.masking.bootstrap import is_bootstrapped
-
-        os.environ["DATAHUB_DISABLE_SECRET_MASKING"] = "true"
+        root = logging.getLogger()
+        fh = logging.FileHandler(str(log_file))
+        fh.setFormatter(logging.Formatter("%(message)s"))
+        root.addHandler(fh)
         try:
-            shutdown_secret_masking()
-            initialize_secret_masking()
-            # Should complete but not actually initialize
-            assert is_bootstrapped()
+            # Re-scan so the FileHandler gets the filter.
+            install_masking_filter(install_stdout_wrapper=False)
+            child = logging.getLogger("datahub.ingestion.some_source")
+            child.setLevel(logging.INFO)
+            child.info("leak propagation_secret_value in child log")
         finally:
-            if "DATAHUB_DISABLE_SECRET_MASKING" in os.environ:
-                del os.environ["DATAHUB_DISABLE_SECRET_MASKING"]
+            root.removeHandler(fh)
+            fh.close()
+
+        contents = log_file.read_text()
+        assert "propagation_secret_value" not in contents
+        assert "***REDACTED:PW***" in contents
+
+
+class TestCeleryProxyNotWrapped:
+    """Invariant 2: a celery-style stream proxy (no usable fileno()) is never
+    wrapped; logging continues normally after initialize + shutdown (no
+    feedback loop, no silenced logs)."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def test_proxy_not_wrapped(self):
+        class LoggingProxy:
+            """Mimics celery's LoggingProxy: no fileno, recurse guard."""
+
+            def __init__(self, target_stream):
+                self._target = target_stream
+                self._recurse = threading.local()
+
+            def fileno(self):
+                raise io.UnsupportedOperation("no fileno on proxy")
+
+            def write(self, text):
+                if getattr(self._recurse, "flag", False):
+                    return 0
+                self._recurse.flag = True
+                try:
+                    # Re-enters logging (like celery's proxy).
+                    logging.getLogger("proxy.target").info(text.rstrip())
+                finally:
+                    self._recurse.flag = False
+                return len(text)
+
+            def flush(self):
+                pass
+
+        import io
+        import threading
+
+        proxy = LoggingProxy(StringIO())
+        original_stdout = sys.stdout
+        sys.stdout = proxy
+        try:
+            initialize_secret_masking()
+            # The proxy must NOT be wrapped.
+            assert sys.stdout is proxy
+            SecretRegistry.get_instance().register_secret("PW", "proxy_secret_value")
+            logging.getLogger("test.proxy").info("leak proxy_secret_value")
             shutdown_secret_masking()
+            # After shutdown, stdout still the proxy (never wrapped).
+            assert sys.stdout is proxy
+            # Logging continues normally after initialize + shutdown: a record
+            # logged on a fresh handler actually arrives (no feedback loop, no
+            # silenced logs).
+            arrived: List[logging.LogRecord] = []
+
+            class _Capture(logging.Handler):
+                def emit(self, record: logging.LogRecord) -> None:
+                    arrived.append(record)
+
+            post_log = logging.getLogger("test.proxy.post_shutdown")
+            post_log.handlers.clear()
+            post_log.propagate = False
+            post_log.setLevel(logging.INFO)
+            cap_handler = _Capture()
+            post_log.addHandler(cap_handler)
+            try:
+                post_log.info("still logging after shutdown")
+            finally:
+                post_log.removeHandler(cap_handler)
+            assert len(arrived) == 1, arrived
+            assert arrived[0].getMessage() == "still logging after shutdown"
+        finally:
+            sys.stdout = original_stdout
+
+
+class TestHandlerAddedAfterInstall:
+    """Invariant 12: a handler added to a logger after install (via plain
+    addHandler and via logging.basicConfig(force=True)) carries the filter
+    and masks; a record routed through a logger-attached QueueHandler to a
+    QueueListener whose target handler was never attached to any logger
+    arrives at that target already masked, and the sentinel short-circuited
+    the nested pass."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def test_plain_addhandler_covers_new_handler(self):
+        initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("PW", "addhandler_secret_value")
+
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        log = logging.getLogger("test.addhandler_after")
+        log.handlers.clear()
+        log.propagate = False
+        log.setLevel(logging.INFO)
+        log.addHandler(h)
+        try:
+            log.info("leak addhandler_secret_value here")
+        finally:
+            log.removeHandler(h)
+        out = cap.getvalue()
+        assert "addhandler_secret_value" not in out
+        assert "***REDACTED:PW***" in out
+
+    def test_basicconfig_force_covers_new_handler(self):
+        initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("PW", "basicconfig_secret_value")
+        # basicConfig(force=True) replaces root handlers.
+        cap = StringIO()
+        root = logging.getLogger()
+        saved_handlers = list(root.handlers)
+        saved_level = root.level
+        logging.basicConfig(force=True, stream=cap, level=logging.INFO)
+        try:
+            logging.getLogger("test.basicconfig").info(
+                "leak basicconfig_secret_value here"
+            )
+        finally:
+            # Restore the root handler setup and level so later tests in the
+            # random order aren't left handler-less / re-leveled.
+            root.handlers.clear()
+            root.handlers.extend(saved_handlers)
+            root.setLevel(saved_level)
+        out = cap.getvalue()
+        assert "basicconfig_secret_value" not in out
+        assert "***REDACTED:PW***" in out
+
+    def test_queuehandler_target_arrives_masked(self):
+        initialize_secret_masking()
+        SecretRegistry.get_instance().register_secret("PW", "queue_secret_value")
+
+        # A target handler that is NEVER attached to a logger; it stores the
+        # records it receives so the sentinel can be checked by value.
+        captured: List[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        target = _Capture()
+
+        # QueueHandler attached to a logger; QueueListener dispatches to target.
+        q = queue.Queue()
+        qh = QueueHandler(q)
+        log = logging.getLogger("test.queuehandler")
+        log.handlers.clear()
+        log.propagate = False
+        log.setLevel(logging.INFO)
+        log.addHandler(qh)
+        listener = QueueListener(q, target)
+        listener.start()
+        try:
+            log.info("leak queue_secret_value here")
+        finally:
+            listener.stop()  # drains and joins the listener thread
+            log.removeHandler(qh)
+        assert len(captured) == 1, captured
+        rec = captured[0]
+        # Sentinel set by value against the module constant (invariant 12).
+        assert getattr(rec, "_datahub_masked", None) is masking_filter._MASKED
+        assert "queue_secret_value" not in rec.getMessage()
+        assert "***REDACTED:PW***" in rec.getMessage()
+
+
+class TestReinstallAfterUninstall:
+    """Invariant 17: after a test-only uninstall, re-install re-covers a
+    handler that was added while the wrap was inert."""
+
+    def setup_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def teardown_method(self):
+        shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
+
+    def test_reinstall_recovers_handler_added_while_inert(self):
+        install_masking_filter(install_stdout_wrapper=False)
+        SecretRegistry.get_instance().register_secret("PW", "first_secret_value")
+        # Uninstall (test-only): wrap goes inert.
+        uninstall_masking_filter()
+        # Add a handler while the wrap is inert — it gets no filter.
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        log = logging.getLogger("test.reinstall")
+        log.handlers.clear()
+        log.propagate = False
+        log.addHandler(h)
+        assert not any(isinstance(f, SecretMaskingFilter) for f in h.filters)
+        # Re-install: the scan re-covers the handler added while inert.
+        install_masking_filter(install_stdout_wrapper=False)
+        SecretRegistry.get_instance().register_secret("PW", "second_secret_value")
+        try:
+            log.info("leak second_secret_value here")
+        finally:
+            log.removeHandler(h)
+        out = cap.getvalue()
+        assert "second_secret_value" not in out
+        assert "***REDACTED:PW***" in out
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_masking_edge_cases.py
+++ b/metadata-ingestion/tests/unit/test_masking_edge_cases.py
@@ -13,10 +13,7 @@ from datahub.masking.bootstrap import (
     is_bootstrapped,
     shutdown_secret_masking,
 )
-from datahub.masking.logging_utils import (
-    get_masking_safe_logger,
-    reset_masking_safe_loggers,
-)
+from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.masking_filter import SecretMaskingFilter
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -57,11 +54,15 @@ class TestMaskingFilterEdgeCases:
         for i in range(100):
             registry.register_secret(f"SECRET_{i}", f"value_{i}")
 
-        # Force pattern rebuild
-        masking_filter._check_and_rebuild_pattern()
-
-        # Verify pattern was rebuilt
-        assert masking_filter._last_version > 0
+        # Force a pattern build via mask_text, then verify a second registration
+        # bumps the version and triggers a rebuild on the next mask.
+        masking_filter.mask_text("leak value_0 here")
+        version_after_build = registry.get_version()
+        registry.register_secret("LATE", "late_secret_value")
+        assert registry.get_version() > version_after_build
+        out = masking_filter.mask_text("leak late_secret_value here")
+        assert "late_secret_value" not in out
+        assert "***REDACTED:LATE***" in out
 
     def test_masking_with_very_long_message(self):
         """Test masking with messages exceeding max_message_size."""
@@ -120,27 +121,35 @@ class TestBootstrapEdgeCases:
 
     def setup_method(self):
         shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
 
     def teardown_method(self):
         shutdown_secret_masking()
+        SecretRegistry.reset_instance()
+        from datahub.masking.bootstrap import reset_bootstrap_state
+
+        reset_bootstrap_state()
 
     def test_double_initialization(self):
         """Test that double initialization is handled gracefully."""
-        initialize_secret_masking()
+        tok1 = initialize_secret_masking()
         assert is_bootstrapped()
-
-        # Second initialization should be no-op
-        initialize_secret_masking()
+        tok2 = initialize_secret_masking()
         assert is_bootstrapped()
+        shutdown_secret_masking(tok2)
+        shutdown_secret_masking(tok1)
 
     def test_force_reinitialization(self):
         """Test force re-initialization."""
-        initialize_secret_masking()
+        tok1 = initialize_secret_masking()
         assert is_bootstrapped()
-
-        # Force re-init
-        initialize_secret_masking(force=True)
+        tok2 = initialize_secret_masking(force=True)
         assert is_bootstrapped()
+        shutdown_secret_masking(tok2)
+        shutdown_secret_masking(tok1)
 
     def test_bootstrap_error_cleared_on_success(self):
         """Test that bootstrap error is cleared after successful init."""
@@ -163,20 +172,6 @@ class TestLoggingUtils:
         assert logger1 is logger2
         # Should not have duplicate handlers
         assert handler_count_1 == handler_count_2
-
-    def test_reset_masking_safe_loggers(self):
-        """Test resetting masking-safe loggers."""
-        # Create a masking-safe logger
-        logger = get_masking_safe_logger("datahub.masking.test")
-        assert not logger.propagate
-        assert len(logger.handlers) > 0
-
-        # Reset
-        reset_masking_safe_loggers()
-
-        # Logger should be reset
-        assert logger.propagate
-        assert len(logger.handlers) == 0
 
 
 class TestSecretRegistryEdgeCases:

--- a/metadata-ingestion/tests/unit/test_masking_error_paths.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_paths.py
@@ -1,10 +1,8 @@
 """
-Tests for error paths and circuit breaker logic in masking framework.
+Tests for error paths in masking framework.
 """
 
 import logging
-import re
-from unittest import mock
 
 import pytest
 
@@ -14,99 +12,6 @@ from datahub.masking.bootstrap import (
 )
 from datahub.masking.masking_filter import SecretMaskingFilter
 from datahub.masking.secret_registry import SecretRegistry
-
-
-class TestCircuitBreakerLogic:
-    """Test circuit breaker behavior in masking filter."""
-
-    def setup_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def test_circuit_breaker_state_tracking(self):
-        """Test circuit breaker state management."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Initial state
-        assert masking_filter._failure_count == 0
-        assert not masking_filter._circuit_open
-        assert masking_filter._max_failures == 10
-
-        # Circuit breaker can be manually opened for testing
-        masking_filter._circuit_open = True
-        assert masking_filter._circuit_open
-
-    def test_circuit_open_message_handling(self):
-        """Test that when circuit is open, messages pass through without errors."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Force circuit open
-        masking_filter._circuit_open = True
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="This message should pass through when circuit is open",
-            args=(),
-            exc_info=None,
-        )
-
-        # Should not raise an error
-        result = masking_filter.filter(record)
-        assert result is True
-
-
-class TestPatternRebuildFailures:
-    """Test pattern rebuild failure scenarios."""
-
-    def setup_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def test_pattern_rebuild_compile_error(self):
-        """Test graceful handling when pattern compilation fails."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register a secret
-        registry.register_secret("SECRET", "test_value_123")
-
-        # Mock re.compile to fail
-        original_compile = re.compile
-
-        def mock_compile_fail(pattern, flags=0):
-            if "test_value_123" in pattern:
-                raise re.error("Simulated compile error")
-            return original_compile(pattern, flags)
-
-        with mock.patch("re.compile", side_effect=mock_compile_fail):
-            # Try to rebuild pattern - should handle error gracefully
-            masking_filter._check_and_rebuild_pattern()
-
-            # Filter should still work (with old pattern or graceful degradation)
-            record = logging.LogRecord(
-                name="test",
-                level=logging.INFO,
-                pathname="",
-                lineno=0,
-                msg="Test message",
-                args=(),
-                exc_info=None,
-            )
-            result = masking_filter.filter(record)
-            assert result is True
 
 
 class TestBootstrapConfiguration:

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -3,6 +3,7 @@ half), 13."""
 
 import logging
 from io import StringIO
+from typing import Any
 from unittest.mock import patch
 
 from datahub.masking.masking_filter import (
@@ -97,7 +98,7 @@ class TestExtrasFailureHalf:
         mf = SecretMaskingFilter(reg)
         reg.register_secret("PW", "deep_secret_value")
 
-        deep = "deep_secret_value"
+        deep: Any = "deep_secret_value"
         for _ in range(mf._MAX_EXTRA_DEPTH + 2):
             deep = {"inner": deep}
         record = logging.LogRecord(
@@ -121,7 +122,7 @@ class TestExtrasFailureHalf:
         mf = SecretMaskingFilter(reg)
         reg.register_secret("PW", "cycle_secret_value")
 
-        d = {"k": "cycle_secret_value"}
+        d: dict[str, Any] = {"k": "cycle_secret_value"}
         d["self"] = d
         record = logging.LogRecord(
             name="test",

--- a/metadata-ingestion/tests/unit/test_masking_error_recovery.py
+++ b/metadata-ingestion/tests/unit/test_masking_error_recovery.py
@@ -1,38 +1,20 @@
-"""
-Tests for error recovery and graceful degradation in masking modules.
-
-This file tests:
-- Circuit breaker behavior with different error types
-- Error recovery and failure handling
-- Stream wrapper error scenarios
-- Bootstrap error handling
-- Pattern rebuild under stress
-"""
+"""Tests for fail-closed behavior — invariants 7 (failure half), 10 (failure
+half), 13."""
 
 import logging
-import sys
-import threading
 from io import StringIO
-from unittest import mock
+from unittest.mock import patch
 
-import pytest
-
-from datahub.masking.bootstrap import (
-    _install_exception_hook,
-    initialize_secret_masking,
-    shutdown_secret_masking,
-)
 from datahub.masking.masking_filter import (
+    MASKING_ERROR_MESSAGE,
     SecretMaskingFilter,
-    StreamMaskingWrapper,
-    _update_existing_handlers,
-    install_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
 
 
-class TestCircuitBreakerBehavior:
-    """Test circuit breaker with different error types."""
+class TestTracebackFailureHalf:
+    """Invariant 7 (failure half): when the exc_text masking step fails,
+    exc_text becomes MASKING_ERROR_MESSAGE (never the unmasked traceback)."""
 
     def setup_method(self):
         SecretRegistry.reset_instance()
@@ -40,640 +22,182 @@ class TestCircuitBreakerBehavior:
     def teardown_method(self):
         SecretRegistry.reset_instance()
 
-    def test_circuit_breaker_opens_after_max_failures(self):
-        """Test that circuit breaker opens after reaching max failures."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register a secret so pattern is built
-        registry.register_secret("SECRET", "test_secret_value")
-
-        # Set failure count close to max
-        masking_filter._failure_count = masking_filter._max_failures - 1
-
-        # Trigger one more failure to open circuit
-        masking_filter._failure_count += 1
-        masking_filter._circuit_open = True
-
-        # Verify circuit is open
-        assert masking_filter._circuit_open
-        assert masking_filter._failure_count >= masking_filter._max_failures
-
-        # Test that mask_text returns circuit open message when circuit is open
-        result = masking_filter.mask_text("test message")
-        assert result == "[REDACTED: Masking Circuit Open]"
-
-    def test_mask_text_with_error_in_pattern_sub(self):
-        """Test that errors during pattern substitution are handled gracefully."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        registry.register_secret("SECRET", "test_value")
-
-        # Build pattern first
-        masking_filter._check_and_rebuild_pattern()
-
-        # Verify pattern exists and masking works
-        result = masking_filter.mask_text("Message with test_value")
-        assert "REDACTED" in result or result == "Message with test_value"
-
-    def test_mask_text_resets_failure_count_on_success(self):
-        """Test that successful masking resets failure count."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        registry.register_secret("SECRET", "test_value")
-
-        # Manually set failure count
-        masking_filter._failure_count = 5
-
-        # Successful masking should reset count
-        result = masking_filter.mask_text("Normal message without secrets")
-        assert masking_filter._failure_count == 0
-        assert result == "Normal message without secrets"
-
-
-class TestMaskingErrorPaths:
-    """Test error handling paths in masking operations."""
-
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_mask_args_with_error(self):
-        """Test that errors in _mask_args are handled."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Mock mask_text to raise an error when processing dict values
-        original_mask_text = masking_filter.mask_text
-
-        def failing_mask_text(text):
-            if isinstance(text, str):
-                raise RuntimeError("Simulated masking error")
-            return original_mask_text(text)
-
-        with mock.patch.object(
-            masking_filter, "mask_text", side_effect=failing_mask_text
-        ):
-            # Pass a dict that would trigger masking
-            result = masking_filter._mask_args({"key": "value"})
-            # Should return error message tuple
-            assert result == ("[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]",)
-
-    def test_mask_exception_with_error(self):
-        """Test that errors in _mask_exception are handled."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Create exception info that will cause an error
-        try:
-            raise ValueError("Test error")
-        except ValueError:
-            exc_info = sys.exc_info()
-
-        # Mock to cause error during exception processing
-        with mock.patch.object(
-            masking_filter, "mask_text", side_effect=RuntimeError("Simulated error")
-        ):
-            result = masking_filter._mask_exception(exc_info)
-
-            # Should return sanitized exception
-            assert result is not None
-            exc_type, exc_value, _ = result
-            assert exc_type is RuntimeError
-            assert "[MASKING_ERROR - OUTPUT_SUPPRESSED_FOR_SECURITY]" in str(exc_value)
-
-    def test_filter_with_masking_error_suppression(self):
-        """Test that errors during filter() are suppressed and logged."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Create a record
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Test message",
-            args=(),
-            exc_info=None,
-        )
-
-        # Mock mask_text to raise an error
-        with mock.patch.object(
-            masking_filter, "mask_text", side_effect=RuntimeError("Simulated error")
-        ):
-            # Should not raise, but suppress the error
-            result = masking_filter.filter(record)
-            assert result is True
-
-    def test_truncate_message_with_non_string(self):
-        """Test that _truncate_message handles non-string input."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Non-string input should be returned as-is
-        assert masking_filter._truncate_message(123) == 123  # type: ignore[arg-type]
-        assert masking_filter._truncate_message(None) is None  # type: ignore[arg-type]
-        assert masking_filter._truncate_message([]) == []  # type: ignore[arg-type]
-
-    def test_mask_text_with_non_string_input(self):
-        """Test that mask_text handles non-string input."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Non-string inputs should be returned as-is
-        assert masking_filter.mask_text(None) is None  # type: ignore[arg-type]
-        assert masking_filter.mask_text(123) == 123  # type: ignore[arg-type]
-        assert masking_filter.mask_text("") == ""
-
-
-class TestStreamWrapperErrorHandling:
-    """Test error handling in StreamMaskingWrapper."""
-
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_wrapper_write_with_masking_failure(self):
-        """Test that wrapper handles masking failures gracefully."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        output = StringIO()
-        wrapper = StreamMaskingWrapper(output, masking_filter)
-
-        # Mock mask_text to raise an error (but not TypeError)
-        with mock.patch.object(
-            masking_filter, "mask_text", side_effect=RuntimeError("Simulated error")
-        ):
-            # Should fall back to writing unmasked text
-            chars_written = wrapper.write("test message")
-            assert chars_written == len("test message")
-            assert output.getvalue() == "test message"
-
-    def test_wrapper_write_with_stream_error(self):
-        """Test that wrapper handles stream write errors."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Create a stream that fails on write
-        class FailingStream:
-            def write(self, text):
-                raise IOError("Simulated write error")
-
-        wrapper = StreamMaskingWrapper(FailingStream(), masking_filter)  # type: ignore[arg-type]
-
-        # Should return 0 on error
-        result = wrapper.write("test")
-        assert result == 0
-
-    def test_wrapper_flush_without_flush_method(self):
-        """Test that wrapper handles streams without flush method."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Create a stream without flush
-        class NoFlushStream:
-            def write(self, text):
-                return len(text)
-
-        wrapper = StreamMaskingWrapper(NoFlushStream(), masking_filter)  # type: ignore[arg-type]
-
-        # Should not raise
-        wrapper.flush()
-
-    def test_wrapper_flush_with_error(self):
-        """Test that wrapper handles flush errors."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Create a stream where flush fails
-        class FailingFlushStream:
-            def write(self, text):
-                return len(text)
-
-            def flush(self):
-                raise IOError("Simulated flush error")
-
-        wrapper = StreamMaskingWrapper(FailingFlushStream(), masking_filter)  # type: ignore[arg-type]
-
-        # Should not raise
-        wrapper.flush()
-
-    def test_wrapper_getattr(self):
-        """Test that wrapper delegates attributes correctly."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        output = StringIO()
-        wrapper = StreamMaskingWrapper(output, masking_filter)
-
-        # Should delegate to original stream
-        assert hasattr(wrapper, "getvalue")
-        assert callable(wrapper.getvalue)
-
-
-class TestUpdateExistingHandlers:
-    """Test _update_existing_handlers function."""
-
-    def setup_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def test_update_existing_handlers_with_stdout_handler(self):
-        """Test that existing stdout handlers are updated."""
-        # Create a logger with a stdout handler
-        test_logger = logging.getLogger("test_stdout_update")
-        test_logger.handlers.clear()
-
-        stdout_handler = logging.StreamHandler(sys.stdout)
-        test_logger.addHandler(stdout_handler)
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Update handlers
-        _update_existing_handlers()
-
-        # Cleanup
-        test_logger.removeHandler(stdout_handler)
-        test_logger.handlers.clear()
-
-    def test_update_existing_handlers_with_stderr_handler(self):
-        """Test that existing stderr handlers are updated."""
-        # Create a logger with a stderr handler
-        test_logger = logging.getLogger("test_stderr_update")
-        test_logger.handlers.clear()
-
-        stderr_handler = logging.StreamHandler(sys.stderr)
-        test_logger.addHandler(stderr_handler)
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Update handlers
-        _update_existing_handlers()
-
-        # Cleanup
-        test_logger.removeHandler(stderr_handler)
-        test_logger.handlers.clear()
-
-    def test_update_existing_handlers_with_custom_stream(self):
-        """Test that handlers with custom streams are not updated."""
-        test_logger = logging.getLogger("test_custom_stream")
-        test_logger.handlers.clear()
-
-        custom_stream = StringIO()
-        custom_handler = logging.StreamHandler(custom_stream)
-        test_logger.addHandler(custom_handler)
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Update handlers
-        _update_existing_handlers()
-
-        # Custom handler should not be updated
-        assert custom_handler.stream is custom_stream
-
-        # Cleanup
-        test_logger.removeHandler(custom_handler)
-        test_logger.handlers.clear()
-
-    def test_update_existing_handlers_skips_placeholders(self):
-        """Test that PlaceHolder objects in logger dict are skipped."""
-        # This tests the check for isinstance(log, logging.Logger)
-        # PlaceHolder objects exist in logging.root.manager.loggerDict
-        # but are not actual Logger instances
-
-        # Install masking
-        install_masking_filter(install_stdout_wrapper=True)
-
-        # Call update (should handle placeholders gracefully)
-        _update_existing_handlers()
-
-        # Should not raise any errors
-
-
-class TestBootstrapErrorHandling:
-    """Test error handling in bootstrap module."""
-
-    def setup_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        shutdown_secret_masking()
-        SecretRegistry.reset_instance()
-
-    def test_exception_hook_with_masking_failure(self):
-        """Test that exception hook handles masking failures."""
-        registry = SecretRegistry.get_instance()
-
-        # Install exception hook
-        _install_exception_hook(registry)
-
-        # Mock traceback.format_exception to test error path
-        def mock_format_fail(*args, **kwargs):
-            raise RuntimeError("Simulated format error")
-
-        with mock.patch("traceback.format_exception", side_effect=mock_format_fail):
-            # Exception hook should handle error gracefully
-            # We can't easily test this without actually calling sys.excepthook
-            # but we've verified the code path exists
-            pass
-
-    def test_initialize_with_filter_installation_error(self):
-        """Test that initialization handles filter installation errors."""
-        # Mock install_masking_filter to raise an error
-        from datahub.masking import bootstrap
-
-        def mock_install_fail(*args, **kwargs):
-            raise RuntimeError("Simulated installation error")
-
-        with mock.patch.object(
-            bootstrap, "install_masking_filter", side_effect=mock_install_fail
-        ):
-            # Should not raise, but should log error
-            initialize_secret_masking()
-
-            # Should have recorded error
-            from datahub.masking.bootstrap import get_bootstrap_error
-
-            error = get_bootstrap_error()
-            assert error is not None
-
-
-class TestSecretRegistryBatchRegistration:
-    """Test batch registration edge cases."""
-
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_register_secrets_batch_with_all_already_present(self):
-        """Test batch registration when all secrets are already registered."""
-        registry = SecretRegistry.get_instance()
-
-        # Register secrets individually first
-        registry.register_secret("SECRET1", "value1_long")
-        registry.register_secret("SECRET2", "value2_long")
-
-        initial_version = registry.get_version()
-
-        # Try to register same secrets in batch
-        registry.register_secrets_batch(
-            {
-                "SECRET1": "value1_long",
-                "SECRET2": "value2_long",
-            }
-        )
-
-        # Version should not change (fast path)
-        assert registry.get_version() == initial_version
-
-    def test_register_secret_with_repr_version(self):
-        """Test that repr version is registered for secrets with special characters."""
-        registry = SecretRegistry.get_instance()
-
-        # Register secret with newline
-        secret_with_newline = "pass\nword\tvalue"
-        registry.register_secret("MULTILINE", secret_with_newline)
-
-        # Get all secrets
-        secrets = registry.get_all_secrets()
-
-        # Both original and repr version should be registered
-        assert secret_with_newline in secrets
-        # The repr version should also be present
-        repr_version = repr(secret_with_newline)[1:-1]
-        if repr_version != secret_with_newline:
-            assert repr_version in secrets
-
-    def test_register_secrets_batch_with_escape_sequences(self):
-        """Test batch registration with escape sequences."""
-        registry = SecretRegistry.get_instance()
-
-        secrets = {
-            "SECRET1": "value\nwith\nnewlines",
-            "SECRET2": "value\twith\ttabs",
-            "SECRET3": "value\\with\\backslashes",
-        }
-
-        registry.register_secrets_batch(secrets)
-
-        # All should be registered
-        assert registry.get_count() >= 3
-
-    def test_register_secrets_batch_memory_limit(self):
-        """Test that batch registration respects memory limit."""
-        registry = SecretRegistry.get_instance()
-
-        # Set low limit
-        original_max = registry.MAX_SECRETS
-        registry.MAX_SECRETS = 5
-
-        # Try to register 10 secrets
-        secrets = {f"SECRET_{i}": f"value_{i}_long" for i in range(10)}
-
-        registry.register_secrets_batch(secrets)
-
-        # Should stop at limit
-        assert registry.get_count() <= 5
-
-        # Restore limit
-        registry.MAX_SECRETS = original_max
-
-
-class TestPatternRebuildStress:
-    """Test pattern rebuild under stress conditions."""
-
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_pattern_rebuild_with_rapidly_changing_registry(self):
-        """Test pattern rebuild when registry changes rapidly."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register initial secret
-        registry.register_secret("SECRET1", "value1_test")
-
-        # Start a thread that continuously modifies the registry
-        stop_flag = threading.Event()
-
-        def modify_registry():
-            counter = 0
-            while not stop_flag.is_set():
-                registry.register_secret(
-                    f"DYNAMIC_{counter}", f"dynamic_value_{counter}"
-                )
-                counter += 1
-                if counter > 100:
-                    break
-
-        modifier_thread = threading.Thread(target=modify_registry)
-        modifier_thread.start()
-
-        # Try to mask text while registry is changing
-        for i in range(10):
-            result = masking_filter.mask_text(f"Message {i} with value1_test")
-            # Should eventually mask the secret
-            assert "value1_test" not in result or "REDACTED" in result
-
-        stop_flag.set()
-        modifier_thread.join()
-
-    def test_pattern_rebuild_with_empty_registry(self):
-        """Test pattern rebuild when registry becomes empty."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register and mask
-        registry.register_secret("SECRET", "test_value_xyz")
-        result1 = masking_filter.mask_text("Message with test_value_xyz")
-        assert "REDACTED" in result1
-
-        # Clear registry
-        registry.clear()
-
-        # Mask again - should not mask anything
-        result2 = masking_filter.mask_text("Message with test_value_xyz")
-        assert result2 == "Message with test_value_xyz"
-
-    def test_check_and_rebuild_pattern_with_large_secret_count_warnings(self):
-        """Test that warnings are logged for large secret counts."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register 101 secrets (triggers warning at 100)
-        for i in range(101):
-            registry.register_secret(f"SECRET_{i}", f"value_{i}_xxx")
-
-        # Trigger pattern rebuild
-        masking_filter._check_and_rebuild_pattern()
-
-        # Pattern should be built
-        assert masking_filter._pattern is not None
-
-    def test_check_and_rebuild_pattern_with_very_large_secret_count(self):
-        """Test warning for very large secret count (>500)."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Register 501 secrets
-        for i in range(501):
-            registry.register_secret(f"SECRET_{i}", f"value_{i}_xxx")
-
-        # Trigger pattern rebuild
-        masking_filter._check_and_rebuild_pattern()
-
-        # Pattern should be built
-        assert masking_filter._pattern is not None
-
-
-class TestLogRecordAttributes:
-    """Test masking of various log record attributes."""
-
-    def setup_method(self):
-        SecretRegistry.reset_instance()
-
-    def teardown_method(self):
-        SecretRegistry.reset_instance()
-
-    def test_filter_with_pre_formatted_message(self):
-        """Test that filter masks pre-formatted message attribute."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        registry.register_secret("SECRET", "secret_value_abc")
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Original message",
-            args=(),
-            exc_info=None,
-        )
-
-        # Set pre-formatted message
-        record.message = "Pre-formatted with secret_value_abc"
-
-        masking_filter.filter(record)
-
-        # Pre-formatted message should be masked
-        assert "secret_value_abc" not in record.message
-        assert "REDACTED" in record.message
-
-    def test_filter_with_exc_text(self):
-        """Test that filter masks exc_text attribute."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
-
-        registry.register_secret("SECRET", "secret_value_def")
+    def test_exc_text_step_failure_becomes_masking_error(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "leak_in_traceback_value")
 
         record = logging.LogRecord(
             name="test",
             level=logging.ERROR,
             pathname="",
             lineno=0,
-            msg="Error occurred",
+            msg="error",
             args=(),
-            exc_info=None,
+            exc_info=(ValueError, ValueError("embed leak_in_traceback_value"), None),
         )
+        original_mask_bounded = mf._mask_bounded
 
-        # Set exc_text
-        record.exc_text = "Exception text with secret_value_def"
+        def failing_mask_bounded(text, budget, original_len=None):
+            if "leak_in_traceback_value" in text:
+                raise RuntimeError("forced exc_text masking failure")
+            return original_mask_bounded(text, budget, original_len)
 
-        masking_filter.filter(record)
+        with patch.object(mf, "_mask_bounded", side_effect=failing_mask_bounded):
+            mf.filter(record)
+        assert record.exc_text == MASKING_ERROR_MESSAGE
+        assert record.exc_info is not None
 
-        # exc_text should be masked
-        assert "secret_value_def" not in record.exc_text
-        assert "REDACTED" in record.exc_text
 
-    def test_filter_with_stack_info(self):
-        """Test that filter masks stack_info attribute."""
-        registry = SecretRegistry.get_instance()
-        masking_filter = SecretMaskingFilter(registry)
+class TestExtrasFailureHalf:
+    """Invariant 10 (failure half): a field whose masking raises becomes
+    MASKING_ERROR_MESSAGE while the other fields are still masked; depth cap
+    and cycles produce a placeholder, never the raw subtree."""
 
-        registry.register_secret("SECRET", "secret_value_ghi")
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_one_bad_field_becomes_error_others_still_masked(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "field_secret_value")
 
         record = logging.LogRecord(
             name="test",
-            level=logging.DEBUG,
+            level=logging.INFO,
             pathname="",
             lineno=0,
-            msg="Debug message",
+            msg="msg",
             args=(),
             exc_info=None,
         )
+        record.__dict__["good"] = "field_secret_value here"
+        original = mf._mask_value_recursive
 
-        # Set stack_info
-        record.stack_info = "Stack trace with secret_value_ghi"
+        def selective_fail(value, _depth=0, _seen=None):
+            if isinstance(value, str) and value == "POISON":
+                raise RuntimeError("forced field failure")
+            return original(value, _depth, _seen)
 
-        masking_filter.filter(record)
+        record.__dict__["bad"] = "POISON"
+        with patch.object(mf, "_mask_value_recursive", side_effect=selective_fail):
+            mf.filter(record)
+        assert record.__dict__["bad"] == MASKING_ERROR_MESSAGE
+        assert "field_secret_value" not in record.__dict__["good"]
+        assert "***REDACTED:PW***" in record.__dict__["good"]
 
-        # stack_info should be masked
-        assert "secret_value_ghi" not in record.stack_info
-        assert "REDACTED" in record.stack_info
+    def test_depth_cap_produces_placeholder(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "deep_secret_value")
+
+        deep = "deep_secret_value"
+        for _ in range(mf._MAX_EXTRA_DEPTH + 2):
+            deep = {"inner": deep}
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.__dict__["deep"] = deep
+        mf.filter(record)
+        flat = str(record.__dict__["deep"])
+        assert "deep_secret_value" not in flat
+        assert "<not masked: depth limit>" in flat
+
+    def test_cycle_produces_placeholder(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "cycle_secret_value")
+
+        d = {"k": "cycle_secret_value"}
+        d["self"] = d
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.__dict__["cyc"] = d
+        mf.filter(record)
+        flat = str(record.__dict__["cyc"])
+        assert "cycle_secret_value" not in flat
+        assert "<not masked: cycle>" in flat
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+class TestFilterInternalException:
+    """Invariant 13: a filter-internal exception never propagates to the
+    logger.info() caller; the record goes out with MASKING_ERROR_MESSAGE,
+    not unmasked and not raised."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_filter_does_not_raise(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "outer_secret_value")
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="leak outer_secret_value",
+            args=(),
+            exc_info=None,
+        )
+        with patch.object(
+            mf, "_mask_record_msg", side_effect=RuntimeError("forced outer failure")
+        ):
+            result = mf.filter(record)
+        assert result is True
+        assert record.msg == MASKING_ERROR_MESSAGE
+        assert record.args == ()
+        assert record.exc_info is None
+        assert record.exc_text is None
+
+    def test_filter_via_logger_info_does_not_raise(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "logger_secret_value")
+
+        test_logger = logging.getLogger("test_filter_no_raise")
+        test_logger.handlers.clear()
+        test_logger.addFilter(mf)
+        cap = StringIO()
+        handler = logging.StreamHandler(cap)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        test_logger.addHandler(handler)
+        test_logger.setLevel(logging.INFO)
+
+        try:
+            with patch.object(
+                mf, "_mask_record_msg", side_effect=RuntimeError("forced")
+            ):
+                test_logger.info("leak logger_secret_value")
+            out = cap.getvalue()
+            assert MASKING_ERROR_MESSAGE in out
+            assert "logger_secret_value" not in out
+        finally:
+            test_logger.removeHandler(handler)
+            test_logger.removeFilter(mf)

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -204,6 +204,7 @@ class TestTracebackHappyHalf:
         assert record.exc_info is exc_info
         exc_type, exc_value, _ = record.exc_info
         assert exc_type is ValueError
+        assert exc_value is not None
         assert "traceback_secret_value" in str(exc_value.args[0])
 
     def test_exc_info_cause_chain_preserved(self):
@@ -231,9 +232,10 @@ class TestTracebackHappyHalf:
         mf.filter(record)
         assert record.exc_info is exc_info
         _t, v, _tb = record.exc_info
-        cause = v.__cause__
-        assert cause is not None
-        assert "cause_secret_value" in str(cause.args[0])
+        assert v is not None
+        exc_cause = v.__cause__
+        assert exc_cause is not None
+        assert "cause_secret_value" in str(exc_cause.args[0])
 
 
 class TestStreamWrapper:

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -1,36 +1,24 @@
-"""
-Unit tests for secret masking filter.
-
-Tests:
-- Basic message masking
-- Argument masking (% and {} formatting)
-- Exception masking
-- Large message truncation
-- Thread safety
-- Performance
-"""
+"""Tests for the SecretMaskingFilter — invariants 4, 6, 7 (happy half), 8,
+14, 15."""
 
 import logging
+import re
 import sys
-import threading
-import time
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 
 from datahub.masking.masking_filter import (
+    MASKING_ERROR_MESSAGE,
     SecretMaskingFilter,
     StreamMaskingWrapper,
-    install_masking_filter,
-    uninstall_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
-from datahub.utilities.perf_timer import PerfTimer
 
 
 @pytest.fixture
 def registry():
-    """Create fresh registry for each test."""
     reg = SecretRegistry()
     reg.clear()
     return reg
@@ -38,19 +26,12 @@ def registry():
 
 @pytest.fixture
 def masking_filter(registry):
-    """Create masking filter with test registry."""
     return SecretMaskingFilter(registry)
 
 
 class TestBasicMasking:
-    """Test basic secret masking functionality."""
-
-    def test_basic_message_masking(self, registry, masking_filter):
-        """Test basic secret masking in log messages."""
-        # Register secret
-        registry.register_secret("TEST_PASSWORD", "secret123")
-
-        # Create log record
+    def test_message_masked(self, registry, masking_filter):
+        registry.register_secret("PW", "secret123")
         record = logging.LogRecord(
             name="test",
             level=logging.INFO,
@@ -60,19 +41,13 @@ class TestBasicMasking:
             args=(),
             exc_info=None,
         )
-
-        # Filter the record
         masking_filter.filter(record)
-
-        # Check masking
         assert "secret123" not in record.msg
-        assert "***REDACTED:TEST_PASSWORD***" in record.msg
+        assert "***REDACTED:PW***" in record.msg
 
-    def test_multiple_secrets_in_message(self, registry, masking_filter):
-        """Test masking multiple secrets in one message."""
+    def test_multiple_secrets(self, registry, masking_filter):
         registry.register_secret("PASSWORD", "pass123")
         registry.register_secret("TOKEN", "tok456")
-
         record = logging.LogRecord(
             name="test",
             level=logging.INFO,
@@ -82,1098 +57,792 @@ class TestBasicMasking:
             args=(),
             exc_info=None,
         )
-
         masking_filter.filter(record)
-
         assert "pass123" not in record.msg
         assert "tok456" not in record.msg
         assert "***REDACTED:PASSWORD***" in record.msg
         assert "***REDACTED:TOKEN***" in record.msg
 
-    def test_no_secrets_registered(self, masking_filter):
-        """Test that filter works when no secrets are registered."""
+    def test_no_secrets_returns_unchanged(self, masking_filter):
         record = logging.LogRecord(
             name="test",
             level=logging.INFO,
             pathname="",
             lineno=0,
-            msg="This is a normal message",
+            msg="normal message",
             args=(),
             exc_info=None,
         )
-
         masking_filter.filter(record)
-
-        assert record.msg == "This is a normal message"
-
-    def test_empty_message(self, registry, masking_filter):
-        """Test that filter handles empty messages."""
-        registry.register_secret("SECRET", "value")
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="",
-            args=(),
-            exc_info=None,
-        )
-
-        masking_filter.filter(record)
-
-        assert record.msg == ""
+        assert record.msg == "normal message"
 
 
-class TestFormattedMessages:
-    """Test masking with formatted messages."""
+class TestMultiHandlerSentinelAndIdempotency:
+    """Invariant 4: a record dispatched to multiple handlers is masked and
+    truncated exactly once (sentinel), and mask_text is idempotent on
+    already-masked text and actually transforms every registered non-marker
+    value."""
 
-    def test_percent_formatting(self, registry, masking_filter):
-        """Test masking with % formatting."""
-        registry.register_secret("TOKEN", "token_abc123")
-
-        # Test % formatting
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Auth token: %s",
-            args=("token_abc123",),
-            exc_info=None,
-        )
-
-        masking_filter.filter(record)
-
-        # Args should be masked
-        assert "token_abc123" not in str(record.args)
-        assert "***REDACTED:TOKEN***" in str(record.args)
-
-    def test_dict_formatting(self, registry, masking_filter):
-        """Test masking with dict formatting."""
-        registry.register_secret("PASSWORD", "mypass")
-
-        # Create a proper logger and log with dict formatting
-        # (LogRecord expects args to be tuple, not dict)
-        test_logger = logging.getLogger("test_dict")
-        test_logger.addFilter(masking_filter)
-
-        # Capture the log record
-        class RecordCapture(logging.Handler):
-            def __init__(self):
-                super().__init__()
-                self.record = None
-
-            def emit(self, record):
-                self.record = record
-
-        handler = RecordCapture()
-        test_logger.addHandler(handler)
-
-        # Log with dict formatting
-        test_logger.info("Password is %(password)s", {"password": "mypass"})
-
-        # Check the record
-        record = handler.record
-        assert record is not None
-        assert "mypass" not in str(record.args)
-
-        # Cleanup
-        test_logger.removeHandler(handler)
-        test_logger.removeFilter(masking_filter)
-
-    def test_multiple_args(self, registry, masking_filter):
-        """Test masking with multiple arguments."""
-        registry.register_secret("USER", "admin")
-        registry.register_secret("PASS", "secret")
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="User: %s, Pass: %s",
-            args=("admin", "secret"),
-            exc_info=None,
-        )
-
-        masking_filter.filter(record)
-
-        assert "admin" not in str(record.args)
-        assert "secret" not in str(record.args)
-
-
-class TestExceptionMasking:
-    """Test masking in exception messages."""
-
-    def test_exception_masking(self, registry, masking_filter):
-        """Test masking in exception messages."""
-        registry.register_secret("SECRET", "my_secret_value")
-
-        # Create exception with secret
+    def test_record_masked_once_across_handlers(self, registry, masking_filter):
+        registry.register_secret("PW", "multi_secret_value")
+        cap1 = StringIO()
+        cap2 = StringIO()
+        h1 = logging.StreamHandler(cap1)
+        h2 = logging.StreamHandler(cap2)
+        for h in (h1, h2):
+            h.setFormatter(logging.Formatter("%(message)s"))
+            h.addFilter(masking_filter)
+        log = logging.getLogger("test.multi_handler")
+        log.handlers.clear()
+        log.propagate = False
+        log.addHandler(h1)
+        log.addHandler(h2)
+        log.setLevel(logging.INFO)
+        # Longer than the 5000-char budget so truncation actually fires.
+        long_msg = "leak multi_secret_value here" + "x" * 6000
         try:
-            raise ValueError("Error with my_secret_value")
+            log.info(long_msg)
+        finally:
+            log.removeHandler(h1)
+            log.removeHandler(h2)
+        out1 = cap1.getvalue()
+        out2 = cap2.getvalue()
+        assert "multi_secret_value" not in out1
+        assert "multi_secret_value" not in out2
+        assert "***REDACTED:PW***" in out1
+        assert "***REDACTED:PW***" in out2
+        # Truncated exactly once per handler (sentinel), not twice.
+        assert out1.count("bytes truncated") == 1, out1
+        assert out2.count("bytes truncated") == 1, out2
+
+    def test_mask_text_idempotent_and_transforms(self, registry, masking_filter):
+        registry.register_secret("PW", "idempotent_secret_value")
+        text = "leak idempotent_secret_value here"
+        once = masking_filter.mask_text(text)
+        twice = masking_filter.mask_text(once)
+        assert once == twice, "mask_text is not idempotent"
+        assert once != text, "mask_text did not transform the input"
+        assert "idempotent_secret_value" not in once
+        assert "***REDACTED:PW***" in once
+
+    def test_mask_text_marker_shaped_value_idempotent(self, registry, masking_filter):
+        registry.register_secret("ORPHAN", "***REDACTED:GONE***")
+        text = "***REDACTED:GONE***"
+        once = masking_filter.mask_text(text)
+        twice = masking_filter.mask_text(once)
+        assert once == twice
+        assert "REDACTED" in once
+
+
+class TestArgsNestedContainers:
+    """Invariant 6: args containing nested containers are masked
+    recursively (not just top-level strings)."""
+
+    def test_args_nested_dict_masked(self, registry, masking_filter):
+        registry.register_secret("PW", "args_secret_value")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="cfg: %s",
+            args=({"a": {"password": "args_secret_value"}},),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "args_secret_value" not in str(record.args)
+        assert "***REDACTED:PW***" in str(record.args)
+
+    def test_args_list_of_dicts_masked(self, registry, masking_filter):
+        registry.register_secret("PW", "list_secret_value")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="items: %s",
+            args=([{"password": "list_secret_value"}],),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "list_secret_value" not in str(record.args)
+        assert "***REDACTED:PW***" in str(record.args)
+
+
+class TestTracebackHappyHalf:
+    """Invariant 7 (happy half): exc_text is masked; exc_info retains the
+    original exception class, args, and __cause__ chain."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_exc_text_masked_exc_info_retained(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "traceback_secret_value")
+        try:
+            raise ValueError("embed traceback_secret_value in message")
         except ValueError:
             exc_info = sys.exc_info()
-
-        # Create log record with exception
         record = logging.LogRecord(
             name="test",
             level=logging.ERROR,
             pathname="",
             lineno=0,
-            msg="An error occurred",
+            msg="error occurred",
             args=(),
             exc_info=exc_info,
         )
+        mf.filter(record)
+        assert record.exc_text is not None
+        assert "traceback_secret_value" not in record.exc_text
+        assert "***REDACTED:PW***" in record.exc_text
+        assert record.exc_info is exc_info
+        exc_type, exc_value, _ = record.exc_info
+        assert exc_type is ValueError
+        assert "traceback_secret_value" in str(exc_value.args[0])
 
-        # Filter
-        masking_filter.filter(record)
-
-        # Exception should be masked
-        assert record.exc_info is not None
-        _, exc_value, _ = record.exc_info
-        assert "my_secret_value" not in str(exc_value)
-        assert "***REDACTED:SECRET***" in str(exc_value)
-
-    def test_exception_with_multiple_args(self, registry, masking_filter):
-        """Test masking exceptions with multiple args."""
-        registry.register_secret("KEY1", "value1")
-        registry.register_secret("KEY2", "value2")
-
+    def test_exc_info_cause_chain_preserved(self):
+        reg = SecretRegistry.get_instance()
+        reg.clear()
+        mf = SecretMaskingFilter(reg)
+        reg.register_secret("PW", "cause_secret_value")
         try:
-            raise RuntimeError("value1", "value2")
+            try:
+                raise ValueError("embed cause_secret_value")
+            except ValueError:
+                cause = RuntimeError("cause_secret_value too")
+                raise RuntimeError("wrapper") from cause
         except RuntimeError:
             exc_info = sys.exc_info()
-
         record = logging.LogRecord(
             name="test",
             level=logging.ERROR,
             pathname="",
             lineno=0,
-            msg="Error",
+            msg="error",
             args=(),
             exc_info=exc_info,
         )
-
-        masking_filter.filter(record)
-
-        assert record.exc_info is not None
-        _, exc_value, _ = record.exc_info
-        exc_str = str(exc_value)
-        assert "value1" not in exc_str
-        assert "value2" not in exc_str
-
-
-class TestMessageTruncation:
-    """Test automatic truncation of large messages."""
-
-    def test_large_message_truncation(self, registry, masking_filter):
-        """Test automatic truncation of large messages."""
-        # Create 10KB message
-        large_msg = "x" * 10000
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg=large_msg,
-            args=(),
-            exc_info=None,
-        )
-
-        # Filter (should truncate)
-        masking_filter.filter(record)
-
-        # Message should be truncated
-        assert len(record.msg) < 10000
-        assert "truncated" in record.msg
-
-    def test_small_message_not_truncated(self, registry, masking_filter):
-        """Test that small messages are not truncated."""
-        small_msg = "x" * 100
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg=small_msg,
-            args=(),
-            exc_info=None,
-        )
-
-        masking_filter.filter(record)
-
-        # Message should not be truncated
-        assert len(record.msg) == 100
-        assert "truncated" not in record.msg
-
-    def test_custom_max_size(self):
-        """Test custom maximum message size."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Create filter with small max size
-        filter = SecretMaskingFilter(registry, max_message_size=100)
-
-        large_msg = "x" * 500
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg=large_msg,
-            args=(),
-            exc_info=None,
-        )
-
-        filter.filter(record)
-
-        # Should be truncated to ~100 bytes
-        assert len(record.msg) < 200
-        assert "truncated" in record.msg
-
-
-class TestThreadSafety:
-    """Test concurrent access from multiple threads."""
-
-    def test_thread_safety(self, registry, masking_filter):
-        """Test concurrent access from multiple threads."""
-        errors = []
-
-        def worker(thread_id):
-            try:
-                # Register secret
-                registry.register_secret(f"SECRET_{thread_id}", f"value_{thread_id}")
-
-                # Create and filter records
-                for i in range(100):
-                    record = logging.LogRecord(
-                        name="test",
-                        level=logging.INFO,
-                        pathname="",
-                        lineno=0,
-                        msg=f"Thread {thread_id} message {i} with value_{thread_id}",
-                        args=(),
-                        exc_info=None,
-                    )
-                    masking_filter.filter(record)
-
-                    # Verify masking
-                    if f"value_{thread_id}" in record.msg:
-                        errors.append(f"Thread {thread_id}: Secret not masked!")
-            except Exception as e:
-                errors.append(f"Thread {thread_id}: {e}")
-
-        # Run 10 concurrent threads
-        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        # Check for errors
-        assert len(errors) == 0, f"Thread safety errors: {errors}"
-
-    def test_concurrent_registration_and_masking(self):
-        """Test concurrent registration and masking."""
-        registry = SecretRegistry()
-        registry.clear()
-        filter = SecretMaskingFilter(registry)
-
-        errors = []
-
-        def register_worker(thread_id):
-            try:
-                for i in range(50):
-                    registry.register_secret(
-                        f"SECRET_{thread_id}_{i}", f"val{thread_id}_{i}"
-                    )
-                    time.sleep(0.001)  # Small delay
-            except Exception as e:
-                errors.append(f"Register thread {thread_id}: {e}")
-
-        def mask_worker(thread_id):
-            try:
-                for i in range(50):
-                    record = logging.LogRecord(
-                        name="test",
-                        level=logging.INFO,
-                        pathname="",
-                        lineno=0,
-                        msg=f"Message {i}",
-                        args=(),
-                        exc_info=None,
-                    )
-                    filter.filter(record)
-                    time.sleep(0.001)  # Small delay
-            except Exception as e:
-                errors.append(f"Mask thread {thread_id}: {e}")
-
-        # Start both registration and masking threads
-        threads = []
-        threads.extend(
-            [threading.Thread(target=register_worker, args=(i,)) for i in range(5)]
-        )
-        threads.extend(
-            [threading.Thread(target=mask_worker, args=(i,)) for i in range(5)]
-        )
-
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        assert len(errors) == 0, f"Concurrent errors: {errors}"
-
-
-class TestPerformance:
-    """Test performance with many secrets and records."""
-
-    def test_performance(self, registry, masking_filter):
-        """Test performance with many secrets and records."""
-        # Register 100 secrets
-        for i in range(100):
-            registry.register_secret(f"SECRET_{i}", f"value_{i}")
-
-        # Process 1000 log records
-        start = time.time()
-
-        for i in range(1000):
-            record = logging.LogRecord(
-                name="test",
-                level=logging.INFO,
-                pathname="",
-                lineno=0,
-                msg=f"Message {i}",
-                args=(),
-                exc_info=None,
-            )
-            masking_filter.filter(record)
-
-        duration = time.time() - start
-
-        # Should complete in reasonable time (< 1 second)
-        assert duration < 1.0, f"Performance test took {duration:.2f}s (too slow)"
-
-    def test_pattern_rebuild_performance(self, registry, masking_filter):
-        """Test that pattern is not rebuilt unnecessarily."""
-        registry.register_secret("SECRET", "value")
-
-        # First call - will build pattern
-        record1 = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Message 1",
-            args=(),
-            exc_info=None,
-        )
-        masking_filter.filter(record1)
-
-        initial_version = masking_filter._last_version
-
-        # Second call - should NOT rebuild pattern
-        record2 = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Message 2",
-            args=(),
-            exc_info=None,
-        )
-        masking_filter.filter(record2)
-
-        # Version should be the same (no rebuild)
-        assert masking_filter._last_version == initial_version
+        mf.filter(record)
+        assert record.exc_info is exc_info
+        _t, v, _tb = record.exc_info
+        cause = v.__cause__
+        assert cause is not None
+        assert "cause_secret_value" in str(cause.args[0])
 
 
 class TestStreamWrapper:
-    """Test StreamMaskingWrapper."""
-
-    def test_stdout_wrapper(self, registry):
-        """Test StreamMaskingWrapper."""
-        registry.register_secret("PASSWORD", "secret_password")
-
-        # Create wrapper
-        output = StringIO()
-        filter = SecretMaskingFilter(registry)
-        wrapper = StreamMaskingWrapper(output, filter)
-
-        # Write through wrapper
-        wrapper.write("Password is secret_password\n")
-
-        # Check masking
-        result = output.getvalue()
-        assert "secret_password" not in result
-        assert "***REDACTED:PASSWORD***" in result
-
-    def test_wrapper_flush(self, registry):
-        """Test that flush works."""
-        output = StringIO()
-        filter = SecretMaskingFilter(registry)
-        wrapper = StreamMaskingWrapper(output, filter)
-
-        wrapper.write("test")
-        wrapper.flush()  # Should not raise
-
-        assert output.getvalue() == "test"
-
-    def test_wrapper_non_string(self, registry):
-        """Test that wrapper handles non-string writes."""
-        output = StringIO()
-        filter = SecretMaskingFilter(registry)
-        wrapper = StreamMaskingWrapper(output, filter)
-
-        # This should pass through without error
-        # (StringIO will handle the error)
-        try:
-            wrapper.write(123)  # type: ignore[arg-type]
-        except TypeError:
-            pass  # Expected for StringIO
-
-
-class TestInstallation:
-    """Test filter installation and removal."""
+    """Invariant 8: print() of a secret through the wrapped stdout is
+    masked; if masking raises inside the wrapper, the output is
+    MASKING_ERROR_MESSAGE, never the raw text."""
 
     def setup_method(self):
-        """Ensure clean state before each test."""
-        uninstall_masking_filter()
-
-    def teardown_method(self):
-        """Clean up after each test."""
-        uninstall_masking_filter()
-
-    def test_install_uninstall(self):
-        """Test filter installation and removal."""
-        registry = SecretRegistry()
-        registry.clear()
-        registry.register_secret("TEST", "test_value")
-
-        # Install
-        install_masking_filter(registry)
-
-        # Verify installed
-        root_logger = logging.getLogger()
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-        assert len(filters) > 0
-
-        # Uninstall
-        uninstall_masking_filter()
-
-        # Verify removed
-        filters = [f for f in root_logger.filters if isinstance(f, SecretMaskingFilter)]
-        assert len(filters) == 0
-
-    def test_double_install(self):
-        """Test that double installation is handled gracefully."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Install twice
-        filter1 = install_masking_filter(registry)
-        filter2 = install_masking_filter(registry)
-
-        # Should return same filter
-        assert filter1 is filter2
-
-        # Cleanup
-        uninstall_masking_filter()
-
-    def test_install_with_options(self):
-        """Test installation with custom options."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Install with custom options
-        filter = install_masking_filter(
-            secret_registry=registry, max_message_size=1000, install_stdout_wrapper=True
-        )
-
-        assert filter._max_message_size == 1000
-        assert isinstance(sys.stdout, StreamMaskingWrapper)
-
-        # Cleanup
-        uninstall_masking_filter()
-
-
-class TestCopyOnWrite:
-    """Test copy-on-write pattern."""
-
-    def test_copy_on_write_no_copy_needed(self, registry, masking_filter):
-        """Test that copy-on-write pattern means no .copy() is needed."""
-        registry.register_secret("SECRET", "secret_value")
-
-        # Get pattern snapshot
-        with masking_filter._pattern_lock:
-            masking_filter._check_and_rebuild_pattern()
-            replacements = masking_filter._replacements  # No .copy()!
-
-        # Change registry in another thread
-        def add_secret():
-            registry.register_secret("NEW_SECRET", "new_value")
-
-        thread = threading.Thread(target=add_secret)
-        thread.start()
-        thread.join()
-
-        # Original replacements dict should still be valid
-        assert "secret_value" in replacements
-        # New secret NOT in our snapshot (as expected)
-        assert "new_value" not in replacements
-
-    def test_version_tracking(self, registry, masking_filter):
-        """Test that version tracking works correctly."""
-        initial_version = registry.get_version()
-
-        # Add a secret
-        registry.register_secret("SECRET1", "value1")
-        version1 = registry.get_version()
-        assert version1 > initial_version
-
-        # Add another secret
-        registry.register_secret("SECRET2", "value2")
-        version2 = registry.get_version()
-        assert version2 > version1
-
-        # Try to add same secret - version should not change
-        registry.register_secret("SECRET1", "value1")
-        version3 = registry.get_version()
-        assert version3 == version2
-
-
-class TestEdgeCases:
-    """Test edge cases and error handling."""
-
-    def test_none_message(self, masking_filter):
-        """Test that None message is handled."""
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg=None,
-            args=(),
-            exc_info=None,
-        )
-
-        # Should not raise
-        masking_filter.filter(record)
-
-    def test_non_string_args(self, registry, masking_filter):
-        """Test that non-string args are handled."""
-        registry.register_secret("SECRET", "value")
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Test %s %d %s",
-            args=("string", 123, ["list"]),
-            exc_info=None,
-        )
-
-        # Should not raise
-        masking_filter.filter(record)
-
-        # Non-string args should be unchanged
-        assert isinstance(record.args, tuple)
-        assert record.args[1] == 123
-        assert record.args[2] == ["list"]
-
-    def test_very_short_secret(self):
-        """Test that very short values are not registered as secrets."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Try to register very short values
-        registry.register_secret("SHORT", "ab")
-        registry.register_secret("EMPTY", "")
-
-        # Should not be registered
-        assert registry.get_count() == 0
-
-    def test_special_characters_in_secret(self, registry, masking_filter):
-        """Test that special regex characters in secrets are handled."""
-        # Register secret with regex special characters
-        registry.register_secret("SPECIAL", "test.$*+?[](){}^|\\")
-
-        record = logging.LogRecord(
-            name="test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Secret: test.$*+?[](){}^|\\",
-            args=(),
-            exc_info=None,
-        )
-
-        masking_filter.filter(record)
-
-        # Should be masked despite special characters
-        assert "test.$*+?[](){}^|\\" not in record.msg
-        assert "***REDACTED:SPECIAL***" in record.msg
-
-
-class TestP1Fixes:
-    """Test P1 critical fixes from production hardening review."""
-
-    def test_stream_wrapper_return_value(self):
-        """
-        P1 FIX #2: Verify write() returns correct character count.
-
-        The wrapper should return len(masked_text), not the original
-        stream's return value.
-        """
-        from io import StringIO
-
-        registry = SecretRegistry()
-        registry.register_secret("PASSWORD", "secret123")
-
-        masking_filter = SecretMaskingFilter(registry)
-        stream = StringIO()
-        wrapper = StreamMaskingWrapper(stream, masking_filter)
-
-        # Write text with secret
-        text = "Password is secret123"
-        chars_written = wrapper.write(text)
-
-        # Should return length of MASKED text, not original
-        masked_text = stream.getvalue()
-        assert masked_text == "Password is ***REDACTED:PASSWORD***", (
-            f"Expected masked text, got: {masked_text}"
-        )
-        assert chars_written == len(masked_text), (
-            f"Expected {len(masked_text)} chars, got {chars_written}"
-        )
-        # "Password is ***REDACTED:PASSWORD***" = 12 + 23 = 35 chars
-        assert chars_written == 35, (
-            f"Expected 35 chars for 'Password is ***REDACTED:PASSWORD***', got {chars_written}"
-        )
-
-    def test_stream_wrapper_type_validation(self):
-        """
-        P1 FIX #2: Verify write() rejects non-string types.
-
-        The wrapper should raise TypeError for non-string input
-        to maintain contract compliance.
-        """
-        from io import StringIO
-
-        registry = SecretRegistry()
-        masking_filter = SecretMaskingFilter(registry)
-        stream = StringIO()
-        wrapper = StreamMaskingWrapper(stream, masking_filter)
-
-        # Should raise TypeError for bytes
-        with pytest.raises(TypeError, match="must be str"):
-            wrapper.write(b"bytes data")  # type: ignore[arg-type]
-
-        # Should raise TypeError for int
-        with pytest.raises(TypeError, match="must be str"):
-            wrapper.write(123)  # type: ignore[arg-type]
-
-        # Should raise TypeError for None
-        with pytest.raises(TypeError, match="must be str"):
-            wrapper.write(None)  # type: ignore[arg-type]
-
-    def test_singleton_thread_safety(self):
-        """
-        P1 FIX #3: Verify singleton is thread-safe under concurrent access.
-
-        The simplified singleton pattern should only create one instance
-        even when accessed concurrently from multiple threads.
-        """
-        # Reset singleton
         SecretRegistry.reset_instance()
 
-        instances = []
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
 
-        def get_instance():
-            instance = SecretRegistry.get_instance()
-            instances.append(id(instance))
+    def test_print_secret_masked(self, registry, masking_filter):
+        registry.register_secret("PW", "print_secret_value")
+        out = StringIO()
+        wrapper = StreamMaskingWrapper(out, masking_filter)
+        wrapper.write("leak print_secret_value here")
+        result = out.getvalue()
+        assert "print_secret_value" not in result
+        assert "***REDACTED:PW***" in result
 
-        # Create 50 threads trying to get instance simultaneously
-        threads = [threading.Thread(target=get_instance) for _ in range(50)]
+    def test_wrapper_failure_writes_masking_error(self, registry, masking_filter):
+        registry.register_secret("PW", "wrapper_secret_value")
+        out = StringIO()
+        wrapper = StreamMaskingWrapper(out, masking_filter)
+        with patch.object(
+            masking_filter, "mask_text", side_effect=RuntimeError("mask boom")
+        ):
+            n = wrapper.write("leak wrapper_secret_value here")
+        written = out.getvalue()
+        assert "wrapper_secret_value" not in written
+        assert MASKING_ERROR_MESSAGE in written
+        assert n == len(MASKING_ERROR_MESSAGE) + 1
 
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
 
-        # All should have same instance ID
-        unique_instances = set(instances)
-        assert len(unique_instances) == 1, (
-            f"Multiple instances created: {len(unique_instances)} unique IDs"
+class TestMaskingNamespaceBypass:
+    """Invariant 14: a record from a masking-safe-namespace logger
+    (datahub.masking.*) reaching a filter-carrying handler bypasses masking.
+    Asserted directly against a handler that carries the filter, so a
+    regression in the record.name early-return is actually caught."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_masking_namespace_record_bypasses(self, registry, masking_filter):
+        registry.register_secret("PW", "namespace_secret_value")
+        cap = StringIO()
+        h = logging.StreamHandler(cap)
+        h.setFormatter(logging.Formatter("%(message)s"))
+        h.addFilter(masking_filter)
+        masking_logger = logging.getLogger("datahub.masking.test_internal")
+        masking_logger.handlers.clear()
+        masking_logger.propagate = False
+        masking_logger.addHandler(h)
+        masking_logger.setLevel(logging.INFO)
+        try:
+            masking_logger.info("leak namespace_secret_value on purpose")
+        finally:
+            masking_logger.removeHandler(h)
+        out = cap.getvalue()
+        assert "namespace_secret_value" in out
+        assert "***REDACTED:PW***" not in out
+
+    def test_exact_namespace_logger_bypassed(self, registry, masking_filter):
+        registry.register_secret("PW", "exact_ns_secret_value")
+        record = logging.LogRecord(
+            name="datahub.masking",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="leak exact_ns_secret_value",
+            args=(),
+            exc_info=None,
         )
-        assert len(instances) == 50, f"Expected 50 calls, got {len(instances)}"
+        masking_filter.filter(record)
+        assert "exact_ns_secret_value" in record.msg
 
-    def test_get_secret_value_performance(self):
-        """
-        P2 BONUS: Verify O(1) lookup with reverse index.
+    def test_trailing_dot_does_not_match_maskingfoo(self, registry, masking_filter):
+        registry.register_secret("PW", "foo_secret_value")
+        record = logging.LogRecord(
+            name="datahub.maskingfoo",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="leak foo_secret_value",
+            args=(),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "foo_secret_value" not in record.msg
+        assert "***REDACTED:PW***" in record.msg
 
-        With the reverse index, lookups should be O(1) instead of O(n).
-        """
 
-        registry = SecretRegistry()
+class TestSecretStraddlingBoundary:
+    """Invariant 15: a secret straddling the max_message_size boundary is
+    never severed by truncation — the two-stage pre-cut either masks it
+    whole or cuts before it."""
 
-        # Register 1000 secrets
-        for i in range(1000):
-            registry.register_secret(f"SECRET_{i}", f"value_{i}")
+    def test_secret_at_boundary_not_severed(self):
+        reg = SecretRegistry()
+        reg.clear()
+        mf = SecretMaskingFilter(reg, max_message_size=100)
+        secret = "boundary_secret_value_12345"  # 26 chars
+        reg.register_secret("PW", secret)
+        text = "x" * 95 + secret + "y" * 50
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=text,
+            args=(),
+            exc_info=None,
+        )
+        mf.filter(record)
+        out = record.msg
+        assert secret not in out, f"secret was severed by truncation: {out!r}"
+        assert secret[:16] not in out, f"leading fragment survived: {out!r}"
 
-        # Lookup should be fast (O(1))
-        with PerfTimer() as timer:
-            for i in range(1000):
-                value = registry.get_secret_value(f"SECRET_{i}")
-                assert value == f"value_{i}", f"Expected value_{i}, got {value}"
+    def test_secret_inside_budget_appears_as_marker(self):
+        reg = SecretRegistry()
+        reg.clear()
+        mf = SecretMaskingFilter(reg, max_message_size=200)
+        secret = "inside_secret_value_12345"
+        reg.register_secret("PW", secret)
+        text = "prefix " + secret + " suffix"
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=text,
+            args=(),
+            exc_info=None,
+        )
+        mf.filter(record)
+        assert "***REDACTED:PW***" in record.msg
 
-        # Should complete in < 10ms (O(1) lookups)
-        elapsed = timer.elapsed_seconds()
-        assert elapsed < 0.01, (
-            f"Lookups too slow: {elapsed:.4f}s (expected <0.01s for 1000 O(1) lookups)"
+    def test_slide_regression_msg_path(self):
+        # Two copies of a long secret; masking the first shrinks the text
+        # below budget and slides the second copy's severed fragment inside
+        # the retained window. A mandatory final cut alone leaves it; the
+        # strip is what removes it.
+        reg = SecretRegistry()
+        reg.clear()
+        budget = 200
+        mf = SecretMaskingFilter(reg, max_message_size=budget)
+        secret = "S" * 300
+        reg.register_secret("PW", secret)
+        text = secret + "x" * 10 + secret + "y" * (budget + 50)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=text,
+            args=(),
+            exc_info=None,
+        )
+        mf.filter(record)
+        assert secret[:16] not in record.msg, (
+            f"severed fragment survived in msg: {record.msg!r}"
+        )
+        assert "truncated" in record.msg
+
+    def test_slide_regression_exc_text_path(self):
+        # Second copy of the secret straddles the exc_text pre-cut: with
+        # max_message_size=200 the exc_text budget is 2*200=400, longest=300,
+        # so the pre-cut is 700. The second copy (~517-817) straddles 700; the
+        # pre-cut severs it, masking slides the fragment inside the window,
+        # and the post-mask strip removes it.
+        reg = SecretRegistry()
+        reg.clear()
+        mf = SecretMaskingFilter(reg, max_message_size=200)
+        secret = "S" * 300
+        reg.register_secret("PW", secret)
+        tb = (
+            "Traceback (most recent call last):\n  File ...\n    raise ValueError(\n"
+            + secret
+            + "p" * 150
+            + secret
+            + "q" * 300
+            + "\n)"
+        )
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="error",
+            args=(),
+            exc_info=None,
+        )
+        record.exc_text = tb
+        mf.filter(record)
+        assert secret[:16] not in (record.exc_text or ""), (
+            f"severed fragment survived in exc_text: {record.exc_text!r}"
+        )
+        assert "truncated" in (record.exc_text or "")
+
+    def test_slide_regression_exc_text_strip_is_load_bearing(self):
+        # Same geometry, but with _strip_severed_tail neutralized: the
+        # severed fragment of the second copy MUST survive, proving the
+        # post-mask strip is what removes it (not the final cut alone).
+        reg = SecretRegistry()
+        reg.clear()
+        mf = SecretMaskingFilter(reg, max_message_size=200)
+        secret = "S" * 300
+        reg.register_secret("PW", secret)
+        tb = (
+            "Traceback (most recent call last):\n  File ...\n    raise ValueError(\n"
+            + secret
+            + "p" * 150
+            + secret
+            + "q" * 300
+            + "\n)"
+        )
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="error",
+            args=(),
+            exc_info=None,
+        )
+        record.exc_text = tb
+        with patch.object(
+            mf, "_strip_severed_tail", side_effect=lambda kept, keys, longest: kept
+        ):
+            mf.filter(record)
+        assert secret[:16] in (record.exc_text or ""), (
+            f"fragment did not survive without the strip: {record.exc_text!r}"
         )
 
-
-class TestRegexSecurityFixes:
-    """Test regex injection prevention and DoS protection."""
-
-    def test_regex_metacharacters_literal_matching(self):
-        """Verify regex metacharacters are treated as literals, not operators."""
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Test each regex metacharacter
-        test_cases = [
-            (
-                "DOT",
-                "api.key",
-                "Found api.key here",
-                "Found ***REDACTED:DOT*** here",
-                "Found apixkey here",
-                "Found apixkey here",
-            ),
-            (
-                "STAR",
-                "pass*word",
-                "Using pass*word",
-                "Using ***REDACTED:STAR***",
-                "Using password",
-                "Using password",
-            ),
-            (
-                "PLUS",
-                "key+value",
-                "Set key+value",
-                "Set ***REDACTED:PLUS***",
-                "Set keyvalue",
-                "Set keyvalue",
-            ),
-            (
-                "QUESTION",
-                "user?name",
-                "Got user?name",
-                "Got ***REDACTED:QUESTION***",
-                "Got username",
-                "Got username",
-            ),
-            (
-                "BRACKETS",
-                "data[0]",
-                "Access data[0]",
-                "Access ***REDACTED:BRACKETS***",
-                "Access data0",
-                "Access data0",
-            ),
-            (
-                "PARENS",
-                "func()",
-                "Call func()",
-                "Call ***REDACTED:PARENS***",
-                "Call func",
-                "Call func",
-            ),
-            (
-                "PIPE",
-                "a|b",
-                "Choose a|b",
-                "Choose ***REDACTED:PIPE***",
-                "Choose a",
-                "Choose a",
-            ),
-            (
-                "CARET",
-                "^start",
-                "Anchor ^start",
-                "Anchor ***REDACTED:CARET***",
-                "Anchor start",
-                "Anchor start",
-            ),
-        ]
-
-        for (
-            name,
-            secret,
-            match_text,
-            expected_masked,
-            no_match_text,
-            expected_not_masked,
-        ) in test_cases:
-            registry.clear()
-            registry.register_secret(name, secret)
-
-            # Should mask literal string
-            masked = masking_filter.mask_text(match_text)
-            assert masked == expected_masked, (
-                f"{name}: Failed to mask literal. Expected '{expected_masked}', got '{masked}'"
+    def test_periodic_secret_strip_after_mask_no_leak(self):
+        # A periodic secret severed by the pre-cut: stripping before masking
+        # can match a coincidental self-overlap longer than the real fragment
+        # and sever a complete earlier occurrence instead. Masking first
+        # turns every complete occurrence into a marker, so a tail matching a
+        # key prefix can only be a severed fragment.
+        reg = SecretRegistry()
+        reg.clear()
+        budget = 200
+        mf = SecretMaskingFilter(reg, max_message_size=budget)
+        secret = "s3cr3t" * 50  # period 6, 300 chars
+        reg.register_secret("P", secret)
+        text = secret + secret
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=text,
+            args=(),
+            exc_info=None,
+        )
+        mf.filter(record)
+        out = record.msg
+        assert "***REDACTED:P***" in out, f"marker missing: {out!r}"
+        # No 8-char substring of the secret survives (period 6 regenerates the
+        # whole value from any 6+ char fragment).
+        for i in range(len(secret) - 8 + 1):
+            assert secret[i : i + 8] not in out, (
+                f"8-char secret fragment at {i} survived: {out!r}"
             )
 
-            # Should NOT over-match similar strings
-            not_masked = masking_filter.mask_text(no_match_text)
-            assert not_masked == expected_not_masked, (
-                f"{name}: Over-matched similar string. Expected '{expected_not_masked}', got '{not_masked}'"
+
+class TestExtrasNotMutated:
+    """Extras: nested containers masked recursively on a copy (caller's dict
+    unmutated)."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_extras_not_mutated_in_place(self, registry, masking_filter):
+        registry.register_secret("PW", "extras_secret_value")
+        caller_dict = {"a": {"password": "extras_secret_value"}, "b": "plain"}
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.__dict__["cfg"] = caller_dict
+        masking_filter.filter(record)
+        assert caller_dict == {"a": {"password": "extras_secret_value"}, "b": "plain"}
+        masked_cfg = record.__dict__["cfg"]
+        assert "extras_secret_value" not in str(masked_cfg)
+        assert "***REDACTED:PW***" in str(masked_cfg)
+
+
+class TestLateRegistrationMaskedOnNextCall:
+    # Invariant 2: a secret registered after the first mask_text is masked
+    # on the next call (version bump triggers a rebuild).
+
+    def test_secret_added_after_first_mask_is_masked_next_call(
+        self, registry, masking_filter
+    ):
+        registry.register_secret("FIRST", "first_secret_value")
+        out1 = masking_filter.mask_text("leak first_secret_value here")
+        assert "first_secret_value" not in out1
+        assert "***REDACTED:FIRST***" in out1
+
+        registry.register_secret("LATE", "late_secret_value")
+        out2 = masking_filter.mask_text("leak late_secret_value here")
+        assert "late_secret_value" not in out2
+        assert "***REDACTED:LATE***" in out2
+
+
+class TestNamedtupleReconstruction:
+    """A multi-field namedtuple in extra= is reconstructed as the same
+    namedtuple type with the secret field masked (not collapsed to a tuple
+    or list)."""
+
+    def test_two_field_namedtuple_preserved(self, registry, masking_filter):
+        from collections import namedtuple
+
+        Pair = namedtuple("Pair", ["user", "secret"])
+        registry.register_secret("PW", "nt_secret_value")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.__dict__["cfg"] = Pair(user="alice", secret="nt_secret_value")
+        masking_filter.filter(record)
+        out = record.__dict__["cfg"]
+        assert isinstance(out, Pair)
+        assert out.user == "alice"
+        assert "nt_secret_value" not in str(out)
+        assert "***REDACTED:PW***" in str(out)
+
+
+class TestNonStringMsg:
+    """Non-str record.msg is masked (dict/list/tuple/set via recursive
+    helper; arbitrary objects str()-ed and replaced only if changed)."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_dict_msg_masked(self, registry, masking_filter):
+        registry.register_secret("PW", "dict_msg_secret_value")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg={"password": "dict_msg_secret_value"},
+            args=(),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "dict_msg_secret_value" not in str(record.msg)
+        assert "***REDACTED:PW***" in str(record.msg)
+
+    def test_object_msg_masked_only_when_secret_present(self, registry, masking_filter):
+        registry.register_secret("PW", "obj_secret_value")
+
+        class Obj:
+            def __str__(self):
+                return "embed obj_secret_value here"
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=Obj(),
+            args=(),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "obj_secret_value" not in str(record.msg)
+        assert "***REDACTED:PW***" in str(record.msg)
+
+    def test_object_msg_preserved_when_no_secret(self, masking_filter):
+        class Obj:
+            def __str__(self):
+                return "no secret here"
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=Obj(),
+            args=(),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert isinstance(record.msg, Obj)
+
+
+class TestFormatStringArgsSkipTruncation:
+    """Truncation is skipped when record.args is present (truncating a
+    format string can sever a %s placeholder)."""
+
+    def test_format_string_not_truncated_with_args(self, registry, masking_filter):
+        registry.register_secret("PW", "format_secret_value")
+        fmt = "x" * 6000 + " %s"
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=fmt,
+            args=("format_secret_value",),
+            exc_info=None,
+        )
+        masking_filter.filter(record)
+        assert "%s" in record.msg
+        assert "format_secret_value" not in str(record.args)
+
+
+class TestRebuildFailureFailClosed:
+    """When secrets exist but no pattern was ever built and the rebuild
+    fails, mask_text returns MASKING_ERROR_MESSAGE (never the raw text).
+    When a previous pattern exists, it is kept."""
+
+    def setup_method(self):
+        SecretRegistry.reset_instance()
+
+    def teardown_method(self):
+        SecretRegistry.reset_instance()
+
+    def test_first_build_failure_returns_masking_error(self, registry):
+        registry.register_secret("PW", "firstbuild_secret_value")
+        mf = SecretMaskingFilter(registry)
+        with patch(
+            "datahub.masking.masking_filter.re.compile",
+            side_effect=re.error("forced compile failure"),
+        ):
+            out = mf.mask_text("leak firstbuild_secret_value here")
+        assert out == MASKING_ERROR_MESSAGE
+        assert "firstbuild_secret_value" not in out
+
+    def test_rebuild_failure_with_previous_keeps_previous(self, registry):
+        registry.register_secret("PW", "previous_secret_value")
+        mf = SecretMaskingFilter(registry)
+        mf.mask_text("leak previous_secret_value")
+        with patch(
+            "datahub.masking.masking_filter.re.compile",
+            side_effect=re.error("forced compile failure"),
+        ):
+            out = mf.mask_text("leak previous_secret_value again")
+        assert "previous_secret_value" not in out
+        assert "***REDACTED:PW***" in out
+
+
+class TestRegexSecurity:
+    """re.escape ensures secrets with regex metacharacters are matched
+    literally, not as regex."""
+
+    def test_metacharacters_literal(self, registry, masking_filter):
+        registry.register_secret("PW", "a+b*c.d?e[f]g")
+        out = masking_filter.mask_text("leak a+b*c.d?e[f]g here")
+        assert "a+b*c.d?e[f]g" not in out
+        assert "***REDACTED:PW***" in out
+
+    def test_alternation_literal(self, registry, masking_filter):
+        registry.register_secret("PW", "test|prod")
+        out = masking_filter.mask_text("leak test|prod here")
+        assert "test|prod" not in out
+        assert "***REDACTED:PW***" in out
+
+    def test_longest_first_prefix_secret(self, registry, masking_filter):
+        """A short secret that is a prefix of a longer one must not win first
+        (longest-first ordering)."""
+        registry.register_secret("SHORT", "secret")
+        registry.register_secret("LONG", "secret_value_long")
+        out = masking_filter.mask_text("leak secret_value_long here")
+        assert "secret_value_long" not in out
+        assert "***REDACTED:LONG***" in out
+
+
+def _strip_truncation_suffix(s: str) -> str:
+    return re.split(r"\n\.\.\. \[\d+ bytes truncated for performance\]", s, maxsplit=1)[
+        0
+    ]
+
+
+def _maximal_alphabet_runs(s: str, alphabet: set) -> list:
+    runs = []
+    i = 0
+    n = len(s)
+    while i < n:
+        if s[i] in alphabet:
+            j = i
+            while j < n and s[j] in alphabet:
+                j += 1
+            runs.append(s[i:j])
+            i = j
+        else:
+            i += 1
+    return runs
+
+
+class TestTruncationDifferentialProperty:
+    """The truncation path leaks nothing that plain masking does not: every
+    maximal run of secret-alphabet chars in the bounded output is a substring
+    of the plain mask_text output."""
+
+    BUDGET = 200
+
+    def _setup_case(self, reg, case_id):
+        # Returns (secret_values, alphabet, period_or_None).
+        if case_id == "periodic_s3cr3t":
+            secret = "s3cr3t" * 50
+            reg.register_secret("P", secret)
+            return [secret], set(secret), 6
+        if case_id == "periodic_ab":
+            secret = "ab" * 150
+            reg.register_secret("P", secret)
+            return [secret], set(secret), 2
+        if case_id == "self_overlap_aab":
+            secret = ("aab" * 100)[:300]
+            reg.register_secret("P", secret)
+            return [secret], set(secret), 3
+        if case_id == "prefix_pair":
+            short = "prefixed_secret_value_12345"
+            long = short + "_extended_tail_part"
+            reg.register_secret("SHORT", short)
+            reg.register_secret("LONG", long)
+            return [short, long], set(long), None
+        if case_id == "marker_adjacent":
+            secret = "***" + "k" * 297
+            reg.register_secret("P", secret)
+            return [secret], set(secret), None
+        if case_id == "random_entropy":
+            import random
+            import string
+
+            rng = random.Random(12345)
+            secret = "".join(
+                rng.choice(string.ascii_letters + string.digits) for _ in range(300)
             )
+            reg.register_secret("P", secret)
+            return [secret], set(secret), None
+        raise AssertionError(case_id)
 
-    def test_dos_prevention_wildcard_secrets(self):
-        """Verify wildcard patterns don't cause over-masking (DoS)."""
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
+    def _longest(self, secrets):
+        return max(len(s) for s in secrets)
 
-        # Register potentially dangerous wildcards (must be >= 3 chars for registry)
-        registry.register_secret("WILDCARD", "secret.*")
-        registry.register_secret("PLUS", "key.+")
-        registry.register_secret("STAR", "pass*")
+    def _build_layout(self, secrets, period, layout_id, reg):
+        longest = self._longest(secrets)
+        secret = secrets[0]
+        if layout_id == "straddle_budget":
+            # A single occurrence straddling the budget boundary.
+            return "Q" * 100 + secret + "Q" * 200
+        if layout_id == "straddle_budget_plus_longest":
+            return "Q" * (self.BUDGET + longest - 100) + secret + "Q" * 200
+        if layout_id == "adjacent_copies":
+            return secret + secret + "Q" * 100
+        if layout_id == "partial_repeat_tail":
+            if period is None:
+                pytest.skip("partial-repeat tail only applies to periodic secrets")
+            return secret + secret[: len(secret) - 2 * period] + "Q" * 100
+        raise AssertionError(layout_id)
 
-        # Should only mask literal strings, not act as wildcards
-        test_text = "Processing request 12345 with secrets and keys"
-        masked = masking_filter.mask_text(test_text)
-
-        # Should NOT mask everything (wildcards should not act as regex)
-        assert masked == test_text, (
-            f"Wildcard acted as regex (security issue). Expected no masking, got: {masked}"
-        )
-
-        # Should only mask literal "secret.*"
-        literal_text = "Password is secret.*"
-        masked = masking_filter.mask_text(literal_text)
-        assert masked == "Password is ***REDACTED:WILDCARD***", (
-            f"Failed to mask literal 'secret.*': {masked}"
-        )
-
-        # Should NOT match "secretABC" (wildcard should not work as regex)
-        not_matching = "Password is secretABC"
-        masked2 = masking_filter.mask_text(not_matching)
-        assert masked2 == not_matching, (
-            f"Wildcard acted as regex (should not match 'secretABC'): {masked2}"
-        )
-
-    def test_catastrophic_backtracking_prevention(self):
-        """Verify complex patterns don't cause DoS via catastrophic backtracking."""
-
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Patterns that would cause catastrophic backtracking if not escaped
-        dangerous_patterns = [
-            "(a+)+",
-            "(a*)*",
-            "(a|a)*",
-            "(a|ab)*",
-            "((a+)+)+",
-        ]
-
-        for i, pattern in enumerate(dangerous_patterns):
-            registry.register_secret(f"DANGER_{i}", pattern)
-
-        # Force pattern rebuild
-        masking_filter._check_and_rebuild_pattern()
-
-        # This should complete quickly (not hang)
-        test_text = "a" * 30 + "b"
-
-        with PerfTimer() as timer:
-            masked = masking_filter.mask_text(test_text)
-
-        # Should complete in milliseconds, not seconds
-        elapsed = timer.elapsed_seconds()
-        assert elapsed < 0.01, (
-            f"Pattern matching too slow: {elapsed:.4f}s (possible backtracking)"
-        )
-
-        # Should not match (these are literals, not regex patterns)
-        assert masked == test_text, (
-            f"Pattern should not match. Expected no masking, got: {masked}"
-        )
-
-    def test_combined_metacharacters_no_regex_interpretation(self):
-        """Verify combinations of metacharacters are treated as literals."""
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Complex combinations
-        registry.register_secret("COMPLEX1", "test.$*+?[](){}^|\\")
-        registry.register_secret("COMPLEX2", ".*secret.*")
-        registry.register_secret("COMPLEX3", "(admin|user)+")
-
-        # Should mask exact literals only
-        test_cases = [
-            ("Creds: test.$*+?[](){}^|\\", "Creds: ***REDACTED:COMPLEX1***"),
-            ("Found .*secret.*", "Found ***REDACTED:COMPLEX2***"),
-            ("Auth (admin|user)+", "Auth ***REDACTED:COMPLEX3***"),
-            # Should NOT match as regex patterns
-            ("Creds: test_anything", "Creds: test_anything"),
-            ("Found mysecret", "Found mysecret"),
-            ("Auth admin", "Auth admin"),
-        ]
-
-        for input_text, expected in test_cases:
-            masked = masking_filter.mask_text(input_text)
-            assert masked == expected, (
-                f"Failed for '{input_text}'. Expected '{expected}', got '{masked}'"
+    @pytest.mark.parametrize(
+        "case_id",
+        [
+            "periodic_s3cr3t",
+            "periodic_ab",
+            "self_overlap_aab",
+            "prefix_pair",
+            "marker_adjacent",
+            "random_entropy",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "layout_id",
+        [
+            "straddle_budget",
+            "straddle_budget_plus_longest",
+            "adjacent_copies",
+            "partial_repeat_tail",
+        ],
+    )
+    def test_bounded_leaks_no_more_than_baseline(self, case_id, layout_id):
+        reg = SecretRegistry()
+        reg.clear()
+        secrets, alphabet, period = self._setup_case(reg, case_id)
+        text = self._build_layout(secrets, period, layout_id, reg)
+        mf = SecretMaskingFilter(reg, max_message_size=self.BUDGET)
+        baseline = mf.mask_text(text)
+        bounded = _strip_truncation_suffix(mf._mask_bounded(text, self.BUDGET))
+        # Every maximal run of secret-alphabet chars in bounded must appear
+        # somewhere in baseline (substring, not run-equality: the final cut
+        # may bisect a residue run; bounded leaking less than baseline is fine).
+        for run in _maximal_alphabet_runs(bounded, alphabet):
+            assert run in baseline, (
+                f"case={case_id} layout={layout_id} run={run!r} not in baseline"
             )
-
-    def test_backslash_escaping(self):
-        """Verify backslashes are properly escaped and don't affect other escapes."""
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Backslashes in various contexts
-        registry.register_secret("WINDOWS_PATH", "C:\\Users\\admin\\secret.txt")
-        registry.register_secret("REGEX_ESCAPE", "\\d+")
-        registry.register_secret("DOUBLE_BACKSLASH", "test\\\\value")
-
-        # Should mask exact strings only
-        assert (
-            masking_filter.mask_text("Path: C:\\Users\\admin\\secret.txt")
-            == "Path: ***REDACTED:WINDOWS_PATH***"
-        )
-        assert (
-            masking_filter.mask_text("Pattern: \\d+")
-            == "Pattern: ***REDACTED:REGEX_ESCAPE***"
-        )
-        assert (
-            masking_filter.mask_text("Value: test\\\\value")
-            == "Value: ***REDACTED:DOUBLE_BACKSLASH***"
-        )
-
-        # Should NOT match as regex
-        assert masking_filter.mask_text("Pattern: 123") == "Pattern: 123"
-        assert masking_filter.mask_text("Value: testvalue") == "Value: testvalue"
-
-
-class TestNestedConfigHandling:
-    """Test secret registration from nested ConfigModel objects."""
-
-    def test_nested_config_secrets_registered(self):
-        """Verify nested configs register secrets properly."""
-        from pydantic import SecretStr
-
-        from datahub.configuration.common import ConfigModel
-
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-
-        class DatabaseConfig(ConfigModel):
-            password: SecretStr
-
-        class AppConfig(ConfigModel):
-            database: DatabaseConfig
-
-        # Create nested config
-        _config = AppConfig(database=DatabaseConfig(password="nested_secret"))
-
-        # Secret should be registered from nested model
-        assert registry.has_secret("password")
-        assert registry.get_secret_value("password") == "nested_secret"
-
-
-class TestThreadSafetyConcurrent:
-    """Test thread safety under concurrent load."""
-
-    def test_concurrent_batch_registration(self):
-        """Test batch registration from multiple threads."""
-        import threading
-
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-
-        def register_batch(thread_id: int) -> None:
-            secrets = {
-                f"SECRET_{thread_id}_{i}": f"value_{thread_id}_{i}" for i in range(50)
-            }
-            registry.register_secrets_batch(secrets)
-
-        threads = [
-            threading.Thread(target=register_batch, args=(i,)) for i in range(10)
-        ]
-
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        # Should have 500 secrets registered (10 threads * 50 secrets)
-        assert registry.get_count() == 500
-
-    def test_concurrent_masking_during_registration(self):
-        """Test masking works correctly during concurrent registration."""
-        import threading
-        import time
-
-        registry = SecretRegistry.get_instance()
-        registry.clear()
-        masking_filter = SecretMaskingFilter(registry)
-
-        # Pre-register some secrets
-        registry.register_secret("EXISTING", "existing_value")
-
-        results = []
-        errors = []
-
-        def register_secrets():
-            try:
-                for i in range(100):
-                    registry.register_secret(f"NEW_{i}", f"new_value_{i}")
-                    time.sleep(0.001)  # Small delay
-            except Exception as e:
-                errors.append(e)
-
-        def mask_text():
-            try:
-                for _ in range(100):
-                    # Mask existing secret
-                    masked = masking_filter.mask_text("existing_value")
-                    results.append(masked)
-                    time.sleep(0.001)
-            except Exception as e:
-                errors.append(e)
-
-        reg_thread = threading.Thread(target=register_secrets)
-        mask_threads = [threading.Thread(target=mask_text) for _ in range(5)]
-
-        reg_thread.start()
-        for t in mask_threads:
-            t.start()
-
-        reg_thread.join()
-        for t in mask_threads:
-            t.join()
-
-        # No errors should occur
-        assert len(errors) == 0
-        # All masked results should be correct
-        assert all("***REDACTED:EXISTING***" in r for r in results)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -117,7 +117,7 @@ class TestRegistrationValidation:
         reg.clear()
         reg.register_secret("N", None)  # type: ignore[arg-type]
         reg.register_secret("E", "")
-        reg.register_secrets_batch({"N": None, "E": ""})  # type: ignore[arg-type]
+        reg.register_secrets_batch({"N": None, "E": ""})  # type: ignore[arg-type,dict-item]
         assert reg.get_count() == 0
 
     def test_duplicate_value_uses_first_name(self):

--- a/metadata-ingestion/tests/unit/test_secret_registry.py
+++ b/metadata-ingestion/tests/unit/test_secret_registry.py
@@ -1,320 +1,498 @@
-"""Test SecretRegistry singleton and is_masking_enabled function."""
+"""Tests for the SecretRegistry — invariants 3 (scope halves), 5, 9, 16."""
+
+import contextlib
+import logging
+from typing import Iterator, List
 
 import pytest
 
-from datahub.masking.secret_registry import SecretRegistry, is_masking_enabled
+from datahub.masking.constants import REDACTED_FORMAT
+from datahub.masking.secret_registry import (
+    _GLOBAL_GROUP,
+    SecretRegistry,
+    is_masking_enabled,
+)
 
 
-class TestSecretRegistrySingleton:
-    """Test SecretRegistry singleton behavior."""
+@contextlib.contextmanager
+def _capture_records(logger_name: str) -> Iterator[List[logging.LogRecord]]:
+    """Attach a handler for the duration of the block; remove the same
+    handler on exit. Masking loggers have propagate=False, so caplog (root)
+    can't see them."""
+    log = logging.getLogger(logger_name)
+    records: List[logging.LogRecord] = []
 
-    def test_get_instance_returns_singleton(self):
-        """get_instance should return the same instance."""
-        instance1 = SecretRegistry.get_instance()
-        instance2 = SecretRegistry.get_instance()
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
 
-        assert instance1 is instance2
-
-    def test_reset_instance_clears_singleton(self):
-        """reset_instance should clear the singleton."""
-        instance1 = SecretRegistry.get_instance()
-
-        SecretRegistry.reset_instance()
-
-        instance2 = SecretRegistry.get_instance()
-
-        # Should be a new instance
-        assert instance1 is not instance2
+    handler = _Capture()
+    log.addHandler(handler)
+    try:
+        yield records
+    finally:
+        log.removeHandler(handler)
 
 
 class TestIsMaskingEnabled:
-    """Test is_masking_enabled function."""
-
-    def test_masking_enabled_by_default(self):
-        """Masking should be enabled when env var is not set."""
+    def test_default_enabled(self):
         with pytest.MonkeyPatch.context() as m:
             m.delenv("DATAHUB_DISABLE_SECRET_MASKING", raising=False)
-            assert is_masking_enabled() is True
+            assert is_masking_enabled()
 
-    def test_masking_disabled_with_true(self):
-        """Masking should be disabled when env var is 'true'."""
+    def test_disabled_true(self):
         with pytest.MonkeyPatch.context() as m:
             m.setenv("DATAHUB_DISABLE_SECRET_MASKING", "true")
-            assert is_masking_enabled() is False
+            assert not is_masking_enabled()
 
-    def test_masking_disabled_with_1(self):
-        """Masking should be disabled when env var is '1'."""
+    def test_disabled_one(self):
         with pytest.MonkeyPatch.context() as m:
             m.setenv("DATAHUB_DISABLE_SECRET_MASKING", "1")
-            assert is_masking_enabled() is False
+            assert not is_masking_enabled()
 
-    def test_masking_enabled_with_false(self):
-        """Masking should be enabled when env var is 'false'."""
+
+class TestSingleton:
+    def test_get_instance_returns_singleton(self):
+        a = SecretRegistry.get_instance()
+        b = SecretRegistry.get_instance()
+        assert a is b
+
+    def test_reset_instance_clears_singleton(self):
+        a = SecretRegistry.get_instance()
+        SecretRegistry.reset_instance()
+        b = SecretRegistry.get_instance()
+        assert a is not b
+
+
+class TestRegistrationValidation:
+    """Invariant 5: registration refuses marker-prefix values and short
+    values on both single and batch paths, with warnings. The marker prefix
+    is derived from constants.REDACTED_FORMAT, not hardcoded."""
+
+    @property
+    def _marker_prefix(self) -> str:
+        return REDACTED_FORMAT.split("{", 1)[0]
+
+    def test_single_marker_prefix_value_refused(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.register_secret("PW", self._marker_prefix + "PW***")
+        assert reg.get_count() == 0
+        assert any("will NOT be masked" in r.getMessage() for r in recs), (
+            "marker-prefix value should warn that it will NOT be masked"
+        )
+
+    def test_batch_marker_prefix_value_refused(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.register_secrets_batch(
+                {"PW": self._marker_prefix + "PW***", "OK": "valid_value_1"}
+            )
+        # OK accepted; marker-prefix value refused.
+        assert reg.has_secret("OK")
+        assert not reg.has_secret("PW")
+        assert any("will NOT be masked" in r.getMessage() for r in recs)
+
+    def test_single_short_value_refused_with_warning(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.register_secret("SHORT", "ab")
+        assert reg.get_count() == 0
+        assert any("minimum floor" in r.getMessage() for r in recs)
+
+    def test_batch_short_value_refused_with_warning(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.register_secrets_batch({"SHORT": "ab", "OK": "valid_value_2"})
+        assert reg.has_secret("OK")
+        assert not reg.has_secret("SHORT")
+        assert any("minimum floor" in r.getMessage() for r in recs)
+
+    def test_non_string_and_empty_ignored(self):
+        reg = SecretRegistry()
+        reg.clear()
+        reg.register_secret("N", None)  # type: ignore[arg-type]
+        reg.register_secret("E", "")
+        reg.register_secrets_batch({"N": None, "E": ""})  # type: ignore[arg-type]
+        assert reg.get_count() == 0
+
+    def test_duplicate_value_uses_first_name(self):
+        reg = SecretRegistry()
+        reg.clear()
+        reg.register_secret("A", "same_value_123")
+        reg.register_secret("B", "same_value_123")
+        snap_ver, snap = reg.snapshot()
+        assert snap["same_value_123"] == "A"
+
+    def test_url_encoded_variant_registered(self):
+        reg = SecretRegistry()
+        reg.clear()
+        reg.register_secret("password", "P#!ss@word")
+        _ver, snap = reg.snapshot()
+        assert "P#!ss@word" in snap
+        assert "P#!ss%40word" in snap
+
+
+class TestPerExecutionScoping:
+    """Invariant 3 (scope halves): ending one execution leaves the other's
+    secrets masked and the filter installed; shutdown with no live scope is
+    a safe no-op; ending by dead/unknown token does not recreate a group."""
+
+    def test_overlapping_executions_isolated(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok_a = reg.begin_execution()
+        reg.register_secret("A", "aaa_secret_value")
+        tok_b = reg.begin_execution()
+        reg.register_secret("B", "bbb_secret_value")
+        assert tok_a != tok_b
+
+        reg.end_execution(tok_a)
+        # B's secret is still registered; A's is gone.
+        assert reg.has_secret("B")
+        assert not reg.has_secret("A")
+        assert reg.get_count() == 1
+
+        reg.end_execution(tok_b)
+        assert reg.get_count() == 0
+
+    def test_shutdown_with_no_live_scope_is_safe_noop(self):
+        reg = SecretRegistry()
+        reg.clear()
+        # No scope open; end_execution is a no-op (debug-level).
+        reg.end_execution(None)
+        reg.end_execution("nonexistent-token")
+        # A dead/unknown id must NOT be recreated (no setdefault revival).
+        assert "nonexistent-token" not in reg._groups
+
+    def test_dead_token_not_recreated(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        reg.register_secret("T", "token_secret_value")
+        reg.end_execution(tok)
+        # Ending again with the dead token does not revive the group.
+        reg.end_execution(tok)
+        assert tok not in reg._groups
+
+    def test_global_dropped_when_last_execution_ends(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        # Register a secret with no ambient scope on another "thread" by
+        # clearing the contextvar first.
+        import datahub.masking.secret_registry as reg_mod
+
+        ctx_tok = reg_mod._current_exec.set(None)
+        try:
+            reg.register_secret("G", "global_secret_value")
+            assert _GLOBAL_GROUP in reg._groups
+            reg.end_execution(tok)
+            # Last real execution ended -> __global__ dropped too.
+            assert _GLOBAL_GROUP not in reg._groups
+        finally:
+            reg_mod._current_exec.reset(ctx_tok)
+
+    def test_register_with_unknown_explicit_id_goes_to_global(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        reg.register_secret("X", "value_xyz_123", exec_id="dead-id")
+        # dead-id is not revived; the secret lands in __global__.
+        assert "dead-id" not in reg._groups
+        assert _GLOBAL_GROUP in reg._groups
+        assert reg.has_secret("X")
+        reg.end_execution(tok)
+
+    def test_cross_thread_register_with_explicit_id(self):
+        import threading
+
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        done = threading.Event()
+
+        def worker():
+            reg.register_secret("PW", "sup3rsecret_value", exec_id=tok)
+            done.set()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(5.0)
+        assert not t.is_alive()
+        assert reg.has_secret("PW")
+        assert "sup3rsecret_value" in reg._groups[tok]
+        reg.end_execution(tok)
+
+    def test_global_fallthrough_warns_once_per_execution(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        import datahub.masking.secret_registry as reg_mod
+
+        ctx_tok = reg_mod._current_exec.set(None)
+        try:
+            with _capture_records("datahub.masking.secret_registry") as recs:
+                reg.register_secret("G1", "global_value_one")
+                reg.register_secret("G2", "global_value_two")
+            warnings = [
+                r for r in recs if "outside any execution scope" in r.getMessage()
+            ]
+            assert len(warnings) == 1, (
+                f"expected one fall-through warning, got {len(warnings)}"
+            )
+            reg.end_execution(tok)
+        finally:
+            reg_mod._current_exec.reset(ctx_tok)
+
+    def test_empty_group_end_no_warning_while_other_live(self):
+        # An execution that registered no secrets pops {} (falsy); it must
+        # not trip the "scope may be leaking" warning while another scope is
+        # live, and the group must actually be gone.
+        reg = SecretRegistry()
+        reg.clear()
+        tok_live = reg.begin_execution()
+        reg.register_secret("LIVE", "live_secret_value")
+        tok_empty = reg.begin_execution()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.end_execution(tok_empty)
+        leak_warnings = [r for r in recs if "scope may be leaking" in r.getMessage()]
+        assert leak_warnings == [], (
+            f"empty-group end should not warn, got {leak_warnings}"
+        )
+        assert tok_empty not in reg._groups
+        assert reg.has_secret("LIVE")
+        reg.end_execution(tok_live)
+
+    def test_noop_shutdown_does_not_bump_version(self):
+        reg = SecretRegistry()
+        reg.clear()
+        v0 = reg.get_version()
+        reg.end_execution(None)
+        reg.end_execution("nonexistent-token")
+        assert reg.get_version() == v0
+
+    def test_noop_end_does_not_drop_global_with_secrets(self):
+        # A completely no-op end call (unknown id, nothing removed) must
+        # not drop __global__ nor bump the version, even if __global__ holds
+        # secrets and no live scope exists.
+        reg = SecretRegistry()
+        reg.clear()
+        import datahub.masking.secret_registry as reg_mod
+
+        reg_mod._current_exec.set(None)
+        reg.register_secret("G", "global_secret_value")
+        assert _GLOBAL_GROUP in reg._groups
+        v0 = reg.get_version()
+        reg.end_execution("nonexistent-token")
+        assert _GLOBAL_GROUP in reg._groups, "no-op end dropped __global__"
+        assert reg.get_version() == v0, "no-op end bumped version"
+
+    def test_unknown_exec_id_no_warning_without_live_scope(self):
+        # Registering under an unknown explicit id with NO live scope must
+        # not warn (the message says "while live scope(s) are active").
+        reg = SecretRegistry()
+        reg.clear()
+        with _capture_records("datahub.masking.secret_registry") as recs:
+            reg.register_secret("X", "value_xyz_123", exec_id="dead-id")
+        fallthrough_warnings = [
+            r for r in recs if "live scope(s) are active" in r.getMessage()
+        ]
+        assert fallthrough_warnings == [], (
+            f"warned without live scope: {fallthrough_warnings}"
+        )
+        assert reg.has_secret("X")
+
+
+class TestVersionAndSnapshot:
+    """Invariant 9: registering N secrets triggers no pattern rebuild;
+    the next mask_text call triggers exactly one snapshot+compile. The
+    version bumps once per batch, and snapshot() is called only on version
+    mismatch."""
+
+    def test_version_increments_on_register(self):
+        reg = SecretRegistry()
+        reg.clear()
+        v0 = reg.get_version()
+        reg.register_secret("K", "value_one_123")
+        assert reg.get_version() > v0
+
+    def test_batch_bumps_version_once(self):
+        reg = SecretRegistry()
+        reg.clear()
+        v0 = reg.get_version()
+        reg.register_secrets_batch(
+            {"A": "value_aaa_123", "B": "value_bbb_123", "C": "value_ccc_123"}
+        )
+        assert reg.get_version() == v0 + 1
+
+    def test_snapshot_returns_expanded_keys(self):
+        reg = SecretRegistry()
+        reg.clear()
+        reg.register_secret("PW", "pa:ss@wo/rd")
+        ver, snap = reg.snapshot()
+        assert ver == reg.get_version()
+        # raw + repr (no change) + sqlalchemy-encoded + json-escaped
+        assert "pa:ss@wo/rd" in snap
+        assert "pa%3Ass%40wo%2Frd" in snap
+
+    def test_snapshot_first_registration_wins_name(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        reg.register_secret("A", "shared_value_123")
+        reg.register_secret("B", "shared_value_123")
+        _ver, snap = reg.snapshot()
+        assert snap["shared_value_123"] == "A"
+        reg.end_execution(tok)
+
+    def test_register_then_mask_is_one_compile(self):
+        """Invariant 9: N registrations followed by one mask_text trigger
+        exactly one snapshot+compile. Asserted by counting snapshot() and
+        re.compile calls, not wall-clock time."""
+        from unittest.mock import patch
+
+        reg = SecretRegistry()
+        reg.clear()
+        from datahub.masking.masking_filter import SecretMaskingFilter
+
+        mf = SecretMaskingFilter(reg)
+        snapshot_calls = [0]
+        original_snapshot = reg.snapshot
+
+        def counting_snapshot():
+            snapshot_calls[0] += 1
+            return original_snapshot()
+
+        compile_calls = [0]
+        original_compile = __import__("re").compile
+
+        def counting_compile(pattern, flags=0):
+            compile_calls[0] += 1
+            return original_compile(pattern, flags)
+
+        with (
+            patch.object(reg, "snapshot", counting_snapshot),
+            patch("re.compile", counting_compile),
+        ):
+            for i in range(20):
+                reg.register_secret(f"K{i}", f"unique_value_{i:03d}_xx")
+            # No snapshot/compile during registration.
+            assert snapshot_calls[0] == 0
+            assert compile_calls[0] == 0
+            mf.mask_text("mask a unique_value_000_xx here")
+            # Exactly one snapshot and one compile for the first mask after
+            # N registrations.
+            assert snapshot_calls[0] == 1
+            assert compile_calls[0] == 1
+
+
+class TestMaxSecrets:
+    """Invariant 16: registration beyond MAX_SECRETS is refused with
+    exactly one warning."""
+
+    def test_register_beyond_max_refused_once(self):
+        reg = SecretRegistry()
+        reg.clear()
         with pytest.MonkeyPatch.context() as m:
-            m.setenv("DATAHUB_DISABLE_SECRET_MASKING", "false")
-            assert is_masking_enabled() is True
-
-
-class TestSecretRegistryVersionTracking:
-    """Test SecretRegistry version tracking."""
-
-    def test_get_version_increments_on_register(self):
-        """Version should increment when secrets are registered."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        initial_version = registry.get_version()
-
-        registry.register_secret("KEY1", "value1")
-
-        assert registry.get_version() > initial_version
-
-    def test_get_version_unchanged_after_clear(self):
-        """Version tracking after clear."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        version_after_clear = registry.get_version()
-
-        registry.register_secret("KEY1", "value1")
-        new_version = registry.get_version()
-
-        assert new_version > version_after_clear
-
-
-class TestSecretRegistryGetAllSecrets:
-    """Test get_all_secrets method."""
-
-    def test_get_all_secrets_returns_copy(self):
-        """get_all_secrets should return a copy of secrets dict."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "value1")
-
-        secrets1 = registry.get_all_secrets()
-        secrets2 = registry.get_all_secrets()
-
-        # Should be different dict objects
-        assert secrets1 is not secrets2
-        # But with same content
-        assert secrets1 == secrets2
-
-
-class TestSecretRegistryInvalidInputs:
-    """Test SecretRegistry with invalid inputs."""
-
-    def test_register_empty_string_value_ignored(self):
-        """Empty string values should be ignored."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "")
-
-        secrets = registry.get_all_secrets()
-        assert len(secrets) == 0
-
-    def test_register_short_string_value_ignored(self):
-        """Strings shorter than 3 characters should be ignored."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "ab")
-        registry.register_secret("KEY2", "x")
-
-        secrets = registry.get_all_secrets()
-        assert len(secrets) == 0
-
-    def test_register_non_string_value_ignored(self):
-        """Non-string values should be ignored."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", 123)  # type: ignore
-
-        secrets = registry.get_all_secrets()
-        assert len(secrets) == 0
-
-    def test_register_none_value_ignored(self):
-        """None values should be ignored."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", None)  # type: ignore
-
-        secrets = registry.get_all_secrets()
-        assert len(secrets) == 0
-
-    def test_duplicate_secret_value_uses_first_name(self):
-        """Registering same value twice should use first variable name."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "same_value")
-        registry.register_secret("KEY2", "same_value")
-
-        secrets = registry.get_all_secrets()
-
-        # Should have only one entry
-        assert len(secrets) == 1
-        # Should use the first name
-        assert secrets["same_value"] == "KEY1"
-
-    def test_register_duplicate_with_different_case_treats_as_different(self):
-        """Secret values are case-sensitive."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "secret")
-        registry.register_secret("KEY2", "SECRET")
-
-        secrets = registry.get_all_secrets()
-
-        # Should have two entries
-        assert len(secrets) == 2
-        assert "secret" in secrets
-        assert "SECRET" in secrets
-
-    def test_register_secret_with_special_chars_registers_url_encoded(self):
-        """Secrets with special characters should also register SQLAlchemy-style URL-encoded version."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Password with special characters that SQLAlchemy encodes (only : @ /)
-        registry.register_secret("password", "P#!ss@word")
-
-        secrets = registry.get_all_secrets()
-
-        # Should have both raw and SQLAlchemy-style encoded versions
-        # SQLAlchemy only encodes : @ / (not # or !)
-        assert "P#!ss@word" in secrets
-        assert "P#!ss%40word" in secrets  # Only @ encoded to %40
-        assert secrets["P#!ss@word"] == "password"
-        assert secrets["P#!ss%40word"] == "password"
-
-
-class TestSecretRegistryMaxSecrets:
-    """Test max secrets limit."""
-
-    def test_register_stops_at_max_secrets(self):
-        """Registry should stop accepting secrets after MAX_SECRETS."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        # Register MAX_SECRETS
-        for i in range(SecretRegistry.MAX_SECRETS):
-            registry.register_secret(f"KEY_{i}", f"value_{i}")
-
-        secrets_at_max = registry.get_all_secrets()
-        count_at_max = len(secrets_at_max)
-
-        # Try to register one more
-        registry.register_secret("EXTRA_KEY", "extra_value")
-
-        secrets_after = registry.get_all_secrets()
-
-        # Should not have increased
-        assert len(secrets_after) == count_at_max
-
-
-class TestRegisterSecretsBatch:
-    """Test batch registration of secrets."""
-
-    def test_register_secrets_batch_with_dict(self):
-        """Should register multiple secrets at once."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        secrets = {"KEY1": "value1", "KEY2": "value2", "KEY3": "value3"}
-
-        registry.register_secrets_batch(secrets)
-
-        all_secrets = registry.get_all_secrets()
-
-        assert "value1" in all_secrets
-        assert "value2" in all_secrets
-        assert "value3" in all_secrets
-
-    def test_register_secrets_batch_with_empty_dict(self):
-        """Should handle empty dict gracefully."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secrets_batch({})
-
-        # Should not raise
-
-    def test_register_secrets_batch_filters_invalid_values(self):
-        """Should filter out invalid values in batch registration."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        secrets = {
-            "VALID": "valid_value",
-            "EMPTY": "",
-            "SHORT": "ab",  # Too short (< 3 chars)
-            "NONE": None,  # type: ignore
-            "INT": 123,  # type: ignore
-        }
-
-        registry.register_secrets_batch(secrets)  # type: ignore[arg-type]
-
-        all_secrets = registry.get_all_secrets()
-
-        # Only valid should be registered
-        assert "valid_value" in all_secrets
-        assert len(all_secrets) == 1
-
-    def test_register_secrets_batch_with_special_chars_registers_url_encoded(self):
-        """Batch registration should also register SQLAlchemy-style URL-encoded versions."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        secrets = {
-            "password1": "P#!ss@word",  # Has @ which SQLAlchemy encodes
-            "password2": "simplepass",  # No special chars
-        }
-
-        registry.register_secrets_batch(secrets)
-
-        all_secrets = registry.get_all_secrets()
-
-        # First password should have SQLAlchemy-style encoded version
-        # SQLAlchemy only encodes : @ / (not # or !)
-        assert "P#!ss@word" in all_secrets
-        assert "P#!ss%40word" in all_secrets  # Only @ encoded
-
-        # Second password should not have duplicate
-        assert "simplepass" in all_secrets
-
-
-class TestClearRegistry:
-    """Test clearing the registry."""
-
-    def test_clear_removes_all_secrets(self):
-        """clear() should remove all secrets."""
-        registry = SecretRegistry()
-        registry.clear()
-
-        registry.register_secret("KEY1", "value1")
-        registry.register_secret("KEY2", "value2")
-
-        assert len(registry.get_all_secrets()) == 2
-
-        registry.clear()
-
-        assert len(registry.get_all_secrets()) == 0
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            with _capture_records("datahub.masking.secret_registry") as recs:
+                for i in range(30):
+                    reg.register_secret(f"K{i}", f"value_{i:03d}_xxx")
+        capacity_warnings = [r for r in recs if "at capacity" in r.getMessage()]
+        assert len(capacity_warnings) == 1, (
+            f"expected exactly one capacity warning, got {len(capacity_warnings)}"
+        )
+        assert reg.get_count() <= 10
+
+    def test_batch_beyond_max_refused_once(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            with _capture_records("datahub.masking.secret_registry") as recs:
+                reg.register_secrets_batch(
+                    {f"K{i}": f"value_{i:03d}_xxx" for i in range(30)}
+                )
+        capacity_warnings = [r for r in recs if "at capacity" in r.getMessage()]
+        assert len(capacity_warnings) == 1
+        assert reg.get_count() <= 10
+
+    def test_capacity_warning_can_fire_again_after_clear(self):
+        reg = SecretRegistry()
+        reg.clear()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            with _capture_records("datahub.masking.secret_registry"):
+                for i in range(30):
+                    reg.register_secret(f"A{i}", f"value_{i:03d}_xxx")
+        reg.clear()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            with _capture_records("datahub.masking.secret_registry") as recs2:
+                for i in range(30):
+                    reg.register_secret(f"B{i}", f"other_{i:03d}_xxx")
+        assert len([r for r in recs2 if "at capacity" in r.getMessage()]) == 1
+
+    def test_capacity_warning_resets_per_execution(self):
+        # begin_execution resets _capacity_warned, so a worker that hits
+        # MAX_SECRETS warns once per execution, not once per process.
+        reg = SecretRegistry()
+        reg.clear()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(SecretRegistry, "MAX_SECRETS", 10)
+            with _capture_records("datahub.masking.secret_registry") as recs1:
+                tok = reg.begin_execution()
+                for i in range(30):
+                    reg.register_secret(f"A{i}", f"value_{i:03d}_xxx")
+            assert len([r for r in recs1 if "at capacity" in r.getMessage()]) == 1
+            reg.end_execution(tok)
+            with _capture_records("datahub.masking.secret_registry") as recs2:
+                tok2 = reg.begin_execution()
+                for i in range(30):
+                    reg.register_secret(f"B{i}", f"other_{i:03d}_xxx")
+            assert len([r for r in recs2 if "at capacity" in r.getMessage()]) == 1
+            reg.end_execution(tok2)
+
+
+class TestClear:
+    def test_clear_removes_all(self):
+        reg = SecretRegistry()
+        reg.clear()
+        reg.register_secret("A", "value_aaa_123")
+        reg.register_secret("B", "value_bbb_123")
+        assert reg.get_count() == 2
+        reg.clear()
+        assert reg.get_count() == 0
 
     def test_clear_increments_version(self):
-        """clear() should increment version."""
-        registry = SecretRegistry()
-        registry.clear()
+        reg = SecretRegistry()
+        reg.clear()
+        v0 = reg.get_version()
+        reg.register_secret("A", "value_aaa_123")
+        reg.clear()
+        assert reg.get_version() > v0
 
-        version_before = registry.get_version()
 
-        registry.register_secret("KEY", "value")
-        registry.clear()
+class TestGetSecretValue:
+    def test_first_wins_across_scopes(self):
+        reg = SecretRegistry()
+        reg.clear()
+        tok = reg.begin_execution()
+        reg.register_secret("PW", "first_value_123")
+        tok2 = reg.begin_execution()
+        reg.register_secret("PW", "second_value_456")
+        # first-wins across scopes
+        assert reg.get_secret_value("PW") == "first_value_123"
+        reg.end_execution(tok)
+        reg.end_execution(tok2)
 
-        version_after = registry.get_version()
-
-        assert version_after > version_before
+    def test_not_found_returns_none(self):
+        reg = SecretRegistry()
+        reg.clear()
+        assert reg.get_secret_value("NOPE") is None
+        assert not reg.has_secret("NOPE")


### PR DESCRIPTION
One design change: shutdown_secret_masking() no longer uninstalls the logging filter — it only drops that execution's secrets. The filter installs once per process, so ending one execution can never unmask another.

That removes everything built to support uninstall: the Handler.__init__ monkeypatch, three of six locks, COW dual-publish, and the circuit breaker. Net −516 lines vs master.

Coverage. Filters attach to handlers (not loggers), so propagated records are masked. A Logger.addHandler wrap covers handlers created mid-run; each initialize_secret_masking() re-scans for pre-existing ones. Streams are wrapped only when OS-backed, so celery's proxy is skipped and its writes are masked as ordinary records.

Leaks closed. One _admit path validates single and batch registration (batch previously skipped it — and batch is the only path production uses). Extras mask per field instead of aborting the loop. The stream wrapper writes a redaction notice on failure instead of raw text. Nested containers in record.args mask recursively. _mask_bounded pre-cuts, masks, then strips the severed tail — strip-after-mask is load-bearing, since stripping first can sever a complete occurrence of a self-overlapping secret.

Behavior changes. datahub ingest aborts cleanly if masking can't initialize rather than running unmasked. mask_text returns MASKING_ERROR_MESSAGE when secrets exist but no pattern was built (fail-closed; affects acryl-executor's direct calls). sys.excepthook is replaced for process lifetime — sign-off item. shutdown_secret_masking is now exported from datahub.masking.

Performance (tests/performance/test_masking_perf.py; only the typical row gates):

secrets | text | ms/mask
-- | -- | --
20 | 100 B | 0.040 ms (gated <1 ms)
20 | 5 KB | 3.5 ms
100 | 5 KB | 65.6 ms
200 | 20 KB | 978.5 ms

Real recipes register well under 20 secrets; larger rows are documented ceilings.

Residuals (deliberate). Handlers reached via handler.handle() or logger.handlers.append() bypass the wrap (mitigated by the re-scan). Formatters calling formatException(record.exc_info) bypass masked exc_text; exc_info stays intact for error reporters. re.sub is non-overlapping, so a periodic secret as a partial trailing repeat leaves up to len(secret) − period raw chars — pre-existing, applies to mask_text generally. Dict subclasses flatten to plain dict. get_secret_value is first-wins across scopes.

CLI. run shuts the scope down on both non-exception exits; error paths keep it so entrypoints.py formats the traceback masked.

Tests. 18 behavioral invariants plus a differential property test proving the truncation path leaks nothing mask_text doesn't already. Truncation regressions are discriminators — verified to fail if the fix is reverted. Full suite: 16,432 passed, 2 pre-existing environmental failures confirmed identical on master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Reworks secret masking so the **logging filter installs once per process** and **`shutdown_secret_masking` only ends that run’s secret scope**—ending one ingest no longer tears down masking for others. `SecretRegistry` now groups secrets by execution (`begin_execution` / `end_execution`) and builds mask patterns from a **`snapshot()`** union with expanded key forms (repr, URL-encoded, JSON-escaped).
> 
> **`SecretMaskingFilter`** attaches to **all handlers** (plus a **`Logger.addHandler` wrap** for mid-run handlers), drops the circuit breaker, uses marker-first regex with fail-closed **`MASKING_ERROR_MESSAGE`**, masks **`extra`** fields recursively, and tightens truncation via **`_mask_bounded`** (strip severed tails after masking). Stdout/stderr wrap only on real streams (skips Celery-style proxies); masking-safe logging uses **`sys.__stderr__`**.
> 
> **Bootstrap / CLI:** masking init **raises and aborts `datahub ingest`** if install fails; success paths call **`shutdown_secret_masking`**; exception paths keep the scope for masked tracebacks. Excepthook is process-lifetime and suppresses raw tracebacks if masking fails.
> 
> Tests add invariant coverage, CLI masking paths, perf gate for typical `mask_text`, and autouse teardown that fails on leaked execution scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0d703b2cddd1e16fe1effad645cdda4967ce22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->