### PR TITLE
docs(agent-context): document mutation tool contracts

### DIFF
--- a/datahub-agent-context/README.md
+++ b/datahub-agent-context/README.md
@@ -1,17 +1,15 @@
-<!-- PyPI long description. Keep concise, feature-discovery-first. -->
-
 # DataHub Agent Context
 
 **MCP tools for AI agents to search and query your DataHub metadata catalog** — works with Claude, Cursor, Copilot, and any MCP-compatible AI assistant.
 
 ## What you can do
 
-- **Search** datasets, dashboards, pipelines, and other data assets by name or description
-- **Retrieve entity details** — schema, lineage, ownership, tags, glossary terms, and more
-- **Trace lineage** upstream and downstream across your data assets
-- **Mutate metadata** — update descriptions, tags, owners, domains, and glossary terms
-- **Build LangChain or Google ADK agents** with pre-built tool bindings
-- **Set up Snowflake AI agents** with one CLI command
+* **Search** datasets, dashboards, pipelines, and other data assets by name or description
+* **Retrieve entity details** — schema, lineage, ownership, tags, glossary terms, and more
+* **Trace lineage** upstream and downstream across your data assets
+* **Mutate metadata** — update descriptions, tags, owners, domains, and glossary terms
+* **Build LangChain or Google ADK agents** with pre-built tool bindings
+* **Set up Snowflake AI agents** with one CLI command
 
 ## Installation
 
@@ -40,6 +38,7 @@ tools = build_langchain_tools(client, include_mutations=True)
 
 # DataHub Cloud: add Ask DataHub AI assistant
 from datahub_agent_context.langchain_tools import build_langchain_cloud_tools
+
 tools += build_langchain_cloud_tools(client, ask_datahub=True)
 ```
 
@@ -64,6 +63,49 @@ datahub agent create snowflake \
 **Mutations** — `add_tags()`, `remove_tags()`, `update_description()`, `set_domains()`, `add_owners()`, `add_glossary_terms()`, `add_structured_properties()`, `save_document()`
 
 **Cloud-only** — `ask_datahub_chat()` (DataHub Cloud AI assistant)
+
+## Mutation tools
+
+Mutation tools can be included when building an agent with
+`include_mutations=True`.
+
+| Tool                           | Required arguments                            | Optional arguments                        |
+| ------------------------------ | --------------------------------------------- | ----------------------------------------- |
+| `add_tags`                     | `tag_urns`, `entity_urns`                     | `column_paths`                            |
+| `remove_tags`                  | `tag_urns`, `entity_urns`                     | `column_paths`                            |
+| `update_description`           | `entity_urn`                                  | `operation`, `description`, `column_path` |
+| `add_owners`                   | `owner_urns`, `entity_urns`, `ownership_type` | —                                         |
+| `remove_owners`                | `owner_urns`, `entity_urns`                   | —                                         |
+| `set_domains`                  | `domain_urn`, `entity_urns`                   | —                                         |
+| `remove_domains`               | `entity_urns`                                 | —                                         |
+| `add_structured_properties`    | `property_values`, `entity_urns`              | —                                         |
+| `remove_structured_properties` | `property_urns`, `entity_urns`                | —                                         |
+| `add_glossary_terms`           | `term_urns`, `entity_urns`                    | `column_paths`                            |
+| `remove_glossary_terms`        | `term_urns`, `entity_urns`                    | `column_paths`                            |
+
+### Examples
+
+Add tags:
+
+```python
+add_tags(
+    tag_urns=["urn:li:tag:PII"],
+    entity_urns=["urn:li:dataset:(...)"],
+)
+```
+
+Add structured properties:
+
+```python
+add_structured_properties(
+    property_values={
+        "urn:li:structuredProperty:example": ["HIGH"]
+    },
+    entity_urns=["urn:li:dataset:(...)"],
+)
+```
+
+For structured properties, `property_values` maps property URNs to lists of values.
 
 ## Links
 


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [✓ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ https://github.com/datahub-project/datahub/issues/19006] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents mutation tools in the Agent Context README by adding a table of tool contracts (required/optional args) and Python examples for adding tags and structured properties. Also cleans up minor list formatting in the features section.

<sup>Written for commit 7615e8e892144585deae26ba62e650cbf2ef8d52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

