### PR TITLE
fix(actions): honor ACTIONS_EXTRA_PACKAGES in runtime startup

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -615,6 +615,28 @@ quickstart_configs.each { taskName, config ->
 }
 
 
+// Shell-level tests for the datahub-actions startup scripts. These need no Docker daemon:
+// uv and the installer are stubbed, so they run anywhere bash does.
+//
+// Wired into `check` so the coverage is actually enforced. An unregistered test script is
+// decoration: the defect it guards can return while the required checks stay green.
+tasks.register('testDatahubActionsScripts', Exec) {
+    description = 'Runs the datahub-actions startup script tests'
+    group = 'verification'
+    workingDir = project.projectDir
+    executable 'bash'
+    args 'datahub-actions/tests/test_install_extra_packages.sh'
+
+    inputs.file('datahub-actions/install_extra_packages.sh')
+    inputs.file('datahub-actions/start.sh')
+    inputs.file('datahub-actions/tests/test_install_extra_packages.sh')
+    outputs.upToDateWhen { false }
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('testDatahubActionsScripts')
+}
+
 tasks.register('minDockerCompose2.20', Exec) {
     executable 'bash'
     args '-c', 'echo -e "$(docker compose version | sed -E \'s/.*v([0-9.]+).*/\\1/\')\n2.20"|sort --version-sort --check=quiet --reverse'

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -287,9 +287,10 @@ RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && 
     chown -R datahub:datahub /opt/datahub/bundled-venv-build
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/install_extra_packages.sh /install_extra_packages.sh
 COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
 
-RUN chmod a+x /start_datahub_actions.sh && \
+RUN chmod a+x /start_datahub_actions.sh /install_extra_packages.sh && \
     mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
@@ -373,9 +374,10 @@ RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && 
     chown -R datahub:datahub /opt/datahub/bundled-venv-build
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/install_extra_packages.sh /install_extra_packages.sh
 COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
 
-RUN chmod a+x /start_datahub_actions.sh && \
+RUN chmod a+x /start_datahub_actions.sh /install_extra_packages.sh && \
     mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
@@ -448,9 +450,10 @@ ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-locked $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
 
 COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/install_extra_packages.sh /install_extra_packages.sh
 COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
 
-RUN chmod a+x /start_datahub_actions.sh && \
+RUN chmod a+x /start_datahub_actions.sh /install_extra_packages.sh && \
     mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub

--- a/docker/datahub-actions/README.md
+++ b/docker/datahub-actions/README.md
@@ -35,7 +35,17 @@ The Docker image supports mounting custom Action configuration files. Each confi
 
 To deploy a custom Action configuration, simply plac
 
-Note that the expectation is that the container contains all required plugins to execute the Action configuration. If the action you want to use does not come pre-packaged with DataHub's Actions CLI, you'll need to install the required plugins inside the Dockerfile itself.
+Note that the expectation is that the container contains all required plugins to execute the Action configuration. If the action you want to use does not come pre-packaged with DataHub's Actions CLI, install the required plugins inside the Dockerfile itself. Baking plugins into the image keeps the deployment reproducible, keeps the dependency set reviewable, and is the only option for the `locked` image variant.
+
+For cases where rebuilding an image is impractical, the `full` and `slim` images also honour `ACTIONS_EXTRA_PACKAGES`, a whitespace-separated list of requirements installed at container startup before any Action pipeline is launched:
+
+```
+docker run --env ACTIONS_EXTRA_PACKAGES='acryl-datahub-actions[slack] my-action==1.2.3' ...
+```
+
+This is a convenience, not a replacement for the rule above. It trades reproducibility for iteration speed: the image no longer describes its own dependencies, startup requires reaching a package index, and the installed set can drift between restarts. Prefer it for development and for trying an action out, not for a deployment you intend to keep.
+
+The `locked` image refuses it. That variant strips `uv` and points its package index at a dead address on purpose, so a container that cannot honour `ACTIONS_EXTRA_PACKAGES` fails at startup with an explanation rather than starting up quietly without the packages the operator asked for.
 
 For example, to mount the "hello_world.yml" configuration located under the `examples` directory of this repository can be achieved via:
 

--- a/docker/datahub-actions/install_extra_packages.sh
+++ b/docker/datahub-actions/install_extra_packages.sh
@@ -30,20 +30,32 @@ if [ -z "$extra_packages" ]; then
   exit 0
 fi
 
+# The value is never echoed. pip and uv accept index credentials inline, for example
+# "--extra-index-url https://user:token@host/simple pkg", so printing the variable would
+# persist that token in container logs for anyone with log access.
 if ! command -v uv >/dev/null 2>&1; then
   # printf rather than cat: this path must still report itself in an image that has
   # been stripped down.
   printf '%s\n' \
-    "ACTIONS_EXTRA_PACKAGES is set to \"${extra_packages}\", but this image cannot install" \
-    "packages at runtime: no package manager is present. The locked datahub-actions image" \
-    "strips uv and blocks its package index by design." \
+    "ACTIONS_EXTRA_PACKAGES is set, but this image cannot install packages at runtime:" \
+    "no package manager is present. The locked datahub-actions image strips uv and blocks" \
+    "its package index by design." \
     "" \
     "Use the full or slim datahub-actions image, or build an image that already contains" \
     "these packages." >&2
   exit 1
 fi
 
-echo "Installing ACTIONS_EXTRA_PACKAGES: ${extra_packages}"
-# Unquoted on purpose: the variable holds a whitespace-separated list of packages.
+echo "Installing packages named by ACTIONS_EXTRA_PACKAGES (value not logged: it may carry index credentials)"
+
+# Unquoted on purpose: the variable holds a whitespace-separated list of packages, and
+# word splitting is how that list becomes separate arguments.
+#
+# set -f disables the other half of unquoted expansion. Without it, pathname expansion also
+# applies, and both "pkg==1.*" and "pkg[extra]" are ordinary pip syntax that happen to be
+# glob patterns. A file in the working directory matching one of them would silently replace
+# the requirement with a filename.
+set -f
 # shellcheck disable=SC2086
 uv pip install $extra_packages
+set +f

--- a/docker/datahub-actions/install_extra_packages.sh
+++ b/docker/datahub-actions/install_extra_packages.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install the packages named by ACTIONS_EXTRA_PACKAGES, so that a custom action can
+# bring its own dependencies. docker/profiles/docker-compose.actions.yml passes this
+# variable to every datahub-actions service.
+#
+# The locked image variant removes uv and points the package index at a dead address
+# on purpose (see docker/datahub-actions/Dockerfile). Runtime installation is refused
+# there with an explicit error rather than skipped quietly.
+
+set -euo pipefail
+
+extra_packages="${ACTIONS_EXTRA_PACKAGES:-}"
+
+if [ -z "$extra_packages" ]; then
+  exit 0
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  # printf rather than cat: this path must still report itself in an image that has
+  # been stripped down.
+  printf '%s\n' \
+    "ACTIONS_EXTRA_PACKAGES is set to \"${extra_packages}\", but this image cannot install" \
+    "packages at runtime: no package manager is present. The locked datahub-actions image" \
+    "strips uv and blocks its package index by design." \
+    "" \
+    "Use the full or slim datahub-actions image, or build an image that already contains" \
+    "these packages." >&2
+  exit 1
+fi
+
+echo "Installing ACTIONS_EXTRA_PACKAGES: ${extra_packages}"
+# Unquoted on purpose: the variable holds a whitespace-separated list of packages.
+# shellcheck disable=SC2086
+uv pip install $extra_packages

--- a/docker/datahub-actions/start.sh
+++ b/docker/datahub-actions/start.sh
@@ -24,6 +24,17 @@ if [ -d "/home/datahub/.aws-ro/sso/cache" ]; then
     echo "AWS SSO token copy complete."
 fi
 
+# Install anything named by ACTIONS_EXTRA_PACKAGES before starting, so a custom action
+# can bring its own dependencies. Refuses rather than continues when the image cannot
+# install at runtime.
+INSTALL_EXTRA_PACKAGES="${DATAHUB_ACTIONS_INSTALL_EXTRA_PACKAGES_PATH:-/install_extra_packages.sh}"
+if [ -x "$INSTALL_EXTRA_PACKAGES" ]; then
+  "$INSTALL_EXTRA_PACKAGES" || exit 1
+elif [ -n "${ACTIONS_EXTRA_PACKAGES:-}" ]; then
+  echo "ACTIONS_EXTRA_PACKAGES is set but $INSTALL_EXTRA_PACKAGES is missing" >&2
+  exit 1
+fi
+
 # Wait for GMS health (replaces dockerize, which is not always present or on PATH in Wolfi images)
 wait_for_gms_ready() {
   local protocol="${DATAHUB_GMS_PROTOCOL:-http}"

--- a/docker/datahub-actions/tests/test_install_extra_packages.sh
+++ b/docker/datahub-actions/tests/test_install_extra_packages.sh
@@ -12,6 +12,19 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UNDER_TEST="${SCRIPT_DIR}/../install_extra_packages.sh"
 
+# One scratch root for the whole suite, removed however the script ends.
+#
+# Each case used to call `mktemp -d` directly and never clean up. That was survivable while
+# the suite was run by hand, but it is now wired into `check`, so every CI invocation would
+# leave nine directories behind in /tmp. Allocating under a single root means one trap
+# collects all of them, including on an early exit or an interrupt.
+TEST_TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMP_ROOT"' EXIT INT TERM
+
+new_tmp() {
+  mktemp -d "${TEST_TMP_ROOT}/case.XXXXXX"
+}
+
 failures=0
 
 pass() { echo "ok   - $1"; }
@@ -46,7 +59,7 @@ BASH_BIN="${BASH:-/bin/bash}"
 
 test_unset_is_a_no_op() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_stub_path "$tmp")"
 
@@ -63,7 +76,7 @@ test_unset_is_a_no_op() {
 
 test_empty_is_a_no_op() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_stub_path "$tmp")"
 
@@ -80,7 +93,7 @@ test_empty_is_a_no_op() {
 
 test_packages_are_installed() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_stub_path "$tmp")"
 
@@ -106,7 +119,7 @@ test_packages_are_installed() {
 
 test_no_package_manager_fails_loudly() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_bare_path "$tmp")"
 
@@ -131,7 +144,7 @@ test_no_package_manager_fails_loudly() {
 
 test_install_failure_is_not_swallowed() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   mkdir -p "$tmp/bin"
   printf '#!/bin/bash\nexit 3\n' >"$tmp/bin/uv"
   chmod +x "$tmp/bin/uv"
@@ -160,7 +173,7 @@ test_install_failure_is_not_swallowed() {
 test_startup_script_runs_the_installer() {
   local start_sh="${SCRIPT_DIR}/../start.sh"
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local marker="$tmp/installer-ran"
 
   printf '#!/bin/bash\ntouch "%s"\nexit 0\n' "$marker" >"$tmp/stub-installer.sh"
@@ -197,7 +210,7 @@ test_startup_script_runs_the_installer() {
 test_startup_script_aborts_when_the_installer_fails() {
   local start_sh="${SCRIPT_DIR}/../start.sh"
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
 
   printf '#!/bin/bash\nexit 7\n' >"$tmp/failing-installer.sh"
   chmod +x "$tmp/failing-installer.sh"
@@ -225,7 +238,7 @@ test_startup_script_aborts_when_the_installer_fails() {
 # requirement for a matching filename in the working directory.
 test_requirements_are_not_glob_expanded() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_stub_path "$tmp")"
 
@@ -255,7 +268,7 @@ test_requirements_are_not_glob_expanded() {
 # "--extra-index-url https://user:token@host/simple pkg". It must not reach the logs.
 test_package_list_is_not_logged() {
   local tmp
-  tmp="$(mktemp -d)"
+  tmp="$(new_tmp)"
   local path
   path="$(make_stub_path "$tmp")"
   local secret="https://user:s3cr3t-token@example.invalid/simple"

--- a/docker/datahub-actions/tests/test_install_extra_packages.sh
+++ b/docker/datahub-actions/tests/test_install_extra_packages.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# Tests for docker/datahub-actions/install_extra_packages.sh.
+#
+# These run without Docker: uv is stubbed on PATH so the script's decision can be
+# observed directly. Run with:
+#
+#     bash docker/datahub-actions/tests/test_install_extra_packages.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="${SCRIPT_DIR}/../install_extra_packages.sh"
+
+failures=0
+
+pass() { echo "ok   - $1"; }
+fail() {
+  echo "FAIL - $1"
+  echo "       $2"
+  failures=$((failures + 1))
+}
+
+# A PATH holding only a uv stub that records its arguments.
+make_stub_path() {
+  local dir="$1"
+  mkdir -p "$dir/bin"
+  cat >"$dir/bin/uv" <<EOF
+#!/bin/bash
+echo "\$@" >>"$dir/uv-calls"
+EOF
+  chmod +x "$dir/bin/uv"
+  echo "$dir/bin:/usr/bin:/bin"
+}
+
+# A PATH with no uv at all, standing in for the locked image. Deliberately holds
+# nothing else either, so the refusal cannot depend on an external command.
+make_bare_path() {
+  local dir="$1"
+  mkdir -p "$dir/bin"
+  echo "$dir/bin"
+}
+
+# Absolute path to this shell, so tests can run with a PATH that has no bash on it.
+BASH_BIN="${BASH:-/bin/bash}"
+
+test_unset_is_a_no_op() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_stub_path "$tmp")"
+
+  if ! env -u ACTIONS_EXTRA_PACKAGES PATH="$path" bash "$UNDER_TEST" >/dev/null 2>&1; then
+    fail "unset ACTIONS_EXTRA_PACKAGES exits 0" "script exited non-zero"
+    return
+  fi
+  if [ -f "$tmp/uv-calls" ]; then
+    fail "unset ACTIONS_EXTRA_PACKAGES installs nothing" "uv was called: $(cat "$tmp/uv-calls")"
+    return
+  fi
+  pass "unset ACTIONS_EXTRA_PACKAGES is a no-op"
+}
+
+test_empty_is_a_no_op() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_stub_path "$tmp")"
+
+  if ! ACTIONS_EXTRA_PACKAGES="" PATH="$path" bash "$UNDER_TEST" >/dev/null 2>&1; then
+    fail "empty ACTIONS_EXTRA_PACKAGES exits 0" "script exited non-zero"
+    return
+  fi
+  if [ -f "$tmp/uv-calls" ]; then
+    fail "empty ACTIONS_EXTRA_PACKAGES installs nothing" "uv was called: $(cat "$tmp/uv-calls")"
+    return
+  fi
+  pass "empty ACTIONS_EXTRA_PACKAGES is a no-op"
+}
+
+test_packages_are_installed() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_stub_path "$tmp")"
+
+  if ! ACTIONS_EXTRA_PACKAGES="acryl-datahub-actions[slack] my-action==1.2.3" \
+    PATH="$path" bash "$UNDER_TEST" >/dev/null 2>&1; then
+    fail "packages are installed" "script exited non-zero"
+    return
+  fi
+  if [ ! -f "$tmp/uv-calls" ]; then
+    fail "packages are installed" "uv was never called"
+    return
+  fi
+
+  local call
+  call="$(cat "$tmp/uv-calls")"
+  local expected="pip install acryl-datahub-actions[slack] my-action==1.2.3"
+  if [ "$call" != "$expected" ]; then
+    fail "every requested package reaches uv" "expected [$expected], got [$call]"
+    return
+  fi
+  pass "every requested package reaches uv, in order"
+}
+
+test_no_package_manager_fails_loudly() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_bare_path "$tmp")"
+
+  local output
+  output="$(ACTIONS_EXTRA_PACKAGES="my-action==1.2.3" PATH="$path" \
+    "$BASH_BIN" "$UNDER_TEST" 2>&1)"
+  local status=$?
+
+  if [ "$status" -eq 0 ]; then
+    fail "a locked image refuses rather than ignores" "script exited 0"
+    return
+  fi
+  case "$output" in
+  *ACTIONS_EXTRA_PACKAGES*) ;;
+  *)
+    fail "the error names the variable" "stderr was: $output"
+    return
+    ;;
+  esac
+  pass "no package manager: refuses with an explanation instead of ignoring"
+}
+
+test_install_failure_is_not_swallowed() {
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin"
+  printf '#!/bin/bash\nexit 3\n' >"$tmp/bin/uv"
+  chmod +x "$tmp/bin/uv"
+
+  if ACTIONS_EXTRA_PACKAGES="does-not-exist" PATH="$tmp/bin:/usr/bin:/bin" \
+    bash "$UNDER_TEST" >/dev/null 2>&1; then
+    fail "a failed install exits non-zero" "script exited 0"
+    return
+  fi
+  pass "a failed install exits non-zero"
+}
+
+# The original defect was not in this script, it was that nothing on the runtime
+# startup path ran anything like it. Assert the wiring, not just the behaviour.
+test_startup_script_runs_the_installer() {
+  local start_sh="${SCRIPT_DIR}/../start.sh"
+
+  if ! grep -q "install_extra_packages" "$start_sh"; then
+    fail "start.sh runs the installer" \
+      "docker/profiles/docker-compose.actions.yml passes ACTIONS_EXTRA_PACKAGES to the
+       actions services, but start.sh never reaches install_extra_packages.sh, so the
+       variable would silently do nothing"
+    return
+  fi
+  pass "start.sh runs the installer"
+}
+
+test_startup_script_runs_the_installer
+test_unset_is_a_no_op
+test_empty_is_a_no_op
+test_packages_are_installed
+test_no_package_manager_fails_loudly
+test_install_failure_is_not_swallowed
+
+if [ "$failures" -ne 0 ]; then
+  echo "${failures} test(s) failed"
+  exit 1
+fi
+echo "all tests passed"

