### PR TITLE
test(ci): DO NOT MERGE — validate the ingestion-only image build

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -469,6 +469,8 @@ class _Chunk:
 
     @staticmethod
     def join(chunk: "_Chunk") -> str:
+        # Items are already serialized, so this concatenates rather than
+        # re-encoding a list of objects.
         return "[" + ",".join(item.payload for item in chunk.items) + "]"
 
 


### PR DESCRIPTION
**Throwaway PR. Do not merge — close once it has reported.**

Validation for #18983, stacked on it so the diff contains nothing but the one file.

## What this exercises

An **ingestion-only** change. The only changed file is `metadata-ingestion/src/datahub/emitter/rest_emitter.py`, so `ingestion` is the only filter that fires.

### One naming point worth being explicit about

There is no `datahub-ingestion` container in the smoke stack. The `quickstart-consumers` profile runs exactly six DataHub images:

```
acryldata/datahub-gms            acryldata/datahub-frontend-react
acryldata/datahub-mae-consumer   acryldata/datahub-upgrade
acryldata/datahub-mce-consumer   acryldata/datahub-actions
```

`docker/datahub-ingestion` is built only by `:docker:buildImagesAll` for publishing; it is not part of the smoke stack and never was.

The container that carries the ingestion library into the stack is **`datahub-actions`**, which `pip install`s `../metadata-ingestion` at image build time. So "only rebuild the ingestion container" means, for this stack, only rebuild `datahub-actions`.

## Expected

| check | expected |
| --- | --- |
| `setup` → "Resolve which images to build" | `build datahub-actions`; the other five `reuse` |
| `image_build_modules` | `:datahub-actions` only |
| `base_build` | bakes only actions — no GMS, consumers, upgrade or frontend `dockerPrepare` |
| `run-quickstart.sh` → "Resolved service images" | `datahub-actions:pr<N>-<sha>-slim`, everything else on `:quickstart` |
| pytest batches | green — `ingestion_only` does run them |

The resolved-image dump is now a hard assertion, not just a log line: `EXPECT_PR_TAGGED_IMAGES=datahub-actions` is passed in, and `run-quickstart.sh` refuses to boot if actions comes up on the reused tag instead of this PR's.

## Companion PRs

- #18984 — zero-build path (`smoke-test/**`, nothing rebuilt)
- #18985 — frontend-only path (only `datahub-frontend-react` rebuilt)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the ingestion-only CI path: rebuilds only the `datahub-actions` image; all other services reuse `:quickstart`. Adds a no-op comment in `metadata-ingestion/src/datahub/emitter/rest_emitter.py` noting `join` concatenates pre-serialized items to trigger the ingestion filter.

- **CI Validation**
  - Only `datahub-actions` is rebuilt; others reuse `:quickstart`.
  - `image_build_modules` resolves to `:datahub-actions` only; no other `dockerPrepare`.
  - `run-quickstart.sh` enforces `EXPECT_PR_TAGGED_IMAGES=datahub-actions` and fails if not PR-tagged.
  - Pytest runs the `ingestion_only` batch and should pass.
  - Note: ingestion library ships via `datahub-actions`; there is no `datahub-ingestion` container in the smoke stack.

<sup>Written for commit a7bd542126096f2cfb490a11a8e59ddc09315338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

