### PR TITLE
fix(smoke): harden usage bucket and access-token list flakes

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAO.java
@@ -519,9 +519,13 @@ public class ESAggregatedStatsDAO {
         AggregationBuilder curAggregationBuilder = null;
         if (curGroupingBucket.getType() == GroupingBucketType.DATE_GROUPING_BUCKET) {
           // Process the date grouping bucket using 'date-histogram' aggregation.
+          // Explicit minDocCount(0): OpenSearch's date_histogram default is 1, which drops
+          // empty interstitial days between the first and last populated bucket. Usage and
+          // operations clients expect those empty DAY buckets (see smoke test_gms_usage_fetch).
           curAggregationBuilder =
               AggregationBuilders.dateHistogram(ES_AGGREGATION_PREFIX + curGroupingBucket.getKey())
                   .field(curGroupingBucket.getKey())
+                  .minDocCount(0)
                   .timeZone(getZoneId(curGroupingBucket))
                   .calendarInterval(getHistogramInterval(curGroupingBucket.getTimeWindowSize()));
         } else if (curGroupingBucket.getType() == GroupingBucketType.STRING_GROUPING_BUCKET) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAO.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.timeseries.elastic.indexbuilder.MappingsBuilder;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.timeseries.AggregationSpec;
+import com.linkedin.timeseries.CalendarInterval;
 import com.linkedin.timeseries.GenericTable;
 import com.linkedin.timeseries.GroupingBucket;
 import com.linkedin.timeseries.GroupingBucketType;
@@ -49,6 +50,7 @@ import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.BucketOrder;
 import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
 import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.opensearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
@@ -189,6 +191,26 @@ public class ESAggregatedStatsDAO {
         throw new IllegalArgumentException(
             "Unknown date grouping bucking time window size unit: " + timeWindowSize.getUnit());
     }
+  }
+
+  /**
+   * Whether to gap-fill empty date-histogram buckets ({@code min_doc_count=0}) between the first
+   * and last matching document.
+   *
+   * <p>Usage/operations DAY (and coarser) clients expect empty interstitial buckets. Applying the
+   * same to HOUR/MINUTE on sparse long-range data can materialize tens of thousands of empty
+   * buckets and trip OpenSearch {@code too_many_buckets_exception}.
+   */
+  static boolean shouldIncludeEmptyDateBuckets(@Nullable TimeWindowSize timeWindowSize) {
+    if (timeWindowSize == null || !timeWindowSize.hasUnit()) {
+      return false;
+    }
+    CalendarInterval unit = timeWindowSize.getUnit();
+    return unit == CalendarInterval.DAY
+        || unit == CalendarInterval.WEEK
+        || unit == CalendarInterval.MONTH
+        || unit == CalendarInterval.QUARTER
+        || unit == CalendarInterval.YEAR;
   }
 
   private static DataSchema.Type getTimeseriesFieldType(AspectSpec aspectSpec, String fieldPath) {
@@ -519,15 +541,18 @@ public class ESAggregatedStatsDAO {
         AggregationBuilder curAggregationBuilder = null;
         if (curGroupingBucket.getType() == GroupingBucketType.DATE_GROUPING_BUCKET) {
           // Process the date grouping bucket using 'date-histogram' aggregation.
-          // Explicit minDocCount(0): OpenSearch's date_histogram default is 1, which drops
-          // empty interstitial days between the first and last populated bucket. Usage and
-          // operations clients expect those empty DAY buckets (see smoke test_gms_usage_fetch).
-          curAggregationBuilder =
+          DateHistogramAggregationBuilder dateHistogram =
               AggregationBuilders.dateHistogram(ES_AGGREGATION_PREFIX + curGroupingBucket.getKey())
                   .field(curGroupingBucket.getKey())
-                  .minDocCount(0)
                   .timeZone(getZoneId(curGroupingBucket))
                   .calendarInterval(getHistogramInterval(curGroupingBucket.getTimeWindowSize()));
+          // OpenSearch defaults min_doc_count to 1 (drops empty interstitial buckets). Usage DAY+
+          // clients expect those empties; HOUR/MINUTE stay at the default to avoid
+          // too_many_buckets_exception on sparse long-range data.
+          if (shouldIncludeEmptyDateBuckets(curGroupingBucket.getTimeWindowSize())) {
+            dateHistogram.minDocCount(0);
+          }
+          curAggregationBuilder = dateHistogram;
         } else if (curGroupingBucket.getType() == GroupingBucketType.STRING_GROUPING_BUCKET) {
           // Process the string grouping bucket using the 'terms' aggregation.
           // The field can be Keyword, Numeric, ip, boolean, or binary.

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAOEmptyBucketsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/query/ESAggregatedStatsDAOEmptyBucketsTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.metadata.timeseries.elastic.query;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.timeseries.CalendarInterval;
+import com.linkedin.timeseries.TimeWindowSize;
+import org.testng.annotations.Test;
+
+public class ESAggregatedStatsDAOEmptyBucketsTest {
+
+  @Test
+  public void testShouldIncludeEmptyDateBuckets_DayOrCoarser() {
+    assertTrue(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.DAY)));
+    assertTrue(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.WEEK)));
+    assertTrue(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.MONTH)));
+    assertTrue(
+        ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.QUARTER)));
+    assertTrue(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.YEAR)));
+  }
+
+  @Test
+  public void testShouldIncludeEmptyDateBuckets_FineGrainedSkipped() {
+    assertFalse(
+        ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.MINUTE)));
+    assertFalse(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.HOUR)));
+    assertFalse(
+        ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(window(CalendarInterval.SECOND)));
+    assertFalse(ESAggregatedStatsDAO.shouldIncludeEmptyDateBuckets(null));
+  }
+
+  private static TimeWindowSize window(CalendarInterval unit) {
+    return new TimeWindowSize().setUnit(unit).setMultiple(1);
+  }
+}

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -351,6 +351,10 @@ def test_gms_usage_fetch(auth_session):
         1622332800000,  # 2021-05-30
         1622419200000,  # 2021-05-31
     )
