### PR TITLE
fix(agent-context): save_document create-or-update keyed on caller URN

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
@@ -18,6 +18,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, List, Literal, Optional, Tuple
 
+from datahub.errors import ItemNotFoundError
 from datahub.metadata import schema_classes as models
 from datahub.sdk import Document
 from datahub_agent_context.context import get_datahub_client
@@ -152,15 +153,34 @@ def _generate_document_id() -> str:
     return f"shared-{unique_id}"
 
 
-def _is_document_in_shared_folder(document_urn: str) -> Tuple[bool, Optional[str]]:
+def _get_existing_document(client, document_urn: str):
+    """Fetch an existing document, returning ``None`` if it does not exist.
+
+    The SDK raises ``ItemNotFoundError`` for a missing document rather than
+    returning ``None``; both mean "does not exist". Real errors (transport,
+    auth, server) propagate so the caller can return a structured failure.
+    """
+    try:
+        return client.entities.get(document_urn)
+    except ItemNotFoundError:
+        return None
+
+
+def _is_document_in_shared_folder(document_urn: str, doc) -> Tuple[bool, Optional[str]]:
     """Check if a document is within the shared documents folder.
+
+    ``doc`` is the already-fetched document (or ``None`` if it does not exist
+    yet). The caller fetches it exactly once and passes it in so the hierarchy
+    validation and the create-or-update decision agree on the same entity (a
+    second read could observe a different state than the one that was
+    validated). A ``None`` document is allowed (it will be created).
 
     Simple validation: document must have the shared folder as a parent/ancestor.
 
     Returns:
         Tuple of (is_valid, error_message)
-        - (True, None) if document is in the shared folder
-        - (False, error_message) if document is outside the folder
+        - (True, None) if the document is in the shared folder or does not exist yet
+        - (False, error_message) if the document is outside the folder
     """
 
     client = get_datahub_client()
