### PR TITLE
chore(ingestion): MLFLow does not depend on setuptools

### DIFF
--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -701,7 +701,6 @@ microstrategy = [
 
 mlflow = [
     "mlflow-skinny>=2.3.0,<2.21.0",
-    "setuptools<82",
 ]
 
 mode = [

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -703,9 +703,6 @@ plugins: Dict[str, Set[str]] = {
         # https://github.com/mlflow/mlflow/pull/14795
         # Upper bound can be removed once the upstream issue is resolved,
         # or we have a reliable and backward-compatible way to handle prompt filtering.
-        # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
-        # setuptools 82 removed pkg_resources, which mlflow uses at runtime.
-        "setuptools<82",
     },
     "datahub-debug": {"dnspython==2.7.0", "requests<3.0.0"},
     "datahub-gc": set(),

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -1193,7 +1193,6 @@ microstrategy = [
 ]
 mlflow = [
     { name = "mlflow-skinny" },
-    { name = "setuptools" },
 ]
 mode = [
     { name = "cachetools" },
@@ -2496,7 +2495,6 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'all'", specifier = "<82" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "<82.0.0" },
     { name = "setuptools", marker = "extra == 'docs'", specifier = "<82.0.0" },
-    { name = "setuptools", marker = "extra == 'mlflow'", specifier = "<82" },
     { name = "setuptools", marker = "extra == 'powerbi'", specifier = "<82" },
     { name = "simple-salesforce", marker = "extra == 'all'", specifier = "<2.0.0" },
     { name = "simple-salesforce", marker = "extra == 'dev'", specifier = "<2.0.0" },


### PR DESCRIPTION
It is incorrect for MLFlow to be the source of that pin for `setuptools`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the incorrect `setuptools<82` dependency from the `mlflow` extra to stop pinning `setuptools` unnecessarily and avoid conflicts in environments with newer versions.
Updated `pyproject.toml`, `setup.py`, and `uv.lock` to reflect the removal.

<sup>Written for commit a880449cc9498ceba2ca17f4eca628ccc5641e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

