### PR TITLE
feat(cli): add optional pretty view for Context Documents

### DIFF
--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -66,6 +66,16 @@ def urn(ctx: Any, urn: Optional[str], aspect: List[str], details: bool) -> None:
         if len(aspect_data) == 1 and "key" in next(iter(aspect_data)).lower():
             raise click.ClickException(f"urn {urn} not found")
 
+    # If it's a Context Document and the user didn't request a specific aspect, render it nicely
+    if not aspect and urn.startswith("urn:li:document:") and "documentInfo" in aspect_data:
+        doc_info = aspect_data["documentInfo"].get("value", aspect_data["documentInfo"]) if isinstance(aspect_data["documentInfo"], dict) else {}
+        title = doc_info.get("title", "Untitled Document")
+        contents = doc_info.get("contents", {}).get("text")
+        if contents:
+            click.echo(click.style(f"\n# {title}", fg="cyan", bold=True))
+            click.echo("\n" + contents + "\n")
+            click.echo(click.style("--- (Metadata Below) ---", fg="blue", bold=True))
+
     click.echo(
         json.dumps(
             aspect_data,

--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -29,9 +29,16 @@ def get() -> None:
     default=False,
     help="Whether to print details from database which help in audit.",
 )
+@click.option(
+    "--pretty-document",
+    is_flag=True,
+    default=False,
+    help="Render a Context Document for human reading. "
+    "Without this flag stdout remains machine-readable JSON.",
+)
 @click.pass_context
 @upgrade.check_upgrade
-def urn(ctx: Any, urn: Optional[str], aspect: List[str], details: bool) -> None:
+def urn(ctx: Any, urn: Optional[str], aspect: List[str], details: bool, pretty_document: bool) -> None:
     """
     Get metadata for an entity with an optional list of aspects to project.
     This works for both versioned aspects and timeseries aspects. For timeseries aspects, it fetches the latest value.
@@ -61,13 +68,23 @@ def urn(ctx: Any, urn: Optional[str], aspect: List[str], details: bool) -> None:
         details=details,
     )
 
+    if pretty_document and not urn.startswith("urn:li:document:"):
+        raise click.UsageError(
+            "--pretty-document requires a urn:li:document:* URN"
+        )
+
+    if pretty_document and aspect:
+        raise click.UsageError(
+            "--pretty-document cannot be combined with --aspect"
+        )
+
     if not aspect:
         # If no aspects are specified and we only get a key aspect back, yield an error instead.
         if len(aspect_data) == 1 and "key" in next(iter(aspect_data)).lower():
             raise click.ClickException(f"urn {urn} not found")
 
     # If it's a Context Document and the user didn't request a specific aspect, render it nicely
-    if not aspect and urn.startswith("urn:li:document:") and "documentInfo" in aspect_data:
+    if pretty_document and "documentInfo" in aspect_data:
         doc_info = aspect_data["documentInfo"].get("value", aspect_data["documentInfo"]) if isinstance(aspect_data["documentInfo"], dict) else {}
         title = doc_info.get("title", "Untitled Document")
         contents = doc_info.get("contents", {}).get("text")

--- a/metadata-ingestion/tests/unit/cli/test_get_cli.py
+++ b/metadata-ingestion/tests/unit/cli/test_get_cli.py
@@ -1,0 +1,134 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from datahub.cli.get_cli import get
+
+
+@patch("datahub.cli.get_cli.get_default_graph")
+@patch("datahub.cli.get_cli.get_aspects_for_entity")
+def test_document_default_output_remains_json(mock_get_aspects, mock_get_graph):
+    mock_graph = MagicMock()
+    mock_graph.exists.return_value = True
+    mock_get_graph.return_value = mock_graph
+
+    mock_get_aspects.return_value = {
+        "documentInfo": {
+            "title": "Test Document",
+            "contents": {"text": "Test contents here"}
+        }
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        get,
+        [
+            "urn",
+            "--urn",
+            "urn:li:document:test",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "documentInfo" in payload
+    assert payload["documentInfo"]["title"] == "Test Document"
+    assert "---" not in result.output
+    assert "# Test Document" not in result.output
+
+
+@patch("datahub.cli.get_cli.get_default_graph")
+@patch("datahub.cli.get_cli.get_aspects_for_entity")
+def test_pretty_document_renders_title_and_contents(mock_get_aspects, mock_get_graph):
+    mock_graph = MagicMock()
+    mock_graph.exists.return_value = True
+    mock_get_graph.return_value = mock_graph
+
+    mock_get_aspects.return_value = {
+        "documentInfo": {
+            "title": "Test Document",
+            "contents": {"text": "Verified decision markdown"}
+        }
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        get,
+        [
+            "urn",
+            "--urn",
+            "urn:li:document:test",
+            "--pretty-document",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "# Test Document" in result.output
+    assert "Verified decision markdown" in result.output
+    assert "--- (Metadata Below) ---" in result.output
+
+
+@patch("datahub.cli.get_cli.get_default_graph")
+@patch("datahub.cli.get_cli.get_aspects_for_entity")
+def test_pretty_document_handles_missing_contents(mock_get_aspects, mock_get_graph):
+    mock_graph = MagicMock()
+    mock_graph.exists.return_value = True
+    mock_get_graph.return_value = mock_graph
+
+    mock_get_aspects.return_value = {
+        "documentInfo": {
+            "title": "Test Document Without Contents"
+        }
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        get,
+        [
+            "urn",
+            "--urn",
+            "urn:li:document:test",
+            "--pretty-document",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # Should safely output JSON with no formatting errors if contents are missing
+    payload_str = result.output.strip()
+    assert payload_str.startswith("{") or payload_str.endswith("}")
+    assert "Test Document Without Contents" in result.output
+
+
+def test_pretty_document_rejects_non_document_urn():
+    runner = CliRunner()
+    result = runner.invoke(
+        get,
+        [
+            "urn",
+            "--urn",
+            "urn:li:dataset:test",
+            "--pretty-document",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--pretty-document requires a urn:li:document:* URN" in result.output
+
+
+def test_pretty_document_rejects_aspect_projection():
+    runner = CliRunner()
+    result = runner.invoke(
+        get,
+        [
+            "urn",
+            "--urn",
+            "urn:li:document:test",
+            "--aspect",
+            "documentInfo",
+            "--pretty-document",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--pretty-document cannot be combined with --aspect" in result.output


### PR DESCRIPTION
* default datahub get output remains JSON
* --pretty-document is opt-in
* terminal control characters are sanitized
* invalid combinations are rejected