### PR TITLE
fix(test/playwright): stabilize flaky playwright test in edit-documentation

### DIFF
--- a/e2e-test/ui/playwright/pages/entity-documentation.page.ts
+++ b/e2e-test/ui/playwright/pages/entity-documentation.page.ts
@@ -80,7 +80,9 @@ export class EntityDocumentationPage extends BasePage {
     // but the element may have zero height until the flex layout resolves.
     await this.proseMirrorEditor.click({ force: true });
     await this.page.keyboard.press('ControlOrMeta+a');
-    await this.page.keyboard.type(text);
+    await this.proseMirrorEditor.pressSequentially(text, { delay: DELAYS.SEQUENTIAL });
+    // Wait for button to be enabled after change detection (same pattern as editFieldDescription)
+    await expect(this.saveDescriptionButton).toBeEnabled({ timeout: TIMEOUTS.EXTRA_LONG });
     await this.saveDescriptionButton.click();
     await this.toast.expectVisible('Description Updated', { timeout: 15000 });
   }
@@ -146,7 +148,7 @@ export class EntityDocumentationPage extends BasePage {
         await this.fieldDescriptionEditor.click({ force: true });
         await this.page.keyboard.press('ControlOrMeta+a');
         await this.page.keyboard.press('Delete');
-        await this.page.keyboard.type(description, { delay: DELAYS.TYPING });
+        await this.fieldDescriptionEditor.pressSequentially(description, { delay: DELAYS.SEQUENTIAL });
 
         // Publish is disabled until Remirror onChange reports a value different from the
         // original description. Waiting for enabled avoids a 60s actionability timeout.


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/PFP-5369/stabilize-flaky-playwright-edit-documentation-test-on-master#comment-7ebbbf7f

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the flaky edit-documentation `playwright` test by simulating typing reliably and waiting for the Save button to enable before submitting. Addresses Linear PFP-5369.

- **Bug Fixes**
  - Use pressSequentially with a small delay for ProseMirror inputs instead of keyboard.type.
  - Wait for the Save Description button to become enabled before clicking to avoid actionability timeouts.

<sup>Written for commit 2cb156c38a31c3088516788049cf72f70ea32c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

