### PR TITLE
fix(test/playwright): fix flaky playwright test in upload-files

### DIFF
--- a/e2e-test/ui/playwright/pages/description-editor.page.ts
+++ b/e2e-test/ui/playwright/pages/description-editor.page.ts
@@ -104,15 +104,23 @@ export default class DescriptionEditorPage extends BasePage {
     await fileNode.waitFor({ state: 'visible', timeout: TIMEOUTS.EXTRA_LONG });
   }
 
+  private async waitForFileUrlAttribute(fileNode: Locator, urlPattern: RegExp): Promise<void> {
+    let actualUrl = '';
+    await this.page.waitForFunction(
+      async () => {
+        actualUrl = (await fileNode.getAttribute('data-file-url')) || '';
+        return actualUrl && urlPattern.test(actualUrl);
+      },
+      { timeout: TIMEOUTS.EXTRA_LONG },
+    );
+  }
+
   async verifyFileNodeInEditor(_fileId: string, fileName: string): Promise<void> {
     const fileNode = this.editorFileNodesContainer.getByTestId(this.getFileNodeTestId(fileName));
     await expect(fileNode).toBeVisible();
 
     const urlPattern = /\/openapi\/v1\/files\/product_assets\/urn:li:dataHubFile:.+/;
-    const actualUrl = await fileNode.getAttribute('data-file-url');
-    if (!actualUrl || !urlPattern.test(actualUrl)) {
-      throw new Error(`File URL does not match expected pattern. Got: ${actualUrl}`);
-    }
+    await this.waitForFileUrlAttribute(fileNode, urlPattern);
     await expect(fileNode).toContainText(fileName);
   }
 
@@ -121,10 +129,7 @@ export default class DescriptionEditorPage extends BasePage {
     await expect(fileNode).toBeVisible();
 
     const urlPattern = /\/openapi\/v1\/files\/product_assets\/urn:li:dataHubFile:.+/;
-    const actualUrl = await fileNode.getAttribute('data-file-url');
-    if (!actualUrl || !urlPattern.test(actualUrl)) {
-      throw new Error(`File URL does not match expected pattern. Got: ${actualUrl}`);
-    }
+    await this.waitForFileUrlAttribute(fileNode, urlPattern);
     await expect(fileNode).toContainText(fileName);
   }
 

--- a/e2e-test/ui/playwright/pages/description-editor.page.ts
+++ b/e2e-test/ui/playwright/pages/description-editor.page.ts
@@ -105,14 +105,7 @@ export default class DescriptionEditorPage extends BasePage {
   }
 
   private async waitForFileUrlAttribute(fileNode: Locator, urlPattern: RegExp): Promise<void> {
-    let actualUrl = '';
-    await this.page.waitForFunction(
-      async () => {
-        actualUrl = (await fileNode.getAttribute('data-file-url')) || '';
-        return actualUrl && urlPattern.test(actualUrl);
-      },
-      { timeout: TIMEOUTS.EXTRA_LONG },
-    );
+    await expect(fileNode).toHaveAttribute('data-file-url', urlPattern, { timeout: TIMEOUTS.EXTRA_LONG });
   }
 
   async verifyFileNodeInEditor(_fileId: string, fileName: string): Promise<void> {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/PRD-2366/fix-flaky-playwright-test-in-upload-filesspects

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky `playwright` test in upload-files by waiting for the `data-file-url` to match the expected pattern before assertions. Addresses Linear PRD-2366.

- **Bug Fixes**
  - Added `waitForFileUrlAttribute(fileNode, urlPattern)` using `expect(...).toHaveAttribute` with `TIMEOUTS.EXTRA_LONG`.
  - Updated editor and read-mode checks to wait for `/openapi/v1/files/product_assets/urn:li:dataHubFile:.+/` before asserting text.
  - Reduces false negatives caused by timing/race conditions.

<sup>Written for commit 91e177ac04771e752618fd830a0c6e8415bc8a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

