### PR TITLE
perf(analytics): batch DailyReport Elasticsearch queries call

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
@@ -2,10 +2,12 @@ package com.linkedin.gms.factory.telemetry;
 
 import static com.linkedin.gms.factory.telemetry.TelemetryUtils.*;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
+import com.linkedin.datahub.graphql.analytics.service.EntityStats;
 import com.linkedin.datahub.graphql.generated.DateRange;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.NamedBar;
@@ -20,9 +22,11 @@ import io.datahubproject.metadata.context.OperationContext;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,6 +49,11 @@ public class DailyReport {
   private final GitVersion _gitVersion;
 
   private static final String MIXPANEL_TOKEN = "5ee83d940754d63cacbf7d34daa6f44a";
+
+  private static final String DAU = "dau";
+  private static final String WAU = "wau";
+  private static final String MAU = "mau";
+  private static final String BROWSER_ID = "browserId";
 
   /** SubType value used to identify service accounts in CorpUser entities. */
   private static final String SERVICE_ACCOUNT_SUB_TYPE = "SERVICE_ACCOUNT";
@@ -131,49 +140,40 @@ public class DailyReport {
     DateTime lastWeek = endDate.minusWeeks(1);
     DateTime lastMonth = endDate.minusMonths(1);
 
-    DateRange dayRange =
-        new DateRange(String.valueOf(yesterday.getMillis()), String.valueOf(endDate.getMillis()));
-    DateRange weekRange =
-        new DateRange(String.valueOf(lastWeek.getMillis()), String.valueOf(endDate.getMillis()));
-    DateRange monthRange =
-        new DateRange(String.valueOf(lastMonth.getMillis()), String.valueOf(endDate.getMillis()));
-
-    // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no per-event
-    // context available
-    int dailyActiveUsers =
-        analyticsService.getHighlights(
-            systemOperationContext,
-            analyticsService.getUsageIndexName(systemOperationContext),
-            Optional.of(dayRange),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            Optional.of("browserId"));
-    // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no per-event
-    // context available
-    int weeklyActiveUsers =
-        analyticsService.getHighlights(
-            systemOperationContext,
-            analyticsService.getUsageIndexName(systemOperationContext),
-            Optional.of(weekRange),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            Optional.of("browserId"));
-    // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no per-event
-    // context available
-    int monthlyActiveUsers =
-        analyticsService.getHighlights(
-            systemOperationContext,
-            analyticsService.getUsageIndexName(systemOperationContext),
-            Optional.of(monthRange),
-            ImmutableMap.of(),
-            ImmutableMap.of(),
-            Optional.of("browserId"));
+    Map<String, DateRange> activeUserRanges = new LinkedHashMap<>();
+    activeUserRanges.put(
+        DAU,
+        new DateRange(String.valueOf(yesterday.getMillis()), String.valueOf(endDate.getMillis())));
+    activeUserRanges.put(
+        WAU,
+        new DateRange(String.valueOf(lastWeek.getMillis()), String.valueOf(endDate.getMillis())));
+    activeUserRanges.put(
+        MAU,
+        new DateRange(String.valueOf(lastMonth.getMillis()), String.valueOf(endDate.getMillis())));
 
     // set user-level properties (all counts anonymized to nearest power of 2)
     JSONObject report = new JSONObject();
-    report.put("dau", anonymizeCount(dailyActiveUsers));
-    report.put("wau", anonymizeCount(weeklyActiveUsers));
-    report.put("mau", anonymizeCount(monthlyActiveUsers));
+
+    // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no per-event
+    // context available
+    try {
+      Map<String, Integer> activeUsers =
+          analyticsService.getUniqueCountsByRange(
+              systemOperationContext,
+              analyticsService.getUsageIndexName(systemOperationContext),
+              activeUserRanges,
+              BROWSER_ID);
+      activeUserRanges
+          .keySet()
+          .forEach(key -> report.put(key, anonymizeCount(activeUsers.get(key))));
+    } catch (Exception e) {
+      // Omit the keys rather than reporting zeros - an absent metric is honest, a fabricated
+      // zero is indistinguishable from a genuinely idle instance. Log the cause, not just the
+      // message: the message is usually the opaque "Search query failed:" wrapper, and this line
+      // is the only signal an operator gets that the metrics were dropped.
+      log.warn("Failed to collect active user counts", e);
+    }
+
     report.put("server_type", _configurationProvider.getDatahub().getServerType());
     report.put("server_version", _gitVersion.getVersion());
 
@@ -297,17 +297,24 @@ public class DailyReport {
    * @param report the JSON report object to populate
    */
   private void addMetadataAnalytics(AnalyticsService analyticsService, JSONObject report) {
-    // Collect entity counts by type
-    Map<String, Integer> entityCounts = collectEntityCounts(analyticsService);
+    // One batched query now covers every entity type, so a single failure costs all of them where
+    // the per-type queries it replaced could not throw at all. Omit the counts rather than
+    // reporting a total_assets of zero, and keep going - platform statistics are independent and
+    // were still collected in this case before batching.
+    try {
+      Map<String, Integer> entityCounts = collectEntityCounts(analyticsService);
 
-    // Calculate total assets - use long to avoid overflow
-    long totalAssets = entityCounts.values().stream().mapToLong(Integer::longValue).sum();
-    report.put("total_assets", anonymizeToBucket((int) Math.min(totalAssets, Integer.MAX_VALUE)));
+      // Calculate total assets - use long to avoid overflow
+      long totalAssets = entityCounts.values().stream().mapToLong(Integer::longValue).sum();
+      report.put("total_assets", anonymizeToBucket((int) Math.min(totalAssets, Integer.MAX_VALUE)));
 
-    // Add entity type counts as flattened properties
-    for (Map.Entry<String, Integer> entry : entityCounts.entrySet()) {
-      String propertyName = "entity_count_" + entry.getKey().toLowerCase();
-      report.put(propertyName, anonymizeToBucket(entry.getValue()));
+      // Add entity type counts as flattened properties
+      for (Map.Entry<String, Integer> entry : entityCounts.entrySet()) {
+        String propertyName = "entity_count_" + entry.getKey().toLowerCase();
+        report.put(propertyName, anonymizeToBucket(entry.getValue()));
+      }
+    } catch (Exception e) {
+      log.warn("Failed to collect entity counts", e);
     }
 
     // Collect platform statistics
@@ -321,34 +328,34 @@ public class DailyReport {
    * @param analyticsService the analytics service for querying
    * @return map of entity type name to count
    */
-  private Map<String, Integer> collectEntityCounts(AnalyticsService analyticsService) {
-    Map<String, Integer> counts = new HashMap<>();
-
-    // Iterate only tracked entity types (not all)
+  @VisibleForTesting
+  Map<String, Integer> collectEntityCounts(AnalyticsService analyticsService) {
+    // A type whose index name cannot be resolved would fail the whole batch, where the previous
+    // per-type queries simply skipped it. Drop those up front to keep that resilience.
+    List<EntityType> resolvableTypes = new ArrayList<>();
     for (EntityType entityType : REPORTING_ENTITY_TYPES) {
       try {
-        String index = analyticsService.getEntityIndexName(systemOperationContext, entityType);
-        // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no
-        // per-event context available
-        int count =
-            analyticsService.getHighlights(
-                systemOperationContext,
-                index,
-                Optional.empty(), // No date range
-                ImmutableMap.of(), // No filters
-                ImmutableMap.of("removed", ImmutableList.of("true")), // Exclude removed
-                Optional.empty()); // No unique field
-
-        // Only include entity types with non-zero counts to keep report concise
-        if (count > 0) {
-          counts.put(entityType.name(), count);
-        }
+        analyticsService.getEntityIndexName(systemOperationContext, entityType);
+        resolvableTypes.add(entityType);
       } catch (Exception e) {
-        log.debug("Failed to count entities for type {}: {}", entityType, e.getMessage());
-        // Don't add to counts if query failed - keeps report cleaner
+        log.debug("Skipping unresolvable entity type {}: {}", entityType, e.getMessage());
       }
     }
 
+    // TODO(opcontext-pr6): cannot use per-event opContext — scheduled telemetry job, no per-event
+    // context available
+    Map<EntityType, EntityStats> stats =
+        analyticsService.getEntityStats(
+            systemOperationContext, resolvableTypes, Collections.emptyList());
+
+    Map<String, Integer> counts = new HashMap<>();
+    stats.forEach(
+        (entityType, entityStats) -> {
+          // Only include entity types with non-zero counts to keep report concise
+          if (entityStats.getTotal() > 0) {
+            counts.put(entityType.name(), entityStats.getTotal());
+          }
+        });
     return counts;
   }
 

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
@@ -4,13 +4,18 @@ import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
 import com.datahub.context.OperationFingerprint;
+import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.version.GitVersion;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.SearchContext;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONObject;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
@@ -26,6 +31,9 @@ import org.testng.annotations.Test;
  * is not tested as it requires external services (Mixpanel).
  */
 public class DailyReportTest {
+
+  /** Size of DailyReport.REPORTING_ENTITY_TYPES. */
+  private static final int REPORTED_ENTITY_TYPE_COUNT = 19;
 
   private OperationContext mockOperationContext;
   private SearchClientShim<?> mockElasticClient;
@@ -48,8 +56,11 @@ public class DailyReportTest {
     // Set up the operation context chain
     when(mockOperationContext.getSearchContext()).thenReturn(mockSearchContext);
     when(mockSearchContext.getIndexConvention()).thenReturn(mockIndexConvention);
+    // A distinct index per entity name, mirroring the real convention. AnalyticsService
+    // de-duplicates the batch's target indices, so stubbing one shared name for every type would
+    // collapse the batch to a single index and hide whether it spans all reported types.
     when(mockIndexConvention.getEntityIndexName(any(OperationFingerprint.class), anyString()))
-        .thenReturn("corpuserindex_v2");
+        .thenAnswer(invocation -> invocation.getArgument(1) + "index_v2");
     when(mockGitVersion.getVersion()).thenReturn("test-version");
   }
 
@@ -388,5 +399,294 @@ public class DailyReportTest {
     assertEquals(anonymizeToBucketMethod.invoke(dailyReport, 100001), "100K-1M");
     assertEquals(anonymizeToBucketMethod.invoke(dailyReport, 1000000), "100K-1M");
     assertEquals(anonymizeToBucketMethod.invoke(dailyReport, 1000001), "1M+");
+  }
+
+  /**
+   * The whole point of batching: one aggregation covering every reported entity type, rather than
+   * one count query per type.
+   */
+  @Test
+  public void testCollectEntityCountsIssuesSingleSearch() throws Exception {
+    org.opensearch.search.aggregations.bucket.filter.Filters byEntity =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.class);
+    // Nested mocks must be fully built before being handed to thenReturn().
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket empty = entityBucket(0L);
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket datasets = entityBucket(100L);
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket tags = entityBucket(7L);
+    when(byEntity.getBucketByKey(anyString())).thenReturn(empty);
+    when(byEntity.getBucketByKey("DATASET")).thenReturn(datasets);
+    when(byEntity.getBucketByKey("TAG")).thenReturn(tags);
+    stubAggregationResponse(byEntity);
+
+    DailyReport dailyReport = createDailyReportForTesting();
+    Map<String, Integer> counts =
+        dailyReport.collectEntityCounts(
+            new AnalyticsService(mockElasticClient, mockIndexConvention));
+
+    org.mockito.ArgumentCaptor<SearchRequest> captor =
+        org.mockito.ArgumentCaptor.forClass(SearchRequest.class);
+    verify(mockElasticClient, times(1))
+        .search(any(OperationContext.class), captor.capture(), any(RequestOptions.class));
+    // One request spanning every reported entity type, not one request per type.
+    assertEquals(captor.getValue().indices().length, REPORTED_ENTITY_TYPE_COUNT);
+
+    assertEquals(counts.get("DATASET"), Integer.valueOf(100));
+    assertEquals(counts.get("TAG"), Integer.valueOf(7));
+  }
+
+  /** Zero-count types are dropped so the telemetry payload stays concise. */
+  @Test
+  public void testCollectEntityCountsOmitsZeroCounts() throws Exception {
+    org.opensearch.search.aggregations.bucket.filter.Filters byEntity =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.class);
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket empty = entityBucket(0L);
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket datasets = entityBucket(5L);
+    when(byEntity.getBucketByKey(anyString())).thenReturn(empty);
+    when(byEntity.getBucketByKey("DATASET")).thenReturn(datasets);
+    stubAggregationResponse(byEntity);
+
+    DailyReport dailyReport = createDailyReportForTesting();
+    Map<String, Integer> counts =
+        dailyReport.collectEntityCounts(
+            new AnalyticsService(mockElasticClient, mockIndexConvention));
+
+    assertEquals(counts.size(), 1, "only the non-zero type should be reported");
+    assertTrue(counts.containsKey("DATASET"));
+  }
+
+  /**
+   * A type whose index name cannot be resolved is dropped before the batch is built. Batched, it
+   * would otherwise throw and take every other entity count with it, where the per-type queries it
+   * replaced simply skipped that one type.
+   */
+  @Test
+  public void testCollectEntityCountsSkipsUnresolvableTypes() throws Exception {
+    when(mockIndexConvention.getEntityIndexName(
+            any(OperationFingerprint.class), eq(Constants.DATASET_ENTITY_NAME)))
+        .thenThrow(new IllegalArgumentException("no index configured for dataset"));
+
+    org.opensearch.search.aggregations.bucket.filter.Filters byEntity =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.class);
+    // Nested mocks must be fully built before being handed to thenReturn().
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket populated = entityBucket(3L);
+    when(byEntity.getBucketByKey(anyString())).thenReturn(populated);
+    stubAggregationResponse(byEntity);
+
+    DailyReport dailyReport = createDailyReportForTesting();
+    Map<String, Integer> counts =
+        dailyReport.collectEntityCounts(
+            new AnalyticsService(mockElasticClient, mockIndexConvention));
+
+    org.mockito.ArgumentCaptor<SearchRequest> captor =
+        org.mockito.ArgumentCaptor.forClass(SearchRequest.class);
+    verify(mockElasticClient, times(1))
+        .search(any(OperationContext.class), captor.capture(), any(RequestOptions.class));
+
+    // The batch still goes out, one index short, rather than failing outright.
+    assertEquals(captor.getValue().indices().length, REPORTED_ENTITY_TYPE_COUNT - 1);
+    assertFalse(counts.containsKey("DATASET"), "unresolvable type must not be reported");
+    assertEquals(counts.size(), REPORTED_ENTITY_TYPE_COUNT - 1);
+  }
+
+  private org.opensearch.search.aggregations.bucket.filter.Filters.Bucket entityBucket(
+      long docCount) {
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket bucket =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.Bucket.class);
+    when(bucket.getDocCount()).thenReturn(docCount);
+    return bucket;
+  }
+
+  /** Wraps the by_entity aggregation in the filtered wrapper AnalyticsService reads back. */
+  private void stubAggregationResponse(
+      org.opensearch.search.aggregations.bucket.filter.Filters byEntity) throws Exception {
+    org.opensearch.search.aggregations.Aggregations filteredAggs =
+        mock(org.opensearch.search.aggregations.Aggregations.class);
+    when(filteredAggs.get("by_entity")).thenReturn(byEntity);
+    org.opensearch.search.aggregations.bucket.filter.Filter filtered =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filter.class);
+    when(filtered.getAggregations()).thenReturn(filteredAggs);
+    org.opensearch.search.aggregations.Aggregations topLevel =
+        mock(org.opensearch.search.aggregations.Aggregations.class);
+    when(topLevel.get("filtered")).thenReturn(filtered);
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(topLevel);
+    when(mockElasticClient.search(
+            any(OperationContext.class), any(SearchRequest.class), any(RequestOptions.class)))
+        .thenReturn(response);
+  }
+
+  /**
+   * Captures the telemetry payload through ping(), which is the only externally observable output
+   * of dailyReport(). Uses nothing but the public entry point, so it runs unchanged against the
+   * pre-batching implementation for a like-for-like payload comparison.
+   */
+  @Test
+  public void testDailyReportPayload() throws Exception {
+    stubEverything();
+
+    DailyReport spy = org.mockito.Mockito.spy(createDailyReportForTesting());
+    org.mockito.Mockito.doNothing().when(spy).ping(anyString(), any(JSONObject.class));
+
+    spy.dailyReport();
+
+    org.mockito.ArgumentCaptor<JSONObject> payload =
+        org.mockito.ArgumentCaptor.forClass(JSONObject.class);
+    verify(spy).ping(eq("service-daily"), payload.capture());
+
+    org.mockito.ArgumentCaptor<SearchRequest> requests =
+        org.mockito.ArgumentCaptor.forClass(SearchRequest.class);
+    verify(mockElasticClient, atLeast(0))
+        .search(any(OperationContext.class), requests.capture(), any(RequestOptions.class));
+
+    // Pre-batching this was 25 searches: 3 active-user windows plus one per reported entity type.
+    List<SearchRequest> issued = requests.getAllValues();
+    assertEquals(issued.size(), 5, "expected one search per concern, not one per entity type");
+
+    List<SearchRequest> multiIndex =
+        issued.stream()
+            .filter(r -> r.indices().length > 1)
+            .collect(java.util.stream.Collectors.toList());
+    assertEquals(multiIndex.size(), 1, "entity counts should collapse into a single search");
+    assertEquals(
+        multiIndex.get(0).indices().length,
+        REPORTED_ENTITY_TYPE_COUNT,
+        "the batch must span every reported entity type");
+
+    // The remaining four are the usage index, total users, service accounts and platform chart.
+    assertEquals(issued.size() - multiIndex.size(), 4);
+
+    // Payload must be unchanged by the batching - these values are what the per-query
+    // implementation produced from the same stubbed counts.
+    JSONObject report = payload.getValue();
+    assertEquals(report.get("dau"), 8);
+    assertEquals(report.get("wau"), 8);
+    assertEquals(report.get("mau"), 8);
+    assertEquals(report.get("total_assets"), "1K-10K");
+    assertEquals(report.get("total_user_count"), 32);
+    assertEquals(report.get("total_service_account_count"), 32);
+    assertEquals(report.get("server_type"), "test");
+
+    long entityCountKeys =
+        keysOf(report).stream().filter(k -> k.startsWith("entity_count_")).count();
+    assertEquals(
+        entityCountKeys,
+        (long) REPORTED_ENTITY_TYPE_COUNT,
+        "every reported entity type should carry a count");
+  }
+
+  /**
+   * Batching made one query carry all 19 entity counts, so its failure must not also cost the
+   * platform statistics, which are independent and were still collected before batching.
+   */
+  @Test
+  public void testPlatformStatsSurviveEntityCountFailure() throws Exception {
+    stubEverything();
+    // Nested mocks must be fully built before being handed to the answer.
+    SearchResponse ok = stubResponse();
+    // The entity batch is the only multi-index search; fail just that one.
+    when(mockElasticClient.search(
+            any(OperationContext.class), any(SearchRequest.class), any(RequestOptions.class)))
+        .thenAnswer(
+            invocation -> {
+              SearchRequest request = invocation.getArgument(1);
+              if (request.indices().length > 1) {
+                throw new RuntimeException("Search query failed:");
+              }
+              return ok;
+            });
+
+    DailyReport spy = org.mockito.Mockito.spy(createDailyReportForTesting());
+    org.mockito.Mockito.doNothing().when(spy).ping(anyString(), any(JSONObject.class));
+    spy.dailyReport();
+
+    org.mockito.ArgumentCaptor<JSONObject> payload =
+        org.mockito.ArgumentCaptor.forClass(JSONObject.class);
+    verify(spy).ping(eq("service-daily"), payload.capture());
+    JSONObject report = payload.getValue();
+
+    assertTrue(keysOf(report).contains("platform_count"), "platform stats must still be collected");
+    // Omitted rather than reported as a fabricated zero.
+    assertFalse(keysOf(report).contains("total_assets"));
+    assertTrue(
+        keysOf(report).stream().noneMatch(k -> k.startsWith("entity_count_")),
+        "entity counts should be absent when their batch failed");
+  }
+
+  private static java.util.List<String> keysOf(JSONObject o) {
+    java.util.List<String> keys = new java.util.ArrayList<>();
+    java.util.Iterator<String> it = o.keys();
+    while (it.hasNext()) {
+      keys.add(it.next());
+    }
+    return keys;
+  }
+
+  /** Stubs the client to answer every search with {@link #stubResponse()}, plus config mocks. */
+  private void stubEverything() throws Exception {
+    // Nested mocks must be fully built before being handed to thenReturn().
+    SearchResponse response = stubResponse();
+    when(mockElasticClient.search(
+            any(OperationContext.class), any(SearchRequest.class), any(RequestOptions.class)))
+        .thenReturn(response);
+
+    when(mockIndexConvention.getIndexName(any(OperationFingerprint.class), anyString()))
+        .thenReturn("datahub_usage_event");
+
+    com.linkedin.metadata.config.DataHubConfiguration dataHub =
+        mock(com.linkedin.metadata.config.DataHubConfiguration.class);
+    when(dataHub.getServerType()).thenReturn("test");
+    when(mockConfigurationProvider.getDatahub()).thenReturn(dataHub);
+    when(mockGitVersion.getVersion()).thenReturn("1.0.0-test");
+  }
+
+  /** Response usable by both the batched and the per-query implementations. */
+  private SearchResponse stubResponse() throws Exception {
+    org.opensearch.search.aggregations.metrics.Cardinality cardinality =
+        mock(org.opensearch.search.aggregations.metrics.Cardinality.class);
+    when(cardinality.getValue()).thenReturn(8L);
+
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket rangeBucket =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.Bucket.class);
+    org.opensearch.search.aggregations.Aggregations rangeAggs =
+        mock(org.opensearch.search.aggregations.Aggregations.class);
+    when(rangeAggs.get("unique")).thenReturn(cardinality);
+    when(rangeBucket.getAggregations()).thenReturn(rangeAggs);
+    org.opensearch.search.aggregations.bucket.filter.Filters byRange =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.class);
+    when(byRange.getBucketByKey(anyString())).thenReturn(rangeBucket);
+
+    org.opensearch.search.aggregations.bucket.filter.Filters.Bucket entityBucket =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.Bucket.class);
+    when(entityBucket.getDocCount()).thenReturn(100L);
+    org.opensearch.search.aggregations.bucket.filter.Filters byEntity =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filters.class);
+    when(byEntity.getBucketByKey(anyString())).thenReturn(entityBucket);
+
+    // One filtered wrapper serving both shapes: the batched sub-aggregations, and the
+    // doc count / cardinality the per-query implementation reads straight off it.
+    org.opensearch.search.aggregations.Aggregations filteredAggs =
+        mock(org.opensearch.search.aggregations.Aggregations.class);
+    when(filteredAggs.get("by_range")).thenReturn(byRange);
+    when(filteredAggs.get("by_entity")).thenReturn(byEntity);
+    when(filteredAggs.get("unique")).thenReturn(cardinality);
+    org.opensearch.search.aggregations.bucket.filter.Filter filtered =
+        mock(org.opensearch.search.aggregations.bucket.filter.Filter.class);
+    when(filtered.getAggregations()).thenReturn(filteredAggs);
+    when(filtered.getDocCount()).thenReturn(100L);
+
+    org.opensearch.search.aggregations.Aggregations topLevel =
+        mock(org.opensearch.search.aggregations.Aggregations.class);
+    when(topLevel.get("filtered")).thenReturn(filtered);
+
+    org.apache.lucene.search.TotalHits totalHits =
+        new org.apache.lucene.search.TotalHits(
+            42, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO);
+    org.opensearch.search.SearchHits hits = mock(org.opensearch.search.SearchHits.class);
+    when(hits.getTotalHits()).thenReturn(totalHits);
+
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(topLevel);
+    when(response.getHits()).thenReturn(hits);
+    return response;
   }
 }


