### PR TITLE
fix(cli): datapack --help crashes for non-TTY callers (CI/scripts/agents) when agent-context resource is missing

### DIFF
--- a/metadata-ingestion/src/datahub/cli/datapack/datapack_cli.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/datapack_cli.py
@@ -30,13 +30,33 @@ class _DatapackGroup(click.Group):
         super().format_help(ctx, formatter)
         formatter.write(f"\n{_EXPERIMENTAL_NOTICE}\n")
         if not sys.stdout.isatty():
-            agent_text = (
+            agent_text = self._read_agent_context()
+            if agent_text is not None:
+                formatter.write("\n")
+                formatter.write(agent_text)
+
+    @staticmethod
+    def _read_agent_context() -> Optional[str]:
+        """Best-effort read of the bundled agent-context doc.
+
+        This resource is optional supplementary text for non-interactive
+        callers (CI, scripts, agents) -- if it's missing from the installed
+        package (e.g. a packaging gap for a given release), that must not
+        break `--help` for exactly the callers who can't handle a crash.
+        """
+        try:
+            return (
                 importlib.resources.files("datahub.cli.datapack.resources")
                 .joinpath("DATAPACK_AGENT_CONTEXT.md")
                 .read_text(encoding="utf-8")
             )
-            formatter.write("\n")
-            formatter.write(agent_text)
+        except (FileNotFoundError, ModuleNotFoundError, OSError):
+            logger.debug(
+                "DATAPACK_AGENT_CONTEXT.md not found in the installed package; "
+                "omitting it from --help output.",
+                exc_info=True,
+            )
+            return None
 
     def invoke(self, ctx: click.Context) -> object:
         if ctx.invoked_subcommand:


### PR DESCRIPTION
## What's broken

`datahub datapack --help` crashes with `FileNotFoundError` for any non-interactive caller (piped output, CI, scripts, AI agents) -- but works fine for a human running it directly in a terminal, which is why this hasn't been noticed:

```
pip install acryl-datahub==1.7.0
datahub datapack --help | cat
```

```
Traceback (most recent call last):
  ...
  File ".../datahub/cli/datapack/datapack_cli.py", line 36, in format_help
    .read_text(encoding="utf-8")
FileNotFoundError: [Errno 2] No such file or directory: '.../datahub/cli/datapack/resources/DATAPACK_AGENT_CONTEXT.md'
```

`_DatapackGroup.format_help()` only reads `resources/DATAPACK_AGENT_CONTEXT.md` when `sys.stdout.isatty()` is `False` -- so a normal interactive user never hits this branch, and the crash only ever shows up for the exact callers who can least afford it (CI pipelines, wrapper scripts, agents piping `--help` for context).

The underlying resource file is missing from the installed package. I checked both `acryl-datahub==1.6.0.6` and `1.7.0` from PyPI -- the file simply isn't in `site-packages/datahub/cli/datapack/resources/` in either. (`resources/registry.json` has the same problem, but it's currently masked because `registry.py`'s `fetch_registry()` tries a remote URL before falling back to the bundled copy -- so it only breaks offline. `datapack --help` has no such fallback.)

## Fix

`_DatapackGroup.format_help()` now wraps the resource read in try/except and falls back to omitting the agent-context section instead of crashing, logging at debug level. This doesn't fix the packaging gap itself (I wasn't able to pin down why this particular resource is excluded from the wheel -- didn't find `package_data`/`MANIFEST.in` entries governing it, might be worth a maintainer's eye), but it means a gap like this in any resource file degrades `--help` gracefully instead of taking down the whole command for non-interactive callers.

## Test plan

- [x] Reproduced the crash against `acryl-datahub==1.7.0` from PyPI (`datahub datapack --help | cat`)
- [x] Confirmed the file is absent from both `1.6.0.6` and `1.7.0` wheels
- [x] With the fix applied, `datahub datapack --help | cat` exits 0 and prints the standard help + experimental notice (agent-context section omitted, as expected when the resource is missing)
- [x] `datahub datapack --help` run directly in a terminal (TTY) is unaffected -- never took this code path either way
- [x] If the resource *is* present (e.g. `pip install -e .` from source), behavior is unchanged -- agent-context text still appends normally


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when running `datahub datapack --help` in non-TTY contexts by handling a missing `DATAPACK_AGENT_CONTEXT.md` gracefully. Non-interactive callers now get help output without errors; TTY behavior is unchanged.

- **Bug Fixes**
  - Read agent-context via `_read_agent_context()`; on missing/OS errors, skip the section and log at debug.
  - Prevents `FileNotFoundError` for CI/scripts/agents when wheels omit the resource; `--help` exits 0.

<sup>Written for commit 0eb3fbf980a7f1f5501bc4de0628b354a475e626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

