### PR TITLE
test(product-update): gate What's New JSONs on the latest release

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParser.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParser.java
@@ -89,7 +89,8 @@ public class ProductUpdateParser {
     }
 
     // Parse primary CTA (new format) - preferred over legacy ctaText/ctaLink
-    if (json.has("primaryCtaText") && json.has("primaryCtaLink")) {
+    boolean hasPrimaryCta = json.hasNonNull("primaryCtaText") && json.hasNonNull("primaryCtaLink");
+    if (hasPrimaryCta) {
       String primaryCtaText = json.get("primaryCtaText").asText();
       String primaryCtaLink = maybeDecorateUrl(json.get("primaryCtaLink").asText(), clientId);
 
@@ -98,7 +99,7 @@ public class ProductUpdateParser {
     }
 
     // Parse secondary CTA (optional)
-    if (json.has("secondaryCtaText") && json.has("secondaryCtaLink")) {
+    if (json.hasNonNull("secondaryCtaText") && json.hasNonNull("secondaryCtaLink")) {
       String secondaryCtaText = json.get("secondaryCtaText").asText();
       String secondaryCtaLink = maybeDecorateUrl(json.get("secondaryCtaLink").asText(), clientId);
 
@@ -108,7 +109,7 @@ public class ProductUpdateParser {
 
     // Parse legacy CTA fields (backward compatibility)
     // Only use if primary CTA is not provided
-    if (!json.has("primaryCtaText") || !json.has("primaryCtaLink")) {
+    if (!hasPrimaryCta) {
       String ctaText = json.has("ctaText") ? json.get("ctaText").asText() : "Learn more";
       String ctaLink =
           maybeDecorateUrl(json.has("ctaLink") ? json.get("ctaLink").asText() : "", clientId);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParser.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParser.java
@@ -110,9 +110,10 @@ public class ProductUpdateParser {
     // Parse legacy CTA fields (backward compatibility)
     // Only use if primary CTA is not provided
     if (!hasPrimaryCta) {
-      String ctaText = json.has("ctaText") ? json.get("ctaText").asText() : "Learn more";
+      String ctaText = json.hasNonNull("ctaText") ? json.get("ctaText").asText() : "Learn more";
       String ctaLink =
-          maybeDecorateUrl(json.has("ctaLink") ? json.get("ctaLink").asText() : "", clientId);
+          maybeDecorateUrl(
+              json.hasNonNull("ctaLink") ? json.get("ctaLink").asText() : "", clientId);
 
       productUpdate.setCtaText(ctaText);
       productUpdate.setCtaLink(ctaLink);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParserTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParserTest.java
@@ -737,6 +737,72 @@ public class ProductUpdateParserTest {
   }
 
   @Test
+  public void testParseProductUpdateNullLegacyCtaFallsBackToDefaults() throws Exception {
+    String jsonString =
+        "{"
+            + "\"enabled\": true,"
+            + "\"id\": \"v1.0.0\","
+            + "\"title\": \"What's New\","
+            + "\"primaryCtaText\": null,"
+            + "\"primaryCtaLink\": null,"
+            + "\"ctaText\": null,"
+            + "\"ctaLink\": null"
+            + "}";
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+    ProductUpdate result = ProductUpdateParser.parseProductUpdate(Optional.of(jsonNode), "abc-123");
+
+    assertNotNull(result);
+    assertEquals(result.getCtaText(), "Learn more");
+    // An absent link stays empty rather than being decorated with the client id.
+    assertEquals(result.getCtaLink(), "");
+  }
+
+  @Test
+  public void testParseProductUpdatePartialPrimaryCtaFallsBackToLegacy() throws Exception {
+    String jsonString =
+        "{"
+            + "\"enabled\": true,"
+            + "\"id\": \"v1.0.0\","
+            + "\"title\": \"What's New\","
+            + "\"primaryCtaText\": \"Get Started\","
+            + "\"ctaText\": \"Learn more\","
+            + "\"ctaLink\": \"https://example.com\""
+            + "}";
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+    ProductUpdate result = ProductUpdateParser.parseProductUpdate(Optional.of(jsonNode));
+
+    assertNotNull(result);
+    assertNull(result.getPrimaryCtaText());
+    assertNull(result.getPrimaryCtaLink());
+    assertEquals(result.getCtaText(), "Learn more");
+    assertEquals(result.getCtaLink(), "https://example.com");
+  }
+
+  @Test
+  public void testParseProductUpdatePartialSecondaryCtaIsIgnored() throws Exception {
+    String jsonString =
+        "{"
+            + "\"enabled\": true,"
+            + "\"id\": \"v1.0.0\","
+            + "\"title\": \"What's New\","
+            + "\"primaryCtaText\": \"Get Started\","
+            + "\"primaryCtaLink\": \"https://example.com\","
+            + "\"secondaryCtaText\": \"Watch Video\","
+            + "\"secondaryCtaLink\": null"
+            + "}";
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+    ProductUpdate result = ProductUpdateParser.parseProductUpdate(Optional.of(jsonNode));
+
+    assertNotNull(result);
+    assertEquals(result.getPrimaryCtaLink(), "https://example.com");
+    assertNull(result.getSecondaryCtaText());
+    assertNull(result.getSecondaryCtaLink());
+  }
+
+  @Test
   public void testParseProductUpdatePrimaryCtaTakesPrecedenceOverLegacy() throws Exception {
     String jsonString =
         "{"

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParserTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/ProductUpdateParserTest.java
@@ -710,6 +710,33 @@ public class ProductUpdateParserTest {
   }
 
   @Test
+  public void testParseProductUpdateNullPrimaryCtaFallsBackToLegacy() throws Exception {
+    String jsonString =
+        "{"
+            + "\"enabled\": true,"
+            + "\"id\": \"v2.1\","
+            + "\"title\": \"Cloud Update\","
+            + "\"primaryCtaText\": null,"
+            + "\"primaryCtaLink\": null,"
+            + "\"secondaryCtaText\": null,"
+            + "\"secondaryCtaLink\": null,"
+            + "\"ctaText\": \"Explore DataHub Cloud 2.1\","
+            + "\"ctaLink\": \"https://datahub.com/blog/datahub-cloud-2-1\""
+            + "}";
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+
+    ProductUpdate result = ProductUpdateParser.parseProductUpdate(Optional.of(jsonNode));
+
+    assertNotNull(result);
+    assertNull(result.getPrimaryCtaText());
+    assertNull(result.getPrimaryCtaLink());
+    assertNull(result.getSecondaryCtaText());
+    assertNull(result.getSecondaryCtaLink());
+    assertEquals(result.getCtaText(), "Explore DataHub Cloud 2.1");
+    assertEquals(result.getCtaLink(), "https://datahub.com/blog/datahub-cloud-2-1");
+  }
+
+  @Test
   public void testParseProductUpdatePrimaryCtaTakesPrecedenceOverLegacy() throws Exception {
     String jsonString =
         "{"

--- a/metadata-service/configuration/build.gradle
+++ b/metadata-service/configuration/build.gradle
@@ -35,6 +35,30 @@ test {
     exclude '**/cigate/GraphqlUsageRegistryCiGateTest.class'
     exclude '**/cigate/OpenApiUsageRegistryCiGateTest.class'
     exclude '**/cigate/RestliUsageRegistryCiGateTest.class'
+    exclude '**/productupdate/ProductUpdateReleaseSyncTest.class'
+}
+
+// The product update JSONs advertise a release, but the release history that makes them stale
+// lives in docs/. Declaring both as inputs of a dedicated task is what makes promoting release
+// notes re-run this gate instead of leaving `test` UP-TO-DATE.
+def productUpdateInputs = files(
+    file("${projectDir}/src/main/resources/product-update.json"),
+    file("${projectDir}/src/main/resources/product-update-saas.json"),
+    file("${rootProject.projectDir}/docs/how/updating-datahub.md"),
+    fileTree("${rootProject.projectDir}/docs/managed-datahub/release-notes") { include '*.md' },
+)
+
+tasks.register('productUpdateReleaseSyncCheck', Test) {
+    description = 'Validate bundled product update ("What\'s New" toast) JSONs advertise the latest release.'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    include '**/productupdate/ProductUpdateReleaseSyncTest.class'
+    inputs.files productUpdateInputs
+    outputs.file("${layout.buildDirectory.get()}/product-update-release-sync-check.stamp")
+    systemProperty 'datahub.repoRoot', rootProject.projectDir.absolutePath
+    reports.junitXml.required = true
+    reports.html.required = true
 }
 
 // Usage registry CI gates skip when git detects no relevant changes. Force a full scan:
@@ -110,7 +134,7 @@ tasks.register('restLiUsageRegistryCheck', Test) {
     reports.html.required = true
 }
 
-check.dependsOn graphqlUsageRegistryCheck, openApiUsageRegistryCheck, restLiUsageRegistryCheck
+check.dependsOn graphqlUsageRegistryCheck, openApiUsageRegistryCheck, restLiUsageRegistryCheck, productUpdateReleaseSyncCheck
 
 tasks.register('updateGraphqlUsageExemptionSnapshot', JavaExec) {
     dependsOn testClasses

--- a/metadata-service/configuration/build.gradle
+++ b/metadata-service/configuration/build.gradle
@@ -38,9 +38,7 @@ test {
     exclude '**/productupdate/ProductUpdateReleaseSyncTest.class'
 }
 
-// The product update JSONs advertise a release, but the release history that makes them stale
-// lives in docs/. Declaring both as inputs of a dedicated task is what makes promoting release
-// notes re-run this gate instead of leaving `test` UP-TO-DATE.
+// Declare the docs/ release history as inputs too, so promoting release notes re-runs this gate.
 def productUpdateInputs = files(
     file("${projectDir}/src/main/resources/product-update.json"),
     file("${projectDir}/src/main/resources/product-update-saas.json"),

--- a/metadata-service/configuration/build.gradle
+++ b/metadata-service/configuration/build.gradle
@@ -47,6 +47,7 @@ def productUpdateInputs = files(
     file("${rootProject.projectDir}/docs/how/updating-datahub.md"),
     fileTree("${rootProject.projectDir}/docs/managed-datahub/release-notes") { include '*.md' },
 )
+def productUpdateStamp = layout.buildDirectory.file("product-update-release-sync-check.stamp")
 
 tasks.register('productUpdateReleaseSyncCheck', Test) {
     description = 'Validate bundled product update ("What\'s New" toast) JSONs advertise the latest release.'
@@ -55,10 +56,15 @@ tasks.register('productUpdateReleaseSyncCheck', Test) {
     classpath = sourceSets.test.runtimeClasspath
     include '**/productupdate/ProductUpdateReleaseSyncTest.class'
     inputs.files productUpdateInputs
-    outputs.file("${layout.buildDirectory.get()}/product-update-release-sync-check.stamp")
+    outputs.file(productUpdateStamp)
     systemProperty 'datahub.repoRoot', rootProject.projectDir.absolutePath
     reports.junitXml.required = true
     reports.html.required = true
+    // Only write the declared output after the test succeeds, so changed inputs rerun the gate
+    // while an unchanged successful result can be UP-TO-DATE.
+    doLast {
+        productUpdateStamp.get().asFile.text = 'ok\n'
+    }
 }
 
 // Usage registry CI gates skip when git detects no relevant changes. Force a full scan:

--- a/metadata-service/configuration/src/main/resources/product-update.json
+++ b/metadata-service/configuration/src/main/resources/product-update.json
@@ -1,9 +1,9 @@
 {
   "enabled": true,
-  "id": "v1.4.0",
+  "id": "v1.7.0",
   "title": "What's New In DataHub",
-  "description": "Explore version v1.4.0",
+  "description": "Explore version v1.7.0",
   "image": "https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/sample-product-update-image.png",
   "primaryCtaText": "Read updates",
-  "primaryCtaLink": "https://docs.datahub.com/docs/releases#v1-4-0"
+  "primaryCtaLink": "https://docs.datahub.com/docs/releases#v1-7-0"
 }

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
@@ -1,0 +1,138 @@
+package com.linkedin.metadata.config.productupdate;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+/**
+ * The two bundled product update ("What's New" toast) JSONs and the release history each one
+ * tracks.
+ *
+ * <p>Core and cloud version independently, so each flavor resolves its own latest release. Both
+ * release histories keep unreleased notes under a draft heading ({@code ## Next} / {@code next.md})
+ * that is promoted to a versioned one at release cut, so drafting notes on master does not make a
+ * flavor look out of date — only actually cutting a release does.
+ */
+public enum ProductUpdateFlavor {
+  CORE(
+      "DataHub Core",
+      "metadata-service/configuration/src/main/resources/product-update.json",
+      "docs/how/updating-datahub.md") {
+    @Override
+    @Nonnull
+    Optional<ReleaseVersion> findLatestRelease(@Nonnull Path repoRoot) {
+      Path releaseNotes = repoRoot.resolve(releaseSource());
+      if (!Files.isRegularFile(releaseNotes)) {
+        return Optional.empty();
+      }
+      Matcher headings = VERSIONED_HEADING.matcher(readString(releaseNotes));
+      Optional<ReleaseVersion> latest = Optional.empty();
+      while (headings.find()) {
+        latest = higherOf(latest, ReleaseVersion.parse(headings.group(1)));
+      }
+      return latest;
+    }
+  },
+
+  CLOUD(
+      "DataHub Cloud",
+      "metadata-service/configuration/src/main/resources/product-update-saas.json",
+      "docs/managed-datahub/release-notes") {
+    @Override
+    @Nonnull
+    Optional<ReleaseVersion> findLatestRelease(@Nonnull Path repoRoot) {
+      Path releaseNotesDir = repoRoot.resolve(releaseSource());
+      if (!Files.isDirectory(releaseNotesDir)) {
+        return Optional.empty();
+      }
+      try (Stream<Path> notes = Files.list(releaseNotesDir)) {
+        return notes
+            .map(note -> VERSIONED_NOTE_FILE.matcher(note.getFileName().toString()))
+            .filter(Matcher::matches)
+            .map(matcher -> ReleaseVersion.parse(matcher.group(1)))
+            .flatMap(Optional::stream)
+            .max(Comparator.naturalOrder());
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  };
+
+  /** A released section in updating-datahub.md, e.g. "## v1.7.0". Skips the "## Next" draft. */
+  private static final Pattern VERSIONED_HEADING = Pattern.compile("(?m)^##\\s+(v[\\d._]+)\\s*$");
+
+  /** A released cloud release note, e.g. "v_2_1_0.md". Skips "next.md". */
+  private static final Pattern VERSIONED_NOTE_FILE = Pattern.compile("(v_[\\d_]+)\\.md");
+
+  private final String label;
+  private final String jsonPath;
+  private final String releaseSource;
+
+  ProductUpdateFlavor(
+      @Nonnull String label, @Nonnull String jsonPath, @Nonnull String releaseSource) {
+    this.label = label;
+    this.jsonPath = jsonPath;
+    this.releaseSource = releaseSource;
+  }
+
+  @Nonnull
+  abstract Optional<ReleaseVersion> findLatestRelease(@Nonnull Path repoRoot);
+
+  /** The latest released version for this flavor, failing loudly if none can be resolved. */
+  @Nonnull
+  public ReleaseVersion latestRelease(@Nonnull Path repoRoot) {
+    return findLatestRelease(repoRoot)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Found no released "
+                        + label
+                        + " version in "
+                        + releaseSource
+                        + " under repo root "
+                        + repoRoot));
+  }
+
+  @Nonnull
+  public String label() {
+    return label;
+  }
+
+  @Nonnull
+  public String jsonPath() {
+    return jsonPath;
+  }
+
+  @Nonnull
+  public String releaseSource() {
+    return releaseSource;
+  }
+
+  @Nonnull
+  private static Optional<ReleaseVersion> higherOf(
+      @Nonnull Optional<ReleaseVersion> left, @Nonnull Optional<ReleaseVersion> right) {
+    if (left.isEmpty()) {
+      return right;
+    }
+    if (right.isEmpty()) {
+      return left;
+    }
+    return Optional.of(left.get().compareTo(right.get()) >= 0 ? left.get() : right.get());
+  }
+
+  @Nonnull
+  private static String readString(@Nonnull Path path) {
+    try {
+      return Files.readString(path);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
@@ -70,7 +70,7 @@ public enum ProductUpdateFlavor {
    * historical {@code ## 1.3.0} convention, plus optional annotations after the version.
    */
   private static final Pattern VERSIONED_HEADING =
-      Pattern.compile("(?m)^##\\s+(v?\\d+(?:[._]\\d+)+)(?:\\s+.*)?$");
+      Pattern.compile("(?m)^##[ \\t]+(v?\\d+(?:[._]\\d+)+)(?:[ \\t]+[^\\r\\n]*)?$");
 
   /** A released cloud release note, e.g. "v_2_1_0.md". Skips "next.md". */
   private static final Pattern VERSIONED_NOTE_FILE = Pattern.compile("(v_[\\d_]+)\\.md");

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavor.java
@@ -65,8 +65,12 @@ public enum ProductUpdateFlavor {
     }
   };
 
-  /** A released section in updating-datahub.md, e.g. "## v1.7.0". Skips the "## Next" draft. */
-  private static final Pattern VERSIONED_HEADING = Pattern.compile("(?m)^##\\s+(v[\\d._]+)\\s*$");
+  /**
+   * A released section in updating-datahub.md. Supports both the current {@code ## v1.7.0} and
+   * historical {@code ## 1.3.0} convention, plus optional annotations after the version.
+   */
+  private static final Pattern VERSIONED_HEADING =
+      Pattern.compile("(?m)^##\\s+(v?\\d+(?:[._]\\d+)+)(?:\\s+.*)?$");
 
   /** A released cloud release note, e.g. "v_2_1_0.md". Skips "next.md". */
   private static final Pattern VERSIONED_NOTE_FILE = Pattern.compile("(v_[\\d_]+)\\.md");

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavorTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavorTest.java
@@ -1,0 +1,52 @@
+package com.linkedin.metadata.config.productupdate;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ProductUpdateFlavorTest {
+
+  @Test
+  public void testCoreIgnoresDraftHeadingAndOutOfOrderSections() throws IOException {
+    Path repoRoot = Files.createTempDirectory("core-release-notes");
+    writeFile(
+        repoRoot.resolve("docs/how/updating-datahub.md"),
+        String.join(
+            "\n",
+            "# Updating DataHub",
+            "## Next",
+            "Draft release notes for the upcoming version.",
+            "## v1.7.0",
+            "## v1.5.0",
+            // Hotfix sections are listed after the minor release they patch.
+            "## v1.5.0.7"));
+
+    Assert.assertEquals(
+        ProductUpdateFlavor.CORE.latestRelease(repoRoot), ReleaseVersion.parse("v1.7.0").get());
+  }
+
+  @Test
+  public void testCloudIgnoresNextNote() throws IOException {
+    Path repoRoot = Files.createTempDirectory("cloud-release-notes");
+    Path releaseNotes = repoRoot.resolve("docs/managed-datahub/release-notes");
+    Files.createDirectories(releaseNotes);
+    for (String note : new String[] {"next.md", "v_0_3_17.md", "v_2_0_0.md", "v_2_1_0.md"}) {
+      Files.writeString(releaseNotes.resolve(note), "");
+    }
+
+    Assert.assertEquals(
+        ProductUpdateFlavor.CLOUD.latestRelease(repoRoot), ReleaseVersion.parse("v2.1.0").get());
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testFailsLoudlyWhenReleaseHistoryIsMissing() throws IOException {
+    ProductUpdateFlavor.CORE.latestRelease(Files.createTempDirectory("empty-repo"));
+  }
+
+  private static void writeFile(Path path, String contents) throws IOException {
+    Files.createDirectories(path.getParent());
+    Files.writeString(path, contents);
+  }
+}

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavorTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateFlavorTest.java
@@ -19,12 +19,13 @@ public class ProductUpdateFlavorTest {
             "## Next",
             "Draft release notes for the upcoming version.",
             "## v1.7.0",
-            "## v1.5.0",
+            "## 1.8.0 — LTS",
+            "## v1.5.0 (2026-03-24)",
             // Hotfix sections are listed after the minor release they patch.
             "## v1.5.0.7"));
 
     Assert.assertEquals(
-        ProductUpdateFlavor.CORE.latestRelease(repoRoot), ReleaseVersion.parse("v1.7.0").get());
+        ProductUpdateFlavor.CORE.latestRelease(repoRoot), ReleaseVersion.parse("v1.8.0").get());
   }
 
   @Test

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateReleaseSyncTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateReleaseSyncTest.java
@@ -30,7 +30,7 @@ public class ProductUpdateReleaseSyncTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  /** Required by ProductUpdateParser; the toast never renders if any is absent. */
+  /** Mirrors ProductUpdateParser's required-field contract; the toast never renders if absent. */
   private static final List<String> REQUIRED_FIELDS = List.of("enabled", "id", "title");
 
   private static final Pattern BUNDLED_IMAGE =
@@ -168,10 +168,10 @@ public class ProductUpdateReleaseSyncTest {
       @Nonnull ReleaseVersion declared,
       @Nonnull ReleaseVersion latest) {
     return String.format(
-        "%s shipped %s but %s still advertises %s.%n"
+        "%s shipped %s but %s still advertises %s.\n"
             + "Update its id, description, and CTA link to %s. The hosted product.datahub.com JSON"
             + " is published from this file, so connected and air-gapped instances both show"
-            + " whatever it says.%n"
+            + " whatever it says.\n"
             + "Latest release resolved from %s.",
         flavor.label(), latest, flavor.jsonPath(), declared, latest, flavor.releaseSource());
   }

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateReleaseSyncTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ProductUpdateReleaseSyncTest.java
@@ -1,0 +1,178 @@
+package com.linkedin.metadata.config.productupdate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.metadata.config.usage.cigate.UsageRegistryRepoPaths;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * CI gate keeping the bundled product update ("What's New" toast) JSONs in step with the releases
+ * they advertise.
+ *
+ * <p>These files are both the air-gapped fallback served by {@code ProductUpdateService} and the
+ * source the hosted product.datahub.com JSONs are published from, so a stale file means every
+ * instance shows a toast for an old release. Nothing else in the build notices — {@code
+ * ProductUpdateParser} happily serves whatever version the JSON names, and drops the toast silently
+ * when a required field is missing.
+ */
+public class ProductUpdateReleaseSyncTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Required by ProductUpdateParser; the toast never renders if any is absent. */
+  private static final List<String> REQUIRED_FIELDS = List.of("enabled", "id", "title");
+
+  private static final Pattern BUNDLED_IMAGE =
+      Pattern.compile("https://raw\\.githubusercontent\\.com/datahub-project/datahub/[^/]+/(.+)");
+
+  private Path repoRoot;
+
+  @BeforeClass
+  public void setUp() {
+    repoRoot = UsageRegistryRepoPaths.repoRoot();
+  }
+
+  @DataProvider(name = "flavors")
+  public Object[][] flavors() {
+    return new Object[][] {{ProductUpdateFlavor.CORE}, {ProductUpdateFlavor.CLOUD}};
+  }
+
+  @Test(dataProvider = "flavors")
+  public void testProductUpdateAdvertisesLatestRelease(@Nonnull ProductUpdateFlavor flavor)
+      throws IOException {
+    JsonNode json = readProductUpdate(flavor);
+
+    for (String field : REQUIRED_FIELDS) {
+      Assert.assertTrue(
+          json.hasNonNull(field),
+          flavor.jsonPath()
+              + " is missing required field '"
+              + field
+              + "'. ProductUpdateParser drops the update entirely without it, so no toast renders.");
+    }
+
+    if (!json.get("enabled").asBoolean()) {
+      // The toast is intentionally switched off for this flavor; it advertises nothing to check.
+      return;
+    }
+
+    String declaredId = json.get("id").asText();
+    ReleaseVersion declared =
+        ReleaseVersion.parse(declaredId)
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        flavor.jsonPath()
+                            + " has id '"
+                            + declaredId
+                            + "', which is not a release version. Expected something like "
+                            + flavor.latestRelease(repoRoot)
+                            + "."));
+
+    ReleaseVersion latest = flavor.latestRelease(repoRoot);
+    Assert.assertTrue(
+        latest.sameMinorSeries(declared), staleUpdateMessage(flavor, declared, latest));
+  }
+
+  @Test(dataProvider = "flavors")
+  public void testProductUpdateIsInternallyConsistent(@Nonnull ProductUpdateFlavor flavor)
+      throws IOException {
+    JsonNode json = readProductUpdate(flavor);
+    Optional<ReleaseVersion> declared = ReleaseVersion.parse(json.path("id").asText());
+    if (declared.isEmpty()) {
+      // testProductUpdateAdvertisesLatestRelease owns reporting an unusable id.
+      return;
+    }
+
+    String ctaLink = effectiveCtaLink(json);
+    if (!ctaLink.isBlank()) {
+      Assert.assertTrue(
+          declared.get().appearsIn(ctaLink),
+          flavor.jsonPath()
+              + " advertises "
+              + declared.get()
+              + " but its CTA link points elsewhere: "
+              + ctaLink
+              + ". Point it at this release's notes so the toast doesn't send users to an older"
+              + " release.");
+    }
+
+    String description = json.path("description").asText("");
+    Optional<ReleaseVersion> describedVersion = ReleaseVersion.highestIn(description);
+    if (describedVersion.isPresent()) {
+      Assert.assertTrue(
+          declared.get().sameMinorSeries(describedVersion.get()),
+          flavor.jsonPath()
+              + " advertises "
+              + declared.get()
+              + " but its description names "
+              + describedVersion.get()
+              + ": \""
+              + description
+              + "\".");
+    }
+  }
+
+  @Test(dataProvider = "flavors")
+  public void testProductUpdateImageExists(@Nonnull ProductUpdateFlavor flavor) throws IOException {
+    JsonNode json = readProductUpdate(flavor);
+    String image = json.path("image").asText("");
+    Matcher bundled = BUNDLED_IMAGE.matcher(image);
+    if (!bundled.matches()) {
+      // Externally hosted images can't be verified from the repo.
+      return;
+    }
+
+    String imagePath = bundled.group(1);
+    Assert.assertTrue(
+        Files.isRegularFile(repoRoot.resolve(imagePath)),
+        flavor.jsonPath()
+            + " references image "
+            + imagePath
+            + ", which does not exist in the repo. The toast would render with a broken image.");
+  }
+
+  @Nonnull
+  private JsonNode readProductUpdate(@Nonnull ProductUpdateFlavor flavor) throws IOException {
+    Path jsonPath = repoRoot.resolve(flavor.jsonPath());
+    Assert.assertTrue(Files.isRegularFile(jsonPath), "Missing product update JSON: " + jsonPath);
+    return MAPPER.readTree(Files.readString(jsonPath));
+  }
+
+  /**
+   * The link the toast button actually uses; the parser prefers the primary CTA over the legacy
+   * one.
+   */
+  @Nonnull
+  private static String effectiveCtaLink(@Nonnull JsonNode json) {
+    if (json.hasNonNull("primaryCtaText") && json.hasNonNull("primaryCtaLink")) {
+      return json.get("primaryCtaLink").asText("");
+    }
+    return json.path("ctaLink").asText("");
+  }
+
+  @Nonnull
+  private static String staleUpdateMessage(
+      @Nonnull ProductUpdateFlavor flavor,
+      @Nonnull ReleaseVersion declared,
+      @Nonnull ReleaseVersion latest) {
+    return String.format(
+        "%s shipped %s but %s still advertises %s.%n"
+            + "Update its id, description, and CTA link to %s. The hosted product.datahub.com JSON"
+            + " is published from this file, so connected and air-gapped instances both show"
+            + " whatever it says.%n"
+            + "Latest release resolved from %s.",
+        flavor.label(), latest, flavor.jsonPath(), declared, latest, flavor.releaseSource());
+  }
+}

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
@@ -1,0 +1,143 @@
+package com.linkedin.metadata.config.productupdate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A dot-separated numeric release version, tolerant of the several spellings DataHub uses for the
+ * same release: {@code v1.7.0} (product update JSON id), {@code v_2_1_0} (cloud release note file
+ * name), and {@code 1-7-0} (docs anchor / blog slug).
+ */
+public final class ReleaseVersion implements Comparable<ReleaseVersion> {
+
+  private static final Pattern SEPARATORS = Pattern.compile("[._]");
+  private static final Pattern DIGITS = Pattern.compile("\\d+");
+  private static final List<String> SEPARATOR_SPELLINGS = List.of(".", "-", "_");
+
+  /** Matches a multi-component version anywhere in free text, e.g. "Explore version v1.7.0". */
+  public static final Pattern VERSION_TOKEN = Pattern.compile("v?\\d+(?:[._]\\d+)+");
+
+  private final List<Integer> components;
+
+  private ReleaseVersion(@Nonnull List<Integer> components) {
+    this.components = List.copyOf(components);
+  }
+
+  @Nonnull
+  public static Optional<ReleaseVersion> parse(@Nullable String raw) {
+    if (raw == null) {
+      return Optional.empty();
+    }
+    String normalized = raw.trim();
+    if (normalized.startsWith("v") || normalized.startsWith("V")) {
+      normalized = normalized.substring(1);
+    }
+    normalized = normalized.replaceAll("^[._]+", "").replaceAll("[._]+$", "");
+    if (normalized.isEmpty()) {
+      return Optional.empty();
+    }
+
+    List<Integer> parsed = new ArrayList<>();
+    for (String part : SEPARATORS.split(normalized)) {
+      if (!DIGITS.matcher(part).matches()) {
+        return Optional.empty();
+      }
+      try {
+        parsed.add(Integer.parseInt(part));
+      } catch (NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+    return Optional.of(new ReleaseVersion(parsed));
+  }
+
+  /** Component at {@code index}, defaulting to 0 so 2.1 and 2.1.0 compare as equal. */
+  public int component(int index) {
+    return index < components.size() ? components.get(index) : 0;
+  }
+
+  /**
+   * Whether both versions belong to the same MAJOR.MINOR series.
+   *
+   * <p>Product update toasts are written per minor release, and the two flavors declare different
+   * levels of precision for the same release (core uses {@code v1.7.0}, cloud uses {@code v2.1} for
+   * what the release notes call {@code v2.1.0}). Comparing on MAJOR.MINOR reconciles those, and
+   * keeps patch releases and hotfix rollups — which don't get their own toast — from failing.
+   */
+  public boolean sameMinorSeries(@Nonnull ReleaseVersion other) {
+    return component(0) == other.component(0) && component(1) == other.component(1);
+  }
+
+  /** Whether this version is referenced in {@code text} under any of its separator spellings. */
+  public boolean appearsIn(@Nonnull String text) {
+    for (String separator : SEPARATOR_SPELLINGS) {
+      // Digit boundaries keep v2.1 from matching the v2.10 in ".../datahub-cloud-2-10".
+      Pattern reference =
+          Pattern.compile("(?<!\\d)" + Pattern.quote(joinWith(separator)) + "(?!\\d)");
+      if (reference.matcher(text).find()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** The highest version referenced in {@code text}, if any. */
+  @Nonnull
+  public static Optional<ReleaseVersion> highestIn(@Nonnull String text) {
+    Matcher matcher = VERSION_TOKEN.matcher(text);
+    Optional<ReleaseVersion> highest = Optional.empty();
+    while (matcher.find()) {
+      Optional<ReleaseVersion> candidate = parse(matcher.group());
+      if (candidate.isPresent()
+          && (highest.isEmpty() || candidate.get().compareTo(highest.get()) > 0)) {
+        highest = candidate;
+      }
+    }
+    return highest;
+  }
+
+  @Nonnull
+  private String joinWith(@Nonnull String separator) {
+    return components.stream().map(String::valueOf).collect(Collectors.joining(separator));
+  }
+
+  @Override
+  public int compareTo(@Nonnull ReleaseVersion other) {
+    int length = Math.max(components.size(), other.components.size());
+    for (int i = 0; i < length; i++) {
+      int comparison = Integer.compare(component(i), other.component(i));
+      if (comparison != 0) {
+        return comparison;
+      }
+    }
+    return 0;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof ReleaseVersion && compareTo((ReleaseVersion) other) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 1;
+    for (int i = 0; i < components.size(); i++) {
+      // Trailing zeros are insignificant (2.1 equals 2.1.0), so they must not affect the hash.
+      if (component(i) != 0) {
+        hash = 31 * hash + Integer.hashCode(component(i)) + i;
+      }
+    }
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "v" + joinWith(".");
+  }
+}

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
@@ -10,9 +10,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * A dot-separated numeric release version, tolerant of the several spellings DataHub uses for the
- * same release: {@code v1.7.0} (product update JSON id), {@code v_2_1_0} (cloud release note file
- * name), and {@code 1-7-0} (docs anchor / blog slug).
+ * A numeric release version, e.g. {@code v1.7.0}. {@link #parse} accepts the dot/underscore
+ * spellings DataHub uses for release ids and note file names ({@code v1.7.0}, {@code v_2_1_0}); the
+ * hyphenated form used in docs anchors and blog slugs ({@code 1-7-0}) is matched only when
+ * searching within text via {@link #appearsIn}.
  */
 public final class ReleaseVersion implements Comparable<ReleaseVersion> {
 

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersion.java
@@ -21,7 +21,7 @@ public final class ReleaseVersion implements Comparable<ReleaseVersion> {
   private static final List<String> SEPARATOR_SPELLINGS = List.of(".", "-", "_");
 
   /** Matches a multi-component version anywhere in free text, e.g. "Explore version v1.7.0". */
-  public static final Pattern VERSION_TOKEN = Pattern.compile("v?\\d+(?:[._]\\d+)+");
+  private static final Pattern VERSION_TOKEN = Pattern.compile("v?\\d+(?:[._]\\d+)+");
 
   private final List<Integer> components;
 

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersionTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/productupdate/ReleaseVersionTest.java
@@ -1,0 +1,64 @@
+package com.linkedin.metadata.config.productupdate;
+
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ReleaseVersionTest {
+
+  @Test
+  public void testParsesTheSpellingsUsedAcrossTheRepo() {
+    Assert.assertEquals(parse("v1.7.0").toString(), "v1.7.0");
+    Assert.assertEquals(parse("1.7.0").toString(), "v1.7.0");
+    Assert.assertEquals(parse("v_2_1_0").toString(), "v2.1.0");
+    Assert.assertEquals(parse("v1.5.0.7").toString(), "v1.5.0.7");
+  }
+
+  @Test
+  public void testRejectsNonVersions() {
+    Assert.assertTrue(ReleaseVersion.parse("Next").isEmpty());
+    Assert.assertTrue(ReleaseVersion.parse("<version number>").isEmpty());
+    Assert.assertTrue(ReleaseVersion.parse("v1.7.0-rc1").isEmpty());
+    Assert.assertTrue(ReleaseVersion.parse(null).isEmpty());
+  }
+
+  @Test
+  public void testSameMinorSeriesSpansPrecisionAndPatches() {
+    // Cloud declares v2.1 for the release its notes call v2.1.0.
+    Assert.assertTrue(parse("v2.1").sameMinorSeries(parse("v2.1.0")));
+    // A hotfix rollup doesn't get its own toast.
+    Assert.assertTrue(parse("v1.7.0").sameMinorSeries(parse("v1.7.0.3")));
+    // A missed minor release does.
+    Assert.assertFalse(parse("v1.4.0").sameMinorSeries(parse("v1.7.0")));
+    Assert.assertFalse(parse("v2.1").sameMinorSeries(parse("v3.1")));
+  }
+
+  @Test
+  public void testOrdersByComponentNotLexically() {
+    Assert.assertTrue(parse("v1.7.0").compareTo(parse("v1.10.0")) < 0);
+    Assert.assertTrue(parse("v1.5.0.7").compareTo(parse("v1.5.0")) > 0);
+    Assert.assertEquals(parse("v2.1"), parse("v2.1.0"));
+  }
+
+  @Test
+  public void testAppearsInAcceptsAnySeparatorAtDigitBoundaries() {
+    Assert.assertTrue(parse("v1.7.0").appearsIn("https://docs.datahub.com/docs/releases#v1-7-0"));
+    Assert.assertTrue(parse("v2.1").appearsIn("https://datahub.com/blog/datahub-cloud-2-1"));
+    Assert.assertTrue(parse("v1.7.0").appearsIn("Explore version v1.7.0"));
+    Assert.assertFalse(parse("v2.1").appearsIn("https://datahub.com/blog/datahub-cloud-2-10"));
+    Assert.assertFalse(parse("v1.4.0").appearsIn("https://docs.datahub.com/docs/releases#v1-7-0"));
+  }
+
+  @Test
+  public void testHighestInFreeText() {
+    Assert.assertEquals(
+        ReleaseVersion.highestIn("Explore version v1.7.0"), Optional.of(parse("v1.7.0")));
+    Assert.assertTrue(ReleaseVersion.highestIn("Business meaning meets your agents").isEmpty());
+  }
+
+  private static ReleaseVersion parse(String raw) {
+    Optional<ReleaseVersion> parsed = ReleaseVersion.parse(raw);
+    Assert.assertTrue(parsed.isPresent(), "Expected to parse " + raw);
+    return parsed.get();
+  }
+}


### PR DESCRIPTION
## Problem

When we cut a new release, we must update product update jsons, otherwise product toast will be obsolete.

## Drive-by

Bump OSS product.json.

