### PR TITLE
fix(ingest/sql): don't inject max_overflow for non-QueuePool dialects

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -22,7 +22,9 @@ import sqlalchemy.dialects.postgresql.base
 from sqlalchemy import create_engine, inspect, log as sqlalchemy_log
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.row import LegacyRow
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import sqltypes as types
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
@@ -366,11 +368,34 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
         self.aggregator = self._create_aggregator()
         self.report.sql_aggregator = self.aggregator.report
 
+    @staticmethod
+    def _uses_queue_pool(sql_config: SQLCommonConfig) -> bool:
+        """Whether this connection will be pooled by a QueuePool.
+
+        `max_overflow` is a QueuePool-only sizing option. SQLAlchemy raises
+        TypeError rather than ignoring it when the dialect resolves to any other
+        pool, so injecting it unconditionally makes ingestion fail outright for
+        those dialects. SQLite is the common case: file URLs resolve to
+        NullPool and in-memory ones to SingletonThreadPool, so simply enabling
+        profiling turns a working recipe into a hard failure that produces zero
+        events.
+
+        Returns True on any uncertainty — an unregistered dialect raises
+        NoSuchModuleError from get_dialect() — so this can only ever withhold an
+        option that would have raised, never one that worked.
+        """
+        try:
+            url = make_url(sql_config.get_sql_alchemy_url())
+            return issubclass(url.get_dialect().get_pool_class(url), QueuePool)
+        except Exception:  # noqa: BLE001 - any failure must fall back to the old behaviour
+            return True
+
     def _add_default_options(self, sql_config: SQLCommonConfig) -> None:
         """Add default SQLAlchemy options. Can be overridden by subclasses to add additional defaults."""
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if sql_config.is_profiling_enabled():
+        # Only for dialects that actually use a QueuePool; see _uses_queue_pool.
+        if sql_config.is_profiling_enabled() and self._uses_queue_pool(sql_config):
             sql_config.options.setdefault(
                 "max_overflow", sql_config.profiling.max_workers
             )

--- a/metadata-ingestion/tests/unit/test_sql_common.py
+++ b/metadata-ingestion/tests/unit/test_sql_common.py
@@ -264,3 +264,69 @@ def test_fine_grained_lineages(
 
     assert actual_downstream == expected_simplified_downstream
     assert actual_upstream == expected_simplified_upstream
+
+
+class _PoolTestConfig(SQLCommonConfig):
+    """Minimal config whose SQLAlchemy URL is settable per test."""
+
+    uri: str = "mysql+pymysql://user:pass@localhost:5330"
+
+    def get_sql_alchemy_url(self):
+        return self.uri
+
+
+class _PoolTestSource(SQLAlchemySource):
+    def __init__(self, config, ctx):
+        super().__init__(config, ctx, "test")
+
+    def get_platform_instance_id(self) -> str:
+        return "test_instance"
+
+
+def _source(uri: str, profiling: bool) -> _PoolTestSource:
+    config = _PoolTestConfig(uri=uri)
+    config.profiling.enabled = profiling
+    with mock.patch.object(SQLAlchemySource, "get_inspectors", return_value=[]):
+        return _PoolTestSource(config, PipelineContext(run_id="test"))
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "sqlite:///tmp/test.db",  # -> NullPool
+        "sqlite://",  # -> SingletonThreadPool
+    ],
+)
+def test_max_overflow_is_not_injected_for_non_queue_pool_dialects(uri: str) -> None:
+    """`max_overflow` is a QueuePool-only option and SQLAlchemy raises TypeError
+    rather than ignoring it, so injecting it unconditionally made *enabling
+    profiling* turn a working SQLite recipe into a hard failure producing zero
+    events:
+
+        TypeError: Invalid argument(s) 'max_overflow' sent to create_engine(),
+        using configuration SQLiteDialect_pysqlite/NullPool/Engine.
+    """
+    source = _source(uri, profiling=True)
+    source._add_default_options(source.config)
+    assert "max_overflow" not in source.config.options
+
+
+def test_max_overflow_is_still_injected_for_queue_pool_dialects() -> None:
+    """The pooling behaviour this option exists for must be unchanged."""
+    source = _source("mysql+pymysql://user:pass@localhost:5330", profiling=True)
+    source._add_default_options(source.config)
+    assert source.config.options["max_overflow"] == source.config.profiling.max_workers
+
+
+def test_max_overflow_is_not_injected_when_profiling_is_disabled() -> None:
+    source = _source("mysql+pymysql://user:pass@localhost:5330", profiling=False)
+    source._add_default_options(source.config)
+    assert "max_overflow" not in source.config.options
+
+
+def test_an_unresolvable_dialect_keeps_the_previous_behaviour() -> None:
+    """get_dialect() raises NoSuchModuleError for a dialect whose driver is not
+    installed. Defaulting to True there means this change can only ever withhold
+    an option that would have raised, never one that worked."""
+    source = _source("not-a-real-dialect://host/db", profiling=True)
+    assert source._uses_queue_pool(source.config) is True