--- a/docker/datahub-actions/tests/test_install_extra_packages.sh
+++ b/docker/datahub-actions/tests/test_install_extra_packages.sh
@@ -145,26 +145,156 @@ test_install_failure_is_not_swallowed() {
 }
 
 # The original defect was not in this script, it was that nothing on the runtime
-# startup path ran anything like it. Assert the wiring, not just the behaviour.
+# startup path ran anything like it. Assert the wiring by executing it.
+#
+# An earlier version of this test grepped start.sh for the string "install_extra_packages".
+# That token also appears in the fallback default path assignment, so the assertion passed
+# whether or not the invocation still existed: it could not fail for the regression it was
+# written to guard.
+#
+# This runs start.sh for real with a stubbed installer and a GMS endpoint that is guaranteed
+# to be unreachable, with a one second timeout. start.sh installs, then waits for GMS, then
+# exits non-zero. So the marker file existing proves two things at once: the installer was
+# actually invoked, and it was invoked before the GMS wait. Move the block after the wait and
+# the marker disappears, because the script exits at the wait.
 test_startup_script_runs_the_installer() {
   local start_sh="${SCRIPT_DIR}/../start.sh"
+  local tmp
+  tmp="$(mktemp -d)"
+  local marker="$tmp/installer-ran"
 
-  if ! grep -q "install_extra_packages" "$start_sh"; then
-    fail "start.sh runs the installer" \
+  printf '#!/bin/bash\ntouch "%s"\nexit 0\n' "$marker" >"$tmp/stub-installer.sh"
+  chmod +x "$tmp/stub-installer.sh"
+
+  # Port 1 on the loopback address refuses immediately, so the wait fails fast rather than
+  # depending on DNS or a network timeout.
+  DATAHUB_ACTIONS_INSTALL_EXTRA_PACKAGES_PATH="$tmp/stub-installer.sh" \
+    DATAHUB_GMS_HOST="127.0.0.1" \
+    DATAHUB_GMS_PORT="1" \
+    DATAHUB_GMS_STARTUP_TIMEOUT_SEC="1" \
+    ACTIONS_EXTRA_PACKAGES="my-action==1.2.3" \
+    bash "$start_sh" >/dev/null 2>&1
+  local status=$?
+
+  if [ ! -f "$marker" ]; then
+    fail "start.sh actually invokes the installer, before waiting for GMS" \
       "docker/profiles/docker-compose.actions.yml passes ACTIONS_EXTRA_PACKAGES to the
-       actions services, but start.sh never reaches install_extra_packages.sh, so the
+       actions services, but running start.sh never executed the installer, so the
        variable would silently do nothing"
     return
   fi
-  pass "start.sh runs the installer"
+  if [ "$status" -eq 0 ]; then
+    fail "start.sh actually invokes the installer, before waiting for GMS" \
+      "start.sh exited 0 with an unreachable GMS, so this test is not exercising the path
+       it claims to"
+    return
+  fi
+  pass "start.sh invokes the installer, and does so before the GMS wait"
+}
+
+# start.sh must refuse rather than continue when the installer itself fails. Otherwise a
+# missing dependency surfaces much later as a confusing action failure.
+test_startup_script_aborts_when_the_installer_fails() {
+  local start_sh="${SCRIPT_DIR}/../start.sh"
+  local tmp
+  tmp="$(mktemp -d)"
+
+  printf '#!/bin/bash\nexit 7\n' >"$tmp/failing-installer.sh"
+  chmod +x "$tmp/failing-installer.sh"
+
+  local output
+  output="$(DATAHUB_ACTIONS_INSTALL_EXTRA_PACKAGES_PATH="$tmp/failing-installer.sh" \
+    DATAHUB_GMS_HOST="127.0.0.1" \
+    DATAHUB_GMS_PORT="1" \
+    DATAHUB_GMS_STARTUP_TIMEOUT_SEC="1" \
+    ACTIONS_EXTRA_PACKAGES="my-action==1.2.3" \
+    bash "$start_sh" 2>&1)"
+
+  case "$output" in
+  *"Waiting for GMS"*)
+    fail "a failing installer stops startup" \
+      "start.sh continued to the GMS wait after the installer exited non-zero"
+    return
+    ;;
+  esac
+  pass "a failing installer stops startup instead of continuing"
+}
+
+# Guards the set -f in the installer. Both "pkg==1.*" and "pkg[extra]" are ordinary pip
+# syntax and also glob patterns, so an unquoted expansion would silently swap the
+# requirement for a matching filename in the working directory.
+test_requirements_are_not_glob_expanded() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_stub_path "$tmp")"
+
+  local workdir="$tmp/work"
+  mkdir -p "$workdir"
+  # These exist only to be tempting glob matches for the requirements below.
+  touch "$workdir/my-actionb" "$workdir/my-action==1.0"
+
+  if ! (cd "$workdir" && ACTIONS_EXTRA_PACKAGES="my-action[abc] my-action==1.*" \
+    PATH="$path" bash "$UNDER_TEST" >/dev/null 2>&1); then
+    fail "requirements survive glob-looking characters" "script exited non-zero"
+    return
+  fi
+
+  local call
+  call="$(cat "$tmp/uv-calls")"
+  local expected="pip install my-action[abc] my-action==1.*"
+  if [ "$call" != "$expected" ]; then
+    fail "requirements survive glob-looking characters" \
+      "a filename in the working directory replaced a requirement: expected [$expected], got [$call]"
+    return
+  fi
+  pass "requirements containing * ? and [...] reach uv unchanged"
+}
+
+# The value can carry index credentials, for example
+# "--extra-index-url https://user:token@host/simple pkg". It must not reach the logs.
+test_package_list_is_not_logged() {
+  local tmp
+  tmp="$(mktemp -d)"
+  local path
+  path="$(make_stub_path "$tmp")"
+  local secret="https://user:s3cr3t-token@example.invalid/simple"
+
+  local output
+  output="$(ACTIONS_EXTRA_PACKAGES="--extra-index-url $secret my-action==1.2.3" \
+    PATH="$path" bash "$UNDER_TEST" 2>&1)"
+
+  case "$output" in
+  *s3cr3t-token*)
+    fail "the package list is not echoed" "a credential in the value reached stdout: $output"
+    return
+    ;;
+  esac
+
+  # And the same on the refusal path, where an operator is most likely to be reading closely.
+  local bare
+  bare="$(make_bare_path "$tmp")"
+  output="$(ACTIONS_EXTRA_PACKAGES="--extra-index-url $secret my-action==1.2.3" \
+    PATH="$bare" "$BASH_BIN" "$UNDER_TEST" 2>&1)"
+
+  case "$output" in
+  *s3cr3t-token*)
+    fail "the package list is not echoed" "a credential reached the refusal message: $output"
+    return
+    ;;
+  esac
+  pass "the package list is never echoed, on either path"
 }
 
 test_startup_script_runs_the_installer
