### PR TITLE
ci: restore Depot runners for build-and-test via determine-runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,6 @@ self-hosted-runner:
     - "depot-ubuntu-22.04"
     - "depot-ubuntu-24.04-small"
     - "depot-ubuntu-24.04"
-    - "depot-ubuntu-24.04-2"
     - "depot-ubuntu-24.04-4"
 
 paths:

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - "depot-ubuntu-22.04"
     - "depot-ubuntu-24.04-small"
     - "depot-ubuntu-24.04"
+    - "depot-ubuntu-24.04-2"
     - "depot-ubuntu-24.04-4"
 
 paths:

--- a/.github/actions/determine-runners/action.yml
+++ b/.github/actions/determine-runners/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: "false"
   default_runner_size:
-    description: "Depot size for default-runner / default-depot-runner / depot-label-runner: small, regular, medium, or large"
+    description: "Depot size for default-runner / default-depot-runner / depot-label-runner: small, regular, or large"
     required: false
     default: "regular"
 
@@ -40,9 +40,6 @@ outputs:
   small-runner:
     description: "Appropriately set small runner based on Depot availability"
     value: ${{ steps.small-runner.outputs.value }}
-  depot-runner-medium:
-    description: "depot-ubuntu-24.04-2 Runner. Use for medium jobs"
-    value: "depot-ubuntu-24.04-2"
   depot-runner-large:
     description: "depot-ubuntu-24.04-4 Runner. Use for heavy jobs"
     value: "depot-ubuntu-24.04-4"
@@ -79,14 +76,11 @@ runs:
           regular|"")
             echo "value=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
             ;;
-          medium)
-            echo "value=depot-ubuntu-24.04-2" >> "$GITHUB_OUTPUT"
-            ;;
           large)
             echo "value=depot-ubuntu-24.04-4" >> "$GITHUB_OUTPUT"
             ;;
           *)
-            echo "::error::Invalid default_runner_size='$DEFAULT_RUNNER_SIZE' (expected small, regular, medium, or large)"
+            echo "::error::Invalid default_runner_size='$DEFAULT_RUNNER_SIZE' (expected small, regular, or large)"
             exit 1
             ;;
         esac

--- a/.github/actions/determine-runners/action.yml
+++ b/.github/actions/determine-runners/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Whether the PR has the 'depot' label (allows Community PRs to opt-in to Depot runners)"
     required: false
     default: "false"
+  default_runner_size:
+    description: "Depot size for default-runner / default-depot-runner / depot-label-runner: small, regular, medium, or large"
+    required: false
+    default: "regular"
 
 outputs:
   depot-config-set:
@@ -32,7 +36,7 @@ outputs:
     value: ubuntu-24.04
   default-depot-runner:
     description: "The runner to use for most regular jobs to be run on Depot Runners. Use when you always want to run a job on Depot runners"
-    value: "depot-ubuntu-24.04"
+    value: ${{ steps.depot-runner-for-size.outputs.value }}
   small-runner:
     description: "Appropriately set small runner based on Depot availability"
     value: ${{ steps.small-runner.outputs.value }}
@@ -44,7 +48,7 @@ outputs:
     value: "depot-ubuntu-24.04-4"
   depot-label-runner:
     description: "Set to depot-runner if depot label is added to Community PR"
-    value: ${{ steps.depot-label-small-runner.outputs.value }}
+    value: ${{ steps.depot-label-runner.outputs.value }}
   depot-label-small-runner:
     description: "Set to depot-runner if depot label is added to Community PR"
     value: ${{ steps.depot-label-small-runner.outputs.value }}
@@ -62,16 +66,42 @@ runs:
           echo "value=false" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Resolve depot runner for default_runner_size
+      id: depot-runner-for-size
+      shell: bash
+      env:
+        DEFAULT_RUNNER_SIZE: ${{ inputs.default_runner_size }}
+      run: |
+        case "$DEFAULT_RUNNER_SIZE" in
+          small)
+            echo "value=depot-ubuntu-24.04-small" >> "$GITHUB_OUTPUT"
+            ;;
+          regular|"")
+            echo "value=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
+            ;;
+          medium)
+            echo "value=depot-ubuntu-24.04-2" >> "$GITHUB_OUTPUT"
+            ;;
+          large)
+            echo "value=depot-ubuntu-24.04-4" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error::Invalid default_runner_size='$DEFAULT_RUNNER_SIZE' (expected small, regular, medium, or large)"
+            exit 1
+            ;;
+        esac
+
     - name: Set default-runner
       id: default-runner
       shell: bash
       env:
         IS_COMMUNITY_PR: ${{ inputs.is-community-pr }}
         DEPOT_CONFIG_SET: ${{ steps.depot-config-set.outputs.value }}
+        DEPOT_RUNNER: ${{ steps.depot-runner-for-size.outputs.value }}
       # Use depot for internal branches and push/schedule events; fall back to GitHub-hosted for fork PRs.
       run: |
         if [[ "$IS_COMMUNITY_PR" == "false" && "$DEPOT_CONFIG_SET" == "true" ]]; then
-          echo "value=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
+          echo "value=$DEPOT_RUNNER" >> "$GITHUB_OUTPUT"
         else
           echo "value=ubuntu-24.04" >> "$GITHUB_OUTPUT"
         fi