### PR DESCRIPTION
## Problem

`DailyReport` runs once every 24h and issues **25 sequential Elasticsearch queries**:

- **3** on the usage index — daily, weekly and monthly active users, one query per window
- **19** across entity indices — one count per type in `REPORTING_ENTITY_TYPES`
- **1** total users, **1** service accounts, **1** platform bar chart

The 19 entity queries are identical apart from the index they target: same `removed: true` exclusion, same empty filter set, no facets. They exist only because `AnalyticsService.getHighlights` takes a single index name.

`AnalyticsService` already carries batched replacements for both patterns — `getUniqueCountsByRange` and `getEntityStats` — added when the same fanout was removed from the Analytics screen's `getHighlights` resolver. `DailyReport` was the remaining caller of the per-query path.

## Change

- The three active-user windows become one keyed `filters` aggregation over the usage index (`getUniqueCountsByRange`).
- The 19 entity counts become one multi-index aggregation keyed by entity type (`getEntityStats`), requesting no facets since only totals are reported.

**25 → 5 queries.**

| Path | Before | After |
|---|---|---|
| Active users (day/week/month) | 3 | **1** |
| Entity counts (19 types) | 19 | **1** |
| Total users | 1 | 1 |
| Service accounts | 1 | 1 |
| Platform bar chart | 1 | 1 |
| **Total** | **25** | **5** |

