### PR TITLE
fix(agent-context): report accurate total and allow deeper pagination in hybrid document search

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/documents.py
@@ -191,10 +191,24 @@ def _merge_search_results(
     )
 
     # Build merged response, preserving facets from keyword search
+    # The keyword server total reflects only the keyword result set. When the
+    # semantic search contributes documents the keyword query did not match, the
+    # keyword total can understate the interleaved union (even dropping below the
+    # number of returned results). The backend cannot provide the union cardinality
+    # directly, so report at least the fetched union size and at least the keyword
+    # total to keep `total >= count` and reflect the available matches.
+    keyword_total = (
+        keyword_results.get("total") if isinstance(keyword_results, dict) else None
+    )
+    merged_count = len(merged_results)
+    if keyword_total is None:
+        resolved_total = merged_count
+    else:
+        resolved_total = max(keyword_total, merged_count)
     merged_response: Dict[str, Any] = {
         "searchResults": merged_results,
-        "total": len(merged_results),
-        "count": len(merged_results),
+        "total": resolved_total,
+        "count": merged_count,
     }
 
     # Include facets from keyword search (more reliable for filtering)
@@ -290,7 +304,9 @@ def _hybrid_search_documents(
 
     # Apply pagination to merged results
     all_results = merged.get("searchResults", [])
-    total_merged = len(all_results)
+    # Preserve the server-reported total from the underlying search(es) rather
+    # than reporting the fetched/deduped page size as the total.
+    total_matches = merged.get("total", len(all_results))
 
     # Slice to get the requested page
     paginated_results = all_results[offset : offset + num_results]
@@ -299,7 +315,7 @@ def _hybrid_search_documents(
     merged["searchResults"] = paginated_results
     merged["start"] = offset
     merged["count"] = len(paginated_results)
-    merged["total"] = total_merged
+    merged["total"] = total_matches
 
     # Add metadata if we hit the fetch limit
     if hit_fetch_limit:
@@ -339,6 +355,15 @@ def search_documents(
     - Top keyword result appears first (exact match priority)
     - Each result includes searchType: "keyword", "semantic", or "both"
     - Results appearing in both searches are high-confidence matches
+
+    HYBRID `total` AND PAGINATION:
+    - `total` reflects the keyword search's full match count (and is never
+      smaller than the number of returned results). It can understate documents
+      that only the semantic query matches, since the platform does not expose a
+      combined union count.
+    - Hybrid search fetches at most MAX_HYBRID_FETCH_RESULTS (100) results before
+      merging, so offsets much beyond 100 return an empty page and set
+      `_hybridSearchLimitReached: true`. Use a narrower query before paginating.
 
     Example: search_documents(
         query="kubernetes deployment",
@@ -408,6 +433,9 @@ def search_documents(
             result = search_documents(query="deployment")
     """
     graph = get_graph()
+    # Cap the caller-facing page size at 50. Internal fetch sizes (used by the
+    # hybrid merge) are allowed to exceed this so pagination can go deeper.
+    num_results = min(num_results, 50)
     with PerfTimer() as timer:
         # If semantic_query is provided, run hybrid search
         if semantic_query:
@@ -462,8 +490,6 @@ def _search_documents_impl(
     offset: int = 0,
 ) -> dict:
     """Internal implementation for document search with keyword or semantic strategy."""
-    # Cap num_results at 50
-    num_results = min(num_results, 50)
 
     # Parse SQL-like filter string and compile to orFilters
     # entity_types is discarded — the GQL queries already hardcode types: [DOCUMENT]

--- a/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
@@ -194,6 +194,144 @@ def test_search_documents_num_results_capped_at_50(
     assert variables["count"] == 50
 
 
+def test_search_documents_hybrid_pagination_past_50(monkeypatch, mock_client):
+    """Test deep hybrid pagination through search_documents (offset > 50).
+
+    The internal fetch must be allowed to page past the caller-facing 50-result
+    cap; this exercises the real boundary by requesting offset 51 and asserting
+    the returned page stays consistent with the caller's offset/count.
+    """
+    monkeypatch.setattr(
+        "datahub_agent_context.mcp_tools.documents.resolve_default_view",
+        lambda graph: None,
+    )
+    docs = [{"entity": {"urn": f"urn:li:document:k_{i:02d}"}} for i in range(60)]
+    mock_client._graph.execute_graphql.side_effect = [
+        {
+            "searchAcrossEntities": {
+                "start": 0,
+                "count": 60,
+                "total": 200,
+                "searchResults": docs,
+                "facets": [],
+            }
+        },
+        {
+            "semanticSearchAcrossEntities": {
+                "start": 0,
+                "count": 1,
+                "total": 200,
+                "searchResults": [docs[2]],
+                "facets": [],
+            }
+        },
+    ]
+
+    with DataHubContext(mock_client):
+        result = search_documents(
+            query="*", semantic_query="x", num_results=5, offset=51
+        )
+
+    assert result["start"] == 51
+    assert result["count"] == 5
+    assert len(result["searchResults"]) == 5
+    assert result["total"] == 200
+    assert {r["entity"]["urn"] for r in result["searchResults"]} == {
+        f"urn:li:document:k_{i:02d}" for i in range(51, 56)
+    }
+
+
+def test_search_documents_hybrid_merge_total_with_semantic_only(
+    monkeypatch, mock_client
+):
+    """Test the successful hybrid-merge total with overlap and a semantic-only hit.
+
+    The semantic search contributes a document the keyword query did not match;
+    the merged response must still report a total that is at least the count and
+    reflects the keyword total when it is larger.
+    """
+    monkeypatch.setattr(
+        "datahub_agent_context.mcp_tools.documents.resolve_default_view",
+        lambda graph: None,
+    )
+    keyword_docs = [{"entity": {"urn": f"urn:li:document:k_{i}"}} for i in range(5)]
+    semantic_docs = [
+        keyword_docs[3],  # overlap with keyword
+        {"entity": {"urn": "urn:li:document:s_only"}},
+    ]
+    mock_client._graph.execute_graphql.side_effect = [
+        {
+            "searchAcrossEntities": {
+                "start": 0,
+                "count": 5,
+                "total": 26,
+                "searchResults": keyword_docs,
+                "facets": [],
+            }
+        },
+        {
+            "semanticSearchAcrossEntities": {
+                "start": 0,
+                "count": 2,
+                "total": 3,
+                "searchResults": semantic_docs,
+                "facets": [],
+            }
+        },
+    ]
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="*", semantic_query="weather", num_results=5)
+
+    returned_urns = {r["entity"]["urn"] for r in result["searchResults"]}
+    # Semantic-only doc is included and the keyword total is preserved.
+    assert "urn:li:document:s_only" in returned_urns
+    assert result["total"] == 26
+    assert result["count"] == min(5, len(returned_urns))
+    assert result["total"] >= result["count"]
+
+
+def test_search_documents_hybrid_total_at_least_count(monkeypatch, mock_client):
+    """Test that hybrid `total` is never smaller than `count`.
+
+    Regression: a keyword search with total=0 plus a single semantic-only hit
+    previously produced total=0, count=1. The merged total must account for
+    fetched semantic-only results.
+    """
+    monkeypatch.setattr(
+        "datahub_agent_context.mcp_tools.documents.resolve_default_view",
+        lambda graph: None,
+    )
+    mock_client._graph.execute_graphql.side_effect = [
+        {
+            "searchAcrossEntities": {
+                "start": 0,
+                "count": 0,
+                "total": 0,
+                "searchResults": [],
+                "facets": [],
+            }
+        },
+        {
+            "semanticSearchAcrossEntities": {
+                "start": 0,
+                "count": 1,
+                "total": 1,
+                "searchResults": [{"entity": {"urn": "urn:li:document:s_only"}}],
+                "facets": [],
+            }
+        },
+    ]
+
+    with DataHubContext(mock_client):
+        result = search_documents(query="x", semantic_query="y", num_results=5)
+
+    assert result["searchResults"][0]["entity"]["urn"] == "urn:li:document:s_only"
+    assert result["total"] == 1
+    assert result["count"] == 1
+    assert result["total"] >= result["count"]
+
+
 def test_search_documents_facet_only(mock_client):
     """Test facet-only query with num_results=0."""
     # Mock response with non-empty facets to verify they're preserved


### PR DESCRIPTION
$b

## Evidence (live quickstart, hybrid path)

```
$ search_documents(query="*", semantic_query="weather", num_results=5)
total: 26     # correct — 26 documents match
count: 5      # returned page
```

**Before this change** the same call reported:
```
total: 5      # WRONG — it echoed the fetched page size, not the 26 matches
count: 5
```

Keyword search (non-hybrid) already reported the correct `total: 26`; only the hybrid merge overwrote it with the number of results it happened to fetch. Deep pagination is also restored: the internal fetch is no longer truncated to the 50-result caller cap, so `offset > 50` works (covered by `test_search_documents_hybrid_pagination_past_50`).
