### PR TITLE
docs: add Windows quickstart commands

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ Want a fully managed DataHub? **[Try DataHub Cloud free](https://datahub.com/fre
 
 - **Launch the Docker engine** from command line or the desktop app.
 - Ensure you have **Python 3.10 or 3.11** installed and configured. Check with `python3 --version` on macOS/Linux or
-  `py --version` on Windows.
+  `py -3.11 --version` on Windows. If you installed Python 3.10, use `py -3.10 --version` instead.
 
 :::note Docker Resource Allocation
 
@@ -68,15 +68,18 @@ Note that DataHub CLI does not support Python 2.x.
 <TabItem value="pip-windows" label="pip (Windows)">
 
 ```powershell
-py -m pip install --upgrade pip wheel setuptools
-py -m pip install --upgrade acryl-datahub
-py -m datahub version
+py -3.11 -m pip install --upgrade pip wheel setuptools
+py -3.11 -m pip install --upgrade acryl-datahub
+py -3.11 -m datahub version
 ```
 
 :::note Command Not Found
 
-The Windows Python installer includes the `py` launcher. If `py` is unavailable, replace it with `python` in the
-commands above.
+The Windows Python installer includes the `py` launcher. Use `py -3.10` instead if Python 3.10 is installed. If `py`
+is unavailable, replace `py -3.11` with the command that runs your Python 3.10 or 3.11 installation.
+
+For the rest of this guide, Windows pip users can replace each `datahub` command with `py -3.11 -m datahub` (or
+`py -3.10 -m datahub`). This also works when the Python Scripts directory is not on `PATH`.
 
 :::
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,8 @@ Want a fully managed DataHub? **[Try DataHub Cloud free](https://datahub.com/fre
   | Linux    | [Docker for Linux](https://docs.docker.com/desktop/install/linux-install/) and [Docker Compose](https://docs.docker.com/compose/install/linux/) |
 
 - **Launch the Docker engine** from command line or the desktop app.
-- Ensure you have **Python 3.10+** installed & configured. (Check using `python3 --version`).
+- Ensure you have **Python 3.10 or 3.11** installed and configured. Check with `python3 --version` on macOS/Linux or
+  `py --version` on Windows.
 
 :::note Docker Resource Allocation
 
@@ -48,7 +49,7 @@ Homebrew manages an isolated Python environment for `datahub`, so there's no ven
 ```
 
 </TabItem>
-<TabItem value="pip" label="pip">
+<TabItem value="pip-unix" label="pip (macOS/Linux)">
 
 ```bash
 python3 -m pip install --upgrade pip wheel setuptools
@@ -60,6 +61,22 @@ datahub version
 
 If you see `command not found`, try running cli commands like `python3 -m datahub version`. <br />
 Note that DataHub CLI does not support Python 2.x.
+
+:::
+
+</TabItem>
+<TabItem value="pip-windows" label="pip (Windows)">
+
+```powershell
+py -m pip install --upgrade pip wheel setuptools
+py -m pip install --upgrade acryl-datahub
+py -m datahub version
+```
+
+:::note Command Not Found
+
+The Windows Python installer includes the `py` launcher. If `py` is unavailable, replace it with `python` in the
+commands above.
 
 :::
 
@@ -157,7 +174,10 @@ Once DataHub is running, use the commands below to manage your local instance. T
 
 By default, DataHub generates a random signing key and salt for authentication tokens on first run and reuses them on later runs (saved to `~/.datahub/quickstart/.local-secrets.env`). Most users don't need to change this.
 
-If you want tokens to stay stable across environments, set your own values **before** running `datahub docker quickstart`:
+If you want tokens to stay stable across environments, set your own values **before** running `datahub docker quickstart`.
+
+<Tabs>
+<TabItem value="signing-key-unix" label="macOS/Linux">
 
 ```bash
 export DATAHUB_TOKEN_SERVICE_SIGNING_KEY=<value>
@@ -165,6 +185,28 @@ export DATAHUB_TOKEN_SERVICE_SALT=<value>
 ```
 
 Generate a value with `openssl rand -base64 32`.
+
+</TabItem>
+<TabItem value="signing-key-windows" label="Windows PowerShell">
+
+```powershell
+function New-DataHubSecret {
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $bytes = New-Object byte[] 32
+        $rng.GetBytes($bytes)
+        [Convert]::ToBase64String($bytes)
+    } finally {
+        $rng.Dispose()
+    }
+}
+
+$env:DATAHUB_TOKEN_SERVICE_SIGNING_KEY = New-DataHubSecret
+$env:DATAHUB_TOKEN_SERVICE_SALT = New-DataHubSecret
+```
+
+</TabItem>
+</Tabs>
 
 If upgrading from a CLI older than v1.5: the signing key is now generated randomly instead of using a hardcoded default, so any personal access tokens (PATs) created before upgrading are invalidated and must be regenerated.
 


### PR DESCRIPTION
## Summary

- add Windows-specific `py` / `python` commands to the pip quickstart
- align the documented Python range with the CLI's current 3.11 recommendation
- add a PowerShell-native way to generate and set the signing key and salt

## Reproduction

On Windows 10 with PowerShell 5.1, the current cross-platform quickstart has three dead ends:

- `python3 --version` exits 9009 while `py --version` succeeds
- `export ...` is not a PowerShell command
- `openssl` is not present in a default Python/Docker Desktop setup

`acryl-datahub==1.7.0` also warns on Python 3.13 that versions above 3.11 are not actively tested. This is related to #18819.

## Test plan

- `git diff --check`
- installed `acryl-datahub==1.7.0` in a fresh Windows venv and ran `python -m datahub version`
- ran the documented PowerShell helper and verified it generated two distinct, valid 32-byte Base64 values

The repository Markdown formatter could not run locally because Java is not installed; CI should provide the final formatting check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Windows-specific quickstart commands with clear `py` launcher guidance and a PowerShell method to set secrets. Updates Python support to 3.10–3.11 to match the CLI and remove common Windows setup dead ends.

- **New Features**
  - Windows pip steps use `py -3.11` (or `-3.10`), with a fallback if `py` is missing; recommends `py -3.x -m datahub` to avoid PATH issues.
  - OS-specific install tabs and version checks (`python3` on macOS/Linux, `py -3.x` on Windows).
  - PowerShell-native secret generation for `DATAHUB_TOKEN_SERVICE_SIGNING_KEY` and `DATAHUB_TOKEN_SERVICE_SALT` (no `openssl`).

<sup>Written for commit a2e551447da29d135d939e8d088cc4d35479a868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

