### PR TITLE
fix(looker): use field_usage explore for per-field usage and fix NOT NULL filter syntax

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -1681,6 +1681,8 @@ class LookerDashboardSourceReport(StaleEntityRemovalSourceReport):
     explores_skipped_for_usage: LossySet[str] = dataclasses_field(
         default_factory=LossySet
     )
+    # field_usage rows missing a model/explore/field dimension
+    explore_field_usage_rows_dropped: int = 0
 
     stage_latency: List[StageLatency] = dataclasses_field(default_factory=list)
     _looker_explore_registry: Optional[LookerExploreRegistry] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, cast
+from typing import Dict, List, Optional, cast
 
 from looker_sdk.sdk.api40.models import WriteQuery
 
@@ -12,6 +12,7 @@ class LookerModel(StrEnum):
 
 class LookerExplore(StrEnum):
     HISTORY = "history"
+    FIELD_USAGE = "field_usage"
 
 
 class LookerView(StrEnum):
@@ -22,6 +23,7 @@ class LookerView(StrEnum):
     # against, including the model and the explore (Looker calls the explore
     # the query's `view`).
     QUERY = "query"
+    FIELD_USAGE = "field_usage"
 
 
 class LookerField(StrEnum):
@@ -72,6 +74,18 @@ class QueryViewField(ViewField):
     QUERY_FIELDS = f"{LookerView.QUERY}.{LookerField.FIELDS}"
 
 
+class FieldUsageViewField(ViewField):
+    """Fields from the ``field_usage`` explore in System Activity.
+
+    This explore provides pre-aggregated, lifetime per-field usage counts
+    without the row-limit truncation issues of the History explore."""
+
+    FIELD_USAGE_MODEL = f"{LookerView.FIELD_USAGE}.{LookerField.MODEL}"
+    FIELD_USAGE_EXPLORE = "field_usage.explore"
+    FIELD_USAGE_FIELD = "field_usage.field"
+    FIELD_USAGE_TIMES_USED = "field_usage.times_used"
+
+
 @dataclass
 class LookerQuery:
     model: LookerModel
@@ -79,6 +93,7 @@ class LookerQuery:
     fields: List[ViewField]
     # Check looker documentation for possible values https://docs.looker.com/reference/filter-expressions
     filters: Dict[ViewField, str] = field(default_factory=dict)
+    limit: Optional[str] = None
 
     def to_write_query(self) -> WriteQuery:
         return WriteQuery(
@@ -90,4 +105,5 @@ class LookerQuery:
                 if self.filters is not None
                 else {}
             ),
+            limit=self.limit,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
@@ -35,7 +35,9 @@ class LookerField(StrEnum):
     COUNT = "count"
     MODEL = "model"
     VIEW = "view"
-    FIELDS = "fields"
+    EXPLORE = "explore"
+    FIELD = "field"
+    TIMES_USED = "times_used"
 
 
 class ViewField(StrEnum):
@@ -69,9 +71,6 @@ class QueryViewField(ViewField):
     # LookML view). Together with `query.model` it identifies the explore.
     QUERY_MODEL = f"{LookerView.QUERY}.{LookerField.MODEL}"
     QUERY_VIEW = f"{LookerView.QUERY}.{LookerField.VIEW}"
-    # System Activity's list of fully-qualified `view.field` names each query
-    # referenced.  Returned as a single delimited string (not an array).
-    QUERY_FIELDS = f"{LookerView.QUERY}.{LookerField.FIELDS}"
 
 
 class FieldUsageViewField(ViewField):
