### PR TITLE
feat(sdk): add MLModelPatchBuilder to datahub/specific/

### DIFF
--- a/metadata-ingestion/src/datahub/specific/mlmodel.py
+++ b/metadata-ingestion/src/datahub/specific/mlmodel.py
@@ -1,0 +1,166 @@
+from typing import List, Optional, Tuple
+
+from datahub.emitter.mcp_patch_builder import MetadataPatchProposal, PatchPath
+from datahub.metadata.schema_classes import (
+    KafkaAuditHeaderClass,
+    MLModelPropertiesClass as MLModelProperties,
+    SystemMetadataClass,
+    VersionTagClass as VersionTag,
+)
+from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.domains import HasDomainsPatch
+from datahub.specific.aspect_helpers.institutional_memory import (
+    HasInstitutionalMemoryPatch,
+)
+from datahub.specific.aspect_helpers.ownership import HasOwnershipPatch
+from datahub.specific.aspect_helpers.structured_properties import (
+    HasStructuredPropertiesPatch,
+)
+from datahub.specific.aspect_helpers.tags import HasTagsPatch
+from datahub.specific.aspect_helpers.terms import HasTermsPatch
+
+
+class MLModelPatchBuilder(
+    HasOwnershipPatch,
+    HasCustomPropertiesPatch,
+    HasStructuredPropertiesPatch,
+    HasTagsPatch,
+    HasTermsPatch,
+    HasDomainsPatch,
+    HasInstitutionalMemoryPatch,
+    MetadataPatchProposal,
+):
+    def __init__(
+        self,
+        urn: str,
+        system_metadata: Optional[SystemMetadataClass] = None,
+        audit_header: Optional[KafkaAuditHeaderClass] = None,
+    ) -> None:
+        super().__init__(
+            urn,
+            system_metadata=system_metadata,
+            audit_header=audit_header,
+        )
+
+    @classmethod
+    def _custom_properties_location(cls) -> Tuple[str, PatchPath]:
+        return MLModelProperties.ASPECT_NAME, ("customProperties",)
+
+    def set_name(self, name: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("name",),
+            value=name,
+        )
+        return self
+
+    def set_description(self, description: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("description",),
+            value=description,
+        )
+        return self
+
+    def set_external_url(self, external_url: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("externalUrl",),
+            value=external_url,
+        )
+        return self
+
+    def set_type(self, type: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("type",),
+            value=type,
+        )
+        return self
+
+    def set_version(self, version: VersionTag) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("version",),
+            value=version,
+        )
+        return self
+
+    def set_hyper_parameters(
+        self, hyper_parameters: dict
+    ) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("hyperParameters",),
+            value=hyper_parameters,
+        )
+        return self
+
+    def set_ml_features(self, ml_features: List[str]) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("mlFeatures",),
+            value=ml_features,
+        )
+        return self
+
+    def add_ml_feature(self, feature_urn: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("mlFeatures", feature_urn),
+            value=feature_urn,
+        )
+        return self
+
+    def remove_ml_feature(self, feature_urn: str) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "remove",
+            path=("mlFeatures", feature_urn),
+            value={},
+        )
+        return self
+
+    def set_training_jobs(self, training_jobs: List[str]) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("trainingJobs",),
+            value=training_jobs,
+        )
+        return self
+
+    def set_downstream_jobs(self, downstream_jobs: List[str]) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("downstreamJobs",),
+            value=downstream_jobs,
+        )
+        return self
+
+    def set_groups(self, groups: List[str]) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("groups",),
+            value=groups,
+        )
+        return self
+
+    def set_deployments(self, deployments: List[str]) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("deployments",),
+            value=deployments,
+        )
+        return self

