### PR TITLE
test(ci): DO NOT MERGE -- validate warm uv-cache restore for stacked PRs

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mcp_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_builder.py
@@ -62,6 +62,8 @@ class DatahubKey(BaseModel):
         return self.model_dump(by_alias=True, exclude_none=True)
 
     def guid(self) -> str:
+        # Stable across runs: the guid is a hash of the key fields, so the same
+        # logical container always maps to the same urn.
         bag = self.guid_dict()
         return datahub_guid(bag)
 


### PR DESCRIPTION
Throwaway validation for #19008. Base branch carries a warmed `uv-python-lint-6a442988…` entry (834 MB) saved by `python-cache-warmup.yml`; this PR touches one `metadata-ingestion/**` file so `python-lint` runs. Expected: `Cache restored from key: uv-python-lint-6a442988…` (exact hit via base-branch scope — the same read path post-merge PRs use against master) and a visibly faster install step vs the cold first runs measured this morning. Close after reading.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate warm restore of the `uv` cache for stacked PRs by triggering the `python-lint` job against a base branch with a prewarmed cache. Adds a comment-only change in `metadata-ingestion/src/datahub/emitter/mcp_builder.py` to confirm an exact cache hit and faster install time.

<sup>Written for commit 0586314716914a25da42cf86253a5b1cede7ac56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