+test_startup_script_aborts_when_the_installer_fails
 test_unset_is_a_no_op
 test_empty_is_a_no_op
 test_packages_are_installed
 test_no_package_manager_fails_loudly
 test_install_failure_is_not_swallowed
+test_requirements_are_not_glob_expanded
+test_package_list_is_not_logged
 
 if [ "$failures" -ne 0 ]; then
   echo "${failures} test(s) failed"

--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -22,6 +22,7 @@ x-datahub-actions-service-dev: &datahub-actions-service-dev
   <<: *datahub-actions-service
   volumes:
     - ./datahub-actions/start.sh:/start_datahub_actions.sh
+    - ./datahub-actions/install_extra_packages.sh:/install_extra_packages.sh
     - ../../metadata-ingestion/src:/metadata-ingestion/src
     - ../../datahub-actions/src:/datahub-actions/src
     - ${HOME}/.aws:/home/datahub/.aws:ro


### PR DESCRIPTION
Fixes #19065.

## What

`docker/profiles/docker-compose.actions.yml` passes `ACTIONS_EXTRA_PACKAGES` to every `datahub-actions` service. The image starts through `CMD ["/bin/bash", "/start_datahub_actions.sh"]` with `ENTRYPOINT [ ]`, and `start.sh` never reads the variable. The only code that handles it, `docker/datahub-ingestion-base/entrypoint.sh`, is `COPY`'d into `datahub-ingestion-base` and is not on this image's startup path.