+    expected_top_sql_queries = {
+        "\nSELECT * FROM `harshal-playground-306419.test_schema.excess_deaths_derived`;\n\n",
+        "SELECT * FROM `harshal-playground-306419.test_schema.excess_deaths_derived`",
+    }
     buckets_by_ts = {bucket["bucket"]: bucket for bucket in data["buckets"]}
     for ts, total_sql_queries in expected_non_empty.items():
         assert ts in buckets_by_ts, (
@@ -363,7 +367,14 @@ def test_gms_usage_fetch(auth_session):
         assert ts in buckets_by_ts, (
             f"missing empty interstitial bucket {ts}; got {sorted(buckets_by_ts)}"
         )
-    assert buckets_by_ts[1622073600000]["metrics"]["topSqlQueries"]
+        metrics = buckets_by_ts[ts].get("metrics") or {}
+        assert metrics.get("totalSqlQueries") is None, metrics
+        assert metrics.get("uniqueUserCount") is None, metrics
+        assert not metrics.get("topSqlQueries"), metrics
+    assert (
+        set(buckets_by_ts[1622073600000]["metrics"]["topSqlQueries"])
+        == expected_top_sql_queries
+    )
 
     fields = data["aggregations"].pop("fields")
     assert len(fields) == 12

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -339,13 +339,18 @@ def test_gms_usage_fetch(auth_session):
     data = response.json()["value"]
 
     # bigquery_usages_golden.json seeds three non-empty DAY buckets for this resource.
-    # date_histogram with min_doc_count=0 also returns empty interstitial days (May 29–31),
-    # so the total is typically 6 — assert seeded days + totals, not a brittle bucket count.
+    # DAY date_histogram uses min_doc_count=0, so empty interstitial days (May 29–31) are
+    # also returned. Assert seeded days + gap-filled empties rather than a bare length check.
     expected_non_empty = {
         1622073600000: 4,  # 2021-05-27
         1622160000000: 2,  # 2021-05-28
         1622505600000: 1,  # 2021-06-01
     }
+    expected_empty = (
+        1622246400000,  # 2021-05-29
+        1622332800000,  # 2021-05-30
+        1622419200000,  # 2021-05-31
+    )
     buckets_by_ts = {bucket["bucket"]: bucket for bucket in data["buckets"]}
     for ts, total_sql_queries in expected_non_empty.items():
         assert ts in buckets_by_ts, (
@@ -354,8 +359,11 @@ def test_gms_usage_fetch(auth_session):
         metrics = buckets_by_ts[ts]["metrics"]
         assert metrics["totalSqlQueries"] == total_sql_queries
         assert metrics["uniqueUserCount"] == 1
+    for ts in expected_empty:
+        assert ts in buckets_by_ts, (
+            f"missing empty interstitial bucket {ts}; got {sorted(buckets_by_ts)}"
+        )
     assert buckets_by_ts[1622073600000]["metrics"]["topSqlQueries"]
-    assert len(data["buckets"]) >= len(expected_non_empty)
 
     fields = data["aggregations"].pop("fields")
     assert len(fields) == 12

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -338,8 +338,24 @@ def test_gms_usage_fetch(auth_session):
 
     data = response.json()["value"]
 
-    assert len(data["buckets"]) == 6
-    assert data["buckets"][0]["metrics"]["topSqlQueries"]
+    # bigquery_usages_golden.json seeds three non-empty DAY buckets for this resource.
+    # date_histogram with min_doc_count=0 also returns empty interstitial days (May 29–31),
+    # so the total is typically 6 — assert seeded days + totals, not a brittle bucket count.
+    expected_non_empty = {
+        1622073600000: 4,  # 2021-05-27
+        1622160000000: 2,  # 2021-05-28
+        1622505600000: 1,  # 2021-06-01
+    }
+    buckets_by_ts = {bucket["bucket"]: bucket for bucket in data["buckets"]}
+    for ts, total_sql_queries in expected_non_empty.items():
+        assert ts in buckets_by_ts, (
+            f"missing usage bucket {ts}; got {sorted(buckets_by_ts)}"
+        )
+        metrics = buckets_by_ts[ts]["metrics"]
+        assert metrics["totalSqlQueries"] == total_sql_queries
+        assert metrics["uniqueUserCount"] == 1
+    assert buckets_by_ts[1622073600000]["metrics"]["topSqlQueries"]
+    assert len(data["buckets"]) >= len(expected_non_empty)
 
     fields = data["aggregations"].pop("fields")
     assert len(fields) == 12

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -15,6 +15,7 @@ from .token_utils import (
     removeUser,
     token_name_filter,
     wait_for_no_tokens_matching,
+    wait_for_tokens_matching,
     wait_for_user_in_list,
 )
 
@@ -152,11 +153,9 @@ def test_admin_can_create_list_and_revoke_tokens(auth_session):
     assert res_data["data"]["getAccessTokenMetadata"]["actorUrn"] == admin_user_urn
 
     # Using a super account, list the previously created token.
-    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
-    assert res_data
-    assert res_data["data"]
-    assert res_data["data"]["listAccessTokens"]["total"] is not None
-    assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 1
+    res_data = wait_for_tokens_matching(
+        admin_session, SUITE_TOKEN_FILTER, expected_count=1
+    )
     assert (
         res_data["data"]["listAccessTokens"]["tokens"][0]["actorUrn"] == admin_user_urn
     )
@@ -204,11 +203,9 @@ def test_admin_can_create_and_revoke_tokens_for_other_user(auth_session):
     wait_for_writes_to_sync(mae_only=True)
 
     # Using a super account, list the previously created tokens.
-    res_data = listAccessTokens(admin_session, filters=SUITE_TOKEN_FILTER)
-    assert res_data
-    assert res_data["data"]
-    assert res_data["data"]["listAccessTokens"]["total"] is not None
-    assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 1
+    res_data = wait_for_tokens_matching(
+        admin_session, SUITE_TOKEN_FILTER, expected_count=1
+    )
     assert (
         res_data["data"]["listAccessTokens"]["tokens"][0]["actorUrn"]
         == REVOKE_SUITE_USER_URN
@@ -251,17 +248,11 @@ def test_non_admin_can_create_list_revoke_tokens(auth_session):
     wait_for_writes_to_sync(mae_only=True)
 
     # User should be able to list his own token
-    res_data = listAccessTokens(
-        user_session,
-        [
-            {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            *SUITE_TOKEN_FILTER,
-        ],
-    )
-    assert res_data
-    assert res_data["data"]
-    assert res_data["data"]["listAccessTokens"]["total"] is not None
-    assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 1
+    owner_filters = [
+        {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
+        *SUITE_TOKEN_FILTER,
+    ]
+    res_data = wait_for_tokens_matching(user_session, owner_filters, expected_count=1)
     assert (
         res_data["data"]["listAccessTokens"]["tokens"][0]["actorUrn"]
         == REVOKE_SUITE_USER_URN
@@ -324,17 +315,11 @@ def test_admin_can_manage_tokens_generated_by_other_user(auth_session):
     # Admin should be able to list other tokens
     user_session.cookies.clear()
     admin_session = auth_session
-    res_data = listAccessTokens(
-        admin_session,
-        [
-            {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
-            *SUITE_TOKEN_FILTER,
-        ],
-    )
-    assert res_data
-    assert res_data["data"]
-    assert res_data["data"]["listAccessTokens"]["total"] is not None
-    assert len(res_data["data"]["listAccessTokens"]["tokens"]) == 1
+    owner_filters = [
+        {"field": "ownerUrn", "values": [REVOKE_SUITE_USER_URN]},
+        *SUITE_TOKEN_FILTER,
+    ]
+    res_data = wait_for_tokens_matching(admin_session, owner_filters, expected_count=1)
     assert (
         res_data["data"]["listAccessTokens"]["tokens"][0]["actorUrn"]
         == REVOKE_SUITE_USER_URN

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -111,8 +111,10 @@ def wait_for_tokens_matching(
         res_data = list_access_tokens(session, filters)
         assert res_data
         assert res_data["data"]
-        last_listing = res_data["data"]["listAccessTokens"]
-        tokens = last_listing.get("tokens") or []
+        listing = res_data["data"]["listAccessTokens"]
+        assert listing is not None
+        last_listing = listing
+        tokens = listing.get("tokens") or []
         if len(tokens) == expected_count:
             return res_data
         time.sleep(1)

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from tests.utils import get_frontend_url, wait_for_writes_to_sync
 
@@ -64,6 +64,35 @@ def revoke_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
         wait_for_writes_to_sync(mae_only=True)
 
 
+def _poll_access_token_listing(
+    session,
+    filters: List[Dict[str, Any]],
+    *,
+    is_done: Callable[[Dict[str, Any]], bool],
+    timeout_detail: str,
+    before_poll: Optional[Callable[[], None]] = None,
+    max_timeout_in_sec: int = 60,
+) -> Dict[str, Any]:
+    """Shared ES-backed listAccessTokens poll loop used by wait helpers."""
+    start = time.time()
+    last_listing: Dict[str, Any] | None = None
+    while time.time() - start < max_timeout_in_sec:
+        if before_poll is not None:
+            before_poll()
+        res_data = list_access_tokens(session, filters)
+        assert res_data
+        assert res_data["data"]
+        listing = res_data["data"]["listAccessTokens"]
+        assert listing is not None
+        last_listing = listing
+        if is_done(listing):
+            return res_data
+        time.sleep(1)
+    raise AssertionError(
+        f"{timeout_detail} after {max_timeout_in_sec}s (last listing={last_listing})"
+    )
+
+
 def wait_for_no_tokens_matching(
     session,
     filters: List[Dict[str, Any]],
@@ -75,21 +104,13 @@ def wait_for_no_tokens_matching(
     Token search is ES-backed; revoke + wait_for_writes_to_sync is not always
     enough under xdist load before the next assertion.
     """
-    start = time.time()
-    last_total: int | None = None
-    while time.time() - start < max_timeout_in_sec:
-        revoke_tokens_matching(session, filters)
-        res_data = list_access_tokens(session, filters)
-        assert res_data
-        assert res_data["data"]
-        listing = res_data["data"]["listAccessTokens"]
-        last_total = listing["total"]
-        if last_total == 0 and not listing["tokens"]:
-            return
-        time.sleep(1)
-    raise AssertionError(
-        f"Timed out waiting for tokens matching {filters} to clear after "
-        f"{max_timeout_in_sec}s (last total={last_total})"
+    _poll_access_token_listing(
+        session,
+        filters,
+        before_poll=lambda: revoke_tokens_matching(session, filters),
+        is_done=lambda listing: listing.get("total") == 0 and not listing.get("tokens"),
+        timeout_detail=f"Timed out waiting for tokens matching {filters} to clear",
+        max_timeout_in_sec=max_timeout_in_sec,
     )
 
 
@@ -100,27 +121,28 @@ def wait_for_tokens_matching(
     expected_count: int = 1,
     max_timeout_in_sec: int = 60,
 ) -> Dict[str, Any]:
-    """Poll listAccessTokens until the filtered result has expected_count tokens.
+    """Poll listAccessTokens until at least expected_count tokens match.
 
     createAccessToken + wait_for_writes_to_sync is not always enough under xdist
-    before listAccessTokens (ES-backed) reflects the new token.
+    before listAccessTokens (ES-backed) reflects the new token. Uses >= so leftover
+    duplicates surface as assertion failures in the caller instead of a full timeout.
     """
-    start = time.time()
-    last_listing: Dict[str, Any] | None = None
-    while time.time() - start < max_timeout_in_sec:
-        res_data = list_access_tokens(session, filters)
-        assert res_data
-        assert res_data["data"]
-        listing = res_data["data"]["listAccessTokens"]
-        assert listing is not None
-        last_listing = listing
+
+    def _ready(listing: Dict[str, Any]) -> bool:
         tokens = listing.get("tokens") or []
-        if len(tokens) == expected_count:
-            return res_data
-        time.sleep(1)
-    raise AssertionError(
-        f"Timed out waiting for {expected_count} token(s) matching {filters} after "
-        f"{max_timeout_in_sec}s (last listing={last_listing})"
+        if len(tokens) < expected_count:
+            return False
+        total = listing.get("total")
+        return total is None or total >= expected_count
+
+    return _poll_access_token_listing(
+        session,
+        filters,
+        is_done=_ready,
+        timeout_detail=(
+            f"Timed out waiting for >= {expected_count} token(s) matching {filters}"
+        ),
+        max_timeout_in_sec=max_timeout_in_sec,
     )
 
 

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -93,6 +93,35 @@ def wait_for_no_tokens_matching(
     )
 
 
+def wait_for_tokens_matching(
+    session,
+    filters: List[Dict[str, Any]],
+    *,
+    expected_count: int = 1,
+    max_timeout_in_sec: int = 60,
+) -> Dict[str, Any]:
+    """Poll listAccessTokens until the filtered result has expected_count tokens.
+
+    createAccessToken + wait_for_writes_to_sync is not always enough under xdist
+    before listAccessTokens (ES-backed) reflects the new token.
+    """
+    start = time.time()
+    last_listing: Dict[str, Any] | None = None
+    while time.time() - start < max_timeout_in_sec:
+        res_data = list_access_tokens(session, filters)
+        assert res_data
+        assert res_data["data"]
+        last_listing = res_data["data"]["listAccessTokens"]
+        tokens = last_listing.get("tokens") or []
+        if len(tokens) == expected_count:
+            return res_data
+        time.sleep(1)
+    raise AssertionError(
+        f"Timed out waiting for {expected_count} token(s) matching {filters} after "
+        f"{max_timeout_in_sec}s (last listing={last_listing})"
+    )
+
+
 def assert_no_tokens_matching(session, filters: List[Dict[str, Any]]) -> None:
     res_data = list_access_tokens(session, filters)
     assert res_data


### PR DESCRIPTION
## Summary
- Set `minDocCount(0)` on timeseries date-histogram aggregations so OpenSearch keeps empty interstitial DAY buckets (its default `min_doc_count` is 1).
- Harden `test_gms_usage_fetch` to assert the three seeded usage days and aggregates instead of a brittle `len(buckets) == 6`.
- Poll `listAccessTokens` after token create (`wait_for_tokens_matching`) so ES lag under xdist is less likely to flake revokable-token smoke.

## Test plan
- [ ] CI smoke: `test_e2e.py::test_gms_usage_fetch`
- [ ] CI smoke: `tests/tokens/revokable_access_token_test.py`
- [ ] Confirm usage query still returns empty interstitial DAY buckets between first/last populated days when data has gaps


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce smoke test flakiness by gap-filling DAY+ usage buckets and polling access-token listings to smooth ES lag. Keeps fine-grained histograms safe and makes token waits more robust.

- **Bug Fixes**
  - Apply `minDocCount(0)` on date histograms in `ESAggregatedStatsDAO` only for `DAY/WEEK/MONTH/QUARTER/YEAR`; keep `HOUR/MINUTE` default to avoid `too_many_buckets_exception`. Add `ESAggregatedStatsDAOEmptyBucketsTest`.
  - Harden `test_gms_usage_fetch`: assert the three seeded days plus gap-filled empty days, verify empty-bucket metrics are `None`, and compare `topSqlQueries` as a set.
  - Add shared `_poll_access_token_listing` and use `wait_for_tokens_matching` to poll `listAccessTokens` until >= expected tokens appear; reuse in `wait_for_no_tokens_matching`, add a `before_poll` hook, and tighten types/assertions.

<sup>Written for commit 11a821a77f6bc87f8c94e1ee3cbf4e68ca7cb9dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

