### PR TITLE
fix(upgrade): gate ZDU alias swap on launch-time doc count

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -450,6 +450,25 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
           nextIndexName,
           phase,
           e);
+      // If the alias update succeeded and then an exception was observed (or reporting failed),
+      // deleting nextIndexName would remove the live backing index. Treat "already swapped" as
+      // success and skip cleanup.
+      try {
+        if (indexBuilder.getBackingIndices(opContext, config.name()).contains(nextIndexName)) {
+          log.warn(
+              "Alias {} already points to {} after swap exception; treating as success and"
+                  + " skipping cleanup.",
+              config.name(),
+              nextIndexName);
+          return true;
+        }
+      } catch (Exception verifyException) {
+        log.warn(
+            "Unable to verify alias target after swap failure for {} -> {}: {}",
+            config.name(),
+            nextIndexName,
+            verifyException.getMessage());
+      }
     }
     failAndCleanUp(context, upgradeState, config.name(), nextIndexName, indexBuilder);
     return false;

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -228,21 +228,22 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
               indexBuilder.undoReindexOptimalSettings(
                   opContext, existingNextIndex.get(), config, pollResult.latestReindexInfo());
 
-              // Swap alias to next index so new code reads from the updated schema
-              boolean swapped =
-                  indexBuilder.validateAndSwapAlias(
-                      opContext, config.name(), existingNextIndex.get());
-              if (!swapped) {
-                log.error(
-                    "Alias swap failed for {} -> {} after resume: doc count mismatch",
-                    config.name(),
-                    existingNextIndex.get());
+              // Swap alias to next index so new code reads from the updated schema. The gate
+              // compares against the source count snapshotted when this index's reindex was
+              // launched, not a live alias count — see ESIndexBuilder#validateAndSwapAlias.
+              if (!swapAliasOrCleanUp(
+                  context,
+                  upgradeState,
+                  config,
+                  existingNextIndex.get(),
+                  persistedSourceDocCount,
+                  indexBuilder,
+                  "after resume")) {
                 return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
               }
-              log.info("Alias swapped: {} -> {}", config.name(), existingNextIndex.get());
               // Only now is Phase 1 truly complete: mark COMPLETED so subsequent runs skip it. A
-              // failed swap above returns before reaching here, leaving the index IN_PROGRESS for
-              // retry.
+              // failed swap above returns before reaching here, having escalated the index to
+              // FAILED so the next run rebuilds it.
               upgradeState =
                   IncrementalReindexState.setPhase1Completed(upgradeState, config.name());
               checkpoint(context, upgradeState, DataHubUpgradeState.IN_PROGRESS);
@@ -282,13 +283,14 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
 
             // Still need to swap the alias so new code reads from the next index with correct
             // mappings, even though both indices have 0 docs.
-            boolean swapped =
-                indexBuilder.validateAndSwapAlias(opContext, config.name(), result.nextIndexName());
-            if (!swapped) {
-              log.error(
-                  "Alias swap failed for {} -> {} (empty index): doc count mismatch",
-                  config.name(),
-                  result.nextIndexName());
+            if (!swapAliasOrCleanUp(
+                context,
+                upgradeState,
+                config,
+                result.nextIndexName(),
+                result.sourceDocCount(),
+                indexBuilder,
+                "empty index")) {
               return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
             }
             log.info(
@@ -323,20 +325,22 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
           indexBuilder.undoReindexOptimalSettings(
               opContext, result.nextIndexName(), config, pollResult.latestReindexInfo());
 
-          // Swap alias to next index so new code reads from the updated schema
-          boolean swapped =
-              indexBuilder.validateAndSwapAlias(opContext, config.name(), result.nextIndexName());
-          if (!swapped) {
-            log.error(
-                "Alias swap failed for {} -> {} after reindex: doc count mismatch",
-                config.name(),
-                result.nextIndexName());
+          // Swap alias to next index so new code reads from the updated schema. The gate compares
+          // against the source count snapshotted when the reindex was launched, not a live alias
+          // count — see ESIndexBuilder#validateAndSwapAlias.
+          if (!swapAliasOrCleanUp(
+              context,
+              upgradeState,
+              config,
+              result.nextIndexName(),
+              sourceDocCount,
+              indexBuilder,
+              "after reindex")) {
             return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
           }
-          log.info("Alias swapped: {} -> {}", config.name(), result.nextIndexName());
           // Only now is Phase 1 truly complete: mark COMPLETED so subsequent runs skip it. A
-          // failed swap above returns before reaching here, leaving the index IN_PROGRESS for
-          // retry.
+          // failed swap above returns before reaching here, having escalated the index to FAILED
+          // so the next run rebuilds it.
           upgradeState = IncrementalReindexState.setPhase1Completed(upgradeState, config.name());
           checkpoint(context, upgradeState, DataHubUpgradeState.IN_PROGRESS);
         }
@@ -398,21 +402,85 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
       log.info("Incremental reindex completed for index: {}", indexName);
     } else {
       log.error("Incremental reindex timed out for index: {}", indexName);
-      upgradeState.put(
-          IncrementalReindexState.key(indexName, IncrementalReindexState.STATUS),
-          IncrementalReindexState.Status.FAILED.name());
-      checkpoint(context, upgradeState, DataHubUpgradeState.FAILED);
-      try {
-        indexBuilder.deleteActionWithRetry(opContext, nextIndexName);
-        log.info("Cleaned up failed next index: {}", nextIndexName);
-      } catch (Exception e) {
-        log.warn(
-            "Failed to clean up next index {} (will be cleaned by retention): {}",
-            nextIndexName,
-            e.getMessage());
-      }
+      failAndCleanUp(context, upgradeState, indexName, nextIndexName, indexBuilder);
     }
     return upgradeState;
+  }
+
+  /**
+   * Swaps the alias onto the next index, escalating the index to {@link
+   * IncrementalReindexState.Status#FAILED} if the swap does not succeed.
+   *
+   * <p>Both failure kinds escalate — a doc-count mismatch and an exception thrown by the swap
+   * itself. Leaving the index IN_PROGRESS instead would strand it: a resumed run re-polls a target
+   * it already satisfies, so the poll returns immediately without copying anything, and the only
+   * action left is to re-attempt the identical swap against a destination that no longer receives
+   * writes. That retry can never make progress, and because nothing transitions the status, it
+   * repeats on every subsequent run. Escalating instead forces the next run down the fresh-start
+   * branch, which rebuilds the index and gives the swap a destination that can actually match.
+   *
+   * @param phase short description of the call site, for log correlation
+   * @return true if the alias was swapped; false if the index was escalated to FAILED
+   */
+  private boolean swapAliasOrCleanUp(
+      UpgradeContext context,
+      Map<String, String> upgradeState,
+      ReindexConfig config,
+      String nextIndexName,
+      final long expectedSourceDocCount,
+      ESIndexBuilder indexBuilder,
+      String phase) {
+    try {
+      if (indexBuilder.validateAndSwapAlias(
+          opContext, config.name(), nextIndexName, expectedSourceDocCount)) {
+        log.info("Alias swapped: {} -> {}", config.name(), nextIndexName);
+        return true;
+      }
+      log.error(
+          "Alias swap failed for {} -> {} ({}): doc count mismatch. Marking FAILED so the next run"
+              + " reindexes from scratch.",
+          config.name(),
+          nextIndexName,
+          phase);
+    } catch (Exception e) {
+      log.error(
+          "Alias swap failed for {} -> {} ({}). Marking FAILED so the next run reindexes from"
+              + " scratch.",
+          config.name(),
+          nextIndexName,
+          phase,
+          e);
+    }
+    failAndCleanUp(context, upgradeState, config.name(), nextIndexName, indexBuilder);
+    return false;
+  }
+
+  /**
+   * Marks an index FAILED, checkpoints, and deletes its next index.
+   *
+   * <p>FAILED is the state that guarantees recovery: it is neither skipped (only COMPLETED and
+   * DUAL_WRITE_DISABLED are) nor resumed (resumption requires IN_PROGRESS), so the following run
+   * takes the fresh-start branch and reindexes. Mutates {@code upgradeState} in place.
+   */
+  private void failAndCleanUp(
+      UpgradeContext context,
+      Map<String, String> upgradeState,
+      String indexName,
+      String nextIndexName,
+      ESIndexBuilder indexBuilder) {
+    upgradeState.put(
+        IncrementalReindexState.key(indexName, IncrementalReindexState.STATUS),
+        IncrementalReindexState.Status.FAILED.name());
+    checkpoint(context, upgradeState, DataHubUpgradeState.FAILED);
+    try {
+      indexBuilder.deleteActionWithRetry(opContext, nextIndexName);
+      log.info("Cleaned up failed next index: {}", nextIndexName);
+    } catch (Exception e) {
+      log.warn(
+          "Failed to clean up next index {} (will be cleaned by retention): {}",
+          nextIndexName,
+          e.getMessage());
+    }
   }
 
   private void checkpoint(

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -463,11 +463,17 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
           return true;
         }
       } catch (Exception verifyException) {
+        // Verification itself failed — we cannot tell whether the alias already points at
+        // nextIndexName. Mark FAILED without deleting so we never remove a potentially live
+        // backing index; retention / the next fresh-start run will reclaim orphans.
         log.warn(
-            "Unable to verify alias target after swap failure for {} -> {}: {}",
+            "Unable to verify alias target after swap failure for {} -> {}. Marking FAILED"
+                + " without cleanup to avoid deleting a potentially live backing index.",
             config.name(),
             nextIndexName,
-            verifyException.getMessage());
+            verifyException);
+        markFailed(context, upgradeState, config.name());
+        return false;
       }
     }
     failAndCleanUp(context, upgradeState, config.name(), nextIndexName, indexBuilder);
