### PR TITLE
fix(gms): Prevent Caffeine 2 from creeping into GMS classpath

### DIFF
--- a/metadata-auth/auth-api/build.gradle
+++ b/metadata-auth/auth-api/build.gradle
@@ -18,9 +18,11 @@ shadowJar {
   zip64 true
   archiveClassifier = ""
   exclude "META-INF/*.RSA", "META-INF/*.SF","META-INF/*.DSA"
-  // metadata-utils pulls Hazelcast; GMS WAR already ships hazelcast-*.jar — bundling duplicates SPI (NodeExtension).
   dependencies {
+    // metadata-utils pulls Hazelcast; GMS WAR already ships hazelcast-*.jar — bundling duplicates SPI (NodeExtension).
     exclude(dependency('com.hazelcast:hazelcast:.*'))
+    // metadata-utils pulls Caffeine 2; GMS requires and ships with Caffeine 3.
+    exclude(dependency('com.github.ben-manes.caffeine:.*')) 
   }
 }
 

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/common/client/ClientCache.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/common/client/ClientCache.java
@@ -113,6 +113,19 @@ public class ClientCache<K, V, C extends ClientCacheConfig> {
         caffeine.recordStats();
       }
 
+      try {
+        /*
+         Caffeine 2 and 3 are mostly API-compatible but differ in the signature of
+         'CacheLoader.loadAll'.
+         Caffeine 2 creeping into the classpath of code meant for Caffeine 3 leads to silent but
+         non-critical issues so we want a warning.
+        */
+        CacheLoader.class.getMethod("loadAll", Set.class);
+      } catch (NoSuchMethodException | SecurityException e) {
+        log.warn(
+            "Could not find CacheLoader.loadAll(Set<>). Please ensure classpath does not contain Caffeine 2");
+      }
+
       LoadingCache<K, V> cache = caffeine.build(loader);
 
       if (config.isStatsEnabled() && metricUtils != null) {


### PR DESCRIPTION
## Summary
The `auth-api` shadow JAR currently pulls in Caffeine 2.7, polluting GMS classpath which requires Caffeine 3. This leads to a very silent but non-critical issue: for cacheable entities, it breaks the ability of `SystemJavaEntityClient.batchGetV2` to fetch multiple aspects at once.

Rough overview of the problem:
 - Assune some GMS code calls `SystemEntityClient.batchGetV2(<cacheable entity>, [aspect1, aspect2, ...])` . e.g.  [here](https://github.com/datahub-project/datahub/blob/65874f70f7f82175de8a3322e6201d3879079474/metadata-service/auth-impl/src/main/java/com/datahub/authentication/group/GroupService.java#L82) where we try to fetch 3 aspects for a user at once while establishing session-level user identity
 - This eventually gets forwarded to Caffeine via `EntityClientCache`
 - Caffeine checks [here](https://github.com/ben-manes/caffeine/blob/v2.dev/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalLoadingCache.java#L182) if our supplied loader ([here](https://github.com/datahub-project/datahub/blob/55e76704c1bf1accfef50a783bbc780524de4ef4/metadata-service/restli-client-api/src/main/java/com/linkedin/common/client/ClientCache.java#L77)) has a `loadAll` defined. In presence of this classpath conflict, the check fails because Caffeine 2 expects `loadAll(Iterable<>)` while we supply `loadAll(Set<>)`.
 - Failing to find a `loadAll`, Caffeine loads keys one at a time, effectively making one call to `EntityClient.batchGetV2` per aspect rather than a single call with the full list of aspects as expected.  


## Changes
- Remove Caffeine from the `auth-api` shadow JAR so GMS does not see Caffeine 2
- Log a warning if Caffeine 2 is detected

## Test Plan
A test would not really help here given that the test classpath was never affected by this problem.  I have manually verified via query logs that the problem described in the summary is fixed now and `SystemEntityClient.batchGetV2` now fetches all aspects at the same time. For the example of fetching user identity per session , we no longer require multiple calls to fetch group information.

Before:
```
2026-08-05T14:21:19.010047Z	11457 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'nativeGroupMembership', 0))
2026-08-05T14:21:19.010883Z	11457 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'roleMembership', 0))
2026-08-05T14:21:19.011351Z	11457 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'groupMembership', 0))
```
After :
```
2026-08-10T08:26:52.404832Z	53080 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'nativeGroupMembership', 0),('urn:li:corpuser:datahub', 'groupMembership', 0),('urn:li:corpuser:datahub', 'roleMembership', 0))
```

## Checklist
- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Linked related issues (if applicable)
- [ ] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Caffeine 2 from leaking into the GMS classpath by excluding it from the `auth-api` shadow JAR and adding a runtime warning if detected. This restores batch aspect fetching in `SystemEntityClient.batchGetV2`, reducing redundant calls.

- **Bug Fixes**
  - Excluded `com.github.ben-manes.caffeine` from the `auth-api` shadow JAR so GMS uses Caffeine 3.
  - Added a reflection check in `ClientCache` to warn when `CacheLoader.loadAll(Set<>)` is missing (indicates Caffeine 2 on classpath).

<sup>Written for commit 7cc94847f9ae56b2f4140215b3a3a0bea323bb7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