The two corpuser counts are deliberately left alone: they read `trackTotalHits` rather than aggregations and one filters on `typeNames`, so folding them in would mean generalising the facet API to arbitrary field/value pairs to save a single query.

## Behavioural changes

Batching concentrates failures: one query now carries all three active-user metrics, and another carries all 19 entity counts. Four consequences:

1. **A failed active-user query no longer kills the whole report.** Before, the error escaped `dailyReport()` and *nothing* was sent. Now it is caught: log a warning, drop `dau`/`wau`/`mau`, send the rest. Consumers should note the event can now arrive without those three keys.
2. **Missing numbers are left out, not reported as `0`.** A fabricated `0` is indistinguishable from a genuinely idle instance. The throw comes from `getUniqueCountsByRange`, which already behaved this way — this PR only catches it.
3. **An entity type with no resolvable index is still skipped**, as before, rather than failing the batch. Covered by a test that fails if the filter is removed.
4. **A failed entity batch no longer costs the platform statistics.** The per-type queries caught individually and could not throw, so platform stats were always reached. One batched query can throw, so `addMetadataAnalytics` guards the entity block and carries on. The counts are omitted rather than zeroed — an empty map would report a `total_assets` of zero, the same lie point 2 removes.

**Does one bad index now lose all 19 counts?** Mostly no, and it no longer takes anything else with it. A missing index is absorbed by `lenientExpandOpen` **so long as at least one index in the batch exists** — verified against a live cluster, where a present/absent pair returns `{DATASET: 6867, GONE: 0}`. If *every* index is absent, Elasticsearch omits the `aggregations` block entirely and the batch throws; that only arises before bootstrap creates the indices. Shard failures return partial results either way. The residual is that an index erroring rather than being absent costs all 19 counts where it used to cost one — but `total_assets`, `platform_count` and the `platform_*` keys now survive it.