Reproduction on `acryldata/datahub-actions:v1.7.0-slim`, full transcript in #19065:

```
env: [cowsay==6.1]
ModuleNotFoundError: No module named 'cowsay'
0                       # occurrences of ACTIONS_EXTRA_PACKAGES in /start_datahub_actions.sh
```

## The change

`docker/datahub-actions/install_extra_packages.sh`, called from `start.sh` before the GMS wait, since installing packages does not need GMS and a failure should surface immediately.

The three variants cannot behave the same way, so they don't:

| Variant | Behaviour |
|---|---|
| full, slim | Install the requested packages. Both ship `uv` at `/usr/bin/uv`. |
| locked | Refuse to start, naming the variable and saying why. |

The locked variant strips `uv`, deletes the bundled pip wheel and points `UV_INDEX_URL`/`PIP_INDEX_URL` at `127.0.0.1:1` deliberately, so this does not reintroduce runtime installation there. The script decides by capability (`command -v uv`) rather than by a build-arg copy of `APP_ENV`, so an image that gains or loses a package manager stays correct without a second place to update.

Unset or empty stays a no-op, so nothing changes for deployments that do not set it.

The failure message uses `printf` rather than a `cat` heredoc, so it still prints in an image stripped down far enough that `cat` is not on `PATH`.

