### PR TITLE
fix(agent-context): require a minimum acryl-datahub rather than an exact pin

### DIFF
--- a/datahub-agent-context/setup.py
+++ b/datahub-agent-context/setup.py
@@ -22,12 +22,14 @@ with open("./src/datahub_agent_context/_version.py") as fp:
 
 _version: str = package_metadata["__version__"]
 
-# Pin acryl-datahub to a known-good stable release (see __acryl_datahub_pin__ in
+# Require a known-good minimum acryl-datahub (see __acryl_datahub_pin__ in
 # _version.py) for published wheels instead of self-pinning to this package's own
-# server-derived version. During local/dev builds the pin is omitted so the
-# editable acryl-datahub from this monorepo resolves.
+# server-derived version. This is a lower bound rather than an exact pin, so the
+# published wheel can be installed alongside projects that pin a different
+# acryl-datahub. During local/dev builds the bound is omitted so the editable
+# acryl-datahub from this monorepo resolves.
 _datahub_pin = (
-    f"=={package_metadata['__acryl_datahub_pin__']}"
+    f">={package_metadata['__acryl_datahub_pin__']}"
     if not (_version.endswith(("dev0", "dev1")) or "docker" in _version)
     else ""
 )

--- a/datahub-agent-context/src/datahub_agent_context/_version.py
+++ b/datahub-agent-context/src/datahub_agent_context/_version.py
@@ -14,9 +14,10 @@
 
 __package_name__ = "datahub-agent-context"
 __version__ = "0.1.0.dev0"
-# Stable acryl-datahub release this package is built and tested against. The CLI
+# Minimum acryl-datahub release this package is built and tested against. The CLI
 # version is borrowed from the server version and does not follow semantic
-# versioning, so we pin a known-good stable release rather than self-pinning to
-# this package's own (server-derived) version. Bump explicitly when newer CLI
-# functionality is required.
-__acryl_datahub_pin__ = "1.6.0.6"
+# versioning, so we set a known-good floor rather than self-pinning to this
+# package's own (server-derived) version. Raise explicitly when newer CLI
+# functionality is required: _registration_core imports datahub.api.entities.agent,
+# which is absent through 1.6.0.17 and first ships in 1.7.0.
+__acryl_datahub_pin__ = "1.7.0"


### PR DESCRIPTION
`datahub-agent-context` pins `acryl-datahub[datahub-rest]==1.6.0.6` through
`__acryl_datahub_pin__` in `_version.py`. That value has not moved since #18085
introduced it, while the package itself has released through 1.7.0.

The exact pin has two effects.

**1. The published wheel cannot be installed alongside any project that pins a
different `acryl-datahub`.** Both resolvers refuse it:

```
ERROR: ResolutionImpossible                       # pip
your project's requirements are unsatisfiable     # uv
```

Confirmed from the PyPI metadata of `datahub-agent-context` 1.7.0, which declares
`acryl-datahub[datahub-rest]==1.6.0.6`, rather than from resolver error text
alone.

**2. It contradicts the package's own imports.** `_registration_core.py` at
`v1.7.0` imports `datahub.api.entities.agent`. That module is absent from the
pinned release:

| acryl-datahub | `datahub/api/entities/agent` |
| --- | --- |
| 1.6.0.6 (currently pinned) | absent |
| 1.6.0.15 | absent |
| 1.6.0.16 | absent |
| 1.6.0.17 | absent |
| 1.7.0 | present |

This is the failure reported in #18686. That issue checked 1.6.0.6 and 1.6.0.15
and concluded the registration core was "ahead of any published acryl-datahub",
which was accurate when it was filed. 1.7.0 has since shipped the module, so the
gap is now closable by the bound alone. Presence at 1.7.0 was verified inside the
published wheel `acryl_datahub-1.7.0-py3-none-any.whl`, not only at the git tag.

### Why a lower bound rather than a raised pin

#18686 asks for the pinned value to be raised. That resolves the import and
leaves the first effect in place, because `==` still excludes every other
version, including the version-matched one. `>=1.7.0` resolves both.

The `==` prefix is constructed in `setup.py` rather than stored in the constant,
so the operator changes there and `__acryl_datahub_pin__` stays a bare version.
Dev and docker builds still omit the bound entirely, so that path is unchanged.

The existing comments described the value as an exact pin, so they are updated to
match; that is the rest of the diff.

### Scope

I verified that `datahub.api.entities.agent` is present in the published 1.7.0
wheel. I have not exercised `datahub-agent-context` against `acryl-datahub` 1.7.0
at runtime, so I am not asserting runtime compatibility beyond the import that
#18686 reports.

No upper bound is proposed, since the CLI version is server-derived and does not
follow semver, as the existing comment notes. If you want one, that call is
better made by someone with the release policy in view.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a minimum `acryl-datahub[datahub-rest] >= 1.7.0` for `datahub-agent-context` instead of an exact pin. This removes resolver conflicts and fixes the missing `datahub.api.entities.agent` import.

- **Dependencies**
  - Switched requirement in `setup.py` from `==` to `>=`; dev/Docker builds still omit the bound.
  - Updated `__acryl_datahub_pin__` from `1.6.0.6` to `1.7.0`.

<sup>Written for commit 35c3f61f1cc878cfd3c497110946b6a862d0dc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