## Testing

Five tests in `DailyReportTest`:

- `testCollectEntityCountsIssuesSingleSearch` — captures the `SearchRequest` and asserts one search spanning all 19 entity indices, not one per type.
- `testCollectEntityCountsOmitsZeroCounts` — zero-count types stay out of the payload.
- `testCollectEntityCountsSkipsUnresolvableTypes` — an unresolvable type is dropped and the batch still goes out one index short.
- `testPlatformStatsSurviveEntityCountFailure` — fails only the multi-index search and asserts platform statistics are still collected while `total_assets` and the entity counts are omitted.
- `testDailyReportPayload` — drives the real `dailyReport()` and captures the telemetry payload by spying the public `ping()`, its only externally observable output.

`collectEntityCounts` is exposed via `@VisibleForTesting` rather than extending the existing reflection-based access to private methods, which `AGENTS.md` lists as an anti-pattern.

Both failure-path tests were verified to fail when the code they guard is removed.

`:metadata-service:factories` passes — 84 tests.

## Measured before / after

Measured on a real GMS container against a real OpenSearch, with OpenTelemetry → Jaeger. `dailyReport()` is `@Scheduled(fixedDelay=24h)`, so it fires once per container start and each restart yields one sample; `DailyReport.java` was swapped between this branch and its parent commit, the war rebuilt, and GMS restarted **3 times per side**.

