### PR TITLE
docs: fix README.md quickstart anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Essential for modern data teams and reliable AI agents:
 
 - [FAQ](#-frequently-asked-questions)
 - [See DataHub in Action](#-see-datahub-in-action)
-- [Quick Start](#-quick-start-60-seconds)
+- [Quick Start](#-quick-start)
 - [Installation Options](#-installation-options)
 - [Architecture](#-architecture-overview)
 - [Use Cases & Examples](#-use-cases--examples)
@@ -201,7 +201,7 @@ pip install acryl-datahub
 datahub docker quickstart
 ```
 
-See the [Quick Start](#-quick-start-60-seconds) section below for full instructions. The PyPI package is [`acryl-datahub`](https://pypi.org/project/acryl-datahub/); the Homebrew tap is [`datahub-project/homebrew-tap`](https://github.com/datahub-project/homebrew-tap).
+See the [Quick Start](#-quick-start) section below for full instructions. The PyPI package is [`acryl-datahub`](https://pypi.org/project/acryl-datahub/); the Homebrew tap is [`datahub-project/homebrew-tap`](https://github.com/datahub-project/homebrew-tap).
 
 </details>
 


### PR DESCRIPTION
   ## Summary
   The Table of Contents and the FAQ section both linked to `#-quick-start-60-seconds`, which doesn't match the actual `## 🚀 Quick Start` heading's generated anchor (`#-quick-start`). This left both links pointing at a non-existent anchor. Updated both to `#-quick-start`. Didn't see an issue or existing PR for this.

   ## Test plan
   - [x] Verified the anchor goes to the right place manually
   - [x] Confirmed no other broken anchors exist in the README's Table of Contents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken Quick Start links in README by changing "#-quick-start-60-seconds" to "#-quick-start" in the Table of Contents and the inline "See the Quick Start" reference.

<sup>Written for commit eef6645f7fa7ebfd629f9df8a09be75d6135cfb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