@@ -475,11 +481,25 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
   }
 
   /**
-   * Marks an index FAILED, checkpoints, and deletes its next index.
+   * Marks an index FAILED and checkpoints, without deleting the next index.
    *
    * <p>FAILED is the state that guarantees recovery: it is neither skipped (only COMPLETED and
    * DUAL_WRITE_DISABLED are) nor resumed (resumption requires IN_PROGRESS), so the following run
    * takes the fresh-start branch and reindexes. Mutates {@code upgradeState} in place.
+   */
+  private void markFailed(
+      UpgradeContext context, Map<String, String> upgradeState, String indexName) {
+    upgradeState.put(
+        IncrementalReindexState.key(indexName, IncrementalReindexState.STATUS),
+        IncrementalReindexState.Status.FAILED.name());
+    checkpoint(context, upgradeState, DataHubUpgradeState.FAILED);
+  }
+
+  /**
+   * Marks an index FAILED, checkpoints, and deletes its next index.
+   *
+   * <p>See {@link #markFailed} for why FAILED is the recovery state. Mutates {@code upgradeState}
+   * in place.
    */
   private void failAndCleanUp(
       UpgradeContext context,
@@ -487,10 +507,7 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
       String indexName,
       String nextIndexName,
       ESIndexBuilder indexBuilder) {
-    upgradeState.put(
-        IncrementalReindexState.key(indexName, IncrementalReindexState.STATUS),
-        IncrementalReindexState.Status.FAILED.name());
-    checkpoint(context, upgradeState, DataHubUpgradeState.FAILED);
+    markFailed(context, upgradeState, indexName);
     try {
       indexBuilder.deleteActionWithRetry(opContext, nextIndexName);
       log.info("Cleaned up failed next index: {}", nextIndexName);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -616,6 +616,42 @@ public class BuildIndicesIncrementalStepTest {
   }
 
   @Test
+  public void testSwapThrowingButAliasAlreadySwapped_treatsAsSuccess() throws Throwable {
+    // If rename/alias update succeeded and a subsequent exception was observed, cleanup must not
+    // delete the live next index — verify backing and treat as success.
+    IncrementalReindexResult incrementalResult =
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), any(), eq(UPGRADE_VERSION)))
+        .thenReturn(incrementalResult);
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            anyString()))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 100L)));
+    when(indexBuilder.validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
+        .thenThrow(new RuntimeException("alias update acknowledged but client timed out"));
+    when(indexBuilder.getBackingIndices(any(OperationContext.class), eq(INDEX_NAME)))
+        .thenReturn(Set.of(NEXT_INDEX_NAME));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    Map<String, String> persisted = captureLastPersistedState();
+    assertEquals(
+        IncrementalReindexState.getStatus(persisted, INDEX_NAME),
+        Optional.of(IncrementalReindexState.Status.COMPLETED));
+    verify(indexBuilder, never())
+        .deleteActionWithRetry(any(OperationContext.class), eq(NEXT_INDEX_NAME));
+  }
+
+  @Test
   public void testRerunAfterSwapFailureReindexesInsteadOfNoOpRetry() throws Throwable {
     // End-to-end: run 1 reindexes then fails the swap; run 2 (fed run 1's persisted state) must
     // REINDEX from scratch. Resuming instead would re-poll a target already satisfied by the

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -652,6 +652,45 @@ public class BuildIndicesIncrementalStepTest {
   }
 
   @Test
+  public void testSwapThrowingAndAliasVerifyFails_marksFailedWithoutCleanup() throws Throwable {
+    // If getBackingIndices itself fails after a swap exception, we cannot tell whether the alias
+    // already points at nextIndexName. Deleting would risk removing the live backing index — mark
+    // FAILED without cleanup instead.
+    IncrementalReindexResult incrementalResult =
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), any(), eq(UPGRADE_VERSION)))
+        .thenReturn(incrementalResult);
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            anyString()))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 100L)));
+    when(indexBuilder.validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
+        .thenThrow(new RuntimeException("alias update acknowledged but client timed out"));
+    // First call resolves the old backing index before reindex; second is the post-swap verify.
+    when(indexBuilder.getBackingIndices(any(OperationContext.class), eq(INDEX_NAME)))
+        .thenReturn(Set.of("datasetindex_v2_old"))
+        .thenThrow(new RuntimeException("getAliases timed out"));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.FAILED);
+    Map<String, String> persisted = captureLastPersistedState();
+    assertEquals(
+        IncrementalReindexState.getStatus(persisted, INDEX_NAME),
+        Optional.of(IncrementalReindexState.Status.FAILED));
+    verify(indexBuilder, never())
+        .deleteActionWithRetry(any(OperationContext.class), eq(NEXT_INDEX_NAME));
+  }
+
+  @Test
   public void testRerunAfterSwapFailureReindexesInsteadOfNoOpRetry() throws Throwable {
     // End-to-end: run 1 reindexes then fails the swap; run 2 (fed run 1's persisted state) must
     // REINDEX from scratch. Resuming instead would re-poll a target already satisfied by the

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.upgrade.system.elasticsearch.steps;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,7 +84,8 @@ public class BuildIndicesIncrementalStepTest {
     when(indexedService.getIndexBuilder()).thenReturn(indexBuilder);
     when(indexBuilder.getBackingIndices(any(OperationContext.class), anyString()))
         .thenReturn(Set.of("datasetindex_v2_old"));
-    when(indexBuilder.validateAndSwapAlias(any(OperationContext.class), anyString(), anyString()))
+    when(indexBuilder.validateAndSwapAlias(
+            any(OperationContext.class), anyString(), anyString(), anyLong()))
         .thenReturn(true);
     when(indexBuilder.indexExists(any(OperationContext.class), anyString())).thenReturn(true);
 
@@ -200,7 +202,84 @@ public class BuildIndicesIncrementalStepTest {
         .undoReindexOptimalSettings(
             any(OperationContext.class), eq(NEXT_INDEX_NAME), any(ReindexConfig.class), anyMap());
     verify(indexBuilder)
-        .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
+        .validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong());
+  }
+
+  @Test
+  public void testSwapGatesOnSourceCountFromReindexLaunch() throws Throwable {
+    // The alias-swap gate must receive the source count snapshotted when the reindex was launched.
+    // Gating on a live source count is unsatisfiable on an index that keeps taking writes for the
+    // duration of the copy, which leaves the swap permanently unable to succeed.
+    long sourceDocCountAtLaunch = 4200L;
+    IncrementalReindexResult incrementalResult =
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, sourceDocCountAtLaunch, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), any(), eq(UPGRADE_VERSION)))
+        .thenReturn(incrementalResult);
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            eq("task1")))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 100L)));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    verify(indexBuilder)
+        .validateAndSwapAlias(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            eq(sourceDocCountAtLaunch));
+  }
+
+  @Test
+  public void testResumedSwapGatesOnPersistedSourceCount() throws Throwable {
+    // A resumed run has no fresh measurement to work from, so it must gate on the snapshot the
+    // original reindex targeted rather than re-measuring the source.
+    long persistedSourceDocCount = 7350L;
+    Map<String, String> previousState =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            NEXT_INDEX_NAME,
+            null,
+            1679000000000L,
+            persistedSourceDocCount,
+            null,
+            false,
+            IncrementalReindexState.Status.IN_PROGRESS);
+    DataHubUpgradeResult upgradeResult = mock(DataHubUpgradeResult.class);
+    when(upgradeResult.getResult()).thenReturn(new StringMap(previousState));
+    when(upgrade.getUpgradeResult(any(), any(), any())).thenReturn(Optional.of(upgradeResult));
+
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            eq("")))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 100L)));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+    verify(indexBuilder, never())
+        .buildIndexIncremental(any(OperationContext.class), any(), anyString());
+    verify(indexBuilder)
+        .validateAndSwapAlias(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            eq(persistedSourceDocCount));
   }
 
   @Test
