### PR TITLE
fix(search): log restricted cluster-info access at WARN instead of ERROR

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/SearchClientShimUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/SearchClientShimUtil.java
@@ -453,7 +453,10 @@ public class SearchClientShimUtil {
 
     // Create a new config with the detected engine type
     ShimConfiguration detectedConfig =
-        new ShimConfigurationBuilder(config).withEngineType(detectedType).build();
+        new ShimConfigurationBuilder(config)
+            .withEngineType(detectedType)
+            .withEngineTypeAutoDetected(true)
+            .build();
 
     return createShim(detectedConfig, objectMapper);
   }
@@ -477,6 +480,7 @@ public class SearchClientShimUtil {
       ShimConfiguration testConfig =
           new ShimConfigurationBuilder(config)
               .withEngineType(SearchEngineType.OPENSEARCH_2)
+              .withEngineTypeAutoDetected(true)
               .build();
 
       try (SearchClientShim<?> testShim = new OpenSearch2SearchClientShim(testConfig)) {
@@ -498,6 +502,7 @@ public class SearchClientShimUtil {
       ShimConfiguration testConfig =
           new ShimConfigurationBuilder(config)
               .withEngineType(SearchEngineType.ELASTICSEARCH_7)
+              .withEngineTypeAutoDetected(true)
               .build();
 
       try (SearchClientShim<?> testShim = new Es7CompatibilitySearchClientShim(testConfig)) {
@@ -519,6 +524,7 @@ public class SearchClientShimUtil {
       ShimConfiguration testConfig =
           new ShimConfigurationBuilder(config)
               .withEngineType(SearchEngineType.ELASTICSEARCH_8)
+              .withEngineTypeAutoDetected(true)
               .build();
 
       try (SearchClientShim<?> testShim = new Es8SearchClientShim(testConfig, objectMapper)) {
@@ -567,6 +573,7 @@ public class SearchClientShimUtil {
     private Integer connectionRequestTimeout = 5000;
     private Integer socketTimeout = 30000;
     private SSLContext sSLContext;
+    private boolean engineTypeAutoDetected = false;
 
     public ShimConfigurationBuilder() {}
 
@@ -584,6 +591,7 @@ public class SearchClientShimUtil {
       this.connectionRequestTimeout = existing.getConnectionRequestTimeout();
       this.socketTimeout = existing.getSocketTimeout();
       this.sSLContext = existing.getSSLContext();
+      this.engineTypeAutoDetected = existing.isEngineTypeAutoDetected();
     }
 
     public ShimConfigurationBuilder withEngineType(SearchEngineType engineType) {
@@ -643,6 +651,11 @@ public class SearchClientShimUtil {
       return this;
     }
 
+    public ShimConfigurationBuilder withEngineTypeAutoDetected(boolean engineTypeAutoDetected) {
+      this.engineTypeAutoDetected = engineTypeAutoDetected;
+      return this;
+    }
+
     public ShimConfiguration build() {
       return new ShimConfigurationImpl(
           engineType,
@@ -657,7 +670,8 @@ public class SearchClientShimUtil {
           threadCount,
           connectionRequestTimeout,
           socketTimeout,
-          sSLContext);
+          sSLContext,
+          engineTypeAutoDetected);
     }
   }
 
@@ -677,6 +691,7 @@ public class SearchClientShimUtil {
     private final Integer connectionRequestTimeout;
     private final Integer socketTimeout;
     private final SSLContext sSLContext;
+    private final boolean engineTypeAutoDetected;
 
     public ShimConfigurationImpl(
         SearchEngineType engineType,
@@ -691,7 +706,8 @@ public class SearchClientShimUtil {
         Integer threadCount,
         Integer connectionRequestTimeout,
         Integer socketTimeout,
-        SSLContext sslContext) {
+        SSLContext sslContext,
+        boolean engineTypeAutoDetected) {
       this.engineType = engineType;
       this.host = host;
       this.port = port;
@@ -705,6 +721,7 @@ public class SearchClientShimUtil {
       this.connectionRequestTimeout = connectionRequestTimeout;
       this.socketTimeout = socketTimeout;
       this.sSLContext = sslContext;
+      this.engineTypeAutoDetected = engineTypeAutoDetected;
     }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
@@ -149,7 +149,12 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
 
   /** Package-private factory for tests; avoids spinning up a real OS connection. */
   static OpenSearch2SearchClientShim forTest(RestHighLevelClient client) {
-    return new OpenSearch2SearchClientShim(client, new ObjectMapper());
+    return new OpenSearch2SearchClientShim(client, new ObjectMapper(), null);
+  }
+
+  /** Package-private factory for tests that need a specific configuration. */
+  static OpenSearch2SearchClientShim forTest(RestHighLevelClient client, ShimConfiguration config) {
+    return new OpenSearch2SearchClientShim(client, new ObjectMapper(), config);
   }
 
   /** The version probe is only benign when the engine type did not have to be auto-detected. */
@@ -157,8 +162,9 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
     return shimConfiguration != null && shimConfiguration.isEngineTypeAutoDetected();
   }
 
-  private OpenSearch2SearchClientShim(RestHighLevelClient client, ObjectMapper objectMapper) {
-    this.shimConfiguration = null;
+  private OpenSearch2SearchClientShim(
+      RestHighLevelClient client, ObjectMapper objectMapper, ShimConfiguration config) {
+    this.shimConfiguration = config;
     this.engineType = SearchEngineType.OPENSEARCH_2;
     this.client = client;
     this.objectMapper = objectMapper;

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
@@ -51,6 +51,7 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.nio.reactor.IOReactorException;
 import org.apache.http.nio.reactor.IOReactorExceptionHandler;
 import org.apache.http.ssl.SSLContexts;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -113,6 +114,7 @@ import org.opensearch.client.indices.ResizeResponse;
 import org.opensearch.client.tasks.GetTaskRequest;
 import org.opensearch.client.tasks.GetTaskResponse;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.index.reindex.ReindexRequest;
@@ -148,6 +150,11 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
   /** Package-private factory for tests; avoids spinning up a real OS connection. */
   static OpenSearch2SearchClientShim forTest(RestHighLevelClient client) {
     return new OpenSearch2SearchClientShim(client, new ObjectMapper());
+  }
+
+  /** The version probe is only benign when the engine type did not have to be auto-detected. */
+  private boolean isEngineTypeAutoDetected() {
+    return shimConfiguration != null && shimConfiguration.isEngineTypeAutoDetected();
   }
 
   private OpenSearch2SearchClientShim(RestHighLevelClient client, ObjectMapper objectMapper) {
@@ -638,6 +645,20 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
       clusterInfo.put("engine_type", "opensearch");
 
       return clusterInfo;
+    } catch (OpenSearchStatusException e) {
+      if (e.status() == RestStatus.FORBIDDEN && !isEngineTypeAutoDetected()) {
+        // Restricted roles (e.g. AWS OpenSearch fine-grained access control without
+        // cluster:monitor/main) cannot call GET /. With an explicitly configured engine type,
+        // callers treat an unreadable version as indeterminate and proceed, so this is an
+        // expected condition in locked-down clusters, not an error. Under auto-detection the
+        // version is required to pick the engine type, so that case stays at ERROR.
+        log.warn(
+            "Cluster info API is restricted for this user (missing cluster:monitor/main?): {}",
+            e.getMessage());
+      } else {
+        log.error("Failed to get cluster info", e);
+      }
+      throw new IOException("Failed to retrieve cluster information", e);
     } catch (Exception e) {
       log.error("Failed to get cluster info", e);
       throw new IOException("Failed to retrieve cluster information", e);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShimClusterInfoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShimClusterInfoTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.metadata.search.elasticsearch.client.shim.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.linkedin.metadata.search.elasticsearch.client.shim.SearchClientShimUtil.ShimConfigurationBuilder;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim.ShimConfiguration;
+import java.io.IOException;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.core.rest.RestStatus;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+public class OpenSearch2SearchClientShimClusterInfoTest {
+
+  private static RestHighLevelClient mockClientReturningForbidden() throws IOException {
+    RestHighLevelClient mockClient = mock(RestHighLevelClient.class);
+    when(mockClient.info(any(RequestOptions.class)))
+        .thenThrow(
+            new OpenSearchStatusException(
+                "security_exception: no permissions for [cluster:monitor/main]",
+                RestStatus.FORBIDDEN));
+    return mockClient;
+  }
+
+  private static ListAppender<ILoggingEvent> captureShimLogs() {
+    Logger shimLogger = (Logger) LoggerFactory.getLogger(OpenSearch2SearchClientShim.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    shimLogger.addAppender(appender);
+    return appender;
+  }
+
+  private static boolean hasLog(ListAppender<ILoggingEvent> appender, Level level, String snippet) {
+    return appender.list.stream()
+        .anyMatch(
+            event -> event.getLevel() == level && event.getFormattedMessage().contains(snippet));
+  }
+
+  @Test
+  public void forbiddenClusterInfoLogsWarnWhenEngineTypeExplicit() throws Exception {
+    ShimConfiguration config = new ShimConfigurationBuilder().build();
+    assertFalse(config.isEngineTypeAutoDetected());
+    OpenSearch2SearchClientShim shim =
+        OpenSearch2SearchClientShim.forTest(mockClientReturningForbidden(), config);
+
+    ListAppender<ILoggingEvent> appender = captureShimLogs();
+    try {
+      expectThrows(IOException.class, shim::getClusterInfo);
+    } finally {
+      ((Logger) LoggerFactory.getLogger(OpenSearch2SearchClientShim.class))
+          .detachAppender(appender);
+    }
+    assertTrue(hasLog(appender, Level.WARN, "Cluster info API is restricted"));
+    assertFalse(hasLog(appender, Level.ERROR, "Failed to get cluster info"));
+  }
+
+  @Test
+  public void forbiddenClusterInfoLogsErrorWhenEngineTypeAutoDetected() throws Exception {
+    ShimConfiguration config =
+        new ShimConfigurationBuilder().withEngineTypeAutoDetected(true).build();
+    assertTrue(new ShimConfigurationBuilder(config).build().isEngineTypeAutoDetected());
+    OpenSearch2SearchClientShim shim =
+        OpenSearch2SearchClientShim.forTest(mockClientReturningForbidden(), config);
+
+    ListAppender<ILoggingEvent> appender = captureShimLogs();
+    try {
+      expectThrows(IOException.class, shim::getClusterInfo);
+    } finally {
+      ((Logger) LoggerFactory.getLogger(OpenSearch2SearchClientShim.class))
+          .detachAppender(appender);
+    }
+    assertTrue(hasLog(appender, Level.ERROR, "Failed to get cluster info"));
+    assertFalse(hasLog(appender, Level.WARN, "Cluster info API is restricted"));
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
@@ -155,6 +155,11 @@ public interface SearchClientShim<T> extends Closeable, IndexSettingsComparison 
     Integer getSocketTimeout();
 
     SSLContext getSSLContext();
+
+    /** Whether the engine type was auto-detected rather than explicitly configured. */
+    default boolean isEngineTypeAutoDetected() {
+      return false;
+    }
   }
 
   @OperationContextExempt(reason = "Local accessor, no I/O.")


### PR DESCRIPTION
## Summary

On AWS OpenSearch domains with fine-grained access control, application roles are commonly index-scoped and lack `cluster:monitor/main`. The cluster info call (`client.info()`, HTTP `GET /`) then returns a 403 `security_exception`, and `OpenSearch2SearchClientShim.getClusterInfo()` logged it at ERROR with a full stack trace even though callers handle the failure (the engine version is treated as indeterminate).

This change:

- Logs the FORBIDDEN case at WARN with a message pointing at the missing cluster permission, but only when the engine type is explicitly configured (the failure is expected and handled in that case).
- Keeps ERROR when the engine type is being auto-detected, because auto-detection requires the cluster info response to pick the engine implementation. `ShimConfiguration` now records whether the engine type was auto-detected (`isEngineTypeAutoDetected`, defaults to false).
- Keeps ERROR for all other failure types. Behavior is unchanged in all cases: the method still throws `IOException`.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly the PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (log-level-only change; behavior covered by existing tests)
- [ ] Docs added/updated (not needed)
- [ ] For any breaking change, entry added to `docs/how/updating-datahub.md` (not breaking)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log restricted OpenSearch cluster-info access at WARN instead of ERROR when the engine type is explicitly configured. Keep ERROR during engine auto-detection and for other failures.

- **Bug Fixes**
  - Log `403 FORBIDDEN` from GET `/` at WARN with a hint about missing `cluster:monitor/main` when the engine type is set explicitly.
  - Add `isEngineTypeAutoDetected` to `ShimConfiguration`; set it in the builder and detection flow to distinguish cases. Keep ERROR for auto-detection and non-403 errors; still throws `IOException`.
  - Add tests to verify WARN vs ERROR behavior and that `getClusterInfo` still throws `IOException` in both cases.

<sup>Written for commit de585871a31186f333d27eed5978a5ec78126dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

