### PR TITLE
fix(agent-context): read existing description for all supported entity types

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
@@ -66,6 +66,11 @@ def _get_existing_description(entity_urn: str, column_path: Optional[str]) -> st
                         description
                     }
                 }
+                ... on MLFeature {
+                    editableProperties {
+                        description
+                    }
+                }
                 ... on MLPrimaryKey {
                     editableProperties {
                         description
@@ -87,6 +92,31 @@ def _get_existing_description(entity_urn: str, column_path: Optional[str]) -> st
                     }
                 }
                 ... on Domain {
+                    properties {
+                        description
+                    }
+                }
+                ... on CorpGroup {
+                    editableProperties {
+                        description
+                    }
+                }
+                ... on Notebook {
+                    editableProperties {
+                        description
+                    }
+                }
+                ... on DataProduct {
+                    properties {
+                        description
+                    }
+                }
+                ... on Application {
+                    properties {
+                        description
+                    }
+                }
+                ... on BusinessAttribute {
                     properties {
                         description
                     }

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/descriptions.py
@@ -141,9 +141,15 @@ def update_description(
     """Update description for a DataHub entity or its column (e.g., schema field).
 
     This tool allows you to set, append to, or remove a description for an entity or its column.
-    Useful for documenting datasets, containers, charts, dashboards, data flows, data jobs,
-    ML models, ML model groups, ML feature tables, ML primary keys, tags, glossary terms,
-    glossary nodes, domains, and schema fields.
+
+    Note: DataHub's updateDescription mutation only accepts a fixed set of entity types. Supported:
+    dataset (including its schema fields, via column_path), container, domain, glossaryTerm,
+    glossaryNode, tag, corpGroup, notebook, mlModel, mlModelGroup, mlFeatureTable, mlFeature,
+    mlPrimaryKey, dataProduct, businessAttribute, application, and document. Other types -
+    including chart, dashboard, dataFlow, dataJob, and corpuser - are rejected server-side with
+    "Failed to update description. Unsupported resource type <urn> provided.". The search tool
+    returns unsupported types alongside supported ones, so a bulk documentation pass over search
+    results should filter by entity type first rather than relying on the error.
 
     Args:
         entity_urn: Entity URN to update description for (e.g., dataset URN, container URN)

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/structured_properties.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/structured_properties.py
@@ -193,6 +193,14 @@ def add_structured_properties(
     This tool allows you to assign structured properties to multiple entities in a single operation.
     Structured properties are schema-defined metadata fields that can store typed values (strings, numbers, etc.).
 
+    Note: every key in property_values must be the URN of a structured property whose definition
+    already exists in DataHub. This tool only assigns values to existing definitions - it does not
+    create them, and no property-definition tool is exposed here. If a property URN does not exist,
+    the call fails with "Structured property URN does not exist in DataHub: ...". Values are also
+    type-checked against the definition's valueType, so the definition must be in place first. Find
+    existing properties with the search tool; create missing definitions out of band, e.g. via the
+    DataHub UI or the Python SDK.
+
     Args:
         property_values: Dictionary mapping structured property URNs to lists of values.
                         Example: {

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/tags.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/tags.py
@@ -171,6 +171,12 @@ def add_tags(
     Useful for bulk tagging operations like marking multiple datasets as PII, deprecated, or applying
     governance classifications.
 
+    Note: every URN in tag_urns must already exist in DataHub. This tool only assigns existing tags -
+    it does not create them, and no tag-creation tool is exposed here. If a tag URN does not exist,
+    the call fails with "The following tag URNs do not exist in DataHub: ...". Find existing tags with
+    the search tool (entity_type filter "TAG"); create missing ones out of band, e.g. via the DataHub
+    UI or the Python SDK, before calling this tool.
+
     Args:
         tag_urns: List of tag URNs to add (e.g., ["urn:li:tag:PII", "urn:li:tag:Sensitive"])
         entity_urns: List of entity URNs to tag (e.g., dataset URNs, dashboard URNs)

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/tags.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/tags.py
@@ -174,8 +174,8 @@ def add_tags(
     Note: every URN in tag_urns must already exist in DataHub. This tool only assigns existing tags -
     it does not create them, and no tag-creation tool is exposed here. If a tag URN does not exist,
     the call fails with "The following tag URNs do not exist in DataHub: ...". Find existing tags with
-    the search tool (entity_type filter "TAG"); create missing ones out of band, e.g. via the DataHub
-    UI or the Python SDK, before calling this tool.
+    the search tool (filter="entity_type = tag"); create missing ones out of band, e.g. via the
+    DataHub UI or the Python SDK, before calling this tool.
 
     Args:
         tag_urns: List of tag URNs to add (e.g., ["urn:li:tag:PII", "urn:li:tag:Sensitive"])

--- a/datahub-agent-context/tests/unit/mcp_tools/test_descriptions.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_descriptions.py
@@ -451,3 +451,46 @@ def test_update_description_remove_glossary_term(mock_client):
     # Verify empty description was sent
     call_args = mock_client._graph.execute_graphql.call_args
     assert call_args.kwargs["variables"]["input"]["description"] == ""
+
+
+def test_append_read_query_covers_supported_entity_types(mock_client):
+    """The append read path must request a description for every entity type that
+    updateDescription accepts.
+
+    If a type has no inline fragment here, _get_existing_description returns "" and
+    append silently replaces the existing description instead of extending it.
+    Document is excluded: its description lives in the documentation aspect
+    (documentation.documentations[]), which this helper does not model.
+    """
+    mock_client._graph.execute_graphql.side_effect = [
+        {"entity": {"editableProperties": {"description": "existing"}}},
+        {"updateDescription": True},
+    ]
+
+    with DataHubContext(mock_client):
+        update_description(
+            entity_urn="urn:li:corpGroup:data-eng",
+            operation="append",
+            description=" more",
+        )
+
+    query = mock_client._graph.execute_graphql.call_args_list[0].kwargs["query"]
+    for entity_type in [
+        "Dataset",
+        "Container",
+        "Domain",
+        "GlossaryTerm",
+        "GlossaryNode",
+        "Tag",
+        "CorpGroup",
+        "Notebook",
+        "MLModel",
+        "MLModelGroup",
+        "MLFeatureTable",
+        "MLFeature",
+        "MLPrimaryKey",
+        "DataProduct",
+        "BusinessAttribute",
+        "Application",
+    ]:
+        assert f"... on {entity_type} {{" in query


### PR DESCRIPTION
> **Updated 2026-08-10:** this PR was opened as docs-only. Automated review then surfaced a
> real bug that the docstring work had exposed, so it now also carries a fix (commit 3) and a
> regression test. Details in "The bug the docstrings exposed" below. The fix is deliberately
> incomplete for one entity type and I say which and why. Happy to split the fix into its own
> PR if a maintainer prefers that shape.

### What

Documentation-only change to three `datahub-agent-context` mutation tool docstrings. These
docstrings are the tool descriptions an LLM receives, so a wrong entity-type list is
something the model acts on, not just something a human reads.

**1. `update_description` lists entity types the mutation does not accept.**

`mcp_tools/descriptions.py` currently says the tool is

> "Useful for documenting datasets, containers, **charts, dashboards, data flows, data jobs**,
> ML models, ML model groups, ML feature tables, ML primary keys, tags, glossary terms,
> glossary nodes, domains, and schema fields."

The tool issues the `updateDescription` GraphQL mutation
(`descriptions.py`, the `mutation updateDescription($input: DescriptionUpdateInput!)` block).
That mutation is resolved by
[`datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java`](https://github.com/datahub-project/datahub/blob/master/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java#L38-L77),
in this repository, which switches on `targetUrn.getEntityType()` over exactly 17 cases
(lines 39-72) and throws in the default branch (lines 73-77):

```
"Failed to update description. Unsupported resource type %s provided."
```

Comparing that switch against the docstring:

- listed as supported but **not** in the switch: `chart`, `dashboard`, `dataFlow`, `dataJob`
- in the switch but **not** listed: `corpGroup`, `notebook`, `mlFeature`, `dataProduct`,
  `businessAttribute`, `application`, `document`

The docstring now carries the resolver's list, the exact error string, and a note to filter
by entity type first — `search` returns charts, dashboards and data flows alongside datasets,
so an agent doing a bulk documentation pass over search results will hit this.

**2. `add_tags` assigns existing tags; it does not create them.**

`_validate_tag_urns` (`mcp_tools/tags.py`) rejects any URN that is not already a `TAG`
entity, and `mcp_tools/__init__.py` exposes no tag-creation tool — so tags have to be created
out of band (UI or Python SDK) first. Reasonable design; it just was not written anywhere the
agent can read it.

**3. `add_structured_properties` has the same prerequisite, one level deeper.**

`_validate_and_fetch_structured_property` requires the property *definition* to exist, and
`_validate_property_value` type-checks each value against that definition's `valueType`. So
the definition must be emitted before values can be assigned.

### The bug the docstrings exposed

Writing down the real supported-type list made a gap visible. `_get_existing_description`
carries inline fragments for **14** entity types, but `updateDescription` accepts **17**.

`update_description(operation="append")` reads the current description through that helper
before writing (`descriptions.py:241-242`), then computes
`existing + description if existing else description` (`descriptions.py:245-248`). For a type
with no inline fragment the GraphQL response has neither `editableProperties` nor
`properties`, both lookups return `""`, and **the append silently degrades into a replace —
destroying the existing description**. No error, no warning.

The third commit adds the six missing fragments, each matched to the aspect the resolver
actually writes, so the read and the write address the same field:

| entity type | aspect written by `DescriptionUtils.java` | fragment added |
|---|---|---|
| `corpGroup` | `CorpGroupEditableInfo` (L190) | `editableProperties` |
| `notebook` | `EditableNotebookProperties` (L274) | `editableProperties` |
| `mlFeature` | `EditableMLFeatureProperties` (L467) | `editableProperties` |
| `dataProduct` | `DataProductProperties` (L545) | `properties` |
| `application` | `ApplicationProperties` (L571) | `properties` |
| `businessAttribute` | `BusinessAttributeInfo` (L597) | `properties` |

**This fix is deliberately incomplete: `document` is not covered.** Its description is not a
scalar field — `DescriptionUtils.updateDocumentDescription` (L662-710) writes a `Documentation`
aspect holding a list of `DocumentationAssociation`s, each with `MetadataAttribution`, and
deliberately preserves the non-UI-authored entries (propagated, inferred, ingested) while
replacing only the UI-authored one. Reading "the current description" back therefore means
selecting the UI-authored association by its `sourceDetail`, which this flat helper cannot
express and which is a product judgement rather than a mechanical fix. `append` on a
`document` URN still has the overwrite behaviour described above. I would rather flag that
than paper over it — happy to follow up separately if you tell me which association should win.

Two related things I also left alone on purpose, both pre-existing:

- `_get_existing_description` swallows read errors and returns `""`, so a transient GraphQL
  failure during `append` also degrades to replace. Propagating that would change behaviour
  for callers that legitimately append to an empty description, so it needs a deliberate
  decision rather than a drive-by change.
- Fragments for `Chart`, `Dashboard`, `DataFlow` and `DataJob` are dead code — the mutation
  rejects those URNs before the read ever matters. Removing them is pure cleanup; say the
  word and I will.

### Scope

Commits 1 and 2 are docstrings only. Commit 3 adds six GraphQL inline fragments to an
existing query plus one regression test — no signatures, no control flow, no behaviour change
for any type that already worked. I deliberately did not touch
`datahub-agent-context/README.md` to avoid overlapping with the open #19032, which is editing
that file.

### Testing

- `ruff check` and `ruff format --check` (pinned `ruff==0.15.22` from `setup.py`) pass on
  every touched file.
- `pytest tests/unit/mcp_tools/test_descriptions.py` — **21 passed** (20 pre-existing, 1 new).
- The new test is a genuine regression test, not a restatement: reverting the six fragments
  makes it fail with `assert '... on CorpGroup {' in query`. It asserts the append read path
  requests a description for every type the resolver accepts, so this cannot silently regress
  when a new entity type is added to the switch.
- `mypy` is unaffected — no annotations or signatures changed.

### Note on the supported-type list

It is derived from `UpdateDescriptionResolver` on `master` in this repository. If DataHub
Cloud's resolver accepts additional types (`chart` / `dashboard` / `dataJob` being the obvious
candidates, given the previous wording), say so and I will adjust the phrasing — I can only
verify against OSS.

### Related

Corresponding correction filed against the standalone MCP server at
[acryldata/mcp-server-datahub#202](https://github.com/acryldata/mcp-server-datahub/pull/202)
(open, not yet reviewed). Same docstring defect, different copy of the tools; this PR is the
port to the kit that ships in this repository. The `_get_existing_description` bug is specific
to this repository's copy.

### How this was found

Building an agent that does a search -> read -> remediate -> verify loop over a live DataHub
instance. Each of the three documentation items cost a debugging cycle that one line of
docstring would have avoided. Every claim here is verifiable from source in this repository:
the resolver switch and `DescriptionUtils` for item 1 and the bug, `_validate_tag_urns` for
item 2, and `_validate_and_fetch_structured_property` / `_validate_property_value` for item 3.
