### PR TITLE
fix: handle Windows drive letters in get_path_schema

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
@@ -1,8 +1,8 @@
+import re
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Iterable
 from urllib import parse
-import re
 
 # Matches Windows absolute paths like "C:\..." or "C:/...". urlparse()
 # misreads the drive letter as a URL scheme (e.g. "c"), so these must be

--- a/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/fs/fs_base.py
@@ -2,6 +2,12 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Iterable
 from urllib import parse
+import re
+
+# Matches Windows absolute paths like "C:\..." or "C:/...". urlparse()
+# misreads the drive letter as a URL scheme (e.g. "c"), so these must be
+# special-cased to "file" before falling through to urlparse.
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[a-zA-Z]:[\\/]")
 
 
 @dataclass
@@ -43,6 +49,8 @@ class FileSystem(metaclass=ABCMeta):
 
 
 def get_path_schema(path: str) -> str:
+    if _WINDOWS_DRIVE_PATH_RE.match(path):
+        return "file"
     scheme = parse.urlparse(path).scheme
     if scheme == "":
         # This makes the default schema "file" for local paths.

--- a/metadata-ingestion/tests/unit/test_fs_base.py
+++ b/metadata-ingestion/tests/unit/test_fs_base.py
@@ -1,4 +1,5 @@
 import pytest
+
 from datahub.ingestion.fs.fs_base import get_path_schema
 
 

--- a/metadata-ingestion/tests/unit/test_fs_base.py
+++ b/metadata-ingestion/tests/unit/test_fs_base.py
@@ -1,0 +1,21 @@
+import pytest
+from datahub.ingestion.fs.fs_base import get_path_schema
+
+
+@pytest.mark.parametrize(
+    "path,expected_schema",
+    [
+        (r"C:\Users\foo\bar.json", "file"),
+        ("C:/Users/foo/bar.json", "file"),
+        (r"D:\data\table.csv", "file"),
+        ("/tmp/foo/bar.json", "file"),
+        ("s3://my-bucket/key.json", "s3"),
+        ("https://example.com/file.json", "https"),
+        # Boundary case: no path separator after the colon, so this must
+        # NOT be treated as a Windows drive letter — falls through to the
+        # existing urlparse behavior instead.
+        ("c:relative", "c"),
+    ],
+)
+def test_get_path_schema(path: str, expected_schema: str) -> None:
+    assert get_path_schema(path) == expected_schema


### PR DESCRIPTION
## Problem
On Windows, local file ingestion (`datahub ingest` with the file source,
`datahub datapack load`, etc.) fails with:

    KeyError: 'Did not find a registered class for c'

This is the same error reported in #11107 (closed without a fix — the
underlying bug is still present on `master`). Multiple other users hit
the same issue in that thread and never got a resolution.

## Root Cause
`get_path_schema()` uses `urllib.parse.urlparse()` to detect whether a
path is local, S3, HTTP, etc. On a Windows absolute path like
`C:\Users\...\file.json`, `urlparse` reads everything before the first
colon as the URL scheme — so it returns `"c"` instead of recognizing this
as a local file path. There's no registered filesystem handler for
scheme `"c"`, hence the KeyError.

This is a known, longstanding quirk of Python's `urlparse` on Windows
paths (see https://github.com/python/cpython/issues/86381) — not
something `urlparse` itself is expected to fix, since it would change
behavior other callers may depend on.

## Fix
Special-case Windows drive-letter paths (matching `^[a-zA-Z]:[\\/]`) as
`"file"` before falling through to `urlparse`, mirroring what
`pathlib.Path.as_uri()` does internally to avoid the same ambiguity.

## Testing
Verified locally on Windows 11 against a real local DataHub instance:
before this fix, both `datahub datapack load <pack>` and file-source
ingestion of local `.json` files failed with the exact KeyError above;
after the fix, both succeed. Existing non-Windows path behavior
(`s3://...`, `http://...`, POSIX paths) is untouched since the new check
only matches the Windows drive-letter pattern.

Related to #11107.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows path parsing in `get_path_schema` so `C:\...` is treated as local. Restores local file ingestion and `datahub datapack load` on Windows; adds tests for drive-letter and `c:relative` edge cases.

- **Bug Fixes**
  - Special-case Windows drive-letter paths to return "file" before `urllib.parse.urlparse()`.
  - Preserve behavior for `s3://`, `https://`, POSIX paths, and `c:relative`.

- **Refactors**
  - Align import grouping with isort first-party configuration.

<sup>Written for commit ba27e04e36793170d21cc7bd4091136bac7708fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