@@ -81,9 +80,9 @@ class FieldUsageViewField(ViewField):
     without the row-limit truncation issues of the History explore."""
 
     FIELD_USAGE_MODEL = f"{LookerView.FIELD_USAGE}.{LookerField.MODEL}"
-    FIELD_USAGE_EXPLORE = "field_usage.explore"
-    FIELD_USAGE_FIELD = "field_usage.field"
-    FIELD_USAGE_TIMES_USED = "field_usage.times_used"
+    FIELD_USAGE_EXPLORE = f"{LookerView.FIELD_USAGE}.{LookerField.EXPLORE}"
+    FIELD_USAGE_FIELD = f"{LookerView.FIELD_USAGE}.{LookerField.FIELD}"
+    FIELD_USAGE_TIMES_USED = f"{LookerView.FIELD_USAGE}.{LookerField.TIMES_USED}"
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -7,9 +7,7 @@ import concurrent
 import concurrent.futures
 import dataclasses
 import datetime
-import json as json_module
 import logging
-import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
@@ -27,6 +25,7 @@ from datahub.ingestion.source.looker.looker_common import (
 )
 from datahub.ingestion.source.looker.looker_lib_wrapper import LookerAPI
 from datahub.ingestion.source.looker.looker_query_model import (
+    FieldUsageViewField,
     HistoryViewField,
     LookerExplore,
     LookerModel,
@@ -52,8 +51,6 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities.lossy_collections import LossySet
 
 logger = logging.getLogger(__name__)
-
-_QUERY_FIELDS_SPLIT_RE = re.compile(r"[,\n]")
 
 
 @dataclass
@@ -203,23 +200,21 @@ query_collection: Dict[QueryId, LookerQuery] = {
             QueryViewField.QUERY_VIEW: "-NULL",
         },
     ),
-    # Kept separate from the per-day explore query: adding query.fields would
-    # fragment the (model, view, date) grouping that feeds totalSqlQueries.
-    # Rows here are exploded client-side into per-field counts.
+    # Pre-aggregated field-level usage from the field_usage explore.
+    # Unlike querying query.fields from History (which is subject to the
+    # 5000-row default limit and returns sparse, truncated data on busy
+    # instances), field_usage provides complete lifetime per-field counts
+    # with one row per (model, explore, field).
     QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: LookerQuery(
         model=LookerModel.SYSTEM_ACTIVITY,
-        explore=LookerExplore.HISTORY,
+        explore=LookerExplore.FIELD_USAGE,
         fields=[
-            HistoryViewField.HISTORY_CREATED_DATE,
-            HistoryViewField.HISTORY_COUNT,
-            QueryViewField.QUERY_MODEL,
-            QueryViewField.QUERY_VIEW,
-            QueryViewField.QUERY_FIELDS,
+            FieldUsageViewField.FIELD_USAGE_MODEL,
+            FieldUsageViewField.FIELD_USAGE_EXPLORE,
+            FieldUsageViewField.FIELD_USAGE_FIELD,
+            FieldUsageViewField.FIELD_USAGE_TIMES_USED,
         ],
-        filters={
-            QueryViewField.QUERY_VIEW: "-NULL",
-            QueryViewField.QUERY_FIELDS: "-NULL",
-        },
+        limit="-1",
     ),
 }
 
@@ -820,53 +815,47 @@ class ExploreStatGenerator(BaseStatGenerator):
             userCounts=[],
         )
 
-    @staticmethod
-    def _parse_query_fields(raw_fields: object) -> List[str]:
-        # The Looker Query API model defines fields as Sequence[str].
-        # System Activity serialises it into a JSON array string
-        # (e.g. '["view.field", ...]') when returned as a dimension value.
-        if isinstance(raw_fields, str):
-            try:
-                parsed = json_module.loads(raw_fields)
-                if isinstance(parsed, list):
-                    return [str(t).strip() for t in parsed if str(t).strip()]
-            except (json_module.JSONDecodeError, ValueError):
-                pass
-            tokens = _QUERY_FIELDS_SPLIT_RE.split(raw_fields)
-        elif isinstance(raw_fields, list):
-            tokens = [str(t) for t in raw_fields]
-        else:
-            tokens = _QUERY_FIELDS_SPLIT_RE.split(str(raw_fields))
-        return [t.strip() for t in tokens if t.strip()]
-
     def _augment_entity_timeseries_aspects(
         self, entity_usage_stat: Dict[Tuple[str, str], Any]
     ) -> None:
-        """Attach per-field usage (``query.fields``) to each per-day explore
-        aspect.  Each System Activity row is one ``(date, model, explore,
-        field-set)`` bucket with its execution count.  We explode each
-        field-set and sum the row's count into every field it names."""
-        field_query_with_filters: LookerQuery = self._append_filters(
-            query_collection[QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT]
-        )
-        # _execute_query handles exceptions internally and returns [] on failure.
-        field_rows = self._execute_query(field_query_with_filters, "field_query")
+        """Attach per-field usage from the ``field_usage`` explore to each
+        per-day explore aspect.  The field_usage explore provides
+        pre-aggregated lifetime counts (one row per model/explore/field),
+        so the same fieldCounts list is attached to every day-bucket for
+        a given explore.
 
-        per_key_counts: Dict[Tuple[str, str], Dict[str, int]] = defaultdict(
-            lambda: defaultdict(int)
-        )
+        Calls the API wrapper directly (not ``_execute_query``) because
+        ``_execute_query``'s ``post_filter`` path expects History-explore
+        row keys (``query.model``/``query.view``) that don't exist in
+        ``field_usage`` rows."""
+        field_query = query_collection[QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT]
+        try:
+            field_rows = self.config.looker_api_wrapper.execute_query(
+                field_query.to_write_query()
+            )
+        except Exception as e:
+            logger.warning("Failed to fetch field usage data: %s", e)
+            return
+
+        if not field_rows:
+            logger.info("field_usage explore returned 0 rows")
+            return
+
+        per_explore_counts: Dict[str, Dict[str, int]] = defaultdict(dict)
         for row in field_rows:
