### PR TITLE
fix(looker): parse JSON array query.fields and use -NULL filter syntax

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -7,6 +7,7 @@ import concurrent
 import concurrent.futures
 import dataclasses
 import datetime
+import json as json_module
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -52,9 +53,6 @@ from datahub.utilities.lossy_collections import LossySet
 
 logger = logging.getLogger(__name__)
 
-# System Activity returns `query.fields` as a single string joining
-# the referenced `view.field` names.  Looker has used both comma and
-# newline separators across versions, so we split on either.
 _QUERY_FIELDS_SPLIT_RE = re.compile(r"[,\n]")
 
 
@@ -120,6 +118,8 @@ class StatGeneratorConfig:
 
 
 # QueryId and query_collection helps to return dummy responses in test cases
+# Filter syntax reference: https://docs.cloud.google.com/looker/docs/filter-expressions
+# String fields use "-NULL" for is-not-null; numeric fields use "NOT NULL".
 class QueryId(StrEnum):
     DASHBOARD_PER_DAY_USAGE_STAT = "counts_per_day_per_dashboard"
     DASHBOARD_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_dashboard"
@@ -186,7 +186,7 @@ query_collection: Dict[QueryId, LookerQuery] = {
             QueryViewField.QUERY_VIEW,
         ],
         filters={
-            QueryViewField.QUERY_VIEW: "NOT NULL",
+            QueryViewField.QUERY_VIEW: "-NULL",
         },
     ),
     QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: LookerQuery(
@@ -200,7 +200,7 @@ query_collection: Dict[QueryId, LookerQuery] = {
             UserViewField.USER_ID,
         ],
         filters={
-            QueryViewField.QUERY_VIEW: "NOT NULL",
+            QueryViewField.QUERY_VIEW: "-NULL",
         },
     ),
     # Kept separate from the per-day explore query: adding query.fields would
@@ -217,8 +217,8 @@ query_collection: Dict[QueryId, LookerQuery] = {
             QueryViewField.QUERY_FIELDS,
         ],
         filters={
-            QueryViewField.QUERY_VIEW: "NOT NULL",
-            QueryViewField.QUERY_FIELDS: "NOT NULL",
+            QueryViewField.QUERY_VIEW: "-NULL",
+            QueryViewField.QUERY_FIELDS: "-NULL",
         },
     ),
 }
@@ -822,7 +822,18 @@ class ExploreStatGenerator(BaseStatGenerator):
 
     @staticmethod
     def _parse_query_fields(raw_fields: object) -> List[str]:
-        if isinstance(raw_fields, (list, tuple)):
+        # The Looker Query API model defines fields as Sequence[str].
+        # System Activity serialises it into a JSON array string
+        # (e.g. '["view.field", ...]') when returned as a dimension value.
+        if isinstance(raw_fields, str):
+            try:
+                parsed = json_module.loads(raw_fields)
+                if isinstance(parsed, list):
+                    return [str(t).strip() for t in parsed if str(t).strip()]
+            except (json_module.JSONDecodeError, ValueError):
+                pass
+            tokens = _QUERY_FIELDS_SPLIT_RE.split(raw_fields)
+        elif isinstance(raw_fields, list):
             tokens = [str(t) for t in raw_fields]
         else:
             tokens = _QUERY_FIELDS_SPLIT_RE.split(str(raw_fields))

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -182,9 +182,9 @@ def test_parse_query_fields_handles_delimiters_and_blanks():
         "orders.state",
     ]
     assert parse("") == []
-    # Some Looker versions / result formats return a JSON array instead of a
-    # delimited string; the parser must handle both.
-    assert parse(["orders.count", "orders.created_date"]) == [
+    # System Activity serialises the Query model's fields (Sequence[str])
+    # into a JSON array string when returned as a dimension value.
+    assert parse('["orders.count","orders.created_date"]') == [
         "orders.count",
         "orders.created_date",
     ]
@@ -242,7 +242,6 @@ def test_explore_stat_generator_skips_unresolved_users():
     ]
 
     mock_api = mock.MagicMock()
-    # entity query, per-field query, per-user query — all after the first are empty.
     mock_api.execute_query.side_effect = [entity_rows, [], user_rows]
 
     def fake_user(user_id: int) -> mock.MagicMock:
@@ -300,7 +299,6 @@ def test_explore_stat_generator_reports_non_ingested_explore_as_skipped():
     ]
 
     mock_api = mock.MagicMock()
-    # entity query, per-field query, per-user query — all after the first are empty.
     mock_api.execute_query.side_effect = [entity_rows, [], []]
 
     report = LookerDashboardSourceReport()


### PR DESCRIPTION
## Summary

Fix explore usage returning 0 results on production Looker instances, and fix `query.fields` parsing for the `fieldCounts` feature (#18955).

## Motivation

Running a local ingestion test with a file sink after #18955 merged showed `fieldCounts` was always empty. Investigating production ingestion logs revealed the root cause affects all explore usage — not just `fieldCounts`: the `query.view` and `query.fields` filters used `NOT NULL`, which is Looker's [numeric filter syntax](https://docs.cloud.google.com/looker/docs/filter-expressions). For string fields, the correct syntax is `-NULL`. The `NOT NULL` filter silently returned 0 rows, causing all three explore queries (per-day, per-field, per-user) to produce nothing.

Additionally, `query.fields` arrives from System Activity as a JSON array string (e.g. `'["orders.count","orders.created_date"]'`), matching the Looker `Query` model's `Sequence[str]` type — not the comma-delimited format the parser expected.

Related PR: #18955

## Changes Overview

**Bug Fixes:**
- **Filter syntax**: Changed `query.view` and `query.fields` null-exclusion filters from `NOT NULL` to `-NULL` per [Looker's filter expression docs](https://docs.cloud.google.com/looker/docs/filter-expressions) — `NOT NULL` is valid for numeric fields only, `-NULL` is the string field equivalent. This was the root cause of 0 explore usage on production instances. Note: `look.id` filters retain `NOT NULL` since `look.id` is a numeric field.
- **JSON array parsing**: `query.fields` from System Activity arrives as a serialised JSON array string per the Looker `Query` model's `Sequence[str]` contract. The parser now tries `json.loads` first and falls back to regex splitting for non-JSON values.

## Testing

- Unit tests extended with JSON array string input
- All 7 unit tests pass
- **Local ingestion**: Ran against a Looker instance with file sink — 67 explore usage MCPs across 10 explores, all with `fieldCounts` populated
- **SDK verification**: Directly compared `NOT NULL` vs `-NULL` against the Looker API — `NOT NULL` returned 0 rows for string fields, `-NULL` returned correct results
- **Production validation**: Re-ran ingestion on a production Looker instance (4.9M System Activity history rows). Before: 0 `datasetUsageStatistics` MCPs. After: 4,915 explore usage MCPs with 577 containing `fieldCounts`

## Impact Assessment

- **Affected Components:** Looker source connector (`looker_usage.py`)
- **Breaking Changes:** None — this fixes explore usage that was silently producing 0 results
- **Risk Level:** Low — filter syntax change per Looker documentation, additive parsing logic with fallback

## References

- Looker filter expressions: https://docs.cloud.google.com/looker/docs/filter-expressions
- Related PR: #18955

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issue: #18955
- [x] Tests added/updated
- [x] Docs added/updated: N/A