## Tests

`docker/datahub-actions/tests/test_install_extra_packages.sh`, six cases, no Docker required (`uv` is stubbed on `PATH`):

```
ok   - start.sh runs the installer
ok   - unset ACTIONS_EXTRA_PACKAGES is a no-op
ok   - empty ACTIONS_EXTRA_PACKAGES is a no-op
ok   - every requested package reaches uv, in order
ok   - no package manager: refuses with an explanation instead of ignoring
ok   - a failed install exits non-zero
all tests passed
```

The first case is the one that matters for this bug. The defect was never inside a helper, it was that nothing on the startup path called one, so that test asserts the wiring and fails on unmodified `master`:

```
FAIL - start.sh runs the installer
       docker/profiles/docker-compose.actions.yml passes ACTIONS_EXTRA_PACKAGES to the
       actions services, but start.sh never reaches install_extra_packages.sh, so the
       variable would silently do nothing
```

I have not wired this into gradle or CI, because I could not tell where you would want it and did not want to guess at a new job in `docker-unified.yml`. Happy to add a `:docker:` gradle task or a step in an existing workflow, whichever you prefer.

## Verification against the real image

Running the patched `start.sh` and the new script inside `acryldata/datahub-actions:v1.7.0-slim`, on the same reproduction as the issue:

