### PR TITLE
test(ci): DO NOT MERGE — validate the partial-image-build path

### DIFF
--- a/datahub-web-react/src/utils/dedupeByUrn.ts
+++ b/datahub-web-react/src/utils/dedupeByUrn.ts
@@ -1,5 +1,6 @@
 // When the same urn appears more than once, prefer the entry where isPropagated is false, since a manually
 // applied entry should win over one that arrived via automated propagation. Ties keep the first occurrence.
+// The result preserves first-seen urn order, not the order of the winning entries.
 export function dedupeByUrn<T>(items: T[], getUrn: (item: T) => string, isPropagated?: (item: T) => boolean): T[] {
     const bestByUrn = new Map<string, T>();
     const urnOrder: string[] = [];


### PR DESCRIPTION
**Throwaway PR. Do not merge — close once it has reported.**

Validation for #18983, stacked on it so the diff contains nothing but the one file.

## What this exercises

The **partial-build** path, which is the more interesting of the two: the run ends up with a *mixed* image set, some baked from this PR and some pulled from the registry.

The only changed file is under `datahub-web-react/**`, so `frontend` is the only filter that fires. The frontend image should be baked and tagged with the PR tag; the other five should come from `quickstart`.

The code change is a comment with no behavioural effect. Its only job is to shape the diff.

## Expected

| check | expected |
| --- | --- |
| `setup` → "Resolve which images to build" | `build datahub-frontend-react`, the other five `reuse` |
| `image_build_modules` | `:datahub-frontend` only |
| `base_build` | bakes only the frontend; `prepareAll` should not build GMS, the consumers, upgrade or actions |
| `depot pull` | runs, pulls just the frontend image |
| `run-quickstart.sh` → "Resolved service images" | `datahub-frontend-react:pr<N>-<sha>`, everything else on `:quickstart` |
| Playwright | green, and the shards log in to Docker Hub before pulling |

## What this is really testing

Whether a mixed image set actually boots. A PR-built frontend against a HEAD GMS is a combination that has never run before, and it is the case most likely to expose a coupling the path filters do not model. If the frontend and GMS have drifted in a way the `backend` filter should have caught, this is where it shows up.

Also the first exercise of the new Docker Hub login in the Playwright reusable workflow — without it, eight shards pulling `quickstart` images anonymously would hit the rate limit.

Note that pytest smoke batches will likely be skipped here: `smoke_test_matrix` does not run them for a frontend-only change. Playwright is the signal on this one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the partial-image-build CI path with a no-op frontend edit so only the `datahub-frontend-react` image builds; others reuse `:quickstart`. Confirms a mixed image set boots and that Playwright shards authenticate to Docker Hub before pulling; the only code change is a comment in `datahub-web-react/src/utils/dedupeByUrn.ts` clarifying the result preserves first-seen urn order, not the order of winning entries.

<sup>Written for commit 43d4fe9a30e28244adda179fdfd7e665df3ab6a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