@@ -247,7 +326,7 @@ public class BuildIndicesIncrementalStepTest {
         .pollReindexCompletion(
             any(OperationContext.class), any(), any(), any(), anyInt(), anyMap(), anyString());
     verify(indexBuilder, never())
-        .validateAndSwapAlias(any(OperationContext.class), anyString(), anyString());
+        .validateAndSwapAlias(any(OperationContext.class), anyString(), anyString(), anyLong());
   }
 
   @Test
@@ -334,7 +413,8 @@ public class BuildIndicesIncrementalStepTest {
         .undoReindexOptimalSettings(
             any(OperationContext.class), eq(NEXT_INDEX_NAME), any(ReindexConfig.class), anyMap());
     verify(indexBuilder)
-        .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
+        .validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong());
   }
 
   @Test
@@ -383,7 +463,7 @@ public class BuildIndicesIncrementalStepTest {
             eq("task-fresh")))
         .thenReturn(pollResult);
     when(indexBuilder.validateAndSwapAlias(
-            any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex)))
+            any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex), anyLong()))
         .thenReturn(true);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
@@ -403,7 +483,8 @@ public class BuildIndicesIncrementalStepTest {
     verify(indexBuilder)
         .buildIndexIncremental(any(OperationContext.class), any(), eq(UPGRADE_VERSION));
     verify(indexBuilder)
-        .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex));
+        .validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(freshNextIndex), anyLong());
   }
 
   @Test
@@ -458,11 +539,13 @@ public class BuildIndicesIncrementalStepTest {
   }
 
   @Test
