### PR TITLE
fix(looker): attach lifetime field_usage counts to a single day bucket

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -1681,6 +1681,8 @@ class LookerDashboardSourceReport(StaleEntityRemovalSourceReport):
     explores_skipped_for_usage: LossySet[str] = dataclasses_field(
         default_factory=LossySet
     )
+    # field_usage rows missing a model/explore/field dimension
+    explore_field_usage_rows_dropped: int = 0
 
     stage_latency: List[StageLatency] = dataclasses_field(default_factory=list)
     _looker_explore_registry: Optional[LookerExploreRegistry] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_query_model.py
@@ -35,7 +35,9 @@ class LookerField(StrEnum):
     COUNT = "count"
     MODEL = "model"
     VIEW = "view"
-    FIELDS = "fields"
+    EXPLORE = "explore"
+    FIELD = "field"
+    TIMES_USED = "times_used"
 
 
 class ViewField(StrEnum):
@@ -69,9 +71,6 @@ class QueryViewField(ViewField):
     # LookML view). Together with `query.model` it identifies the explore.
     QUERY_MODEL = f"{LookerView.QUERY}.{LookerField.MODEL}"
     QUERY_VIEW = f"{LookerView.QUERY}.{LookerField.VIEW}"
-    # System Activity's list of fully-qualified `view.field` names each query
-    # referenced.  Returned as a single delimited string (not an array).
-    QUERY_FIELDS = f"{LookerView.QUERY}.{LookerField.FIELDS}"
 
 
 class FieldUsageViewField(ViewField):
@@ -81,9 +80,9 @@ class FieldUsageViewField(ViewField):
     without the row-limit truncation issues of the History explore."""
 
     FIELD_USAGE_MODEL = f"{LookerView.FIELD_USAGE}.{LookerField.MODEL}"
-    FIELD_USAGE_EXPLORE = "field_usage.explore"
-    FIELD_USAGE_FIELD = "field_usage.field"
-    FIELD_USAGE_TIMES_USED = "field_usage.times_used"
+    FIELD_USAGE_EXPLORE = f"{LookerView.FIELD_USAGE}.{LookerField.EXPLORE}"
+    FIELD_USAGE_FIELD = f"{LookerView.FIELD_USAGE}.{LookerField.FIELD}"
+    FIELD_USAGE_TIMES_USED = f"{LookerView.FIELD_USAGE}.{LookerField.TIMES_USED}"
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -124,7 +124,8 @@ class QueryId(StrEnum):
     LOOK_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_look"
     EXPLORE_PER_DAY_USAGE_STAT = "counts_per_day_per_explore"
     EXPLORE_PER_USER_PER_DAY_USAGE_STAT = "counts_per_day_per_user_per_explore"
-    EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT = "counts_per_day_per_field_per_explore"
+    # Lifetime totals, not day-scoped — see the query definition below.
+    EXPLORE_FIELD_USAGE_STAT = "lifetime_counts_per_field_per_explore"
 
 
 query_collection: Dict[QueryId, LookerQuery] = {
@@ -204,8 +205,11 @@ query_collection: Dict[QueryId, LookerQuery] = {
     # Unlike querying query.fields from History (which is subject to the
     # 5000-row default limit and returns sparse, truncated data on busy
     # instances), field_usage provides complete lifetime per-field counts
-    # with one row per (model, explore, field).
-    QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: LookerQuery(
+    # with one row per (model, explore, field).  Counts are lifetime totals,
+    # so this query is deliberately not date-filtered — see
+    # ExploreStatGenerator._augment_entity_timeseries_aspects for how they
+    # are mapped onto day buckets.
+    QueryId.EXPLORE_FIELD_USAGE_STAT: LookerQuery(
         model=LookerModel.SYSTEM_ACTIVITY,
         explore=LookerExplore.FIELD_USAGE,
         fields=[
@@ -423,12 +427,16 @@ class BaseStatGenerator(ABC):
         return rows
 
     def _append_filters(self, query: LookerQuery) -> LookerQuery:
-        query.filters.update(
-            {HistoryViewField.HISTORY_CREATED_DATE: self.config.interval}
-        )
+        # Returns a copy: `query_collection` holds one shared LookerQuery per
+        # QueryId, so mutating it here would leak this run's interval and
+        # entity-id filters into every later generator in the same process.
+        filters: Dict[ViewField, str] = {
+            **query.filters,
+            HistoryViewField.HISTORY_CREATED_DATE: self.config.interval,
+        }
         if not self.post_filter:
-            query.filters.update(self.get_filter())
-        return query
+            filters.update(self.get_filter())
+        return dataclasses.replace(query, filters=filters)
 
     def emits_absolute_stats(self) -> bool:
         """Whether the source exposes an absolute usage snapshot for this entity.
