### PR TITLE
perf(ci): unfreeze the Gradle cache, scale workers, and cut JDK download time

### DIFF
--- a/.github/actions/restore-dependency-caches/action.yml
+++ b/.github/actions/restore-dependency-caches/action.yml
@@ -1,9 +1,9 @@
 name: Restore dependency caches (docker-unified buckets)
 description: >
-  Read-only restore of ~/.cache/uv, ~/.cache/yarn, and optionally shared ~/.gradle
-  cache paths. Callers pass keys produced by the same
-  hashFiles / prefix convention as docker-unified. Do not add actions/cache/save
-  for these buckets in workflows that only restore here.
+  Read-only restore of ~/.cache/uv and ~/.cache/yarn. Callers pass keys produced
+  by the same hashFiles / prefix convention as docker-unified. Do not add
+  actions/cache/save for these buckets in workflows that only restore here.
+  Gradle caching is handled by gradle/actions/setup-gradle, not here.
 
 inputs:
   uv_cache_key:
@@ -18,18 +18,6 @@ inputs:
   yarn_cache_key_prefix:
     description: restore-keys prefix for the Yarn path.
     required: true
-  restore_gradle:
-    description: If true, also restore the shared ~/.gradle dependency caches.
-    required: false
-    default: "false"
-  gradle_cache_key:
-    description: Full Actions cache key for the Gradle dependency caches.
-    required: false
-    default: ""
-  gradle_cache_key_prefix:
-    description: restore-keys prefix for the Gradle dependency caches.
-    required: false
-    default: ""
 
 runs:
   using: composite
@@ -49,22 +37,3 @@ runs:
         key: ${{ inputs.yarn_cache_key }}
         restore-keys: |
           ${{ inputs.yarn_cache_key_prefix }}
