### PR TITLE
fix(agent-context): search_documents keeps its result contract and fails loudly

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
@@ -42,6 +42,22 @@ def _annotate_search_type(results: Dict[str, Any], search_type: str) -> Dict[str
     return results
 
 
+def _ensure_search_results_key(
+    result: Dict[str, Any], num_results: int
+) -> Dict[str, Any]:
+    """Guarantee the documented ``searchResults`` key is present.
+
+    ``clean_gql_response`` drops empty arrays, so an otherwise-empty search
+    response would lack the ``searchResults`` key entirely. Keep it as an empty
+    list instead, so callers can always read ``result["searchResults"]`` and can
+    distinguish "no matches" from a malformed response. Facet-only queries
+    (num_results=0) intentionally omit it.
+    """
+    if num_results != 0 and isinstance(result, dict):
+        result.setdefault("searchResults", [])
+    return result
+
+
 def _build_urn_lookup(results: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
     """Build URN lookup map from search results."""
     urn_map: Dict[str, Dict[str, Any]] = {}
@@ -332,6 +348,11 @@ def search_documents(
     Returns document metadata WITHOUT content to keep responses concise.
     Use get_entities() with a document URN to retrieve full content when needed.
 
+    VISIBILITY: Search respects your deployment's access controls. Documents
+    that are unpublished or otherwise not visible to the calling user may not
+    be returned, even if the caller owns them. Documents created via
+    save_document are published and therefore discoverable through this tool.
+
     HYBRID SEARCH (recommended for natural language queries):
     When both query and semantic_query are provided, runs keyword and semantic
     searches in parallel and merges results intelligently:
@@ -427,7 +448,7 @@ def search_documents(
                 len(result.get("searchResults", [])),
             )
 
-            return result
+            return _ensure_search_results_key(result, num_results)
 
         # Otherwise, run keyword-only search
         result = _search_documents_impl(
@@ -445,7 +466,7 @@ def search_documents(
             len(result.get("searchResults", [])),
         )
 
-    return result
+    return _ensure_search_results_key(result, num_results)
 
 
 search_documents.__doc__ = (search_documents.__doc__ or "").format(
@@ -485,7 +506,12 @@ def _search_documents_impl(
             "viewUrn": view_urn,
         }
     else:
-        # Default: keyword search
+        # Keyword search: use the generic cross-entity search for both plain
+        # and filtered queries. It ranks by match relevance, supports arbitrary
+        # orFilters, and applies consistent visibility, so filtered and
+        # unfiltered results behave the same (the dedicated searchDocuments API
+        # sorts by creation time and has no backfill for its post-fetch authz
+        # filtering, making it unsuitable for the agent's search path).
         gql_query = document_search_gql
         operation_name = "documentSearch"
         response_key = "searchAcrossEntities"
@@ -503,6 +529,21 @@ def _search_documents_impl(
         variables=variables,
         operation_name=operation_name,
     )[response_key]
+
+    # Fail loudly on a payload that is not a search result at all (e.g. a
+    # schema or backend incompatibility) rather than fabricating an empty
+    # catalog. A valid response always exposes the SearchResults shape; some GMS
+    # versions may omit the empty `searchResults` array for a zero-hit page, so
+    # only treat a payload that has none of searchResults/total/count as
+    # malformed.
+    if isinstance(response, dict) and not any(
+        key in response for key in ("searchResults", "total", "count")
+    ):
+        raise ValueError(
+            "Unexpected document search response: missing SearchResults fields "
+            "(searchResults/total/count). This may indicate a schema or backend "
+            f"incompatibility for operation '{operation_name}'."
+        )
 
     if num_results == 0 and isinstance(response, dict):
         # Support num_results=0 for facet-only queries

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/document_search.gql
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/document_search.gql
@@ -1,5 +1,10 @@
-# GraphQL query for searching Document entities (keyword search)
-# Returns document metadata WITHOUT content to avoid context bloat
+# GraphQL query for searching Document entities via the generic cross-entity
+# search (searchAcrossEntities). This endpoint ranks by match relevance and
+# supports arbitrary orFilters, so both plain and filtered keyword searches use
+# it for consistent ordering and visibility. Returns results under a
+# `searchResults` key.
+#
+# Returns document metadata WITHOUT content to avoid context bloat.
 
 fragment DocumentSearchInfo on Document {
   urn

--- a/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
@@ -28,12 +28,16 @@ def mock_client():
 
 @pytest.fixture
 def mock_doc_search_response():
-    """Sample document search response."""
+    """Sample document search response from the generic cross-entity search.
+
+    Keyword search (plain and filtered) uses searchAcrossEntities, which
+    returns hits under a ``searchResults`` key.
+    """
     return {
         "searchAcrossEntities": {
             "start": 0,
-            "count": 2,
-            "total": 2,
+            "count": 1,
+            "total": 1,
             "searchResults": [
                 {
                     "entity": {
@@ -51,7 +55,7 @@ def mock_doc_search_response():
                             },
                         },
                     }
-                },
+                }
             ],
             "facets": [],
         }
@@ -102,16 +106,167 @@ def test_search_documents_basic(mock_client, mock_doc_search_response):
     assert len(result["searchResults"]) == 1
 
 
+def test_search_documents_reads_search_results(mock_client):
+    """Test that keyword search reads `searchResults` from searchAcrossEntities.
+
+    Regression test for #19026: keyword search must return the hits it receives
+    under the documented `searchResults` contract rather than a silently empty
+    list.
+    """
+    mock_client._graph.execute_graphql.return_value = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "entity": {
+                        "urn": "urn:li:document:doc1",
+                        "subType": "Runbook",
+                        "platform": {
+                            "urn": "urn:li:dataPlatform:notion",
+                            "name": "Notion",
+                        },
+                        "info": {
+                            "title": "Deployment Guide",
+                            "source": {"sourceType": "EXTERNAL"},
+                        },
+                    }
+                }
+            ],
+            "facets": [],
+        }
+    }
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="deployment")
+
+    assert result["total"] == 1
+    assert len(result["searchResults"]) == 1
+    assert result["searchResults"][0]["entity"]["urn"] == "urn:li:document:doc1"
+    call_args = mock_client._graph.execute_graphql.call_args
+    assert call_args.kwargs["operation_name"] == "documentSearch"
+
+
+def test_search_documents_malformed_response_fails_loud(mock_client):
+    """Test that a genuinely malformed response surfaces an error, not empty.
+
+    Regression test for #19026: if the response is not a search result at all
+    (e.g. a backend error payload), the tool must fail loudly rather than
+    fabricate an empty catalog that looks like "no documents".
+    """
+    mock_client._graph.execute_graphql.return_value = {
+        "searchAcrossEntities": {"message": "Internal server error"}
+    }
+
+    with DataHubContext(mock_client):
+        with pytest.raises(ValueError, match="missing SearchResults fields"):
+            search_documents(query="deployment")
+
+
+def test_search_documents_empty_without_searchresults_key(mock_client):
+    """Test that an empty page omitting `searchResults` is still a clean empty.
+
+    Some GMS versions omit the empty `searchResults` array for a zero-hit page;
+    that must be reported as a normal empty result (kept under `searchResults`)
+    rather than treated as a malformed response.
+    """
+    mock_client._graph.execute_graphql.return_value = {
+        "searchAcrossEntities": {"start": 0, "count": 0, "total": 0, "facets": []}
+    }
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="zzz-no-matches")
+
+    assert result["total"] == 0
+    assert result["searchResults"] == []
+
+
+def test_search_documents_empty_results_key_present(mock_client):
+    """Test that an empty search still returns the `searchResults` key.
+
+    Regression test for #19026: an empty hit set must not strip `searchResults`
+    (empty arrays are otherwise removed during response cleaning), so callers
+    can distinguish "no matches" from a malformed response.
+    """
+    mock_client._graph.execute_graphql.return_value = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 0,
+            "total": 0,
+            "searchResults": [],
+            "facets": [],
+        }
+    }
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="zzz-no-matches")
+
+    assert result["total"] == 0
+    assert result["searchResults"] == []
+
+
+def test_search_documents_hybrid_empty_results_key_present(monkeypatch, mock_client):
+    """Test the hybrid merge also keeps `searchResults` present when empty."""
+    # Avoid the default-view lookups issuing extra GraphQL calls so the
+    # side_effect below matches the two search calls exactly.
+    monkeypatch.setattr(
+        "datahub_agent_context.mcp_tools.documents.resolve_default_view",
+        lambda graph: None,
+    )
+    mock_client._graph.execute_graphql.side_effect = [
+        {
+            "searchAcrossEntities": {
+                "start": 0,
+                "count": 0,
+                "total": 0,
+                "searchResults": [],
+                "facets": [],
+            }
+        },
+        {
+            "semanticSearchAcrossEntities": {
+                "start": 0,
+                "count": 0,
+                "total": 0,
+                "searchResults": [],
+                "facets": [],
+            }
+        },
+    ]
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="deployment", semantic_query="how to deploy")
+
+    assert result["total"] == 0
+    assert result["searchResults"] == []
+
+
 def test_search_documents_with_platforms(mock_client, mock_doc_search_response):
