### PR TITLE
perf(ci): run only the touched smoke tests when a PR changes nothing else

### DIFF
--- a/.github/scripts/resolve_smoke_test_filter.sh
+++ b/.github/scripts/resolve_smoke_test_filter.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# When a pull request touches nothing but smoke test modules, run just those
+# modules instead of the whole suite.
+#
+# Writes one GitHub output:
+#
+#   smoke_test_modules  Newline-separated test module paths to run. Empty means
+#                       run everything, which is the default for anything this
+#                       script is not certain about.
+#
+# Scope is deliberately narrow. A feature PR that also adds or edits smoke tests
+# still runs the full battery -- that is the case where regressions matter and
+# where the changed product code is what needs covering. This only fires when
+# the diff is smoke tests and nothing else, which is the case where running 7
+# batches of unrelated tests buys nothing.
+#
+# The tradeoff, stated plainly: smoke tests share one live DataHub instance, so
+# running a subset means a test that leaks state (ingested entities it does not
+# delete, a policy it does not restore) will not be caught by its neighbours
+# here. Master runs the full suite on every merge, so it is caught there. The
+# first line of defence is the isolation rules in smoke-test/CLAUDE.md and
+# review enforcing them.
+
+set -euo pipefail
+
+# Shared machinery rather than a leaf test: conftest.py, tests/utils.py,
+# tests/utilities/**, fixture JSON, requirements, the runner scripts. A change
+# to any of these can alter the behaviour of tests it does not name, so the
+# subset is no longer knowable and the full suite runs.
+is_test_module() {
+  local path="$1" base
+  base="${path##*/}"
+  [[ "${base}" == conftest.py ]] && return 1
+  [[ "${base}" == test_*.py || "${base}" == *_test.py ]]
+}
+
+modules=()
+filter=1
+
+while IFS= read -r path; do
+  [[ -n "${path}" ]] || continue
+  # Anything outside smoke-test/ means product code changed: run the full suite.
+  if [[ "${path}" != smoke-test/* ]] || ! is_test_module "${path}"; then
+    filter=0
+    break
+  fi
+  # conftest.py collects against paths relative to the smoke-test directory.
+  modules+=("${path#smoke-test/}")
+done < <(jq -r '.[]?' <<<"${CHANGED_FILES:-[]}" 2>/dev/null)
+
+# No files at all means the list never arrived; run everything.
+if ((${#modules[@]} == 0)); then
+  filter=0
+fi
+
+{
+  echo "smoke_test_modules<<SMOKE_TEST_MODULES_EOF"
+  if ((filter)); then
+    printf '%s\n' "${modules[@]}"
+  fi
+  echo "SMOKE_TEST_MODULES_EOF"
+} >>"${GITHUB_OUTPUT}"
+
+if ((filter)); then
+  echo "Smoke-test-only diff: running ${#modules[@]} touched module(s) instead of the full suite"
+  printf '  %s\n' "${modules[@]}"
+  {
+    echo "## Smoke test filter"
+    echo ""
+    echo "Diff touches smoke tests only, so the suite is narrowed to:"
+    echo ""
+    printf -- "-  \`%s\`\n" "${modules[@]}"
+  } >>"${GITHUB_STEP_SUMMARY}"
+else
+  echo "Running the full smoke test suite"
+fi

--- a/.github/scripts/test_resolve_smoke_test_filter.sh
+++ b/.github/scripts/test_resolve_smoke_test_filter.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Scenario table for resolve_smoke_test_filter.sh.
+#
+# The risk this guards is one-directional: narrowing the suite when the diff
+# reaches beyond smoke tests, or when it touches shared machinery whose blast
+# radius is not knowable from the path. Every case below that expects "" is
+# asserting the full suite still runs.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="${SCRIPT_DIR}/resolve_smoke_test_filter.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+passed=0
+failed=0
+
+# check <name> <expected modules, comma separated> <changed files json>
+check() {
+  local name="$1" expected="$2" changed="$3"
+  local out="${WORK_DIR}/out" summary="${WORK_DIR}/summary"
+  : >"${out}"
+  : >"${summary}"
+
+  GITHUB_OUTPUT="${out}" GITHUB_STEP_SUMMARY="${summary}" \
+    CHANGED_FILES="${changed}" "${UNDER_TEST}" >/dev/null 2>&1
+
+  local actual
+  actual=$(sed -n '/^smoke_test_modules<</,/^SMOKE_TEST_MODULES_EOF$/p' "${out}" |
+    sed '1d;$d' | paste -sd, -)
+
+  if [[ "${actual}" == "${expected}" ]]; then
+    passed=$((passed + 1))
+    printf '  ok    %s\n' "${name}"
+    return
+  fi
+  failed=$((failed + 1))
+  printf '  FAIL  %s\n        expected: %s\n        actual:   %s\n' \
+    "${name}" "${expected:-<full suite>}" "${actual:-<full suite>}"
+}
+
+echo "narrows to the touched modules"
+check "one modified test" "tests/policies/test_policies.py" \
+  '["smoke-test/tests/policies/test_policies.py"]'
+check "two modified tests" "tests/a/test_one.py,tests/b/two_test.py" \
+  '["smoke-test/tests/a/test_one.py","smoke-test/tests/b/two_test.py"]'
+check "test at the smoke-test root" "test_system_info.py" \
+  '["smoke-test/test_system_info.py"]'
+
+echo "runs the full suite when product code is involved"
+check "feature PR that also edits a test" "" \
+  '["metadata-io/src/main/java/A.java","smoke-test/tests/a/test_one.py"]'
+check "frontend PR that also edits a test" "" \
+  '["datahub-web-react/src/App.tsx","smoke-test/tests/a/test_one.py"]'
+check "ingestion change alone" "" \
+  '["metadata-ingestion/src/datahub/x.py"]'
+
+echo "runs the full suite for shared smoke-test machinery"
+check "root conftest" "" '["smoke-test/conftest.py"]'
+check "nested conftest" "" '["smoke-test/tests/cypress/conftest.py"]'
+check "tests/utils.py" "" '["smoke-test/tests/utils.py"]'
+check "tests/utilities" "" '["smoke-test/tests/utilities/concurrent_test_runner.py"]'
+check "consistency_utils" "" '["smoke-test/tests/consistency_utils.py"]'
+check "a feature helper module" "" '["smoke-test/tests/knowledge/document_helpers.py"]'
+check "fixture json" "" '["smoke-test/tests/policies/data.json"]'
+check "requirements" "" '["smoke-test/requirements.txt"]'
+check "the runner script" "" '["smoke-test/smoke.sh"]'
+check "one test plus one helper" "" \
+  '["smoke-test/tests/a/test_one.py","smoke-test/tests/utils.py"]'
+
+echo "fails safe"
+check "empty list" "" '[]'
+check "unreadable list" "" 'not-json'
+
+echo
+echo "${passed} passed, ${failed} failed"
+[[ "${failed}" -eq 0 ]]

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -25,6 +25,7 @@ on:
       - ".github/scripts/send_failed_tests_to_posthog.py"
       - ".github/scripts/docker_helpers.sh"
       - ".github/scripts/resolve_image_builds.sh"
+      - ".github/scripts/resolve_smoke_test_filter.sh"
       - ".github/scripts/test_resolve_image_builds.sh"
       - ".github/actions/ci-optimization"
       - ".github/actions/restore-dependency-caches"
@@ -45,6 +46,7 @@ on:
       - ".github/scripts/send_failed_tests_to_posthog.py"
       - ".github/scripts/docker_helpers.sh"
       - ".github/scripts/resolve_image_builds.sh"
+      - ".github/scripts/resolve_smoke_test_filter.sh"
       - ".github/scripts/test_resolve_image_builds.sh"
       - ".github/actions/ci-optimization"
       - ".github/actions/restore-dependency-caches"
@@ -132,6 +134,9 @@ jobs:
       # Docker repos baked for this run. run-quickstart.sh fails if any of them
       # resolves to the reused tag instead of this PR's.
       image_built_repos: ${{ steps.image-build-plan.outputs.image_built_repos }}
+      # Test modules to run when the diff is smoke tests and nothing else.
+      # Empty means the full suite.
+      smoke_test_modules: ${{ steps.smoke-test-filter.outputs.smoke_test_modules }}
     steps:
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
@@ -217,7 +222,15 @@ jobs:
       # ~1s, and it is the only thing that notices when the path classification
       # in resolve_image_builds.sh drifts out of sync with the repo layout.
       - name: Test the image build decision
-        run: .github/scripts/test_resolve_image_builds.sh
+        run: |
+          .github/scripts/test_resolve_image_builds.sh
+          .github/scripts/test_resolve_smoke_test_filter.sh
+
+      - name: Resolve the smoke test filter
+        id: smoke-test-filter
+        env:
+          CHANGED_FILES: ${{ steps.ci-optimize.outputs.changed-files }}
+        run: .github/scripts/resolve_smoke_test_filter.sh
 
       - name: Resolve which images to build
         id: image-build-plan
@@ -511,13 +524,19 @@ jobs:
     needs: setup
     outputs:
       pytest_matrix: ${{ steps.set-matrix.outputs.pytest_matrix }}
+    env:
+      SMOKE_TEST_MODULES: ${{ needs.setup.outputs.smoke_test_modules }}
     steps:
       - id: set-batch-count
         # Tests are split simply to ensure the configured number of batches for parallelization. This may need some
         # increase as a new tests added increase the duration where an additional parallel batch helps.
         # python_batch_count is used to split pytests in the smoke-test (batches of actual test functions)
         run: |
-          if [[ "${{ env.IS_FORK }}" == "true" ]]; then
+          if [[ -n "$SMOKE_TEST_MODULES" ]]; then
+            # A filtered run bypasses conftest's batching entirely, so extra
+            # batches would each re-run the same narrowed set.
+            echo "python_batch_count=1" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ env.IS_FORK }}" == "true" ]]; then
             echo "python_batch_count=3" >> "$GITHUB_OUTPUT"
           else
             echo "python_batch_count=7" >> "$GITHUB_OUTPUT"
@@ -888,6 +907,18 @@ jobs:
         if: steps.retry-check.outputs.parse_result != 'all_passed'
         run: ./gradlew :metadata-ingestion:install
 
+      - name: Write the smoke test filter
+        id: smoke-filter-file
+        if: ${{ steps.retry-check.outputs.parse_result != 'all_passed' && needs.setup.outputs.smoke_test_modules != '' }}
+        env:
+          SMOKE_TEST_MODULES: ${{ needs.setup.outputs.smoke_test_modules }}
+        run: |
+          path="${GITHUB_WORKSPACE}/smoke-test-filter.txt"
+          printf '%s' "$SMOKE_TEST_MODULES" > "$path"
+          echo "Narrowing the suite to:"
+          cat "$path"
+          echo "path=${path}" >> "$GITHUB_OUTPUT"
+
       - name: Pytest smoke tests
         if: steps.retry-check.outputs.parse_result != 'all_passed'
         env:
@@ -902,7 +933,10 @@ jobs:
           # (see run-quickstart.sh), so the trailing post-wait sleep can match.
           # The library default stays conservative for other environments.
           ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: "1"
-          FILTERED_TESTS: ${{ steps.retry-check.outputs.filtered_tests_file || '' }}
+          # A retry's failed-module list wins: it is a subset of whatever this
+          # run was already scoped to. Otherwise fall back to the smoke-test
+          # filter, which is empty for anything but a smoke-test-only diff.
+          FILTERED_TESTS: ${{ steps.retry-check.outputs.filtered_tests_file || steps.smoke-filter-file.outputs.path || '' }}
           # On a retry, fall back to the conservative aggregate-lag wait. It is
           # the wrong default (under full concurrent load the lag may never
           # reach zero) but the right choice here: a retry runs a smaller

--- a/smoke-test/CLAUDE.MD
+++ b/smoke-test/CLAUDE.MD
@@ -7,6 +7,35 @@
     - should not depend on the order in which they run
     - should not depend on another test doing their cleanup
 
+### Isolation is enforced by review, not by CI
+
+**A PR that touches only smoke tests runs only the modules it changed** — CI narrows
+the suite instead of running all seven batches (see
+`.github/scripts/resolve_smoke_test_filter.sh`). Any other PR runs the full battery.
+
+These tests share one live DataHub instance, so a module that leaks state is normally
+caught by whichever unrelated test trips over it. On a narrowed run there are no
+neighbours to trip. Master still runs everything on merge, so the leak is caught —
+but on master, by someone else, after your PR is in.
+
+So treat these as hard requirements when writing or reviewing a smoke test:
+
+- **Delete every entity you create**, in a fixture teardown that runs even when the
+  test fails. `_ingest_cleanup_data_impl` and `delete_urns_from_file` exist for this.
+- **Restore any global state you mutate** — policies, settings, feature flags,
+  ownership on shared fixtures. Mutating a policy without restoring it is the single
+  most common way to break unrelated tests.
+- **Never assert on global counts** (`total == N`, "the list has 12 entries"). Another
+  test creating an entity concurrently invalidates it. Assert on your own URNs.
+- **Generate unique identifiers per run** rather than reusing a fixed name, so two
+  tests — or two concurrent workers — cannot collide.
+- **Do not rely on a prior test having set something up.** If you need it, create it.
+
+If a change cannot satisfy these, put the shared setup in a fixture rather than
+leaving the coupling implicit. A change to `conftest.py`, `tests/utils.py`,
+`tests/utilities/**`, or any non-test module under `smoke-test/` correctly forces the
+full suite, because its blast radius is not knowable from the path alone.
+
 ## Logging
 
 **IMPORTANT: Use logger.info() instead of print() in all test files**


### PR DESCRIPTION
Stacked on #18983, which introduces the `changed-files` output this depends on.

## Problem

A PR that edits one smoke test runs all seven batches of the full suite. On a measured run that is ~19 min of tests behind a stack boot, none of which exercises the change.

## Approach

`conftest.py` already supports this. `FILTERED_TESTS` points at a file of module paths, filters collected items to those modules, and bypasses batching. It was built for the retry path but nothing about it is retry-specific.

So this adds the decision, reuses the plumbing, and collapses the matrix to one batch — otherwise all seven batches would each re-run the same narrowed set.

## Scope

Deliberately narrow, because the common case should not be narrowed:

| diff | suite |
| --- | --- |
| smoke tests only | just the touched modules |
| feature code **+** smoke tests | full battery |
| anything else | full battery |

A feature PR that also adds or edits smoke tests runs everything — that is the case where regressions matter and where changed product code is what needs covering.

Any change to shared machinery also falls back to the full suite, since its blast radius is not knowable from the path: `conftest.py` (all four), `tests/utils.py`, `tests/consistency_utils.py`, `tests/utilities/**`, feature helper modules, fixture JSON, `requirements.txt`, the runner scripts. The rule is "filter only if every changed path is a test module", so this holds by construction rather than by an exclusion list that can rot.

## The tradeoff, stated plainly

These tests share one live DataHub instance. A module that leaks state — entities it does not delete, a policy it does not restore — is normally caught by whichever unrelated test trips over it. **On a narrowed run there are no neighbours to trip.** Master runs the full suite on every merge, so the leak is still caught, but later and by someone else.

That risk is accepted deliberately and pushed onto review. `smoke-test/CLAUDE.md` now spells out the isolation rules as hard requirements: delete what you create in teardown that survives failure, restore global state you mutate, never assert on global counts, generate unique identifiers, never depend on another test's setup.

This is a different risk profile from #18983, which is signal-neutral by construction — same binaries, same tests. Hence a separate PR.

## Tests

`.github/scripts/test_resolve_smoke_test_filter.sh` — 18 cases, run in CI on every PR alongside the image-plan table. Every case expecting the full suite is asserting that narrowing does *not* happen: product code present, shared machinery touched, empty or unreadable file list.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [x] Docs updated (`smoke-test/CLAUDE.md` isolation rules)
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run only the touched smoke test modules when a PR changes smoke tests and nothing else. This cuts CI time while keeping full coverage for all other changes.

- **New Features**
  - Added `.github/scripts/resolve_smoke_test_filter.sh` to narrow the suite only when every changed path is a smoke test module; changes to product code or shared machinery (`conftest.py`, `tests/utils.py`, `tests/utilities/**`, non-test files) run the full suite.
  - Integrated into `.github/workflows/docker-unified.yml`: resolves modules from `changed-files`, sets `python_batch_count` to 1 for filtered runs, writes the filter file, and feeds it to `FILTERED_TESTS` (retry’s failed-module list still wins).
  - Added `.github/scripts/test_resolve_smoke_test_filter.sh` (18 cases) and run it in CI to validate narrowing and safe fallbacks.
  - Updated `smoke-test/CLAUDE.md` with strict isolation rules to mitigate subset-run risks.

<sup>Written for commit cefdce3ed2e609e3e03fb98ced20ac0e350455d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

