### PR TITLE
docs: clarify assertion API support across SDK versions

### DIFF
--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -175,17 +175,23 @@ To create or update a custom assertion in Python, use `client.assertions.sync_cu
 This wraps the same `upsertCustomAssertion` GraphQL mutation.
 
 :::note
-`client.assertions` is provided by the `acryl-datahub-cloud` package. On an
-open-source `acryl-datahub` install it raises
-`SdkUsageError: AssertionsClient is not installed`, so use the
-`DataHubGraph.upsert_custom_assertion` form shown below instead.
+With `acryl-datahub` 1.7.0 and earlier, `client.assertions` requires the
+`acryl-datahub-cloud` package and raises `SdkUsageError` without it. Use
+`DataHubGraph.upsert_custom_assertion` below instead.
+
+In releases after 1.7.0, open-source `acryl-datahub` provides an
+`AssertionClient` fallback, so `client.assertions.sync_custom_assertion` works
+without the cloud package. Other cloud-only assertion methods still require
+`acryl-datahub-cloud`.
 :::
 
 ```python
 {{ inline /metadata-ingestion/examples/library/sync_custom_assertion.py show_path_as_comment }}
 ```
 
-Lower-level `DataHubGraph.upsert_custom_assertion` is also available if you are not using the V2 SDK, and is the supported path on open-source DataHub:
+If you are not using the V2 SDK, you can call the lower-level
+`DataHubGraph.upsert_custom_assertion` directly. This is also the path to use
+with `acryl-datahub` 1.7.0 and earlier:
 
 ```python
 {{ inline /metadata-ingestion/examples/library/upsert_custom_assertion.py show_path_as_comment }}
@@ -257,8 +263,10 @@ If the result is `true`, the result was successfully reported.
 </TabItem>
 <TabItem value="python" label="Python">
 
-To report an assertion result in Python, use `client.assertions.report_assertion_result`
-(or `DataHubGraph.report_assertion_result`).
+To report an assertion result in Python, use `client.assertions.report_assertion_result`.
+On `acryl-datahub` 1.7.0 and earlier, use
+`DataHubGraph.report_assertion_result` instead if `acryl-datahub-cloud` is not
+installed.
 
 ```python
 {{ inline /metadata-ingestion/examples/library/report_assertion_result.py show_path_as_comment }}

--- a/docs/api/tutorials/custom-assertions.md
+++ b/docs/api/tutorials/custom-assertions.md
@@ -174,11 +174,18 @@ The upsert API will return the unique identifier (URN) for the assertion if you 
 To create or update a custom assertion in Python, use `client.assertions.sync_custom_assertion`.
 This wraps the same `upsertCustomAssertion` GraphQL mutation.
 
+:::note
+`client.assertions` is provided by the `acryl-datahub-cloud` package. On an
+open-source `acryl-datahub` install it raises
+`SdkUsageError: AssertionsClient is not installed`, so use the
+`DataHubGraph.upsert_custom_assertion` form shown below instead.
+:::
+
 ```python
 {{ inline /metadata-ingestion/examples/library/sync_custom_assertion.py show_path_as_comment }}
 ```
 
-Lower-level `DataHubGraph.upsert_custom_assertion` is also available if you are not using the V2 SDK:
+Lower-level `DataHubGraph.upsert_custom_assertion` is also available if you are not using the V2 SDK, and is the supported path on open-source DataHub:
 
 ```python
 {{ inline /metadata-ingestion/examples/library/upsert_custom_assertion.py show_path_as_comment }}


### PR DESCRIPTION
## Summary

Clarifies the Python examples in the custom assertions tutorial across SDK versions:

- On `acryl-datahub` 1.7.0 and earlier, `client.assertions` requires `acryl-datahub-cloud`; OSS users can use the corresponding `DataHubGraph` methods.
- In releases after 1.7.0, the OSS `AssertionClient` fallback supports `sync_custom_assertion` and `report_assertion_result` without the cloud package.
- Other cloud-only assertion APIs still require `acryl-datahub-cloud`.

The same compatibility guidance now appears in both the create/update and report-results Python sections.

## Why

I ran into the `SdkUsageError` while emitting custom assertions from an OSS v1.7.0 quickstart. That behavior is correct for 1.7.0, but #18748 added the OSS fallback shortly after the release was cut. The tutorial therefore needs a version split rather than a blanket warning for all OSS installs.

## Validation

- Checked the current `AssertionClient` fallback: both documented methods delegate to `DataHubGraph`, while unsupported cloud-only methods still raise `SdkUsageError`.
- Ran `git diff --check`.
- Documentation only; no runtime behavior changed.