-    """Test filtering by platform."""
+    """Test filtering by platform.
+
+    Asserts the exact compiled orFilters sent to the query so a dropped or
+    corrupted filter cannot pass silently (regression for filtered-search
+    routing).
+    """
     mock_client._graph.execute_graphql.return_value = mock_doc_search_response
 
     with DataHubContext(mock_client):
         result = search_documents(query="*", filter="platform = notion")
 
-    assert result is not None
+    # The returned doc is the one the backend returned.
+    assert result["searchResults"][0]["entity"]["urn"] == "urn:li:document:doc1"
+    # The platform filter must actually be compiled and sent as orFilters.
     call_args = mock_client._graph.execute_graphql.call_args
-    assert call_args.kwargs["operation_name"] == "documentSearch"
+    or_filters = call_args.kwargs["variables"]["orFilters"]
+    platform_criteria = [
+        c
+        for and_group in or_filters
+        for c in and_group["and"]
+        if c["field"] == "platform.keyword"
+    ]
+    assert platform_criteria, "no platform filter compiled into orFilters"
+    assert platform_criteria[0]["values"] == ["urn:li:dataPlatform:notion"]
 
 
 def test_search_documents_with_domains(mock_client, mock_doc_search_response):
@@ -124,6 +279,8 @@ def test_search_documents_with_domains(mock_client, mock_doc_search_response):
         )
 
     assert result is not None