@@ -107,10 +137,12 @@ runs:
       shell: bash
       env:
         HAS_DEPOT_LABEL: ${{ inputs.has-depot-label }}
+        DEPOT_RUNNER: ${{ steps.depot-runner-for-size.outputs.value }}
       # Community (fork) PRs can opt-in to Depot runners by adding the 'depot' label.
+      # Uses the same size as default_runner_size so labeled community PRs match internal sizing.
       run: |
         if [[ "$HAS_DEPOT_LABEL" == "true" ]]; then
-          echo "value=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
+          echo "value=$DEPOT_RUNNER" >> "$GITHUB_OUTPUT"
         else
           echo "value=ubuntu-24.04" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,6 @@ concurrency:
 
 env:
   DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
-  HAS_DEPOT_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'depot') }}
   # Toggle backend test sharding. Repo variable (Settings → Actions → Variables); unset → '' →
   # falsy → defaults OFF, so it flips without a commit and each repo sets its own value.
   SHARDED_TESTS_RUNS_ENABLED: ${{ vars.SHARDED_TESTS_RUNS_ENABLED || 'false' }}
@@ -70,15 +69,28 @@ jobs:
           else
             echo "backend_sharding=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Determine runner type
+      - uses: ./.github/actions/determine-runners
+        id: runners
+        with:
+          # Only fork PRs are community; push/schedule/release/internal PRs are not.
+          is-community-pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          has-depot-label: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'depot') }}
+          # Heavy Gradle build/test jobs — matches prior depot-ubuntu-*-4 sizing.
+          default_runner_size: large
+      - name: Select runner
         id: set-runner
-        # Use depot runners only when a maintainer has explicitly added the "depot" label.
-        # vars.DEPOT_PROJECT_ID is not accessible to fork PRs, so we rely solely on the label.
+        env:
+          HAS_DEPOT_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'depot') }}
+          DEFAULT_RUNNER: ${{ steps.runners.outputs.default-runner }}
+          DEPOT_LABEL_RUNNER: ${{ steps.runners.outputs.depot-label-runner }}
+        # 1. Internal PRs / push / schedule → default-runner (Depot when configured)
+        # 2. Community PRs without depot label → default-runner (ubuntu)
+        # 3. Community PRs with depot label → depot-label-runner (Depot)
         run: |
-          if [[ "${{ env.HAS_DEPOT_LABEL }}" == "true" ]]; then
-            echo "runner_type=depot-ubuntu-latest-4" >> "$GITHUB_OUTPUT"
+          if [[ "$HAS_DEPOT_LABEL" == "true" ]]; then
+            echo "runner_type=$DEPOT_LABEL_RUNNER" >> "$GITHUB_OUTPUT"
           else
-            echo "runner_type=ubuntu-latest" >> "$GITHUB_OUTPUT"
+            echo "runner_type=$DEFAULT_RUNNER" >> "$GITHUB_OUTPUT"
           fi
 
   # Runs unless the sharding toggle (SHARDED_TESTS_RUNS_ENABLED repo variable) is on. When on,

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -451,6 +451,6 @@ tasks.withType(Test) {
 }
 
 clean {
-  //TODO: Is this really needed? dont see generated folder in projectDir. It is in build, but that doest need explicit clean
+  //TODO: Is this really needed? dont see generated folder in projectDir. It is in build, but that doest need explicit clean?
   delete "$projectDir/generated"
 }


### PR DESCRIPTION
## Summary
- Wire `build-and-test.yml` to `.github/actions/determine-runners` so internal/push/schedule jobs use Depot, unlabeled community PRs stay on ubuntu, and community PRs with the `depot` label opt into Depot.
- Add `default_runner_size` (`small` / `regular` / `medium` / `large`, default `regular`) so callers can pick Depot size; `build-and-test` uses `large`.
- Fix `depot-label-runner` output mapping and register `depot-ubuntu-24.04-2` in actionlint.

## Test plan
- [ ] Confirm setup job selects `depot-ubuntu-24.04-4` on an internal PR / push to this branch
- [ ] Confirm an unlabeled fork PR would resolve to `ubuntu-24.04`
- [ ] Confirm a fork PR with the `depot` label resolves to `depot-ubuntu-24.04-4`
- [ ] Existing `determine-runners` callers (lint-jobs, etc.) still default to `regular` with no workflow changes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Depot runners for `build-and-test` using the shared `determine-runners` action. Internal/push/schedule jobs default to Depot; community PRs run on `ubuntu-24.04` unless labeled `depot`.

- **New Features**
  - Use `./.github/actions/determine-runners` for consistent runner selection; workflow consumes `default-runner` and `depot-label-runner`.
  - Support runner sizing via `default_runner_size` (small, regular, large); `build-and-test` uses `large` → `depot-ubuntu-24.04-4`. Removed the medium runner.

- **Bug Fixes**
  - Fix `depot-label-runner` output mapping and make `default-depot-runner` size-aware.
  - Register `depot-ubuntu-24.04-2` in `.github/actionlint.yaml`; minor comment tweak in `metadata-io/build.gradle` to trigger CI.

<sup>Written for commit 14acab0fa4a4b27eebba99fcfa9e2c3488925f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/18998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