@@ -173,17 +193,12 @@ def _is_document_in_shared_folder(document_urn: str) -> Tuple[bool, Optional[str
             "Only documents within this folder can be updated."
         )
 
-    try:
-        # Fetch the document
-        doc = client.entities.get(document_urn)
-        logger.debug(
-            f"Validating document {document_urn} for update, fetched: {doc is not None}"
-        )
-        if doc is None:
-            # Document doesn't exist yet - allow (will be created)
-            logger.debug(f"Document {document_urn} does not exist, allowing update")
-            return True, None
+    # A document that does not exist yet is allowed (it will be created below).
+    if doc is None:
+        logger.debug(f"Document {document_urn} does not exist, allowing update")
+        return True, None
 
+    try:
         # Get documentInfo aspect
         aspects = getattr(doc, "aspects", None) or getattr(doc, "_aspects", {})
         logger.debug(
@@ -379,9 +394,11 @@ def save_document(
     - Under a configurable parent folder (default: "Shared" for global context)
     - Optionally grouped by the user who authored them
 
-    UPSERT BEHAVIOR:
+    UPSERT BEHAVIOR (create-or-update keyed on the URN):
     - If `urn` is NOT provided: Creates a NEW document with a unique URN
-    - If `urn` IS provided: Updates the EXISTING document with that URN
+    - If `urn` IS provided and the document does not exist yet: Creates it at
+      that URN (stable and addressable across runs)
+    - If `urn` IS provided and the document already exists: Updates it
 
     IMPORTANT USAGE GUIDELINES:
     - Always confirm with the user before saving
@@ -409,11 +426,14 @@ def save_document(
 
     OPTIONAL PARAMETERS:
 
-    urn: The URN of an existing document to update.
-        - ONLY use after a search_documents or get_entity call returns a document URN
-        - Example: "urn:li:document:agent-insight-abc123"
-        - If not provided, a new document is created with a unique URN
-        - If provided, the existing document is updated (upsert operation)
+    urn: Optional URN to create or update a document at (create-or-update keyed
+        on the URN).
+        - If the document does not exist, it is created at this URN.
+        - If it already exists, it is updated.
+        - Publishing to a stable, addressable URN lets an agent read/write its
+          own memory deterministically across runs (e.g.
+          "urn:li:document:memory:<run>:<channel>").
+        - If not provided, a new document is created with a unique URN.
 
     topics: List of topic tags for categorization and discovery (like a word cloud).
         - These become searchable tags in DataHub that users can click to find related documents
@@ -523,10 +543,25 @@ def save_document(
                 "author": None,
             }
 
-        # Validate that the document is within the agent-authored hierarchy
-        # This prevents accidental modification of user-created or imported documents
+        # Fetch the existing document exactly once so the shared-folder check
+        # and the create-or-update decision agree on the same entity (a second
+        # read could observe a different state than the one that was validated).
+        try:
+            existing_doc = _get_existing_document(client, urn)
+        except Exception as probe_error:
+            logger.error(f"Failed to read document {urn}: {probe_error}", exc_info=True)
+            return {
+                "success": False,
+                "urn": None,
+                "message": f"Error reading document {urn}: {str(probe_error)}",
+                "author": None,
+            }
+
+        # Validate that the document is within the agent-authored hierarchy.
+        # This prevents accidental modification of user-created or imported
+        # documents, and also prohibits updating the root shared folder.
         if _restrict_updates_to_shared_folder():
-            is_valid, error_message = _is_document_in_shared_folder(urn)
+            is_valid, error_message = _is_document_in_shared_folder(urn, existing_doc)
             if not is_valid:
                 return {
                     "success": False,
@@ -535,10 +570,19 @@ def save_document(
                     "author": None,
                 }
 
-        is_update = True
         document_urn = urn
         # Extract document ID from URN
         document_id = urn.replace("urn:li:document:", "")
+        if not document_id:
+            return {
+                "success": False,
+                "urn": None,
+                "message": f"Invalid urn format '{urn}'. A document URN must have a non-empty id.",
+                "author": None,
+            }
+        # A caller-supplied URN is create-or-update keyed on the URN: create at
+        # that URN when the document does not exist yet, update it otherwise.
+        is_update = existing_doc is not None
     else:
         is_update = False
         # Generate new document ID

--- a/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
@@ -3,10 +3,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from datahub.errors import ItemNotFoundError
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.save_document import (
     ROOT_PARENT_DOC_ID,
     _generate_document_id,
+    _get_existing_document,
     _get_parent_title,
     _get_root_parent_id,
     _get_root_parent_urn,
@@ -240,6 +242,94 @@ class TestSaveDocument:
 
         assert result["success"] is True
         assert result["urn"] is not None
+
+    def test_save_document_creates_at_caller_urn(self, mock_client, mock_user_info):
+        """Test creating a NEW document at a caller-supplied URN.
+
+        Regression test for #19027: supplying urn= for a not-yet-existing
+        document must create it at that URN (create-or-update keyed on the
+        URN) rather than being rejected as update-only.
+        """
+        mock_client.entities.get.return_value = None  # document does not exist
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        caller_urn = "urn:li:document:memory:my-run:weather"
+        # RESTRICT_UPDATES left at its default (true) to prove the shared-folder
+        # check does not reject creating a brand-new caller URN.
+        with DataHubContext(mock_client):
+            result = save_document(
+                urn=caller_urn,
+                document_type="Note",
+                title="Weather Memo",
+                content="Sunny today.",
+            )
+
+        assert result["success"] is True
+        assert result["urn"] == caller_urn
+        assert "created" in result["message"].lower()
+
+    def test_save_document_creates_at_caller_urn_when_get_raises_not_found(
+        self, mock_client, mock_user_info
+    ):
+        """Test create-at-URN when the SDK raises instead of returning None.
+
+        The SDK's ``entities.get`` raises ItemNotFoundError for a missing
+        document rather than returning None; this is the exact failure from
+        #19027, where existence probing collapsed into the update path and the
+        shared-folder guard rejected the create.
+        """
+        mock_client.entities.get.side_effect = ItemNotFoundError(
+            "Entity urn:li:document:memory:my-run:weather not found"
+        )
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        caller_urn = "urn:li:document:memory:my-run:weather"
+        with DataHubContext(mock_client):
+            result = save_document(
+                urn=caller_urn,
+                document_type="Note",
+                title="Weather Memo",
+                content="Sunny today.",
+            )
+
+        assert result["success"] is True
+        assert result["urn"] == caller_urn
+        assert "created" in result["message"].lower()
+        # Creation at a new URN sets authorship ownership rather than preserving
+        # existing ownership — verify the created document carries the caller as
+        # an owner (the fix that create-at-URN does not strip ownership).
+        created_doc = mock_client.entities.upsert.call_args.args[0]
+        ownership = created_doc._aspects["ownership"]
+        owner_urns = [owner.owner for owner in ownership.owners]
+        assert owner_urns == ["urn:li:corpuser:john.doe"]
+
+    def test_save_document_probe_error_returns_structured_failure(
+        self, mock_client, mock_user_info
+    ):
+        """Test that an existence-probe error (non-not-found) yields the tool's
+        structured failure response rather than escaping save_document."""
+        mock_client.entities.get.side_effect = Exception("connection refused")
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                urn="urn:li:document:memory:some-doc",
+                document_type="Note",
+                title="Title",
+                content="Content",
+            )
+
+        assert result["success"] is False
+        assert "Error reading document" in result["message"]
+        # The outer upsert error handler is not what produced this; the probe
+        # failed before any upsert was attempted.
+        mock_client.entities.upsert.assert_not_called()
 
     def test_save_document_update_existing_document(self, mock_client, mock_user_info):
         """Test updating an existing document by providing URN."""
@@ -491,11 +581,10 @@ class TestDocumentInSharedFolder:
         mock_doc_info.parentDocument = mock_parent
         mock_doc = Mock()
         mock_doc.aspects = {"documentInfo": mock_doc_info}
-        mock_client.entities.get.return_value = mock_doc
 
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
-                "urn:li:document:test-doc-123"
+                "urn:li:document:test-doc-123", mock_doc
             )
 
         assert is_valid is True
@@ -510,11 +599,10 @@ class TestDocumentInSharedFolder:
         mock_doc_info.parentDocument = mock_parent
         mock_doc = Mock()
         mock_doc.aspects = {"documentInfo": mock_doc_info}
-        mock_client.entities.get.return_value = mock_doc
 
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
-                "urn:li:document:external-doc-123"
+                "urn:li:document:external-doc-123", mock_doc
             )
 
         assert is_valid is False
@@ -526,11 +614,10 @@ class TestDocumentInSharedFolder:
         mock_doc_info.parentDocument = None
         mock_doc = Mock()
         mock_doc.aspects = {"documentInfo": mock_doc_info}
-        mock_client.entities.get.return_value = mock_doc
 
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
-                "urn:li:document:orphan-doc-123"
+                "urn:li:document:orphan-doc-123", mock_doc
             )
 
         assert is_valid is False
@@ -538,11 +625,9 @@ class TestDocumentInSharedFolder:
 
     def test_nonexistent_document_returns_true(self, mock_client):
         """Test that non-existent document is allowed (will be created)."""
-        mock_client.entities.get.return_value = None
-
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
-                "urn:li:document:new-doc-123"
+                "urn:li:document:new-doc-123", None
             )
 
         assert is_valid is True
@@ -553,7 +638,7 @@ class TestDocumentInSharedFolder:
         root_urn = _get_root_parent_urn()
 
         with DataHubContext(mock_client):
-            is_valid, error = _is_document_in_shared_folder(root_urn)
+            is_valid, error = _is_document_in_shared_folder(root_urn, None)
 
         assert is_valid is False
         assert "Cannot update the root shared documents folder" in error
@@ -562,11 +647,10 @@ class TestDocumentInSharedFolder:
         """Test that document without documentInfo aspect is invalid."""
         mock_doc = Mock()
         mock_doc.aspects = {}  # No documentInfo
-        mock_client.entities.get.return_value = mock_doc
 
         with DataHubContext(mock_client):
             is_valid, error = _is_document_in_shared_folder(
-                "urn:li:document:no-info-doc-123"
+                "urn:li:document:no-info-doc-123", mock_doc
             )
 
         assert is_valid is False
@@ -642,6 +726,15 @@ class TestUpdateOwnership:
             "me": {"corpUser": mock_user_info}
         }
 
