### PR TITLE
fix(ingestion): add missing limit field to getTimeseriesAspectValues payload (#19016)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -576,6 +576,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             "aspect": "datasetUsageStatistics",
             "startTimeMillis": start_timestamp,
             "endTimeMillis": end_timestamp,
+            "limit": 10000,
         }
         headers: Dict[str, Any] = {}
         url = f"{self._gms_server}/aspects?action=getTimeseriesAspectValues"
@@ -585,8 +586,8 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 url, data=json.dumps(payload), headers=headers
             )
             if response.status_code != 200:
-                logger.debug(
-                    f"Non 200 status found while fetching usage aspects - {response.status_code}"
+                logger.warning(
+                    f"Non-200 fetching usage aspects for {entity_urn}: HTTP {response.status_code}"
                 )
                 return None
             json_resp = response.json()


### PR DESCRIPTION
## Summary

`DataHubGraph.get_usage_aspects_from_urn` POSTs to
`/aspects?action=getTimeseriesAspectValues` without a `limit` field. GMS
requires the field and dereferences it without a null-guard, causing the
server to return a **500 NullPointerException**. The helper then silently
returns `None` — indistinguishable from a dataset with genuinely no usage
data. Callers (usage ingestion sources) therefore report every table as
having zero usage when GMS has data.

## Root Cause

`get_usage_aspects_from_urn` constructs its payload with `urn`, `entity`,
`aspect`, `startTimeMillis`, and `endTimeMillis` but omits `limit`. The
newer `get_timeseries_aspect_values` helper (line ~656 in the same file)
correctly includes `"limit": limit`. The gap was never caught because the
non-200 response was logged at **DEBUG**, so no operational alert fired.

## Changes

| File | Change |
|------|--------|
| `metadata-ingestion/src/datahub/ingestion/graph/client.py` | Add `"limit": 10000` to the payload (matching the upper bound in `get_timeseries_aspect_values`); upgrade non-200 log level from `DEBUG` → `WARNING` so failures surface in logs |

```diff
 payload = {
     "urn": entity_urn,
     "entity": "dataset",
     "aspect": "datasetUsageStatistics",
     "startTimeMillis": start_timestamp,
     "endTimeMillis": end_timestamp,
+    "limit": 10000,
 }
 ...
 if response.status_code != 200:
-    logger.debug(
-        f"Non 200 status found while fetching usage aspects - {response.status_code}"
+    logger.warning(
+        f"Non-200 fetching usage aspects for {entity_urn}: HTTP {response.status_code}"
     )
```

## Testing

Reproducer from issue #19016 — against an OSS quickstart with
`datasetUsageStatistics` ingested:

```python
# Before fix
print("without limit", session.post(url, data=json.dumps(base)).status_code)    # 500
print("with limit",    session.post(url, data=json.dumps({**base, "limit": 100})).status_code)  # 200
print("helper:", g.get_usage_aspects_from_urn(urn, start, now))  # None (wrong)

# After fix
print("helper:", g.get_usage_aspects_from_urn(urn, start, now))  # [DatasetUsageStatisticsClass(...)]
```

Closes #19016.

---

> Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing "limit" field to usage timeseries requests so GMS stops 500ing and `get_usage_aspects_from_urn` returns real usage data instead of None. Raise non-200 response logging to WARNING for visibility. Fixes #19016.

<sup>Written for commit a364215b8e5d418b89885db7b308bc3102064b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

