### PR TITLE
test(ci): DO NOT MERGE — validate the zero-image-build path

### DIFF
--- a/smoke-test/tests/utilities/concurrent_test_runner.py
+++ b/smoke-test/tests/utilities/concurrent_test_runner.py
@@ -30,6 +30,9 @@ def run_concurrent_tests(
         AssertionError: If any test case fails, raises with details of all failures
         pytest.skip.Exception: If every case skipped and none passed/failed
 
+    Failures are collected across all cases and reported together, so one bad
+    case does not hide the others behind whichever future finished first.
+
     Example:
         >>> def test_entity(entity_type):
         ...     result = search(entity_type)


### PR DESCRIPTION
**Throwaway PR. Do not merge — close once it has reported.**

Validation for #18983, stacked on it so the diff contains nothing but the one file.

## What this exercises

The **zero-build** path. The only changed file is under `smoke-test/**`, which is classified as unable to affect any docker image, so the plan should reuse all six images from the floating `quickstart` tag and bake nothing.

The code change itself is a docstring comment with no behavioural effect. Its only job is to shape the diff.

## Expected

| check | expected |
| --- | --- |
| `setup` → "Resolve which images to build" | all six lines say `reuse`; `image_build_modules` empty |
| step summary | plan table shows `quickstart` / `quickstart-slim` for all six |
| `base_build` | runs, skips its build steps, finishes in well under a minute |
| `base_build` build id | empty — downstream jobs skip `depot pull` |
| `run-quickstart.sh` → "Resolved service images" | every `acryldata/*` image on `:quickstart` (actions on `:quickstart-slim`), **no** `pr*` tag |
| pytest batches | green |
| time to first assertion | roughly 9.3m earlier than the baseline |

## Reading the result

A green run does **not** on its own prove this works. The reused images are known-good, so the batches would pass even if the tag map were wrong. **The assertion is the resolved-image dump, not the test result.**

## Also worth doing on this PR

Two label flips, no new PR needed. Both should flip the plan to a full build, with the log naming the label as the reason:

- add `build-images` → the manual escape hatch
- add `publish-docker` → a publish label is still a `pull_request`, and the publish path bakes everything

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the CI zero-image-build path with a no-op docstring update in `smoke-test/tests/utilities/concurrent_test_runner.py`, so the plan reuses all six `:quickstart`/`:quickstart-slim` images and builds none.
This only clarifies that failures are aggregated across cases; no runtime changes—just exercising image resolution.

<sup>Written for commit 665b1c36b985a035051bbb7491cc9ce475db4037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