+    call_args = mock_client._graph.execute_graphql.call_args
+    assert call_args.kwargs["operation_name"] == "documentSearch"
 
 
 def test_search_documents_with_tags(mock_client, mock_doc_search_response):


### PR DESCRIPTION
Closes #19026

## Problem
Empty document searches dropped the `searchResults` key during response cleaning, so a zero-hit result was indistinguishable from a malformed/empty catalog — the "silently empty" symptom in #19026. An agent cannot tell "no documents" from a bug.

## Fix
- `search_documents` now **always returns `searchResults`** (empty list) for non-facet searches, so callers can rely on the documented contract.
- **Fails loudly** when a search response lacks the results list (schema/backend incompatibility) instead of fabricating an empty catalog.
- Keyword search stays on the generic `searchAcrossEntities` endpoint for **both** plain and filtered queries (relevance-ranked, full `orFilters` support, consistent visibility).

## Why not the dedicated `searchDocuments` API
It was considered but is unsuitable for the agent search path:
- It sorts by **creation time** instead of match relevance, so an older exact match can fall outside the fetched page while newer weaker matches win.
- It applies authorization **after** fetching the page without backfilling, so mixed-access users can receive empty/short pages despite authorized matches existing.
- Its input schema varies across GMS versions.

These were flagged in review; reverting to a single generic search path resolves the relevance-ordering, mixed-access backfill, and filtered-vs-unfiltered visibility inconsistencies while keeping the real #19026 fix (contract + fail-loud).

## Tests
`pytest tests/unit/mcp_tools/test_documents.py` — 56 passed, including:
- empty results still return `searchResults`; malformed response raises
- filtered search asserts the exact compiled `orFilters` and returned URN
## Evidence (live quickstart)

Frontend search returns the agent-authored doc:
![bug1-search](https://raw.githubusercontent.com/nrynss/datahub/pr-media/pr-media/bug1-search.png)

Document profile after the fix:
![bug1-after](https://raw.githubusercontent.com/nrynss/datahub/pr-media/pr-media/bug1-after.png)

**Screen recording:** 

**After**

https://github.com/user-attachments/assets/fd9a9e9d-d372-4328-b95b-328b64a94a54

