### PR TITLE
perf(gms): chunk large ingestAspects txns and batch soft-delete status reads

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DeleteUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DeleteUtils.java
@@ -7,6 +7,7 @@ import com.datahub.authorization.AuthUtil;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
@@ -14,8 +15,13 @@ import com.linkedin.metadata.entity.EntityUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -33,26 +39,57 @@ public class DeleteUtils {
       boolean removed,
       List<String> urnStrs,
       Urn actor,
-      EntityService entityService) {
-    final List<MetadataChangeProposal> changes = new ArrayList<>();
-    for (String urnStr : urnStrs) {
-      changes.add(buildSoftDeleteProposal(opContext, removed, urnStr, actor, entityService));
+      EntityService<?> entityService) {
+    if (urnStrs.isEmpty()) {
+      return;
+    }
+
+    Set<Urn> urns =
+        urnStrs.stream().map(UrnUtils::getUrn).collect(Collectors.toCollection(LinkedHashSet::new));
+
+    // One batch read for status aspects — avoids N sequential getAspect round-trips (each borrowing
+    // an Ebean connection) before the single ingestProposal write.
+    Map<Urn, List<RecordTemplate>> statusByUrn =
+        entityService.getLatestAspects(
+            opContext, urns, Set.of(Constants.STATUS_ASPECT_NAME), false);
+
+    // Iterate the deduped set — duplicate input URNs must not emit duplicate Status MCPs.
+    final List<MetadataChangeProposal> changes = new ArrayList<>(urns.size());
+    for (Urn urn : urns) {
+      Status status = copyStatus(findStatusAspect(statusByUrn.get(urn)));
+      status.setRemoved(removed);
+      changes.add(buildMetadataChangeProposalWithUrn(urn, Constants.STATUS_ASPECT_NAME, status));
     }
     EntityUtils.ingestChangeProposals(opContext, changes, entityService, actor, false);
   }
 
-  private static MetadataChangeProposal buildSoftDeleteProposal(
-      @Nonnull OperationContext opContext,
-      boolean removed,
-      String urnStr,
-      Urn actor,
-      EntityService entityService) {
-    Status status =
-        (Status)
-            EntityUtils.getAspectFromEntity(
-                opContext, urnStr, Constants.STATUS_ASPECT_NAME, entityService, new Status());
-    status.setRemoved(removed);
-    return buildMetadataChangeProposalWithUrn(
-        UrnUtils.getUrn(urnStr), Constants.STATUS_ASPECT_NAME, status);
+  @Nullable
+  private static Status findStatusAspect(@Nullable List<RecordTemplate> aspects) {
+    if (aspects == null) {
+      return null;
+    }
+    for (RecordTemplate aspect : aspects) {
+      if (aspect instanceof Status) {
+        return (Status) aspect;
+      }
+    }
+    return null;
+  }
+
+  /** Mutable copy so we never mutate cached/shared aspect instances from the batch read. */
+  @Nonnull
+  private static Status copyStatus(@Nullable Status existing) {
+    if (existing == null) {
+      return new Status();
+    }
+    try {
+      return new Status(existing.data().copy());
+    } catch (CloneNotSupportedException e) {
+      Status copy = new Status();
+      if (existing.hasRemoved()) {
+        copy.setRemoved(existing.isRemoved());
+      }
+      return copy;
+    }
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
@@ -19,6 +19,8 @@ import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
 import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -35,20 +37,13 @@ public class BatchUpdateSoftDeletedResolverTest {
     EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
-            mockService.getAspect(
+            mockService.getLatestAspects(
                 any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(null);
-
-    Mockito.when(
-            mockService.getAspect(
-                any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(null);
+                Mockito.eq(
+                    Set.of(UrnUtils.getUrn(TEST_ENTITY_URN_1), UrnUtils.getUrn(TEST_ENTITY_URN_2))),
+                Mockito.eq(Set.of(Constants.STATUS_ASPECT_NAME)),
+                Mockito.eq(false)))
+        .thenReturn(Map.of());
 
     stubExistingUrns(
         mockService,
@@ -88,20 +83,18 @@ public class BatchUpdateSoftDeletedResolverTest {
     EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
-            mockService.getAspect(
+            mockService.getLatestAspects(
                 any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(originalStatus);
-
-    Mockito.when(
-            mockService.getAspect(
-                any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(originalStatus);
+                Mockito.eq(
+                    Set.of(UrnUtils.getUrn(TEST_ENTITY_URN_1), UrnUtils.getUrn(TEST_ENTITY_URN_2))),
+                Mockito.eq(Set.of(Constants.STATUS_ASPECT_NAME)),
+                Mockito.eq(false)))
+        .thenReturn(
+            Map.of(
+                UrnUtils.getUrn(TEST_ENTITY_URN_1),
+                List.of(originalStatus),
+                UrnUtils.getUrn(TEST_ENTITY_URN_2),
+                List.of(originalStatus)));
 
     stubExistingUrns(
         mockService,
@@ -138,22 +131,7 @@ public class BatchUpdateSoftDeletedResolverTest {
   public void testGetFailureResourceDoesNotExist() throws Exception {
     EntityService<?> mockService = getMockEntityService();
 
-    Mockito.when(
-            mockService.getAspect(
-                any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(null);
-    Mockito.when(
-            mockService.getAspect(
-                any(),
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.STATUS_ASPECT_NAME),
-                Mockito.eq(0L)))
-        .thenReturn(null);
-
-    // The first resource does not exist.
+    // The first resource does not exist — status batch read never runs.
     stubExistingUrns(mockService, Urn.createFromString(TEST_ENTITY_URN_2));
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
@@ -170,6 +148,8 @@ public class BatchUpdateSoftDeletedResolverTest {
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
     verifyNoIngestProposal(mockService);
+    Mockito.verify(mockService, Mockito.never())
+        .getLatestAspects(any(), any(), any(), any(Boolean.class));
   }
 
   @Test
@@ -195,6 +175,20 @@ public class BatchUpdateSoftDeletedResolverTest {
   @Test
   public void testGetEntityClientException() throws Exception {
     EntityService<?> mockService = getMockEntityService();
+
+    Mockito.when(
+            mockService.getLatestAspects(
+                any(),
+                Mockito.eq(
+                    Set.of(UrnUtils.getUrn(TEST_ENTITY_URN_1), UrnUtils.getUrn(TEST_ENTITY_URN_2))),
+                Mockito.eq(Set.of(Constants.STATUS_ASPECT_NAME)),
+                Mockito.eq(false)))
+        .thenReturn(Map.of());
+
+    stubExistingUrns(
+        mockService,
+        Urn.createFromString(TEST_ENTITY_URN_1),
+        Urn.createFromString(TEST_ENTITY_URN_2));
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DeleteUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DeleteUtilsTest.java
@@ -1,0 +1,155 @@
+package com.linkedin.datahub.graphql.resolvers.mutate.util;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockEntityService;
+import static com.linkedin.datahub.graphql.TestUtils.verifyIngestProposal;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.mxe.MetadataChangeProposal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class DeleteUtilsTest {
+
+  private static final String URN_1 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+  private static final String URN_2 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test-2,PROD)";
+
+  @Test
+  public void updateStatusForResources_batchesStatusReads() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    QueryContext mockContext = getMockAllowContext();
+    Urn urn1 = UrnUtils.getUrn(URN_1);
+    Urn urn2 = UrnUtils.getUrn(URN_2);
+
+    Status existing = new Status().setRemoved(false);
+    when(mockService.getLatestAspects(
+            any(), eq(Set.of(urn1, urn2)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false)))
+        .thenReturn(Map.of(urn1, List.<RecordTemplate>of(existing), urn2, List.of()));
+
+    DeleteUtils.updateStatusForResources(
+        mockContext.getOperationContext(),
+        true,
+        List.of(URN_1, URN_2),
+        UrnUtils.getUrn(mockContext.getActorUrn()),
+        mockService);
+
+    verify(mockService)
+        .getLatestAspects(
+            any(), eq(Set.of(urn1, urn2)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false));
+    verify(mockService, never()).getAspect(any(), any(), any(), any(Long.class));
+
+    Status expected = new Status().setRemoved(true);
+    MetadataChangeProposal proposal1 =
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            urn1, Constants.STATUS_ASPECT_NAME, expected);
+    MetadataChangeProposal proposal2 =
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            urn2, Constants.STATUS_ASPECT_NAME, expected);
+    verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
+  }
+
+  @Test
+  public void updateStatusForResources_undeleteExistingStatus() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    QueryContext mockContext = getMockAllowContext();
+    Urn urn1 = UrnUtils.getUrn(URN_1);
+
+    Status existing = new Status().setRemoved(true);
+    when(mockService.getLatestAspects(
+            any(), eq(Set.of(urn1)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false)))
+        .thenReturn(Map.of(urn1, List.<RecordTemplate>of(existing)));
+
+    DeleteUtils.updateStatusForResources(
+        mockContext.getOperationContext(),
+        false,
+        List.of(URN_1),
+        UrnUtils.getUrn(mockContext.getActorUrn()),
+        mockService);
+
+    Status expected = new Status().setRemoved(false);
+    MetadataChangeProposal proposal =
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            urn1, Constants.STATUS_ASPECT_NAME, expected);
+    verifyIngestProposal(mockService, 1, List.of(proposal));
+  }
+
+  @Test
+  public void updateStatusForResources_doesNotMutateCachedStatus() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    QueryContext mockContext = getMockAllowContext();
+    Urn urn1 = UrnUtils.getUrn(URN_1);
+
+    Status existing = new Status().setRemoved(false);
+    when(mockService.getLatestAspects(
+            any(), eq(Set.of(urn1)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false)))
+        .thenReturn(Map.of(urn1, List.<RecordTemplate>of(existing)));
+
+    DeleteUtils.updateStatusForResources(
+        mockContext.getOperationContext(),
+        true,
+        List.of(URN_1),
+        UrnUtils.getUrn(mockContext.getActorUrn()),
+        mockService);
+
+    // copyStatus must not mutate the aspect instance returned by the batch read
+    assertFalse(existing.isRemoved());
+  }
+
+  @Test
+  public void updateStatusForResources_dedupesDuplicateUrns() throws Exception {
+    EntityService<?> mockService = getMockEntityService();
+    QueryContext mockContext = getMockAllowContext();
+    Urn urn1 = UrnUtils.getUrn(URN_1);
+
+    when(mockService.getLatestAspects(
+            any(), eq(Set.of(urn1)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false)))
+        .thenReturn(Map.of());
+
+    DeleteUtils.updateStatusForResources(
+        mockContext.getOperationContext(),
+        true,
+        List.of(URN_1, URN_1, URN_1),
+        UrnUtils.getUrn(mockContext.getActorUrn()),
+        mockService);
+
+    verify(mockService)
+        .getLatestAspects(
+            any(), eq(Set.of(urn1)), eq(Set.of(Constants.STATUS_ASPECT_NAME)), eq(false));
+
+    Status expected = new Status().setRemoved(true);
+    MetadataChangeProposal proposal =
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            urn1, Constants.STATUS_ASPECT_NAME, expected);
+    // One MCP only — not three for the three duplicate input strings.
+    verifyIngestProposal(mockService, 1, List.of(proposal));
+  }
+
+  @Test
+  public void updateStatusForResources_emptyListNoOps() {
+    EntityService<?> mockService = getMockEntityService();
+    QueryContext mockContext = getMockAllowContext();
+    DeleteUtils.updateStatusForResources(
+        mockContext.getOperationContext(),
+        true,
+        List.of(),
+        UrnUtils.getUrn(mockContext.getActorUrn()),
+        mockService);
+    verify(mockService, never()).getLatestAspects(any(), any(), any(), any(Boolean.class));
+    verify(mockService, never()).ingestProposal(any(), any(), any(Boolean.class));
+  }
+}

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
@@ -183,6 +183,11 @@ public class SystemUpdateConfig {
     log.info(
         "Creating EntityService with system update CDC mode override: {}", systemUpdateCDCMode);
 
+    int maxRequestBatchSize =
+        java.util.Optional.ofNullable(configurationProvider.getEbean())
+            .map(com.linkedin.metadata.config.EbeanConfiguration::getQueryKeysCountForBatch)
+            .orElse(com.linkedin.metadata.config.EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT);
+
     EntityServiceImpl entityService =
         new EntityServiceImpl(
             aspectDao,
@@ -193,7 +198,8 @@ public class SystemUpdateConfig {
                 .setCdcModeChangeLog(systemUpdateCDCMode)
                 .setRetry(ebeanMaxTransactionRetry)
                 .setEnableBrowseV2(enableBrowsePathV2)
-                .setPostCommitRetentionEnabled(featureFlags.isPostCommitRetentionEnabled()),
+                .setPostCommitRetentionEnabled(featureFlags.isPostCommitRetentionEnabled())
+                .setMaxRequestBatchSize(maxRequestBatchSize),
             null);
 
     // Usually NO_OP in upgrade (see method javadoc). Attaches if a buffer bean exists.

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -187,6 +187,11 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
   // When true, retention runs after upsert commit (best-effort). When false, legacy in-tx path.
   private final boolean postCommitRetentionEnabled;
   private final com.linkedin.metadata.utils.metrics.MetricUtils metricUtils;
+  /**
+   * Max AspectsBatch items per DB transaction when ingesting. {@code <= 0} disables chunking (one
+   * txn for the whole request). Prefer aligning with {@code ebean.queryKeysCountForBatch}.
+   */
+  private final int maxRequestBatchSize;
 
   @Getter
   private final Map<Set<ThrottleType>, ThrottleEvent> throttleEvents = new ConcurrentHashMap<>();
@@ -210,8 +215,10 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
             : DEFAULT_MAX_TRANSACTION_RETRY;
     this.enableBrowseV2 = entityServiceConfiguration.isEnableBrowseV2();
     this.postCommitRetentionEnabled = entityServiceConfiguration.isPostCommitRetentionEnabled();
+    this.maxRequestBatchSize = entityServiceConfiguration.getMaxRequestBatchSize();
     this.metricUtils = metricUtils;
     log.info("EntityService cdcModeChangeLog is {}", this.cdcModeChangeLog);
+    log.info("EntityService maxRequestBatchSize is {}", this.maxRequestBatchSize);
   }
 
   /**
@@ -913,7 +920,11 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     // Handle throttling
     APIThrottle.evaluate(opContext, new HashSet<>(throttleEvents.values()), false);
 
-    IngestAspectsResult ingestResults = ingestAspectsToLocalDB(opContext, aspectsBatch, overwrite);
+    // Split oversized batches into multiple short FOR UPDATE txns (chunk size =
+    // ebean.queryKeysCountForBatch / maxRequestBatchSize). UI/API can still send one large
+    // request; each chunk commits independently — mid-fail leaves earlier chunks applied.
+    IngestAspectsResult ingestResults =
+        ingestAspectsToLocalDBChunked(opContext, aspectsBatch, overwrite);
 
     // Produce MCLs & run side effects
     List<MetadataChangeLog> mcls =
@@ -1131,6 +1142,55 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                 log.debug("Generated {} MCP SideEffects for async processing", count);
               });
     }
+  }
+
+  /**
+   * Runs {@link #ingestAspectsToLocalDB} once, or in successive transactions of at most {@code
+   * maxRequestBatchSize} items when chunking is enabled. Callers still see one logical ingest; each
+   * chunk commits before the next starts.
+   */
+  @Nonnull
+  private IngestAspectsResult ingestAspectsToLocalDBChunked(
+      @Nonnull OperationContext opContext,
+      @Nonnull final AspectsBatch aspectsBatch,
+      boolean overwrite) {
+    if (maxRequestBatchSize <= 0 || aspectsBatch.getItems().size() <= maxRequestBatchSize) {
+      return ingestAspectsToLocalDB(opContext, aspectsBatch, overwrite);
+    }
+
+    List<BatchItem> items = new ArrayList<>(aspectsBatch.getItems());
+    int totalChunks = (items.size() + maxRequestBatchSize - 1) / maxRequestBatchSize;
+    log.info(
+        "Chunking ingestAspects batch of {} items into {} transactions of at most {}",
+        items.size(),
+        totalChunks,
+        maxRequestBatchSize);
+
+    IngestAspectsResult combined = IngestAspectsResult.EMPTY;
+    int chunkIndex = 0;
+    for (List<BatchItem> chunk : Iterables.partition(items, maxRequestBatchSize)) {
+      chunkIndex++;
+      AspectsBatch chunkBatch =
+          AspectsBatchImpl.builder()
+              .retrieverContext(aspectsBatch.getRetrieverContext())
+              .items(chunk)
+              .build(opContext);
+      try {
+        combined =
+            IngestAspectsResult.combine(
+                combined, ingestAspectsToLocalDB(opContext, chunkBatch, overwrite));
+      } catch (RuntimeException e) {
+        throw new RuntimeException(
+            String.format(
+                "ingestAspects failed on chunk %d/%d after earlier chunks committed (%d results in prior chunks). Cause: %s",
+                chunkIndex,
+                totalChunks,
+                combined.getUpdateAspectResults().size(),
+                e.getMessage()),
+            e);
+      }
+    }
+    return combined;
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -187,6 +187,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
   // When true, retention runs after upsert commit (best-effort). When false, legacy in-tx path.
   private final boolean postCommitRetentionEnabled;
   private final com.linkedin.metadata.utils.metrics.MetricUtils metricUtils;
+
   /**
    * Max AspectsBatch items per DB transaction when ingesting. {@code <= 0} disables chunking (one
    * txn for the whole request). Prefer aligning with {@code ebean.queryKeysCountForBatch}.
@@ -1183,10 +1184,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
         throw new RuntimeException(
             String.format(
                 "ingestAspects failed on chunk %d/%d after earlier chunks committed (%d results in prior chunks). Cause: %s",
-                chunkIndex,
-                totalChunks,
-                combined.getUpdateAspectResults().size(),
-                e.getMessage()),
+                chunkIndex, totalChunks, combined.getUpdateAspectResults().size(), e.getMessage()),
             e);
       }
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
@@ -43,6 +43,7 @@ import com.linkedin.metadata.aspect.EntityAspect;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.aspect.batch.AspectsBatch;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.config.EbeanConfiguration;
 import com.linkedin.metadata.config.EntityServiceConfiguration;
 import com.linkedin.metadata.config.PreProcessHooks;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventType;
@@ -1639,6 +1640,129 @@ public class EntityServiceImplTest {
         .setRetry(0)
         .setEnableBrowseV2(true)
         .setPostCommitRetentionEnabled(postCommitRetentionEnabled);
+  }
+
+  @Test
+  public void testIngestAspectsChunksOversizedBatchIntoMultipleTransactions() throws Exception {
+    AspectDao dao = mock(AspectDao.class);
+    when(dao.runInTransactionWithRetry(any(), any(), any(AspectsBatch.class), anyInt()))
+        .thenReturn(Optional.of(IngestAspectsResult.EMPTY));
+
+    final int chunkSize = 2;
+    EntityServiceImpl svc =
+        new EntityServiceImpl(
+            dao,
+            mockEventProducer,
+            mock(PreProcessHooks.class),
+            testConfig().setMaxRequestBatchSize(chunkSize),
+            metricUtils);
+
+    // 5 items → chunks of 2,2,1
+    AspectsBatch batch = statusBatch(5);
+    svc.ingestAspects(opContext, batch, true, true);
+
+    ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
+    verify(dao, times(3))
+        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    List<AspectsBatch> chunks = batchCaptor.getAllValues();
+    assertEquals(chunks.get(0).getItems().size(), 2);
+    assertEquals(chunks.get(1).getItems().size(), 2);
+    assertEquals(chunks.get(2).getItems().size(), 1);
+  }
+
+  @Test
+  public void testIngestAspectsSingleTransactionWhenAtOrBelowChunkSize() throws Exception {
+    AspectDao dao = mock(AspectDao.class);
+    when(dao.runInTransactionWithRetry(any(), any(), any(AspectsBatch.class), anyInt()))
+        .thenReturn(Optional.of(IngestAspectsResult.EMPTY));
+
+    EntityServiceImpl svc =
+        new EntityServiceImpl(
+            dao,
+            mockEventProducer,
+            mock(PreProcessHooks.class),
+            testConfig().setMaxRequestBatchSize(EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT),
+            metricUtils);
+
+    AspectsBatch batch = statusBatch(EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT);
+    svc.ingestAspects(opContext, batch, true, true);
+
+    ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
+    verify(dao, times(1))
+        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    assertEquals(
+        batchCaptor.getValue().getItems().size(), EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT);
+  }
+
+  @Test
+  public void testIngestAspectsSkipsChunkingWhenDisabled() throws Exception {
+    AspectDao dao = mock(AspectDao.class);
+    when(dao.runInTransactionWithRetry(any(), any(), any(AspectsBatch.class), anyInt()))
+        .thenReturn(Optional.of(IngestAspectsResult.EMPTY));
+
+    EntityServiceImpl svc =
+        new EntityServiceImpl(
+            dao,
+            mockEventProducer,
+            mock(PreProcessHooks.class),
+            testConfig().setMaxRequestBatchSize(0),
+            metricUtils);
+
+    int oversized = EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT + 50;
+    AspectsBatch batch = statusBatch(oversized);
+    svc.ingestAspects(opContext, batch, true, true);
+
+    ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
+    verify(dao, times(1))
+        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    assertEquals(batchCaptor.getValue().getItems().size(), oversized);
+  }
+
+  @Test
+  public void testIngestAspectsPartialApplyWhenLaterChunkFails() throws Exception {
+    AspectDao dao = mock(AspectDao.class);
+    when(dao.runInTransactionWithRetry(any(), any(), any(AspectsBatch.class), anyInt()))
+        .thenReturn(Optional.of(IngestAspectsResult.EMPTY))
+        .thenThrow(new RuntimeException("simulated lock timeout"));
+
+    EntityServiceImpl svc =
+        new EntityServiceImpl(
+            dao,
+            mockEventProducer,
+            mock(PreProcessHooks.class),
+            testConfig().setMaxRequestBatchSize(2),
+            metricUtils);
+
+    try {
+      svc.ingestAspects(opContext, statusBatch(5), true, true);
+      fail("expected RuntimeException after partial commit");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("chunk 2/3"));
+      assertTrue(e.getMessage().contains("earlier chunks committed"));
+    }
+
+    // First chunk committed (txn entered); second failed — only 2 attempts.
+    verify(dao, times(2))
+        .runInTransactionWithRetry(any(), any(), any(AspectsBatch.class), anyInt());
+  }
+
+  private AspectsBatch statusBatch(int size) {
+    List<ChangeItemImpl> items = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      Urn urn = UrnUtils.getUrn("urn:li:corpuser:batch-cap-" + i);
+      items.add(
+          ChangeItemImpl.builder()
+              .urn(urn)
+              .aspectName(STATUS_ASPECT_NAME)
+              .recordTemplate(new Status().setRemoved(true))
+              .systemMetadata(SystemMetadataUtils.createDefaultSystemMetadata())
+              .auditStamp(TEST_AUDIT_STAMP)
+              .build(opContext.getAspectRetriever()));
+    }
+    return AspectsBatchImpl.builder()
+        .retrieverContext(opContext.getRetrieverContext())
+        .items(items)
+        .build(opContext);
   }
 
   private UpdateAspectResult postCommitUpsertResult() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplTest.java
@@ -1662,8 +1662,7 @@ public class EntityServiceImplTest {
     svc.ingestAspects(opContext, batch, true, true);
 
     ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
-    verify(dao, times(3))
-        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    verify(dao, times(3)).runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
     List<AspectsBatch> chunks = batchCaptor.getAllValues();
     assertEquals(chunks.get(0).getItems().size(), 2);
     assertEquals(chunks.get(1).getItems().size(), 2);
@@ -1688,8 +1687,7 @@ public class EntityServiceImplTest {
     svc.ingestAspects(opContext, batch, true, true);
 
     ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
-    verify(dao, times(1))
-        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    verify(dao, times(1)).runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
     assertEquals(
         batchCaptor.getValue().getItems().size(), EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT);
   }
@@ -1713,8 +1711,7 @@ public class EntityServiceImplTest {
     svc.ingestAspects(opContext, batch, true, true);
 
     ArgumentCaptor<AspectsBatch> batchCaptor = ArgumentCaptor.forClass(AspectsBatch.class);
-    verify(dao, times(1))
-        .runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
+    verify(dao, times(1)).runInTransactionWithRetry(any(), any(), batchCaptor.capture(), anyInt());
     assertEquals(batchCaptor.getValue().getItems().size(), oversized);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -813,6 +813,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "entityClient.restli.ingest.batchThreadKeepAlive",
           "entityClient.retryInterval",
           "entityService.impl",
+          "entityService.maxRequestBatchSize",
           "entityService.retention.applyOnBootstrap",
           "entityService.retention.applyOnPolicyChange",
           "entityService.retention.enabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityServiceConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityServiceConfiguration.java
@@ -12,4 +12,12 @@ public class EntityServiceConfiguration {
   @Nullable private Integer retry = null;
   private boolean enableBrowseV2 = false;
   private boolean postCommitRetentionEnabled = false;
+
+  /**
+   * Max items per DB transaction when ingesting aspects. Values &lt;= 0 disable chunking (one txn
+   * for the whole request). Default should match {@link
+   * EbeanConfiguration#DEFAULT_QUERY_KEYS_COUNT} / {@code ebean.queryKeysCountForBatch}. Oversized
+   * API batches are split into successive transactions of this size.
+   */
+  private int maxRequestBatchSize = 0;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -562,7 +562,7 @@ ebean:
   useIamAuth: ${EBEAN_USE_IAM_AUTH:false} # Generic IAM auth for cross-cloud compatibility
   cloudProvider: ${EBEAN_CLOUD_PROVIDER:auto} # auto, aws, gcp, or traditional
   batchGetMethod: ${EBEAN_BATCH_GET_METHOD:IN} # Alternative UNION
-  queryKeysCountForBatch: ${EBEAN_QUERY_KEYS_COUNT_FOR_BATCH:375} # Chunk size for batch queries (default 375). Set to avoid large IN clauses that exceed range_optimizer_max_mem_size.
+  queryKeysCountForBatch: ${EBEAN_QUERY_KEYS_COUNT_FOR_BATCH:375} # Chunk size for batch queries (default 375). Also used as EntityService ingestAspects transaction chunk size (override with ENTITY_SERVICE_MAX_REQUEST_BATCH_SIZE). Set to avoid large IN clauses that exceed range_optimizer_max_mem_size.
   transactionRetry:
     # SQLStates / vendor codes that get exponential backoff between retries (all PersistenceExceptions still retry).
     backoffSqlStates: ${EBEAN_RETRY_BACKOFF_SQL_STATES:40001,40P01}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EntityServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EntityServiceFactory.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.entity.retention.buffer.RetentionBuffer;
 import com.linkedin.metadata.event.EventProducer;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -27,6 +28,14 @@ public class EntityServiceFactory {
   @Value("${EBEAN_MAX_TRANSACTION_RETRY:#{null}}")
   private Integer _ebeanMaxTransactionRetry;
 
+  /**
+   * Optional override for ingestAspects transaction chunk size. When unset, uses {@code
+   * ebean.queryKeysCountForBatch} (default 375). Set to {@code 0} to disable chunking (single txn
+   * for the whole request).
+   */
+  @Value("${ENTITY_SERVICE_MAX_REQUEST_BATCH_SIZE:#{null}}")
+  private Integer maxRequestBatchSizeOverride;
+
   @Bean(name = "entityService")
   @DependsOn({"entityAspectDao", "kafkaEventProducer"})
   @Nonnull
@@ -42,6 +51,14 @@ public class EntityServiceFactory {
 
     FeatureFlags featureFlags = configurationProvider.getFeatureFlags();
 
+    int maxRequestBatchSize =
+        Optional.ofNullable(configurationProvider.getEbean())
+            .map(com.linkedin.metadata.config.EbeanConfiguration::getQueryKeysCountForBatch)
+            .orElse(com.linkedin.metadata.config.EbeanConfiguration.DEFAULT_QUERY_KEYS_COUNT);
+    if (maxRequestBatchSizeOverride != null) {
+      maxRequestBatchSize = maxRequestBatchSizeOverride;
+    }
+
     EntityServiceImpl entityService =
         new EntityServiceImpl(
             aspectDao,
@@ -52,7 +69,8 @@ public class EntityServiceFactory {
                 .setCdcModeChangeLog(featureFlags.isCdcModeChangeLog())
                 .setRetry(_ebeanMaxTransactionRetry)
                 .setEnableBrowseV2(enableBrowsePathV2)
-                .setPostCommitRetentionEnabled(featureFlags.isPostCommitRetentionEnabled()),
+                .setPostCommitRetentionEnabled(featureFlags.isPostCommitRetentionEnabled())
+                .setMaxRequestBatchSize(maxRequestBatchSize),
             metricUtils);
 
     // Absent (NO_OP) unless RetentionBufferFactory activated a coalesce-backed buffer.


### PR DESCRIPTION
## Summary

- **Chunk oversized `ingestAspects` writes** into successive DB transactions of at most `ebean.queryKeysCountForBatch` (default **375**, override `ENTITY_SERVICE_MAX_REQUEST_BATCH_SIZE`; `0` disables). UI/API can still send one large soft-delete or bulk ingest; the server splits so each txn holds fewer `SELECT … FOR UPDATE` locks.
- **Batch soft-delete status reads** in `DeleteUtils` (`getLatestAspects` once instead of N `getAspect` calls) and dedupe duplicate input URNs before building Status MCPs.
- Document behavior in `docs/how/updating-datahub.md` and `docs/deploy/environment-vars.md`.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| Soft-delete / ingest 2000 items in one request | One long FOR UPDATE txn | ~6 txns of ≤375; same API call |
| Batch ≤375 | One txn | Unchanged |
| Later chunk fails | N/A (single txn) | Earlier chunks already committed; error names chunk `i/n` |
| Soft-delete status preload | N sequential reads | One batch read; duplicate URNs → one MCP |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5248d583db564f555c5ac6d2ede009f3024766cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chunks oversized `ingestAspects` writes and batches soft-delete status reads to reduce DB lock contention and connection usage. This lowers deadlocks on large bulk ingests while keeping the same API behavior.

- **New Features**
  - `EntityServiceImpl`: split large `AspectsBatch` into transactions of up to `ebean.queryKeysCountForBatch` (default 375). Override with `ENTITY_SERVICE_MAX_REQUEST_BATCH_SIZE` (set 0 to disable). Earlier chunks commit; failures name chunk i/n.
  - `DeleteUtils`: replace per-URN `getAspect` calls with one `getLatestAspects`. Deduplicate URNs, emit one Status MCP per URN, and copy `Status` to avoid mutating cached aspects.
  - Config wiring: `EntityServiceConfiguration.maxRequestBatchSize`; `EntityServiceFactory` and `SystemUpdateConfig` source from `ebean.queryKeysCountForBatch` or the env override. Tests updated to cover chunking and batching.

<sup>Written for commit 5248d583db564f555c5ac6d2ede009f3024766cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

