### PR TITLE
test(ci): DO NOT MERGE — validate the server-only image build

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/messaging/ConsumerGroupLagSnapshot.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/messaging/ConsumerGroupLagSnapshot.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import lombok.Builder;
 import lombok.Value;
 
+/** Lag for one consumer group, keyed by topic. Empty topics means the group reported nothing. */
 @Value
 @Builder
 public class ConsumerGroupLagSnapshot {


### PR DESCRIPTION
**Throwaway PR. Do not merge — close once it has reported.**

Validation for #18983, stacked on it so the diff contains nothing but the one file.

## What this exercises

**Server-side business logic only.** The single changed file is under `metadata-io/**`, which no part of the frontend image compiles. Under the rule "if all that changed is business logic, the frontend should not be rebuilt", this should bake the four JVM server images and reuse the frontend and actions.

This is the case with the most to gain. On this branch the frontend is roughly **92% of image build time** — 5.8 min of a 6.3 min full build — so skipping it is worth far more than any other narrowing. Backend-only PRs are also the most common kind.

## Expected

| check | expected |
| --- | --- |
| plan | `build` gms, upgrade, mae-consumer, mce-consumer; `reuse` frontend-react and actions |
| `image_build_modules` | `:metadata-service:war,:datahub-upgrade,:metadata-jobs:mae-consumer-job,:metadata-jobs:mce-consumer-job` |
| `base_build` | no `:datahub-frontend:dockerPrepare`, no yarn build |
| `base_build` duration | meaningfully under the ~6.3 min full build |
| resolved images | four on `pr<N>-<sha>`, `datahub-frontend-react:quickstart`, `datahub-actions:quickstart-slim` |
| pytest + Java integration | green |

## Why reusing the frontend here is sound

GraphQL executes in GMS — `datahub-graphql-core` is a dependency of `metadata-service/factories`, not of the frontend, which proxies. The two ship as independently versioned images and run mixed through any rolling upgrade, so a newer GMS serving an older frontend is a normal supported combination rather than an untested one.

The genuine build-time coupling is narrower and is still honoured: `datahub-web-react/codegen.yml` reads `../datahub-graphql-core/src/main/resources/*.graphql`, so a **schema** change rebuilds the frontend. Resolver code in that same project does not. `metadata-models/**` still rebuilds everything, since the frontend compiles the restli data templates generated from PDL.

## Companion PRs

- #18984 — nothing rebuilt (`smoke-test/**`)
- #18985 — frontend only (`datahub-web-react/**`)
- #18989 — actions only (`metadata-ingestion/**`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate server-only image builds in CI by adding a single Javadoc to `metadata-io` (`ConsumerGroupLagSnapshot.java`). Only JVM server images should rebuild; frontend and actions should be reused.

- **Expected CI behavior**
  - Build `:metadata-service:war`, `:datahub-upgrade`, `:metadata-jobs:mae-consumer-job`, `:metadata-jobs:mce-consumer-job`.
  - Reuse `datahub-frontend-react:quickstart` and `datahub-actions:quickstart-slim`.
  - Skip `:datahub-frontend:dockerPrepare` and Yarn build.
  - Pytest and Java integration tests pass.

<sup>Written for commit 113c9144a3c8be1f668d46281d22652497ac9213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

