### PR TITLE
fix(ci): stop the Gradle build cache ratcheting until it cannot save

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,11 @@ concurrency:
 
 env:
   DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
+  # Enables the Depot remote Gradle build cache. settings.gradle gates it on
+  # DEPOT_TOKEN being present, so without this the workflow has no cross-run task
+  # output reuse at all -- which is why the run-scoped actions/cache entry below
+  # was given a prefix restore-key and grew without bound.
+  DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
   # Toggle backend test sharding. Repo variable (Settings → Actions → Variables); unset → '' →
   # falsy → defaults OFF, so it flips without a commit and each repo sets its own value.
   SHARDED_TESTS_RUNS_ENABLED: ${{ vars.SHARDED_TESTS_RUNS_ENABLED || 'false' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -500,13 +500,26 @@ jobs:
           # setup-gradle handles deps/wrapper; the local build cache is managed explicitly
           # below with a run-scoped key so shards deterministically restore the seed's output.
           gradle-home-cache-excludes: caches/build-cache-1
+      # Deliberately no restore-keys. This entry exists to hand the seed job's
+      # build cache to the parallel jobs in the SAME run, which match on the exact
+      # run-scoped key. A prefix restore-key here instead made it a ratchet: each
+      # run restored the previous run's cache, compiled into it, and saved the
+      # union, with nothing pruning it. gradle-metadata-io-build-cache reached
+      # 16.6GB, at which point `tar | zstd` ran the runner out of disk mid-save:
+      #
+      #   zstd: error 70 : Write error : cannot write block : No space left on device
+      #   ##[warning]Failed to save: "/usr/bin/tar" failed with exit code 2
+      #
+      # A failed save is a warning, so nothing went red -- and because the entry
+      # could never be replaced, every run since restored the same frozen blob.
+      # It cost 194s to restore and 128s to fail to save, against 106s of actual
+      # compile, while hitting on only 23 of 183 tasks. The cache had become
+      # slower than not having one.
       - name: Cache Gradle build cache (seed writes; run-scoped key)
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-backend-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-backend-build-cache-
       - name: Build + non-test checks once (assemble, spotless, etc.)
         # Compile main + test + non-test checks (no tests) to warm the shard cache.
         # Keep yarnGenerate / generateLazyIconStubs (codegen + graphqlUsageRegistryCheck need them);
@@ -578,12 +591,14 @@ jobs:
           cache-read-only: true
           gradle-home-cache-excludes: caches/build-cache-1
       - name: Restore Gradle build cache (exact key from seed this run)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        # cache/restore, not cache: these jobs consume the seed's output and
+        # must never write. With the full action they also saved at post-step,
+        # and the prefix restore-key let them pull a previous run's cache and
+        # re-save the union -- the same ratchet the seed job had.
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-backend-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-backend-build-cache-
       - name: Compute this shard's modules
         # Broad globs: a module is included by having ANY test source, so nothing depends on
         # class naming — each shard runs `:module:test` whole. Excludes mirror build-except's
@@ -703,12 +718,14 @@ jobs:
           cache-read-only: true
           gradle-home-cache-excludes: caches/build-cache-1
       - name: Restore Gradle build cache (exact key from seed this run)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        # cache/restore, not cache: these jobs consume the seed's output and
+        # must never write. With the full action they also saved at post-step,
+        # and the prefix restore-key let them pull a previous run's cache and
+        # re-save the union -- the same ratchet the seed job had.
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-backend-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-backend-build-cache-
       - name: Download all shards' JaCoCo exec
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -509,17 +509,12 @@ jobs:
       # build cache to the parallel jobs in the SAME run, which match on the exact
       # run-scoped key. A prefix restore-key here instead made it a ratchet: each
       # run restored the previous run's cache, compiled into it, and saved the
-      # union, with nothing pruning it. gradle-metadata-io-build-cache reached
-      # 16.6GB, at which point `tar | zstd` ran the runner out of disk mid-save:
-      #
-      #   zstd: error 70 : Write error : cannot write block : No space left on device
-      #   ##[warning]Failed to save: "/usr/bin/tar" failed with exit code 2
-      #
-      # A failed save is a warning, so nothing went red -- and because the entry
-      # could never be replaced, every run since restored the same frozen blob.
-      # It cost 194s to restore and 128s to fail to save, against 106s of actual
-      # compile, while hitting on only 23 of 183 tasks. The cache had become
-      # slower than not having one.
+      # union, with nothing pruning it -- this entry grew 3.2GB -> 7.2GB over 11
+      # runs in 4.5 hours (~+400MB/run) and was headed for the same wall its
+      # metadata-io sibling already hit: at 16.6GB that one could no longer be
+      # re-archived within the runner's disk, every save failed with a warning,
+      # and every run restored the same frozen blob. Cross-run reuse belongs to
+      # the remote build cache; this entry is intra-run handoff only.
       - name: Cache Gradle build cache (seed writes; run-scoped key)
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -31,6 +31,11 @@ concurrency:
 
 env:
   DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
+  # Enables the Depot remote Gradle build cache. settings.gradle gates it on
+  # DEPOT_TOKEN being present, so without this the workflow has no cross-run task
+  # output reuse at all -- which is why the run-scoped actions/cache entry below
+  # was given a prefix restore-key and grew without bound.
+  DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
 
 jobs:
   setup:

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -71,13 +71,26 @@ jobs:
           # build-cache-1 is managed explicitly below with a run-scoped key so the legs restore
           # exactly this run's compiled output.
           gradle-home-cache-excludes: caches/build-cache-1
+      # Deliberately no restore-keys. This entry exists to hand the seed job's
+      # build cache to the parallel jobs in the SAME run, which match on the exact
+      # run-scoped key. A prefix restore-key here instead made it a ratchet: each
+      # run restored the previous run's cache, compiled into it, and saved the
+      # union, with nothing pruning it. gradle-metadata-io-build-cache reached
+      # 16.6GB, at which point `tar | zstd` ran the runner out of disk mid-save:
+      #
+      #   zstd: error 70 : Write error : cannot write block : No space left on device
+      #   ##[warning]Failed to save: "/usr/bin/tar" failed with exit code 2
+      #
+      # A failed save is a warning, so nothing went red -- and because the entry
+      # could never be replaced, every run since restored the same frozen blob.
+      # It cost 194s to restore and 128s to fail to save, against 106s of actual
+      # compile, while hitting on only 23 of 183 tasks. The cache had become
+      # slower than not having one.
       - name: Cache Gradle build cache (seed writes; run-scoped key)
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-metadata-io-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-metadata-io-build-cache-
       - name: Compile metadata-io test classes once (no tests)
         run: ./gradlew :metadata-io:testClasses --build-cache
 
@@ -119,12 +132,14 @@ jobs:
           cache-read-only: true
           gradle-home-cache-excludes: caches/build-cache-1
       - name: Restore Gradle build cache (seed's output, this run)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        # cache/restore, not cache: these jobs consume the seed's output and
+        # must never write. With the full action they also saved at post-step,
+        # and the prefix restore-key let them pull a previous run's cache and
+        # re-save the union -- the same ratchet the seed job had.
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-metadata-io-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-metadata-io-build-cache-
       - name: Gradle test (${{ matrix.suite.name }} suite)
         run: |
           ./gradlew :metadata-io:${{ matrix.suite.task }} --build-cache
@@ -213,12 +228,14 @@ jobs:
           cache-read-only: true
           gradle-home-cache-excludes: caches/build-cache-1
       - name: Restore Gradle build cache (seed's output, this run)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        # cache/restore, not cache: these jobs consume the seed's output and
+        # must never write. With the full action they also saved at post-step,
+        # and the prefix restore-key let them pull a previous run's cache and
+        # re-save the union -- the same ratchet the seed job had.
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-metadata-io-build-cache-${{ github.run_id }}
-          restore-keys: |
-            gradle-metadata-io-build-cache-
       - name: Materialize generated sources (FROM-CACHE)
         run: ./gradlew :metadata-io:testClasses --build-cache
       - name: Ensure codegen is updated

--- a/settings.gradle
+++ b/settings.gradle
@@ -188,7 +188,11 @@ buildCache {
         // a null check enables the cache with an empty password and every build
         // opens with a 403 that Gradle swallows before disabling the cache.
         enabled = depotSecret ? true : false
-        push = isCi // Push only on CI. Local development only pulls
+        // Push only from master. PR runs pull but never write: with push enabled
+        // on any CI run, code executing in a same-repo PR could populate cache
+        // entries that trusted master builds later consume (cache poisoning).
+        // Master-only writes match every other cache in this repo.
+        push = isCi && System.getenv('GITHUB_REF') == 'refs/heads/master'
         credentials {
             username = ''
             password = depotSecret

--- a/settings.gradle
+++ b/settings.gradle
@@ -183,7 +183,11 @@ buildCache {
 
     remote(HttpBuildCache) {
         url = 'https://cache.depot.dev'
-        enabled = depotSecret != null
+        // Truthiness, not a null check: GitHub sets secrets that are unavailable
+        // (fork PRs) to the empty string, not to nothing. `"" != null` is true, so
+        // a null check enables the cache with an empty password and every build
+        // opens with a 403 that Gradle swallows before disabling the cache.
+        enabled = depotSecret ? true : false
         push = isCi // Push only on CI. Local development only pulls
         credentials {
             username = ''


### PR DESCRIPTION
Independent of the other CI work in flight — based on `master`, touches only `metadata-io.yml` and `build-and-test.yml`.

## What's broken

Both workflows have a "seed" job that compiles once and hands its Gradle build cache to parallel jobs in the same run. The cache step:

```yaml
key: gradle-metadata-io-build-cache-${{ github.run_id }}   # unique per run
restore-keys: |
  gradle-metadata-io-build-cache-                          # ← newest previous run
```

That's a **ratchet**. Every run restores the previous run's cache by prefix, compiles into it, and saves the **union** under a new key. Nothing prunes it.

| cache | state |
| --- | --- |
| `gradle-backend-build-cache` | 3217 → 7224 MB over 11 runs in 4.5h, ~+400 MB/run, still growing |
| `gradle-metadata-io-build-cache` | **16.6 GB — already deadlocked** |

## The deadlock

At 16.6 GB, restoring the blob and then writing the archive back exceeds the runner's disk:

```
zstd: error 70 : Write error : cannot write block : No space left on device
##[warning]Failed to save: "/usr/bin/tar" failed with exit code 2
```

**A failed save is a warning, so nothing goes red.** And since the entry can never be replaced, every run restores the same frozen blob. Confirmed individually on 7 of the last 8 runs — all restoring `gradle-metadata-io-build-cache-31207979174`, written **2026-08-07**.

## What it costs

Measured on the seed job (run `31272691360`, 8.0 min total):

```
194s   restore the 16.6 GB blob        ← 40% of the job
106s   compile metadata-io testClasses ← the actual work
128s   fail to save                    ← 27% of the job, pure loss
```

**322 of 480 seconds — 67% — is spent moving a cache that no longer helps.** Hit rate on the restored blob: **23 of 183 tasks**. It's frozen at 2026-08-07, so every commit since has changed inputs and the hit rate decays further while the 194s restore cost stays fixed.

**This job is now slower than if the cache did not exist.**

To be precise about the risk: Gradle's build cache is content-addressed, so a stale entry cannot serve wrong outputs — it misses. This is waste, not a correctness bug.

## The fix — two commits

**1. Enable the Depot remote build cache in both workflows.**

`settings.gradle` configures a remote `HttpBuildCache` at `cache.depot.dev`, gated on `DEPOT_TOKEN`. **Neither workflow sets it**, so both have been running with no cross-run reuse of Gradle task outputs at all.

That absence is *why* the ratchet exists. With no remote cache, the only way to carry compiled output between runs was a prefix restore-key that folded the previous run's cache into the next one, forever. With the remote cache on, cross-run reuse is server-side and content-addressed, so it cannot accumulate.

The token was re-issued as an org token on 2026-08-08 (the previous project token 403'd against the cache endpoint) and `docker-unified.yml` already uses it exactly this way.

**2. Stop the ratchet.**

**Seed jobs:** drop `restore-keys`. The entry's job is to hand this run's output to this run's parallel jobs, which match on the exact run-scoped key. The prefix was serving cross-run reuse — which is legitimate, and is now served properly by the remote cache instead of by unbounded accumulation. The seed saves only what it produced.

**Consumer jobs:** `actions/cache` → `actions/cache/restore`. Despite being named *"Restore Gradle build cache"* they used the full action, so they also saved at post-step — and with the prefix restore-key they could pull a previous run's cache and re-save the union. Same ratchet, second path.

## Expected

- `metadata-io-seed`: **~8.0 → ~3 min**, and it stops writing a 16.6 GB entry
- `backend-seed`: stops growing ~400 MB/run before it hits the same wall
- Cross-run reuse moves from the local ratchet to the remote build cache, so it should improve rather than regress — the frozen local blob was hitting only 23/183 tasks.

## A note on the three Depot mechanisms

They are independent and were not aligned, which is what made this confusing to diagnose:

| mechanism | what it is | gated on | state before this PR |
| --- | --- | --- | --- |
| Depot **runners** | `runs-on: depot-ubuntu-*` | `vars.DEPOT_PROJECT_ID` | on |
| Depot **Cache backend** | `actions/cache` redirected to Depot when on a Depot runner | the runner, automatically | on |
| Depot **remote Gradle build cache** | `HttpBuildCache` at `cache.depot.dev` | `DEPOT_TOKEN` | **off** |

Because the first two were on, the ratcheting entry lived in Depot Cache rather than GitHub's — so it never counted against the 10 GB Actions budget, and grew to 16.6 GB unnoticed.

## Verification

- Confirm `metadata-io-seed` no longer logs `Failed to save` and its post-cache step drops from ~128s.
- Confirm Gradle reports `FROM-CACHE` tasks sourced from the remote cache, and **no** `403: Forbidden` from `cache.depot.dev`.
- Confirm the parallel suite jobs still get `Cache restored from key: gradle-metadata-io-build-cache-<this run id>` (exact hit, not a prefix fallback).
- The 16.6 GB entry will age out on its own; it is not deleted here.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests — n/a, CI workflow change; verification steps above
- [ ] Docs — n/a
- [ ] Breaking changes — none