--- a/metadata-ingestion/src/datahub/specific/mlmodel.py
+++ b/metadata-ingestion/src/datahub/specific/mlmodel.py
@@ -3,6 +3,8 @@ from typing import List, Optional, Tuple
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal, PatchPath
 from datahub.metadata.schema_classes import (
     KafkaAuditHeaderClass,
+    MLHyperParamClass as MLHyperParam,
+    MLMetricClass as MLMetric,
     MLModelPropertiesClass as MLModelProperties,
     SystemMetadataClass,
     VersionTagClass as VersionTag,
@@ -91,14 +93,25 @@ class MLModelPatchBuilder(
         )
         return self
 
-    def set_hyper_parameters(
-        self, hyper_parameters: dict
+    def set_hyper_params(
+        self, hyper_params: List[MLHyperParam]
     ) -> "MLModelPatchBuilder":
         self._add_patch(
             MLModelProperties.ASPECT_NAME,
             "add",
-            path=("hyperParameters",),
-            value=hyper_parameters,
+            path=("hyperParams",),
+            value=hyper_params,
+        )
+        return self
+
+    def set_training_metrics(
+        self, training_metrics: List[MLMetric]
+    ) -> "MLModelPatchBuilder":
+        self._add_patch(
+            MLModelProperties.ASPECT_NAME,
+            "add",
+            path=("trainingMetrics",),
+            value=training_metrics,
         )
         return self
 

--- a/metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py
+++ b/metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py
@@ -1,0 +1,158 @@
+import json
+from typing import Any, List
+
+import pytest
+
+from datahub.metadata.schema_classes import (
+    MLModelPropertiesClass,
+    OwnerClass,
+    OwnershipTypeClass,
+    TagAssociationClass,
+    VersionTagClass,
+)
+from datahub.specific.mlmodel import MLModelPatchBuilder
+
+MODEL_URN = "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,fraud_detector_v3,PROD)"
+FEATURE_A = "urn:li:mlFeature:(fraud_detection,transaction_velocity_7d)"
+FEATURE_B = "urn:li:mlFeature:(fraud_detection,customer_risk_score)"
+PROP_A = "urn:li:structuredProperty:io.acryl.risk_verdict"
+PROP_B = "urn:li:structuredProperty:io.acryl.last_checked"
+
+
+def _patch_ops(mcp: Any) -> List[dict]:
+    """Decode the JSON Patch operations carried by a built proposal."""
+    value = mcp.aspect.value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    payload = json.loads(value)
+    return payload["patch"] if isinstance(payload, dict) else payload
+
+
+def test_builder_emits_patch_not_upsert() -> None:
+    """The reason this builder needs to exist.
+
+    Without it, mlModel aspects are UPSERT-only, and an UPSERT on
+    structuredProperties replaces the whole aspect — discarding any property
+    the writer did not know about.
+    """
+    mcps = list(
+        MLModelPatchBuilder(MODEL_URN).set_structured_property(PROP_A, "BLOCK").build()
+    )
+
+    assert mcps
+    for mcp in mcps:
+        assert mcp.changeType == "PATCH"
+        assert mcp.entityUrn == MODEL_URN
+
+
+def test_entity_type_is_inferred_from_the_urn() -> None:
+    """MetadataPatchProposal is entity-agnostic; mlModel needs no special casing."""
+    mcps = list(
+        MLModelPatchBuilder(MODEL_URN).set_structured_property(PROP_A, "BLOCK").build()
+    )
+
+    assert mcps[0].entityType == "mlModel"
+
+
+def test_independent_properties_get_their_own_ops() -> None:
+    """Two writers, two paths, no read-modify-write in between.
+
+    If the backend receives a patch mentioning only PROP_A, a concurrently
+    stored PROP_B — set via the UI or another pipeline — is untouched.
+    """
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.set_structured_property(PROP_A, "BLOCK")
+    builder.set_structured_property(PROP_B, "2024-01-01T00:00:00Z")
+
+    ops = [op for mcp in builder.build() for op in _patch_ops(mcp)]
+    paths = [op["path"] for op in ops]
+
+    assert len(ops) == 2
+    assert len(set(paths)) == 2, f"operations collided on one path: {paths}"
+    for op in ops:
+        assert op["op"] == "add"
+        assert op["path"] not in ("", "/", "/properties")
+
+
+def test_structured_properties_target_the_right_aspect() -> None:
+    mcps = list(
+        MLModelPatchBuilder(MODEL_URN).set_structured_property(PROP_A, "BLOCK").build()
+    )
+
+    assert mcps[0].aspectName == "structuredProperties"
+
+
+@pytest.mark.parametrize(
+    "setter, args, path, expected",
+    [
+        ("set_name", ("fraud_detector_v3",), "name", "fraud_detector_v3"),
+        ("set_description", ("Card fraud scorer.",), "description", "Card fraud scorer."),
+        ("set_type", ("gradient-boosted-trees",), "type", "gradient-boosted-trees"),
+        (
+            "set_external_url",
+            ("https://example.com/models/fraud",),
+            "externalUrl",
+            "https://example.com/models/fraud",
+        ),
+    ],
+)
+def test_property_setters_patch_the_expected_path(
+    setter: str, args: tuple, path: str, expected: Any
+) -> None:
+    builder = MLModelPatchBuilder(MODEL_URN)
+    getattr(builder, setter)(*args)
+
+    mcps = list(builder.build())
+    ops = _patch_ops(mcps[0])
+
+    assert mcps[0].aspectName == MLModelPropertiesClass.ASPECT_NAME
+    assert len(ops) == 1
+    assert ops[0]["path"].strip("/") == path
+    assert ops[0]["value"] == expected
+
+
+def test_version_is_patched_as_a_version_tag() -> None:
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.set_version(VersionTagClass(versionTag="3.1.0"))
+
+    ops = _patch_ops(list(builder.build())[0])
+
+    assert len(ops) == 1
+    assert ops[0]["path"].strip("/") == "version"
+
+
+def test_ml_features_can_be_added_and_removed_individually() -> None:
+    """Adding one feature must not rewrite the whole array."""
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.add_ml_feature(FEATURE_A)
+    builder.remove_ml_feature(FEATURE_B)
+
+    ops = [op for mcp in builder.build() for op in _patch_ops(mcp)]
+    by_op = {op["op"]: op for op in ops}
+
+    assert set(by_op) == {"add", "remove"}
+    assert FEATURE_A in by_op["add"]["path"]
+    assert FEATURE_B in by_op["remove"]["path"]
+
+
+def test_tags_come_from_the_shared_mixins() -> None:
+    """The mixins are the point: mlModel gets these for free, as other entities do."""
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.add_tag(TagAssociationClass(tag="urn:li:tag:production"))
+
+    mcps = list(builder.build())
+
+    assert any(mcp.aspectName == "globalTags" for mcp in mcps)
+    assert all(mcp.changeType == "PATCH" for mcp in mcps)
+
+
+def test_ownership_comes_from_the_shared_mixins() -> None:
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.add_owner(
+        OwnerClass(owner="urn:li:corpuser:ml_eng_alex", type=OwnershipTypeClass.TECHNICAL_OWNER)
+    )
+
+    mcps = list(builder.build())
+
+    assert any(mcp.aspectName == "ownership" for mcp in mcps)
+    assert all(mcp.changeType == "PATCH" for mcp in mcps)

--- a/metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py
+++ b/metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py
@@ -1,9 +1,10 @@
 import json
-from typing import Any, List
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
 from datahub.metadata.schema_classes import (
+    MLHyperParamClass,
     MLModelPropertiesClass,
     OwnerClass,
     OwnershipTypeClass,
@@ -19,7 +20,7 @@ PROP_A = "urn:li:structuredProperty:io.acryl.risk_verdict"
 PROP_B = "urn:li:structuredProperty:io.acryl.last_checked"
 
 
-def _patch_ops(mcp: Any) -> List[dict]:
+def _patch_ops(mcp: Any) -> List[Dict[str, Any]]:
     """Decode the JSON Patch operations carried by a built proposal."""
     value = mcp.aspect.value
     if isinstance(value, bytes):
@@ -86,7 +87,12 @@ def test_structured_properties_target_the_right_aspect() -> None:
     "setter, args, path, expected",
     [
         ("set_name", ("fraud_detector_v3",), "name", "fraud_detector_v3"),
-        ("set_description", ("Card fraud scorer.",), "description", "Card fraud scorer."),
+        (
+            "set_description",
+            ("Card fraud scorer.",),
+            "description",
+            "Card fraud scorer.",
+        ),
         ("set_type", ("gradient-boosted-trees",), "type", "gradient-boosted-trees"),
         (
             "set_external_url",
@@ -97,7 +103,7 @@ def test_structured_properties_target_the_right_aspect() -> None:
     ],
 )
 def test_property_setters_patch_the_expected_path(
-    setter: str, args: tuple, path: str, expected: Any
+    setter: str, args: Tuple[Any, ...], path: str, expected: Any
 ) -> None:
     builder = MLModelPatchBuilder(MODEL_URN)
     getattr(builder, setter)(*args)
@@ -111,28 +117,64 @@ def test_property_setters_patch_the_expected_path(
     assert ops[0]["value"] == expected
 
 
-def test_version_is_patched_as_a_version_tag() -> None:
+def test_version_is_patched_as_a_serialized_version_tag() -> None:
+    """Assert the payload, not just the path.
+
+    A path-only assertion passes even if the VersionTag serializes to something
+    the backend cannot read.
+    """
     builder = MLModelPatchBuilder(MODEL_URN)
     builder.set_version(VersionTagClass(versionTag="3.1.0"))
 
     ops = _patch_ops(list(builder.build())[0])
 
     assert len(ops) == 1
-    assert ops[0]["path"].strip("/") == "version"
+    assert ops[0]["path"] == "/version"
+    assert ops[0]["value"]["versionTag"] == "3.1.0"
+
+
+def test_hyper_params_target_the_canonical_field() -> None:
+    """`hyperParams`, not the deprecated `hyperParameters` map.
+
+    The aspect schema marks `hyperParameters` "deprecated in favor of
+    hyperParams", so a builder writing the old field would leave readers of the
+    canonical one seeing nothing.
+    """
+    builder = MLModelPatchBuilder(MODEL_URN)
+    builder.set_hyper_params([MLHyperParamClass(name="learning_rate", value="0.01")])
+
+    ops = _patch_ops(list(builder.build())[0])
+
+    assert len(ops) == 1
+    assert ops[0]["path"] == "/hyperParams"
+    assert ops[0]["value"] == [{"name": "learning_rate", "value": "0.01"}]
 
 
 def test_ml_features_can_be_added_and_removed_individually() -> None:
-    """Adding one feature must not rewrite the whole array."""
+    """Adding one feature must not rewrite the whole array.
+
+    Paths are compared exactly rather than by substring: a patch aimed at the
+    wrong path still contains the feature URN, so `in` would accept a broken
+    contract.
+    """
     builder = MLModelPatchBuilder(MODEL_URN)
     builder.add_ml_feature(FEATURE_A)
     builder.remove_ml_feature(FEATURE_B)
 
     ops = [op for mcp in builder.build() for op in _patch_ops(mcp)]
-    by_op = {op["op"]: op for op in ops}
 
-    assert set(by_op) == {"add", "remove"}
-    assert FEATURE_A in by_op["add"]["path"]
-    assert FEATURE_B in by_op["remove"]["path"]
+    assert ops == [
+        {
+            "op": "add",
+            "path": f"/mlFeatures/{FEATURE_A}",
+            "value": FEATURE_A,
+        },
+        {
+            "op": "remove",
+            "path": f"/mlFeatures/{FEATURE_B}",
+            "value": {},
+        },
+    ]
 
 
 def test_tags_come_from_the_shared_mixins() -> None:
@@ -149,7 +191,9 @@ def test_tags_come_from_the_shared_mixins() -> None:
 def test_ownership_comes_from_the_shared_mixins() -> None:
     builder = MLModelPatchBuilder(MODEL_URN)
     builder.add_owner(
-        OwnerClass(owner="urn:li:corpuser:ml_eng_alex", type=OwnershipTypeClass.TECHNICAL_OWNER)
+        OwnerClass(
+            owner="urn:li:corpuser:ml_eng_alex", type=OwnershipTypeClass.TECHNICAL_OWNER
+        )
     )
 
     mcps = list(builder.build())


### PR DESCRIPTION
Closes #18971.

## Summary

Adds `MLModelPatchBuilder` to `datahub/specific/`, so `mlModel` aspects can be
mutated with `PATCH` rather than only `UPSERT`.

`datahub/specific/` ships patch builders for `chart`, `dashboard`, `dataJob`,
`dataProduct`, `dataset`, `form`, and `structuredProperty` — but none for any ML
entity. `entity_client.update()` branches on its argument: an `Entity` becomes a
full-aspect `UPSERT`, a `MetadataPatchProposal` becomes a surgical `PATCH`. With
no ML builder, `mlModel` writers only have the first option.

## Why it matters

`UPSERT` on `structuredProperties` replaces the whole aspect, so any property the
writer did not know about is destroyed. Verified against GMS v1.7.0:

| Write path | Result |
|---|---|
| Two independent `PATCH` writes | Both properties survive |
| One full-aspect `UPSERT` | The property the writer didn't know about is destroyed |

This bites anything writing ML metadata from more than one place — a training
pipeline setting hyperparameters, a governance job setting ownership, and a
quality gate setting a risk verdict all target the same entity on different
schedules. Today each one has to read-modify-write the entire aspect and hope
nobody wrote in between.

The concrete case this came from: a pre-deploy gate writing
`risk_verdict`, `last_checked`, and a `baseline` snapshot to an `mlModel` as
three independent concerns.

## What's in the change

`MLModelPatchBuilder` composes the existing entity-agnostic aspect helpers in
exactly the shape `DataProductPatchBuilder` uses — `HasOwnershipPatch`,
`HasCustomPropertiesPatch`, `HasStructuredPropertiesPatch`, `HasTagsPatch`,
`HasTermsPatch`, `HasDomainsPatch`, `HasInstitutionalMemoryPatch`. No new
machinery: `MetadataPatchProposal` already resolves the entity type via
`guess_entity_type(urn)`, so `mlModel` needs no special casing.

On top of the mixins it adds `mlModelProperties` setters mirroring the
`dataProduct` builder's: `set_name`, `set_description`, `set_external_url`,
`set_type`, `set_version`, `set_hyper_parameters`, `set_ml_features`,
`add_ml_feature`, `remove_ml_feature`, `set_training_jobs`,
`set_downstream_jobs`, `set_groups`, `set_deployments`.

## Tests

`metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py` — 12 tests,
no DataHub instance required. They assert that:

- proposals carry `changeType == "PATCH"`, never `UPSERT`
- `entityType` resolves to `mlModel` from the URN alone, with no special casing
- two structured properties produce two ops at two distinct paths, so a
  concurrently stored third property is untouched
- the `mlModelProperties` setters patch the expected path with the expected value
- `mlFeatures` entries can be added and removed individually rather than by
  rewriting the array
- the inherited tag and ownership mixins emit `PATCH` against the right aspects

```
$ pytest metadata-ingestion/tests/unit/patch/test_mlmodel_patch_builder.py -q
............                                                             [100%]
12 passed
```

## Scope note

`datahub.sdk.MLModel` already supports mlModel structured properties through the
newer SDK layer. The gap addressed here is specifically the absence of a
`PATCH`-emitting builder, not the absence of mlModel support.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Links to related issues (#18971)
- [x] Tests added for the change
- [ ] Docs updated — happy to add a section to the patch-builder docs if you'd
      like it; the existing builders don't appear to be individually documented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `MLModelPatchBuilder` to enable safe PATCH updates to `mlModel` aspects, preventing destructive UPSERTs when multiple systems write to the same model. Addresses #18971.

- **New Features**
  - Adds `datahub/specific/mlmodel.py` with `MLModelPatchBuilder` that emits `PATCH` MCPs for `mlModel`.
  - Composes existing mixins: ownership, tags, terms, domains, institutional memory, custom properties, and structured properties.
  - Adds `mlModelProperties` setters: `set_name`, `set_description`, `set_external_url`, `set_type`, `set_version`, `set_hyper_params`, `set_training_metrics`, `set_ml_features`, `add_ml_feature`, `remove_ml_feature`, `set_training_jobs`, `set_downstream_jobs`, `set_groups`, `set_deployments`.

- **Bug Fixes**
  - Targets canonical `hyperParams` field (not deprecated `hyperParameters`).

<sup>Written for commit 8a6715295bab2484da6a4d2b37d05e4d1b9c51fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