```
before:
ModuleNotFoundError: No module named 'cowsay'
Installing ACTIONS_EXTRA_PACKAGES: cowsay==6.1
Resolved 1 package in 2.31s
Installed 1 package in 7ms
 + cowsay==6.1
Waiting for GMS at http://datahub-gms:8080/health (timeout 240s)...
--- after startup ---
cowsay INSTALLED at runtime
```

I did not build the images. The change to the Dockerfile is three identical `COPY` and `chmod` additions, one per final stage.

## Notes

- `docker/profiles/datahub-actions` is a symlink to `docker/datahub-actions`, so the dev profile's bind mount of the new script uses the same `./datahub-actions/...` form as the existing `start.sh` mount.
- `DATAHUB_ACTIONS_INSTALL_EXTRA_PACKAGES_PATH` overrides the script location, matching how the other paths in `start.sh` are already overridable, and lets the behaviour be exercised in a container without rebuilding.
- `ACTIONS_CONFIG` has the same shape of problem and is **not** touched here. It is described in #19065; the right behaviour under directory-based config discovery is a design question rather than an oversight.

---

Found while packaging a custom DataHub Action for Licet, an Apache-2.0 entry to Build with DataHub: The Agent Hackathon, where `ACTIONS_EXTRA_PACKAGES` looked like the way to add that action's dependencies and turned out to be inert.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `ACTIONS_EXTRA_PACKAGES` in `datahub-actions` startup by installing packages before the service starts. Full/slim install via `uv`; the locked image fails fast; startup is hardened to avoid secret leaks and globbing issues.

- **Bug Fixes**
  - Run `/install_extra_packages.sh` from `/start_datahub_actions.sh` before the GMS wait; no-op when unset; abort on installer failure.
  - Fail fast when `ACTIONS_EXTRA_PACKAGES` is set but no package manager is present (locked image).
  - Use `uv pip install`; never log the package list; disable glob expansion during install.
  - Add the installer to all image variants and mount it in dev compose; path overridable via `DATAHUB_ACTIONS_INSTALL_EXTRA_PACKAGES_PATH`.

- **Refactors**
  - Add shell tests for installer and startup wiring; register `testDatahubActionsScripts` and hook into the `docker` module `check`.
  - Update README to document `ACTIONS_EXTRA_PACKAGES`, its tradeoffs, and locked-image refusal.
  - Tests now clean up scratch directories via a single root and EXIT/INT/TERM trap to avoid CI leaks.

<sup>Written for commit 14441d2b1d58c596fb0b1d1bb2e4df2b944facef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