### PR DESCRIPTION
### Problem

Enabling profiling on a SQLite source makes ingestion fail outright:

```
TypeError: Invalid argument(s) 'max_overflow' sent to create_engine(),
using configuration SQLiteDialect_pysqlite/NullPool/Engine.
```

`SQLAlchemySource._add_default_options` injects `max_overflow` whenever profiling is enabled, but `max_overflow` is a **QueuePool-only** sizing option and SQLAlchemy raises rather than ignoring it when the dialect resolves to a different pool. SQLite file URLs resolve to `NullPool` and in-memory ones to `SingletonThreadPool`, so adding `profiling: {enabled: true}` to an otherwise working recipe turns it into a hard failure that produces **zero events**.

### Repro on `master`

```yaml
source:
  type: sqlalchemy
  config:
    connect_uri: sqlite:///test.db
    platform: sqlite
    profiling: {enabled: true}
sink:
  type: file
  config: {filename: out.json}
```

```
Pipeline finished with at least 1 failures; produced 0 events in 1.02 seconds.
```

With this change, the same recipe:

```
Pipeline finished successfully; produced 17 events in 1.42 seconds.
```

…including the `datasetProfile` the user enabled profiling to get.

### Fix

Inject the option only when the dialect actually resolves to a `QueuePool`.

`_uses_queue_pool` returns `True` on any uncertainty — `get_dialect()` raises `NoSuchModuleError` when a dialect's driver isn't installed — so this can only ever withhold an option that **would have raised**, never one that worked. Pooling behaviour for Postgres, MySQL, Snowflake et al. is unchanged.

### Related

This is the same root cause as the NullPool/usage-engine issue that `mysql.py` already works around locally with `_QUEUE_POOL_ONLY_OPTIONS` (referencing #18319). Fixing it at the source means individual dialects don't each need to strip the option back out.

### Tests

Added to `tests/unit/test_sql_common.py`:

- `max_overflow` withheld for `NullPool` (`sqlite:///…`) and `SingletonThreadPool` (`sqlite://`) URLs
- still injected for QueuePool dialects, at `profiling.max_workers`
- not injected when profiling is disabled
- unresolvable dialect keeps the previous behaviour

`ruff check` and `ruff format --check` produce no new findings (146 pre-existing findings in these files before and after). Full `tests/unit/test_sql_common.py` passes; the one unrelated failure (`test_test_connection_failure`) also fails on a clean `master` in this environment because `pymysql` isn't installed locally.

### Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://datahubproject.io/docs/contributing)
- [x] Links to related issues / PRs are provided (#18319 — same root cause, mirror-image case)
- [x] Tests added for the fixed behaviour

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ingestion crashes when profiling is enabled on SQLite by only setting `max_overflow` for dialects that use a `QueuePool`. Ingestion now succeeds and produces profiles; behavior for other databases is unchanged.

- **Bug Fixes**
  - Added `_uses_queue_pool` to detect if the dialect uses a `QueuePool` (falls back to True on unknown dialects).
  - Guarded default options so `max_overflow` is only injected when `QueuePool` is used.
  - Added unit tests for SQLite (`NullPool`/`SingletonThreadPool`), `QueuePool` dialects, profiling disabled, and unknown dialects.

<sup>Written for commit 5e8c237e8829040f2ca2e731a8a5d81b94ce0c23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