| Metric | Before | After | Δ |
|---|---|---|---|
| Elasticsearch round trips | **25** | **5** | **−80%** |
| ES time, sum of request durations | 65.9 ms | 29.9 ms | **2.21× / −54.7%** |
| ES phase, first request → last | 94.5 ms | 50.8 ms | **1.86× / −46.3%** |
| Database calls | 0 | 0 | 0 |
| Telemetry payload | — | — | **unchanged** |

Medians of 3 runs; the round-trip count was identical across every run on each side.

The trace makes the fanout explicit. Before — one request per index:

```
+25.2ms  datahub_usage_event          <- dau
+39.2ms  datahub_usage_event          <- wau
+46.6ms  datahub_usage_event          <- mau
+55.7ms  corpuserindex_v2             <- total users
+57.7ms  corpuserindex_v2             <- service accounts
+68.0ms  datasetindex_v2          |
+72.0ms  dashboardindex_v2        |   19 separate entity queries
   ...                            |
+110.4ms containerindex_v2        |
+114.7ms *index_v2                    <- platform chart
```

After — the same work in five:

```
+27.9ms  datahub_usage_event                                 <- dau + wau + mau, one filters agg
+48.3ms  corpuserindex_v2
+50.2ms  corpuserindex_v2
+59.6ms  datasetindex_v2,dashboardindex_v2,chartindex_v2,... <- all 19, one request
+65.1ms  *index_v2
```