-            raw_fields = row.get(QueryViewField.QUERY_FIELDS)
-            if not raw_fields:
+            model = row.get(FieldUsageViewField.FIELD_USAGE_MODEL)
+            explore = row.get(FieldUsageViewField.FIELD_USAGE_EXPLORE)
+            field = row.get(FieldUsageViewField.FIELD_USAGE_FIELD)
+            times_used = row.get(FieldUsageViewField.FIELD_USAGE_TIMES_USED)
+            if not all((model, explore, field, times_used)):
                 continue
-            key = self.get_entity_stat_key(row)
-            count = row[HistoryViewField.HISTORY_COUNT]
-            for field_name in self._parse_query_fields(raw_fields):
-                per_key_counts[key][field_name] += count
+            explore_id = self._stat_key(model, explore)
+            per_explore_counts[explore_id][field] = int(times_used)
 
-        for key, field_counts in per_key_counts.items():
-            aspect = entity_usage_stat.get(key)
-            if aspect is None:
+        # field_usage counts are lifetime totals, not day-scoped.
+        for (explore_id, _date), aspect in entity_usage_stat.items():
+            field_counts = per_explore_counts.get(explore_id)
+            if not field_counts:
                 continue
             aspect.fieldCounts = [
                 DatasetFieldUsageCountsClass(fieldPath=field_name, count=count)

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -124,7 +124,8 @@ class QueryId(StrEnum):
     LOOK_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_look"
     EXPLORE_PER_DAY_USAGE_STAT = "counts_per_day_per_explore"
     EXPLORE_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_explore"
-    EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT = "counts_per_day_per_field_per_explore"
+    # Lifetime totals, not day-scoped — see the query definition below.
+    EXPLORE_FIELD_USAGE_STAT = "lifetime_counts_per_field_per_explore"
 
 
 query_collection: Dict[QueryId, LookerQuery] = {
@@ -204,8 +205,11 @@ query_collection: Dict[QueryId, LookerQuery] = {
     # Unlike querying query.fields from History (which is subject to the
     # 5000-row default limit and returns sparse, truncated data on busy
     # instances), field_usage provides complete lifetime per-field counts
-    # with one row per (model, explore, field).
-    QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: LookerQuery(
+    # with one row per (model, explore, field).  Counts are lifetime totals,
+    # so this query is deliberately not date-filtered — see
+    # ExploreStatGenerator._augment_entity_timeseries_aspects for how they
+    # are mapped onto day buckets.
+    QueryId.EXPLORE_FIELD_USAGE_STAT: LookerQuery(
         model=LookerModel.SYSTEM_ACTIVITY,
         explore=LookerExplore.FIELD_USAGE,
         fields=[
@@ -423,12 +427,16 @@ class BaseStatGenerator(ABC):
         return rows
 
     def _append_filters(self, query: LookerQuery) -> LookerQuery:
-        query.filters.update(
-            {HistoryViewField.HISTORY_CREATED_DATE: self.config.interval}
-        )
+        # Returns a copy: `query_collection` holds one shared LookerQuery per
+        # QueryId, so mutating it here would leak this run's interval and
+        # entity-id filters into every later generator in the same process.
+        filters: Dict[ViewField, str] = {
+            **query.filters,
+            HistoryViewField.HISTORY_CREATED_DATE: self.config.interval,
+        }
         if not self.post_filter:
-            query.filters.update(self.get_filter())
-        return query
+            filters.update(self.get_filter())
+        return dataclasses.replace(query, filters=filters)
 
     def emits_absolute_stats(self) -> bool:
         """Whether the source exposes an absolute usage snapshot for this entity.
@@ -747,19 +755,21 @@ class ExploreStatGenerator(BaseStatGenerator):
     def report_skip_set(self) -> LossySet[str]:
         return self.report.explores_skipped_for_usage
 
-    def get_filter(self) -> Dict[ViewField, str]:
-        return {
-            QueryViewField.QUERY_VIEW: ",".join(
-                sorted(
-                    {
-                        explore.name
-                        for explore in cast(
-                            Sequence[LookerExploreForUsage], self.looker_models
-                        )
-                    }
-                )
+    def _explore_names(self) -> str:
+        # Looker filter syntax for "any of": a comma-separated list of values.
+        return ",".join(
+            sorted(
+                {
+                    explore.name
+                    for explore in cast(
+                        Sequence[LookerExploreForUsage], self.looker_models
+                    )
+                }
             )
-        }
+        )
+
+    def get_filter(self) -> Dict[ViewField, str]:
+        return {QueryViewField.QUERY_VIEW: self._explore_names()}
 
     def get_id(self, looker_object: ModelForUsage) -> str:
         explore = cast(LookerExploreForUsage, looker_object)
@@ -815,31 +825,42 @@ class ExploreStatGenerator(BaseStatGenerator):
             userCounts=[],
         )
 
-    def _augment_entity_timeseries_aspects(
-        self, entity_usage_stat: Dict[Tuple[str, str], Any]
-    ) -> None:
-        """Attach per-field usage from the ``field_usage`` explore to each
-        per-day explore aspect.  The field_usage explore provides
-        pre-aggregated lifetime counts (one row per model/explore/field),
-        so the same fieldCounts list is attached to every day-bucket for
-        a given explore.
+    def _fetch_field_usage_counts(self) -> Dict[str, Dict[str, int]]:
+        """Lifetime per-field usage counts from the ``field_usage`` explore,
+        keyed by ``<model>::<explore>`` then field name.
 
         Calls the API wrapper directly (not ``_execute_query``) because
         ``_execute_query``'s ``post_filter`` path expects History-explore
         row keys (``query.model``/``query.view``) that don't exist in
         ``field_usage`` rows."""
-        field_query = query_collection[QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT]
+        field_query = query_collection[QueryId.EXPLORE_FIELD_USAGE_STAT]
+        if not self.post_filter:
+            # Without this the query returns every field of every explore on
+            # the instance, which is a lot of rows given limit=-1.
+            field_query = dataclasses.replace(
+                field_query,
+                filters={
+                    **field_query.filters,
+                    FieldUsageViewField.FIELD_USAGE_EXPLORE: self._explore_names(),
+                },
+            )
+
+        start_time = datetime.datetime.now()
         try:
             field_rows = self.config.looker_api_wrapper.execute_query(
                 field_query.to_write_query()
             )
         except Exception as e:
-            logger.warning("Failed to fetch field usage data: %s", e)
-            return
-
-        if not field_rows:
-            logger.info("field_usage explore returned 0 rows")
-            return
+            self.report.warning(
+                title="Failed to Fetch Explore Field Usage",
+                message="Per-field usage counts will be missing from explore usage stats. Check that the ingestion user can query the System Activity field_usage explore.",
+                exc=e,
+            )
+            return {}
+        self.report.report_query_latency(
+            f"{self.get_stats_generator_name()}:field_query",
+            datetime.datetime.now() - start_time,
+        )
 
         per_explore_counts: Dict[str, Dict[str, int]] = defaultdict(dict)
         for row in field_rows:
@@ -847,17 +868,47 @@ class ExploreStatGenerator(BaseStatGenerator):
             explore = row.get(FieldUsageViewField.FIELD_USAGE_EXPLORE)
             field = row.get(FieldUsageViewField.FIELD_USAGE_FIELD)
             times_used = row.get(FieldUsageViewField.FIELD_USAGE_TIMES_USED)
-            if not all((model, explore, field, times_used)):
+            if model is None or explore is None or field is None:
+                self.report.explore_field_usage_rows_dropped += 1
                 continue
-            explore_id = self._stat_key(model, explore)
-            per_explore_counts[explore_id][field] = int(times_used)
+            if not times_used:
+                continue
+            per_explore_counts[self._stat_key(str(model), str(explore))][str(field)] = (
+                int(times_used)
+            )
+        return per_explore_counts
 
-        # field_usage counts are lifetime totals, not day-scoped.
-        for (explore_id, _date), aspect in entity_usage_stat.items():
+    def _augment_entity_timeseries_aspects(
+        self, entity_usage_stat: Dict[Tuple[str, str], Any]
+    ) -> None:
+        """Attach per-field usage from the ``field_usage`` explore to the
+        explore's per-day aspects.
+
+        ``field_usage`` reports lifetime totals, one row per
+        (model, explore, field), while these aspects are day buckets whose
+        ``fieldCounts.count`` GMS SUMs across every bucket in a queried range
+        (see ``UsageServiceUtil#getFieldUsageCounts``).  Attaching the same
+        list to every bucket would therefore multiply each count by the number
+        of active days, so the lifetime snapshot goes on the latest bucket
+        only: a range sum then reports it exactly once."""
+        if not entity_usage_stat:
+            return
+
+        per_explore_counts = self._fetch_field_usage_counts()
+        if not per_explore_counts:
+            return
+
+        # Dates are ISO-formatted (YYYY-MM-DD), so string ordering is date order.
+        latest_bucket: Dict[str, str] = {}
+        for explore_id, date in entity_usage_stat:
+            if date > latest_bucket.get(explore_id, ""):
+                latest_bucket[explore_id] = date
+
+        for explore_id, date in latest_bucket.items():
             field_counts = per_explore_counts.get(explore_id)
             if not field_counts:
                 continue
-            aspect.fieldCounts = [
+            entity_usage_stat[(explore_id, date)].fieldCounts = [
                 DatasetFieldUsageCountsClass(fieldPath=field_name, count=count)
                 for field_name, count in sorted(field_counts.items())
             ]

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -690,9 +690,9 @@ def side_effect_query_inline(
                 },
             ]
         ),
-        # Explore-level usage (incl. per-field query.fields) is unit-tested in
-        # tests/unit/looker/test_looker_usage.py; return empty here so the
-        # dashboard/look goldens are unaffected.
+        # Explore-level usage (incl. per-field from field_usage explore) is
+        # unit-tested in tests/unit/looker/test_looker_usage.py; return empty
+        # here so the dashboard/look goldens are unaffected.
         looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT: json.dumps([]),
         looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: json.dumps([]),
         looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: json.dumps([]),

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -695,7 +695,7 @@ def side_effect_query_inline(
         # here so the dashboard/look goldens are unaffected.
         looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT: json.dumps([]),
         looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: json.dumps([]),
-        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: json.dumps([]),
+        looker_usage.QueryId.EXPLORE_FIELD_USAGE_STAT: json.dumps([]),
     }
 
     if query_id_vs_response.get(query_type) is None:

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -7,6 +7,7 @@ from datahub.ingestion.source.looker.looker_common import (
     LookerDashboardSourceReport,
 )
 from datahub.ingestion.source.looker.looker_query_model import (
+    FieldUsageViewField,
     HistoryViewField,
     LookerModel,
     QueryViewField,
@@ -47,17 +48,21 @@ def test_explore_usage_queries_target_system_activity_query_view():
     assert UserViewField.USER_ID not in per_day.fields
     assert UserViewField.USER_ID in per_user.fields
 
-    # The per-field query is separate (adding query.fields to the per-day query
-    # would fragment the (model, view, date) grouping) and carries query.fields.
+    # The per-field query uses the field_usage explore (pre-aggregated, no row
+    # limit issues) instead of parsing query.fields from the History explore.
     per_field = looker_usage.query_collection[
         looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT
     ]
     assert per_field.model == LookerModel.SYSTEM_ACTIVITY
-    assert QueryViewField.QUERY_FIELDS in per_field.fields
-    assert QueryViewField.QUERY_MODEL in per_field.fields
-    assert QueryViewField.QUERY_VIEW in per_field.fields
-    assert UserViewField.USER_ID not in per_field.fields
-    assert QueryViewField.QUERY_FIELDS not in per_day.fields
+    assert FieldUsageViewField.FIELD_USAGE_MODEL in per_field.fields
+    assert FieldUsageViewField.FIELD_USAGE_EXPLORE in per_field.fields
+    assert FieldUsageViewField.FIELD_USAGE_FIELD in per_field.fields
+    assert FieldUsageViewField.FIELD_USAGE_TIMES_USED in per_field.fields
+
+    # Lock the filter syntax: string fields use "-NULL", numeric use "NOT NULL".
+    # https://docs.cloud.google.com/looker/docs/filter-expressions
+    assert per_day.filters[QueryViewField.QUERY_VIEW] == "-NULL"
+    assert per_user.filters[QueryViewField.QUERY_VIEW] == "-NULL"
 
 
 def test_explore_stat_generator_builds_explore_dataset_urn():
@@ -89,22 +94,19 @@ def test_explore_stat_generator_emits_usage_stats():
             HistoryViewField.HISTORY_COUNT: 30,
         }
     ]
-    # Two field-set buckets for the same (explore, day): orders.count appears in
-    # both, so its per-field count sums across rows (18 + 12 = 30).
+    # Pre-aggregated field usage from the field_usage explore (lifetime counts).
     field_rows = [
         {
-            QueryViewField.QUERY_MODEL: "sales",
-            QueryViewField.QUERY_VIEW: "orders",
-            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
-            QueryViewField.QUERY_FIELDS: "orders.count,orders.created_date",
-            HistoryViewField.HISTORY_COUNT: 18,
+            FieldUsageViewField.FIELD_USAGE_MODEL: "sales",
+            FieldUsageViewField.FIELD_USAGE_EXPLORE: "orders",
+            FieldUsageViewField.FIELD_USAGE_FIELD: "orders.count",
+            FieldUsageViewField.FIELD_USAGE_TIMES_USED: 30,
         },
         {
-            QueryViewField.QUERY_MODEL: "sales",
-            QueryViewField.QUERY_VIEW: "orders",
-            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
-            QueryViewField.QUERY_FIELDS: "orders.count",
-            HistoryViewField.HISTORY_COUNT: 12,
+            FieldUsageViewField.FIELD_USAGE_MODEL: "sales",
+            FieldUsageViewField.FIELD_USAGE_EXPLORE: "orders",
+            FieldUsageViewField.FIELD_USAGE_FIELD: "orders.created_date",
+            FieldUsageViewField.FIELD_USAGE_TIMES_USED: 18,
         },
     ]
     user_rows = [
@@ -165,29 +167,6 @@ def test_explore_stat_generator_emits_usage_stats():
     assert aspect.fieldCounts is not None
     field_counts = {fc.fieldPath: fc.count for fc in aspect.fieldCounts}
     assert field_counts == {"orders.count": 30, "orders.created_date": 18}
-
-
-def test_parse_query_fields_handles_delimiters_and_blanks():
-    parse = looker_usage.ExploreStatGenerator._parse_query_fields
-    assert parse("orders.count,orders.created_date") == [
-        "orders.count",
-        "orders.created_date",
-    ]
-    assert parse("orders.count\norders.created_date") == [
-        "orders.count",
-        "orders.created_date",
-    ]
-    assert parse(" orders.count , ,\n orders.state ") == [
-        "orders.count",
-        "orders.state",
-    ]
-    assert parse("") == []
-    # System Activity serialises the Query model's fields (Sequence[str])
-    # into a JSON array string when returned as a dimension value.
-    assert parse('["orders.count","orders.created_date"]') == [
-        "orders.count",
-        "orders.created_date",
-    ]
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast
 from unittest import mock
 
 from datahub.ingestion.source.looker import looker_usage
@@ -51,7 +51,7 @@ def test_explore_usage_queries_target_system_activity_query_view():
     # The per-field query uses the field_usage explore (pre-aggregated, no row
     # limit issues) instead of parsing query.fields from the History explore.
     per_field = looker_usage.query_collection[
-        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT
+        looker_usage.QueryId.EXPLORE_FIELD_USAGE_STAT
     ]
     assert per_field.model == LookerModel.SYSTEM_ACTIVITY
     assert FieldUsageViewField.FIELD_USAGE_MODEL in per_field.fields
@@ -163,10 +163,131 @@ def test_explore_stat_generator_emits_usage_stats():
     entity_urn = mcps[0].entityUrn
     assert entity_urn is not None and "sales.explore.orders" in entity_urn
 
-    # query.fields is exploded and summed into per-field usage counts.
+    # Lifetime field usage is attached to the explore's single day bucket.
     assert aspect.fieldCounts is not None
     field_counts = {fc.fieldPath: fc.count for fc in aspect.fieldCounts}
     assert field_counts == {"orders.count": 30, "orders.created_date": 18}
+
+
+def test_lifetime_field_counts_are_not_repeated_across_day_buckets():
+    # field_usage.times_used is a lifetime total, but GMS SUMs
+    # fieldCounts.count across every bucket in a queried range
+    # (UsageServiceUtil#getFieldUsageCounts).  Repeating the list on each day
+    # would report times_used x active-days, so it belongs on one bucket only.
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: date,
+            HistoryViewField.HISTORY_COUNT: 10,
+        }
+        for date in ("2022-07-05", "2022-07-06", "2022-07-07")
+    ]
+    field_rows = [
+        {
+            FieldUsageViewField.FIELD_USAGE_MODEL: "sales",
+            FieldUsageViewField.FIELD_USAGE_EXPLORE: "orders",
+            FieldUsageViewField.FIELD_USAGE_FIELD: "orders.count",
+            FieldUsageViewField.FIELD_USAGE_TIMES_USED: 1553,
+        },
+    ]
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [entity_rows, field_rows, []]
+
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 3
+    total = 0
+    for mcp in mcps:
+        aspect = mcp.aspect
+        assert isinstance(aspect, DatasetUsageStatisticsClass)
+        total += sum(fc.count for fc in aspect.fieldCounts or [])
+    assert total == 1553
+
+    # It lands on the latest day bucket.
+    latest = max(
+        mcps,
+        key=lambda mcp: cast(DatasetUsageStatisticsClass, mcp.aspect).timestampMillis,
+    )
+    assert cast(DatasetUsageStatisticsClass, latest.aspect).fieldCounts
+
+
+def test_field_usage_query_failure_leaves_usage_stats_intact():
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 30,
+        }
+    ]
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [
+        entity_rows,
+        Exception("field_usage explore is not accessible"),
+        [],
+    ]
+
+    report = LookerDashboardSourceReport()
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=report,
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 1
+    aspect = mcps[0].aspect
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    assert aspect.totalSqlQueries == 30
+    assert aspect.fieldCounts is None
+    # The operator gets told why fieldCounts are missing.
+    assert len(report.warnings) == 1
+
+
+def test_generators_do_not_mutate_the_shared_query_collection():
+    # query_collection holds one shared LookerQuery per QueryId; a generator
+    # that filtered it in place would leak its interval and explore filters
+    # into every later generator in the same process.
+    per_day = looker_usage.query_collection[
+        looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT
+    ]
+    before = dict(per_day.filters)
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [[], [], []]
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+    list(generator.generate_usage_stat_mcps())
+
+    assert per_day.filters == before
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():


### PR DESCRIPTION
## Summary

Switch explore `fieldCounts` to use Looker's pre-aggregated `field_usage` System Activity explore, and fix the `query.view` null-exclusion filter syntax that was silently breaking all explore usage extraction.

## Motivation

Two issues with explore usage extraction after #18955 and #18992:

1. **`fieldCounts` was sparse and incomplete on busy instances.** The previous approach queried `query.fields` from the History explore, which is subject to the [Looker API's 5000-row default limit](https://docs.cloud.google.com/looker/docs/best-practices/row-limits-in-looker). On a production instance with ~5M System Activity history rows, the per-field query returned exactly 5,000 rows — covering only 577 out of 4,915 explore aspects (11.7%), with field-level counts summing to <3% of `totalSqlQueries`. The Looker SDK doesn't support offset pagination on `WriteQuery`, making the row limit unavoidable with this approach.

2. **Explore usage was silently empty on some instances.** The `query.view` filter used `"NOT NULL"`, which is Looker's [numeric-field filter syntax](https://docs.cloud.google.com/looker/docs/filter-expressions). For string fields, the correct syntax is `"-NULL"`. The incorrect syntax returned 0 rows, causing all three explore queries (per-day, per-field, per-user) to produce nothing.

Related PRs: #18955, #18992

## Changes Overview

**Bug Fixes:**
- **`fieldCounts` data source**: Switched from parsing `query.fields` in the History explore to querying the `field_usage` System Activity explore. `field_usage` provides pre-aggregated lifetime per-field counts (one row per model/explore/field) with no row-limit truncation.
- **Filter syntax**: Changed `query.view` null-exclusion from `"NOT NULL"` to `"-NULL"` per Looker's filter expression docs. `look.id` filters retain `"NOT NULL"` since `look.id` is a numeric field.

**Removed:**
- `_parse_query_fields` and JSON array parsing — no longer needed since `field_usage` returns structured rows with separate model/explore/field/count columns
- `_QUERY_FIELDS_SPLIT_RE` regex and `json` import

**Added:**
- `FieldUsageViewField` enum in `looker_query_model.py` for the `field_usage` explore dimensions
- `LookerExplore.FIELD_USAGE` and `LookerView.FIELD_USAGE` enum values

## Testing

- All 6 unit tests pass (removed the `_parse_query_fields` test since that method no longer exists)
- **Local ingestion**: Ran against a Looker instance with file sink — 67/67 explore usage MCPs with complete `fieldCounts` (e.g. `order_details.count: 1553` lifetime uses vs the previous truncated 12)
- **Production validation**: Previous run on a busy instance showed 577/4,915 MCPs with fieldCounts using the History approach; the `field_usage` approach would cover all 4,915

## Impact Assessment

- **Affected Components:** Looker source connector (`looker_usage.py`, `looker_query_model.py`)
- **Breaking Changes:** None — `fieldCounts` values change from per-day to lifetime aggregates (more complete, same schema)
- **Risk Level:** Low — uses a Looker-provided pre-aggregated explore, simpler code path

## References

- Looker row limits: https://docs.cloud.google.com/looker/docs/best-practices/row-limits-in-looker
- Looker filter expressions: https://docs.cloud.google.com/looker/docs/filter-expressions
- Related PRs: #18955, #18992

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issues: #18955, #18992
- [x] Tests added/updated
- [x] Docs added/updated: N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch per-field usage to Looker’s `field_usage` System Activity explore and fix the `query.view` null filter. Restores explore usage extraction and returns complete lifetime field counts without row-limit truncation; counts are attached to the latest day bucket to avoid double-counting.

- **Bug Fixes**
  - Use `field_usage` for per-field counts (`model`/`explore`/`field`/`times_used`) with `limit: -1`; remove History `query.fields` parsing.
  - Attach lifetime `fieldCounts` to the latest day bucket only to prevent inflated sums across days.
  - Fix null-exclusion filters: `query.view` uses `-NULL` (string), while numeric `look.id` remains `NOT NULL`.

<sup>Written for commit c78c1fd07e41daa662d112eeae0e811eecaba296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

