### PR TITLE
feat(models): add docFreshnessInfo aspect for documentation-drift detection

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
@@ -1,0 +1,43 @@
+namespace com.linkedin.common
+
+/**
+ * Records when an entity's external documentation (agent context files, memory,
+ * runbooks) was last verified as accurate against the entity's actual state, so
+ * that drift in the entity or its lineage upstreams can flag that documentation
+ * as stale without the documentation itself ever changing.
+ */
+@Aspect = {
+  "name": "docFreshnessInfo"
+}
+record DocFreshnessInfo {
+
+  /**
+   * URNs (the documented entity itself, plus its lineage upstreams) that the
+   * documentation was checked against at the time of last verification.
+   */
+  verifiedAgainstUrns: array[Urn] = [ ]
+
+  /**
+   * Fingerprint hash of the entity's schema/ownership/deprecation state (and one
+   * hop of its lineage upstreams' state) captured when the documentation was last
+   * verified as accurate. Compared against the live fingerprint to detect drift.
+   */
+  verifiedAtVersion: string
+
+  /**
+   * When the documentation was last verified.
+   */
+  verifiedAtTime: Time
+
+  /**
+   * The user or agent URN that performed the verification.
+   */
+  actor: optional Urn
+
+  /**
+   * Human-readable explanation of why the documentation was flagged stale,
+   * including which upstream entity changed. Unset while the documentation is
+   * considered fresh.
+   */
+  staleReason: optional string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
@@ -21,9 +21,14 @@ record DocFreshnessInfo {
 
   /**
    * URNs (the documented entity itself, plus its lineage upstreams) that the
-   * documentation was checked against at the time of last verification. Always
-   * includes at least the documented entity itself — required, not defaulted,
-   * so a producer can't silently write a verification bound to nothing.
+   * documentation was checked against at the time of last verification. Should
+   * always include at least the documented entity itself — a verification that
+   * doesn't is meaningless. Required rather than defaulted so a producer has to
+   * explicitly decide what to put here instead of silently inheriting an empty
+   * list, but the schema alone can't guarantee non-emptiness or that the
+   * documented entity is actually included; producers are responsible for both,
+   * and a validator (see AspectPayloadValidator) would be needed to enforce it
+   * server-side.
    */
   @Searchable = {
     "/*": {

--- a/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/DocFreshnessInfo.pdl
@@ -5,6 +5,14 @@ namespace com.linkedin.common
  * runbooks) was last verified as accurate against the entity's actual state, so
  * that drift in the entity or its lineage upstreams can flag that documentation
  * as stale without the documentation itself ever changing.
+ *
+ * v1 scope: one verification record per entity, covering that entity's
+ * canonical documentation as a whole (the same granularity as the existing
+ * `documentation` aspect's own staleness would be judged at) — not one record
+ * per external document. An entity documented by multiple independent files
+ * shares a single freshness state; per-document tracking would need a
+ * document/source identifier added to this shape, deferred until there's a
+ * concrete use case for it.
  */
 @Aspect = {
   "name": "docFreshnessInfo"
@@ -13,14 +21,30 @@ record DocFreshnessInfo {
 
   /**
    * URNs (the documented entity itself, plus its lineage upstreams) that the
-   * documentation was checked against at the time of last verification.
+   * documentation was checked against at the time of last verification. Always
+   * includes at least the documented entity itself — required, not defaulted,
+   * so a producer can't silently write a verification bound to nothing.
    */
-  verifiedAgainstUrns: array[Urn] = [ ]
+  @Searchable = {
+    "/*": {
+      "fieldName": "docFreshnessVerifiedAgainstUrns",
+      "fieldType": "URN",
+      "queryByDefault": false,
+      "hasValuesFieldName": "hasDocFreshnessVerification",
+      "addHasValuesToFilters": true,
+    }
+  }
+  verifiedAgainstUrns: array[Urn]
 
   /**
    * Fingerprint hash of the entity's schema/ownership/deprecation state (and one
    * hop of its lineage upstreams' state) captured when the documentation was last
    * verified as accurate. Compared against the live fingerprint to detect drift.
+   * The hashing algorithm itself is producer-defined and not specified here —
+   * only a single producer's own fingerprints are meant to be compared against
+   * each other. A producer that changes its algorithm should treat that as a
+   * breaking change requiring every existing record to be re-verified, since an
+   * old and new fingerprint for identical state are not guaranteed to match.
    */
   verifiedAtVersion: string
 

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -57,6 +57,7 @@ entities:
       - logicalParent
       - assetSettings
       - documentation
+      - docFreshnessInfo
   - name: dataHubPolicy
     doc: DataHub Policies represent access policies granted to users or groups on metadata operations like edit, view etc.
     category: internal
@@ -92,6 +93,7 @@ entities:
       - testResults
       - dataTransformLogic
       - documentation
+      - docFreshnessInfo
   - name: dataFlow
     category: core
     keyAspect: dataFlowKey
@@ -118,6 +120,7 @@ entities:
       - subTypes
       - testResults
       - documentation
+      - docFreshnessInfo
   - name: dataProcess
     keyAspect: dataProcessKey
     aspects:

--- a/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
+++ b/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
@@ -1,0 +1,54 @@
+import logging
+from random import randint
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import DocFreshnessInfoClass
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utils import delete_urns
+
+logger = logging.getLogger(__name__)
+
+
+def test_doc_freshness_info_round_trips(graph_client):
+    dataset_urn = make_dataset_urn(
+        "hive", f"doc_freshness_smoke_test_{randint(10000, 99999)}"
+    )
+
+    try:
+        aspect = DocFreshnessInfoClass(
+            verifiedAgainstUrns=[dataset_urn],
+            verifiedAtVersion="abc123fingerprint",
+            verifiedAtTime=1785700000000,
+            actor="urn:li:corpuser:datahub",
+            staleReason=None,
+        )
+        graph_client.emit(
+            MetadataChangeProposalWrapper(entityUrn=dataset_urn, aspect=aspect)
+        )
+        wait_for_writes_to_sync()
+
+        fresh = graph_client.get_aspect(dataset_urn, DocFreshnessInfoClass)
+        assert fresh is not None
+        assert fresh.verifiedAgainstUrns == [dataset_urn]
+        assert fresh.verifiedAtVersion == "abc123fingerprint"
+        assert fresh.staleReason is None
+
+        stale_aspect = DocFreshnessInfoClass(
+            verifiedAgainstUrns=[dataset_urn],
+            verifiedAtVersion="abc123fingerprint",
+            verifiedAtTime=1785700000000,
+            actor="urn:li:corpuser:datahub",
+            staleReason="upstream schema changed",
+        )
+        graph_client.emit(
+            MetadataChangeProposalWrapper(entityUrn=dataset_urn, aspect=stale_aspect)
+        )
+        wait_for_writes_to_sync()
+
+        stale = graph_client.get_aspect(dataset_urn, DocFreshnessInfoClass)
+        assert stale is not None
+        assert stale.staleReason == "upstream schema changed"
+    finally:
+        delete_urns(graph_client, [dataset_urn])
+        wait_for_writes_to_sync()

--- a/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
+++ b/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
@@ -1,26 +1,25 @@
 import logging
-from random import randint
 
-from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import DocFreshnessInfoClass
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import delete_urns
+from tests.utils import delete_urns, unique_dataset_urn
 
 logger = logging.getLogger(__name__)
 
+VERIFIED_AT_TIME = 1785700000000
+ACTOR = "urn:li:corpuser:datahub"
+
 
 def test_doc_freshness_info_round_trips(graph_client):
-    dataset_urn = make_dataset_urn(
-        "hive", f"doc_freshness_smoke_test_{randint(10000, 99999)}"
-    )
+    dataset_urn = unique_dataset_urn("doc_freshness_smoke_test", platform="hive")
 
     try:
         aspect = DocFreshnessInfoClass(
             verifiedAgainstUrns=[dataset_urn],
             verifiedAtVersion="abc123fingerprint",
-            verifiedAtTime=1785700000000,
-            actor="urn:li:corpuser:datahub",
+            verifiedAtTime=VERIFIED_AT_TIME,
+            actor=ACTOR,
             staleReason=None,
         )
         graph_client.emit(
@@ -32,13 +31,15 @@ def test_doc_freshness_info_round_trips(graph_client):
         assert fresh is not None
         assert fresh.verifiedAgainstUrns == [dataset_urn]
         assert fresh.verifiedAtVersion == "abc123fingerprint"
+        assert fresh.verifiedAtTime == VERIFIED_AT_TIME
+        assert fresh.actor == ACTOR
         assert fresh.staleReason is None
 
         stale_aspect = DocFreshnessInfoClass(
             verifiedAgainstUrns=[dataset_urn],
             verifiedAtVersion="abc123fingerprint",
-            verifiedAtTime=1785700000000,
-            actor="urn:li:corpuser:datahub",
+            verifiedAtTime=VERIFIED_AT_TIME,
+            actor=ACTOR,
             staleReason="upstream schema changed",
         )
         graph_client.emit(
@@ -48,6 +49,10 @@ def test_doc_freshness_info_round_trips(graph_client):
 
         stale = graph_client.get_aspect(dataset_urn, DocFreshnessInfoClass)
         assert stale is not None
+        assert stale.verifiedAgainstUrns == [dataset_urn]
+        assert stale.verifiedAtVersion == "abc123fingerprint"
+        assert stale.verifiedAtTime == VERIFIED_AT_TIME
+        assert stale.actor == ACTOR
         assert stale.staleReason == "upstream schema changed"
     finally:
         delete_urns(graph_client, [dataset_urn])

--- a/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
+++ b/smoke-test/tests/doc_freshness/test_doc_freshness_info.py
@@ -3,7 +3,7 @@ import logging
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import DocFreshnessInfoClass
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import delete_urns, unique_dataset_urn
+from tests.utils import delete_urns, unique_dataset_urn, with_test_retry
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +34,28 @@ def test_doc_freshness_info_round_trips(graph_client):
         assert fresh.verifiedAtTime == VERIFIED_AT_TIME
         assert fresh.actor == ACTOR
         assert fresh.staleReason is None
+
+        # Exercise the @Searchable annotation itself, not just the raw aspect
+        # read above: this is the actual reverse-lookup query the annotation
+        # exists for ("which docs point at this entity"), not a proxy for it.
+        @with_test_retry(max_attempts=15)
+        def _assert_indexed_for_reverse_lookup() -> None:
+            urns = list(
+                graph_client.get_urns_by_filter(
+                    extraFilters=[
+                        {
+                            "field": "docFreshnessVerifiedAgainstUrns",
+                            "negated": False,
+                            "condition": "EQUAL",
+                            "values": [dataset_urn],
+                        }
+                    ],
+                    skip_cache=True,
+                )
+            )
+            assert urns == [dataset_urn]
+
+        _assert_indexed_for_reverse_lookup()
 
         stale_aspect = DocFreshnessInfoClass(
             verifiedAgainstUrns=[dataset_urn],


### PR DESCRIPTION
## Summary

Adds a new `docFreshnessInfo` aspect (`dataset`, `dataJob`, `dataFlow`) that
records when an entity's *external* documentation — an agent's `CLAUDE.md`,
a runbook, memory a coding agent maintains — was last verified as accurate
against the entity's actual state. The idea: nothing today ties a piece of
documentation to the state it was written against, so nothing can compute
"this doc is now stale because the entity (or its lineage upstream) changed."

This is a small, additive proposal — not a merge-ready feature. It's the
model layer for [docFreshness](https://github.com/prats-2311/docfreshness), a
tool I built for the DataHub hackathon that currently stores this same
information as Structured Properties (works today, no schema changes
needed). This PR is what first-class support would look like, submitted
separately so it can get real feedback on the shape before anything bigger
is built on top of it.

## Why this shape — a concrete example

Say a doc claims: *"`revenue_summary` is built from `orders` and
`customers`."* Someone renames a column on `orders`. DataHub's Timeline
records that perfectly — but nothing connects it back to the doc that's now
wrong, even though the doc never mentions `orders` by name.

`docFreshnessInfo` closes that gap: `verifiedAgainstUrns` captures the
entity *plus one hop of its lineage upstreams* at verification time, and
`verifiedAtVersion` is a fingerprint of their combined schema/ownership/
deprecation state. When `orders` changes, re-checking that fingerprint flips
the doc to stale — `staleReason` says why — without ever touching or
re-scanning the doc text itself. That's the one piece existing aspects
(`documentation`, `institutionalMemory`) don't capture: a binding between a
doc and the *state* it was written against.

## What's here

- `DocFreshnessInfo.pdl`: `verifiedAgainstUrns`, `verifiedAtVersion`,
  `verifiedAtTime`, `actor`, `staleReason`
- Registered on `dataset`, `dataJob`, `dataFlow` in `entity-registry.yml`
- A smoke test (`smoke-test/tests/doc_freshness/test_doc_freshness_info.py`)
  that emits the aspect on a live GMS instance built from this branch, reads
  it back, updates it to a stale state, reads that back too — a genuine
  round-trip, not just a compile check.

## What's intentionally not here

- GraphQL surfacing (no resolver/type mapping yet — nothing reads this via
  the API/UI today)
- No producer wiring into any ingestion source
- No `Constants.java` entry

Happy to scope this down further, rename fields, or fold it into an existing
aspect if that's a better fit — posting it now mainly to get the conversation
started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `docFreshnessInfo` aspect to record when external docs were last verified and flag them as stale when the entity or its upstreams change. Adds a reverse-lookup index and a smoke test that covers round-trip and search; registered on `dataset`, `dataJob`, and `dataFlow`.

- New PDL `DocFreshnessInfo` with fields: `verifiedAgainstUrns`, `verifiedAtVersion`, `verifiedAtTime`, `actor`, `staleReason`.
- `verifiedAgainstUrns` is required (no default) and indexed via `@Searchable` for reverse lookup; producers must ensure non-empty and inclusion of the documented entity (server-side validation would enforce).
- Smoke test validates fresh→stale round-trip, uses `unique_dataset_urn`, asserts all fields, and exercises the reverse-lookup search filter.
- Model-only; no GraphQL, UI, or ingestion wiring yet.

<sup>Written for commit 3b5590c6e84d082a4334c31e53769fd21c3db155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

