### PR TITLE
feat(sdk): add get_documents_by_asset to DataHubGraph

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1416,38 +1416,144 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         start: int = 0,
         count: int = 20,
     ) -> Iterable[str]:
-        """
-        Yields Document URNs connected to the provided data asset via native Context Documents.
-        """
-        params: dict = {
-            "input": {
-                "start": start,
-                "count": count,
-                "relatedAssets": [urn],
-            }
+        query = """
+        fragment relatedDocumentsFields on RelatedDocumentsResult {
+          start
+          count
+          total
+          documents {
+            urn
+          }
         }
-        query: str = """
-            query searchDocuments($input: SearchDocumentsInput!) {
-              searchDocuments(input: $input) {
-                total
-                documents {
-                  urn
-                }
+
+        query getRelatedDocuments(
+          $urn: String!,
+          $input: RelatedDocumentsInput!
+        ) {
+          entity(urn: $urn) {
+            ... on Dataset {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
               }
             }
+            ... on Dashboard {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on Chart {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on DataJob {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on DataFlow {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on Container {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on MLModel {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on MLModelGroup {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on MLPrimaryKey {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on MLFeature {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on MLFeatureTable {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on DataProduct {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on Domain {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on GlossaryTerm {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on GlossaryNode {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+            ... on Application {
+              relatedDocuments(input: $input) {
+                ...relatedDocumentsFields
+              }
+            }
+          }
+        }
         """
 
-        while True:
-            response = self.execute_graphql(query, variables=params)
-            payload = response.get("searchDocuments", {})
-            documents = payload.get("documents", [])
-            for doc in documents:
-                if "urn" in doc:
-                    yield doc["urn"]
+        next_start = start
 
-            if not documents:
+        while True:
+            # IMPORTANT: construct a NEW dict every iteration.
+            # Don't mutate one dict because that's exactly what broke the current test.
+            variables = {
+                "urn": urn,
+                "input": {
+                    "start": next_start,
+                    "count": count,
+                },
+            }
+
+            response = self.execute_graphql(query, variables=variables)
+
+            entity = response.get("entity")
+            if not entity:
                 break
-            params["input"]["start"] += len(documents)
+
+            result = entity.get("relatedDocuments")
+            if not result:
+                break
+
+            documents = result.get("documents") or []
+
+            for document in documents:
+                document_urn = document.get("urn")
+                if document_urn:
+                    yield document_urn
+
+            returned = len(documents)
+            if returned == 0:
+                break
+
+            next_start += returned
+
+            total = result.get("total")
+            if isinstance(total, int) and next_start >= total:
+                break
 
     def execute_graphql(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1410,6 +1410,45 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         results = self._post_generic(self._aspect_count_endpoint, args)
         return results["value"]
 
+    def get_documents_by_asset(
+        self,
+        urn: str,
+        start: int = 0,
+        count: int = 20,
+    ) -> Iterable[str]:
+        """
+        Yields Document URNs connected to the provided data asset via native Context Documents.
+        """
+        params: dict = {
+            "input": {
+                "start": start,
+                "count": count,
+                "relatedAssets": [urn],
+            }
+        }
+        query: str = """
+            query searchDocuments($input: SearchDocumentsInput!) {
+              searchDocuments(input: $input) {
+                total
+                documents {
+                  urn
+                }
+              }
+            }
+        """
+
+        while True:
+            response = self.execute_graphql(query, variables=params)
+            payload = response.get("searchDocuments", {})
+            documents = payload.get("documents", [])
+            for doc in documents:
+                if "urn" in doc:
+                    yield doc["urn"]
+
+            if not documents:
+                break
+            params["input"]["start"] += len(documents)
+
     def execute_graphql(
         self,
         query: str,

--- a/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
@@ -162,16 +162,19 @@ class TestGetEntityAspectSpecs:
         assert session2.request.call_count == 0
 
 class TestGetDocumentsByAsset:
-    def test_fetches_and_yields_urns(self) -> None:
+    def test_get_documents_by_asset_paginates(self) -> None:
         session = MagicMock()
         graph = _graph(session)
+        dataset_urn = "urn:li:dataset:test"
         
         page1 = MagicMock()
         page1.json.return_value = {
             "data": {
-                "searchDocuments": {
-                    "total": 3,
-                    "documents": [{"urn": "urn:li:document:1"}, {"urn": "urn:li:document:2"}]
+                "entity": {
+                    "relatedDocuments": {
+                        "total": 2,
+                        "documents": [{"urn": "urn:li:document:doc1"}]
+                    }
                 }
             }
         }
@@ -180,28 +183,103 @@ class TestGetDocumentsByAsset:
         page2 = MagicMock()
         page2.json.return_value = {
             "data": {
-                "searchDocuments": {
-                    "total": 3,
-                    "documents": [{"urn": "urn:li:document:3"}]
+                "entity": {
+                    "relatedDocuments": {
+                        "total": 2,
+                        "documents": [{"urn": "urn:li:document:doc2"}]
+                    }
                 }
             }
         }
         page2.raise_for_status.return_value = None
 
-        page3 = MagicMock()
-        page3.json.return_value = {
+        session.post.side_effect = [page1, page2]
+        
+        docs = list(graph.get_documents_by_asset(dataset_urn, count=1))
+        
+        assert docs == [
+            "urn:li:document:doc1",
+            "urn:li:document:doc2",
+        ]
+        
+        # Verify query semantics
+        query_str = session.post.call_args_list[0][1]["json"]["query"]
+        assert "relatedDocuments" in query_str
+        assert "entity(urn: $urn)" in query_str
+        assert "searchDocuments" not in query_str
+
+        # Verify pagination variables were correct
+        captured_variables = [call[1]["json"]["variables"] for call in session.post.call_args_list]
+        assert captured_variables == [
+            {
+                "urn": dataset_urn,
+                "input": {"start": 0, "count": 1},
+            },
+            {
+                "urn": dataset_urn,
+                "input": {"start": 1, "count": 1},
+            },
+        ]
+
+    def test_get_documents_by_asset_empty(self) -> None:
+        session = MagicMock()
+        graph = _graph(session)
+        
+        page1 = MagicMock()
+        page1.json.return_value = {
             "data": {
-                "searchDocuments": {
-                    "total": 3,
-                    "documents": []
+                "entity": {
+                    "relatedDocuments": {
+                        "total": 0,
+                        "documents": []
+                    }
                 }
             }
         }
-        page3.raise_for_status.return_value = None
-
-        session.post.side_effect = [page1, page2, page3]
+        page1.raise_for_status.return_value = None
+        session.post.side_effect = [page1]
         
-        urns = list(graph.get_documents_by_asset("urn:li:dataset:test", count=2))
-        assert urns == ["urn:li:document:1", "urn:li:document:2", "urn:li:document:3"]
-        assert session.post.call_count == 3
+        docs = list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
+        assert docs == []
 
+    def test_get_documents_by_asset_missing_entity(self) -> None:
+        session = MagicMock()
+        graph = _graph(session)
+        
+        page1 = MagicMock()
+        # DataHub returns null for entity if not found
+        page1.json.return_value = {
+            "data": {
+                "entity": None
+            }
+        }
+        page1.raise_for_status.return_value = None
+        session.post.side_effect = [page1]
+        
+        docs = list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
+        assert docs == []
+
+    def test_get_documents_by_asset_uses_related_documents_query(self) -> None:
+        session = MagicMock()
+        graph = _graph(session)
+        
+        page1 = MagicMock()
+        page1.json.return_value = {
+            "data": {
+                "entity": {
+                    "relatedDocuments": {
+                        "total": 0,
+                        "documents": []
+                    }
+                }
+            }
+        }
+        page1.raise_for_status.return_value = None
+        session.post.side_effect = [page1]
+        
+        list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
+        query_str = session.post.call_args_list[0][1]["json"]["query"]
+        
+        assert "relatedDocuments" in query_str
+        assert "entity(urn: $urn)" in query_str
+        assert "searchDocuments" not in query_str

--- a/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
@@ -160,3 +160,48 @@ class TestGetEntityAspectSpecs:
         specs2 = _graph(session2).get_entity_aspect_specs()
         assert specs2 is not None and specs2.supports("dataset", "status")
         assert session2.request.call_count == 0
+
+class TestGetDocumentsByAsset:
+    def test_fetches_and_yields_urns(self) -> None:
+        session = MagicMock()
+        graph = _graph(session)
+        
+        page1 = MagicMock()
+        page1.json.return_value = {
+            "data": {
+                "searchDocuments": {
+                    "total": 3,
+                    "documents": [{"urn": "urn:li:document:1"}, {"urn": "urn:li:document:2"}]
+                }
+            }
+        }
+        page1.raise_for_status.return_value = None
+        
+        page2 = MagicMock()
+        page2.json.return_value = {
+            "data": {
+                "searchDocuments": {
+                    "total": 3,
+                    "documents": [{"urn": "urn:li:document:3"}]
+                }
+            }
+        }
+        page2.raise_for_status.return_value = None
+
+        page3 = MagicMock()
+        page3.json.return_value = {
+            "data": {
+                "searchDocuments": {
+                    "total": 3,
+                    "documents": []
+                }
+            }
+        }
+        page3.raise_for_status.return_value = None
+
+        session.post.side_effect = [page1, page2, page3]
+        
+        urns = list(graph.get_documents_by_asset("urn:li:dataset:test", count=2))
+        assert urns == ["urn:li:document:1", "urn:li:document:2", "urn:li:document:3"]
+        assert session.post.call_count == 3
+

--- a/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/ingestion/graph/test_client.py
@@ -193,7 +193,7 @@ class TestGetDocumentsByAsset:
         }
         page2.raise_for_status.return_value = None
 
-        session.post.side_effect = [page1, page2]
+        session.request.side_effect = [page1, page2]
         
         docs = list(graph.get_documents_by_asset(dataset_urn, count=1))
         
@@ -203,13 +203,13 @@ class TestGetDocumentsByAsset:
         ]
         
         # Verify query semantics
-        query_str = session.post.call_args_list[0][1]["json"]["query"]
+        query_str = session.request.call_args_list[0][1]["json"]["query"]
         assert "relatedDocuments" in query_str
         assert "entity(urn: $urn)" in query_str
         assert "searchDocuments" not in query_str
 
         # Verify pagination variables were correct
-        captured_variables = [call[1]["json"]["variables"] for call in session.post.call_args_list]
+        captured_variables = [call[1]["json"]["variables"] for call in session.request.call_args_list]
         assert captured_variables == [
             {
                 "urn": dataset_urn,
@@ -237,7 +237,7 @@ class TestGetDocumentsByAsset:
             }
         }
         page1.raise_for_status.return_value = None
-        session.post.side_effect = [page1]
+        session.request.side_effect = [page1]
         
         docs = list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
         assert docs == []
@@ -254,7 +254,7 @@ class TestGetDocumentsByAsset:
             }
         }
         page1.raise_for_status.return_value = None
-        session.post.side_effect = [page1]
+        session.request.side_effect = [page1]
         
         docs = list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
         assert docs == []
@@ -275,10 +275,10 @@ class TestGetDocumentsByAsset:
             }
         }
         page1.raise_for_status.return_value = None
-        session.post.side_effect = [page1]
+        session.request.side_effect = [page1]
         
         list(graph.get_documents_by_asset("urn:li:dataset:test", count=20))
-        query_str = session.post.call_args_list[0][1]["json"]["query"]
+        query_str = session.request.call_args_list[0][1]["json"]["query"]
         
         assert "relatedDocuments" in query_str
         assert "entity(urn: $urn)" in query_str

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -121,3 +121,35 @@ def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() ->
             )
 
     assert mock_execute_graphql.call_count == 1
+
+
+def test_get_documents_by_asset() -> None:
+    graph = DataHubGraph(DatahubClientConfig(server="http://fake-domain.local"))
+
+    with patch.object(
+        graph,
+        "execute_graphql",
+        side_effect=[
+            {
+                "searchDocuments": {
+                    "documents": [{"urn": "urn:li:document:doc1"}],
+                    "total": 1,
+                }
+            },
+            {
+                "searchDocuments": {
+                    "documents": [],
+                    "total": 1,
+                }
+            },
+        ],
+    ) as mock_execute_graphql:
+        docs = list(graph.get_documents_by_asset("urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"))
+
+    assert docs == ["urn:li:document:doc1"]
+    assert mock_execute_graphql.call_count == 2
+    query = mock_execute_graphql.call_args_list[0].kwargs["query"]
+    variables = mock_execute_graphql.call_args_list[0].kwargs["variables"]
+    assert "searchDocuments" in query
+    assert variables["input"]["relatedAssets"] == ["urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"]
+    assert variables["input"]["start"] == 0

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -123,33 +123,4 @@ def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() ->
     assert mock_execute_graphql.call_count == 1
 
 
-def test_get_documents_by_asset() -> None:
-    graph = DataHubGraph(DatahubClientConfig(server="http://fake-domain.local"))
 
-    with patch.object(
-        graph,
-        "execute_graphql",
-        side_effect=[
-            {
-                "searchDocuments": {
-                    "documents": [{"urn": "urn:li:document:doc1"}],
-                    "total": 1,
-                }
-            },
-            {
-                "searchDocuments": {
-                    "documents": [],
-                    "total": 1,
-                }
-            },
-        ],
-    ) as mock_execute_graphql:
-        docs = list(graph.get_documents_by_asset("urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"))
-
-    assert docs == ["urn:li:document:doc1"]
-    assert mock_execute_graphql.call_count == 2
-    query = mock_execute_graphql.call_args_list[0].kwargs["query"]
-    variables = mock_execute_graphql.call_args_list[0].kwargs["variables"]
-    assert "searchDocuments" in query
-    assert variables["input"]["relatedAssets"] == ["urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"]
-    assert variables["input"]["start"] == 0


### PR DESCRIPTION
## Description

Added get_documents_by_asset to the DataHubGraph client to natively fetch Context Documents linked to an asset URN.

## Testing
- [x] Added unit tests for the new method.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `get_documents_by_asset` to `DataHubGraph` to fetch document URNs linked to an asset via GraphQL `relatedDocuments`. Provides a simple, paginated API for retrieving context documents.

- New Features
  - `DataHubGraph.get_documents_by_asset(urn, start=0, count=20)` yields related document URNs using `entity(urn: $urn).relatedDocuments` with start/count pagination until total.
  - Unit tests cover pagination, empty/missing entity cases, query shape, and variable sequencing.

- Bug Fixes
  - Deduplicated a test and corrected test mocks to avoid false failures.

<sup>Written for commit 23ffa9823b05ac63928a8c9f6ac5c29d13e38b14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

