### PR TITLE
docs(agents): add CI caching facts and verification discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -751,6 +751,36 @@ Full reference: [`e2e-test/ui/playwright/README.md`](e2e-test/ui/playwright/READ
 feature per run. Do **not** set `featureName` for suites that create their own data
 via `apiMock` or direct API calls.
 
+### Timing and waits
+
+`page.waitForTimeout(ms)` is a code smell in every new Playwright test and page
+object. It is never the right tool for the two things it keeps getting used for:
+
+- **Waiting for a write to become readable** (a create/update/delete needs to flow
+  through the consumer/index pipeline before a reload or search re-reads it). A
+  fixed sleep is either too short (flaky under CI load) or too long (wastes the
+  same fixed cost on every run regardless of actual system speed). Use
+  `waitForWritesToSync()` from `utils/writes-sync.ts` — it polls the real consumer
+  offsets and returns as soon as the write is actually consumed.
+- **Waiting for a UI render/dropdown/menu to appear.** If the next line is (or could
+  be) a Playwright web-first assertion — `expect(locator).toBeVisible()`,
+  `.toContainText()`, `.toHaveAttribute()`, etc. — that assertion already retries
+  for its own timeout. A sleep placed before it adds fixed latency and verifies
+  nothing; delete the sleep and let the assertion's timeout do the waiting.
+
+`document-management.spec.ts` carried both anti-patterns in its page object for
+months — 13 blind `waitForTimeout(TIMEOUTS.OPERATION)` calls, most redundant with
+a retrying assertion two lines later, three of them races against ES indexing —
+and became the long pole of the entire Playwright CI shard split as a direct
+result (~70s of a single spec file's ~237s runtime was dead sleep). Check any new
+`waitForTimeout()` against both bullets above before adding it; when in doubt,
+add the assertion and delete the sleep rather than the reverse.
+
+A short, fixed sleep is still acceptable for the narrow case of a genuine UI
+settle with no assertable signal (e.g. letting a text-selection register before
+typing) — but even there, default to the smallest timeout tier (`QUICK` /
+`BETWEEN_OPS`) rather than reaching for `OPERATION` out of caution.
+
 ## Frontend CI Checklist
 
 This checklist is for **commit- or PR-ready** frontend work — i.e. when you're about to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -775,6 +775,60 @@ cd datahub-web-react && yarn test src/path/to/file.test.ts --run
 unrelated files. Focus on errors in files **you touched** — in particular, optional
 prop calls (`prop?.(arg)`) and import aliases.
 
+## Working on CI (GitHub Actions, Gradle, caches)
+
+Verified facts about this repo's CI. Check changes against these — every one was
+learned from a silent failure:
+
+- **Lint workflows locally before pushing:** `actionlint` in addition to YAML
+  parse and `githubActionsPrettierCheck`. Only actionlint knows GitHub's
+  semantics — e.g. the `secrets` context is not allowed in step-level `if:`
+  (compute a job output in `setup` instead, as `docker-login` does). A context
+  violation fails the whole run with zero jobs.
+- **`gh run view --log` silently truncates.** Always fetch complete logs via
+  `gh api repos/{owner}/{repo}/actions/jobs/{job_id}/logs` before concluding
+  anything from a log.
+- **Actions cache entries are immutable and ref-scoped.** A fixed key string
+  means the first save wins forever and every later save fails — as a warning,
+  so nothing goes red. A cache saved on a PR ref is invisible to every other PR.
+  PRs can read entries from master and from their PR's base branch. Pattern:
+  write on master (or a master-gated warmup job), restore-by-prefix on PRs.
+  Never a fixed literal key; never a save that can only run on a ref where the
+  workflow never triggers.
+- **Two cache backends exist.** On `depot-*` runners `actions/cache` is served
+  by Depot Cache (no 10 GB limit, not ref-scoped); on `ubuntu-*` runners by
+  GitHub (10 GB repo budget, ref-scoped). A writer on one backend cannot warm a
+  reader on the other — check `runs-on` for both sides of any cache pair.
+- **The Gradle remote build cache** (`settings.gradle` → cache.depot.dev) is
+  gated on `DEPOT_TOKEN` (org token, not project token) and must push only from
+  master: PR runs that can write to it can poison what trusted builds read. It
+  fails silently — one 403 and Gradle disables it for the rest of the build at
+  info level.
+- **CI caching fails silently by design** (failed save = warning, missed
+  restore = nothing, disabled remote = info line). A PR that touches caching
+  must state the log line proving it works (`FROM-CACHE`,
+  `Cache restored from key: …`) and the log line that would reveal it broken
+  (`Unable to reserve cache`, `response status 403`, `Failed to save`).
+- **Per-task timings attributed from log-line gaps are not a profile** under
+  `org.gradle.parallel=true`. Use `--profile` or job-level durations, and treat
+  ±0.3 min as noise on runner timings.
+
+## Verification discipline
+
+- **Hunt the counterexample, not the confirmation.** Before claiming "X is only
+  used by Y", search for X itself (`grep -rln <filename>`), not for the one
+  consumption mechanism you already know about. An absence claim needs a search
+  shaped to find presence _anywhere_.
+- **New guardrails must be walked against existing special cases.** When adding
+  an assertion or backstop to a workflow, re-check it against every existing
+  mode in that workflow — labels, fork PRs, `workflow_dispatch`, non-default
+  profiles — not just the happy path it was written for.
+- **Treat PR-controlled strings as hostile** anywhere they reach rendered
+  output (step summaries render markdown) or a shell. Treat any credential
+  visible to a `pull_request` job as readable by PR code.
+- **Stage files explicitly** (`git add <path>…`), never `git add -A` — this is
+  a public repo and scratch/analysis files must not enter history.
+
 ## Python Virtual Environments
 
 Gradle tasks manage all venvs automatically. Never create, activate, or pip-install into them manually. When running smoke tests outside Gradle: `smoke-test/venv/bin/python -m pytest ...`


### PR DESCRIPTION
Two additions to AGENTS.md, distilled from a day of CI-caching archaeology (#19003, #19007, #19008, #18983 and the DEPOT_TOKEN fix).

**Working on CI** — repo-specific facts that cannot be re-derived under time pressure and were each learned from a silent failure: Actions cache immutability + ref scoping, the Depot-vs-GitHub cache backend split by runner type, the `DEPOT_TOKEN` gating and its failure mode, `gh run view --log` truncation, actionlint as the only local check that knows GitHub's expression semantics, and the requirement that cache PRs name the log lines proving them working and broken.

**Verification discipline** — the generalized form of what this week's review findings caught: counterexample-shaped searches for absence claims, walking new guardrails against existing workflow modes, treating PR-controlled strings and PR-visible credentials as hostile, and explicit staging in a public repo.

Design constraint applied throughout: every rule is mechanical and checkable ("run actionlint", "grep for the filename"), not advisory ("be careful") — guidance that can't fail a check doesn't prevent anything.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Tests — n/a, docs
- [x] Docs — this is the doc
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `AGENTS.md` with CI caching facts and Playwright timing/waits hygiene to prevent silent breakage and wasted runtime: immutable/ref‑scoped `actions/cache`, Depot vs GitHub cache backends by runner, `DEPOT_TOKEN` gating for the Gradle remote cache, `gh` log truncation, and replacing `page.waitForTimeout()` with `waitForWritesToSync()` or web‑first assertions. Added a mechanical verification checklist that demands named proof lines, counterexample‑shaped searches, walking guardrails across workflow modes, treating PR‑controlled strings/credentials as hostile, and explicit file staging.

<sup>Written for commit d54590a4a80830f699f5ff48af3e859e6f544a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

