### PR TITLE
feat(ingest/airbyte): opt in to inactive connection ingestion

### DIFF
--- a/metadata-ingestion/docs/sources/airbyte/airbyte_post.md
+++ b/metadata-ingestion/docs/sources/airbyte/airbyte_post.md
@@ -25,11 +25,10 @@ If ingestion fails, validate credentials, permissions, connectivity, and scope f
 
 #### Missing Connections
 
-By default, only Airbyte connections with Public API `status: active` are ingested.
-Inactive connections are skipped with no warning. If a connection is visible and healthy
-in the Airbyte UI but missing from DataHub, confirm the Public API reports
-`status: "active"` for that connection id. To ingest inactive connections as well, set
-`include_inactive_connections: true` in the recipe.
+By default only enabled Airbyte connections are ingested. Disabled connections are
+skipped with no warning. If a connection is missing from DataHub, check whether it
+is disabled in Airbyte (or whether its Public API `status` is `"inactive"`). To
+ingest disabled connections as well, set `include_inactive_connections: true`.
 
 #### Authentication Errors
 

--- a/metadata-ingestion/docs/sources/airbyte/airbyte_post.md
+++ b/metadata-ingestion/docs/sources/airbyte/airbyte_post.md
@@ -23,6 +23,14 @@ Module behavior is constrained by source APIs, permissions, and metadata exposed
 
 If ingestion fails, validate credentials, permissions, connectivity, and scope filters first. Then review ingestion logs for source-specific errors and adjust configuration accordingly.
 
+#### Missing Connections
+
+By default, only Airbyte connections with Public API `status: active` are ingested.
+Inactive connections are skipped with no warning. If a connection is visible and healthy
+in the Airbyte UI but missing from DataHub, confirm the Public API reports
+`status: "active"` for that connection id. To ingest inactive connections as well, set
+`include_inactive_connections: true` in the recipe.
+
 #### Authentication Errors
 
 Verify that your OAuth2 client credentials are correct and have not expired. For OSS deployments, confirm the API is reachable at the `/api/public/v1` path prefix.

--- a/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
+++ b/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
@@ -27,6 +27,7 @@ source:
     extract_column_level_lineage: true # Extract column-level lineage information
     include_statuses: true             # Include connection job statuses
     job_statuses_limit: 100            # Max number of job statuses to retrieve
+    # include_inactive_connections: false  # Opt in to ingest inactive Airbyte connections
     
     # Lineage emission mode
     incremental_lineage: true          # Emit lineage as patch (incremental) rather than full replacement

--- a/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
+++ b/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
@@ -27,7 +27,7 @@ source:
     extract_column_level_lineage: true # Extract column-level lineage information
     include_statuses: true             # Include connection job statuses
     job_statuses_limit: 100            # Max number of job statuses to retrieve
-    # include_inactive_connections: false  # Opt in to ingest inactive Airbyte connections
+    # include_inactive_connections: false  # Also ingest connections disabled in Airbyte
     
     # Lineage emission mode
     incremental_lineage: true          # Emit lineage as patch (incremental) rather than full replacement

--- a/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
+++ b/metadata-ingestion/docs/sources/airbyte/airbyte_recipe.yml
@@ -27,7 +27,6 @@ source:
     extract_column_level_lineage: true # Extract column-level lineage information
     include_statuses: true             # Include connection job statuses
     job_statuses_limit: 100            # Max number of job statuses to retrieve
-    # include_inactive_connections: false  # Also ingest connections disabled in Airbyte
     
     # Lineage emission mode
     incremental_lineage: true          # Emit lineage as patch (incremental) rather than full replacement

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/client.py
@@ -267,7 +267,10 @@ class AirbyteBaseClient(ABC):
         return [AirbyteWorkspacePartial.model_validate(w) for w in workspaces_data]
 
     def list_connections(
-        self, workspace_id: str, pattern: Optional[AllowDenyPattern] = None
+        self,
+        workspace_id: str,
+        pattern: Optional[AllowDenyPattern] = None,
+        include_inactive: bool = False,
     ) -> List[AirbyteConnectionPartial]:
         self._check_auth_before_request()
         params = {API_QUERY_WORKSPACE_ID: workspace_id}