+        # Capture what gets passed to upsert
+        captured_doc = None
+
+        def capture_upsert(doc):
+            nonlocal captured_doc
+            captured_doc = doc
+
+        mock_client.entities.upsert = capture_upsert
+
         existing_urn = "urn:li:document:shared-existing-doc-123"
 
         with DataHubContext(mock_client):
@@ -654,6 +747,40 @@ class TestUpdateOwnership:
 
         assert result["success"] is True
         assert "updated" in result["message"].lower()
+        # The update path must not set authorship ownership: the upserted
+        # document carries no ownership aspect, so existing ownership is left
+        # untouched.
+        assert "ownership" not in captured_doc._aspects
+
+
+class TestGetExistingDocument:
+    """Tests for the _get_existing_document existence helper."""
+
+    def test_returns_document_when_it_exists(self, mock_client):
+        """Test that an existing document is returned as-is."""
+        doc = Mock()
+        mock_client.entities.get.return_value = doc
+
+        assert _get_existing_document(mock_client, "urn:li:document:doc-1") is doc
+
+    def test_returns_none_when_sdk_returns_none(self, mock_client):
+        """Test that a None result (missing) becomes None."""
+        mock_client.entities.get.return_value = None
+
+        assert _get_existing_document(mock_client, "urn:li:document:doc-1") is None
+
+    def test_returns_none_on_item_not_found(self, mock_client):
+        """Test that ItemNotFoundError (missing) becomes None."""
+        mock_client.entities.get.side_effect = ItemNotFoundError("missing")
+
+        assert _get_existing_document(mock_client, "urn:li:document:doc-1") is None
+
+    def test_propagates_other_errors(self, mock_client):
+        """Test that non-not-found errors propagate for structured handling."""
+        mock_client.entities.get.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            _get_existing_document(mock_client, "urn:li:document:doc-1")
 
 
 class TestOrganizeByUser:


