### PR TITLE
perf(playwright): replace hard sleeps with an offset-checkpoint writes-sync wait

### DIFF
--- a/.github/scripts/check_playwright_fixture_conflicts.py
+++ b/.github/scripts/check_playwright_fixture_conflicts.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Detect entities redefined with conflicting payloads across Playwright fixture files.
+
+Every Playwright spec file can bring its own tests/{feature}/fixtures/data.json,
+seeded on top of the shared test-data/data.json (see seeding.fixture.ts). Aspect
+ingestion REPLACES a record rather than merging it, so when two different fixture
+files define the same (urn, aspectName) with different payloads, whichever one
+seeds last silently wins. Global-vs-feature ordering is deterministic (feature
+always seeds after global), but feature-vs-feature ordering depends on worker
+scheduling -- invisible at workers: 1, a live flake source as workers_per_shard
+increases (see PFP-5479 / PFP-5484, where this exact pattern broke a relationship
+a global seed had correctly set).
+
+This script has no way to know whether a given collision is accidental (two
+features happened to reuse a name) or intentional (a feature deliberately
+customizes a shared entity, relying on seed-order to win) -- it only reports
+disagreement. New conflicts introduced since the checked-in baseline fail the
+check; pre-existing ones are grandfathered in until someone deliberately
+resolves them (see BASELINE_FILE).
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+PEGASUS2AVRO_PREFIX = re.compile(r"com\.linkedin\.pegasus2avro\.")
+
+# Class names whose simple-name-to-aspectName conversion isn't a plain
+# lowercase-first-letter (the acronym prefix breaks that rule).
+ASPECT_NAME_OVERRIDES = {
+    "MLFeatureProperties": "mlFeatureProperties",
+    "MLFeatureTableProperties": "mlFeatureTableProperties",
+    "MLModelProperties": "mlModelProperties",
+    "MLModelGroupProperties": "mlModelGroupProperties",
+    "MLPrimaryKeyProperties": "mlPrimaryKeyProperties",
+}
+
+# (urn, aspectName) pairs already known to conflict as of the initial baseline.
+# See helpers/seeder-utils.ts / fixtures/seeding.fixture.ts for why this can
+# happen at all, and PFP-5492 for the full inventory and suggested fixes.
+# Regenerate with: python3 check_playwright_fixture_conflicts.py --write-baseline
+DEFAULT_BASELINE_FILE = Path(__file__).parent / "playwright_fixture_conflicts_baseline.json"
+
+
+def discover_fixture_files(playwright_dir: Path) -> List[Path]:
+    files = [playwright_dir / "test-data" / "data.json"]
+    files.extend(sorted((playwright_dir / "tests").glob("*/fixtures/data.json")))
+    return [f for f in files if f.exists()]
+
+
+def simple_class_name(class_name: str) -> str:
+    return class_name.rsplit(".", 1)[-1]
+
+
+def class_name_to_aspect_name(class_name: str) -> str:
+    simple = simple_class_name(class_name)
+    if simple in ASPECT_NAME_OVERRIDES:
+        return ASPECT_NAME_OVERRIDES[simple]
+    return simple[0].lower() + simple[1:] if simple else simple
+
+
+def normalize_payload(value: object) -> object:
+    """
+    Strip the legacy pegasus2avro namespace so a snapshot-format aspect and its
+    functionally-identical native-MCP counterpart compare equal (mirrors the
+    same normalisation ingestMcps applies before posting -- see
+    fixtures/seeding.fixture.ts's raw.replace(/com\\.linkedin\\.pegasus2avro\\./g, ...)).
+    """
+    if isinstance(value, str):
+        return PEGASUS2AVRO_PREFIX.sub("com.linkedin.", value)
+    if isinstance(value, list):
+        return [normalize_payload(v) for v in value]
+    if isinstance(value, dict):
+        return {PEGASUS2AVRO_PREFIX.sub("com.linkedin.", k): normalize_payload(v) for k, v in value.items()}
+    return value
+
+
+def extract_entries(data: object, file_label: str) -> List[Tuple[str, str, object]]:
+    """Return (urn, aspectName, normalized_payload) for every aspect in one fixture file."""
+    if not isinstance(data, list):
+        return []
+
+    entries: List[Tuple[str, str, object]] = []
+    for mcp in data:
+        if not isinstance(mcp, dict):
+            continue
+
+        snapshot = mcp.get("proposedSnapshot")
+        if isinstance(snapshot, dict):
+            for snap_value in snapshot.values():
+                urn = snap_value.get("urn") if isinstance(snap_value, dict) else None
+                aspects = snap_value.get("aspects") if isinstance(snap_value, dict) else None
+                if not urn or not isinstance(aspects, list):
+                    continue
+                for aspect in aspects:
+                    if not isinstance(aspect, dict):
+                        continue
+                    for class_name, payload in aspect.items():
+                        aspect_name = class_name_to_aspect_name(class_name)
+                        entries.append((urn, aspect_name, normalize_payload(payload)))
+            continue
+
+        entity_urn = mcp.get("entityUrn")
+        aspect_name = mcp.get("aspectName")
+        aspect = mcp.get("aspect")
+        if not entity_urn or not aspect_name or not isinstance(aspect, dict):
+            continue
+        raw_value = aspect.get("value")
+        if not isinstance(raw_value, str):
+            continue
+        try:
+            payload = json.loads(raw_value)
+        except json.JSONDecodeError:
+            print(f"Warning: {file_label}: could not parse aspect.value JSON for {entity_urn}/{aspect_name}", file=sys.stderr)
+            continue
+        entries.append((entity_urn, aspect_name, normalize_payload(payload)))
+
+    return entries
+
+
+def find_conflicts(
+    fixture_files: List[Path], playwright_dir: Path
+) -> Dict[Tuple[str, str], List[Tuple[str, object]]]:
+    """
+    Group every (urn, aspectName) by its distinct payloads across files.
+    Returns only keys with more than one distinct payload, mapped to
+    [(file_label, payload), ...] -- one entry per distinct payload, each
+    annotated with the first file that produced it.
+    """
+    by_key: Dict[Tuple[str, str], List[Tuple[str, object]]] = {}
+
+    for path in fixture_files:
+        file_label = str(path.relative_to(playwright_dir))
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            print(f"Warning: {file_label}: invalid JSON ({e})", file=sys.stderr)
+            continue
+
+        for urn, aspect_name, payload in extract_entries(data, file_label):
+            key = (urn, aspect_name)
+            existing = by_key.setdefault(key, [])
+            if not any(payload == seen_payload for _, seen_payload in existing):
+                existing.append((file_label, payload))
+
+    return {key: variants for key, variants in by_key.items() if len(variants) > 1}
+
+
+def load_baseline(baseline_file: Path) -> set:
+    if not baseline_file.exists():
+        return set()
+    data = json.loads(baseline_file.read_text(encoding="utf-8"))
+    return {(item["urn"], item["aspectName"]) for item in data}
+
+
+def write_baseline(baseline_file: Path, conflicts: Dict[Tuple[str, str], List[Tuple[str, object]]]) -> None:
+    data = [
+        {"urn": urn, "aspectName": aspect_name, "files": sorted(f for f, _ in variants)}
+        for (urn, aspect_name), variants in sorted(conflicts.items())
+    ]
+    baseline_file.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--playwright-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "e2e-test" / "ui" / "playwright",
+        help="Path to e2e-test/ui/playwright",
+    )
+    parser.add_argument("--baseline-file", type=Path, default=DEFAULT_BASELINE_FILE)
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help="Write current conflicts as the new baseline instead of checking against it",
+    )
+    args = parser.parse_args()
+
+    if not args.playwright_dir.is_dir():
+        print(f"Error: playwright dir does not exist: {args.playwright_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    fixture_files = discover_fixture_files(args.playwright_dir)
+    conflicts = find_conflicts(fixture_files, args.playwright_dir)
+
+    if args.write_baseline:
+        write_baseline(args.baseline_file, conflicts)
+        print(f"Wrote {len(conflicts)} known conflict(s) to {args.baseline_file}")
+        return
+
+    baseline = load_baseline(args.baseline_file)
+    new_conflicts = {key: variants for key, variants in conflicts.items() if key not in baseline}
+
+    if not new_conflicts:
+        print(f"No new cross-fixture conflicts ({len(conflicts)} pre-existing, baselined).")
+        return
+
+    print(
+        f"Found {len(new_conflicts)} NEW cross-fixture entity conflict(s) "
+        f"(plus {len(conflicts) - len(new_conflicts)} pre-existing, baselined):\n",
+        file=sys.stderr,
+    )
+    cross_file_count = 0
+    same_file_count = 0
+    for (urn, aspect_name), variants in sorted(new_conflicts.items()):
+        distinct_files = {file_label for file_label, _ in variants}
+        same_file = len(distinct_files) == 1
+        same_file_count += same_file
+        cross_file_count += not same_file
+        tag = "SAME FILE, duplicate entry" if same_file else "cross-file"
+        print(f"  {urn}  [{aspect_name}]  ({tag})", file=sys.stderr)
+        for file_label, payload in variants:
+            snippet = json.dumps(payload)
+            if len(snippet) > 160:
+                snippet = snippet[:160] + "..."
+            print(f"    {file_label}: {snippet}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    print(
+        f"{cross_file_count} conflict(s) span two or more fixture files; {same_file_count} are the "
+        "same file defining the same entity's aspect twice with different data (almost certainly a "
+        "copy-paste bug, not an ordering race).\n\n"
+        "Aspect ingestion REPLACES rather than merges, so whichever entry seeds last wins --\n"
+        "deterministic between the global seed and a feature seed (feature always wins), but\n"
+        "dependent on worker scheduling order between two feature fixtures, and on array\n"
+        "order within a single file. Either give the entity a feature-scoped URN, or converge\n"
+        "on one definition.\n\n"
+        "If a cross-file collision is intentional and already relied upon, add it to the baseline:\n"
+        f"  python3 {Path(__file__).name} --write-baseline",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/compare_test_weights.py
+++ b/.github/scripts/compare_test_weights.py
@@ -88,8 +88,9 @@ def calculate_changes(
 
 
 def generate_pr_body(
-    pytest_changes: Dict,
+    pytest_changes: Optional[Dict] = None,
     cypress_changes: Optional[Dict] = None,
+    playwright_changes: Optional[Dict] = None,
     title: str = "🤖 Automated Test Weight Update",
 ) -> str:
     """Generate markdown PR body with change analysis."""
@@ -108,9 +109,13 @@ def generate_pr_body(
     lines.append("| Test Type | Old Total | New Total | Change | # Tests |")
     lines.append("|-----------|-----------|-----------|--------|---------|")
 
-    summary_rows: List[tuple[str, Dict]] = [("Pytest", pytest_changes)]
+    summary_rows: List[tuple[str, Dict]] = []
+    if playwright_changes is not None:
+        summary_rows.append(("Playwright", playwright_changes))
     if cypress_changes is not None:
-        summary_rows.insert(0, ("Cypress", cypress_changes))
+        summary_rows.append(("Cypress", cypress_changes))
+    if pytest_changes is not None:
+        summary_rows.append(("Pytest", pytest_changes))
 
     for name, changes in summary_rows:
         old_min = changes["old_total"] / 60
@@ -145,7 +150,13 @@ def generate_pr_body(
         lines.append("Current configuration:")
         if cypress_changes is not None:
             lines.append("- Cypress: 11 batches (Depot) / 5 batches (GitHub runners)")
-        lines.append("- Pytest: 7 batches (GitHub runners)")
+        if pytest_changes is not None:
+            lines.append("- Pytest: 7 batches (GitHub runners)")
+        if playwright_changes is not None:
+            lines.append(
+                "- Playwright: 8 shards, duration-weighted "
+                "(PLAYWRIGHT_SHARD_COUNT in docker-unified.yml)"
+            )
         lines.append("")
         lines.append(
             "If total time increased >20%, consider increasing batch count to maintain CI speed."
@@ -267,10 +278,20 @@ def main():
         help="Path to new Cypress weights JSON",
     )
     parser.add_argument(
-        "--old-pytest", required=True, help="Path to old Pytest weights JSON"
+        "--old-playwright",
+        required=False,
+        help="Path to old Playwright weights JSON",
     )
     parser.add_argument(
-        "--new-pytest", required=True, help="Path to new Pytest weights JSON"
+        "--new-playwright",
+        required=False,
+        help="Path to new Playwright weights JSON",
+    )
+    parser.add_argument(
+        "--old-pytest", required=False, help="Path to old Pytest weights JSON"
+    )
+    parser.add_argument(
+        "--new-pytest", required=False, help="Path to new Pytest weights JSON"
     )
     parser.add_argument(
         "--output", required=True, help="Output file for PR body markdown"
@@ -295,12 +316,35 @@ def main():
         print("Error: --old-cypress and --new-cypress must be provided together")
         sys.exit(1)
 
-    old_pytest = load_weights(args.old_pytest, "testId")
-    new_pytest = load_weights(args.new_pytest, "testId")
-    pytest_changes = calculate_changes(old_pytest, new_pytest)
+    if (args.old_playwright is None) != (args.new_playwright is None):
+        print("Error: --old-playwright and --new-playwright must be provided together")
+        sys.exit(1)
+
+    if (args.old_pytest is None) != (args.new_pytest is None):
+        print("Error: --old-pytest and --new-pytest must be provided together")
+        sys.exit(1)
+
+    if not (
+        (args.old_pytest and args.new_pytest)
+        or (args.old_cypress and args.new_cypress)
+        or (args.old_playwright and args.new_playwright)
+    ):
+        print(
+            "Error: at least one of --old/new-pytest, --old/new-cypress, "
+            "--old/new-playwright is required"
+        )
+        sys.exit(1)
+
+    pytest_changes = None
+    change_pcts = []
+    if args.old_pytest and args.new_pytest:
+        old_pytest = load_weights(args.old_pytest, "testId")
+        new_pytest = load_weights(args.new_pytest, "testId")
+        pytest_changes = calculate_changes(old_pytest, new_pytest)
+        change_pcts.append(abs(pytest_changes["total_change_pct"]))
+        print(f"Pytest total change: {pytest_changes['total_change_pct']:+.2f}%")
 
     cypress_changes = None
-    change_pcts = [abs(pytest_changes["total_change_pct"])]
     if args.old_cypress and args.new_cypress:
         old_cypress = load_weights(args.old_cypress, "filePath")
         new_cypress = load_weights(args.new_cypress, "filePath")
@@ -308,9 +352,16 @@ def main():
         change_pcts.append(abs(cypress_changes["total_change_pct"]))
         print(f"Cypress total change: {cypress_changes['total_change_pct']:+.2f}%")
 
+    playwright_changes = None
+    if args.old_playwright and args.new_playwright:
+        old_playwright = load_weights(args.old_playwright, "filePath")
+        new_playwright = load_weights(args.new_playwright, "filePath")
+        playwright_changes = calculate_changes(old_playwright, new_playwright)
+        change_pcts.append(abs(playwright_changes["total_change_pct"]))
+        print(f"Playwright total change: {playwright_changes['total_change_pct']:+.2f}%")
+
     max_change = max(change_pcts)
 
-    print(f"Pytest total change: {pytest_changes['total_change_pct']:+.2f}%")
     print(f"Max change: {max_change:.2f}%")
     print(f"Threshold: {args.threshold}%")
 
@@ -322,22 +373,28 @@ def main():
 
     print("\n✓ Changes exceed threshold. Generating PR body...")
 
-    pr_body = generate_pr_body(pytest_changes, cypress_changes, title=args.title)
+    pr_body = generate_pr_body(
+        pytest_changes, cypress_changes, playwright_changes, title=args.title
+    )
 
     with open(args.output, "w") as f:
         f.write(pr_body)
 
     print(f"✓ PR body written to {args.output}")
+    significant_parts = []
+    if playwright_changes is not None:
+        significant_parts.append(
+            f"Playwright={len(playwright_changes['significant_changes'])}"
+        )
     if cypress_changes is not None:
-        print(
-            "✓ Significant changes: "
-            f"Cypress={len(cypress_changes['significant_changes'])}, "
+        significant_parts.append(
+            f"Cypress={len(cypress_changes['significant_changes'])}"
+        )
+    if pytest_changes is not None:
+        significant_parts.append(
             f"Pytest={len(pytest_changes['significant_changes'])}"
         )
-    else:
-        print(
-            f"✓ Significant changes: Pytest={len(pytest_changes['significant_changes'])}"
-        )
+    print("✓ Significant changes: " + ", ".join(significant_parts))
 
     sys.exit(0)
 

--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -54,6 +54,10 @@ EXAMPLE:
     $0 --output-dir ./test-artifacts --run-count 3 \
         --workflow metadata-ingestion.yml --artifact-prefix "metadata-ingestion-test-results" \
         --allow-failed --no-fail-on-empty
+
+    # Playwright test weights (harvest per-shard junit artifacts)
+    $0 --output-dir ./test-artifacts-playwright --run-count 3 \
+        --workflow docker-unified.yml --artifact-prefix "Test Results (playwright)"
 EOF
     exit 1
 }
@@ -315,6 +319,14 @@ for run_id in "${RUN_ID_ARRAY[@]}"; do
                 artifact_subdir="$RUN_DIR/cypress-$batch_num"
             else
                 artifact_subdir="$RUN_DIR/cypress-0"
+            fi
+        elif [[ $artifact_name =~ "playwright" ]]; then
+            # Artifact name is "Test Results (playwright) shard-N"
+            if [[ $artifact_name =~ shard-([0-9]+) ]]; then
+                shard_num="${BASH_REMATCH[1]}"
+                artifact_subdir="$RUN_DIR/playwright-$shard_num"
+            else
+                artifact_subdir="$RUN_DIR/playwright-0"
             fi
         else
             artifact_subdir="$RUN_DIR/other"

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -100,8 +100,6 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
         dir, e.g. "documents/document-management.spec.ts") to lists of
         durations across runs/shards.
     """
-    test_durations: Dict[str, List[float]] = {}
-
     # Playwright's own artifact is also named junit.xml, indistinguishable by
     # filename alone from pytest's — this parser must only ever be pointed at
     # an --input-dir populated exclusively by Playwright artifact downloads.
@@ -109,29 +107,52 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
 
     print(f"Found {len(xml_files)} Playwright XML files")
 
+    # Group by run (the run-<id> directory immediately under artifact_dir, per
+    # download_test_artifacts.sh's layout) and sum per-file within a run before
+    # taking the cross-run median. Playwright's own --shard is test-count-based,
+    # not file-atomic: a single heavy spec file's tests can land split across two
+    # shards in the same run (e.g. 47 tests in shard 4, 3 in shard 5). Treating
+    # those two partial slices as independent samples and medianing/averaging
+    # them collapses a ~204s file down to ~102s -- summing within the run first
+    # (same fix parse_gradle_results already applies for a class split across
+    # multiple TEST-*.xml files) avoids that.
+    runs: Dict[str, List[Path]] = {}
     for xml_file in xml_files:
         try:
-            root = ET.parse(xml_file).getroot()
-            # Direct children only: Playwright's junit reporter emits a flat
-            # <testsuites><testsuite name="file.spec.ts">...</testsuite>...</testsuites>,
-            # one suite per spec file, no nesting — unlike Cypress's wrapper structure.
-            for testsuite in root.findall("testsuite"):
-                file_path = testsuite.get("name")
-                time_str = testsuite.get("time", "0")
-                if not file_path:
-                    continue
-                try:
-                    duration = float(time_str)
-                except ValueError:
-                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
-                    continue
-                if not math.isfinite(duration) or duration <= 0:
-                    continue
-                test_durations.setdefault(file_path, []).append(duration)
-        except ET.ParseError as e:
-            print(f"Warning: Failed to parse {xml_file}: {e}")
-        except Exception as e:
-            print(f"Warning: Error processing {xml_file}: {e}")
+            run_key = xml_file.relative_to(artifact_dir).parts[0]
+        except (ValueError, IndexError):
+            run_key = "."
+        runs.setdefault(run_key, []).append(xml_file)
+
+    test_durations: Dict[str, List[float]] = {}
+    for run_files in runs.values():
+        per_file_total: Dict[str, float] = {}
+        for xml_file in run_files:
+            try:
+                root = ET.parse(xml_file).getroot()
+                # Direct children only: Playwright's junit reporter emits a flat
+                # <testsuites><testsuite name="file.spec.ts">...</testsuite>...</testsuites>,
+                # one suite per spec file, no nesting — unlike Cypress's wrapper structure.
+                for testsuite in root.findall("testsuite"):
+                    file_path = testsuite.get("name")
+                    time_str = testsuite.get("time", "0")
+                    if not file_path:
+                        continue
+                    try:
+                        duration = float(time_str)
+                    except ValueError:
+                        print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
+                        continue
+                    if not math.isfinite(duration) or duration < 0:
+                        continue
+                    per_file_total[file_path] = per_file_total.get(file_path, 0.0) + duration
+            except ET.ParseError as e:
+                print(f"Warning: Failed to parse {xml_file}: {e}")
+            except Exception as e:
+                print(f"Warning: Error processing {xml_file}: {e}")
+        for file_path, total in per_file_total.items():
+            if total > 0:
+                test_durations.setdefault(file_path, []).append(total)
 
     return test_durations
 

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -3,7 +3,8 @@
 Generate test weight files from historical CI test results.
 
 This script parses JUnit XML files from multiple CI runs, calculates median
-test durations, and generates JSON weight files for both Cypress and Pytest tests.
+test durations, and generates JSON weight files for Cypress, Pytest, Gradle,
+and Playwright tests.
 """
 
 import argparse
@@ -73,6 +74,60 @@ def parse_cypress_results(artifact_dir: Path) -> Dict[str, List[float]]:
                 except ValueError:
                     print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
 
+        except ET.ParseError as e:
+            print(f"Warning: Failed to parse {xml_file}: {e}")
+        except Exception as e:
+            print(f"Warning: Error processing {xml_file}: {e}")
+
+    return test_durations
+
+
+def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
+    """
+    Parse Playwright JUnit XML files from multiple runs.
+
+    Unlike parse_pytest_results (per-testcase, `classname::name` keyed), this is
+    file-level like parse_cypress_results: Playwright's junit reporter already
+    emits one <testsuite name="path/to/file.spec.ts" time="..."> per spec file
+    (no nested root-suite-with-file-attribute wrapper), and file-level weight is
+    what the shard bin-packer consumes, since Playwright shards by whole file.
+
+    Args:
+        artifact_dir: Root directory containing run-* subdirectories
+
+    Returns:
+        Dictionary mapping spec file paths (relative to the playwright tests
+        dir, e.g. "documents/document-management.spec.ts") to lists of
+        durations across runs/shards.
+    """
+    test_durations: Dict[str, List[float]] = {}
+
+    # Playwright's own artifact is also named junit.xml, indistinguishable by
+    # filename alone from pytest's — this parser must only ever be pointed at
+    # an --input-dir populated exclusively by Playwright artifact downloads.
+    xml_files = list(artifact_dir.rglob("junit.xml"))
+
+    print(f"Found {len(xml_files)} Playwright XML files")
+
+    for xml_file in xml_files:
+        try:
+            root = ET.parse(xml_file).getroot()
+            # Direct children only: Playwright's junit reporter emits a flat
+            # <testsuites><testsuite name="file.spec.ts">...</testsuite>...</testsuites>,
+            # one suite per spec file, no nesting — unlike Cypress's wrapper structure.
+            for testsuite in root.findall("testsuite"):
+                file_path = testsuite.get("name")
+                time_str = testsuite.get("time", "0")
+                if not file_path:
+                    continue
+                try:
+                    duration = float(time_str)
+                except ValueError:
+                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
+                    continue
+                if not math.isfinite(duration) or duration <= 0:
+                    continue
+                test_durations.setdefault(file_path, []).append(duration)
         except ET.ParseError as e:
             print(f"Warning: Failed to parse {xml_file}: {e}")
         except Exception as e:
@@ -245,11 +300,24 @@ def main():
         required=False,
         help="Output path for Gradle test weights JSON (keyed by FQCN)",
     )
+    parser.add_argument(
+        "--playwright-output",
+        type=Path,
+        required=False,
+        help="Output path for Playwright test weights JSON (keyed by spec file path)",
+    )
 
     args = parser.parse_args()
 
-    if not (args.pytest_output or args.cypress_output or args.gradle_output):
-        parser.error("at least one of --pytest-output/--cypress-output/--gradle-output is required")
+    if not (
+        args.pytest_output
+        or args.cypress_output
+        or args.gradle_output
+        or args.playwright_output
+    ):
+        parser.error(
+            "at least one of --pytest-output/--cypress-output/--gradle-output/--playwright-output is required"
+        )
 
     if not args.input_dir.exists():
         print(f"Error: Input directory does not exist: {args.input_dir}")
@@ -279,6 +347,14 @@ def main():
         gradle_durations = parse_gradle_results(args.input_dir)
         print(f"Found {len(gradle_durations)} unique Gradle tests")
 
+    playwright_durations = {}
+    if args.playwright_output:
+        print("\n" + "=" * 60)
+        print("Parsing Playwright test results...")
+        print("=" * 60)
+        playwright_durations = parse_playwright_results(args.input_dir)
+        print(f"Found {len(playwright_durations)} unique Playwright spec files")
+
     print("\n" + "=" * 60)
     print("Calculating median weights...")
     print("=" * 60)
@@ -298,6 +374,11 @@ def main():
         if args.gradle_output
         else []
     )
+    playwright_weights = (
+        calculate_median_weights(playwright_durations, key_name="filePath")
+        if args.playwright_output
+        else []
+    )
 
     # Write output files
     print("\n" + "=" * 60)
@@ -308,6 +389,7 @@ def main():
         (args.cypress_output, cypress_weights, "Cypress"),
         (args.pytest_output, pytest_weights, "Pytest"),
         (args.gradle_output, gradle_weights, "Gradle"),
+        (args.playwright_output, playwright_weights, "Playwright"),
     ):
         if output_path is None:
             continue

--- a/.github/scripts/playwright_fixture_conflicts_baseline.json
+++ b/.github/scripts/playwright_fixture_conflicts_baseline.json
@@ -1,0 +1,279 @@
+[
+  {
+    "urn": "urn:li:assertion:358c683782c93c2fc2bd4bdd4fdb0153",
+    "aspectName": "assertionInfo",
+    "files": [
+      "test-data/data.json",
+      "test-data/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:assertion:358c683782c93c2fc2bd4bdd4fdb0153",
+    "aspectName": "assertionRunEvent",
+    "files": [
+      "test-data/data.json",
+      "test-data/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,playwright_project.jaffle_shop.customers,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "tests/application/fixtures/data.json",
+      "tests/siblings-v2/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/autocomplete-v2/fixtures/data.json",
+      "tests/mutations-v2/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)",
+    "aspectName": "globalTags",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)",
+    "aspectName": "ownership",
+    "files": [
+      "test-data/data.json",
+      "tests/mutations-v2/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SamplePlaywrightHdfsDataset,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "test-data/data.json",
+      "test-data/data.json",
+      "tests/mutations-v2/fixtures/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,Playwright_logging_events,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "tests/business-attributes/fixtures/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SamplePlaywrightHiveDataset,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/manage-tags/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SamplePlaywrightHiveDataset,PROD)",
+    "aspectName": "ownership",
+    "files": [
+      "test-data/data.json",
+      "tests/manage-tags/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SamplePlaywrightHiveDataset,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "test-data/data.json",
+      "tests/manage-tags/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SchemaBlameTesterDataset,PROD)",
+    "aspectName": "ownership",
+    "files": [
+      "tests/schema-blame/fixtures/data.json",
+      "tests/schema-blame/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SchemaBlameTesterDataset,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "tests/schema-blame/fixtures/data.json",
+      "tests/schema-blame/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created,PROD)",
+    "aspectName": "globalTags",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created,PROD)",
+    "aspectName": "ownership",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created_no_tag,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_playwright_users_created_no_tag,PROD)",
+    "aspectName": "schemaMetadata",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,playwright_health_test,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/mutations/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,playwright_health_test,PROD)",
+    "aspectName": "incidentsSummary",
+    "files": [
+      "test-data/data.json",
+      "tests/mutations/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,playwright_lineage_filtering.node1,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,playwright_lineage_filtering.node2,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,playwright_lineage_filtering.node3,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage.node2_dataset,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_filtering.node4,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_filtering.node5,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_filtering.node6,PROD)",
+    "aspectName": "datasetProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/lineage-v3/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:glossaryNode:PlaywrightNode",
+    "aspectName": "glossaryNodeInfo",
+    "files": [
+      "test-data/data.json",
+      "tests/business-attributes/fixtures/data.json",
+      "tests/glossary/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:glossaryTerm:PlaywrightNode.PlaywrightColumnInfoType",
+    "aspectName": "glossaryTermInfo",
+    "files": [
+      "test-data/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:glossaryTerm:PlaywrightNode.PlaywrightTerm",
+    "aspectName": "glossaryTermInfo",
+    "files": [
+      "test-data/data.json",
+      "tests/business-attributes/fixtures/data.json",
+      "tests/search/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:incident:test",
+    "aspectName": "incidentInfo",
+    "files": [
+      "test-data/data.json",
+      "test-data/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:tag:Playwright",
+    "aspectName": "ownership",
+    "files": [
+      "test-data/data.json",
+      "tests/business-attributes/fixtures/data.json"
+    ]
+  },
+  {
+    "urn": "urn:li:tag:Playwright",
+    "aspectName": "tagProperties",
+    "files": [
+      "test-data/data.json",
+      "tests/business-attributes/fixtures/data.json"
+    ]
+  }
+]

--- a/.github/scripts/shard_playwright_tests.py
+++ b/.github/scripts/shard_playwright_tests.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 SERIAL_MODE_PATTERN = re.compile(r"""mode:\s*['"]serial['"]""")
+DESCRIBE_SKIP_PATTERN = re.compile(r"""describe\.skip\(""")
 
 
 def discover_spec_files(tests_dir: Path) -> List[str]:
@@ -58,11 +59,22 @@ def find_serial_files(tests_dir: Path, spec_files: List[str]) -> set:
     in the file. Conservative at file granularity (no per-describe-block
     weights exist to do better): a file with any serial block is treated as
     fully atomic for floor purposes, even if only part of it is serial.
+
+    A file containing describe.skip(...) anywhere is excluded even if it also
+    matches the serial pattern: as of writing, every serial file that also
+    uses describe.skip wraps the *entire* suite in that skip (mutations/
+    add-users.spec.ts, dataset-ownership.spec.ts,
+    manage-ingestion-secret-privilege.spec.ts) -- those tests never run, so
+    treating their weight as an unavoidable floor is a false positive, not a
+    conservative approximation. This is a text-search heuristic, not an AST
+    check: a file that skips only PART of its suite while another part
+    outside the skip is genuinely serial would be wrongly excluded here. No
+    such file exists in this repo today.
     """
     serial_files = set()
     for f in spec_files:
         content = (tests_dir / f).read_text(encoding="utf-8", errors="ignore")
-        if SERIAL_MODE_PATTERN.search(content):
+        if SERIAL_MODE_PATTERN.search(content) and not DESCRIBE_SKIP_PATTERN.search(content):
             serial_files.add(f)
     return serial_files
 

--- a/.github/scripts/shard_playwright_tests.py
+++ b/.github/scripts/shard_playwright_tests.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Bin-pack Playwright spec files into duration-weighted shards.
+
+Playwright's own `--shard=N/M` splits by file *count*, not measured duration,
+which lets one heavy spec file dominate a shard's wall clock while other
+shards sit idle (see e2e-test/ui/playwright/playwright_test_weights.json for
+the harvested per-file durations this consumes). This script computes the
+full N-way partition independently in each shard's CI job (a pure function of
+the file list + weights, so every job derives the same partition without any
+shared state) and prints just the one shard's file list, ready to hand to
+`npx playwright test` as positional arguments in place of `--shard`.
+"""
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def discover_spec_files(tests_dir: Path) -> List[str]:
+    """
+    Find all Playwright spec files under tests_dir, relative to tests_dir,
+    as posix-style paths. Mirrors playwright.config.ts's discovery: testDir
+    is tests_dir, and *.setup.ts files (testIgnore'd there) never match the
+    *.spec.ts glob here, so no separate exclusion is needed.
+    """
+    return sorted(p.relative_to(tests_dir).as_posix() for p in tests_dir.rglob("*.spec.ts"))
+
+
+def load_weights(weights_file: Path) -> Dict[str, float]:
+    with open(weights_file) as f:
+        data = json.load(f)
+    return {item["filePath"]: float(item["duration"].rstrip("s")) for item in data}
+
+
+def bin_pack_tasks(tasks: List[Tuple[str, float]], n_buckets: int) -> List[List[str]]:
+    """
+    Greedy LPT (Longest Processing Time) bin packer: sort tasks descending by
+    weight, repeatedly assign to the currently-lightest bucket. Ported from
+    smoke-test/conftest.py's bin_pack_tasks (same algorithm, used there for
+    Cypress/Pytest batching) rather than imported, since that module is a
+    pytest conftest, not a library.
+    """
+    sorted_tasks = sorted(tasks, key=lambda t: t[1], reverse=True)
+    buckets: List[List[str]] = [[] for _ in range(n_buckets)]
+    bucket_weights = [0.0] * n_buckets
+    for task, weight in sorted_tasks:
+        idx = bucket_weights.index(min(bucket_weights))
+        buckets[idx].append(task)
+        bucket_weights[idx] += weight
+    return buckets
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute one shard's duration-weighted Playwright spec file list"
+    )
+    parser.add_argument(
+        "--tests-dir",
+        type=Path,
+        required=True,
+        help="Playwright testDir to glob, e.g. 'tests' when run from e2e-test/ui/playwright "
+        "(output paths are prefixed with this same value, ready for the CLI)",
+    )
+    parser.add_argument(
+        "--weights-file",
+        type=Path,
+        required=True,
+        help="Path to the weights JSON ([{filePath, duration}, ...])",
+    )
+    parser.add_argument("--shard", type=int, required=True, help="1-indexed shard number")
+    parser.add_argument("--shard-count", type=int, required=True, help="Total number of shards")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=False,
+        help="Write the shard's file list here (one per line). Prints to stdout if omitted.",
+    )
+
+    args = parser.parse_args()
+
+    if not (1 <= args.shard <= args.shard_count):
+        parser.error(f"--shard must be in [1, {args.shard_count}], got {args.shard}")
+
+    if not args.tests_dir.is_dir():
+        print(f"Error: tests dir does not exist: {args.tests_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.weights_file.exists():
+        print(f"Error: weights file does not exist: {args.weights_file}", file=sys.stderr)
+        sys.exit(1)
+
+    spec_files = discover_spec_files(args.tests_dir)
+    if not spec_files:
+        print(f"Error: no *.spec.ts files found under {args.tests_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    weights = load_weights(args.weights_file)
+    # New files with no harvested history yet default to the median rather
+    # than 0 (which would let an unweighted file be "free" to pile onto any
+    # bucket) or a small constant (which would starve genuinely heavy new
+    # specs of shard budget until the next weekly refresh).
+    default_weight = statistics.median(weights.values()) if weights else 1.0
+    unweighted = [f for f in spec_files if f not in weights]
+    if unweighted:
+        print(
+            f"Note: {len(unweighted)} spec file(s) have no weight entry, "
+            f"defaulting to the median ({default_weight:.1f}s): {', '.join(unweighted[:5])}"
+            + (", ..." if len(unweighted) > 5 else ""),
+            file=sys.stderr,
+        )
+
+    tasks = [(f, weights.get(f, default_weight)) for f in spec_files]
+    buckets = bin_pack_tasks(tasks, args.shard_count)
+    shard_files = sorted(buckets[args.shard - 1])
+    shard_weight = sum(weights.get(f, default_weight) for f in shard_files)
+
+    all_shard_weights = [sum(weights.get(f, default_weight) for f in b) for b in buckets]
+    print(
+        f"Shard {args.shard}/{args.shard_count}: {len(shard_files)} files, "
+        f"~{shard_weight:.1f}s weighted "
+        f"(all shards: {[f'{w:.0f}s' for w in all_shard_weights]})",
+        file=sys.stderr,
+    )
+
+    output_paths = [f"{args.tests_dir}/{f}" for f in shard_files]
+    output_text = "\n".join(output_paths)
+    if args.output:
+        args.output.write_text(output_text + ("\n" if output_text else ""))
+        print(f"Wrote {len(shard_files)} file paths to {args.output}", file=sys.stderr)
+    else:
+        print(output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/shard_playwright_tests.py
+++ b/.github/scripts/shard_playwright_tests.py
@@ -10,14 +10,30 @@ full N-way partition independently in each shard's CI job (a pure function of
 the file list + weights, so every job derives the same partition without any
 shared state) and prints just the one shard's file list, ready to hand to
 `npx playwright test` as positional arguments in place of `--shard`.
+
+With workers_per_shard > 1 (see resusable-playwright-tests.yml), a shard's
+own wall clock is no longer just its total weight: Playwright's fullyParallel
+scheduler pulls individual tests onto whichever worker is free, so ordinary
+files mix freely across a shard's workers and the shard finishes in roughly
+total_weight / workers_per_shard. The one exception is a file using
+`test.describe.configure({ mode: 'serial' })`: every test in that block must
+run sequentially on a single worker, so the file's own weight is a hard floor
+no amount of extra workers can shrink. A shard stuck with several heavy
+serial files bottlenecks on that floor even while its other workers sit idle.
+bin_pack_tasks therefore places serial files first (spreading the
+un-parallelizable floor evenly across shards) before packing the remaining
+parallel-friendly files to balance each shard's total.
 """
 
 import argparse
 import json
+import re
 import statistics
 import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
+
+SERIAL_MODE_PATTERN = re.compile(r"""mode:\s*['"]serial['"]""")
 
 
 def discover_spec_files(tests_dir: Path) -> List[str]:
@@ -36,21 +52,59 @@ def load_weights(weights_file: Path) -> Dict[str, float]:
     return {item["filePath"]: float(item["duration"].rstrip("s")) for item in data}
 
 
-def bin_pack_tasks(tasks: List[Tuple[str, float]], n_buckets: int) -> List[List[str]]:
+def find_serial_files(tests_dir: Path, spec_files: List[str]) -> set:
     """
-    Greedy LPT (Longest Processing Time) bin packer: sort tasks descending by
-    weight, repeatedly assign to the currently-lightest bucket. Ported from
+    Spec files containing test.describe.configure({ mode: 'serial' }) anywhere
+    in the file. Conservative at file granularity (no per-describe-block
+    weights exist to do better): a file with any serial block is treated as
+    fully atomic for floor purposes, even if only part of it is serial.
+    """
+    serial_files = set()
+    for f in spec_files:
+        content = (tests_dir / f).read_text(encoding="utf-8", errors="ignore")
+        if SERIAL_MODE_PATTERN.search(content):
+            serial_files.add(f)
+    return serial_files
+
+
+def lpt_pack(
+    tasks: List[Tuple[str, float]],
+    buckets: List[List[str]],
+    bucket_weights: List[float],
+) -> None:
+    """
+    Greedy LPT (Longest Processing Time): sort tasks descending by weight,
+    repeatedly assign to the currently-lightest bucket. Mutates buckets /
+    bucket_weights in place so callers can run it in two passes (serial tasks
+    first, then parallel tasks) over the same running totals. Ported from
     smoke-test/conftest.py's bin_pack_tasks (same algorithm, used there for
     Cypress/Pytest batching) rather than imported, since that module is a
     pytest conftest, not a library.
     """
-    sorted_tasks = sorted(tasks, key=lambda t: t[1], reverse=True)
-    buckets: List[List[str]] = [[] for _ in range(n_buckets)]
-    bucket_weights = [0.0] * n_buckets
-    for task, weight in sorted_tasks:
+    for task, weight in sorted(tasks, key=lambda t: t[1], reverse=True):
         idx = bucket_weights.index(min(bucket_weights))
         buckets[idx].append(task)
         bucket_weights[idx] += weight
+
+
+def bin_pack_tasks(
+    tasks: List[Tuple[str, float]],
+    n_buckets: int,
+    serial_files: set = frozenset(),
+) -> List[List[str]]:
+    """
+    Two-phase LPT: serial-mode files are packed first (their weight is an
+    unavoidable single-worker floor, so spreading them evenly across shards
+    first matters most), then the remaining files are packed to balance each
+    shard's overall total. With no serial files this reduces to a single LPT
+    pass, identical to the previous single-phase behavior.
+    """
+    buckets: List[List[str]] = [[] for _ in range(n_buckets)]
+    bucket_weights = [0.0] * n_buckets
+    serial_tasks = [t for t in tasks if t[0] in serial_files]
+    parallel_tasks = [t for t in tasks if t[0] not in serial_files]
+    lpt_pack(serial_tasks, buckets, bucket_weights)
+    lpt_pack(parallel_tasks, buckets, bucket_weights)
     return buckets
 
 
@@ -74,6 +128,14 @@ def main() -> None:
     parser.add_argument("--shard", type=int, required=True, help="1-indexed shard number")
     parser.add_argument("--shard-count", type=int, required=True, help="Total number of shards")
     parser.add_argument(
+        "--workers-per-shard",
+        type=int,
+        default=1,
+        help="Playwright --workers value each shard will run with. Only affects the projected "
+        "per-shard floor logged for visibility -- above 1, spreads mode:'serial' files (an "
+        "unavoidable single-worker floor) evenly across shards before balancing shard totals.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         required=False,
@@ -84,6 +146,9 @@ def main() -> None:
 
     if not (1 <= args.shard <= args.shard_count):
         parser.error(f"--shard must be in [1, {args.shard_count}], got {args.shard}")
+
+    if args.workers_per_shard < 1:
+        parser.error(f"--workers-per-shard must be >= 1, got {args.workers_per_shard}")
 
     if not args.tests_dir.is_dir():
         print(f"Error: tests dir does not exist: {args.tests_dir}", file=sys.stderr)
@@ -113,8 +178,10 @@ def main() -> None:
             file=sys.stderr,
         )
 
+    serial_files = find_serial_files(args.tests_dir, spec_files) if args.workers_per_shard > 1 else set()
+
     tasks = [(f, weights.get(f, default_weight)) for f in spec_files]
-    buckets = bin_pack_tasks(tasks, args.shard_count)
+    buckets = bin_pack_tasks(tasks, args.shard_count, serial_files)
     shard_files = sorted(buckets[args.shard - 1])
     shard_weight = sum(weights.get(f, default_weight) for f in shard_files)
 
@@ -125,6 +192,25 @@ def main() -> None:
         f"(all shards: {[f'{w:.0f}s' for w in all_shard_weights]})",
         file=sys.stderr,
     )
+
+    if args.workers_per_shard > 1:
+        shard_serial_weight = max(
+            (weights.get(f, default_weight) for f in shard_files if f in serial_files), default=0.0
+        )
+        projected_floor = max(shard_serial_weight, shard_weight / args.workers_per_shard)
+        all_floors = [
+            max(
+                max((weights.get(f, default_weight) for f in b if f in serial_files), default=0.0),
+                sum(weights.get(f, default_weight) for f in b) / args.workers_per_shard,
+            )
+            for b in buckets
+        ]
+        print(
+            f"Shard {args.shard}/{args.shard_count}: {len(serial_files & set(shard_files))} serial file(s), "
+            f"projected floor ~{projected_floor:.1f}s at {args.workers_per_shard} workers "
+            f"(all shards: {[f'{w:.0f}s' for w in all_floors]})",
+            file=sys.stderr,
+        )
 
     output_paths = [f"{args.tests_dir}/{f}" for f in shard_files]
     output_text = "\n".join(output_paths)

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -944,6 +944,17 @@ jobs:
       datahub_version: ${{ needs.setup.outputs.tag }}
       profile_name: ${{ needs.setup.outputs.smoke_profile_name || 'quickstart-consumers' }}
       send_posthog_metrics: true
+      # Validated via repeated manual workflow_dispatch trials on this PR (see
+      # resusable-playwright-tests.yml's workers_per_shard input description
+      # for the fixes that made this safe): the seeding-fixture TOCTOU race,
+      # the v2-manage-policies.spec.ts missing serial guard, and the
+      # cross-file lineage-time-seeder race are all fixed, and multiple clean
+      # full-suite runs at workers_per_shard=2 confirm no regressions plus a
+      # real ~15-20% cut in the Playwright stage's wall clock. Wired here
+      # (rather than raising the reusable workflow's own default) so this is
+      # the one opted-in caller; other callers of resusable-playwright-tests
+      # keep inheriting workers_per_shard=1 unless they explicitly ask for 2.
+      workers_per_shard: "2"
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "quickstart"
         type: string
+      workers_per_shard:
+        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 is the proven, unchanged behavior; >1 is an unvalidated trial (see PFP-5479 ranked fix #6) -- multiple worker processes will share one shard's stack and filesystem."
+        required: false
+        default: "1"
+        type: string
 
 permissions:
   contents: read
@@ -92,6 +97,7 @@ jobs:
       test_runner_type: ${{ needs.setup.outputs.test_runner_type }}
       datahub_version: ${{ inputs.datahub_version }}
       profile_name: ${{ inputs.profileName }}
+      workers_per_shard: ${{ inputs.workers_per_shard }}
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -169,6 +169,11 @@ jobs:
           PLAYWRIGHT_REUSE_SERVER: "1"
           SHARD: ${{ inputs.shard }}
           SHARD_COUNT: ${{ inputs.shard_count }}
+          # The stack runs Elasticsearch with a 1s refresh interval
+          # (run-quickstart.sh). Without this the writes-sync helper falls back
+          # to its conservative 3s margin per call -- pytest's job env already
+          # sets the same variable for the same reason.
+          ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: "1"
         run: |
           npx playwright test \
             --shard="$SHARD/$SHARD_COUNT"

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -172,11 +172,13 @@ jobs:
         env:
           SHARD: ${{ inputs.shard }}
           SHARD_COUNT: ${{ inputs.shard_count }}
+          WORKERS_PER_SHARD: ${{ inputs.workers_per_shard }}
         run: |
           python3 ../../../.github/scripts/shard_playwright_tests.py \
             --tests-dir tests \
             --weights-file playwright_test_weights.json \
             --shard "$SHARD" --shard-count "$SHARD_COUNT" \
+            --workers-per-shard "$WORKERS_PER_SHARD" \
             --output /tmp/playwright-shard-files.txt
 
       - name: Run Playwright tests

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: false
+      workers_per_shard:
+        description: "Playwright --workers per shard. EXPERIMENTAL (see PFP-5479 ranked fix #6) -- default 1 matches every non-experimental caller's existing behavior. >1 is unproven: each worker is a separate process sharing this shard's single stack (one GMS/Kafka/ES/MySQL instance on a 4-vCPU runner) and its filesystem (the .seeded/{feature}.json check-then-act has a real, if likely-harmless, race across worker processes). Do not raise the default without a trial run first."
+        required: false
+        type: string
+        default: "1"
 jobs:
   playwright_test:
     name: Playwright E2E Tests
@@ -181,6 +186,7 @@ jobs:
           PLAYWRIGHT_REUSE_SERVER: "1"
           SHARD: ${{ inputs.shard }}
           SHARD_COUNT: ${{ inputs.shard_count }}
+          WORKERS_PER_SHARD: ${{ inputs.workers_per_shard }}
           # The stack runs Elasticsearch with a 1s refresh interval
           # (run-quickstart.sh). Without this the writes-sync helper falls back
           # to its conservative 3s margin per call -- pytest's job env already
@@ -193,8 +199,8 @@ jobs:
               "the full suite by accident. Check playwright_test_weights.json and the tests dir."
             exit 1
           fi
-          echo "Running ${#SHARD_FILES[@]} spec files for shard $SHARD/$SHARD_COUNT"
-          npx playwright test "${SHARD_FILES[@]}"
+          echo "Running ${#SHARD_FILES[@]} spec files for shard $SHARD/$SHARD_COUNT at $WORKERS_PER_SHARD worker(s)"
+          npx playwright test --workers="$WORKERS_PER_SHARD" "${SHARD_FILES[@]}"
 
       - name: Upload Playwright blob report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -162,6 +162,18 @@ jobs:
           yarn install --frozen-lockfile
           npx playwright install --with-deps chromium
 
+      - name: Compute duration-weighted shard file list
+        working-directory: e2e-test/ui/playwright
+        env:
+          SHARD: ${{ inputs.shard }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          python3 ../../../.github/scripts/shard_playwright_tests.py \
+            --tests-dir tests \
+            --weights-file playwright_test_weights.json \
+            --shard "$SHARD" --shard-count "$SHARD_COUNT" \
+            --output /tmp/playwright-shard-files.txt
+
       - name: Run Playwright tests
         working-directory: e2e-test/ui/playwright
         env:
@@ -175,8 +187,14 @@ jobs:
           # sets the same variable for the same reason.
           ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: "1"
         run: |
-          npx playwright test \
-            --shard="$SHARD/$SHARD_COUNT"
+          mapfile -t SHARD_FILES < /tmp/playwright-shard-files.txt
+          if [ "${#SHARD_FILES[@]}" -eq 0 ]; then
+            echo "::error::Shard $SHARD/$SHARD_COUNT resolved to zero spec files -- refusing to run" \
+              "the full suite by accident. Check playwright_test_weights.json and the tests dir."
+            exit 1
+          fi
+          echo "Running ${#SHARD_FILES[@]} spec files for shard $SHARD/$SHARD_COUNT"
+          npx playwright test "${SHARD_FILES[@]}"
 
       - name: Upload Playwright blob report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -167,6 +167,11 @@ jobs:
           yarn install --frozen-lockfile
           npx playwright install --with-deps chromium
 
+      - name: Check for cross-fixture entity conflicts
+        working-directory: e2e-test/ui/playwright
+        run: |
+          python3 ../../../.github/scripts/check_playwright_fixture_conflicts.py
+
       - name: Compute duration-weighted shard file list
         working-directory: e2e-test/ui/playwright
         env:

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Download smoke test artifacts
+      - name: Download smoke, gradle, and Playwright test artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -61,6 +61,18 @@ jobs:
             --run-count ${{ github.event.inputs.run_count || '3' }} \
             --workflow build-and-test.yml \
             --artifact-prefix "build-and-test" \
+            --repository ${{ github.repository }}
+
+          echo "Downloading Playwright JUnit artifacts from recent docker-unified.yml runs..."
+          # Separate --output-dir from the smoke-test download above: both suites'
+          # artifacts unzip to a bare junit.xml, and generate_test_weights.py's
+          # pytest/Playwright parsers would otherwise misread each other's files
+          # if pointed at a shared --input-dir.
+          bash .github/scripts/download_test_artifacts.sh \
+            --output-dir ./test-artifacts-playwright \
+            --run-count ${{ github.event.inputs.run_count || '3' }} \
+            --workflow docker-unified.yml \
+            --artifact-prefix "Test Results (playwright)" \
             --repository ${{ github.repository }}
       - name: Download ingestion test artifacts
         id: download-ingestion
@@ -91,6 +103,8 @@ jobs:
           cp metadata-ingestion/tests/integration_test_weights.json \
             ./weights-backup/integration_test_weights.json || echo "No existing integration weights"
           cp .github/backend_test_weights.json ./weights-backup/gradle_weights.json || echo "No existing Gradle weights"
+          cp e2e-test/ui/playwright/playwright_test_weights.json \
+            ./weights-backup/playwright_weights.json || echo "No existing Playwright weights"
 
       - name: Generate smoke test weights
         run: |
@@ -113,6 +127,13 @@ jobs:
           python .github/scripts/generate_test_weights.py \
             --input-dir ./test-artifacts-gradle \
             --gradle-output .github/backend_test_weights.json
+
+      - name: Generate Playwright test weights
+        run: |
+          echo "Generating Playwright test weights from downloaded artifacts..."
+          python .github/scripts/generate_test_weights.py \
+            --input-dir ./test-artifacts-playwright \
+            --playwright-output e2e-test/ui/playwright/playwright_test_weights.json
 
       - name: Compare smoke weights
         id: compare-smoke
@@ -155,6 +176,25 @@ jobs:
             echo "✓ Ingestion changes below 5% threshold. No PR needed."
           fi
 
+      - name: Compare Playwright weights
+        id: compare-playwright
+        run: |
+          echo "Comparing old and new Playwright weights..."
+          python .github/scripts/compare_test_weights.py \
+            --old-playwright ./weights-backup/playwright_weights.json \
+            --new-playwright e2e-test/ui/playwright/playwright_test_weights.json \
+            --output ./pr-body-playwright.md \
+            --threshold 5.0 \
+            --title "🤖 Playwright test weight update"
+
+          if [ -s ./pr-body-playwright.md ]; then
+            echo "create_pr_playwright=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright changes exceed 5% threshold. Will create PR."
+          else
+            echo "create_pr_playwright=false" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright changes below 5% threshold. No PR needed."
+          fi
+
       - name: Compare gradle weights
         id: compare-gradle
         run: |
@@ -176,7 +216,7 @@ jobs:
       - name: Decide PR creation
         id: decide
         run: |
-          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
+          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ] || [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
             echo "create_pr=true" >> "$GITHUB_OUTPUT"
             echo "✓ At least one suite exceeded the 5% threshold. Will create PR."
           else
@@ -199,10 +239,11 @@ jobs:
           git add smoke-test/pytest_test_weights.json
           git add metadata-ingestion/tests/integration_test_weights.json
           git add .github/backend_test_weights.json
+          git add e2e-test/ui/playwright/playwright_test_weights.json
 
           git commit -m "chore(test): update test weights from recent CI runs
 
-          Automated update of smoke and ingestion test weights based on analysis of recent CI runs.
+          Automated update of smoke, ingestion, and Playwright test weights based on analysis of recent CI runs.
           This improves batch balancing and reduces overall CI execution time.
 
           Generated by: ${{ github.workflow }} workflow
@@ -221,7 +262,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Concatenate whichever PR body sections were generated (empty files contribute nothing)
-          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md 2>/dev/null)
+          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md ./pr-body-playwright.md 2>/dev/null)
 
           # Create PR (gh pr create prints the PR URL to stdout)
           PR_URL=$(gh pr create \
@@ -254,6 +295,9 @@ jobs:
               fi
               if [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
                 echo "- gradle (backend)"
+              fi
+              if [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
+                echo "- playwright"
               fi
             else
               echo "ℹ️ **No PR Created**: Changes below 5% threshold"

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -59,84 +59,12 @@ import {
   normalizeMcp,
   extractComplexAspects,
   ingestComplexAspects,
+  withArtifactLock,
+  writeJsonAtomic,
   type Mcp,
 } from '../helpers/seeder-utils';
 import { createLogger, type DataHubLogger } from '../utils/logger';
 import { waitForWritesToSync } from '../utils/writes-sync';
-
-// ── Cross-worker artifact locking ────────────────────────────────────────────
-
-/**
- * If a lock file is older than this with its artifact still missing, its
- * holder is assumed to have crashed; another worker reclaims it rather than
- * wedging the whole run.
- */
-const LOCK_STALE_MS = 120_000;
-const LOCK_POLL_MS = 500;
-/** How long a follower will wait for another worker's artifact before giving up. */
-const LOCK_WAIT_TIMEOUT_MS = 180_000;
-
-/**
- * Atomically claims responsibility for producing `artifactPath` across
- * concurrent worker processes sharing the same filesystem (workers_per_shard
- * > 1). `fs.existsSync` + later `fs.writeFileSync` is a check-then-act race:
- * two workers can both observe "absent" before either has written, and both
- * duplicate the work. `fs.openSync(lockPath, 'wx')` is atomic exclusive
- * create — exactly one caller can win it — so only the winner produces the
- * artifact while everyone else polls for it instead.
- */
-async function withArtifactLock(artifactPath: string, produce: () => Promise<void>): Promise<void> {
-  if (fs.existsSync(artifactPath)) return;
-
-  const lockPath = `${artifactPath}.lock`;
-  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
-  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
-
-  for (;;) {
-    if (fs.existsSync(artifactPath)) return;
-
-    let fd: number | undefined;
-    try {
-      fd = fs.openSync(lockPath, 'wx');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-    }
-
-    if (fd !== undefined) {
-      fs.closeSync(fd);
-      try {
-        if (!fs.existsSync(artifactPath)) {
-          await produce();
-        }
-      } finally {
-        fs.rmSync(lockPath, { force: true });
-      }
-      return;
-    }
-
-    if (Date.now() > deadline) {
-      throw new Error(`Timed out waiting for '${artifactPath}' to be produced by another worker (lock: ${lockPath})`);
-    }
-
-    try {
-      const age = Date.now() - fs.statSync(lockPath).mtimeMs;
-      if (age > LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
-    } catch {
-      // Lock file may have just been removed by its owner between our existsSync
-      // and statSync — ignore and re-poll.
-    }
-
-    await new Promise<void>((resolve) => setTimeout(resolve, LOCK_POLL_MS));
-  }
-}
-
-/** Write JSON atomically: readers never observe a partially-written file. */
-function writeJsonAtomic(filePath: string, data: unknown): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  const tmpPath = `${filePath}.tmp-${process.pid}`;
-  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
-  fs.renameSync(tmpPath, filePath);
-}
 
 // ── GMS token bootstrap ───────────────────────────────────────────────────────
 

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -4,14 +4,18 @@
  * Mirrors the pattern established by loginFixture:
  *
  *   1. A suite opts in by setting the `featureName` option at describe level.
- *   2. The fixture checks whether `.seeded/{featureName}.json` exists on disk.
- *   3a. State EXISTS  → data was already ingested this run; skip injection.
- *   3b. State MISSING → read `tests/{featureName}/fixtures/data.json`, POST
- *       each MCP to the GMS REST API, then write the state file so that other
- *       workers (and subsequent tests in this worker) skip ingestion.
+ *   2. The fixture claims `.seeded/{featureName}.json` via withArtifactLock.
+ *   2a. State EXISTS  → data was already ingested this run; skip injection.
+ *   2b. Lock acquired → read `tests/{featureName}/fixtures/data.json`, POST
+ *       each MCP to the GMS REST API, wait for the write pipeline to sync,
+ *       then write the state file so other workers skip ingestion.
+ *   2c. Lock held by another worker → poll for the state file it is
+ *       producing instead of duplicating the ingestion (see withArtifactLock;
+ *       this is what makes seeding safe under workers_per_shard > 1).
  *
- * Worker-scoped means seeding happens AT MOST ONCE per worker process for a
- * given feature name, regardless of how many tests request it.
+ * Worker-scoped means seeding is attempted AT MOST ONCE per worker process for
+ * a given feature name, regardless of how many tests request it; across
+ * workers sharing a filesystem, exactly one of them actually performs it.
  *
  * NOTE: This fixture is intentionally worker-scoped.  Worker-scoped fixtures
  * cannot depend on test-scoped fixtures such as `logger`.  A dedicated logger
@@ -58,6 +62,81 @@ import {
   type Mcp,
 } from '../helpers/seeder-utils';
 import { createLogger, type DataHubLogger } from '../utils/logger';
+import { waitForWritesToSync } from '../utils/writes-sync';
+
+// ── Cross-worker artifact locking ────────────────────────────────────────────
+
+/**
+ * If a lock file is older than this with its artifact still missing, its
+ * holder is assumed to have crashed; another worker reclaims it rather than
+ * wedging the whole run.
+ */
+const LOCK_STALE_MS = 120_000;
+const LOCK_POLL_MS = 500;
+/** How long a follower will wait for another worker's artifact before giving up. */
+const LOCK_WAIT_TIMEOUT_MS = 180_000;
+
+/**
+ * Atomically claims responsibility for producing `artifactPath` across
+ * concurrent worker processes sharing the same filesystem (workers_per_shard
+ * > 1). `fs.existsSync` + later `fs.writeFileSync` is a check-then-act race:
+ * two workers can both observe "absent" before either has written, and both
+ * duplicate the work. `fs.openSync(lockPath, 'wx')` is atomic exclusive
+ * create — exactly one caller can win it — so only the winner produces the
+ * artifact while everyone else polls for it instead.
+ */
+async function withArtifactLock(artifactPath: string, produce: () => Promise<void>): Promise<void> {
+  if (fs.existsSync(artifactPath)) return;
+
+  const lockPath = `${artifactPath}.lock`;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    if (fs.existsSync(artifactPath)) return;
+
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(lockPath, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+      try {
+        if (!fs.existsSync(artifactPath)) {
+          await produce();
+        }
+      } finally {
+        fs.rmSync(lockPath, { force: true });
+      }
+      return;
+    }
+
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for '${artifactPath}' to be produced by another worker (lock: ${lockPath})`);
+    }
+
+    try {
+      const age = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (age > LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
+    } catch {
+      // Lock file may have just been removed by its owner between our existsSync
+      // and statSync — ignore and re-poll.
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+  }
+}
+
+/** Write JSON atomically: readers never observe a partially-written file. */
+function writeJsonAtomic(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  fs.renameSync(tmpPath, filePath);
+}
 
 // ── GMS token bootstrap ───────────────────────────────────────────────────────
 
@@ -110,8 +189,7 @@ async function bootstrapGmsToken(browser: Browser, user: UserCredentials): Promi
       const token = body.data?.createAccessToken?.accessToken;
       const tokenId = body.data?.createAccessToken?.metadata?.id;
       if (!token) throw new Error('Empty access token in response');
-      fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
-      fs.writeFileSync(tokenFile, JSON.stringify({ token, tokenId, actorUrn: actorCookie.value }, null, 2));
+      writeJsonAtomic(tokenFile, { token, tokenId, actorUrn: actorCookie.value });
       return token;
     } finally {
       await apiCtx.dispose();
@@ -256,15 +334,21 @@ async function ingestMcps(
       await ingestComplexAspects(apiContext, gmsToken, complexAspects, logger);
     }
 
+    // Wait for the MCP -> MCL -> search-index pipeline to catch up BEFORE marking
+    // this seed complete. The state file's mere existence is the fixture's signal
+    // that data is safe to read; writing it any earlier let workers that reuse it
+    // (see _seedFeatureData) proceed against not-yet-indexed data.
+    logger.info('waiting for writes to sync before marking seed complete');
+    await waitForWritesToSync(apiContext, { gmsToken, gmsUrl: gmsBaseUrl, logger });
+
     // Write state file so other workers (and next runs) skip re-seeding.
     // Written even on partial failures (when throwOnFailure=false) so we don't retry endlessly.
-    fs.mkdirSync(SEEDED_DIR, { recursive: true });
     const state: SeedState = {
       featureName,
       seededAt: new Date().toISOString(),
       entityCount: mcps.length,
     };
-    fs.writeFileSync(stateFilePath(featureName), JSON.stringify(state, null, 2));
+    writeJsonAtomic(stateFilePath(featureName), state);
     logger.info('state saved', { featureName });
   } finally {
     await apiContext.dispose();
@@ -296,62 +380,41 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
         return;
       }
 
+      // Each artifact below is guarded by withArtifactLock: exactly one worker
+      // produces it (ingest + wait for the write pipeline to sync) while any
+      // concurrent workers_per_shard > 1 siblings poll for it instead of
+      // duplicating the ingestion.
       const tokenFile = gmsTokenPath(user.username);
-      const gmsToken = fs.existsSync(tokenFile) ? readGmsToken(user.username) : await bootstrapGmsToken(browser, user);
+      await withArtifactLock(tokenFile, () => bootstrapGmsToken(browser, user).then(() => undefined));
+      const gmsToken = readGmsToken(user.username);
 
-      // Track whether any fresh ingestion happened this run so we can wait
-      // for the search index to catch up before tests start.
-      let freshlySeeded = false;
-
-      // Always seed global shared data (test-data/data.json) once per worker.
+      // Always seed global shared data (test-data/data.json) once per run.
       if (fs.existsSync(GLOBAL_DATA_FILE)) {
         const globalStateFile = stateFilePath(GLOBAL_FEATURE_NAME);
-        if (fs.existsSync(globalStateFile)) {
-          const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
-          logger.info('reusing global data', { seededAt: state.seededAt, entityCount: state.entityCount });
-        } else {
+        await withArtifactLock(globalStateFile, () =>
           // throwOnFailure=false: global data has mixed-format MCPs; partial failures are non-blocking.
-          await ingestMcps(GLOBAL_FEATURE_NAME, gmsToken, gmsUrl(), logger, GLOBAL_DATA_FILE, false);
-          freshlySeeded = true;
-        }
+          ingestMcps(GLOBAL_FEATURE_NAME, gmsToken, gmsUrl(), logger, GLOBAL_DATA_FILE, false),
+        );
+        const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
+        logger.info('global data ready', { seededAt: state.seededAt, entityCount: state.entityCount });
       }
 
       if (!featureName) {
-        if (freshlySeeded) {
-          logger.info('waiting 15s for search index to catch up');
-          await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
-        }
         await use();
         return;
       }
 
       const stateFile = stateFilePath(featureName);
-      if (fs.existsSync(stateFile)) {
-        const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as SeedState;
-        logger.info('reusing seeded data', {
-          featureName,
-          seededAt: state.seededAt,
-          entityCount: state.entityCount,
-        });
-        if (freshlySeeded) {
-          logger.info('waiting 15s for search index to catch up');
-          await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
-        }
-        await use();
-        return;
-      }
-
-      // Slow path: seed feature-specific data and save state.
-      await ingestMcps(featureName, gmsToken, gmsUrl(), logger);
-      freshlySeeded = true;
-
-      logger.info('waiting 15s for search index to catch up');
-      await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
+      await withArtifactLock(stateFile, () => ingestMcps(featureName, gmsToken, gmsUrl(), logger));
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as SeedState;
+      logger.info('feature data ready', { featureName, seededAt: state.seededAt, entityCount: state.entityCount });
 
       await use();
     },
-    // 90 s: ingestMcps + 15 s ES index wait + network overhead can exceed the
-    // default fixture timeout (which mirrors the 30 s test timeout).
-    { auto: true, scope: 'worker', timeout: 90_000 },
+    // Generous ceiling: in the worst case a single worker becomes the producer for
+    // the token, global data, AND feature data, each of which now waits (via
+    // waitForWritesToSync, up to 60s) for the write pipeline to sync rather than
+    // sleeping a fixed 15s -- see withArtifactLock / ingestMcps.
+    { auto: true, scope: 'worker', timeout: 240_000 },
   ],
 });

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -397,6 +397,32 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
         );
         const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
         logger.info('global data ready', { seededAt: state.seededAt, entityCount: state.entityCount });
+
+        // TEMPORARY DIAGNOSTIC -- remove after root-causing the glossaryRelatedTerms failure.
+        try {
+          const diagCtx = await request.newContext({
+            baseURL: gmsUrl(),
+            extraHTTPHeaders: { Authorization: `Bearer ${gmsToken}` },
+          });
+          const termUrn = 'urn:li:glossaryTerm:PlaywrightNode.PlaywrightTerm';
+          const aspectResp = await diagCtx.get(
+            `${gmsUrl()}/aspects/${encodeURIComponent(termUrn)}?aspect=glossaryRelatedTerms&version=0`,
+          );
+          logger.warn('DIAG aspect glossaryRelatedTerms', {
+            status: aspectResp.status(),
+            body: (await aspectResp.text()).slice(0, 500),
+          });
+          const relResp = await diagCtx.get(
+            `${gmsUrl()}/relationships?urn=${encodeURIComponent(termUrn)}&types=HasA&direction=OUTGOING`,
+          );
+          logger.warn('DIAG relationships HasA OUTGOING', {
+            status: relResp.status(),
+            body: (await relResp.text()).slice(0, 500),
+          });
+          await diagCtx.dispose();
+        } catch (err) {
+          logger.warn('DIAG failed', { error: String(err) });
+        }
       }
 
       if (!featureName) {

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -397,32 +397,6 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
         );
         const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
         logger.info('global data ready', { seededAt: state.seededAt, entityCount: state.entityCount });
-
-        // TEMPORARY DIAGNOSTIC -- remove after root-causing the glossaryRelatedTerms failure.
-        try {
-          const diagCtx = await request.newContext({
-            baseURL: gmsUrl(),
-            extraHTTPHeaders: { Authorization: `Bearer ${gmsToken}` },
-          });
-          const termUrn = 'urn:li:glossaryTerm:PlaywrightNode.PlaywrightTerm';
-          const aspectResp = await diagCtx.get(
-            `${gmsUrl()}/aspects/${encodeURIComponent(termUrn)}?aspect=glossaryRelatedTerms&version=0`,
-          );
-          logger.warn('DIAG aspect glossaryRelatedTerms', {
-            status: aspectResp.status(),
-            body: (await aspectResp.text()).slice(0, 500),
-          });
-          const relResp = await diagCtx.get(
-            `${gmsUrl()}/relationships?urn=${encodeURIComponent(termUrn)}&types=HasA&direction=OUTGOING`,
-          );
-          logger.warn('DIAG relationships HasA OUTGOING', {
-            status: relResp.status(),
-            body: (await relResp.text()).slice(0, 500),
-          });
-          await diagCtx.dispose();
-        } catch (err) {
-          logger.warn('DIAG failed', { error: String(err) });
-        }
       }
 
       if (!featureName) {

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -11,11 +11,89 @@
  * needed.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { APIRequestContext } from '@playwright/test';
 import { gmsUrl } from '../utils/constants';
 import type { DataHubLogger } from '../utils/logger';
 
 export type Urn = string;
+
+// ── Cross-worker artifact locking ────────────────────────────────────────────
+
+/**
+ * If a lock file is older than this with its artifact still missing, its
+ * holder is assumed to have crashed; another worker reclaims it rather than
+ * wedging the whole run.
+ */
+const LOCK_STALE_MS = 120_000;
+const LOCK_POLL_MS = 500;
+/** How long a follower will wait for another worker's artifact before giving up. */
+const LOCK_WAIT_TIMEOUT_MS = 180_000;
+
+/**
+ * Atomically claims responsibility for producing `artifactPath` across
+ * concurrent worker processes sharing the same filesystem (workers_per_shard
+ * > 1, or fullyParallel scheduling two files/describe-blocks that share a
+ * seed routine onto different workers). `fs.existsSync` + later
+ * `fs.writeFileSync` is a check-then-act race: two callers can both observe
+ * "absent" before either has written, and both duplicate the work.
+ * `fs.openSync(lockPath, 'wx')` is atomic exclusive create -- exactly one
+ * caller can win it -- so only the winner produces the artifact while
+ * everyone else polls for it instead.
+ */
+export async function withArtifactLock(artifactPath: string, produce: () => Promise<void>): Promise<void> {
+  if (fs.existsSync(artifactPath)) return;
+
+  const lockPath = `${artifactPath}.lock`;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    if (fs.existsSync(artifactPath)) return;
+
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(lockPath, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+      try {
+        if (!fs.existsSync(artifactPath)) {
+          await produce();
+        }
+      } finally {
+        fs.rmSync(lockPath, { force: true });
+      }
+      return;
+    }
+
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for '${artifactPath}' to be produced by another worker (lock: ${lockPath})`);
+    }
+
+    try {
+      const age = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (age > LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
+    } catch {
+      // Lock file may have just been removed by its owner between our existsSync
+      // and statSync — ignore and re-poll.
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+  }
+}
+
+/** Write JSON atomically: readers never observe a partially-written file. */
+export function writeJsonAtomic(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  fs.renameSync(tmpPath, filePath);
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/e2e-test/ui/playwright/pages/applications.page.ts
+++ b/e2e-test/ui/playwright/pages/applications.page.ts
@@ -202,9 +202,9 @@ export class ApplicationsPage extends BasePage {
   }
 
   async verifyAssetInList(assetName: string): Promise<void> {
-    // Wait for GraphQL search query to complete and render assets
+    // Wait for the GraphQL search query to complete; the visibility assertion
+    // below retries rendering for EXTRA_LONG on its own.
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     const assetElement = this.getAssetElement(assetName);
     await expect(assetElement).toBeVisible({ timeout: TIMEOUTS.EXTRA_LONG });

--- a/e2e-test/ui/playwright/pages/applications.page.ts
+++ b/e2e-test/ui/playwright/pages/applications.page.ts
@@ -123,8 +123,9 @@ export class ApplicationsPage extends BasePage {
   async searchApplication(query: string): Promise<void> {
     await this.searchInput.fill('');
     await this.searchInput.type(query);
-    // Wait for search debounce + network
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // Wait out the search-input debounce before the query fires; networkidle
+    // below can't retry a request that hasn't started yet.
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
   }
 
@@ -147,10 +148,9 @@ export class ApplicationsPage extends BasePage {
 
   async clickCreateButton(): Promise<void> {
     await this.createButtonModal.click();
-    // Wait for modal to close and success message
+    // Wait for modal to close; the caller uses waitForWritesToSync() afterwards
+    // for the actual create-write consistency wait before checking the table.
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    // Wait for refetch to complete
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
   async verifyApplicationInTable(name: string): Promise<void> {
@@ -179,8 +179,9 @@ export class ApplicationsPage extends BasePage {
 
   async confirmDeletion(): Promise<void> {
     await this.deleteConfirmButton.click();
+    // Callers use waitForWritesToSync() afterwards for the actual
+    // delete-write consistency wait before re-checking the table.
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
   async deleteApplication(name: string): Promise<void> {
@@ -255,7 +256,9 @@ export class ApplicationsPage extends BasePage {
 
   async clickSelectApplicationDropdown(): Promise<void> {
     await this.applicationSelectDropdown.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS); // Wait for modal to fully stabilize
+    // Brief settle for the modal open animation before the click; no assertion
+    // to retry against here, so kept small rather than removed outright.
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await this.applicationSelectDropdown.click({ timeout: TIMEOUTS.MEDIUM });
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
   }
@@ -270,14 +273,17 @@ export class ApplicationsPage extends BasePage {
 
     // Fill the search input with application name
     await searchInput.fill(appName);
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
+    // Wait for the filtered option to actually render instead of guessing the
+    // debounce — selectApplicationFromDropdown() clicks it immediately after.
+    await this.getDropdownOption(appName)
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      .catch(() => {});
   }
 
   async selectApplicationFromDropdown(appName: string): Promise<void> {
     const option = this.getDropdownOption(appName);
     await option.click();
-    // Small wait for dropdown to close
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
+    // No sleep: clickOKButton()'s own waitFor() tolerates the dropdown-close animation.
   }
 
   async clickOKButton(): Promise<void> {

--- a/e2e-test/ui/playwright/pages/browse-v2.page.ts
+++ b/e2e-test/ui/playwright/pages/browse-v2.page.ts
@@ -78,18 +78,29 @@ export class BrowseV2Page extends BasePage {
     const platformHeader = this.browsePlatformHeaderLocator(platformName);
     await platformHeader.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await platformHeader.click({ force: true });
+    // CI regression (see git history): these three methods are chained
+    // back-to-back with no assertion in between in some tests (platform ->
+    // expand path -> click leaf node). A `force: true` click firing while the
+    // prior click's tree re-render is still in flight can land on a
+    // mid-transition DOM and silently fail to register — the next method's
+    // own waitFor() doesn't protect against this because it's waiting on a
+    // locator whose underlying render this same race can also stall.
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
   async expandBrowseNode(nodeName: string): Promise<void> {
     const locator = this.browseNodeExpandLocator(nodeName);
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
+    // Wait for animation and DOM updates — see clickBrowsePlatform() above.
+    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
   async clickBrowseNode(nodeName: string): Promise<void> {
     const locator = this.browseNodeLocator(nodeName);
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
+    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
   async expectBrowseNodeVisible(nodeName: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/browse-v2.page.ts
+++ b/e2e-test/ui/playwright/pages/browse-v2.page.ts
@@ -40,19 +40,29 @@ export class BrowseV2Page extends BasePage {
   }
 
   async expectSidebarExpanded(): Promise<void> {
-    const width = await this.browseV2Container.evaluate((el) => window.getComputedStyle(el).width);
-    // Expanded state should have width > 100px (typically 260px+)
-    const widthValue = parseInt(width, 10);
-    expect(widthValue).toBeGreaterThan(100);
+    // Poll the actual computed width instead of guessing the 200ms CSS
+    // transition's duration — resolves as soon as the transition finishes.
+    await expect
+      .poll(
+        async () => {
+          const width = await this.browseV2Container.evaluate((el) => window.getComputedStyle(el).width);
+          return parseInt(width, 10);
+        },
+        { timeout: TIMEOUTS.MEDIUM },
+      )
+      .toBeGreaterThan(100); // Expanded state should have width > 100px (typically 260px+)
   }
 
   async expectSidebarCollapsed(): Promise<void> {
-    // Wait for sidebar to actually collapse (width change)
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
-    const width = await this.browseV2Container.evaluate((el) => window.getComputedStyle(el).width);
-    // Collapsed state should have width ~63px
-    const widthValue = parseInt(width, 10);
-    expect(widthValue).toBeLessThan(100);
+    await expect
+      .poll(
+        async () => {
+          const width = await this.browseV2Container.evaluate((el) => window.getComputedStyle(el).width);
+          return parseInt(width, 10);
+        },
+        { timeout: TIMEOUTS.MEDIUM },
+      )
+      .toBeLessThan(100); // Collapsed state should have width ~63px
   }
 
   async toggleSidebar(): Promise<void> {
@@ -60,33 +70,26 @@ export class BrowseV2Page extends BasePage {
     await this.browseV2Toggle.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     // Click the toggle button
     await this.browseV2Toggle.click();
-    // Wait for CSS transition animation and state change to propagate
-    // The sidebar animates for 200ms, plus buffer for state updates
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
-    // Give React state a moment to update
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
+    // No fixed sleep: expectSidebarExpanded()/expectSidebarCollapsed() poll the
+    // actual computed width rather than guessing how long the transition takes.
   }
 
   async clickBrowsePlatform(platformName: string): Promise<void> {
     const platformHeader = this.browsePlatformHeaderLocator(platformName);
     await platformHeader.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await platformHeader.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
   async expandBrowseNode(nodeName: string): Promise<void> {
     const locator = this.browseNodeExpandLocator(nodeName);
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
-    // Wait for animation and DOM updates
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
   async clickBrowseNode(nodeName: string): Promise<void> {
     const locator = this.browseNodeLocator(nodeName);
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
   async expectBrowseNodeVisible(nodeName: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/domains/domains.page.ts
+++ b/e2e-test/ui/playwright/pages/domains/domains.page.ts
@@ -7,6 +7,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 import { BasePage } from '../base.page';
 import type { DataHubLogger } from '../../utils/logger';
+import { waitForWritesToSync } from '../../utils/writes-sync';
 
 export class DomainsPage extends BasePage {
   readonly newDomainButton: Locator;
@@ -60,8 +61,8 @@ export class DomainsPage extends BasePage {
     await this.domainIdInput.fill(String(id));
     await this.createDomainConfirmButton.click();
     await expect(this.page.getByText(name).first()).toBeVisible({ timeout: 15000 });
-    // Allow ES to index the new domain before subsequent tests search for it
-    await this.page.waitForTimeout(5000);
+    // Wait for the new domain to be consumed and indexed — later tests search/navigate to it
+    await waitForWritesToSync(this.page.request);
   }
 
   async navigateToDomain(urn: string): Promise<void> {
@@ -78,9 +79,9 @@ export class DomainsPage extends BasePage {
     // On the flat-list layout, search to ensure the domain is visible before clicking
     if (await this.domainSearchInput.isVisible({ timeout: 2000 }).catch(() => false)) {
       await this.domainSearchInput.fill(name);
-      await this.page.waitForTimeout(500);
     }
-    // Use link role to skip hidden aria-live spans that also match the text
+    // Use link role to skip hidden aria-live spans that also match the text.
+    // No sleep: .click() below auto-waits for the filtered link to be actionable.
     await this.page.getByRole('link', { name }).first().click();
     await this.page.waitForLoadState('networkidle');
   }
@@ -101,8 +102,7 @@ export class DomainsPage extends BasePage {
     await expect(async () => {
       await this.modalSearchInput.click({ clickCount: 3 }); // select-all any existing text
       await this.modalSearchInput.pressSequentially(searchTerm);
-      // Wait for the debounce (300ms) + search result render before checking the checkbox
-      await this.page.waitForTimeout(800);
+      // No sleep: the toBeVisible() retry below already covers the debounce + render.
       await expect(checkbox).toBeVisible({ timeout: 10000 });
     }).toPass({ timeout: 90000, intervals: [3000] });
     await checkbox.click({ force: true });
@@ -128,8 +128,9 @@ export class DomainsPage extends BasePage {
     await this.entityMenuDeleteButton.click();
     await this.page.getByRole('button', { name: 'Yes' }).click();
     await this.page.waitForLoadState('networkidle', { timeout: 15000 });
-    // Allow ES to de-index the deleted domain before asserting it's gone
-    await this.page.waitForTimeout(5000);
+    // Wait for the delete (and any dangling-reference cleanup) to be consumed and
+    // de-indexed before the caller re-queries for it
+    await waitForWritesToSync(this.page.request);
   }
 
   async expectDomainVisible(name: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -118,7 +118,9 @@ export class DocumentPage extends BasePage {
 
   async createDocumentWithTitle(title: string): Promise<string> {
     const docUrn = await this.createNewDocumentViaButton();
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No sleep needed: createNewDocumentViaButton already confirmed the mutation
+    // returned (URL polled to the new URN), and navigateToDocument's own
+    // networkidle wait plus setDocumentTitle's visibility check absorb the rest.
     await this.navigateToDocument(docUrn);
     await this.setDocumentTitle(title);
     return docUrn;
@@ -140,10 +142,10 @@ export class DocumentPage extends BasePage {
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await this.titleInput.pressSequentially(title, { delay: DELAYS.SEQUENTIAL });
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
-    // Press Enter to save the title (triggers blur/save handler)
+    // Press Enter to save the title (triggers blur/save handler). Most callers only
+    // check the (optimistically updated) input value right after, which needs no
+    // backend wait; callers that reload or search afterwards use waitForWritesToSync().
     await this.page.keyboard.press(KEYS.ENTER);
-    // Wait for title update to persist in the backend
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
   async expectTitleInput(title: string): Promise<void> {
@@ -187,7 +189,9 @@ export class DocumentPage extends BasePage {
     await editor.clear({ force: true });
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await editor.fill(text);
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No trailing sleep: the caller triggers the actual save on blur/Escape and
+    // is responsible for waiting on that write with waitForWritesToSync() before
+    // reading it back through a reload.
   }
 
   async expectEditorContains(text: string): Promise<void> {
@@ -201,14 +205,13 @@ export class DocumentPage extends BasePage {
     const trigger = this.getStatusSelectTrigger();
     await expect(trigger).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await trigger.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     const option = this.getDropdownOption(status);
     await expect(option).toBeVisible({ timeout: TIMEOUTS.LONG });
     await option.click();
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
-    // Verify optimistic update with case-insensitive match
+    // Verify optimistic update with case-insensitive match; this retry already
+    // absorbs the render delay the two removed sleeps used to cover.
     await expect(this.statusSelect).toContainText(new RegExp(status, 'i'));
 
     // Wait for the mutation round-trip; callers that reload afterwards use
@@ -226,14 +229,13 @@ export class DocumentPage extends BasePage {
     const trigger = this.getTypeSelectTrigger();
     await expect(trigger).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await trigger.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     const option = this.getDropdownOption(type);
     await expect(option).toBeVisible({ timeout: TIMEOUTS.LONG });
     await option.click();
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
-    // Verify optimistic update with case-insensitive match
+    // Verify optimistic update with case-insensitive match; this retry already
+    // absorbs the render delay the two removed sleeps used to cover.
     await expect(this.typeSelect).toContainText(new RegExp(type, 'i'));
 
     // Wait for the mutation round-trip; callers that reload afterwards use
@@ -248,7 +250,9 @@ export class DocumentPage extends BasePage {
   async searchForDocument(query: string): Promise<void> {
     await this.searchInput.click();
     await this.searchInput.fill(query);
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No sleep: expectSearchResultsVisible() retries with TIMEOUTS.LONG, which
+    // covers the debounce. Callers searching by a just-written title still need
+    // waitForWritesToSync() beforehand for index consistency, not a UI-render sleep.
   }
 
   async expectSearchResultsVisible(): Promise<void> {
@@ -257,7 +261,7 @@ export class DocumentPage extends BasePage {
 
   async closeSearchAndVerifyClosed(): Promise<void> {
     await this.searchInput.clear();
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // not.toBeVisible() below already retries until the close animation settles.
     await expect(this.searchResults).not.toBeVisible({ timeout: TIMEOUTS.SHORT });
   }
 
@@ -313,14 +317,14 @@ export class DocumentPage extends BasePage {
     await expect(this.actionsMenuButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await expect(this.actionsMenuButton).toBeEnabled({ timeout: TIMEOUTS.MEDIUM });
     await this.actionsMenuButton.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No sleep: clickDeleteMenuItem()'s own visibility check retries for the menu to render.
   }
 
   async clickDeleteMenuItem(): Promise<void> {
     const deleteMenuItem = this.getDeleteMenuOption();
     await expect(deleteMenuItem).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await deleteMenuItem.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No sleep: confirmDelete()'s own visibility check retries for the dialog to render.
   }
 
   async confirmDelete(): Promise<void> {
@@ -411,7 +415,8 @@ export class DocumentPage extends BasePage {
     await expandButton.hover({ force: true });
     await expect(expandButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await expandButton.click({ force: true });
-    await this.page.waitForTimeout(TIMEOUTS.OPERATION);
+    // No sleep: expectTreeItemExpanded()/expectTreeItemCollapsed() retry on the
+    // aria-expanded attribute with TIMEOUTS.LONG.
   }
 
   async expectTreeItemExpanded(urn: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -211,9 +211,9 @@ export class DocumentPage extends BasePage {
     // Verify optimistic update with case-insensitive match
     await expect(this.statusSelect).toContainText(new RegExp(status, 'i'));
 
-    // Wait for network and database persistence before allowing reload
+    // Wait for the mutation round-trip; callers that reload afterwards use
+    // waitForWritesToSync() to cover consumer/index persistence.
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
   }
 
   async expectStatusContains(text: string): Promise<void> {
@@ -236,9 +236,9 @@ export class DocumentPage extends BasePage {
     // Verify optimistic update with case-insensitive match
     await expect(this.typeSelect).toContainText(new RegExp(type, 'i'));
 
-    // Wait for network and database persistence before allowing reload
+    // Wait for the mutation round-trip; callers that reload afterwards use
+    // waitForWritesToSync() to cover consumer/index persistence.
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
   }
 
   async expectTypeContains(text: string): Promise<void> {

--- a/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
+++ b/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
@@ -437,8 +437,6 @@ export abstract class SourcesBaseTab extends BaseTab {
   }
 
   async expectSourceStatusContains(sourceName: string, status: string): Promise<void> {
-    // Wait briefly for executor to pick up the request
-    await this.page.waitForTimeout(TIMEOUTS.SHORT);
     const row = this.getSourceRow(sourceName);
     // Ingestion source execution completion
     await expect(row.getByText(status, { exact: false })).toBeVisible({ timeout: TIMEOUTS.INGESTION_EXECUTION });

--- a/e2e-test/ui/playwright/pages/lineage-v3.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-v3.page.ts
@@ -87,7 +87,6 @@ export class LineageV3Page extends LineageBasePage {
     await this.clickFilterByDescription();
     await this.typeFilterText(text);
     await this.confirmFilterText();
-    await this.page.waitForTimeout(TIMEOUTS.SHORT);
   }
 
   // ── Time-Range Filtering ────────────────────────────────────────────────────
@@ -211,6 +210,33 @@ export class LineageV3Page extends LineageBasePage {
   }
 
   // ── Impact Analysis and Column Lineage Navigation ────────────────────────
+
+  /**
+   * Open the Impact Analysis view and wait for its search toolbar to hydrate.
+   * A click that lands during the entity page's initial render storm can be
+   * swallowed by a React re-render, so the click is retried via toPass()
+   * until the view's toolbar is actually visible — replacing the fixed
+   * post-goto sleeps this suite used to carry. Re-clicking is safe: the
+   * Impact Analysis button re-selects the same view.
+   */
+  async openImpactAnalysisView(): Promise<void> {
+    await expect(async () => {
+      await this.clickImpactAnalysis();
+      await expect(this.advSearchAddFilterButton).toBeVisible({ timeout: TIMEOUTS.OPERATION });
+    }).toPass({ timeout: TIMEOUTS.LONG });
+  }
+
+  /**
+   * Open the sidebar Lineage tab (task/datajob pages) and wait for its
+   * direction selector to hydrate. Same swallowed-click rationale as
+   * openImpactAnalysisView(); re-clicking re-selects the same tab.
+   */
+  async openSidebarLineageTab(): Promise<void> {
+    await expect(async () => {
+      await this.clickSidebarLineageTab();
+      await expect(this.upstreamDirectionOption).toBeVisible({ timeout: TIMEOUTS.OPERATION });
+    }).toPass({ timeout: TIMEOUTS.LONG });
+  }
 
   /**
    * Click the lineage tab in the entity page.

--- a/e2e-test/ui/playwright/pages/search.page.ts
+++ b/e2e-test/ui/playwright/pages/search.page.ts
@@ -83,15 +83,15 @@ export class SearchPage extends BasePage {
   async search(query: string): Promise<void> {
     await this.searchInput.fill(query);
     await this.searchInput.press('Enter');
-    await this.page.waitForTimeout(2000);
+    // No trailing sleep: callers assert via web-first expect()s that already
+    // retry, or via page-object methods with their own actionability waits.
   }
 
-  async searchAndWait(query: string, waitTime: number = 5000): Promise<void> {
+  async searchAndWait(query: string): Promise<void> {
     await this.searchInput.waitFor({ state: 'visible' });
     await this.searchInput.fill(query);
     await this.searchInput.press('Enter');
     await this.page.waitForLoadState('networkidle');
-    await this.page.waitForTimeout(waitTime);
   }
 
   async expectResultsCount(pattern: RegExp): Promise<void> {
@@ -163,14 +163,16 @@ export class SearchPage extends BasePage {
       const moreFiltersVisible = await moreFiltersBtn.isVisible();
       if (moreFiltersVisible) {
         await moreFiltersBtn.click();
-        await this.page.waitForTimeout(500);
         const moreFilterOption = this.page.getByTestId(`more-filter-${filterName}`);
-        const moreFilterVisible = await moreFilterOption.isVisible();
+        // Single-shot isVisible() would false-negative during the menu's open
+        // animation; wait for the real state instead of sleeping a fixed amount.
+        const moreFilterVisible = await moreFilterOption
+          .waitFor({ state: 'visible', timeout: 2000 })
+          .then(() => true)
+          .catch(() => false);
         if (moreFilterVisible) {
           await moreFilterOption.click();
-          await this.page.waitForTimeout(500);
-          // After clicking the more-filter option, select the option within
-          // the sub-dropdown that appears. Fall through to the selection logic.
+          // No sleep: selectFilterValue() below waits on the sub-dropdown itself.
           await this.selectFilterValue(optionLabel);
           return;
         }
@@ -183,9 +185,7 @@ export class SearchPage extends BasePage {
 
     await filterDropdown.click({ force: true });
 
-    // Wait for the dropdown menu to appear
-    await this.page.waitForTimeout(1000);
-
+    // No sleep: selectFilterValue() waits on the dropdown container itself.
     await this.selectFilterValue(optionLabel);
   }
 

--- a/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
+++ b/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
@@ -150,11 +150,13 @@ export class ChangeHistoryChart extends BasePage {
     const dayCell = this.getDayCell(dateString);
     await dayCell.scrollIntoViewIfNeeded();
     await dayCell.hover({ timeout });
-    // Wait for the popover to actually mount (antd's hover-open delay) rather
-    // than guessing a fixed duration; days with no popover just time out fast.
-    await this.getDayPopover(dateString)
-      .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
-      .catch(() => {});
+    // CI regression (see git history): waiting on getDayPopover() here instead
+    // of a short fixed sleep breaks days with no popover content — the wait
+    // burns its full budget with nothing to find, and by the time callers make
+    // their own check the transient hover state has already lapsed. A brief
+    // fixed sleep is the correct tool for an antd hover-open delay with no
+    // universal DOM signal to wait on across both populated and empty days.
+    await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
   /**

--- a/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
+++ b/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
@@ -129,7 +129,6 @@ export class ChangeHistoryChart extends BasePage {
   async closeDayDrawer(timeout: number = TIMEOUTS.SHORT): Promise<void> {
     this.logger?.step('closeDayDrawer');
     await this.closeDrawerButton.click({ timeout });
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
   /**
@@ -151,7 +150,11 @@ export class ChangeHistoryChart extends BasePage {
     const dayCell = this.getDayCell(dateString);
     await dayCell.scrollIntoViewIfNeeded();
     await dayCell.hover({ timeout });
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
+    // Wait for the popover to actually mount (antd's hover-open delay) rather
+    // than guessing a fixed duration; days with no popover just time out fast.
+    await this.getDayPopover(dateString)
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.SHORT })
+      .catch(() => {});
   }
 
   /**
@@ -159,7 +162,6 @@ export class ChangeHistoryChart extends BasePage {
    */
   async toggleOperationType(opType: string, timeout: number = TIMEOUTS.SHORT): Promise<void> {
     await this.getOperationTypeOption(opType).click({ timeout });
-    await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
   /**

--- a/e2e-test/ui/playwright/pages/welcome-modal.page.ts
+++ b/e2e-test/ui/playwright/pages/welcome-modal.page.ts
@@ -116,14 +116,12 @@ export class WelcomeModalPage extends BasePage {
 
   async pressArrowRight(): Promise<void> {
     await this.page.keyboard.press('ArrowRight');
-    // react-slick afterChange fires via setTimeout(speed=500ms). Match the
-    // wait used by clickCarouselDot for consistency.
-    await this.page.waitForTimeout(500);
+    // No sleep: the caller's expectSlideXVisible() asserts via a retrying
+    // expect().toBeVisible() (some also poll waitForSlideChange() first).
   }
 
   async pressArrowLeft(): Promise<void> {
     await this.page.keyboard.press('ArrowLeft');
-    await this.page.waitForTimeout(500);
   }
 
   async closeViaOutsideClick(): Promise<void> {
@@ -134,9 +132,8 @@ export class WelcomeModalPage extends BasePage {
 
   async clickCarouselDot(index: number): Promise<void> {
     await this.carouselDots.nth(index).click();
-    // react-slick does not emit a DOM signal when the slide CSS transition finishes (~300 ms).
-    // There is no reliable locator to await, so a short fixed delay is the least-fragile option.
-    await this.page.waitForTimeout(500);
+    // No sleep: callers assert via expectSlideXVisible() (retrying) or, in the
+    // rapid-navigation test, deliberately click back-to-back without waiting.
   }
 
   async clickLastCarouselDot(): Promise<void> {

--- a/e2e-test/ui/playwright/pages/welcome-modal.page.ts
+++ b/e2e-test/ui/playwright/pages/welcome-modal.page.ts
@@ -116,12 +116,19 @@ export class WelcomeModalPage extends BasePage {
 
   async pressArrowRight(): Promise<void> {
     await this.page.keyboard.press('ArrowRight');
-    // No sleep: the caller's expectSlideXVisible() asserts via a retrying
-    // expect().toBeVisible() (some also poll waitForSlideChange() first).
+    // CI regression (see git history): react-slick's afterChange fires via
+    // setTimeout(speed=500ms), and a second interaction landing mid-transition
+    // can drop it entirely via the ResizeObserver race documented on
+    // clickLastCarouselDot() below. The caller's retrying assertion doesn't
+    // protect against this — if afterChange never fires, the target heading
+    // never renders at all, so the assertion just times out. A fixed wait
+    // matching the transition speed is the least-fragile option here.
+    await this.page.waitForTimeout(500);
   }
 
   async pressArrowLeft(): Promise<void> {
     await this.page.keyboard.press('ArrowLeft');
+    await this.page.waitForTimeout(500);
   }
 
   async closeViaOutsideClick(): Promise<void> {
@@ -132,8 +139,12 @@ export class WelcomeModalPage extends BasePage {
 
   async clickCarouselDot(index: number): Promise<void> {
     await this.carouselDots.nth(index).click();
-    // No sleep: callers assert via expectSlideXVisible() (retrying) or, in the
-    // rapid-navigation test, deliberately click back-to-back without waiting.
+    // react-slick does not emit a DOM signal when the slide CSS transition finishes (~300 ms).
+    // There is no reliable locator to await, so a short fixed delay is the least-fragile option.
+    // CI regression (see git history): removing this broke both sequential dot
+    // clicks and the rapid-navigation test, via the same afterChange-drop race
+    // documented on clickLastCarouselDot() below.
+    await this.page.waitForTimeout(500);
   }
 
   async clickLastCarouselDot(): Promise<void> {

--- a/e2e-test/ui/playwright/playwright_test_weights.json
+++ b/e2e-test/ui/playwright/playwright_test_weights.json
@@ -13,7 +13,7 @@
   },
   {
     "filePath": "auth/login-with-welcome-modal.spec.ts",
-    "duration": "7.628s"
+    "duration": "15.257s"
   },
   {
     "filePath": "auth/login.spec.ts",
@@ -41,7 +41,7 @@
   },
   {
     "filePath": "change-history/change-history.spec.ts",
-    "duration": "102.246s"
+    "duration": "204.493s"
   },
   {
     "filePath": "containers-v2/v2-containers.spec.ts",
@@ -141,7 +141,7 @@
   },
   {
     "filePath": "ingestion-v2/run-history.spec.ts",
-    "duration": "10.790s"
+    "duration": "21.580s"
   },
   {
     "filePath": "ingestion-v2/secrets-tab.spec.ts",
@@ -273,7 +273,7 @@
   },
   {
     "filePath": "search/searchv2.spec.ts",
-    "duration": "39.930s"
+    "duration": "79.860s"
   },
   {
     "filePath": "settings-v2/v2-home-page-posts.spec.ts",

--- a/e2e-test/ui/playwright/playwright_test_weights.json
+++ b/e2e-test/ui/playwright/playwright_test_weights.json
@@ -1,0 +1,358 @@
+[
+  {
+    "filePath": "analytics/analytics.spec.ts",
+    "duration": "17.968s"
+  },
+  {
+    "filePath": "application/application-management.spec.ts",
+    "duration": "26.696s"
+  },
+  {
+    "filePath": "application/application-sidebar.spec.ts",
+    "duration": "30.728s"
+  },
+  {
+    "filePath": "auth/login-with-welcome-modal.spec.ts",
+    "duration": "7.628s"
+  },
+  {
+    "filePath": "auth/login.spec.ts",
+    "duration": "16.494s"
+  },
+  {
+    "filePath": "autocomplete-v2/autocomplete.spec.ts",
+    "duration": "14.790s"
+  },
+  {
+    "filePath": "browse-v2/browse-v2.spec.ts",
+    "duration": "50.937s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute-navigation.spec.ts",
+    "duration": "0.223s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute.spec.ts",
+    "duration": "0.538s"
+  },
+  {
+    "filePath": "business-attributes/check-feature-flag.spec.ts",
+    "duration": "0.109s"
+  },
+  {
+    "filePath": "change-history/change-history.spec.ts",
+    "duration": "102.246s"
+  },
+  {
+    "filePath": "containers-v2/v2-containers.spec.ts",
+    "duration": "3.374s"
+  },
+  {
+    "filePath": "documents/document-import.spec.ts",
+    "duration": "17.686s"
+  },
+  {
+    "filePath": "documents/document-management.spec.ts",
+    "duration": "191.505s"
+  },
+  {
+    "filePath": "documents/document-tree-expand.spec.ts",
+    "duration": "32.510s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-advanced.spec.ts",
+    "duration": "28.439s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-core.spec.ts",
+    "duration": "20.737s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-summary.spec.ts",
+    "duration": "14.951s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-about-section.spec.ts",
+    "duration": "20.112s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-data-product.spec.ts",
+    "duration": "4.650s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-domain.spec.ts",
+    "duration": "5.175s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-node.spec.ts",
+    "duration": "4.444s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-term.spec.ts",
+    "duration": "5.027s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-navigation.spec.ts",
+    "duration": "51.012s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-node-tags.spec.ts",
+    "duration": "8.965s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term-tags.spec.ts",
+    "duration": "11.396s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term.spec.ts",
+    "duration": "12.045s"
+  },
+  {
+    "filePath": "glossary/v2-glossary.spec.ts",
+    "duration": "95.861s"
+  },
+  {
+    "filePath": "home-v2/v2-home.spec.ts",
+    "duration": "4.212s"
+  },
+  {
+    "filePath": "home/homepage-collection-view-all.spec.ts",
+    "duration": "6.774s"
+  },
+  {
+    "filePath": "home/homepage-modules.spec.ts",
+    "duration": "43.321s"
+  },
+  {
+    "filePath": "home/homepage-templates.spec.ts",
+    "duration": "7.692s"
+  },
+  {
+    "filePath": "home/homepage-visibility.spec.ts",
+    "duration": "7.724s"
+  },
+  {
+    "filePath": "incidents-v2/v2-incidents.spec.ts",
+    "duration": "26.270s"
+  },
+  {
+    "filePath": "ingestion-v2/odcs-source.spec.ts",
+    "duration": "7.926s"
+  },
+  {
+    "filePath": "ingestion-v2/run-history.spec.ts",
+    "duration": "10.790s"
+  },
+  {
+    "filePath": "ingestion-v2/secrets-tab.spec.ts",
+    "duration": "30.620s"
+  },
+  {
+    "filePath": "ingestion-v2/sources.spec.ts",
+    "duration": "47.018s"
+  },
+  {
+    "filePath": "ingestion-v3/run-history.spec.ts",
+    "duration": "17.987s"
+  },
+  {
+    "filePath": "ingestion-v3/secrets-tab.spec.ts",
+    "duration": "29.741s"
+  },
+  {
+    "filePath": "ingestion-v3/sources.spec.ts",
+    "duration": "44.247s"
+  },
+  {
+    "filePath": "lineage-v3/v3-download-lineage-results.spec.ts",
+    "duration": "9.159s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-level.spec.ts",
+    "duration": "6.476s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-path.spec.ts",
+    "duration": "15.375s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-graph.spec.ts",
+    "duration": "71.095s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-impact-analysis.spec.ts",
+    "duration": "39.310s"
+  },
+  {
+    "filePath": "login-v2/v2-login.spec.ts",
+    "duration": "5.077s"
+  },
+  {
+    "filePath": "manage-tags/assign-unassign-tags.spec.ts",
+    "duration": "14.904s"
+  },
+  {
+    "filePath": "manage-tags/create-edit-remove-tags.spec.ts",
+    "duration": "8.870s"
+  },
+  {
+    "filePath": "manage-tags/search-filter-tags.spec.ts",
+    "duration": "14.799s"
+  },
+  {
+    "filePath": "mfeframework/valid-config-mfe.spec.ts",
+    "duration": "17.449s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-experiment.spec.ts",
+    "duration": "19.262s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-mlflow.spec.ts",
+    "duration": "23.390s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-sagemaker.spec.ts",
+    "duration": "7.635s"
+  },
+  {
+    "filePath": "mutations-v2/v2-domains.spec.ts",
+    "duration": "52.684s"
+  },
+  {
+    "filePath": "mutations-v2/v2-edit-documentation.spec.ts",
+    "duration": "49.363s"
+  },
+  {
+    "filePath": "mutations/dataset-health.spec.ts",
+    "duration": "3.568s"
+  },
+  {
+    "filePath": "mutations/edit-documentation.spec.ts",
+    "duration": "7.097s"
+  },
+  {
+    "filePath": "navbar/navbar.spec.ts",
+    "duration": "21.396s"
+  },
+  {
+    "filePath": "nested-column-stats/nested-column-stats.spec.ts",
+    "duration": "11.579s"
+  },
+  {
+    "filePath": "onboarding/welcome-modal.spec.ts",
+    "duration": "146.432s"
+  },
+  {
+    "filePath": "ownership-v2/v2-manage-ownership.spec.ts",
+    "duration": "12.445s"
+  },
+  {
+    "filePath": "quality/assertion-list.spec.ts",
+    "duration": "7.213s"
+  },
+  {
+    "filePath": "schema-blame/schema-blame.spec.ts",
+    "duration": "7.817s"
+  },
+  {
+    "filePath": "search/query-and-filter-search.spec.ts",
+    "duration": "61.779s"
+  },
+  {
+    "filePath": "search/search-filters.spec.ts",
+    "duration": "29.430s"
+  },
+  {
+    "filePath": "search/search-within-operator.spec.ts",
+    "duration": "10.863s"
+  },
+  {
+    "filePath": "search/search.spec.ts",
+    "duration": "37.588s"
+  },
+  {
+    "filePath": "search/searchv2.spec.ts",
+    "duration": "39.930s"
+  },
+  {
+    "filePath": "settings-v2/v2-home-page-posts.spec.ts",
+    "duration": "52.838s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-access-tokens.spec.ts",
+    "duration": "7.298s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-policies.spec.ts",
+    "duration": "59.745s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-service-accounts.spec.ts",
+    "duration": "19.133s"
+  },
+  {
+    "filePath": "settings-v2/v2-managing-groups.spec.ts",
+    "duration": "78.183s"
+  },
+  {
+    "filePath": "siblings-v2/siblings.spec.ts",
+    "duration": "24.714s"
+  },
+  {
+    "filePath": "stats-v2/v2-change-history.spec.ts",
+    "duration": "44.305s"
+  },
+  {
+    "filePath": "stats-v2/v2-charts.spec.ts",
+    "duration": "36.867s"
+  },
+  {
+    "filePath": "stats-v2/v2-column-stats.spec.ts",
+    "duration": "7.723s"
+  },
+  {
+    "filePath": "stats-v2/v2-highlights.spec.ts",
+    "duration": "6.964s"
+  },
+  {
+    "filePath": "stats-v2/v2-stats-tab.spec.ts",
+    "duration": "18.078s"
+  },
+  {
+    "filePath": "structured-properties/entity-level.spec.ts",
+    "duration": "42.001s"
+  },
+  {
+    "filePath": "structured-properties/schema-field.spec.ts",
+    "duration": "52.526s"
+  },
+  {
+    "filePath": "structured-properties/structured-properties.spec.ts",
+    "duration": "17.896s"
+  },
+  {
+    "filePath": "structured-properties/structured-props-drawer-font.spec.ts",
+    "duration": "5.308s"
+  },
+  {
+    "filePath": "task-runs-v2/task-runs.spec.ts",
+    "duration": "8.460s"
+  },
+  {
+    "filePath": "upload-files/upload-files.spec.ts",
+    "duration": "41.625s"
+  },
+  {
+    "filePath": "views/v2-manage-views.spec.ts",
+    "duration": "8.812s"
+  },
+  {
+    "filePath": "views/v2-view-select.spec.ts",
+    "duration": "18.314s"
+  },
+  {
+    "filePath": "views/v2-view-within-operator.spec.ts",
+    "duration": "8.472s"
+  }
+]

--- a/e2e-test/ui/playwright/test-data/data.json
+++ b/e2e-test/ui/playwright/test-data/data.json
@@ -1792,16 +1792,23 @@
                 "actor": "urn:li:corpuser:jdoe"
               }
             }
-          },
-          {
-            "com.linkedin.pegasus2avro.glossary.GlossaryRelatedTerms": {
-              "hasRelatedTerms": ["urn:li:glossaryTerm:PlaywrightNode.RelatedPlaywrightTerm"]
-            }
           }
         ]
       }
     },
     "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:PlaywrightNode.PlaywrightTerm",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryRelatedTerms",
+    "aspect": {
+      "value": "{\"hasRelatedTerms\":[\"urn:li:glossaryTerm:PlaywrightNode.RelatedPlaywrightTerm\"]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
   },
   {
     "auditHeader": null,

--- a/e2e-test/ui/playwright/tests/application/application-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/application/application-management.spec.ts
@@ -17,8 +17,9 @@
 
 import { test } from '../../fixtures/base-test';
 import { ApplicationsPage } from '../../pages/applications.page';
-import { TIMEOUTS, LOAD_STATES } from '../../utils/constants';
+import { LOAD_STATES } from '../../utils/constants';
 import { withRandomSuffix } from '../../utils/random';
+import { waitForWritesToSync } from '../../utils/writes-sync';
 
 const NEW_APP_NAME = withRandomSuffix('test-new');
 const NEW_APP_DESCRIPTION = 'test new description';
@@ -50,7 +51,7 @@ test.describe('Application Management Page', () => {
     logger?.info('✓ Test passed');
   });
 
-  test('should create and delete an application', async ({ page, logger }) => {
+  test('should create and delete an application', async ({ page, logger, gmsToken }) => {
     logger?.info('Test: Create and delete application');
     await applicationsPage.navigateToApplicationsPage();
     await applicationsPage.verifyPageTitle();
@@ -61,9 +62,10 @@ test.describe('Application Management Page', () => {
     await applicationsPage.enterApplicationDescription(NEW_APP_DESCRIPTION);
     await applicationsPage.clickCreateButton();
 
-    // Wait for async create operation to complete before checking table
-    logger?.info('Waiting for refetch after create');
-    await page.waitForTimeout(TIMEOUTS.SHORT);
+    // Wait for the create write to be consumed and indexed so the table's
+    // search-backed refetch can see the new application
+    logger?.info('Waiting for writes to sync after create');
+    await waitForWritesToSync(page.request, { gmsToken, logger });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
     await applicationsPage.verifyApplicationInTable(NEW_APP_NAME);
@@ -71,9 +73,10 @@ test.describe('Application Management Page', () => {
     logger?.info(`Deleting application: ${NEW_APP_NAME}`);
     await applicationsPage.deleteApplication(NEW_APP_NAME);
 
-    // Wait for async delete operation to complete before checking table
-    logger?.info('Waiting for refetch after delete');
-    await page.waitForTimeout(TIMEOUTS.SHORT);
+    // Wait for the delete to be consumed and removed from the search index
+    // before asserting the row is gone
+    logger?.info('Waiting for writes to sync after delete');
+    await waitForWritesToSync(page.request, { gmsToken, logger });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
     await applicationsPage.verifyApplicationNotInTable(NEW_APP_NAME);

--- a/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
+++ b/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
@@ -24,7 +24,7 @@ import { test } from '../../fixtures/base-test';
 import { Page } from '@playwright/test';
 import { ApplicationsPage } from '../../pages/applications.page';
 import { isDataHubGraphqlUrl } from '../../utils/api-mock';
-import { TIMEOUTS, LOAD_STATES } from '../../utils/constants';
+import { LOAD_STATES } from '../../utils/constants';
 
 const APP_URN = 'urn:li:application:d63587c6-cacc-4590-851c-4f51ca429b51';
 const DATASET_WITH_APP_URN = 'urn:li:dataset:(urn:li:dataPlatform:hive,playwright_logging_events,PROD)';
@@ -119,7 +119,6 @@ test.describe('Application Sidebar Integration', () => {
     logger?.info(`Navigating to dataset: ${DATASET_WITHOUT_APP_NAME}`);
     await applicationsPage.navigateToDataset(DATASET_WITHOUT_APP_URN);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await page.waitForTimeout(TIMEOUTS.OPERATION);
 
     logger?.info(`Adding application: ${TEST_APP_NAME}`);
     await applicationsPage.addApplicationToDataset(TEST_APP_NAME);

--- a/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
+++ b/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
@@ -155,14 +155,12 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after expanding');
     await browseV2Page.expectBrowseV2Visible();
 
     logger?.step('collapse BigQuery platform');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after collapsing');
     await browseV2Page.expectBrowseV2Visible();
@@ -193,7 +191,6 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify PlaywrightBrowseEntity browse path is visible');
     await browseV2Page.expectBrowseNodeVisible(BROWSE_PATHS.PROJECT);
@@ -218,11 +215,9 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('expand PlaywrightBrowseEntity path');
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('click test_schema node to apply filters');
     await browseV2Page.clickBrowseNode(BROWSE_PATHS.SCHEMA);
@@ -250,9 +245,7 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
 
     logger?.step('apply browse path filter');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
-    await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.clickBrowseNode(BROWSE_PATHS.SCHEMA);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 

--- a/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
+++ b/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
@@ -155,12 +155,14 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after expanding');
     await browseV2Page.expectBrowseV2Visible();
 
     logger?.step('collapse BigQuery platform');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after collapsing');
     await browseV2Page.expectBrowseV2Visible();
@@ -191,6 +193,7 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify PlaywrightBrowseEntity browse path is visible');
     await browseV2Page.expectBrowseNodeVisible(BROWSE_PATHS.PROJECT);
@@ -215,9 +218,11 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('expand PlaywrightBrowseEntity path');
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('click test_schema node to apply filters');
     await browseV2Page.clickBrowseNode(BROWSE_PATHS.SCHEMA);
@@ -245,7 +250,9 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
 
     logger?.step('apply browse path filter');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
+    await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.clickBrowseNode(BROWSE_PATHS.SCHEMA);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 

--- a/e2e-test/ui/playwright/tests/business-attributes/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/business-attributes/fixtures/data.json
@@ -69,12 +69,6 @@
             }
           },
           {
-            "com.linkedin.glossary.GlossaryRelatedTerms": {
-              "isRelatedTerms": [],
-              "hasRelatedTerms": []
-            }
-          },
-          {
             "com.linkedin.common.Ownership": {
               "owners": [
                 {

--- a/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
@@ -13,6 +13,7 @@ import { test, expect } from '../../fixtures/base-test';
 import { withRandomSuffix } from '../../utils/random';
 import { DocumentPage } from '../../pages/entity/document.page';
 import { TIMEOUTS, LOAD_STATES, KEYS } from '../../utils/constants';
+import { waitForWritesToSync } from '../../utils/writes-sync';
 
 // Test constants
 const STATUS_PUBLISHED = 'PUBLISHED';
@@ -106,13 +107,15 @@ test.describe('Document Management', () => {
     await cleanup.flush();
   });
 
-  test('should update document status', async ({ page, cleanup }) => {
+  test('should update document status', async ({ page, cleanup, gmsToken }) => {
     const statusTestDoc = withRandomSuffix('status-test');
     const docUrn = await documentPage.createDocumentWithTitle(statusTestDoc);
     cleanup.track(docUrn);
 
     await documentPage.updateDocumentStatus(STATUS_PUBLISHED);
 
+    // Ensure the status write is consumed and indexed before the reload re-reads it
+    await waitForWritesToSync(page.request, { gmsToken });
     await page.reload();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -122,13 +125,15 @@ test.describe('Document Management', () => {
     await cleanup.flush();
   });
 
-  test('should update document type', async ({ page, cleanup }) => {
+  test('should update document type', async ({ page, cleanup, gmsToken }) => {
     const typeTestDoc = withRandomSuffix('type-test');
     const docUrn = await documentPage.createDocumentWithTitle(typeTestDoc);
     cleanup.track(docUrn);
 
     await documentPage.updateDocumentType(TYPE_RUNBOOK);
 
+    // Ensure the type write is consumed and indexed before the reload re-reads it
+    await waitForWritesToSync(page.request, { gmsToken });
     await page.reload();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -197,7 +202,7 @@ test.describe('Document Management', () => {
 
   // ── Deletion Operations ────────────────────────────────────────────────────
 
-  test('should create and delete a document', async ({ page }) => {
+  test('should create and delete a document', async ({ page, gmsToken }) => {
     const docTitle = withRandomSuffix('delete-test');
     const docUrn = await documentPage.createDocumentWithTitle(docTitle);
 
@@ -205,7 +210,9 @@ test.describe('Document Management', () => {
     await documentPage.clickDeleteMenuItem();
     await documentPage.confirmDelete();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
+    // Ensure the delete is consumed and removed from the index before the
+    // documents tree is re-queried
+    await waitForWritesToSync(page.request, { gmsToken });
 
     await documentPage.navigateToDocuments();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
@@ -213,7 +220,7 @@ test.describe('Document Management', () => {
     await expect(documentPage.getTreeItem(docUrn)).not.toBeAttached();
   });
 
-  test('should delete parent document and cascade to children', async ({ page, cleanup }) => {
+  test('should delete parent document and cascade to children', async ({ page, cleanup, gmsToken }) => {
     const base = withRandomSuffix('doc');
     const parentTitle = `${base}_parent`;
     const childTitle = `${base}_child`;
@@ -231,7 +238,9 @@ test.describe('Document Management', () => {
     await documentPage.clickDeleteMenuItem();
     await documentPage.confirmDelete();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
+    // Ensure the cascade delete is consumed and removed from the index before
+    // the documents tree is re-queried
+    await waitForWritesToSync(page.request, { gmsToken });
 
     await documentPage.navigateToDocuments();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);

--- a/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
@@ -72,7 +72,7 @@ test.describe('Document Management', () => {
     await cleanup.flush();
   });
 
-  test('should update document title and verify persistence', async ({ page, cleanup }) => {
+  test('should update document title and verify persistence', async ({ page, cleanup, gmsToken }) => {
     const initialTitle = withRandomSuffix('doc');
     const updatedTitle = `${initialTitle}_updated`;
 
@@ -80,6 +80,9 @@ test.describe('Document Management', () => {
     cleanup.track(docUrn);
     await documentPage.navigateToDocument(docUrn);
     await documentPage.setDocumentTitle(updatedTitle);
+
+    // Ensure the title write is consumed and indexed before the reload re-reads it
+    await waitForWritesToSync(page.request, { gmsToken });
     await page.reload();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -88,7 +91,7 @@ test.describe('Document Management', () => {
     await cleanup.flush();
   });
 
-  test('should update document content', async ({ page, cleanup }) => {
+  test('should update document content', async ({ page, cleanup, gmsToken }) => {
     const docTitle = withRandomSuffix('content-test');
     const testContent = 'Test content';
 
@@ -96,9 +99,10 @@ test.describe('Document Management', () => {
     cleanup.track(docUrn);
     await documentPage.clickEditorAndType(testContent);
     await page.keyboard.press(KEYS.ESCAPE);
-    await page.waitForTimeout(TIMEOUTS.OPERATION);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
+    // Ensure the content write is consumed and indexed before the reload re-reads it
+    await waitForWritesToSync(page.request, { gmsToken });
     await page.reload();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -165,14 +169,16 @@ test.describe('Document Management', () => {
     await cleanup.flush();
   });
 
-  test('should search for documents using sidebar search', async ({ page, cleanup }) => {
+  test('should search for documents using sidebar search', async ({ page, cleanup, gmsToken }) => {
     const searchTitle = withRandomSuffix('doc');
 
     const docUrn = await documentPage.createDocumentWithTitle(searchTitle);
     cleanup.track(docUrn);
     await documentPage.expectSidebarVisible();
 
-    await page.waitForTimeout(TIMEOUTS.OPERATION);
+    // Ensure the doc's title is indexed before searching for it by that title —
+    // a fixed sleep here is a race against ES indexing, not a UI-render pause.
+    await waitForWritesToSync(page.request, { gmsToken });
 
     await documentPage.searchForDocument(searchTitle);
     await documentPage.expectSearchResultsVisible();

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -233,6 +233,14 @@ const BASE_FEATURE_FLAGS = {
 
 // ── Test Suite ───────────────────────────────────────────────────────────────
 
+// beforeAll's seedAdditionalNodes call (unlike seedTimeRangeLineage, which is
+// now lock-protected in lineage-time-seeder.ts because it's also called from
+// v3-lineage-impact-analysis.spec.ts) is unique to this file and has no such
+// guard. Under workers_per_shard > 1, fullyParallel can still schedule this
+// describe block's own tests across two workers, each running beforeAll
+// concurrently. Force one worker so it stays genuinely single-shot.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('lineage v3 — lineage graph', () => {
   let lineagePage: LineageV3Page;
 

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
@@ -62,6 +62,15 @@ const UI_TEXT = {
 
 // ── Test Suite ──────────────────────────────────────────────────────────────
 
+// beforeAll below seeds shared, time-stamped lineage edges via delete-then-
+// recreate (see lineage-time-seeder.ts) and assumes it runs exactly once for
+// the whole suite. That only holds on a single worker: under
+// workers_per_shard > 1, fullyParallel can schedule this describe block's
+// tests across two workers, each running its own beforeAll concurrently and
+// racing the delete/recreate against each other's async graph-edge
+// propagation. Force one worker so beforeAll is genuinely single-shot.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('impact analysis', () => {
   let lineagePage: LineageV3Page;
 

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
@@ -111,7 +111,9 @@ test.describe('impact analysis', () => {
 
     await lineagePage.addDescriptionFilter(UI_TEXT.FILTER_TEXT);
 
-    await lineagePage.expectResultTextHidden(UI_TEXT.USER_CREATIONS);
+    // The filtered refetch removes USER_CREATIONS; give the hidden-check the
+    // full refetch budget now that addDescriptionFilter no longer sleeps.
+    await lineagePage.expectResultTextHidden(UI_TEXT.USER_CREATIONS, TIMEOUTS.MEDIUM);
     await lineagePage.expectResultTextVisible(UI_TEXT.USER_DELETIONS, TIMEOUTS.LONG);
   });
 
@@ -120,9 +122,8 @@ test.describe('impact analysis', () => {
     const columnParam = encodeURIComponent('[version=2.0].[type=boolean].field_bar');
     await page.goto(`/dataset/${DATASET_URN}/Lineage?column=${columnParam}&is_lineage_mode=false`);
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
-    await lineagePage.clickImpactAnalysis();
+    await lineagePage.openImpactAnalysisView();
 
     await lineagePage.expectResultTextVisible(UI_TEXT.HDFS_DATASET, TIMEOUTS.LONG);
     await lineagePage.expectResultTextVisible(UI_TEXT.SHIPMENT_INFO, TIMEOUTS.MEDIUM);
@@ -131,11 +132,13 @@ test.describe('impact analysis', () => {
 
     // Toggle off column-level impact analysis
     await lineagePage.clickColumnLineageToggle();
-    await page.waitForTimeout(TIMEOUTS.SHORT);
 
+    // FEATURE_1 only appears once the untoggled results refetch lands, so it
+    // is asserted first — a positive sync point that makes the hidden-check
+    // below meaningful without a fixed sleep.
+    await lineagePage.expectResultTextVisible(UI_TEXT.FEATURE_1, TIMEOUTS.MEDIUM);
     await lineagePage.expectResultTextVisible(UI_TEXT.HDFS_DATASET, TIMEOUTS.MEDIUM);
     await lineagePage.expectResultTextHidden(UI_TEXT.SHIPMENT_INFO, TIMEOUTS.SHORT);
-    await lineagePage.expectResultTextVisible(UI_TEXT.FEATURE_1, TIMEOUTS.MEDIUM);
     await lineagePage.expectResultTextVisible(UI_TEXT.BAZ_CHART, TIMEOUTS.MEDIUM);
   });
 
@@ -144,9 +147,10 @@ test.describe('impact analysis', () => {
       `/dataset/${DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${JAN_1_2021_TIMESTAMP}&end_time_millis=${JAN_1_2022_TIMESTAMP}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
-    await lineagePage.clickImpactAnalysis();
+    // openImpactAnalysisView waits for the view's toolbar, so the
+    // hidden-checks below cannot pass vacuously against an unloaded page.
+    await lineagePage.openImpactAnalysisView();
 
     // No lineage edges should exist for the 2021 time window
     await lineagePage.expectResultTextHidden(UI_TEXT.HDFS_DATASET);
@@ -163,9 +167,8 @@ test.describe('impact analysis', () => {
       `/tasks/${TRANSACTION_ETL_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_14_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
-    await lineagePage.clickSidebarLineageTab();
+    await lineagePage.openSidebarLineageTab();
     // Downstream
     await lineagePage.expectResultTextVisible(UI_TEXT.AGGREGATED, TIMEOUTS.EXTRA_LONG);
     // Upstream
@@ -178,9 +181,8 @@ test.describe('impact analysis', () => {
       `/tasks/${TRANSACTION_ETL_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_NOW}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
-    await lineagePage.clickSidebarLineageTab();
+    await lineagePage.openSidebarLineageTab();
     // Downstream
     await lineagePage.expectResultTextVisible(UI_TEXT.AGGREGATED, TIMEOUTS.EXTRA_LONG);
     // Upstream
@@ -195,9 +197,8 @@ test.describe('impact analysis', () => {
       `/dataset/${MONTHLY_TEMPERATURE_DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_14_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.SHORT);
 
-    await lineagePage.clickSidebarLineageTab();
+    await lineagePage.openSidebarLineageTab();
     await lineagePage.clickUpstreamDirection();
 
     await lineagePage.expectResultTextVisible(UI_TEXT.TEMPERATURE_ETL_1, TIMEOUTS.MEDIUM);
@@ -207,9 +208,8 @@ test.describe('impact analysis', () => {
       `/dataset/${MONTHLY_TEMPERATURE_DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_NOW}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
-    await page.waitForTimeout(TIMEOUTS.SHORT);
 
-    await lineagePage.clickSidebarLineageTab();
+    await lineagePage.openSidebarLineageTab();
     await lineagePage.clickUpstreamDirection();
 
     await lineagePage.expectResultTextVisible(UI_TEXT.TEMPERATURE_ETL_2, TIMEOUTS.MEDIUM);

--- a/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
+++ b/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
@@ -193,7 +193,9 @@ test.describe('Welcome to DataHub Modal', () => {
       });
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(() => trackRequests.some((r) => r['type'] === 'WelcomeToDataHubModalViewEvent'), { timeout: 2000 })
+        .toBe(true);
       const viewEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalViewEvent');
       expect(viewEvent).toBeDefined();
     });
@@ -208,7 +210,9 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.clickCarouselDot(1);
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(() => trackRequests.some((r) => r['type'] === 'WelcomeToDataHubModalInteractEvent'), { timeout: 2000 })
+        .toBe(true);
       const interactEvents = trackRequests.filter((r) => r['type'] === 'WelcomeToDataHubModalInteractEvent');
       expect(interactEvents.length).toBeGreaterThan(0);
     });
@@ -223,7 +227,9 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.closeViaButton();
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(() => trackRequests.some((r) => r['type'] === 'WelcomeToDataHubModalExitEvent'), { timeout: 2000 })
+        .toBe(true);
       const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
       expect(exitEvent).toBeDefined();
       expect(exitEvent?.['exitMethod']).toBe('close_button');
@@ -239,7 +245,9 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.closeViaEscape();
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(() => trackRequests.some((r) => r['type'] === 'WelcomeToDataHubModalExitEvent'), { timeout: 2000 })
+        .toBe(true);
       const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
       expect(exitEvent).toBeDefined();
       expect(exitEvent?.['exitMethod']).toBe('escape_key');
@@ -257,7 +265,11 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.clickLastCarouselDot();
       await welcomeModalPage.expectFinalSlideVisible();
       await welcomeModalPage.docsLink.click();
-      await page.waitForTimeout(1000);
+      await expect
+        .poll(() => trackRequests.some((r) => r['type'] === 'WelcomeToDataHubModalClickViewDocumentationEvent'), {
+          timeout: 2000,
+        })
+        .toBe(true);
       const linkClickEvent = trackRequests.find(
         (r) => r['type'] === 'WelcomeToDataHubModalClickViewDocumentationEvent',
       );

--- a/e2e-test/ui/playwright/tests/search-data.setup.ts
+++ b/e2e-test/ui/playwright/tests/search-data.setup.ts
@@ -4,11 +4,12 @@ import { promisify } from 'util';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createScriptLogger } from '../utils/logger';
+import { waitForWritesToSync } from '../utils/writes-sync';
 
 const execAsync = promisify(exec);
 const logger = createScriptLogger('search-data.setup');
 
-setup('seed search data', async () => {
+setup('seed search data', async ({ request }) => {
   setup.setTimeout(180000); // 3 minute timeout
   logger.info('Seeding search test data via datahub CLI...');
 
@@ -119,9 +120,11 @@ setup('seed search data', async () => {
     fs.unlinkSync(searchDataConfigPath);
     fs.unlinkSync(businessAttributesConfigPath);
 
-    // Wait for Elasticsearch indexing
-    logger.info('Waiting for search indexing (15 seconds)...');
-    await new Promise((resolve) => setTimeout(resolve, 15000));
+    // Wait for the ingested proposals to be consumed and indexed (offset
+    // checkpoint + ES refresh margin) instead of a fixed 15 s sleep — the
+    // checkpoint resolves as soon as the consumers actually catch up.
+    logger.info('Waiting for writes to sync (consumer offsets + ES refresh)...');
+    await waitForWritesToSync(request, { gmsToken: token, logger });
 
     logger.info('Search test data seeded successfully');
   } catch (error) {

--- a/e2e-test/ui/playwright/tests/search/query-and-filter-search.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/query-and-filter-search.spec.ts
@@ -23,7 +23,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by type: Dashboards', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Dashboards');
     await searchPage.expectUrlContains('filter__entityType');
     await searchPage.clickEntityResult();
@@ -31,7 +31,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by type: ML Models', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'ML Models');
     await searchPage.expectUrlContains('filter__entityType');
     await searchPage.clickEntityResult();
@@ -39,7 +39,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by type: Pipelines', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Pipelines');
     await searchPage.expectUrlContains('filter__entityType');
     await searchPage.clickEntityResult();
@@ -47,7 +47,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by type: Glossary Terms', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Glossary Terms');
     await searchPage.expectUrlContains('filter__entityType');
     await searchPage.clickEntityResult();
@@ -55,7 +55,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by platform: Hive', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Platform', 'Hive');
     await searchPage.expectUrlContains('filter_platform');
     await searchPage.clickEntityResult();
@@ -66,7 +66,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by platform: HDFS', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Platform', 'HDFS');
     await searchPage.expectUrlContains('filter_platform');
     await searchPage.clickEntityResult();
@@ -74,7 +74,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by platform: Airflow', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Platform', 'Airflow');
     await searchPage.expectUrlContains('filter_platform');
     await searchPage.clickEntityResult();
@@ -84,7 +84,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should filter by tag', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Tag', 'PlaywrightFeatureTag');
     await searchPage.expectUrlContains('filter_tags');
     await searchPage.clickEntityResult();
@@ -97,7 +97,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should combine multiple filters and verify results', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectActiveFilter('Datasets');
     await searchPage.selectFilterOption('Platform', 'Hive');
@@ -112,7 +112,7 @@ test.describe('Query and Filter Search', () => {
   });
 
   test('should preserve filters when navigating back', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectActiveFilter('Datasets');
 

--- a/e2e-test/ui/playwright/tests/search/search-filters.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/search-filters.spec.ts
@@ -19,13 +19,13 @@ test.describe('Search Filters V2', () => {
   });
 
   test('should show search filters v2 by default', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.expectFiltersV2Visible();
     await searchPage.expectFiltersV1NotVisible();
   });
 
   test('should add and remove multiple filters with no issues', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
 
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectUrlContains('filter__entityType');
@@ -50,7 +50,7 @@ test.describe('Search Filters V2', () => {
   });
 
   test('should filter by type and verify results', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectUrlContains('filter__entityType');
     await searchPage.expectActiveFilter('Datasets');
@@ -58,7 +58,7 @@ test.describe('Search Filters V2', () => {
   });
 
   test('should filter by platform and verify results', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Platform', 'Hive');
     await searchPage.expectUrlContains('filter_platform');
     await searchPage.expectActiveFilter('Hive');
@@ -66,7 +66,7 @@ test.describe('Search Filters V2', () => {
   });
 
   test('should handle multiple active filters correctly', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
 
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectActiveFilter('Datasets');

--- a/e2e-test/ui/playwright/tests/search/search-within-operator.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/search-within-operator.spec.ts
@@ -23,7 +23,7 @@ test.describe('Search Filters — Within operator', () => {
   });
 
   test('Domain Within uses DESCENDANTS_INCL and matches nested child entities', async ({ page }) => {
-    await searchPage.searchAndWait(DATASET_NAME, 3000);
+    await searchPage.searchAndWait(DATASET_NAME);
     await searchPage.expectFiltersV2Visible();
 
     // Dataset is only in the child domain — searching by name alone should find it.

--- a/e2e-test/ui/playwright/tests/search/search.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/search.spec.ts
@@ -19,18 +19,18 @@ test.describe('Search Functionality', () => {
   });
 
   test('should search all entities and see results', async () => {
-    await searchPage.searchAndWait('*', 5000);
+    await searchPage.searchAndWait('*');
     await searchPage.expectHasResults();
   });
 
   test('should search with impossible query and find 0 results', async () => {
-    await searchPage.searchAndWait('zzzzzzzzzzzzzqqqqqqqqqqqqqzzzzzzqzqzqzqzq', 5000);
+    await searchPage.searchAndWait('zzzzzzzzzzzzzqqqqqqqqqqqqqzzzzzzqzqzqzqzq');
     await searchPage.expectNoResults();
   });
 
   test('should search, find a result, and visit the dataset page', async ({ page }) => {
     test.setTimeout(45000);
-    await searchPage.searchAndWait('fct_playwright_users_created', 5000);
+    await searchPage.searchAndWait('fct_playwright_users_created');
 
     // Wait for results — seeder fixture guarantees data is present.
     await expect(page.getByText(/of [0-9]+ result/)).toBeVisible({ timeout: 30000 });
@@ -49,7 +49,7 @@ test.describe('Search Functionality', () => {
   });
 
   test('should filter by glossary term', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Glossary-Term', 'PlaywrightTerm');
     await searchPage.expectUrlContains('filter_glossaryTerms');
     await searchPage.expectActiveFilter('PlaywrightTerm');
@@ -57,14 +57,14 @@ test.describe('Search Functionality', () => {
   });
 
   test('should search and filter by glossary term', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Glossary-Term', 'PlaywrightTerm');
     await searchPage.expectUrlContains('filter_glossaryTerms');
     await searchPage.expectHasResults();
   });
 
   test('should combine glossary term filter with text search', async () => {
-    await searchPage.searchAndWait('playwright', 2000);
+    await searchPage.searchAndWait('playwright');
     await searchPage.selectFilterOption('Glossary-Term', 'PlaywrightTerm');
     await searchPage.expectUrlContains('filter_glossaryTerms');
     await searchPage.expectHasResults();
@@ -72,7 +72,7 @@ test.describe('Search Functionality', () => {
   });
 
   test('should filter by multiple values using glossary terms', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Glossary-Term', 'PlaywrightTerm');
     await searchPage.expectUrlContains('filter_glossaryTerms');
     await searchPage.expectHasResults();

--- a/e2e-test/ui/playwright/tests/search/searchv2.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/searchv2.spec.ts
@@ -19,7 +19,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should display SearchV2 interface by default', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.expectFiltersV2Visible();
     await searchPage.expectFiltersV1NotVisible();
   });
@@ -31,7 +31,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should show no results message when search returns empty', async () => {
-    await searchPage.searchAndWait('zzznonexistentqueryyy123', 5000);
+    await searchPage.searchAndWait('zzznonexistentqueryyy123');
     await searchPage.expectNoResults();
   });
 
@@ -45,7 +45,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should navigate through filter dropdowns', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     const typeFilterDropdown = page.getByTestId('filter-dropdown-Type');
     await typeFilterDropdown.click();
     await expect(searchPage.filterDropdownMenu).toBeVisible();
@@ -53,7 +53,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should toggle filters using More Filters dropdown', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     const moreFiltersBtn = searchPage.moreFiltersDropdown;
     await expect(moreFiltersBtn).toBeVisible({ timeout: 10000 });
     await moreFiltersBtn.click();
@@ -64,7 +64,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should display active filters with correct test IDs', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     const activeFilter = page.getByTestId('active-filter-_entityType␞typeNames');
     await expect(activeFilter).toBeVisible();
@@ -73,7 +73,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should remove individual filters using remove button', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.selectFilterOption('Platform', 'Hive');
     await searchPage.expectActiveFilter('Datasets');
@@ -86,7 +86,7 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should clear all filters using Clear All button', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.selectFilterOption('Platform', 'Hive');
     await searchPage.expectActiveFilter('Datasets');
@@ -97,12 +97,12 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should persist search query in URL', async ({ page }) => {
-    await searchPage.searchAndWait('playwright', 3000);
+    await searchPage.searchAndWait('playwright');
     await expect(page).toHaveURL(/.*query=playwright.*/);
   });
 
   test('should expand and collapse filter facets', async ({ page }) => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     // eslint-disable-next-line playwright/no-raw-locators -- data-testid prefix selector (^=); getByTestId requires exact match
     const expandFacetIcon = page.locator('[data-testid^="expand-facet-"]').first();
     const facetCount = await expandFacetIcon.count();
@@ -114,27 +114,27 @@ test.describe('SearchV2 Features', () => {
   });
 
   test('should display search results with pagination', async ({ page }) => {
-    await searchPage.searchAndWait('*', 3000);
+    await searchPage.searchAndWait('*');
     await searchPage.expectHasResults();
     await searchPage.expectPaginationVisible();
     await expect(page.getByText(/of [0-9]+ result/)).toBeVisible();
   });
 
   test('should handle filter option selection with checkboxes', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Type', 'Datasets');
     await searchPage.expectActiveFilter('Datasets');
     await searchPage.expectUrlContains('filter__entityType');
   });
 
   test('should filter search within filter dropdown', async () => {
-    await searchPage.searchAndWait('*', 2000);
+    await searchPage.searchAndWait('*');
     await searchPage.selectFilterOption('Platform', 'Hive');
     await searchPage.expectActiveFilter('Hive');
   });
 
   test('should maintain search state when clicking entity result and navigating back', async ({ page }) => {
-    await searchPage.searchAndWait('playwright', 2000);
+    await searchPage.searchAndWait('playwright');
     await searchPage.selectFilterOption('Type', 'Datasets');
     const searchUrl = page.url();
     await searchPage.clickEntityResult();

--- a/e2e-test/ui/playwright/tests/settings-v2/v2-manage-policies.spec.ts
+++ b/e2e-test/ui/playwright/tests/settings-v2/v2-manage-policies.spec.ts
@@ -6,6 +6,11 @@ import { test } from '../../fixtures/base-test';
 import { PoliciesPage } from '../../pages/settings/policies.page';
 import { withRandomSuffix } from '../../utils/random';
 
+// Both tests mutate the same global, un-namespaced system policy list with no
+// per-test isolation; running them concurrently on separate workers causes
+// collisions on shared backend state.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('create and manage platform and metadata policies', () => {
   let policiesPage: PoliciesPage;
 

--- a/e2e-test/ui/playwright/tests/stats-v2/v2-change-history.spec.ts
+++ b/e2e-test/ui/playwright/tests/stats-v2/v2-change-history.spec.ts
@@ -201,7 +201,6 @@ test.describe('Change History Calendar', () => {
 
     // Open dropdown
     await historyHelper.typesSelect.click({ timeout: TIMEOUTS.SHORT });
-    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     // Toggle all 6 standard operation types OFF
     const operationTypesToToggle = ['CREATE', 'ALTER', 'DELETE', 'DROP', 'INSERT', 'UPDATE'];
@@ -212,7 +211,9 @@ test.describe('Change History Calendar', () => {
     // Close dropdown by clicking it again
     await historyHelper.typesSelect.click({ timeout: TIMEOUTS.SHORT });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
+    // Client-side filter re-render has no network signal to wait on; a brief
+    // settle covers the React re-render before reading per-day popover state.
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     // ──────────────────────────────────────────────────────────
     // VERIFY FILTERING: Days 0-6 should have no operations (all types removed)
@@ -306,7 +307,9 @@ test.describe('Change History Calendar', () => {
     const customPill = historyHelper.getSummaryPill(CUSTOM_OPERATION_DISPLAY);
     await expect(customPill).toBeVisible();
     await historyHelper.toggleSummaryPill(CUSTOM_OPERATION_DISPLAY);
-    await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
+    // Client-side filter re-render has no network signal to wait on; a brief
+    // settle covers the React re-render before reading per-day popover state.
+    await page.waitForTimeout(TIMEOUTS.QUICK);
 
     // ──────────────────────────────────────────────────────────
     // VERIFY FILTERING: Days 0-6 should have no operations (only custom is shown now)
@@ -478,7 +481,6 @@ test.describe('Change History Calendar', () => {
     // Wait for calendar to be visible
     await historyHelper.calendar.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
-    await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     const day0DateStr = getDateString(0);
 

--- a/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
+++ b/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
@@ -25,9 +25,13 @@
  *     factor_income → gnp  (created 8 days ago, updated 8 days ago — removed since then)
  */
 
+import * as path from 'path';
 import type { APIRequestContext } from '@playwright/test';
 import { gmsUrl } from './constants';
 import type { DataHubLogger } from './logger';
+import { withArtifactLock, writeJsonAtomic } from '../helpers/seeder-utils';
+
+const STATE_FILE = path.join(__dirname, '../.seeded/lineage-time-range.json');
 
 // ── Timestamp helpers ─────────────────────────────────────────────────────────
 
@@ -199,10 +203,34 @@ async function ingestProposal(
 // ── Public seeding entry point ────────────────────────────────────────────────
 
 /**
- * Seed all time-range lineage scenarios.
- * Safe to call multiple times — each call simply overwrites the aspect.
+ * Seed all time-range lineage scenarios, guarded by withArtifactLock so it
+ * only actually runs once across the whole test run.
+ *
+ * Two different spec files (v3-lineage-impact-analysis.spec.ts and
+ * v3-lineage-graph.spec.ts) each call this from their own test.beforeAll,
+ * on the — previously correct only under workers:1 — assumption that
+ * "once per describe block" means "once, period". Under workers_per_shard
+ * > 1 (or just fullyParallel scheduling these two files onto different
+ * workers), both beforeAll hooks can run concurrently, each doing its own
+ * delete-then-recreate of the SAME shared dataJobInputOutput/upstreamLineage
+ * aspects (see doSeedTimeRangeLineage). Deletes and the graph-edge writes
+ * they gate on propagate asynchronously, so interleaving two independent
+ * delete/recreate sequences can leave a partially-overwritten, wrong-
+ * timestamp result even though each sequence alone is correct -- exactly
+ * the class of bug the seeding fixture's global-data race was.
  */
 export async function seedTimeRangeLineage(
+  request: APIRequestContext,
+  gmsToken: string,
+  logger?: DataHubLogger,
+): Promise<void> {
+  await withArtifactLock(STATE_FILE, async () => {
+    await doSeedTimeRangeLineage(request, gmsToken, logger);
+    writeJsonAtomic(STATE_FILE, { seededAt: new Date().toISOString() });
+  });
+}
+
+async function doSeedTimeRangeLineage(
   request: APIRequestContext,
   gmsToken: string,
   logger?: DataHubLogger,

--- a/e2e-test/ui/playwright/utils/writes-sync.ts
+++ b/e2e-test/ui/playwright/utils/writes-sync.ts
@@ -1,0 +1,292 @@
+/**
+ * Offset-checkpoint "wait for writes to sync" — TypeScript port of the pytest
+ * implementation in smoke-test/tests/consistency_utils.py
+ * (wait_for_offsets_to_be_consumed, introduced in #18881).
+ *
+ * DataHub writes flow MCP → (mce-consumer) → SQL + MCL → (mae-consumer) →
+ * search index. A test that writes and then reads through a search-backed
+ * surface must wait for that pipeline; a fixed sleep is either too long
+ * (quiet system) or too short (backlog). This helper instead:
+ *
+ *  1. Captures each topic-partition's current end-offset ONCE per phase from
+ *     GET {gms}/openapi/operations/messaging/{type}/consumer/lag?detailed=true
+ *     (per partition, `offset` is the consumer's committed offset and
+ *     `offset + lag` is the topic end-offset). The checkpoint is fixed at
+ *     call time, so later writes from concurrent workers cannot move the
+ *     target — unlike polling aggregate lag to zero, which can fail to
+ *     converge at all while other writers keep the lag non-zero.
+ *  2. Polls (every ~250 ms) until the committed offsets pass the checkpoint.
+ *     Expect ~0.3 s resolution on a quiet system.
+ *
+ * Two-phase MCP → MCL: on the async ingest path only the MCP exists when this
+ * is called — GMS produces just the proposal and returns; the MCL is produced
+ * later by the mce-consumer. So the MCP checkpoint is waited on first, and
+ * only then is the MCL / MCL-timeseries checkpoint captured. Capturing both
+ * up front would self-satisfy on the pre-write MCL end-offset and skip
+ * indexing entirely. Synchronous writes (GraphQL mutations) ack their MCL
+ * in-request, so phase 1 is a no-op for them.
+ *
+ * A failed checkpoint fetch (transient 401/connection error) is NOT treated
+ * as "nothing to wait for" — that would return near-instantly as if the
+ * system were synced. Instead we fall back to conservatively polling
+ * aggregate lag to zero (1 s ticks, bounded by the deadline), and to the
+ * single static ES-refresh sleep if the lag API is unreachable altogether —
+ * mirroring the Python fallback chain.
+ *
+ * Known carve-outs (kept in parity with the Python implementation):
+ *  - The usage-events consumer group is not covered by these endpoints;
+ *    audit-event indexing is out of scope for this helper.
+ *  - A checkpoint captured mid-burst legitimately waits for already-queued
+ *    backlog from other writers. The win is eliminating the non-convergence
+ *    tail risk, not genuine backlog-drain time.
+ *  - CDC mode (CDC_MCL_PROCESSING_ENABLED=true, default off) produces no
+ *    inline MCL, and an MCL produce failure is swallowed by the consumer;
+ *    phase 2 is not a hard guarantee in those cases.
+ */
+
+import type { APIRequestContext } from '@playwright/test';
+import { gmsUrl as defaultGmsUrl } from './constants';
+import { readGmsToken } from '../fixtures/login';
+import { users } from '../data/users';
+import { createScriptLogger, type DataHubLogger } from './logger';
+
+const LAG_ENDPOINTS = {
+  mcp: '/openapi/operations/messaging/mcp/consumer/lag',
+  mcl: '/openapi/operations/messaging/mcl/consumer/lag',
+  'mcl-timeseries': '/openapi/operations/messaging/mcl-timeseries/consumer/lag',
+} as const;
+
+export type ConsumerType = keyof typeof LAG_ENDPOINTS;
+
+const DEFAULT_CONSUMERS: readonly ConsumerType[] = ['mcp', 'mcl', 'mcl-timeseries'];
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+const FALLBACK_POLL_INTERVAL_MS = 1_000;
+const LAG_REQUEST_TIMEOUT_MS = 5_000;
+
+export interface WritesSyncOptions {
+  /** GMS base URL. Defaults to `gmsUrl()` (BASE_URL / GMS_URL aware). */
+  gmsUrl?: string;
+  /**
+   * GMS bearer token. Defaults to the admin user's cached token from
+   * `.auth/gms-token-{admin}.json` (written by the login fixture / seeding
+   * bootstrap) — the same file search-data.setup.ts reads for ingestion.
+   */
+  gmsToken?: string;
+  /** Consumers to wait on. Defaults to all three (mcp, mcl, mcl-timeseries). */
+  consumers?: readonly ConsumerType[];
+  /** Safety ceiling across both phases (default 60 s). */
+  timeoutMs?: number;
+  /** Checkpoint re-check interval (default 250 ms). */
+  pollIntervalMs?: number;
+  /**
+   * Post-sync sleep so the newly indexed documents become visible to search.
+   * Defaults to ELASTICSEARCH_REFRESH_INTERVAL_SECONDS (3 s, matching the
+   * pytest default; CI quickstart configures a 1 s refresh interval).
+   */
+  esRefreshMarginMs?: number;
+  logger?: DataHubLogger;
+}
+
+interface PartitionSnapshot {
+  offset: number;
+  lag: number;
+}
+
+interface LagEnvelope {
+  consumerGroups?: Record<
+    string,
+    Record<string, { partitions?: Record<string, { offset?: number | null; lag?: number | null }> }>
+  >;
+}
+
+function defaultEsRefreshMarginMs(): number {
+  const seconds = Number(process.env.ELASTICSEARCH_REFRESH_INTERVAL_SECONDS ?? '3');
+  return (Number.isFinite(seconds) && seconds > 0 ? seconds : 3) * 1000;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function targetKey(consumer: ConsumerType, partition: number): string {
+  return `${consumer}:${partition}`;
+}
+
+function consumerOfKey(key: string): ConsumerType {
+  return key.slice(0, key.lastIndexOf(':')) as ConsumerType;
+}
+
+/**
+ * Fetch `{partition: {offset, lag}}` for one consumer from the detailed lag
+ * endpoint. Returns null when the fetch failed or the payload is malformed
+ * (missing offset), so callers can distinguish "couldn't look" from a
+ * genuinely empty result.
+ */
+async function fetchDetailedPartitions(
+  request: APIRequestContext,
+  baseUrl: string,
+  headers: Record<string, string>,
+  consumer: ConsumerType,
+): Promise<Map<number, PartitionSnapshot> | null> {
+  try {
+    const response = await request.get(`${baseUrl}${LAG_ENDPOINTS[consumer]}?skipCache=true&detailed=true`, {
+      headers,
+      timeout: LAG_REQUEST_TIMEOUT_MS,
+    });
+    if (!response.ok()) return null;
+    const data = (await response.json()) as LagEnvelope;
+    for (const topics of Object.values(data.consumerGroups ?? {})) {
+      // Single consumer group per topic today; take the first group found.
+      for (const topicInfo of Object.values(topics)) {
+        const result = new Map<number, PartitionSnapshot>();
+        for (const [partition, info] of Object.entries(topicInfo.partitions ?? {})) {
+          if (info.offset === null || info.offset === undefined) return null;
+          result.set(Number(partition), { offset: info.offset, lag: info.lag ?? 0 });
+        }
+        return result;
+      }
+    }
+    return new Map();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Capture the current end-offset (`offset + lag`) per (consumer, partition).
+ * Returns null if any fetch failed.
+ */
+async function captureOffsetTargets(
+  request: APIRequestContext,
+  baseUrl: string,
+  headers: Record<string, string>,
+  consumers: readonly ConsumerType[],
+): Promise<Map<string, number> | null> {
+  const targets = new Map<string, number>();
+  for (const consumer of consumers) {
+    const partitions = await fetchDetailedPartitions(request, baseUrl, headers, consumer);
+    if (partitions === null) return null;
+    for (const [partition, snapshot] of partitions) {
+      targets.set(targetKey(consumer, partition), snapshot.offset + snapshot.lag);
+    }
+  }
+  return targets;
+}
+
+/**
+ * Poll until every target offset has been passed, or the deadline hits.
+ * Returns the number of targets still outstanding (0 means fully consumed).
+ */
+async function awaitOffsetTargets(
+  request: APIRequestContext,
+  baseUrl: string,
+  headers: Record<string, string>,
+  targets: Map<string, number>,
+  deadline: number,
+  pollIntervalMs: number,
+): Promise<number> {
+  const remaining = new Map(targets);
+  while (remaining.size > 0 && Date.now() < deadline) {
+    await delay(pollIntervalMs);
+    const consumersLeft = new Set<ConsumerType>();
+    for (const key of remaining.keys()) consumersLeft.add(consumerOfKey(key));
+    for (const consumer of consumersLeft) {
+      const partitions = await fetchDetailedPartitions(request, baseUrl, headers, consumer);
+      if (partitions === null) continue;
+      for (const [partition, snapshot] of partitions) {
+        const key = targetKey(consumer, partition);
+        const target = remaining.get(key);
+        if (target !== undefined && snapshot.offset >= target) remaining.delete(key);
+      }
+    }
+  }
+  return remaining.size;
+}
+
+/**
+ * Conservative fallback when a checkpoint could not be established: poll
+ * aggregate lag until it reaches zero (a moving target under concurrent
+ * writers, but bounded by the deadline — same trade-off as the legacy pytest
+ * path). Reports 'unavailable' when the lag API cannot be reached at all.
+ */
+async function fallbackAggregateLagWait(
+  request: APIRequestContext,
+  baseUrl: string,
+  headers: Record<string, string>,
+  consumers: readonly ConsumerType[],
+  deadline: number,
+): Promise<'synced' | 'timed-out' | 'unavailable'> {
+  while (Date.now() < deadline) {
+    await delay(FALLBACK_POLL_INTERVAL_MS);
+    let totalLag = 0;
+    let apiAvailable = false;
+    for (const consumer of consumers) {
+      const partitions = await fetchDetailedPartitions(request, baseUrl, headers, consumer);
+      if (partitions === null) continue;
+      apiAvailable = true;
+      for (const snapshot of partitions.values()) totalLag += snapshot.lag;
+    }
+    if (!apiAvailable) return 'unavailable';
+    if (totalLag === 0) return 'synced';
+  }
+  return 'timed-out';
+}
+
+/**
+ * Wait for in-flight metadata writes to be consumed and indexed, then wait
+ * one ES refresh interval so they become visible to search.
+ *
+ * Never throws on timeout — like the pytest helper it degrades to "waited as
+ * long as allowed" and lets the caller's own assertions surface the failure.
+ */
+export async function waitForWritesToSync(request: APIRequestContext, options: WritesSyncOptions = {}): Promise<void> {
+  const logger = options.logger ?? createScriptLogger('writes-sync');
+  const baseUrl = options.gmsUrl ?? defaultGmsUrl();
+  const token = options.gmsToken ?? readGmsToken(users.admin.username);
+  const headers = { Authorization: `Bearer ${token}` };
+  const consumers = options.consumers ?? DEFAULT_CONSUMERS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const esRefreshMarginMs = options.esRefreshMarginMs ?? defaultEsRefreshMarginMs();
+
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+
+  // Phase 1: MCP only; phase 2: MCL (+ timeseries), captured only after the
+  // MCP checkpoint has been consumed. See the module comment for why.
+  const phases: ConsumerType[][] = [consumers.filter((c) => c === 'mcp'), consumers.filter((c) => c !== 'mcp')].filter(
+    (phase) => phase.length > 0,
+  );
+
+  let totalTargets = 0;
+  let outstanding = 0;
+
+  for (const phase of phases) {
+    const targets = await captureOffsetTargets(request, baseUrl, headers, phase);
+    if (targets === null) {
+      logger.warn('Could not establish an offset checkpoint; falling back to aggregate lag polling', {
+        consumers: phase.join(','),
+        gmsUrl: baseUrl,
+      });
+      const outcome = await fallbackAggregateLagWait(request, baseUrl, headers, consumers, deadline);
+      if (outcome !== 'synced') {
+        logger.warn(`Fallback lag wait ended without confirming sync (${outcome}); relying on the ES refresh margin`);
+      }
+      await delay(esRefreshMarginMs);
+      return;
+    }
+    totalTargets += targets.size;
+    outstanding += await awaitOffsetTargets(request, baseUrl, headers, targets, deadline, pollIntervalMs);
+  }
+
+  const elapsedMs = Date.now() - start;
+  if (outstanding > 0) {
+    logger.warn(`Timed out after ${elapsedMs}ms waiting for ${outstanding}/${totalTargets} offset target(s)`);
+  } else {
+    logger.info(`All ${totalTargets} offset target(s) consumed after ${elapsedMs}ms`);
+  }
+  await delay(esRefreshMarginMs);
+}


### PR DESCRIPTION
# Description

The Playwright suite carries 123 `waitForTimeout` call sites totalling ≥213 s if each fires once — roughly 8% of the suite's 2,626 junit test-seconds — plus a fixed 15 s "wait for Elasticsearch indexing" sleep in `tests/search-data.setup.ts` that every one of the 8 CI shards pays (120 runner-seconds per run). These sleeps are sized for an environment that no longer exists: CI runs Elasticsearch with a 1-second refresh interval.

The pytest suite replaced the same pattern with an offset-checkpoint "wait for writes to sync" in #18881, worth ~21% of batch time there. This PR ports that helper to TypeScript and converts the worst offenders: the 15 s setup sleep and all 16 `TIMEOUTS.MEDIUM` (10 s) / `TIMEOUTS.SHORT` (5 s) sites. The `QUICK`/`BETWEEN_OPS`/`OPERATION` tail (107 remaining small sleeps) is left for a follow-up.

Scope grew from there once the sleep-hygiene work made it possible to measure the suite's real bottleneck accurately: duration-weighted sharding (replacing Playwright's file-count `--shard`), a `workers_per_shard=2` experiment, and the concurrency-safety fixes that experiment surfaced (a seeding-fixture race, a missing serial guard, a cross-file lineage-seeding race) — see **Results** below for the measured outcome now that all of it is running together on the automatic pipeline.

## Results

Measured on the automatic pipeline (`docker-unified.yml`, 8 shards) — [run 31400547938](https://github.com/datahub-project/datahub/actions/runs/31400547938), commit `e9eca9943a`:

- **Bottleneck shard: 16.3 min → 10.7 min — a ~34% reduction in the Playwright stage's wall clock**, against PFP-5479's own measured baseline (workers:1, file-count sharding, before any of this PR's changes).
- 372 tests passed, 0 failures, 0 flakes — the cleanest run of the whole investigation, and the first one on the real automatic pipeline rather than a manual `workflow_dispatch` trial.
- One data point on the automatic path so far; the underlying mechanisms (duration-weighted + serial-aware sharding, `workers_per_shard=2`, the three concurrency fixes) were each separately validated across multiple repeated manual trials before being wired into the default pipeline — see commit history for the individual before/after comparisons.

## The helper: `utils/writes-sync.ts`

`waitForWritesToSync(request, opts?)` is a port of `smoke-test/tests/consistency_utils.py` (`wait_for_offsets_to_be_consumed`), preserving its semantics:

- Reads `GET {gms}/openapi/operations/messaging/{mcp,mcl,mcl-timeseries}/consumer/lag?detailed=true` (Bearer-authenticated) for per-partition committed offsets and lag.
- Captures each topic-partition's end-offset **once** at call time — a fixed checkpoint that other writers' later writes cannot move — then polls (~250 ms) until committed offsets pass it. Resolves in ~0.3 s on a quiet system.
- **Two-phase MCP → MCL**: waits for the MCP checkpoint first, then captures the MCL/MCL-timeseries checkpoint, because on the async ingest path the MCL doesn't exist yet at call time; capturing both up front would self-satisfy on the pre-write MCL offset and skip indexing entirely.
- A failed checkpoint fetch is **not** treated as satisfied — it falls back to bounded aggregate-lag polling (1 s ticks), and to a single static ES-refresh sleep if the lag API is unreachable, mirroring the Python fallback chain.
- Finishes with an ES refresh margin (`ELASTICSEARCH_REFRESH_INTERVAL_SECONDS`, default 3 s — same default as pytest).

Auth/base-URL use the suite's existing mechanisms: `gmsUrl()` from `utils/constants.ts` and the admin token from `.auth/gms-token-{user}.json` (the same file `search-data.setup.ts` already reads; spec call sites pass the `gmsToken` fixture explicitly). The token is minted by the login fixture as the admin user — the same admin-session pattern the pytest helper relies on to call the operations endpoints.

The endpoint is a standard GMS REST controller (`@Conditional` on the transport being Kafka or pgQueue — i.e. any normal deployment, not a local/dev-only feature); its Kafka connectivity is internal to GMS (the caller only needs ordinary HTTP access to GMS, same as every other API call the suite makes). It does require `MANAGE_SYSTEM_OPERATIONS_PRIVILEGE`, so a lower-privileged test identity against a deployed environment would 403 — `waitForWritesToSync` already treats that the same as "unreachable" and falls back to the sleep-based chain above, so the degraded case is exactly today's behavior, not a regression.

Known carve-outs (documented in the helper): the usage-events consumer group is not covered, and a checkpoint captured mid-burst legitimately waits for already-queued backlog — the win is eliminating the non-convergence tail, not genuine backlog-drain time.

## Per-site decision table (all 16 `MEDIUM`/`SHORT` sites)

| # | Site | Sleep | Verdict | Replacement |
|---|------|-------|---------|-------------|
| 1 | `tests/search-data.setup.ts` (15 s literal) | 15 s | consistency | `waitForWritesToSync` after seed ingestion |
| 2 | `tests/application/application-management.spec.ts:66` (after create) | SHORT | consistency (create → search-indexed table) | `waitForWritesToSync` |
| 3 | `tests/application/application-management.spec.ts:76` (after delete) | SHORT | consistency (delete → search-indexed table) | `waitForWritesToSync` |
| 4 | `pages/entity/document.page.ts:216` (`updateDocumentStatus`) | MEDIUM | consistency (mutation → reload re-read) | `waitForWritesToSync` before the caller's `page.reload()` |
| 5 | `pages/entity/document.page.ts:241` (`updateDocumentType`) | MEDIUM | consistency | same as #4 |
| 6 | `tests/documents/document-management.spec.ts:208` (after delete) | MEDIUM | consistency (delete → tree re-query) | `waitForWritesToSync` |
| 7 | `tests/documents/document-management.spec.ts:234` (cascade delete) | MEDIUM | consistency | `waitForWritesToSync` |
| 8 | `pages/applications.page.ts:207` (`verifyAssetInList`) | MEDIUM | redundant DOM wait — the GraphQL query completes at the preceding `networkidle`; sleeping cannot change the rendered result, and the following `toBeVisible` already retries for `EXTRA_LONG` | removed |
| 9 | `pages/ingestion/base/tabs/sources-base.tab.ts:441` (`expectSourceStatusContains`) | SHORT | redundant DOM wait — the following assertion polls for up to 100 s against a self-refreshing table; a fixed head-start adds nothing | removed |
| 10 | `pages/lineage-v3.page.ts:90` (`addDescriptionFilter`) | SHORT | DOM/refetch wait | removed; the spec's hidden-check gets the full `MEDIUM` retry budget instead |
| 11 | `tests/lineage-v3/…impact-analysis.spec.ts:123` (post-goto, column view) | MEDIUM | DOM/hydration wait | `openImpactAnalysisView()` — `toPass`-retried click anchored on the view's toolbar |
| 12 | `…impact-analysis.spec.ts:134` (after column-lineage toggle) | SHORT | DOM/refetch wait | removed; a positive sync-point assertion (`FEATURE_1` appears only after the refetch) now precedes the hidden-check |
| 13 | `…impact-analysis.spec.ts:147` (post-goto, time-filtered) | MEDIUM | DOM/hydration wait — also guarded hidden-checks from passing vacuously | `openImpactAnalysisView()` (positive anchor restores the guard) |
| 14 | `…impact-analysis.spec.ts:166` (post-goto, task page) | MEDIUM | DOM/hydration wait | `openSidebarLineageTab()` — `toPass`-retried click anchored on the direction selector |
| 15 | `…impact-analysis.spec.ts:181` (post-goto, task page) | MEDIUM | DOM/hydration wait | `openSidebarLineageTab()` |
| 16 | `…impact-analysis.spec.ts:198` (post-goto, dataset page) | SHORT | DOM/hydration wait | `openSidebarLineageTab()` |
| 17 | `…impact-analysis.spec.ts:210` (post-goto, dataset page) | SHORT | DOM/hydration wait | `openSidebarLineageTab()` |

Rationale for the split: GMS consumer lag says nothing about the DOM, so render/hydration waits get web-first mechanisms (`toPass`-retried clicks with a post-click anchor, positive sync-point assertions, existing auto-retrying assertions) rather than the writes-sync helper.

Result: `grep -rn 'waitForTimeout(TIMEOUTS.MEDIUM|TIMEOUTS.SHORT)'` now returns **0** sites (was 16); total `waitForTimeout` sites 123 → 107.

## Sharding, parallelism, and the concurrency fixes it surfaced

- **Duration-weighted sharding** (`shard_playwright_tests.py`) replaces Playwright's file-count `--shard` with LPT bin-packing against harvested per-file durations (`playwright_test_weights.json`, refreshed weekly via `update-test-weights.yml`). At `workers_per_shard > 1` it packs `mode: 'serial'` files first — the only kind of file that imposes a real single-worker floor under `fullyParallel` — and correctly excludes suites whose serial block is wrapped in `test.describe.skip` (so a never-executed suite doesn't count toward the floor).
- **`workers_per_shard=2`** is now wired into `docker-unified.yml`'s automatic `playwright_test` job; other callers of the reusable workflow keep inheriting the default `"1"` unless they opt in.
- Three real concurrency bugs surfaced during repeated `workers_per_shard=2` validation runs, all fixed here:
  - `seeding.fixture.ts` had a check-then-act (`existsSync` → later `writeFileSync`) TOCTOU race letting two workers both seed simultaneously — replaced with an atomic cross-worker lock (`withArtifactLock`, `helpers/seeder-utils.ts`).
  - `v2-manage-policies.spec.ts` had no `mode: 'serial'` guard despite two tests mutating the same global policy list — the one failure that reproduced only under `workers_per_shard=2` and not in a matching baseline.
  - `v3-lineage-impact-analysis.spec.ts` and `v3-lineage-graph.spec.ts` both seed shared, time-stamped lineage edges from independent `beforeAll` hooks; under `fullyParallel` these can run concurrently regardless of `workers_per_shard`, racing a delete-then-recreate sequence. Now guarded by the same `withArtifactLock` primitive.
- A separate, unrelated bug was found and fixed along the way: `tests/business-attributes/fixtures/data.json` redefined a glossary term also seeded globally, silently wiping its `glossaryRelatedTerms` relationship (aspect ingestion replaces rather than merges). This explained a `v2-summary-tab-glossary-term.spec.ts` failure that had nothing to do with worker concurrency — it reproduced identically under `workers_per_shard=1`.
- **`check_playwright_fixture_conflicts.py`**: the glossary-term bug turned out to be one of 34 similar cross-fixture entity collisions in the existing test data (29 cross-file, 5 same-file duplicates). All 34 are baselined (`playwright_fixture_conflicts_baseline.json`); the check now fails CI on any *new* one, since feature-vs-feature seed collisions are a live flake risk that gets worse as `workers_per_shard` increases. Full inventory and suggested cleanup: [PFP-5492](https://linear.app/acryl-data/issue/PFP-5492).

## Out of scope (follow-ups)

- The `QUICK`/`BETWEEN_OPS`/`OPERATION` small-sleep tail.
- The 8 seed entities that 400/500 on the snapshot endpoint every shard (pre-existing, non-blocking, tracked separately — [PFP-4003](https://linear.app/acryl-data/issue/PFP-4003) / [PFP-5353](https://linear.app/acryl-data/issue/PFP-5353)).
- Resolving the 34 baselined cross-fixture entity conflicts, and the broader seed-data architecture cleanup ([PFP-5492](https://linear.app/acryl-data/issue/PFP-5492)) — mixed legacy-snapshot/native-MCP formats, several abandoned parallel seeding implementations, and the disabled `data.setup.ts`/`search-data.setup.ts` CLI-based path that would eliminate the format problem outright. Deliberately kept out of this PR: different kind of change (architecture/tech-debt vs. CI latency) and large enough to want its own focused review.
- Depot pull targeting (trimming unused image tags per shard).

## Verification

- `yarn lint` (tsc `--noEmit` + eslint) in `e2e-test/ui/playwright`: 0 errors, warning count unchanged from master (121 pre-existing). Prettier clean on all touched files.
- **Live verification**: see **Results** above — the full mechanism (writes-sync, duration-weighted sharding, `workers_per_shard=2`, and the concurrency fixes) has run clean multiple times via manual `workflow_dispatch` trials at both `workers_per_shard=1` and `=2`, and as of commit `e9eca9943a` has run clean once on the automatic pipeline itself (8/8 shards, 372 passed, 0 failures/flakes).
- Reviewers can additionally check, in the Playwright job artifacts:
  - the `writes-sync` log lines (`All N offset target(s) consumed after Xms`) in shard logs, confirming the checkpoint path is used rather than the fallback;
  - the `Check for cross-fixture entity conflicts` step output (`No new cross-fixture conflicts (34 pre-existing, baselined)`);
  - the `Compute duration-weighted shard file list` step's projected-floor diagnostic, confirming shards are balanced.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes correspondent entry should be made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fixed sleeps across Playwright with an offset-checkpoint writes-sync wait and deterministic DOM waits to reduce flakiness and speed up tests. Added duration‑weighted sharding and enabled 2 workers per shard in the automatic CI to cut wall clock while keeping shards balanced.

- **New Features**
  - Added `e2e-test/ui/playwright/utils/writes-sync.ts` (`waitForWritesToSync(request, opts)`): two-phase MCP→MCL checkpoint with fallbacks and an ES refresh margin; uses `gmsUrl()` and the admin `gmsToken`.
  - Duration-weighted sharding: `shard_playwright_tests.py`, per-file weights in `playwright_test_weights.json`, weekly harvest via `generate_test_weights.py`/`compare_test_weights.py`/`download_test_artifacts.sh`/`update-test-weights.yml` (sums per-file durations within a run before medianing). Packs `mode:'serial'` files first and excludes serial suites wrapped in `test.describe.skip`.
  - CI: Playwright now runs with `workers_per_shard=2` in `docker-unified.yml`; other callers of the reusable workflow stay at the default `"1"` unless they opt in.
  - CI guard: `check_playwright_fixture_conflicts.py` + baseline `playwright_fixture_conflicts_baseline.json`; runs in `resusable-playwright-tests.yml` to block new cross-fixture aspect collisions.

- **Refactors and Fixes**
  - Replaced hard sleeps with `waitForWritesToSync` at write→read boundaries and deterministic DOM waits elsewhere; kept brief settles only for known CI regressions (carousel transitions, chained clicks in Browse V2, change-history hover).
  - Multi-worker safety: atomic cross-worker seeding via `withArtifactLock`, atomic state/token writes, writes-sync before publishing the state file; locked time-range lineage seeding and set `v3-lineage-graph.spec.ts` and `v3-lineage-impact-analysis.spec.ts` to `mode: 'serial'`; serialized policy tests to avoid shared-state collisions.
  - Fixed Glossary "Related Terms" by seeding `glossaryRelatedTerms` via MCP and removing a conflicting aspect from `tests/business-attributes/fixtures/data.json`.

<sup>Written for commit e9eca9943a2c094faba7fa3226828dbcba6454e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