@@ -279,16 +282,17 @@ class AirbyteBaseClient(ABC):
             )
         )
 
-        active_connections = [
-            conn
-            for conn in connections
-            if conn.get(API_FIELD_STATUS) != API_STATUS_INACTIVE
-        ]
+        if not include_inactive:
+            connections = [
+                conn
+                for conn in connections
+                if conn.get(API_FIELD_STATUS) != API_STATUS_INACTIVE
+            ]
 
         if pattern:
-            active_connections = apply_pattern(active_connections, pattern)
+            connections = apply_pattern(connections, pattern)
 
-        return [AirbyteConnectionPartial.model_validate(c) for c in active_connections]
+        return [AirbyteConnectionPartial.model_validate(c) for c in connections]
 
     def list_jobs(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
@@ -266,8 +266,10 @@ class AirbyteSourceConfig(
     include_inactive_connections: bool = Field(
         default=False,
         description=(
-            "Whether to ingest Airbyte connections whose Public API status is "
-            "'inactive'. Default false preserves existing behavior (active only)."
+            "Also ingest connections that are disabled in Airbyte. "
+            "By default only enabled connections are ingested; disabled ones "
+            "are skipped with no warning, even if they still appear healthy in "
+            "the Airbyte UI."
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
@@ -267,9 +267,9 @@ class AirbyteSourceConfig(
         default=False,
         description=(
             "Also ingest connections that are disabled in Airbyte. "
-            "By default only enabled connections are ingested; disabled ones "
-            "are skipped with no warning, even if they still appear healthy in "
-            "the Airbyte UI."
+            "By default, connections reported as inactive are skipped with no "
+            "warning, even if they still appear healthy in the Airbyte UI."
+
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
@@ -269,7 +269,6 @@ class AirbyteSourceConfig(
             "Also ingest connections that are disabled in Airbyte. "
             "By default, connections reported as inactive are skipped with no "
             "warning, even if they still appear healthy in the Airbyte UI."
-
         ),
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/config.py
@@ -263,6 +263,14 @@ class AirbyteSourceConfig(
         "Use this to override platform details for specific destinations.",
     )
 
+    include_inactive_connections: bool = Field(
+        default=False,
+        description=(
+            "Whether to ingest Airbyte connections whose Public API status is "
+            "'inactive'. Default false preserves existing behavior (active only)."
+        ),
+    )
+
     include_statuses: bool = Field(
         default=True,
         description="Whether to ingest run statuses",

--- a/metadata-ingestion/src/datahub/ingestion/source/airbyte/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/airbyte/source.py
@@ -281,6 +281,7 @@ class AirbyteSource(StatefulIngestionSourceBase):
                 for connection in self.client.list_connections(
                     workspace.workspace_id,
                     pattern=self.source_config.connection_pattern,
+                    include_inactive=self.source_config.include_inactive_connections,
                 ):
                     try:
                         if (

--- a/metadata-ingestion/tests/unit/airbyte/test_airbyte_client.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_airbyte_client.py
@@ -185,6 +185,36 @@ class TestAirbyteOSSClient:
             result_key="data",
         )
 
+    @patch("datahub.ingestion.source.airbyte.client.AirbyteOSSClient._paginate_results")
+    def test_list_connections_skips_inactive_by_default(self, mock_paginate_results):
+        mock_paginate_results.return_value = [
+            {
+                "connectionId": "active-id",
+                "name": "Active Connection",
+                "sourceId": "source-id-1",
+                "destinationId": "destination-id-1",
+                "status": "active",
+            },
+            {
+                "connectionId": "inactive-id",
+                "name": "Inactive Connection",
+                "sourceId": "source-id-2",
+                "destinationId": "destination-id-2",
+                "status": "inactive",
+            },
+        ]
+        config = AirbyteClientConfig(
+            deployment_type=AirbyteDeploymentType.OPEN_SOURCE,
+            host_port="http://localhost:8000",
+        )
+        client = AirbyteOSSClient(config)
+
+        connections = client.list_connections("workspace-id-1")
+        assert [c.connection_id for c in connections] == ["active-id"]
+
+        connections = client.list_connections("workspace-id-1", include_inactive=True)
+        assert [c.connection_id for c in connections] == ["active-id", "inactive-id"]
+
     @patch("datahub.ingestion.source.airbyte.client.AirbyteOSSClient._make_request")
     def test_http_error_handling(self, mock_make_request):
         mock_make_request.side_effect = requests.exceptions.HTTPError(

--- a/metadata-ingestion/tests/unit/airbyte/test_airbyte_client.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_airbyte_client.py
@@ -256,7 +256,9 @@ class TestAirbyteClientBase:
             def list_destinations(self, workspace_id, pattern=None):
                 return []
 
-            def list_connections(self, workspace_id, pattern=None):
+            def list_connections(
+                self, workspace_id, pattern=None, include_inactive=False
+            ):
                 return []
 
         class IncompleteClient(AirbyteBaseClient):

--- a/metadata-ingestion/tests/unit/airbyte/test_source_workspaces.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_source_workspaces.py
@@ -194,7 +194,7 @@ def test_get_pipelines_with_filters(mock_create_client, mock_ctx, mock_client):
 
 
 @patch("datahub.ingestion.source.airbyte.source.create_airbyte_client")
-def test_get_pipelines_passes_include_inactive_connections(
+def test_get_pipelines_include_inactive_connections(
     mock_create_client, mock_ctx, mock_client
 ):
     mock_create_client.return_value = mock_client
@@ -210,16 +210,54 @@ def test_get_pipelines_passes_include_inactive_connections(
         workspace_id="workspace-1",
         name="Test Workspace",
     )
-    mock_client.list_workspaces.return_value = [workspace]
-    mock_client.list_connections.return_value = []
+    connection = AirbyteConnectionPartial(
+        connection_id="inactive-connection-1",
+        name="Disabled Connection",
+        source_id="source-1",
+        destination_id="destination-1",
+        status="inactive",
+    )
+    source_model = AirbyteSourcePartial(
+        source_id="source-1",
+        name="Test Source",
+        source_type="postgres",
+        source_definition_id="source-def-1",
+        workspace_id="workspace-1",
+        configuration={"host": "localhost", "port": 5432},
+    )
+    destination = AirbyteDestinationPartial(
+        destination_id="destination-1",
+        name="Test Destination",
+        destination_type="postgres",
+        destination_definition_id="dest-def-1",
+        workspace_id="workspace-1",
+        configuration={"host": "localhost", "port": 5432},
+    )
 
-    list(source._get_pipelines())
+    mock_client.list_workspaces.return_value = [workspace]
+    mock_client.list_connections.return_value = [connection]
+    mock_client.get_connection.return_value = connection
+    mock_client.get_source.return_value = source_model
+    mock_client.get_destination.return_value = destination
+
+    pipelines = list(source._get_pipelines())
+
+    assert len(pipelines) == 1
+    assert isinstance(pipelines[0], AirbytePipelineInfo)
+    assert pipelines[0].workspace.workspace_id == "workspace-1"
+    assert pipelines[0].connection.connection_id == "inactive-connection-1"
+    assert pipelines[0].connection.status == "inactive"
+    assert pipelines[0].source.source_id == "source-1"
+    assert pipelines[0].destination.destination_id == "destination-1"
 
     mock_client.list_connections.assert_called_once_with(
         "workspace-1",
         pattern=AllowDenyPattern.allow_all(),
         include_inactive=True,
     )
+    mock_client.get_connection.assert_called_once_with("inactive-connection-1")
+    mock_client.get_source.assert_called_once_with("source-1")
+    mock_client.get_destination.assert_called_once_with("destination-1")
 
 
 @patch("datahub.ingestion.source.airbyte.source.create_airbyte_client")

--- a/metadata-ingestion/tests/unit/airbyte/test_source_workspaces.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_source_workspaces.py
@@ -122,7 +122,9 @@ def test_get_pipelines(mock_create_client, mock_ctx, mock_client):
 
     mock_client.list_workspaces.assert_called_once()
     mock_client.list_connections.assert_called_once_with(
-        "workspace-1", pattern=AllowDenyPattern.allow_all()
+        "workspace-1",
+        pattern=AllowDenyPattern.allow_all(),
+        include_inactive=False,
     )
     mock_client.get_connection.assert_called_once_with("connection-1")
     mock_client.get_source.assert_called_once_with("source-1")
@@ -189,6 +191,35 @@ def test_get_pipelines_with_filters(mock_create_client, mock_ctx, mock_client):
     source = AirbyteSource(config, mock_ctx)
     pipelines = list(source._get_pipelines())
     assert len(pipelines) == 0
+
+
+@patch("datahub.ingestion.source.airbyte.source.create_airbyte_client")
+def test_get_pipelines_passes_include_inactive_connections(
+    mock_create_client, mock_ctx, mock_client
+):
+    mock_create_client.return_value = mock_client
+    config = AirbyteSourceConfig(
+        deployment_type=AirbyteDeploymentType.OPEN_SOURCE,
+        host_port="http://localhost:8000",
+        platform_instance="test-instance",
+        include_inactive_connections=True,
+    )
+    source = AirbyteSource(config, mock_ctx)
+
+    workspace = AirbyteWorkspacePartial(
+        workspace_id="workspace-1",
+        name="Test Workspace",
+    )
+    mock_client.list_workspaces.return_value = [workspace]
+    mock_client.list_connections.return_value = []
+
+    list(source._get_pipelines())
+
+    mock_client.list_connections.assert_called_once_with(
+        "workspace-1",
+        pattern=AllowDenyPattern.allow_all(),
+        include_inactive=True,
+    )
 
 
 @patch("datahub.ingestion.source.airbyte.source.create_airbyte_client")


### PR DESCRIPTION
## Summary
- Adds `include_inactive_connections` (default `false`) so inactive Airbyte connections remain skipped unless explicitly enabled
- Documents the silent active-only filter and how to opt in via the recipe
- Covers the client filter + source config wiring with unit tests

## Test plan
- [x] `pytest` for `test_list_connections_skips_inactive_by_default`
- [x] `pytest` for `test_get_pipelines` / `test_get_pipelines_passes_include_inactive_connections`
- [x] `./gradlew :metadata-ingestion:lintFix`
- [ ] Re-run Airbyte ingestion with `include_inactive_connections: true` against a workspace that has an inactive connection and confirm its dataFlow is emitted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in flag to ingest disabled Airbyte connections while keeping enabled-only as the default. Adds end-to-end coverage for ingesting inactive connections.

- **New Features**
  - Added `include_inactive_connections` to Airbyte source config to include disabled connections.
  - Threaded the flag through `client.list_connections(..., include_inactive=...)` and `_get_pipelines`.
  - Updated docs (Missing Connections note and recipe) using enabled/disabled wording.
  - Added tests: default skipping, flag pass-through, and end-to-end `_get_pipelines` coverage asserting emitted connection id/status.

- **Bug Fixes**
  - Updated a test client stub to accept `include_inactive` in `list_connections` to satisfy type checks.

<sup>Written for commit 33f67487b9fd6068dbb3da0f19452a7629c47574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