### PR DESCRIPTION
Closes #19027

## Problem
`save_document(urn=...)` treated a supplied URN as update-only, so creating at a caller-controlled URN was rejected. The SDK's `entities.get` raises `ItemNotFoundError` for a missing document rather than returning `None`; that exception was swallowed by the shared-folder validation into a failure, and the existence probe never reached the create path. An agent could not publish to a stable, addressable URN to reuse on the next run.

## Fix
Distinguish create vs. update by probing for the URN, so a caller-supplied URN becomes create-or-update keyed on the URN:

- New `_document_exists()` probes existence, handling both the raised `ItemNotFoundError` and a `None` result.
- `_is_document_in_shared_folder()` treats a not-yet-existing document as allowed (it will be created), keeping the shared-folder/prefix validation intact.
- `save_document` sets `is_update` from actual existence, so a create sets authorship ownership while an update preserves existing ownership.

## Validation
- Reproduced the rejection against a live quickstart, then confirmed the fix: create at a new URN succeeds and the URN is preserved; a second call updates the same URN (stability check passed).
- New regression tests cover both the SDK-returns-`None` and SDK-raises-`ItemNotFoundError` cases.

## Test
`pytest tests/unit/mcp_tools/test_save_document.py` — 48 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `save_document` to create or update at a caller-supplied URN, fixing the rejection when the document didn’t exist. Fixes #19027 and lets agents publish to stable URNs across runs.

- **Bug Fixes**
  - Added `_get_existing_document()` to probe URN existence, treating `ItemNotFoundError` and `None` as "missing"; other probe errors return a structured failure.
  - Fetch once and pass the result to `_is_document_in_shared_folder(urn, doc)` so shared-folder checks allow missing docs and stay consistent; still blocks updating the root shared folder.
  - Set `is_update` from actual existence so creates set authorship and updates preserve ownership; validate URN has a non-empty id.
  - Expanded tests for SDK returning `None` vs. raising `ItemNotFoundError`, probe-error handling, ownership on create vs. update, and `_get_existing_document` coverage.

<sup>Written for commit 6afc5978e97d5b9d9c5e436beb8a45aa752e8ae6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
## Evidence (live quickstart)

**Before** — the caller URN has no document yet (empty profile):
![bug2-before](https://raw.githubusercontent.com/nrynss/datahub/pr-media/pr-media/bug2-before.png)

**After** — document created at the caller URN via `save_document(urn=...)`:
![bug2-after](https://raw.githubusercontent.com/nrynss/datahub/pr-media/pr-media/bug2-after.png)

**Screen recordings:** 

**Before**

https://github.com/user-attachments/assets/5644925d-7a84-4b4e-9e75-fbd4f39e78e2

**After**

https://github.com/user-attachments/assets/6970d001-e1c9-457d-8821-c7d2fd1de85b