**On what the latency numbers exclude.** The whole `DailyReport.dailyReport` span is not a useful comparison: it is dominated by a ~400 ms outbound HTTPS call to the telemetry endpoint inside `ping()`, which this change does not touch and which swamps the query work. The figures above cover the Elasticsearch phase only.

**Why 2× and not 5×.** Round trips collapse 5:1 but shard work does not — the 19-index aggregation scans the same shards the 19 separate queries did, and the cardinality aggregation over the usage index is the single most expensive item and survives in both. What is eliminated is 20 round trips plus their per-request overhead. A separate JVM-level run driving the same two query patterns against the same cluster independently reproduced this (38.4 ms → 19.3 ms, 1.99×).

**Functional correctness.** Both query patterns were run against the same live cluster and their results compared key by key: **24 keys, 0 mismatches** — the three active-user windows, every non-zero entity count, total users, service accounts and platform count. One reported type had zero documents on that instance and both paths omitted it, exercising the zero-count filtering on real data. At mock level `testDailyReportPayload` produces a byte-identical 28-key payload before and after (same md5), and the pre-batching run recording 25 searches confirms the query-count assertion is not vacuous.

**Database calls.** `dailyReport()`'s collection path issues none, before or after — `verifyNoInteractions(EntityService)` holds across the run, and no SQL spans appear between the first and last Elasticsearch call in any trace. The only primary-storage touch is `getClientId()`, in the constructor and in `ping()`; neither is modified here.

## Reproducing the measurement

`DailyReport` has no API surface and is gated behind `telemetry.enabledServer`, which the local stack forces off in two places — `docker/build.gradle` and `scripts/dev/datahub_dev.py`, the latter injecting `DATAHUB_TELEMETRY_ENABLED=false` into the environment it hands to `quickstartDebug`, where it outranks the compose interpolation. Setting `TELEMETRY_ENABLEDSERVER=true` reaches the property through Spring's relaxed binding without touching that tooling. No smoke test can reach this code, and enabling telemetry to benchmark it would break `smoke-test/tests/telemetry/telemetry_test.py`, which asserts the `telemetryClientId` aspect is absent — a condition that only holds while telemetry stays off.

Note also that Elasticsearch `_stats/search` `query_total` cannot show this improvement — it counts per-shard operations, so 19 single-index queries and one 19-index query both register 19 (verified directly against the cluster). The saving is entirely in round trips.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs — n/a, no user-facing surface change
- [ ] Updating DataHub — n/a, telemetry payload shape unchanged except the failure case noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
