### PR TITLE
docs(quickstart): document silent hang when DOCKER_HOST is unset with Colima/Rancher Desktop/Podman

### DIFF
--- a/docs/troubleshooting/quickstart.md
+++ b/docs/troubleshooting/quickstart.md
@@ -68,7 +68,7 @@ pulls, no containers created, no error — while `docker ps` works fine in the s
 is most likely talking to a different Docker endpoint than your `docker` CLI is.
 
 The quickstart uses the `docker` Python SDK (`docker.from_env()`), which reads the `DOCKER_HOST`
-environment variable but does **not** read Docker CLI *contexts*. Alternative runtimes such as
+environment variable but does **not** read Docker CLI _contexts_. Alternative runtimes such as
 Colima, Rancher Desktop, and Podman install a context instead of exporting `DOCKER_HOST`, so the
 SDK falls back to the default socket path and waits there.
 

--- a/docs/troubleshooting/quickstart.md
+++ b/docs/troubleshooting/quickstart.md
@@ -57,6 +57,44 @@ no matching manifest for linux/arm64/v8 in the manifest list entries
 On Mac computers with Apple Silicon (M1, M2 etc.), you might see an error like `no matching manifest for linux/arm64/v8 in the manifest list entries`, this typically means that the datahub cli was not able to detect that you are running it on Apple Silicon. To resolve this issue, override the default architecture detection by issuing `datahub docker quickstart --arch m1`
 
 </details>
+
+<details>
+<summary>
+Quickstart hangs at "Starting up DataHub..." with Colima, Rancher Desktop, or Podman
+</summary>
+
+If `datahub docker quickstart` prints `Starting up DataHub...` followed only by dots — no image
+pulls, no containers created, no error — while `docker ps` works fine in the same shell, the CLI
+is most likely talking to a different Docker endpoint than your `docker` CLI is.
+
+The quickstart uses the `docker` Python SDK (`docker.from_env()`), which reads the `DOCKER_HOST`
+environment variable but does **not** read Docker CLI *contexts*. Alternative runtimes such as
+Colima, Rancher Desktop, and Podman install a context instead of exporting `DOCKER_HOST`, so the
+SDK falls back to the default socket path and waits there.
+
+Check which endpoint your active context uses, then export it:
+
+```sh
+docker context inspect --format '{{.Endpoints.docker.Host}}'
+```
+
+```sh
+# Colima
+export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+
+# Rancher Desktop
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+
+# Podman (rootless)
+export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
+
+datahub docker quickstart
+```
+
+Add the `export` line to your shell profile to make it persistent.
+
+</details>
+
 <details>
 <summary>
 Miscellaneous Docker issues

--- a/docs/troubleshooting/quickstart.md
+++ b/docs/troubleshooting/quickstart.md
@@ -72,26 +72,19 @@ environment variable but does **not** read Docker CLI _contexts_. Alternative ru
 Colima, Rancher Desktop, and Podman install a context instead of exporting `DOCKER_HOST`, so the
 SDK falls back to the default socket path and waits there.
 
-Check which endpoint your active context uses, then export it:
+Point `DOCKER_HOST` at the endpoint of your active context, then run the quickstart:
 
 ```sh
-docker context inspect --format '{{.Endpoints.docker.Host}}'
-```
-
-```sh
-# Colima
-export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
-
-# Rancher Desktop
-export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
-
-# Podman (rootless)
-export DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock"
-
+docker context inspect --format '{{.Endpoints.docker.Host}}'   # see which socket is active
+export DOCKER_HOST="$(docker context inspect --format '{{.Endpoints.docker.Host}}')"
 datahub docker quickstart
 ```
 
-Add the `export` line to your shell profile to make it persistent.
+Taking the endpoint from the active context works for every runtime, including custom Colima
+profiles, Rancher Desktop, and rootless Podman, whose socket paths differ between installations.
+Re-run the `export` after switching Docker contexts: the SDK keeps using whatever `DOCKER_HOST`
+held when it was set. To have it set automatically in new shells, add the `export` line above,
+rather than a fixed socket path, to your shell profile so that it follows the active context.
 
 </details>
 


### PR DESCRIPTION
### Problem

`datahub docker quickstart` uses docker-py's `docker.from_env()`, which honors the `DOCKER_HOST` environment variable but does **not** read Docker CLI *contexts*.

Runtimes like **Colima**, **Rancher Desktop**, and **Podman** install a Docker *context* rather than exporting `DOCKER_HOST`. In that setup the quickstart prints `Starting up DataHub...` and then hangs indefinitely on dots — no image pulls, no containers, and no error — while `docker ps` works normally in the same shell. There is nothing in the output pointing at the endpoint mismatch.

I hit this on macOS arm64 + Colima and lost ~15 minutes before realizing the CLI and my shell were talking to different Docker endpoints.

### Fix

Adds a troubleshooting entry to `docs/troubleshooting/quickstart.md` that:
- explains why the hang happens (docker-py reads `DOCKER_HOST`, not contexts),
- shows how to confirm it (`docker context inspect --format '{{.Endpoints.docker.Host}}'`),
- gives the `DOCKER_HOST` export for Colima, Rancher Desktop, and Podman.

Docs-only change, placed next to the existing Apple Silicon entry since they hit the same audience.

### Possible follow-up (not in this PR)

`datahub docker check` could detect this case directly: if docker-py cannot connect but a `docker context inspect` endpoint is reachable, emit a targeted error suggesting `DOCKER_HOST`. Happy to open a separate PR if maintainers think that's worthwhile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents why `datahub docker quickstart` hangs at “Starting up DataHub…” on Colima, Rancher Desktop, and Podman, and how to fix it.

- The quickstart uses docker-py, which reads `DOCKER_HOST` but ignores Docker CLI contexts; these runtimes install a context, so the CLI waits on the default socket.
- The new troubleshooting entry derives `DOCKER_HOST` from the active context via `docker context inspect`, which also works for custom Colima profiles and rootless Podman.
- Advises re-exporting after switching contexts and adding the export to the shell profile so it follows the active context.

<sup>Written for commit ab0d2e2d97b7914a1ee244992afe7b81f63d624b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

