### PR TITLE
docs(ml-tutorial): add "Read ML Lineage Back" section for downstream agents

### DIFF
--- a/docs/api/tutorials/ml.md
+++ b/docs/api/tutorials/ml.md
@@ -883,6 +883,58 @@ Find dataset relationships in the **Lineage** tab of either the **Dataset** or *
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/apis/tutorials/ml/run-lineage-dataset-graph.png"/>
 </p>
 
+## Read ML Lineage Back
+
+Now that you've written models, features, and lineage into DataHub, here's how a downstream agent can read that same graph back. This is the pattern used by monitoring, drift-detection, and model-observability agents — walk from a deployed model up to its features and source tables, then pull per-asset schema and profile snapshots.
+
+The full walk uses a handful of `DataHubGraph` reads:
+
+```python
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+from datahub.metadata.schema_classes import (
+    MLModelPropertiesClass,
+    MLFeaturePropertiesClass,
+    SchemaMetadataClass,
+    DatasetProfileClass,
+    OwnershipClass,
+)
+
+graph = DataHubGraph(DataHubGraphConfig(server="http://localhost:8080"))
+
+# 1. Read the deployed model's properties (upstream features live here)
+model_urn = "urn:li:mlModel:(urn:li:dataPlatform:mlflow,arima_model,PROD)"
+model_props = graph.get_aspect(entity_urn=model_urn, aspect_type=MLModelPropertiesClass)
+
+# 2. Walk each feature the model consumes
+for feature_urn in (model_props.mlFeatures or []):
+    feature_props = graph.get_aspect(entity_urn=feature_urn, aspect_type=MLFeaturePropertiesClass)
+
+    # 3. Each feature points at its source dataset(s)
+    for source_urn in (feature_props.sources or []):
+        schema = graph.get_aspect(entity_urn=source_urn, aspect_type=SchemaMetadataClass)
+        owners = graph.get_aspect(entity_urn=source_urn, aspect_type=OwnershipClass)
+
+        # 4. Latest profile snapshot — see the note below
+        profile = graph.get_latest_timeseries_value(
+            entity_urn=source_urn,
+            aspect_type=DatasetProfileClass,
+            filter_criteria_map={},  # empty dict, NOT None
+        )
+
+        # `schema`, `owners`, `profile` may each be None if that aspect was never emitted.
+        ...
+```
+
+:::note DatasetProfile is a timeseries aspect
+`DatasetProfileClass` is a **timeseries** aspect, so `graph.get_aspect(...)` will raise. Use `graph.get_latest_timeseries_value(...)` instead, and always pass `filter_criteria_map={}` (an empty dict — passing `None` crashes the client with an unhelpful `AttributeError`).
+:::
+
+### Why this matters for agents
+
+An agent that only reads static properties (schemas, ownership) misses the signal that matters most for ML observability: **whether the training data has silently shifted since the model was deployed**. Reading the latest `DatasetProfile` on each upstream source lets the agent compute per-hop signatures (row count, null-rate, distribution moments, freshness) and score drift against a last-known-good baseline.
+
+For a working reference implementation of exactly this walk — nine drift dimensions, write-back into DataHub as tags on the affected assets, persistent incident memory to avoid re-paging — see the [Ogle](https://github.com/BenDuske/ogle) hackathon project, in particular [`src/ogle/walker.py`](https://github.com/BenDuske/ogle/blob/main/src/ogle/walker.py).
+
 ## Update Properties
 
 ### Update Model Group Properties


### PR DESCRIPTION
## What

The AI/ML Framework Integration tutorial (`docs/api/tutorials/ml.md`) teaches how to write ML entities and lineage into DataHub, but doesn't show how a downstream agent reads that same graph back — the pattern every ML monitoring / drift-detection / observability agent needs.

This PR adds a "Read ML Lineage Back" section after "Define Relationships" with a ~30-line Python snippet walking `MLModel → MLFeatures → source datasets → SchemaMetadata + DatasetProfile + Ownership`.

## Why

Two gotchas cost me half a day building [Ogle](https://github.com/BenDuske/ogle) for the Build with DataHub Agent Hackathon:

1. **`DatasetProfile` is a timeseries aspect** — `graph.get_aspect(..., aspect_type=DatasetProfileClass)` raises. The SDK points at `get_latest_timeseries_value` but the ML tutorial never mentions this.
2. **`filter_criteria_map=None` crashes.** Passing `{}` (empty dict) works. Not documented anywhere I could find.

Both are worth calling out in the tutorial where a first-time reader will hit them.

## The change

- Adds one new section (`## Read ML Lineage Back`) after "Define Relationships" in `docs/api/tutorials/ml.md`.
- Snippet is faithful to the pattern used in Ogle's [`walker.DataHubBackend`](https://github.com/BenDuske/ogle/blob/main/src/ogle/walker.py) — real code, not a hypothetical.
- Includes an admonition documenting the timeseries + `filter_criteria_map` gotchas.
- Links Ogle as an end-to-end reference implementation of a drift-detection agent built on this pattern.

## How it was verified

- Snippet was extracted from Ogle's [`walker.py`](https://github.com/BenDuske/ogle/blob/main/src/ogle/walker.py) which runs live against a DataHub Quickstart (see [`docs/live-verification.md`](https://github.com/BenDuske/ogle/blob/main/docs/live-verification.md)).
- Verified the aspects (`MLModelPropertiesClass`, `MLFeaturePropertiesClass`, `SchemaMetadataClass`, `DatasetProfileClass`, `OwnershipClass`) all exist in the current `acryl-datahub` release.

## Related

- Ogle repo: https://github.com/BenDuske/ogle
- Ogle's walker (reference implementation): https://github.com/BenDuske/ogle/blob/main/src/ogle/walker.py

## Notes for reviewers

- I picked "after Define Relationships / before Update Properties" as the insertion point since it's the natural progression (write → link → read → update). Happy to move it if maintainers prefer a different location.
- Snippet uses `DataHubGraph` directly to stay minimal; the tutorial's existing `DatahubAIClient` wrapper doesn't expose these reads yet — separate follow-up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Read ML Lineage Back” section to the ML tutorial showing how downstream agents traverse model → features → source datasets and read `SchemaMetadata`, `DatasetProfile`, and `Ownership` via `DataHubGraph`. Calls out two gotchas: `DatasetProfile` is timeseries (use `get_latest_timeseries_value`) and `filter_criteria_map` must be `{}`.

- **New Features**
  - Added a ~30-line Python snippet that walks `MLModel → MLFeatures → datasets` and fetches `SchemaMetadata`, `DatasetProfile`, and `Ownership`.
  - Included a note: use `get_latest_timeseries_value` for `DatasetProfileClass` and pass `filter_criteria_map={}`.
  - Linked the Ogle project as a working reference for this agent pattern.

<sup>Written for commit a90c56af5c11d713339173b0a6dfd19fb931d33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