-  public void testSwapFailurePersistsInProgressNotCompleted() throws Throwable {
-    // Regression: a reindex that completes but whose alias swap fails (doc-count mismatch) must be
-    // persisted as IN_PROGRESS, NOT COMPLETED. If it were marked COMPLETED, a rerun would hit the
-    // "already COMPLETED, skipping" branch and silently succeed while the alias still points at the
-    // stale index. Keeping it IN_PROGRESS lets the rerun resume and retry the swap.
+  public void testSwapFailurePersistsFailedAndCleansUpNextIndex() throws Throwable {
+    // A reindex that completes but whose alias swap fails must be persisted as FAILED — not
+    // COMPLETED (a rerun would hit "already COMPLETED, skipping" and silently succeed while the
+    // alias still points at the stale index) and not IN_PROGRESS (a rerun would resume into a poll
+    // it already satisfies and re-attempt the identical swap forever, never copying anything). Only
+    // FAILED routes the next run to the fresh-start branch. The next index is deleted so that
+    // rebuild starts clean.
     IncrementalReindexResult incrementalResult =
         new IncrementalReindexResult(
             NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
@@ -483,7 +566,7 @@ public class BuildIndicesIncrementalStepTest {
         .thenReturn(pollResult);
     // ...but the alias swap fails (e.g. doc-count mismatch on a live, high-write index).
     when(indexBuilder.validateAndSwapAlias(
-            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME)))
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
         .thenReturn(false);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
@@ -491,21 +574,53 @@ public class BuildIndicesIncrementalStepTest {
     // The run must fail loudly, not silently succeed.
     assertEquals(result.result(), DataHubUpgradeState.FAILED);
 
-    // The last persisted checkpoint must record IN_PROGRESS (not COMPLETED), with the next index
-    // name retained so a resumed run can re-poll and retry the swap.
     Map<String, String> persisted = captureLastPersistedState();
     assertEquals(
         IncrementalReindexState.getStatus(persisted, INDEX_NAME),
-        Optional.of(IncrementalReindexState.Status.IN_PROGRESS));
-    assertEquals(
-        IncrementalReindexState.get(persisted, INDEX_NAME, IncrementalReindexState.NEXT_INDEX_NAME),
-        Optional.of(NEXT_INDEX_NAME));
+        Optional.of(IncrementalReindexState.Status.FAILED));
+    verify(indexBuilder).deleteActionWithRetry(any(OperationContext.class), eq(NEXT_INDEX_NAME));
   }
 
   @Test
-  public void testRerunAfterSwapFailureRetriesSwapInsteadOfSkipping() throws Throwable {
+  public void testSwapThrowingAlsoPersistsFailed() throws Throwable {
+    // An exception out of the swap must escalate exactly like a doc-count mismatch. Letting it
+    // propagate to the step's outer catch would return FAILED while leaving the persisted status
+    // IN_PROGRESS — the stranded state whose only possible retry action is the same failing swap.
+    IncrementalReindexResult incrementalResult =
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
+    when(indexBuilder.buildIndexIncremental(
+            any(OperationContext.class), any(), eq(UPGRADE_VERSION)))
+        .thenReturn(incrementalResult);
+    when(indexBuilder.pollReindexCompletion(
+            any(OperationContext.class),
+            eq(INDEX_NAME),
+            eq(NEXT_INDEX_NAME),
+            any(),
+            anyInt(),
+            anyMap(),
+            anyString()))
+        .thenReturn(new PollReindexResult(true, Map.of(), Pair.of(100L, 90L)));
+    when(indexBuilder.validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
+        .thenThrow(new RuntimeException("alias update rejected"));
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+
+    assertEquals(result.result(), DataHubUpgradeState.FAILED);
+    Map<String, String> persisted = captureLastPersistedState();
+    assertEquals(
+        IncrementalReindexState.getStatus(persisted, INDEX_NAME),
+        Optional.of(IncrementalReindexState.Status.FAILED));
+    verify(indexBuilder).deleteActionWithRetry(any(OperationContext.class), eq(NEXT_INDEX_NAME));
+  }
+
+  @Test
+  public void testRerunAfterSwapFailureReindexesInsteadOfNoOpRetry() throws Throwable {
     // End-to-end: run 1 reindexes then fails the swap; run 2 (fed run 1's persisted state) must
-    // resume and RETRY the swap — not skip the index as "already COMPLETED".
+    // REINDEX from scratch. Resuming instead would re-poll a target already satisfied by the
+    // frozen destination, returning "complete" without copying anything, and then re-attempt the
+    // identical swap — a retry that can never make progress and never transitions state.
     IncrementalReindexResult incrementalResult =
         new IncrementalReindexResult(
             NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
@@ -525,7 +640,7 @@ public class BuildIndicesIncrementalStepTest {
 
     // Run 1: swap fails.
     when(indexBuilder.validateAndSwapAlias(
-            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME)))
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
         .thenReturn(false);
     UpgradeStepResult run1 = step.executable().apply(upgradeContext);
     assertEquals(run1.result(), DataHubUpgradeState.FAILED);
@@ -538,17 +653,17 @@ public class BuildIndicesIncrementalStepTest {
 
     // Run 2: swap now succeeds.
     when(indexBuilder.validateAndSwapAlias(
-            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME)))
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong()))
         .thenReturn(true);
     UpgradeStepResult run2 = step.executable().apply(upgradeContext);
 
     assertEquals(run2.result(), DataHubUpgradeState.SUCCEEDED);
-    // Run 2 must have resumed (re-polled + retried the swap), NOT re-run the reindex from scratch,
-    // and NOT skipped the index.
-    verify(indexBuilder, times(1))
+    // Run 2 must have rebuilt the index (FAILED is neither skipped nor resumed), then swapped.
+    verify(indexBuilder, times(2))
         .buildIndexIncremental(any(OperationContext.class), any(), eq(UPGRADE_VERSION));
     verify(indexBuilder, times(2))
-        .validateAndSwapAlias(any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
+        .validateAndSwapAlias(
+            any(OperationContext.class), eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyLong());
   }
 
   private Map<String, String> captureLastPersistedState() {

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -59,6 +59,8 @@ Requirements:
 
 ### Other Notable Changes
 
+- **(Operations / Elasticsearch ZDU)** Incremental (zero-downtime) reindex Phase 1 now validates the alias swap against the **launch-time source document count**, not a live alias count. Live writes during the copy are expected and are covered by Phase 2 catch-up after the swap. A failed swap marks the index `FAILED` and deletes the next index so the following system-update run reindexes from scratch instead of retrying a doomed swap. Reindex polling also waits for the ES `_reindex` task to finish (when status is available) before treating matching doc counts as complete, so a mid-copy sample cannot falsely finish Phase 1.
+
 - **(Metadata Model / Data Products)** `dataProductProperties` now includes an optional `parentDataProduct` URN so Data Products can nest in a parent-child taxonomy (mirroring Domains' `parentDomain`). The field is additive; existing Data Products are unchanged (null parent). No migration or reindex is required. Free-text search may match child products on the parent URN string, the same way `parentDomain` already behaves.
 
 ## v1.7.0

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -675,9 +675,11 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
   public boolean validateAndSwapAlias(
       @Nonnull OperationContext opContext,
       @Nonnull String aliasName,
-      @Nonnull String newBackingIndex)
+      @Nonnull String newBackingIndex,
+      long expectedSourceDocCount)
       throws Exception {
-    return indexBuilder.validateAndSwapAlias(opContext, aliasName, newBackingIndex);
+    return indexBuilder.validateAndSwapAlias(
+        opContext, aliasName, newBackingIndex, expectedSourceDocCount);
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -930,6 +930,10 @@ public class ESIndexBuilder {
    * re-query the live source (stable since writes are blocked). For incremental reindex where
    * writes continue to the source, pass a fixed snapshot: {@code () -> snapshotCount}.
    *
+   * <p>When counts match but a resolvable ES task reports it is still running, polling continues —
+   * a mid-copy sample of {@code dest == expected} must not complete. Status unavailable (blank task
+   * id, or 404 after ES purged a finished task) allows count-equality success.
+   *
    * @param sourceIndex the source index name (for logging and stall-retry resubmission)
    * @param destIndex the destination index name
    * @param expectedCountSupplier supplies the expected doc count; called each poll iteration
@@ -987,34 +991,53 @@ public class ESIndexBuilder {
               currentTime - pollStartTimeMillis,
               latestCounts.getFirst() - latestCounts.getSecond());
 
-      if (documentCounts.getFirst().equals(documentCounts.getSecond())) {
-        log.info(
-            "Reindex {} -> {} complete. Doc count: {}",
-            sourceIndex,
-            destIndex,
-            documentCounts.getFirst());
-        return new PollReindexResult(true, latestReindexInfo, documentCounts);
-      }
-
-      float progressPercentage =
-          documentCounts.getFirst() > 0
-              ? (100 * (1.0f * documentCounts.getSecond())) / documentCounts.getFirst()
-              : 0;
-
       // Read the ES _reindex task itself rather than inferring only from doc counts: doc-count-only
       // monitoring cannot tell a still-running reindex apart from one that finished while dropping
       // documents (version conflicts, and any bulk failures the task's own retries could not clear,
       // are skipped because the request uses setAbortOnVersionConflict(false)). Logging the task
-      // counters turns an opaque timeout into an actionable diagnosis.
+      // counters turns an opaque timeout into an actionable diagnosis. Also used below to reject a
+      // mid-copy sample where dest briefly equals the expected count while the task is still
+      // running — once swap and poll share the same launch-time expected count, that sample would
+      // otherwise falsely complete.
       final Optional<GetTaskResponse> taskStatus = tryGetReindexTaskStatus(opContext, activeTaskId);
-      log.warn(
-          "Document counts do not match {} != {}. Complete: {}%. Estimated time remaining: {} minutes. Reindex task [{}]: {}",
-          documentCounts.getFirst(),
-          documentCounts.getSecond(),
-          progressPercentage,
-          estimatedMinutesRemaining,
-          activeTaskId,
-          describeReindexTaskStatus(taskStatus));
+
+      if (documentCounts.getFirst().equals(documentCounts.getSecond())) {
+        // When status is present and the task is still running, keep polling. Status unavailable
+        // (blank task id on resume, or 404 after ES purged a finished task) falls through to
+        // count-equality success.
+        if (taskStatus.map(status -> !status.isCompleted()).orElse(false)) {
+          log.info(
+              "Document counts match for {} -> {} ({}), but reindex task [{}] is still running: {}. Continuing to poll.",
+              sourceIndex,
+              destIndex,
+              documentCounts.getFirst(),
+              activeTaskId,
+              describeReindexTaskStatus(taskStatus));
+        } else {
+          log.info(
+              "Reindex {} -> {} complete. Doc count: {}. Reindex task [{}]: {}",
+              sourceIndex,
+              destIndex,
+              documentCounts.getFirst(),
+              activeTaskId,
+              describeReindexTaskStatus(taskStatus));
+          return new PollReindexResult(true, latestReindexInfo, documentCounts);
+        }
+      } else {
+        float progressPercentage =
+            documentCounts.getFirst() > 0
+                ? (100 * (1.0f * documentCounts.getSecond())) / documentCounts.getFirst()
+                : 0;
+
+        log.warn(
+            "Document counts do not match {} != {}. Complete: {}%. Estimated time remaining: {} minutes. Reindex task [{}]: {}",
+            documentCounts.getFirst(),
+            documentCounts.getSecond(),
+            progressPercentage,
+            estimatedMinutesRemaining,
+            activeTaskId,
+            describeReindexTaskStatus(taskStatus));
+      }
 
       // A completed task whose destination is still short of the source dropped documents. Waiting
       // out the no-progress timer is pointless, so re-trigger immediately; the retry (bounded by

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -922,6 +922,24 @@ public class ESIndexBuilder {
       Pair<Long, Long> finalDocumentCounts) {}
 
   /**
+   * Outcome of looking up an ES {@code _reindex} task. Distinguishes blank ids and confirmed
+   * not-found (safe for count-based completion) from transient lookup failures (must not complete
+   * on counts alone — that reopens the mid-copy false-complete hole).
+   */
+  enum ReindexTaskLookup {
+    /** No usable task id (blank / malformed) — typical on some resume paths. */
+    BLANK_TASK_ID,
+    /** Task exists and is still running. */
+    RUNNING,
+    /** Task exists and reports completed. */
+    COMPLETED,
+    /** Task API returned empty (e.g. 404 after ES purged a finished task). */
+    NOT_FOUND,
+    /** Transient transport / API error fetching task status. */
+    LOOKUP_ERROR
+  }
+
+  /**
    * Polls an in-progress reindex until document counts converge or timeout. Includes stall
    * detection with automatic reindex re-submission and progress estimation.
    *
@@ -930,9 +948,12 @@ public class ESIndexBuilder {
    * re-query the live source (stable since writes are blocked). For incremental reindex where
    * writes continue to the source, pass a fixed snapshot: {@code () -> snapshotCount}.
    *
-   * <p>When counts match but a resolvable ES task reports it is still running, polling continues —
-   * a mid-copy sample of {@code dest == expected} must not complete. Status unavailable (blank task
-   * id, or 404 after ES purged a finished task) allows count-equality success.
+   * <p>Completion requires {@code dest >= expected} once the reindex task is known finished
+   * (completed or confirmed not-found), or when there is no usable task id. A mid-copy sample where
+   * counts already match while the task is still running does not complete. Transient task-status
+   * lookup failures also do not complete on counts alone. Destination overshoot ({@code dest >
+   * expected}) after the task finishes is accepted — writes between the launch-time snapshot and
+   * scroll open are copied into the destination and are expected on busy indices.
    *
    * @param sourceIndex the source index name (for logging and stall-retry resubmission)
    * @param destIndex the destination index name
@@ -991,63 +1012,65 @@ public class ESIndexBuilder {
               currentTime - pollStartTimeMillis,
               latestCounts.getFirst() - latestCounts.getSecond());
 
-      // Read the ES _reindex task itself rather than inferring only from doc counts: doc-count-only
-      // monitoring cannot tell a still-running reindex apart from one that finished while dropping
-      // documents (version conflicts, and any bulk failures the task's own retries could not clear,
-      // are skipped because the request uses setAbortOnVersionConflict(false)). Logging the task
-      // counters turns an opaque timeout into an actionable diagnosis. Also used below to reject a
-      // mid-copy sample where dest briefly equals the expected count while the task is still
-      // running — once swap and poll share the same launch-time expected count, that sample would
-      // otherwise falsely complete.
-      final Optional<GetTaskResponse> taskStatus = tryGetReindexTaskStatus(opContext, activeTaskId);
+      final ReindexTaskLookup taskLookup = lookupReindexTask(opContext, activeTaskId);
+      final long expectedCount = documentCounts.getFirst();
+      final long destCount = documentCounts.getSecond();
 
-      if (documentCounts.getFirst().equals(documentCounts.getSecond())) {
-        // When status is present and the task is still running, keep polling. Status unavailable
-        // (blank task id on resume, or 404 after ES purged a finished task) falls through to
-        // count-equality success.
-        if (taskStatus.map(status -> !status.isCompleted()).orElse(false)) {
-          log.info(
-              "Document counts match for {} -> {} ({}), but reindex task [{}] is still running: {}. Continuing to poll.",
-              sourceIndex,
-              destIndex,
-              documentCounts.getFirst(),
-              activeTaskId,
-              describeReindexTaskStatus(taskStatus));
-        } else {
-          log.info(
-              "Reindex {} -> {} complete. Doc count: {}. Reindex task [{}]: {}",
-              sourceIndex,
-              destIndex,
-              documentCounts.getFirst(),
-              activeTaskId,
-              describeReindexTaskStatus(taskStatus));
-          return new PollReindexResult(true, latestReindexInfo, documentCounts);
-        }
-      } else {
+      // dest >= expected: equality or overshoot after scroll captured writes past the launch
+      // snapshot. Only accept when the task is known finished (or there is no usable task id) —
+      // not while RUNNING, and not on LOOKUP_ERROR (transient getTask failures).
+      if (destCount >= expectedCount && allowsCountBasedCompletion(taskLookup)) {
+        log.info(
+            "Reindex {} -> {} complete. expected={} dest={} taskLookup={} taskId={}",
+            sourceIndex,
+            destIndex,
+            expectedCount,
+            destCount,
+            taskLookup,
+            activeTaskId);
+        return new PollReindexResult(true, latestReindexInfo, documentCounts);
+      }
+
+      if (destCount >= expectedCount && taskLookup == ReindexTaskLookup.RUNNING) {
+        log.info(
+            "Document counts meet expected for {} -> {} (dest={} expected={}), but reindex task"
+                + " [{}] is still running. Continuing to poll.",
+            sourceIndex,
+            destIndex,
+            destCount,
+            expectedCount,
+            activeTaskId);
+      } else if (destCount >= expectedCount && taskLookup == ReindexTaskLookup.LOOKUP_ERROR) {
+        log.warn(
+            "Document counts meet expected for {} -> {} (dest={} expected={}), but task status"
+                + " lookup failed for [{}]. Continuing to poll (will not complete on counts alone).",
+            sourceIndex,
+            destIndex,
+            destCount,
+            expectedCount,
+            activeTaskId);
+      } else if (destCount < expectedCount) {
         float progressPercentage =
-            documentCounts.getFirst() > 0
-                ? (100 * (1.0f * documentCounts.getSecond())) / documentCounts.getFirst()
-                : 0;
+            expectedCount > 0 ? (100 * (1.0f * destCount)) / expectedCount : 0;
 
         log.warn(
-            "Document counts do not match {} != {}. Complete: {}%. Estimated time remaining: {} minutes. Reindex task [{}]: {}",
-            documentCounts.getFirst(),
-            documentCounts.getSecond(),
+            "Document counts do not match {} != {}. Complete: {}%. Estimated time remaining: {}"
+                + " minutes. Reindex task [{}]: {}",
+            expectedCount,
+            destCount,
             progressPercentage,
             estimatedMinutesRemaining,
             activeTaskId,
-            describeReindexTaskStatus(taskStatus));
+            taskLookup);
       }
 
       // A completed task whose destination is still short of the source dropped documents. Waiting
       // out the no-progress timer is pointless, so re-trigger immediately; the retry (bounded by
       // numRetries) lets a transient shortfall converge on a fresh attempt, and a persistent one
-      // fails loudly once retries are exhausted. Guard on the direction of the mismatch: with live
-      // dual-writes the destination can legitimately exceed the fixed source snapshot, which is not
-      // a drop.
+      // fails loudly once retries are exhausted. Overshoot (dest > expected) is accepted above once
+      // the task is finished — it is not treated as a drop.
       final boolean completedButShort =
-          taskStatus.map(GetTaskResponse::isCompleted).orElse(false)
-              && documentCounts.getSecond() < documentCounts.getFirst();
+          taskLookup == ReindexTaskLookup.COMPLETED && destCount < expectedCount;
 
       final long lastUpdateDelta = System.currentTimeMillis() - documentCountsLastUpdated;
       final int noProgressRetryMinutes = getReindexNoProgressRetryMinutes();
@@ -1061,7 +1084,7 @@ public class ESIndexBuilder {
                   ? "task completed but destination is short"
                   : String.format("no progress for %d minutes", noProgressRetryMinutes),
               activeTaskId,
-              describeReindexTaskStatus(taskStatus));
+              taskLookup);
           latestReindexInfo =
               submitReindex(
                   opContext,
@@ -1096,32 +1119,39 @@ public class ESIndexBuilder {
         documentCounts.getSecond(),
         documentCounts.getFirst(),
         activeTaskId,
-        describeReindexTaskStatus(tryGetReindexTaskStatus(opContext, activeTaskId)));
+        lookupReindexTask(opContext, activeTaskId));
     return new PollReindexResult(false, latestReindexInfo, documentCounts);
   }
 
   /**
-   * Best-effort fetch of the ES {@code _reindex} task status for diagnostics. Never throws: a
-   * blank/malformed task id (e.g. an empty id passed on resume) or any transport error yields
-   * {@link Optional#empty()}, so a status lookup can never break the polling loop it is meant to
-   * instrument.
+   * Whether count-based poll completion is allowed for this task-lookup outcome. Blank task ids
+   * (resume) and finished/not-found tasks are safe; running or lookup-error are not.
    */
-  private Optional<GetTaskResponse> tryGetReindexTaskStatus(
-      @Nonnull OperationContext opContext, @Nullable final String taskId) {
-    if (taskId == null || taskId.isBlank() || !taskId.contains(":")) {
-      return Optional.empty();
-    }
-    try {
-      return getTaskStatus(opContext, taskId);
-    } catch (Exception e) {
-      log.debug("Unable to fetch reindex task status for {}: {}", taskId, e.getMessage());
-      return Optional.empty();
-    }
+  static boolean allowsCountBasedCompletion(@Nonnull final ReindexTaskLookup lookup) {
+    return lookup == ReindexTaskLookup.BLANK_TASK_ID
+        || lookup == ReindexTaskLookup.COMPLETED
+        || lookup == ReindexTaskLookup.NOT_FOUND;
   }
 
-  /** Renders an optional task status for logging, or {@code "status unavailable"} when absent. */
-  private static String describeReindexTaskStatus(Optional<GetTaskResponse> status) {
-    return status.map(ESIndexBuilder::describeReindexTaskStatus).orElse("status unavailable");
+  /**
+   * Resolves the ES {@code _reindex} task state for poll gating. Never throws: transport errors
+   * become {@link ReindexTaskLookup#LOOKUP_ERROR}.
+   */
+  private ReindexTaskLookup lookupReindexTask(
+      @Nonnull OperationContext opContext, @Nullable final String taskId) {
+    if (taskId == null || taskId.isBlank() || !taskId.contains(":")) {
+      return ReindexTaskLookup.BLANK_TASK_ID;
+    }
+    try {
+      final Optional<GetTaskResponse> status = getTaskStatus(opContext, taskId);
+      if (status.isEmpty()) {
+        return ReindexTaskLookup.NOT_FOUND;
+      }
+      return status.get().isCompleted() ? ReindexTaskLookup.COMPLETED : ReindexTaskLookup.RUNNING;
+    } catch (Exception e) {
+      log.debug("Unable to fetch reindex task status for {}: {}", taskId, e.getMessage());
+      return ReindexTaskLookup.LOOKUP_ERROR;
+    }
   }
 
   /**
@@ -1573,7 +1603,7 @@ public class ESIndexBuilder {
   }
 
   /**
-   * Validates that the new backing index holds exactly the documents the reindex set out to copy,
+   * Validates that the new backing index holds at least the documents the reindex set out to copy,
    * then atomically swaps the alias to point to the new index.
    *
    * <p>The comparison is against {@code expectedSourceDocCount} — the source count snapshotted when
@@ -1584,12 +1614,10 @@ public class ESIndexBuilder {
    * does not block writes, and the writes landing during the copy window are replayed afterwards by
    * the Phase 2 catch-up step, so that residual gap is expected by design rather than an error.
    *
-   * <p>The check stays strict equality against that point-in-time snapshot: the destination is
-   * expected to reproduce the source exactly as it stood when the reindex started, no more and no
-   * less. Note that the reindex scroll opens slightly after the count is taken, so writes landing
-   * in that narrow window end up in the scroll snapshot and push the destination above it — this
-   * check then fails, loudly and recoverably, rather than swapping onto an index whose contents do
-   * not correspond to any known point in time.
+   * <p>The check requires {@code nextCount >= expectedSourceDocCount}: the destination must hold at
+   * least the documents present when the reindex launched. Destination overshoot is accepted —
+   * writes landing between the launch-time count and scroll open are copied into the destination on
+   * busy indices. Undershoot (next below expected) fails the gate.
    *
    * @param aliasName the alias to swap
    * @param newBackingIndex the physical index to point the alias to
@@ -1605,10 +1633,10 @@ public class ESIndexBuilder {
       throws Exception {
     final long nextCount = getCount(opContext, newBackingIndex);
 
-    if (nextCount != expectedSourceDocCount) {
+    if (nextCount < expectedSourceDocCount) {
       log.warn(
-          "Doc count mismatch for alias swap {} -> {}: expected={} (source count at reindex start),"
-              + " next={}",
+          "Doc count mismatch for alias swap {} -> {}: expected>={} (source count at reindex"
+              + " start), next={}",
           aliasName,
           newBackingIndex,
           expectedSourceDocCount,
@@ -1617,9 +1645,10 @@ public class ESIndexBuilder {
     }
 
     log.info(
-        "Doc counts match for {} -> {}: count={}. Swapping alias.",
+        "Doc counts acceptable for {} -> {}: expected>={}, next={}. Swapping alias.",
         aliasName,
         newBackingIndex,
+        expectedSourceDocCount,
         nextCount);
     renameReindexedIndices(
         searchClient, opContext, aliasName, null, newBackingIndex, false, requestOptionsLong);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -1550,28 +1550,45 @@ public class ESIndexBuilder {
   }
 
   /**
-   * Validates doc counts match between an alias and a new backing index, then atomically swaps the
-   * alias to point to the new index.
+   * Validates that the new backing index holds exactly the documents the reindex set out to copy,
+   * then atomically swaps the alias to point to the new index.
+   *
+   * <p>The comparison is against {@code expectedSourceDocCount} — the source count snapshotted when
+   * the reindex was launched — and deliberately <b>not</b> against a live count read from the
+   * alias. Reading the alias here compares "what the source holds right now" against "what the copy
+   * captured a while ago"; on an index that keeps taking writes for the duration of the copy those
+   * two can never agree, which makes the swap permanently unsatisfiable. The incremental (ZDU) path
+   * does not block writes, and the writes landing during the copy window are replayed afterwards by
+   * the Phase 2 catch-up step, so that residual gap is expected by design rather than an error.
+   *
+   * <p>The check stays strict equality against that point-in-time snapshot: the destination is
+   * expected to reproduce the source exactly as it stood when the reindex started, no more and no
+   * less. Note that the reindex scroll opens slightly after the count is taken, so writes landing
+   * in that narrow window end up in the scroll snapshot and push the destination above it — this
+   * check then fails, loudly and recoverably, rather than swapping onto an index whose contents do
+   * not correspond to any known point in time.
    *
    * @param aliasName the alias to swap
    * @param newBackingIndex the physical index to point the alias to
-   * @return true if swapped, false if doc counts didn't match
+   * @param expectedSourceDocCount source doc count snapshotted at reindex submission time
+   * @return true if swapped, false if the destination doc count does not match
    * @throws Exception if the swap operation fails
    */
   public boolean validateAndSwapAlias(
       @Nonnull OperationContext opContext,
       @Nonnull String aliasName,
-      @Nonnull String newBackingIndex)
+      @Nonnull String newBackingIndex,
+      final long expectedSourceDocCount)
       throws Exception {
-    long currentCount = getCount(opContext, aliasName);
-    long nextCount = getCount(opContext, newBackingIndex);
+    final long nextCount = getCount(opContext, newBackingIndex);
 
-    if (currentCount != nextCount) {
+    if (nextCount != expectedSourceDocCount) {
       log.warn(
-          "Doc count mismatch for alias swap {} -> {}: current={}, next={}",
+          "Doc count mismatch for alias swap {} -> {}: expected={} (source count at reindex start),"
+              + " next={}",
           aliasName,
           newBackingIndex,
-          currentCount,
+          expectedSourceDocCount,
           nextCount);
       return false;
     }
@@ -1580,7 +1597,7 @@ public class ESIndexBuilder {
         "Doc counts match for {} -> {}: count={}. Swapping alias.",
         aliasName,
         newBackingIndex,
-        currentCount);
+        nextCount);
     renameReindexedIndices(
         searchClient, opContext, aliasName, null, newBackingIndex, false, requestOptionsLong);
     return true;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -1931,71 +1931,8 @@ public class ESIndexBuilderTest {
 
   // --- Incremental reindex tests ---
 
-  /**
-   * When the ES {@code _reindex} task has COMPLETED but the destination is still short of the
-   * source, documents were dropped. With no retry budget left the poll loop must give up promptly
-   * (returning not-completed) instead of silently spinning on doc counts until the reindex timeout.
-   */
-  @Test
-  void testPollReindexCompletion_completedButShort_failsWithoutRetriggerWhenRetriesExhausted()
-      throws Throwable {
-    // numRetries=0 leaves no retry budget and keeps getDocumentCounts' mismatch back-off short.
-    when(elasticSearchConfiguration.getIndex())
-        .thenReturn(
-            IndexConfiguration.builder()
-                .numShards(NUM_SHARDS)
-                .numReplicas(NUM_REPLICAS)
-                .numRetries(0)
-                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
-                .maxReindexHours(1)
-                .build());
-    ESIndexBuilder builder =
-        new ESIndexBuilder(
-            searchClient,
-            elasticSearchConfiguration,
-            TEST_ES_STRUCT_PROPS_DISABLED,
-            Map.of(),
-            gitVersion);
-
-    // Destination holds fewer docs than the source (900 of 1000) — the dropped-docs signature.
-    CountResponse countResponse = mock(CountResponse.class);
-    when(countResponse.getCount()).thenReturn(900L);
-    when(searchClient.count(
-            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
-        .thenReturn(countResponse);
-    when(searchClient.refreshIndex(
-            any(OperationFingerprint.class),
-            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
-            any(RequestOptions.class)))
-        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
-
-    // ES reports the reindex task itself has COMPLETED, even though the target is short.
-    GetTaskResponse completedTask = mock(GetTaskResponse.class);
-    when(completedTask.isCompleted()).thenReturn(true);
-    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
-        .thenReturn(Optional.of(completedTask));
-
-    ESIndexBuilder.PollReindexResult result =
-        builder.pollReindexCompletion(
-            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:99");
-
-    assertFalse(
-        result.completed(), "A completed-but-short reindex must be reported as not completed");
-    assertEquals(result.finalDocumentCounts().getFirst(), Long.valueOf(1000L));
-    assertEquals(result.finalDocumentCounts().getSecond(), Long.valueOf(900L));
-    // With no retry budget it must give up rather than re-submitting.
-    verify(searchClient, never())
-        .submitReindexTask(
-            any(OperationFingerprint.class), any(ReindexRequest.class), any(RequestOptions.class));
-  }
-
-  /**
-   * Mid-copy false positive: dest has already reached the expected count but the ES task is still
-   * running. Poll must not complete — otherwise the launch-time swap gate would accept a partial
-   * copy.
-   */
-  @Test
-  void testPollReindexCompletion_countsMatchButTaskRunning_doesNotComplete() throws Throwable {
+  /** Shared poll-completion fixture: zero-retry builder + fixed dest count for both indices. */
+  private ESIndexBuilder setupPollReindexBuilder(long destDocCount) throws IOException {
     when(elasticSearchConfiguration.getIndex())
         .thenReturn(
             IndexConfiguration.builder()
@@ -2008,16 +1945,9 @@ public class ESIndexBuilderTest {
     when(buildIndicesConfig.getReindexNoProgressRetryMinutes()).thenReturn(0);
     when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
     when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
-    ESIndexBuilder builder =
-        new ESIndexBuilder(
-            searchClient,
-            elasticSearchConfiguration,
-            TEST_ES_STRUCT_PROPS_DISABLED,
-            Map.of(),
-            gitVersion);
 
     CountResponse countResponse = mock(CountResponse.class);
-    when(countResponse.getCount()).thenReturn(1000L);
+    when(countResponse.getCount()).thenReturn(destDocCount);
     when(searchClient.count(
             any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
         .thenReturn(countResponse);
@@ -2027,10 +1957,54 @@ public class ESIndexBuilderTest {
             any(RequestOptions.class)))
         .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
 
-    GetTaskResponse runningTask = mock(GetTaskResponse.class);
-    when(runningTask.isCompleted()).thenReturn(false);
+    return new ESIndexBuilder(
+        searchClient,
+        elasticSearchConfiguration,
+        TEST_ES_STRUCT_PROPS_DISABLED,
+        Map.of(),
+        gitVersion);
+  }
+
+  private void stubReindexTaskCompleted(boolean completed) throws IOException {
+    GetTaskResponse task = mock(GetTaskResponse.class);
+    when(task.isCompleted()).thenReturn(completed);
     when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
-        .thenReturn(Optional.of(runningTask));
+        .thenReturn(Optional.of(task));
+  }
+
+  /**
+   * When the ES {@code _reindex} task has COMPLETED but the destination is still short of the
+   * source, documents were dropped. With no retry budget left the poll loop must give up promptly
+   * (returning not-completed) instead of silently spinning on doc counts until the reindex timeout.
+   */
+  @Test
+  void testPollReindexCompletion_completedButShort_failsWithoutRetriggerWhenRetriesExhausted()
+      throws Throwable {
+    ESIndexBuilder builder = setupPollReindexBuilder(900L);
+    stubReindexTaskCompleted(true);
+
+    ESIndexBuilder.PollReindexResult result =
+        builder.pollReindexCompletion(
+            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:99");
+
+    assertFalse(
+        result.completed(), "A completed-but-short reindex must be reported as not completed");
+    assertEquals(result.finalDocumentCounts().getFirst(), Long.valueOf(1000L));
+    assertEquals(result.finalDocumentCounts().getSecond(), Long.valueOf(900L));
+    verify(searchClient, never())
+        .submitReindexTask(
+            any(OperationFingerprint.class), any(ReindexRequest.class), any(RequestOptions.class));
+  }
+
+  /**
+   * Mid-copy false positive: dest has already reached the expected count but the ES task is still
+   * running. Poll must not complete — otherwise the launch-time swap gate would accept a partial
+   * copy.
+   */
+  @Test
+  void testPollReindexCompletion_countsMatchButTaskRunning_doesNotComplete() throws Throwable {
+    ESIndexBuilder builder = setupPollReindexBuilder(1000L);
+    stubReindexTaskCompleted(false);
 
     ESIndexBuilder.PollReindexResult result =
         builder.pollReindexCompletion(
@@ -2044,40 +2018,8 @@ public class ESIndexBuilderTest {
   /** Counts match and the ES task reports completed — poll succeeds. */
   @Test
   void testPollReindexCompletion_countsMatchAndTaskCompleted_completes() throws Throwable {
-    when(elasticSearchConfiguration.getIndex())
-        .thenReturn(
-            IndexConfiguration.builder()
-                .numShards(NUM_SHARDS)
-                .numReplicas(NUM_REPLICAS)
-                .numRetries(0)
-                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
-                .maxReindexHours(1)
-                .build());
-    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
-    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
-    ESIndexBuilder builder =
-        new ESIndexBuilder(
-            searchClient,
-            elasticSearchConfiguration,
-            TEST_ES_STRUCT_PROPS_DISABLED,
-            Map.of(),
-            gitVersion);
-
-    CountResponse countResponse = mock(CountResponse.class);
-    when(countResponse.getCount()).thenReturn(1000L);
-    when(searchClient.count(
-            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
-        .thenReturn(countResponse);
-    when(searchClient.refreshIndex(
-            any(OperationFingerprint.class),
-            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
-            any(RequestOptions.class)))
-        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
-
-    GetTaskResponse completedTask = mock(GetTaskResponse.class);
-    when(completedTask.isCompleted()).thenReturn(true);
-    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
-        .thenReturn(Optional.of(completedTask));
+    ESIndexBuilder builder = setupPollReindexBuilder(1000L);
+    stubReindexTaskCompleted(true);
 
     ESIndexBuilder.PollReindexResult result =
         builder.pollReindexCompletion(
@@ -2094,40 +2036,8 @@ public class ESIndexBuilderTest {
    */
   @Test
   void testPollReindexCompletion_destOvershootAndTaskCompleted_completes() throws Throwable {
-    when(elasticSearchConfiguration.getIndex())
-        .thenReturn(
-            IndexConfiguration.builder()
-                .numShards(NUM_SHARDS)
-                .numReplicas(NUM_REPLICAS)
-                .numRetries(0)
-                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
-                .maxReindexHours(1)
-                .build());
-    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
-    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
-    ESIndexBuilder builder =
-        new ESIndexBuilder(
-            searchClient,
-            elasticSearchConfiguration,
-            TEST_ES_STRUCT_PROPS_DISABLED,
-            Map.of(),
-            gitVersion);
-
-    CountResponse countResponse = mock(CountResponse.class);
-    when(countResponse.getCount()).thenReturn(1005L);
-    when(searchClient.count(
-            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
-        .thenReturn(countResponse);
-    when(searchClient.refreshIndex(
-            any(OperationFingerprint.class),
-            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
-            any(RequestOptions.class)))
-        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
-
-    GetTaskResponse completedTask = mock(GetTaskResponse.class);
-    when(completedTask.isCompleted()).thenReturn(true);
-    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
-        .thenReturn(Optional.of(completedTask));
+    ESIndexBuilder builder = setupPollReindexBuilder(1005L);
+    stubReindexTaskCompleted(true);
 
     ESIndexBuilder.PollReindexResult result =
         builder.pollReindexCompletion(
@@ -2143,37 +2053,7 @@ public class ESIndexBuilderTest {
    */
   @Test
   void testPollReindexCompletion_countsMatchButTaskLookupError_doesNotComplete() throws Throwable {
-    when(elasticSearchConfiguration.getIndex())
-        .thenReturn(
-            IndexConfiguration.builder()
-                .numShards(NUM_SHARDS)
-                .numReplicas(NUM_REPLICAS)
-                .numRetries(0)
-                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
-                .maxReindexHours(1)
-                .build());
-    when(buildIndicesConfig.getReindexNoProgressRetryMinutes()).thenReturn(0);
-    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
-    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
-    ESIndexBuilder builder =
-        new ESIndexBuilder(
-            searchClient,
-            elasticSearchConfiguration,
-            TEST_ES_STRUCT_PROPS_DISABLED,
-            Map.of(),
-            gitVersion);
-
-    CountResponse countResponse = mock(CountResponse.class);
-    when(countResponse.getCount()).thenReturn(1000L);
-    when(searchClient.count(
-            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
-        .thenReturn(countResponse);
-    when(searchClient.refreshIndex(
-            any(OperationFingerprint.class),
-            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
-            any(RequestOptions.class)))
-        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
-
+    ESIndexBuilder builder = setupPollReindexBuilder(1000L);
     when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
         .thenThrow(new IOException("connection reset"));
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -2088,6 +2088,104 @@ public class ESIndexBuilderTest {
     assertEquals(result.finalDocumentCounts().getSecond(), Long.valueOf(1000L));
   }
 
+  /**
+   * Destination overshoot after the ES task finishes (writes between launch-time snapshot and
+   * scroll open) must complete — otherwise busy-index ZDU Phase 1 times out forever.
+   */
+  @Test
+  void testPollReindexCompletion_destOvershootAndTaskCompleted_completes() throws Throwable {
+    when(elasticSearchConfiguration.getIndex())
+        .thenReturn(
+            IndexConfiguration.builder()
+                .numShards(NUM_SHARDS)
+                .numReplicas(NUM_REPLICAS)
+                .numRetries(0)
+                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
+                .maxReindexHours(1)
+                .build());
+    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
+    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
+    ESIndexBuilder builder =
+        new ESIndexBuilder(
+            searchClient,
+            elasticSearchConfiguration,
+            TEST_ES_STRUCT_PROPS_DISABLED,
+            Map.of(),
+            gitVersion);
+
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(1005L);
+    when(searchClient.count(
+            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+    when(searchClient.refreshIndex(
+            any(OperationFingerprint.class),
+            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
+
+    GetTaskResponse completedTask = mock(GetTaskResponse.class);
+    when(completedTask.isCompleted()).thenReturn(true);
+    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
+        .thenReturn(Optional.of(completedTask));
+
+    ESIndexBuilder.PollReindexResult result =
+        builder.pollReindexCompletion(
+            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:42");
+
+    assertTrue(result.completed(), "Completed task with dest > expected must complete");
+    assertEquals(result.finalDocumentCounts().getSecond(), Long.valueOf(1005L));
+  }
+
+  /**
+   * Transient getTask failures must not complete on matching counts alone — that reopens the
+   * mid-copy false-complete hole.
+   */
+  @Test
+  void testPollReindexCompletion_countsMatchButTaskLookupError_doesNotComplete() throws Throwable {
+    when(elasticSearchConfiguration.getIndex())
+        .thenReturn(
+            IndexConfiguration.builder()
+                .numShards(NUM_SHARDS)
+                .numReplicas(NUM_REPLICAS)
+                .numRetries(0)
+                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
+                .maxReindexHours(1)
+                .build());
+    when(buildIndicesConfig.getReindexNoProgressRetryMinutes()).thenReturn(0);
+    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
+    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
+    ESIndexBuilder builder =
+        new ESIndexBuilder(
+            searchClient,
+            elasticSearchConfiguration,
+            TEST_ES_STRUCT_PROPS_DISABLED,
+            Map.of(),
+            gitVersion);
+
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(1000L);
+    when(searchClient.count(
+            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+    when(searchClient.refreshIndex(
+            any(OperationFingerprint.class),
+            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
+
+    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
+        .thenThrow(new IOException("connection reset"));
+
+    ESIndexBuilder.PollReindexResult result =
+        builder.pollReindexCompletion(
+            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:42");
+
+    assertFalse(
+        result.completed(),
+        "Matching counts during a transient task-status lookup failure must not complete");
+  }
+
   @Test
   void testExtractTargetShards() {
     ReindexConfig config = mock(ReindexConfig.class);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/ESIndexBuilderTest.java
@@ -1989,6 +1989,105 @@ public class ESIndexBuilderTest {
             any(OperationFingerprint.class), any(ReindexRequest.class), any(RequestOptions.class));
   }
 
+  /**
+   * Mid-copy false positive: dest has already reached the expected count but the ES task is still
+   * running. Poll must not complete — otherwise the launch-time swap gate would accept a partial
+   * copy.
+   */
+  @Test
+  void testPollReindexCompletion_countsMatchButTaskRunning_doesNotComplete() throws Throwable {
+    when(elasticSearchConfiguration.getIndex())
+        .thenReturn(
+            IndexConfiguration.builder()
+                .numShards(NUM_SHARDS)
+                .numReplicas(NUM_REPLICAS)
+                .numRetries(0)
+                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
+                .maxReindexHours(1)
+                .build());
+    when(buildIndicesConfig.getReindexNoProgressRetryMinutes()).thenReturn(0);
+    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
+    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
+    ESIndexBuilder builder =
+        new ESIndexBuilder(
+            searchClient,
+            elasticSearchConfiguration,
+            TEST_ES_STRUCT_PROPS_DISABLED,
+            Map.of(),
+            gitVersion);
+
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(1000L);
+    when(searchClient.count(
+            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+    when(searchClient.refreshIndex(
+            any(OperationFingerprint.class),
+            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
+
+    GetTaskResponse runningTask = mock(GetTaskResponse.class);
+    when(runningTask.isCompleted()).thenReturn(false);
+    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
+        .thenReturn(Optional.of(runningTask));
+
+    ESIndexBuilder.PollReindexResult result =
+        builder.pollReindexCompletion(
+            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:42");
+
+    assertFalse(
+        result.completed(),
+        "Matching counts while the reindex task is still running must not complete");
+  }
+
+  /** Counts match and the ES task reports completed — poll succeeds. */
+  @Test
+  void testPollReindexCompletion_countsMatchAndTaskCompleted_completes() throws Throwable {
+    when(elasticSearchConfiguration.getIndex())
+        .thenReturn(
+            IndexConfiguration.builder()
+                .numShards(NUM_SHARDS)
+                .numReplicas(NUM_REPLICAS)
+                .numRetries(0)
+                .refreshIntervalSeconds(REFRESH_INTERVAL_SECONDS)
+                .maxReindexHours(1)
+                .build());
+    when(buildIndicesConfig.getCountRetryMaxAttempts()).thenReturn(1);
+    when(buildIndicesConfig.getCountRetryWaitSeconds()).thenReturn(0);
+    ESIndexBuilder builder =
+        new ESIndexBuilder(
+            searchClient,
+            elasticSearchConfiguration,
+            TEST_ES_STRUCT_PROPS_DISABLED,
+            Map.of(),
+            gitVersion);
+
+    CountResponse countResponse = mock(CountResponse.class);
+    when(countResponse.getCount()).thenReturn(1000L);
+    when(searchClient.count(
+            any(OperationContext.class), any(CountRequest.class), any(RequestOptions.class)))
+        .thenReturn(countResponse);
+    when(searchClient.refreshIndex(
+            any(OperationFingerprint.class),
+            any(org.opensearch.action.admin.indices.refresh.RefreshRequest.class),
+            any(RequestOptions.class)))
+        .thenReturn(mock(org.opensearch.action.admin.indices.refresh.RefreshResponse.class));
+
+    GetTaskResponse completedTask = mock(GetTaskResponse.class);
+    when(completedTask.isCompleted()).thenReturn(true);
+    when(searchClient.getTask(any(GetTaskRequest.class), any(RequestOptions.class)))
+        .thenReturn(Optional.of(completedTask));
+
+    ESIndexBuilder.PollReindexResult result =
+        builder.pollReindexCompletion(
+            opContext, "src_index", "dest_index", () -> 1000L, 1, new HashMap<>(), "node1:42");
+
+    assertTrue(result.completed(), "Matching counts with a completed task must complete");
+    assertEquals(result.finalDocumentCounts().getFirst(), Long.valueOf(1000L));
+    assertEquals(result.finalDocumentCounts().getSecond(), Long.valueOf(1000L));
+  }
+
   @Test
   void testExtractTargetShards() {
     ReindexConfig config = mock(ReindexConfig.class);

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -454,14 +454,16 @@ public interface EntitySearchService {
   }
 
   /**
-   * Validates doc counts match between an alias and a new backing index, then atomically swaps the
-   * alias.
+   * Validates the new backing index's doc count against the source count snapshotted when the
+   * reindex was launched, then atomically swaps the alias.
    *
+   * @param expectedSourceDocCount source doc count snapshotted at reindex submission time
    * @return true if swapped, false if doc counts didn't match
    */
   boolean validateAndSwapAlias(
       @Nonnull OperationContext opContext,
       @Nonnull String aliasName,
-      @Nonnull String newBackingIndex)
+      @Nonnull String newBackingIndex,
+      long expectedSourceDocCount)
       throws Exception;
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/search/EntitySearchServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/search/EntitySearchServiceTest.java
@@ -362,7 +362,8 @@ public class EntitySearchServiceTest {
     public boolean validateAndSwapAlias(
         @NonNull OperationContext opContext,
         @NonNull String aliasName,
-        @NonNull String newBackingIndex)
+        @NonNull String newBackingIndex,
+        long expectedSourceDocCount)
         throws Exception {
       return false;
     }


### PR DESCRIPTION
## Summary
- Incremental (ZDU) Phase 1 alias swap now validates against the **launch-time** source document count instead of a live alias count, so busy indices can finish under live writes (catch-up still covers the write window).
- Failed swaps escalate the index to `FAILED` and delete the next index so the next system-update run reindexes from scratch instead of retrying a doomed `IN_PROGRESS` swap.
- `pollReindexCompletion` no longer treats matching doc counts as complete while the ES `_reindex` task is still running (closes the mid-copy false-complete hole once poll and swap share the same expected count).

Follow-up to #18598 (checkpoint half). Related discussion: #18949 / #18950 (legacy `allowDocCountMismatch` poll exits — out of scope here; do not apply percentage early-exits to the shared poll without an incremental opt-out).

## Test plan
- [x] `./gradlew :datahub-upgrade:test --tests '*BuildIndicesIncrementalStepTest*'` (19 tests, including swap-gate / FAILED recovery)
- [x] `./gradlew :metadata-io:test --tests '*ESIndexBuilderTest*'` poll completion cases (`countsMatchButTaskRunning`, `countsMatchAndTaskCompleted`, `completedButShort`)
- [ ] Manual / staging: enable incremental reindex on a large live index and confirm Phase 1 swap succeeds while writes continue; confirm a deliberate swap mismatch leaves `FAILED` and a rerun rebuilds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ZDU Phase 1 alias swap by gating on the source doc count captured at reindex launch and accepting destination overshoot once reindexing finishes, so swaps can complete on busy indices. Also makes swap failures recoverable, closes the mid-copy false-complete gap in the reindex poll, and avoids unsafe cleanup when alias verification is uncertain.

- **Bug Fixes**
  - Swap gate now uses the launch-time source count; live alias reads removed. Accepts `next >= expected` after the reindex task completes.
  - Reindex polling now requires the ES `_reindex` task to finish before treating counts as complete; allows overshoot post-finish. Transient task-status lookup errors no longer complete on counts alone; blank task id/not-found still allowed.
  - On swap failure (mismatch or exception): mark index as FAILED and delete the next index so the next run reindexes from scratch. If a swap throws but the alias already points to the next index, treat as success and skip cleanup. If alias verification itself fails after a swap exception, mark FAILED without deleting the next index to avoid removing a potentially live backing index.
  - Resume path gates swap on the persisted source count snapshot from the original launch.
  - API change: `validateAndSwapAlias` now accepts `expectedSourceDocCount`; updated in `EntitySearchService` and `ElasticSearchService`. Tests and docs updated.

<sup>Written for commit 45a0cf5afd916b1a5f92474cb285bcb7fa869f0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