-
-    # `caches/*/transforms` and `caches/*/generated-gradle-jars` are the Gradle 8
-    # layout; the old `caches/transforms-*` glob is Gradle 7 and matches nothing
-    # on 8.14. `caches/*/groovy-dsl` is the compiled build-script cache -- without
-    # it every run recompiles the root build.gradle and ~100 subproject scripts.
-    - name: Restore Gradle dependency caches (docker-unified bucket)
-      if: ${{ inputs.restore_gradle == 'true' }}
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: |
-          ~/.gradle/wrapper
-          ~/.gradle/caches/modules-2
-          ~/.gradle/caches/jars-*
-          ~/.gradle/caches/*/transforms
-          ~/.gradle/caches/*/groovy-dsl
-          ~/.gradle/caches/*/generated-gradle-jars
-        key: ${{ inputs.gradle_cache_key }}
-        restore-keys: |
-          ${{ inputs.gradle_cache_key_prefix }}

--- a/.github/actions/restore-dependency-caches/action.yml
+++ b/.github/actions/restore-dependency-caches/action.yml
@@ -1,7 +1,7 @@
 name: Restore dependency caches (docker-unified buckets)
 description: >
   Read-only restore of ~/.cache/uv, ~/.cache/yarn, and optionally shared ~/.gradle
-  cache paths (gradle-plugins-cache key). Callers pass keys produced by the same
+  cache paths. Callers pass keys produced by the same
   hashFiles / prefix convention as docker-unified. Do not add actions/cache/save
   for these buckets in workflows that only restore here.
 
@@ -19,9 +19,17 @@ inputs:
     description: restore-keys prefix for the Yarn path.
     required: true
   restore_gradle:
-    description: If true, also restore ~/.gradle/* for the gradle-plugins-cache key.
+    description: If true, also restore the shared ~/.gradle dependency caches.
     required: false
     default: "false"
+  gradle_cache_key:
+    description: Full Actions cache key for the Gradle dependency caches.
+    required: false
+    default: ""
+  gradle_cache_key_prefix:
+    description: restore-keys prefix for the Gradle dependency caches.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -42,7 +50,11 @@ runs:
         restore-keys: |
           ${{ inputs.yarn_cache_key_prefix }}
 
-    - name: Restore Gradle plugins cache (docker-unified bucket)
+    # `caches/*/transforms` and `caches/*/generated-gradle-jars` are the Gradle 8
+    # layout; the old `caches/transforms-*` glob is Gradle 7 and matches nothing
+    # on 8.14. `caches/*/groovy-dsl` is the compiled build-script cache -- without
+    # it every run recompiles the root build.gradle and ~100 subproject scripts.
+    - name: Restore Gradle dependency caches (docker-unified bucket)
       if: ${{ inputs.restore_gradle == 'true' }}
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
@@ -50,7 +62,9 @@ runs:
           ~/.gradle/wrapper
           ~/.gradle/caches/modules-2
           ~/.gradle/caches/jars-*
-          ~/.gradle/caches/transforms-*
-        key: gradle-plugins-cache
+          ~/.gradle/caches/*/transforms
+          ~/.gradle/caches/*/groovy-dsl
+          ~/.gradle/caches/*/generated-gradle-jars
+        key: ${{ inputs.gradle_cache_key }}
         restore-keys: |
-          gradle-plugins-cache
+          ${{ inputs.gradle_cache_key_prefix }}

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 21
 
       - name: Check out the repo
@@ -527,7 +527,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 21
 
       - name: Free up disk space
@@ -708,7 +708,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 21
 
       - name: Free up disk space

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -313,8 +313,11 @@ jobs:
       #
       # cache-read-only defaults to `ref_name != default_branch`, which is the same
       # master-only-write rule the hand-rolled version enforced with an `if:` --
-      # important here, because base_build runs alongside 7 pytest batches and 8
-      # Playwright shards that must not all write.
+      # important here because pytest_tests and playwright_test each fan out into
+      # many concurrent shard jobs sharing this same branch-scoped cache
+      # namespace. Restricting writes to master keeps every PR's shards from also
+      # saving into it, which would churn/evict entries and contribute to
+      # exhausting the repo's 10GB Actions cache budget (see build-cache-1 below).
       #
       # build-cache-1 is excluded: task outputs come from the Depot remote build
       # cache (cache.depot.dev), and including it here is what has been reported to

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -114,6 +114,8 @@ jobs:
       uv_cache_key_prefix: ${{ steps.uv-cache-key.outputs.uv_cache_key_prefix }}
       yarn_cache_key: ${{ steps.yarn-cache-key.outputs.yarn_cache_key }}
       yarn_cache_key_prefix: ${{ steps.yarn-cache-key.outputs.yarn_cache_key_prefix }}
+      gradle_cache_key: ${{ steps.gradle-cache-key.outputs.gradle_cache_key }}
+      gradle_cache_key_prefix: ${{ steps.gradle-cache-key.outputs.gradle_cache_key_prefix }}
       playwright_matrix: ${{ steps.set-playwright-matrix.outputs.matrix }}
       playwright_change: ${{ steps.ci-optimize.outputs.playwright-change == 'true' }}
       smoke_build_task: ${{ steps.smoke-profile.outputs.smoke_build_task }}
@@ -250,6 +252,20 @@ jobs:
             './metadata-ingestion/setup.py') }}" >> "$GITHUB_OUTPUT"
           echo "uv_cache_key_prefix=docker-unified-${{ runner.os }}-uv-" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Gradle Cache Key
+        id: gradle-cache-key
+        # The previous key was the literal string `gradle-plugins-cache`. Actions
+        # cache entries are immutable, so after the first save every later save
+        # failed with "Unable to reserve cache with key" and the blob was frozen
+        # from 2026-07-22 onward. A content-hashed key lets it refresh; the prefix
+        # restore-key still gives a near-miss hit when dependencies move.
+        run: |
+          {
+            echo "gradle_cache_key=docker-unified-${{ runner.os }}-gradle-${{ hashFiles(
+              '**/*.gradle', '**/gradle.lockfile', 'gradle/**', 'gradle.properties') }}"
+            echo "gradle_cache_key_prefix=docker-unified-${{ runner.os }}-gradle-"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Compute Yarn Cache Key
         id: yarn-cache-key
         run: |
@@ -302,6 +318,8 @@ jobs:
           uv_cache_key_prefix: ${{ needs.setup.outputs.uv_cache_key_prefix }}
           yarn_cache_key: ${{ needs.setup.outputs.yarn_cache_key }}
           yarn_cache_key_prefix: ${{ needs.setup.outputs.yarn_cache_key_prefix }}
+          gradle_cache_key: ${{ needs.setup.outputs.gradle_cache_key }}
+          gradle_cache_key_prefix: ${{ needs.setup.outputs.gradle_cache_key_prefix }}
           restore_gradle: true
 
       - name: Set up Depot CLI
@@ -383,8 +401,10 @@ jobs:
             ~/.gradle/wrapper
             ~/.gradle/caches/modules-2
             ~/.gradle/caches/jars-*
-            ~/.gradle/caches/transforms-*
-          key: gradle-plugins-cache
+            ~/.gradle/caches/*/transforms
+            ~/.gradle/caches/*/groovy-dsl
+            ~/.gradle/caches/*/generated-gradle-jars
+          key: ${{ needs.setup.outputs.gradle_cache_key }}
 
   comment_pr_images:
     name: Comment PR image tags

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -114,8 +114,6 @@ jobs:
       uv_cache_key_prefix: ${{ steps.uv-cache-key.outputs.uv_cache_key_prefix }}
       yarn_cache_key: ${{ steps.yarn-cache-key.outputs.yarn_cache_key }}
       yarn_cache_key_prefix: ${{ steps.yarn-cache-key.outputs.yarn_cache_key_prefix }}
-      gradle_cache_key: ${{ steps.gradle-cache-key.outputs.gradle_cache_key }}
-      gradle_cache_key_prefix: ${{ steps.gradle-cache-key.outputs.gradle_cache_key_prefix }}
       playwright_matrix: ${{ steps.set-playwright-matrix.outputs.matrix }}
       playwright_change: ${{ steps.ci-optimize.outputs.playwright-change == 'true' }}
       smoke_build_task: ${{ steps.smoke-profile.outputs.smoke_build_task }}
@@ -252,20 +250,6 @@ jobs:
             './metadata-ingestion/setup.py') }}" >> "$GITHUB_OUTPUT"
           echo "uv_cache_key_prefix=docker-unified-${{ runner.os }}-uv-" >> "$GITHUB_OUTPUT"
 
-      - name: Compute Gradle Cache Key
-        id: gradle-cache-key
-        # The previous key was the literal string `gradle-plugins-cache`. Actions
-        # cache entries are immutable, so after the first save every later save
-        # failed with "Unable to reserve cache with key" and the blob was frozen
-        # from 2026-07-22 onward. A content-hashed key lets it refresh; the prefix
-        # restore-key still gives a near-miss hit when dependencies move.
-        run: |
-          {
-            echo "gradle_cache_key=docker-unified-${{ runner.os }}-gradle-${{ hashFiles(
-              '**/*.gradle', '**/gradle.lockfile', 'gradle/**', 'gradle.properties') }}"
-            echo "gradle_cache_key_prefix=docker-unified-${{ runner.os }}-gradle-"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Compute Yarn Cache Key
         id: yarn-cache-key
         run: |
@@ -318,9 +302,26 @@ jobs:
           uv_cache_key_prefix: ${{ needs.setup.outputs.uv_cache_key_prefix }}
           yarn_cache_key: ${{ needs.setup.outputs.yarn_cache_key }}
           yarn_cache_key_prefix: ${{ needs.setup.outputs.yarn_cache_key_prefix }}
-          gradle_cache_key: ${{ needs.setup.outputs.gradle_cache_key }}
-          gradle_cache_key_prefix: ${{ needs.setup.outputs.gradle_cache_key_prefix }}
-          restore_gradle: true
+
+      # Replaces a hand-rolled actions/cache pair that used the literal key
+      # `gradle-plugins-cache`. Actions cache entries are immutable, so the first
+      # save on master claimed that name and every save after it failed; the entry
+      # froze on 2026-07-22 and was later evicted, leaving this job restoring
+      # nothing. Its path globs were also Gradle 7 (`caches/transforms-*` matches
+      # nothing on 8.14). setup-gradle hashes and versions its own keys, splits the
+      # buckets, and is what the repo's other 19 workflows already use.
+      #
+      # cache-read-only defaults to `ref_name != default_branch`, which is the same
+      # master-only-write rule the hand-rolled version enforced with an `if:` --
+      # important here, because base_build runs alongside 7 pytest batches and 8
+      # Playwright shards that must not all write.
+      #
+      # build-cache-1 is excluded: task outputs come from the Depot remote build
+      # cache (cache.depot.dev), and including it here is what has been reported to
+      # exhaust the repo's 10GB Actions cache budget.
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          gradle-home-cache-excludes: caches/build-cache-1
 
       - name: Set up Depot CLI
         if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
@@ -397,17 +398,6 @@ jobs:
           path: |
             ~/.cache/yarn
           key: ${{ needs.setup.outputs.yarn_cache_key }}
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        if: ${{ github.ref == 'refs/heads/master' }}
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/*/transforms
-            ~/.gradle/caches/*/groovy-dsl
-            ~/.gradle/caches/*/generated-gradle-jars
-          key: ${{ needs.setup.outputs.gradle_cache_key }}
 
   comment_pr_images:
     name: Comment PR image tags

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -346,6 +346,9 @@ jobs:
           chainguard_python_token: ${{ secrets.CHAINGUARD_PYTHON_TOKEN }}
 
       - name: Build all Images (For Smoke tests)
+        # --max-workers=$(nproc): gradle.properties caps workers at 2 (a laptop-safe
+        # default); the runner has 4+ vCPU, so that throttles this multi-module build.
+        # Same override build-and-test.yml already applies.
         if: ${{ needs.setup.outputs.publish != 'true' && needs.setup.outputs.pr-publish != 'true' }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
@@ -356,13 +359,13 @@ jobs:
             BUILD_TASK=":docker:buildImagesQuickstart"
           fi
           echo "Using build task: $BUILD_TASK"
-          ./gradlew $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
+          ./gradlew --max-workers="$(nproc)" $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
       - name: Build all Images (Publish)
         if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' }}
         # Push immutable tags (sha-*, pr*, release v*) to the registry during the coordinated depot bake.
         # The floating quickstart tag is applied only after smoke tests pass (see publish_images).
         run: |
-          ./gradlew :docker:buildImagesAll -PmatrixBuild=true  -Ptag=${{ needs.setup.outputs.tag }} -PshaTag=${{ needs.setup.outputs.unique_tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -PdockerPush=true -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
+          ./gradlew --max-workers="$(nproc)" :docker:buildImagesAll -PmatrixBuild=true  -Ptag=${{ needs.setup.outputs.tag }} -PshaTag=${{ needs.setup.outputs.unique_tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -PdockerPush=true -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
       - name: Capture build Id
         id: capture-build-id
         run: |
@@ -572,7 +575,7 @@ jobs:
         run: |
           BUILD_TASK="${{ needs.setup.outputs.smoke_build_task || ':docker:buildImagesQuickstart' }}"
           echo "Using build task: $BUILD_TASK"
-          ./gradlew $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
+          ./gradlew --max-workers="$(nproc)" $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
           docker images
 
       - name: Pull images from depot
@@ -764,7 +767,7 @@ jobs:
         run: |
           BUILD_TASK="${{ needs.setup.outputs.smoke_build_task || ':docker:buildImagesQuickstart' }}"
           echo "Using build task: $BUILD_TASK"
-          ./gradlew $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
+          ./gradlew --max-workers="$(nproc)" $BUILD_TASK -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
           docker images
 
       - name: Pull images from depot

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
-          distribution: "zulu"
+          distribution: "temurin"
           java-version: 21
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -43,11 +43,15 @@ graphqlCodegen {
     // The task type is not annotated @CacheableTask, so Gradle reports "Caching has
     // not been enabled for the task" and re-runs it on every build. Its output is a
     // pure function of the schema files and the options below, so opt in explicitly
-    // and declare the inputs -- same pattern as :datahub-web-react:yarnGenerateCacheable.
+    // -- same pattern as :datahub-web-react:yarnGenerateCacheable. The schema files
+    // themselves are already registered as @InputFiles by the plugin's own
+    // getActualSchemaPaths()/getGraphqlSchemaPaths() (graphql-java-codegen 5.10.0),
+    // so no separate inputs.files(...) declaration is needed here -- it would only
+    // re-snapshot the same files under a second property name, and since the
+    // plugin's registration has no @PathSensitive annotation (Gradle defaults
+    // @InputFiles to ABSOLUTE), a RELATIVE-sensitivity duplicate can't make the
+    // task's overall cache key portable across checkouts anyway.
     outputs.cacheIf { true }
-    inputs.files(fileTree(dir: "${projectDir}/src/main/resources", include: '**/*.graphql'))
-        .withPropertyName('graphqlSchemas')
-        .withPathSensitivity(PathSensitivity.RELATIVE)
 
     // For options: https://github.com/kobylynskyi/graphql-java-codegen/blob/master/docs/codegen-options.md
     graphqlSchemaPaths = fileTree(dir: "${projectDir}/src/main/resources", include: '**/*.graphql').collect { it.absolutePath }

--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -40,6 +40,15 @@ dependencies {
 }
 
 graphqlCodegen {
+    // The task type is not annotated @CacheableTask, so Gradle reports "Caching has
+    // not been enabled for the task" and re-runs it on every build. Its output is a
+    // pure function of the schema files and the options below, so opt in explicitly
+    // and declare the inputs -- same pattern as :datahub-web-react:yarnGenerateCacheable.
+    outputs.cacheIf { true }
+    inputs.files(fileTree(dir: "${projectDir}/src/main/resources", include: '**/*.graphql'))
+        .withPropertyName('graphqlSchemas')
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+
     // For options: https://github.com/kobylynskyi/graphql-java-codegen/blob/master/docs/codegen-options.md
     graphqlSchemaPaths = fileTree(dir: "${projectDir}/src/main/resources", include: '**/*.graphql').collect { it.absolutePath }
     outputDir = new File("${projectDir}/src/mainGeneratedGraphQL/java")


### PR DESCRIPTION
Independent of the change-aware image build work — based on `master`, not stacked.

Comes out of a measured breakdown of `base_build`, which after the `DEPOT_TOKEN` fix (org token, 2026-08-08) runs ~3.9 min. Of that, **~59.5s is Gradle pre-execution overhead** — daemon startup, buildSrc, and a 44s configuration phase — before a single task runs.

## The controlled comparison

`backend-seed` from `build-and-test.yml` ran on the **same commit** (PR 18991), started within a minute of `base_build`, and reports the **same runner spec** (15.3GB RAM). It uses `gradle/actions/setup-gradle`; `base_build` uses the hand-rolled cache. It also runs a *superset* task graph (`build testClasses`).

| Gradle sub-phase | `base_build` | `backend-seed` | delta |
| --- | --- | --- | --- |
| daemon → `:buildSrc:compileJava` | 9.0s | 3.4s | −5.6 |
| `:buildSrc:jar` → `Configure project :` | 6.7s | 2.1s | −4.6 |
| `Configure project :` → first task | 43.8s | 16.4s | −27.4 |
| **total** | **59.5s** | **21.9s** | **−37.6s** |

Not graph size — the faster side does more. The two differ in cache strategy and worker count, which is why those land as separate commits below.

## What's here

**1. `fix(ci)`: use `gradle/actions/setup-gradle` in `base_build`** — tracked as PFP-5478

The cache key was the literal string `gradle-plugins-cache`. Actions cache entries are immutable, so the first save on master claimed it and every save since failed:

```
Failed to save: Unable to reserve cache with key gradle-plugins-cache
```

The entry froze on **2026-07-22**, was later **evicted for age**, and `base_build` has since been restoring **nothing at all** — with no failing step, because a failed save is a warning and a missing restore is silent.

The path globs were Gradle 7 as well:

| glob | on Gradle 8.14 |
| --- | --- |
| `caches/transforms-*` | **matches nothing** — it's `caches/<version>/transforms` |
| `caches/*/groovy-dsl` | never covered — compiled build scripts |

**An earlier revision of this PR patched the key and the globs.** That was the wrong fix: it leaves us maintaining a bespoke cache that the next Gradle layout change can silently break again, in exactly the same way. This now uses the action the repo's other **19 workflows already use** — including two jobs in this same file — which hashes and versions its own keys and splits the buckets, so editing one build file re-saves a small bucket instead of an 850 MB blob.

The hand-rolled version existed for a real reason: `base_build` runs alongside 7 pytest batches and 8 Playwright shards, which must not all *write* to the cache. `setup-gradle` covers that by default —

```yaml
cache-read-only:
  default: 'github.ref_name != default_branch'   # verified at the pinned SHA
```

— the same master-only-write rule, built in rather than hand-enforced with an `if:`.

`build-cache-1` is excluded: task outputs now come from the Depot remote build cache, and including it in the Actions cache is what was reported to exhaust the repo's 10 GB budget.

The gradle bucket in `restore-dependency-caches` is orphaned by this and removed — no workflow passes `restore_gradle` any more.

**2. `perf(ci)`: scale Gradle workers to the runner**

`gradle.properties` caps `org.gradle.workers.max=2` (laptop-safe). `base_build` runs on `depot-ubuntu-24.04-4` and never overrides it, so a ~500-task build runs two-wide. `build-and-test.yml` already applies `--max-workers="$(nproc)"` with the same reasoning; `docker-unified` was missed.

**3. `perf(ci)`: use the tool-cached temurin JDK**

`setup-java` only tool-caches the distribution the runner image ships. `zulu` isn't it, so every job logs `Downloading Java 21.0.12+8 (Zulu) from cdn.azul.com` — 6.8–7.9s. `metadata-models-custom-ci.yml` uses `temurin` and logs `Resolved Java 21.0.11+10 from tool-cache`. Scoped to the two workflows actually measured; 19 others still use zulu, same one-line change, left as follow-up so this PR's claim stays measurable.

**4. `perf(build)`: make `graphqlCodegen` cacheable**

Reported *"Caching has not been enabled for the task"* and re-ran every build (1.05s local, 2.6–2.9s CI), on the critical path of every image containing GMS. Verified: deleting `src/mainGeneratedGraphQL/java` and re-running now returns `FROM-CACHE`.

## Expected

Roughly **50–65s off a ~205s build (25–30%)**, dominated by item 1.

## Deliberately not here

- **`copyGitProperties` → `auth-api:shadowJar` permanently uncacheable.** Proven by perturbing only `git.commit.id` and watching the cache key change (`2c20fcb…` → `7927526…`, FROM-CACHE → EXECUTED). Worth ~15s, but it's the one finding that can alter runtime classpath behaviour, so it belongs in its own PR.
- **Gating the yarn/uv/python cache restores on what's actually being built.** Server-only plans restore a 1169 MB yarn cache (13.5s) for zero yarn tasks — but that situation only exists once change-aware image builds land, so it belongs on that PR.
- **The Actions cache budget** currently sits at ~9.99 GB of 10 GB, with ~4.6 GB in duplicated uv/yarn entries. A bigger lever than anything here, and untouched by this PR.
- **Repo-wide zulu → temurin** (19 workflows).

## Verification

- `graphqlCodegen` round-trip confirmed locally (`FROM-CACHE` after wiping output).
- Items 1–3 only exercise on CI. Watch `base_build`'s "Run ./.github/actions/restore-dependency-caches" duration, the gap between `Configure project :` and the first `> Task`, and confirm the master save no longer logs *Unable to reserve cache*.
- Items 1 and 2 are confounded in the 37.6s measurement — separate commits so they can be attributed by reverting one.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests — n/a, CI infra; `graphqlCodegen` verified by cache round-trip
- [ ] Docs — n/a
- [ ] Breaking changes — none