@@ -747,19 +755,21 @@ class ExploreStatGenerator(BaseStatGenerator):
     def report_skip_set(self) -> LossySet[str]:
         return self.report.explores_skipped_for_usage
 
-    def get_filter(self) -> Dict[ViewField, str]:
-        return {
-            QueryViewField.QUERY_VIEW: ",".join(
-                sorted(
-                    {
-                        explore.name
-                        for explore in cast(
-                            Sequence[LookerExploreForUsage], self.looker_models
-                        )
-                    }
-                )
+    def _explore_names(self) -> str:
+        # Looker filter syntax for "any of": a comma-separated list of values.
+        return ",".join(
+            sorted(
+                {
+                    explore.name
+                    for explore in cast(
+                        Sequence[LookerExploreForUsage], self.looker_models
+                    )
+                }
             )
-        }
+        )
+
+    def get_filter(self) -> Dict[ViewField, str]:
+        return {QueryViewField.QUERY_VIEW: self._explore_names()}
 
     def get_id(self, looker_object: ModelForUsage) -> str:
         explore = cast(LookerExploreForUsage, looker_object)
@@ -815,31 +825,42 @@ class ExploreStatGenerator(BaseStatGenerator):
             userCounts=[],
         )
 
-    def _augment_entity_timeseries_aspects(
-        self, entity_usage_stat: Dict[Tuple[str, str], Any]
-    ) -> None:
-        """Attach per-field usage from the ``field_usage`` explore to each
-        per-day explore aspect.  The field_usage explore provides
-        pre-aggregated lifetime counts (one row per model/explore/field),
-        so the same fieldCounts list is attached to every day-bucket for
-        a given explore.
+    def _fetch_field_usage_counts(self) -> Dict[str, Dict[str, int]]:
+        """Lifetime per-field usage counts from the ``field_usage`` explore,
+        keyed by ``<model>::<explore>`` then field name.
 
         Calls the API wrapper directly (not ``_execute_query``) because
         ``_execute_query``'s ``post_filter`` path expects History-explore
         row keys (``query.model``/``query.view``) that don't exist in
         ``field_usage`` rows."""
-        field_query = query_collection[QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT]
+        field_query = query_collection[QueryId.EXPLORE_FIELD_USAGE_STAT]
+        if not self.post_filter:
+            # Without this the query returns every field of every explore on
+            # the instance, which is a lot of rows given limit=-1.
+            field_query = dataclasses.replace(
+                field_query,
+                filters={
+                    **field_query.filters,
+                    FieldUsageViewField.FIELD_USAGE_EXPLORE: self._explore_names(),
+                },
+            )
+
+        start_time = datetime.datetime.now()
         try:
             field_rows = self.config.looker_api_wrapper.execute_query(
                 field_query.to_write_query()
             )
         except Exception as e:
-            logger.warning("Failed to fetch field usage data: %s", e)
-            return
-
-        if not field_rows:
-            logger.info("field_usage explore returned 0 rows")
-            return
+            self.report.warning(
+                title="Failed to Fetch Explore Field Usage",
+                message="Per-field usage counts will be missing from explore usage stats. Check that the ingestion user can query the System Activity field_usage explore.",
+                exc=e,
+            )
+            return {}
+        self.report.report_query_latency(
+            f"{self.get_stats_generator_name()}:field_query",
+            datetime.datetime.now() - start_time,
+        )
 
         per_explore_counts: Dict[str, Dict[str, int]] = defaultdict(dict)
         for row in field_rows:
@@ -847,17 +868,47 @@ class ExploreStatGenerator(BaseStatGenerator):
             explore = row.get(FieldUsageViewField.FIELD_USAGE_EXPLORE)
             field = row.get(FieldUsageViewField.FIELD_USAGE_FIELD)
             times_used = row.get(FieldUsageViewField.FIELD_USAGE_TIMES_USED)
-            if not all((model, explore, field, times_used)):
+            if model is None or explore is None or field is None:
+                self.report.explore_field_usage_rows_dropped += 1
                 continue
-            explore_id = self._stat_key(model, explore)
-            per_explore_counts[explore_id][field] = int(times_used)
+            if not times_used:
+                continue
+            per_explore_counts[self._stat_key(str(model), str(explore))][str(field)] = (
+                int(times_used)
+            )
+        return per_explore_counts
 
-        # field_usage counts are lifetime totals, not day-scoped.
-        for (explore_id, _date), aspect in entity_usage_stat.items():
+    def _augment_entity_timeseries_aspects(
+        self, entity_usage_stat: Dict[Tuple[str, str], Any]
+    ) -> None:
+        """Attach per-field usage from the ``field_usage`` explore to the
+        explore's per-day aspects.
+
+        ``field_usage`` reports lifetime totals, one row per
+        (model, explore, field), while these aspects are day buckets whose
+        ``fieldCounts.count`` GMS SUMs across every bucket in a queried range
+        (see ``UsageServiceUtil#getFieldUsageCounts``).  Attaching the same
+        list to every bucket would therefore multiply each count by the number
+        of active days, so the lifetime snapshot goes on the latest bucket
+        only: a range sum then reports it exactly once."""
+        if not entity_usage_stat:
+            return
+
+        per_explore_counts = self._fetch_field_usage_counts()
+        if not per_explore_counts:
+            return
+
+        # Dates are ISO-formatted (YYYY-MM-DD), so string ordering is date order.
+        latest_bucket: Dict[str, str] = {}
+        for explore_id, date in entity_usage_stat:
+            if date > latest_bucket.get(explore_id, ""):
+                latest_bucket[explore_id] = date
+
+        for explore_id, date in latest_bucket.items():
             field_counts = per_explore_counts.get(explore_id)
             if not field_counts:
                 continue
-            aspect.fieldCounts = [
+            entity_usage_stat[(explore_id, date)].fieldCounts = [
                 DatasetFieldUsageCountsClass(fieldPath=field_name, count=count)
                 for field_name, count in sorted(field_counts.items())
             ]

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -695,7 +695,7 @@ def side_effect_query_inline(
         # here so the dashboard/look goldens are unaffected.
         looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT: json.dumps([]),
         looker_usage.QueryId.EXPLORE_PER_USER_PER_DAY_USAGE_STAT: json.dumps([]),
-        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT: json.dumps([]),
+        looker_usage.QueryId.EXPLORE_FIELD_USAGE_STAT: json.dumps([]),
     }
 
     if query_id_vs_response.get(query_type) is None:

--- a/metadata-ingestion/tests/unit/looker/test_looker_usage.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_usage.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, cast
 from unittest import mock
 
 from datahub.ingestion.source.looker import looker_usage
@@ -51,7 +51,7 @@ def test_explore_usage_queries_target_system_activity_query_view():
     # The per-field query uses the field_usage explore (pre-aggregated, no row
     # limit issues) instead of parsing query.fields from the History explore.
     per_field = looker_usage.query_collection[
-        looker_usage.QueryId.EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT
+        looker_usage.QueryId.EXPLORE_FIELD_USAGE_STAT
     ]
     assert per_field.model == LookerModel.SYSTEM_ACTIVITY
     assert FieldUsageViewField.FIELD_USAGE_MODEL in per_field.fields
@@ -163,10 +163,131 @@ def test_explore_stat_generator_emits_usage_stats():
     entity_urn = mcps[0].entityUrn
     assert entity_urn is not None and "sales.explore.orders" in entity_urn
 
-    # query.fields is exploded and summed into per-field usage counts.
+    # Lifetime field usage is attached to the explore's single day bucket.
     assert aspect.fieldCounts is not None
     field_counts = {fc.fieldPath: fc.count for fc in aspect.fieldCounts}
     assert field_counts == {"orders.count": 30, "orders.created_date": 18}
+
+
+def test_lifetime_field_counts_are_not_repeated_across_day_buckets():
+    # field_usage.times_used is a lifetime total, but GMS SUMs
+    # fieldCounts.count across every bucket in a queried range
+    # (UsageServiceUtil#getFieldUsageCounts).  Repeating the list on each day
+    # would report times_used x active-days, so it belongs on one bucket only.
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: date,
+            HistoryViewField.HISTORY_COUNT: 10,
+        }
+        for date in ("2022-07-05", "2022-07-06", "2022-07-07")
+    ]
+    field_rows = [
+        {
+            FieldUsageViewField.FIELD_USAGE_MODEL: "sales",
+            FieldUsageViewField.FIELD_USAGE_EXPLORE: "orders",
+            FieldUsageViewField.FIELD_USAGE_FIELD: "orders.count",
+            FieldUsageViewField.FIELD_USAGE_TIMES_USED: 1553,
+        },
+    ]
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [entity_rows, field_rows, []]
+
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 3
+    total = 0
+    for mcp in mcps:
+        aspect = mcp.aspect
+        assert isinstance(aspect, DatasetUsageStatisticsClass)
+        total += sum(fc.count for fc in aspect.fieldCounts or [])
+    assert total == 1553
+
+    # It lands on the latest day bucket.
+    latest = max(
+        mcps,
+        key=lambda mcp: cast(DatasetUsageStatisticsClass, mcp.aspect).timestampMillis,
+    )
+    assert cast(DatasetUsageStatisticsClass, latest.aspect).fieldCounts
+
+
+def test_field_usage_query_failure_leaves_usage_stats_intact():
+    entity_rows = [
+        {
+            QueryViewField.QUERY_MODEL: "sales",
+            QueryViewField.QUERY_VIEW: "orders",
+            HistoryViewField.HISTORY_CREATED_DATE: "2022-07-05",
+            HistoryViewField.HISTORY_COUNT: 30,
+        }
+    ]
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [
+        entity_rows,
+        Exception("field_usage explore is not accessible"),
+        [],
+    ]
+
+    report = LookerDashboardSourceReport()
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=report,
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+
+    mcps = list(generator.generate_usage_stat_mcps())
+
+    assert len(mcps) == 1
+    aspect = mcps[0].aspect
+    assert isinstance(aspect, DatasetUsageStatisticsClass)
+    assert aspect.totalSqlQueries == 30
+    assert aspect.fieldCounts is None
+    # The operator gets told why fieldCounts are missing.
+    assert len(report.warnings) == 1
+
+
+def test_generators_do_not_mutate_the_shared_query_collection():
+    # query_collection holds one shared LookerQuery per QueryId; a generator
+    # that filtered it in place would leak its interval and explore filters
+    # into every later generator in the same process.
+    per_day = looker_usage.query_collection[
+        looker_usage.QueryId.EXPLORE_PER_DAY_USAGE_STAT
+    ]
+    before = dict(per_day.filters)
+
+    mock_api = mock.MagicMock()
+    mock_api.execute_query.side_effect = [[], [], []]
+    generator = looker_usage.create_explore_stat_generator(
+        config=_stat_config(api=mock_api),
+        report=LookerDashboardSourceReport(),
+        source_config=LookerCommonConfig(),
+        looker_explores=[
+            looker_usage.LookerExploreForUsage(
+                id=None, model_name="sales", name="orders"
+            )
+        ],
+    )
+    list(generator.generate_usage_stat_mcps())
+
+    assert per_day.filters == before
 
 
 def test_explore_stat_key_round_trips_between_model_and_row():


### PR DESCRIPTION
## Summary

Stacked on #19002 (base is that PR's branch, so the diff here is just the delta). Fixes the day-bucket accounting for the new `field_usage` counts, plus the smaller items from my review of that PR.

## Motivation

`field_usage.times_used` is a lifetime total, but #19002 writes the same `fieldCounts` list into every per-day explore aspect. GMS SUMs `fieldCounts.count` across every bucket in a queried range — [`UsageServiceUtil#getFieldUsageCounts`](https://github.com/datahub-project/datahub/blob/master/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/UsageServiceUtil.java#L334-L350):

```java
AggregationSpec sumFieldCountAggSpec =
    new AggregationSpec().setAggregationType(AggregationType.SUM)
        .setFieldPath("fieldCounts.count");
```

So an explore active on 20 days reports `20 x times_used` per field. Using the example from #19002 (`order_details.count: 1553`), a 30-day window with 20 active days surfaces ~31k uses for that column, while `totalSqlQueries` over the same range is a genuine per-day sum — the two stop being comparable, and field ranking ends up favouring explores that were active on more days rather than ones that were used more.

## Changes Overview

**Bug fixes:**

- Attach the lifetime snapshot to the **latest day bucket per explore** instead of every bucket, so a range sum reports `times_used` exactly once. The `_augment_entity_timeseries_aspects` docstring records why, so the constraint isn't rediscovered later.
- `_append_filters` returns a copy (`dataclasses.replace`) rather than mutating the shared `query_collection` entry. Today a second Looker source in the same process inherits the first one's interval and explore-list filters, and a source with >100 explores takes the `post_filter=True` path, skips `get_filter()` entirely, and silently queries the previous source's explores.

**Improvements:**

- Push an explore-name filter down into the `field_usage` query (extracted `_explore_names()`, shared with `get_filter()`), instead of pulling every field of every explore on the instance with `limit=-1`. Early-return when there is no explore activity at all.
- Report query failures through `self.report.warning` with a permissions hint, and restore `report_query_latency` for the field query. Malformed rows increment a new `explore_field_usage_rows_dropped` counter rather than disappearing.
- Check `model`/`explore`/`field` with `is None`; a `times_used` of 0 is skipped separately rather than being treated as malformed.

**Cleanup:**

- Remove `QueryViewField.QUERY_FIELDS` / `LookerField.FIELDS`, unused since `_parse_query_fields` was deleted.
- Compose all four `FieldUsageViewField` names from `LookerView`/`LookerField` instead of hardcoding three of them.
- Rename `EXPLORE_PER_FIELD_PER_DAY_USAGE_STAT` -> `EXPLORE_FIELD_USAGE_STAT`, since the query is neither per-day nor date-filtered.

## Testing

Three new unit tests:

- cross-bucket sum equals `times_used` once, and lands on the latest bucket (the regression that was missing — every existing fixture used a single date)
- explore usage stats survive a `field_usage` query failure, with a warning in the report
- `query_collection` is unchanged after a generator runs

Verified locally:

- `./gradlew :metadata-ingestion:lint` — ruff + mypy clean
- `pytest tests/unit/looker/test_looker_usage.py --random-order` — 9 passed, re-run several times to confirm order independence
- `pytest tests/integration/looker/` — 60 passed. `test_looker_ingest_usage_history` fails in my checkout with `lastViewedAt` off by exactly 14h; it fails identically on the unmodified base branch, so it's a local timezone artifact rather than something here.

## Impact Assessment

- **Affected Components:** Looker source connector (`looker_usage.py`, `looker_query_model.py`, `looker_common.py`)
- **Breaking Changes:** None. `fieldCounts` still carries lifetime totals, they just aren't multiplied by the active-day count any more.
- **Risk Level:** Low

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issues: #19002
- [x] Tests added/updated
- [x] Docs added/updated: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overcounting of Looker field usage by attaching lifetime counts to only the latest day bucket per explore. Also prevents shared query filter leakage and tightens the `field_usage` path for better performance and reporting.

- **Bug Fixes**
  - Attach lifetime `field_usage.times_used` to the latest day bucket per explore so range sums count it once.
  - `_append_filters` returns a copy to avoid leaking interval/explore filters across generators.

- **Refactors**
  - Scope the `field_usage` query to selected explores; add warning with permission hint on failure; restore latency reporting; track malformed rows and skip only `times_used=0`.
  - Rename query id to `EXPLORE_FIELD_USAGE_STAT`; remove unused `QueryViewField.QUERY_FIELDS`/`LookerField.FIELDS`; compose `FieldUsageViewField` names from `LookerView`/`LookerField`.

<sup>Written for commit 79ed155b04c93cb32050a3a8043a562a23c42ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

