### PR TITLE
chore(tests): Fix flaky, order-based test

### DIFF
--- a/metadata-ingestion/tests/unit/informatica/test_source.py
+++ b/metadata-ingestion/tests/unit/informatica/test_source.py
@@ -1124,6 +1124,8 @@ class TestFilteringAndErrorHandling:
         # 5 mapping ids + batch_size=2 → 3 export submissions with the
         # expected slices [ids[0:2], ids[2:4], ids[4:5]]. Ensures the
         # batching math doesn't drop or duplicate a mapping at the edge.
+        # Batches submit concurrently via a ThreadPoolExecutor, so compare
+        # order-independently — the contract is the set of slices, not order.
         source = _make_source(export_batch_size=2)
         source._connections_by_id["c"] = IdmcConnection(id="c", name="n", conn_type="")
         source._connections_by_fed_id["fed"] = IdmcConnection(
@@ -1149,7 +1151,7 @@ class TestFilteringAndErrorHandling:
         ):
             list(source._extract_lineage())
 
-        assert submitted_batches == [
+        assert sorted(submitted_batches) == [
             ["guid-0", "guid-1"],
             ["guid-2", "guid-3"],
             ["guid-4"],


### PR DESCRIPTION
The test run actually produces non-deterministically ordered list, test was flaky due to that.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky Informatica lineage batching test by making the assertion order-independent. Batch submissions run concurrently, so we now sort `submitted_batches` before comparing to the expected slices.

<sup>Written for commit 8c9217c3bbef9cc9b7e70c527e4a7717ed81ba35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

