### PR TITLE
perf(playwright): enable workers_per_shard=2 with cross-worker seed locking

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -960,16 +960,7 @@ jobs:
       datahub_version: ${{ needs.setup.outputs.tag }}
       profile_name: ${{ needs.setup.outputs.smoke_profile_name || 'quickstart-consumers' }}
       send_posthog_metrics: true
-      # Validated via repeated manual workflow_dispatch trials on PR #19018 (see
-      # resusable-playwright-tests.yml's workers_per_shard input description
-      # for the fixes that made this safe): the seeding-fixture TOCTOU race,
-      # the v2-manage-policies.spec.ts missing serial guard, and the
-      # cross-file lineage-time-seeder race are all fixed, and multiple clean
-      # full-suite runs at workers_per_shard=2 confirm no regressions plus a
-      # real ~15-20% cut in the Playwright stage's wall clock. Wired here
-      # (rather than raising the reusable workflow's own default) so this is
-      # the one opted-in caller; other callers of resusable-playwright-tests
-      # keep inheriting workers_per_shard=1 unless they explicitly ask for 2.
+      # Opt in here only; other callers of the reusable workflow keep the default of 1.
       workers_per_shard: "2"
     secrets: inherit
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -960,6 +960,17 @@ jobs:
       datahub_version: ${{ needs.setup.outputs.tag }}
       profile_name: ${{ needs.setup.outputs.smoke_profile_name || 'quickstart-consumers' }}
       send_posthog_metrics: true
+      # Validated via repeated manual workflow_dispatch trials on PR #19018 (see
+      # resusable-playwright-tests.yml's workers_per_shard input description
+      # for the fixes that made this safe): the seeding-fixture TOCTOU race,
+      # the v2-manage-policies.spec.ts missing serial guard, and the
+      # cross-file lineage-time-seeder race are all fixed, and multiple clean
+      # full-suite runs at workers_per_shard=2 confirm no regressions plus a
+      # real ~15-20% cut in the Playwright stage's wall clock. Wired here
+      # (rather than raising the reusable workflow's own default) so this is
+      # the one opted-in caller; other callers of resusable-playwright-tests
+      # keep inheriting workers_per_shard=1 unless they explicitly ask for 2.
+      workers_per_shard: "2"
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -960,8 +960,8 @@ jobs:
       datahub_version: ${{ needs.setup.outputs.tag }}
       profile_name: ${{ needs.setup.outputs.smoke_profile_name || 'quickstart-consumers' }}
       send_posthog_metrics: true
-      # Opt in here only; other callers of the reusable workflow keep the default of 1.
-      workers_per_shard: "2"
+      # Opt in to 2 workers on first attempt; fall back to 1 on re-runs for stability.
+      workers_per_shard: ${{ github.run_attempt > 1 && '1' || '2' }}
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -19,7 +19,7 @@ on:
         default: "quickstart"
         type: string
       workers_per_shard:
-        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 is the proven, unchanged behavior; >1 is an unvalidated trial (see PFP-5479 ranked fix #6) -- multiple worker processes will share one shard's stack and filesystem."
+        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 is the proven, unchanged behavior; >1 is an unvalidated trial -- multiple worker processes will share one shard's stack and filesystem."
         required: false
         default: "1"
         type: string

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -19,7 +19,7 @@ on:
         default: "quickstart"
         type: string
       workers_per_shard:
-        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 is the proven, unchanged behavior; >1 is an unvalidated trial -- multiple worker processes will share one shard's stack and filesystem."
+        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 preserves existing behavior; >1 enables multiple worker processes that share one shard's stack and filesystem."
         required: false
         default: "1"
         type: string

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: "quickstart"
         type: string
+      workers_per_shard:
+        description: "EXPERIMENTAL: Playwright --workers per shard. Default 1 is the proven, unchanged behavior; >1 is an unvalidated trial (see PFP-5479 ranked fix #6) -- multiple worker processes will share one shard's stack and filesystem."
+        required: false
+        default: "1"
+        type: string
 
 permissions:
   contents: read
@@ -92,6 +97,7 @@ jobs:
       test_runner_type: ${{ needs.setup.outputs.test_runner_type }}
       datahub_version: ${{ inputs.datahub_version }}
       profile_name: ${{ inputs.profileName }}
+      workers_per_shard: ${{ inputs.workers_per_shard }}
     secrets: inherit
 
   playwright_report:

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -52,7 +52,7 @@ on:
         type: boolean
         default: false
       workers_per_shard:
-        description: "Playwright --workers per shard. EXPERIMENTAL (see PFP-5479 ranked fix #6) -- default 1 matches every non-experimental caller's existing behavior. >1 is unproven: each worker is a separate process sharing this shard's single stack (one GMS/Kafka/ES/MySQL instance on a 4-vCPU runner) and its filesystem (the .seeded/{feature}.json check-then-act has a real, if likely-harmless, race across worker processes). Do not raise the default without a trial run first."
+        description: "Number of Playwright workers per shard. Defaults to 1; values above 1 share the shard's stack and filesystem."
         required: false
         type: string
         default: "1"

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: boolean
         default: false
+      workers_per_shard:
+        description: "Playwright --workers per shard. EXPERIMENTAL (see PFP-5479 ranked fix #6) -- default 1 matches every non-experimental caller's existing behavior. >1 is unproven: each worker is a separate process sharing this shard's single stack (one GMS/Kafka/ES/MySQL instance on a 4-vCPU runner) and its filesystem (the .seeded/{feature}.json check-then-act has a real, if likely-harmless, race across worker processes). Do not raise the default without a trial run first."
+        required: false
+        type: string
+        default: "1"
 jobs:
   playwright_test:
     name: Playwright E2E Tests
@@ -169,9 +174,12 @@ jobs:
           PLAYWRIGHT_REUSE_SERVER: "1"
           SHARD: ${{ inputs.shard }}
           SHARD_COUNT: ${{ inputs.shard_count }}
+          WORKERS_PER_SHARD: ${{ inputs.workers_per_shard }}
         run: |
+          echo "Running Playwright shard $SHARD/$SHARD_COUNT at $WORKERS_PER_SHARD worker(s)"
           npx playwright test \
-            --shard="$SHARD/$SHARD_COUNT"
+            --shard="$SHARD/$SHARD_COUNT" \
+            --workers="$WORKERS_PER_SHARD"
 
       - name: Upload Playwright blob report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/e2e-test/ui/playwright/fixtures/login.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/login.fixture.ts
@@ -166,12 +166,13 @@ export const loginFixture = base.extend<LoginFixtures, LoginFixtureOptions>({
       // cannot race a torn writeFileSync against that producer (or each other).
       const tokenFile = gmsTokenPath(user.username);
       await withArtifactLock(tokenFile, async () => {
-        const cookies = await ctx.cookies();
+        const baseURL = process.env.BASE_URL ?? 'http://localhost:9002';
+        const graphqlUrl = new URL(DATAHUB_GRAPHQL_PATH, baseURL).toString();
+        const cookies = await ctx.cookies(graphqlUrl);
         const actorCookie = cookies.find((c) => c.name === 'actor');
         if (!actorCookie) return;
 
         const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
-        const baseURL = process.env.BASE_URL ?? 'http://localhost:9002';
         const apiCtx = await playwright.request.newContext({
           baseURL,
           extraHTTPHeaders: { Cookie: cookieHeader },

--- a/e2e-test/ui/playwright/fixtures/login.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/login.fixture.ts
@@ -18,10 +18,11 @@
  * Tests never need to call loginPage.login() themselves.
  *
  * Parallel execution note:
- *   Two workers using the same user may rarely hit a race condition when both
- *   enter the "state missing" branch simultaneously. In practice this is
- *   harmless (both write the same valid state), but a file lock can be added
- *   later if needed.
+ *   Two workers using the same user may rarely both enter the "state missing"
+ *   branch for `.auth/{username}.json` simultaneously. In practice that is
+ *   harmless (both write the same valid storageState). The GMS token file is
+ *   guarded by withArtifactLock + writeJsonAtomic so it cannot race seeding's
+ *   bootstrapGmsToken under workers_per_shard > 1.
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * User injection example (set at describe level, not inside tests):
@@ -46,6 +47,7 @@ import { users, type UserCredentials } from '../data/users';
 import { LoginPage } from '../pages/login.page';
 import { gmsTokenPath } from './login';
 import { DATAHUB_GRAPHQL_PATH } from '../utils/constants';
+import { withArtifactLock, writeJsonAtomic } from '../helpers/seeder-utils';
 import type { DataHubLogger } from '../utils/logger';
 
 // ── Fixture types ─────────────────────────────────────────────────────────────
@@ -159,11 +161,15 @@ export const loginFixture = base.extend<LoginFixtures, LoginFixtureOptions>({
 
       // Mint a GMS personal access token using the live session cookies so
       // that API-level fixtures (seeding, cleanup) don't need a separate
-      // auth-setup project to run first.
+      // auth-setup project to run first. Same path as seeding.fixture's
+      // bootstrapGmsToken — take the artifact lock so workers_per_shard > 1
+      // cannot race a torn writeFileSync against that producer (or each other).
       const tokenFile = gmsTokenPath(user.username);
-      const cookies = await ctx.cookies();
-      const actorCookie = cookies.find((c) => c.name === 'actor');
-      if (actorCookie) {
+      await withArtifactLock(tokenFile, async () => {
+        const cookies = await ctx.cookies();
+        const actorCookie = cookies.find((c) => c.name === 'actor');
+        if (!actorCookie) return;
+
         const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
         const baseURL = process.env.BASE_URL ?? 'http://localhost:9002';
         const apiCtx = await playwright.request.newContext({
@@ -186,21 +192,19 @@ export const loginFixture = base.extend<LoginFixtures, LoginFixtureOptions>({
               },
             },
           });
-          if (resp.ok()) {
-            const body = (await resp.json()) as {
-              data?: { createAccessToken?: { accessToken?: string; metadata?: { id?: string } } };
-            };
-            const token = body.data?.createAccessToken?.accessToken;
-            const tokenId = body.data?.createAccessToken?.metadata?.id;
-            if (token) {
-              fs.writeFileSync(tokenFile, JSON.stringify({ token, tokenId, actorUrn: actorCookie.value }, null, 2));
-              logger.info('GMS token saved', { user: user.username, tokenFile });
-            }
-          }
+          if (!resp.ok()) return;
+          const body = (await resp.json()) as {
+            data?: { createAccessToken?: { accessToken?: string; metadata?: { id?: string } } };
+          };
+          const token = body.data?.createAccessToken?.accessToken;
+          const tokenId = body.data?.createAccessToken?.metadata?.id;
+          if (!token) return;
+          writeJsonAtomic(tokenFile, { token, tokenId, actorUrn: actorCookie.value });
+          logger.info('GMS token saved', { user: user.username, tokenFile });
         } finally {
           await apiCtx.dispose();
         }
-      }
+      });
     } catch (err) {
       logger.error('login failed', { user: user.username, error: String(err) });
       throw err;

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -4,14 +4,18 @@
  * Mirrors the pattern established by loginFixture:
  *
  *   1. A suite opts in by setting the `featureName` option at describe level.
- *   2. The fixture checks whether `.seeded/{featureName}.json` exists on disk.
- *   3a. State EXISTS  → data was already ingested this run; skip injection.
- *   3b. State MISSING → read `tests/{featureName}/fixtures/data.json`, POST
- *       each MCP to the GMS REST API, then write the state file so that other
- *       workers (and subsequent tests in this worker) skip ingestion.
+ *   2. The fixture claims `.seeded/{featureName}.json` via withArtifactLock.
+ *   2a. State EXISTS  → data was already ingested this run; skip injection.
+ *   2b. Lock acquired → read `tests/{featureName}/fixtures/data.json`, POST
+ *       each MCP to the GMS REST API, wait for the search index to catch up,
+ *       then write the state file so other workers skip ingestion.
+ *   2c. Lock held by another worker → poll for the state file it is
+ *       producing instead of duplicating the ingestion (see withArtifactLock;
+ *       this is what makes seeding safe under workers_per_shard > 1).
  *
- * Worker-scoped means seeding happens AT MOST ONCE per worker process for a
- * given feature name, regardless of how many tests request it.
+ * Worker-scoped means seeding is attempted AT MOST ONCE per worker process for
+ * a given feature name, regardless of how many tests request it; across
+ * workers sharing a filesystem, exactly one of them actually performs it.
  *
  * NOTE: This fixture is intentionally worker-scoped.  Worker-scoped fixtures
  * cannot depend on test-scoped fixtures such as `logger`.  A dedicated logger
@@ -55,6 +59,8 @@ import {
   normalizeMcp,
   extractComplexAspects,
   ingestComplexAspects,
+  withArtifactLock,
+  writeJsonAtomic,
   type Mcp,
 } from '../helpers/seeder-utils';
 import { createLogger, type DataHubLogger } from '../utils/logger';
@@ -110,8 +116,7 @@ async function bootstrapGmsToken(browser: Browser, user: UserCredentials): Promi
       const token = body.data?.createAccessToken?.accessToken;
       const tokenId = body.data?.createAccessToken?.metadata?.id;
       if (!token) throw new Error('Empty access token in response');
-      fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
-      fs.writeFileSync(tokenFile, JSON.stringify({ token, tokenId, actorUrn: actorCookie.value }, null, 2));
+      writeJsonAtomic(tokenFile, { token, tokenId, actorUrn: actorCookie.value });
       return token;
     } finally {
       await apiCtx.dispose();
@@ -256,15 +261,21 @@ async function ingestMcps(
       await ingestComplexAspects(apiContext, gmsToken, complexAspects, logger);
     }
 
+    // Wait for the search index to catch up BEFORE marking this seed complete.
+    // The state file's mere existence is the fixture's signal that data is safe
+    // to read; writing it any earlier let workers that reuse it proceed against
+    // not-yet-indexed data.
+    logger.info('waiting 15s for search index to catch up before marking seed complete');
+    await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
+
     // Write state file so other workers (and next runs) skip re-seeding.
     // Written even on partial failures (when throwOnFailure=false) so we don't retry endlessly.
-    fs.mkdirSync(SEEDED_DIR, { recursive: true });
     const state: SeedState = {
       featureName,
       seededAt: new Date().toISOString(),
       entityCount: mcps.length,
     };
-    fs.writeFileSync(stateFilePath(featureName), JSON.stringify(state, null, 2));
+    writeJsonAtomic(stateFilePath(featureName), state);
     logger.info('state saved', { featureName });
   } finally {
     await apiContext.dispose();
@@ -296,62 +307,39 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
         return;
       }
 
+      // Each artifact below is guarded by withArtifactLock: exactly one worker
+      // produces it (ingest + wait for the search index) while any concurrent
+      // workers_per_shard > 1 siblings poll for it instead of duplicating the
+      // ingestion.
       const tokenFile = gmsTokenPath(user.username);
-      const gmsToken = fs.existsSync(tokenFile) ? readGmsToken(user.username) : await bootstrapGmsToken(browser, user);
+      await withArtifactLock(tokenFile, () => bootstrapGmsToken(browser, user).then(() => undefined));
+      const gmsToken = readGmsToken(user.username);
 
-      // Track whether any fresh ingestion happened this run so we can wait
-      // for the search index to catch up before tests start.
-      let freshlySeeded = false;
-
-      // Always seed global shared data (test-data/data.json) once per worker.
+      // Always seed global shared data (test-data/data.json) once per run.
       if (fs.existsSync(GLOBAL_DATA_FILE)) {
         const globalStateFile = stateFilePath(GLOBAL_FEATURE_NAME);
-        if (fs.existsSync(globalStateFile)) {
-          const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
-          logger.info('reusing global data', { seededAt: state.seededAt, entityCount: state.entityCount });
-        } else {
+        await withArtifactLock(globalStateFile, () =>
           // throwOnFailure=false: global data has mixed-format MCPs; partial failures are non-blocking.
-          await ingestMcps(GLOBAL_FEATURE_NAME, gmsToken, gmsUrl(), logger, GLOBAL_DATA_FILE, false);
-          freshlySeeded = true;
-        }
+          ingestMcps(GLOBAL_FEATURE_NAME, gmsToken, gmsUrl(), logger, GLOBAL_DATA_FILE, false),
+        );
+        const state = JSON.parse(fs.readFileSync(globalStateFile, 'utf-8')) as SeedState;
+        logger.info('global data ready', { seededAt: state.seededAt, entityCount: state.entityCount });
       }
 
       if (!featureName) {
-        if (freshlySeeded) {
-          logger.info('waiting 15s for search index to catch up');
-          await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
-        }
         await use();
         return;
       }
 
       const stateFile = stateFilePath(featureName);
-      if (fs.existsSync(stateFile)) {
-        const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as SeedState;
-        logger.info('reusing seeded data', {
-          featureName,
-          seededAt: state.seededAt,
-          entityCount: state.entityCount,
-        });
-        if (freshlySeeded) {
-          logger.info('waiting 15s for search index to catch up');
-          await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
-        }
-        await use();
-        return;
-      }
-
-      // Slow path: seed feature-specific data and save state.
-      await ingestMcps(featureName, gmsToken, gmsUrl(), logger);
-      freshlySeeded = true;
-
-      logger.info('waiting 15s for search index to catch up');
-      await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
+      await withArtifactLock(stateFile, () => ingestMcps(featureName, gmsToken, gmsUrl(), logger));
+      const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as SeedState;
+      logger.info('feature data ready', { featureName, seededAt: state.seededAt, entityCount: state.entityCount });
 
       await use();
     },
-    // 90 s: ingestMcps + 15 s ES index wait + network overhead can exceed the
-    // default fixture timeout (which mirrors the 30 s test timeout).
-    { auto: true, scope: 'worker', timeout: 90_000 },
+    // Generous ceiling: worst case one worker produces token + global + feature,
+    // each with ingest + a 15s ES index wait under withArtifactLock.
+    { auto: true, scope: 'worker', timeout: 180_000 },
   ],
 });

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -124,9 +124,9 @@ export async function withArtifactLock(artifactPath: string, produce: () => Prom
     try {
       const age = Date.now() - fs.statSync(lockPath).mtimeMs;
       if (age > LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
-    } catch {
-      // Lock file may have just been removed by its owner between our existsSync
-      // and statSync — ignore and re-poll.
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      // Lock file was removed between the acquisition attempt and stat/rm; re-poll.
     }
 
     await new Promise<void>((resolve) => setTimeout(resolve, LOCK_POLL_MS));

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -11,11 +11,89 @@
  * needed.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { APIRequestContext } from '@playwright/test';
 import { gmsUrl } from '../utils/constants';
 import type { DataHubLogger } from '../utils/logger';
 
 export type Urn = string;
+
+// ── Cross-worker artifact locking ────────────────────────────────────────────
+
+/**
+ * If a lock file is older than this with its artifact still missing, its
+ * holder is assumed to have crashed; another worker reclaims it rather than
+ * wedging the whole run.
+ */
+const LOCK_STALE_MS = 120_000;
+const LOCK_POLL_MS = 500;
+/** How long a follower will wait for another worker's artifact before giving up. */
+const LOCK_WAIT_TIMEOUT_MS = 180_000;
+
+/**
+ * Atomically claims responsibility for producing `artifactPath` across
+ * concurrent worker processes sharing the same filesystem (workers_per_shard
+ * > 1, or fullyParallel scheduling two files/describe-blocks that share a
+ * seed routine onto different workers). `fs.existsSync` + later
+ * `fs.writeFileSync` is a check-then-act race: two callers can both observe
+ * "absent" before either has written, and both duplicate the work.
+ * `fs.openSync(lockPath, 'wx')` is atomic exclusive create -- exactly one
+ * caller can win it -- so only the winner produces the artifact while
+ * everyone else polls for it instead.
+ */
+export async function withArtifactLock(artifactPath: string, produce: () => Promise<void>): Promise<void> {
+  if (fs.existsSync(artifactPath)) return;
+
+  const lockPath = `${artifactPath}.lock`;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_TIMEOUT_MS;
+
+  for (;;) {
+    if (fs.existsSync(artifactPath)) return;
+
+    let fd: number | undefined;
+    try {
+      fd = fs.openSync(lockPath, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+      try {
+        if (!fs.existsSync(artifactPath)) {
+          await produce();
+        }
+      } finally {
+        fs.rmSync(lockPath, { force: true });
+      }
+      return;
+    }
+
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for '${artifactPath}' to be produced by another worker (lock: ${lockPath})`);
+    }
+
+    try {
+      const age = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (age > LOCK_STALE_MS) fs.rmSync(lockPath, { force: true });
+    } catch {
+      // Lock file may have just been removed by its owner between our existsSync
+      // and statSync — ignore and re-poll.
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+  }
+}
+
+/** Write JSON atomically: readers never observe a partially-written file. */
+export function writeJsonAtomic(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+  fs.renameSync(tmpPath, filePath);
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -22,14 +22,48 @@ export type Urn = string;
 // ── Cross-worker artifact locking ────────────────────────────────────────────
 
 /**
- * If a lock file is older than this with its artifact still missing, its
- * holder is assumed to have crashed; another worker reclaims it rather than
- * wedging the whole run.
+ * Live holders refresh the lock mtime on this interval. Must be well below
+ * LOCK_STALE_MS so a healthy producer never looks crashed to followers.
  */
-const LOCK_STALE_MS = 120_000;
+const LOCK_HEARTBEAT_MS = 10_000;
+/**
+ * If a lock file is older than this with its artifact still missing, its
+ * holder is assumed to have crashed (missed several heartbeats); another
+ * worker reclaims it rather than wedging the whole run.
+ */
+const LOCK_STALE_MS = 45_000;
 const LOCK_POLL_MS = 500;
 /** How long a follower will wait for another worker's artifact before giving up. */
 const LOCK_WAIT_TIMEOUT_MS = 180_000;
+
+function newLockToken(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Renew mtime while we hold the lock so slow-but-live producers aren't stolen. */
+function startLockHeartbeat(lockPath: string, token: string): NodeJS.Timeout {
+  const heartbeat = setInterval(() => {
+    try {
+      if (fs.readFileSync(lockPath, 'utf-8') !== token) return;
+      const now = new Date();
+      fs.utimesSync(lockPath, now, now);
+    } catch {
+      // Lock gone or raced — produce()'s finally will no-op the release.
+    }
+  }, LOCK_HEARTBEAT_MS);
+  heartbeat.unref();
+  return heartbeat;
+}
+
+/** Remove the lock only if we still own it — never delete a reclaimer's lock. */
+function releaseLockIfOwned(lockPath: string, token: string): void {
+  try {
+    if (fs.readFileSync(lockPath, 'utf-8') !== token) return;
+    fs.rmSync(lockPath, { force: true });
+  } catch {
+    // Already gone.
+  }
+}
 
 /**
  * Atomically claims responsibility for producing `artifactPath` across
@@ -41,6 +75,11 @@ const LOCK_WAIT_TIMEOUT_MS = 180_000;
  * `fs.openSync(lockPath, 'wx')` is atomic exclusive create -- exactly one
  * caller can win it -- so only the winner produces the artifact while
  * everyone else polls for it instead.
+ *
+ * Ownership is a token written into the lock file; the holder heartbeats
+ * mtime during `produce()` so LOCK_STALE_MS reclaim cannot steal a live
+ * producer, and `finally` only deletes the lock when the token still matches
+ * (so a finishing holder cannot clobber a reclaimer's lock).
  */
 export async function withArtifactLock(artifactPath: string, produce: () => Promise<void>): Promise<void> {
   if (fs.existsSync(artifactPath)) return;
@@ -60,13 +99,20 @@ export async function withArtifactLock(artifactPath: string, produce: () => Prom
     }
 
     if (fd !== undefined) {
-      fs.closeSync(fd);
+      const token = newLockToken();
+      try {
+        fs.writeFileSync(fd, token);
+      } finally {
+        fs.closeSync(fd);
+      }
+      const heartbeat = startLockHeartbeat(lockPath, token);
       try {
         if (!fs.existsSync(artifactPath)) {
           await produce();
         }
       } finally {
-        fs.rmSync(lockPath, { force: true });
+        clearInterval(heartbeat);
+        releaseLockIfOwned(lockPath, token);
       }
       return;
     }

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -233,6 +233,14 @@ const BASE_FEATURE_FLAGS = {
 
 // ── Test Suite ───────────────────────────────────────────────────────────────
 
+// beforeAll's seedAdditionalNodes call (unlike seedTimeRangeLineage, which is
+// now lock-protected in lineage-time-seeder.ts because it's also called from
+// v3-lineage-impact-analysis.spec.ts) is unique to this file and has no such
+// guard. Under workers_per_shard > 1, fullyParallel can still schedule this
+// describe block's own tests across two workers, each running beforeAll
+// concurrently. Force one worker so it stays genuinely single-shot.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('lineage v3 — lineage graph', () => {
   let lineagePage: LineageV3Page;
 

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -239,7 +239,7 @@ const BASE_FEATURE_FLAGS = {
 // guard. Under workers_per_shard > 1, fullyParallel can still schedule this
 // describe block's own tests across two workers, each running beforeAll
 // concurrently. Force one worker so it stays genuinely single-shot.
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: 'default' });
 
 test.describe('lineage v3 — lineage graph', () => {
   let lineagePage: LineageV3Page;

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
@@ -62,6 +62,15 @@ const UI_TEXT = {
 
 // ── Test Suite ──────────────────────────────────────────────────────────────
 
+// beforeAll below seeds shared, time-stamped lineage edges via delete-then-
+// recreate (see lineage-time-seeder.ts) and assumes it runs exactly once for
+// the whole suite. That only holds on a single worker: under
+// workers_per_shard > 1, fullyParallel can schedule this describe block's
+// tests across two workers, each running its own beforeAll concurrently and
+// racing the delete/recreate against each other's async graph-edge
+// propagation. Force one worker so beforeAll is genuinely single-shot.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('impact analysis', () => {
   let lineagePage: LineageV3Page;
 

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
@@ -69,7 +69,7 @@ const UI_TEXT = {
 // tests across two workers, each running its own beforeAll concurrently and
 // racing the delete/recreate against each other's async graph-edge
 // propagation. Force one worker so beforeAll is genuinely single-shot.
-test.describe.configure({ mode: 'serial' });
+test.describe.configure({ mode: 'default' });
 
 test.describe('impact analysis', () => {
   let lineagePage: LineageV3Page;

--- a/e2e-test/ui/playwright/tests/settings-v2/v2-manage-policies.spec.ts
+++ b/e2e-test/ui/playwright/tests/settings-v2/v2-manage-policies.spec.ts
@@ -6,6 +6,11 @@ import { test } from '../../fixtures/base-test';
 import { PoliciesPage } from '../../pages/settings/policies.page';
 import { withRandomSuffix } from '../../utils/random';
 
+// Both tests mutate the same global, un-namespaced system policy list with no
+// per-test isolation; running them concurrently on separate workers causes
+// collisions on shared backend state.
+test.describe.configure({ mode: 'serial' });
+
 test.describe('create and manage platform and metadata policies', () => {
   let policiesPage: PoliciesPage;
 

--- a/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
+++ b/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
@@ -31,7 +31,21 @@ import { gmsUrl } from './constants';
 import type { DataHubLogger } from './logger';
 import { withArtifactLock, writeJsonAtomic } from '../helpers/seeder-utils';
 
-const STATE_FILE = path.join(__dirname, '../.seeded/lineage-time-range.json');
+/**
+ * Run-scoped so cross-worker dedupe lasts for one `npx playwright test`
+ * invocation only. Timestamps in this seeder are relative to Date.now(); a
+ * sticky `.seeded/lineage-time-range.json` would skip reseeding on later local
+ * runs and leave stale absolute edges that break moving-window assertions.
+ *
+ * Shared across workers via CI run id+attempt, or the Playwright runner's pid
+ * (workers are child processes of that runner).
+ */
+function lineageTimeRangeStateFile(): string {
+  const runId = process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT ?? '1'}`
+    : `ppid-${process.ppid}`;
+  return path.join(__dirname, '../.seeded', `lineage-time-range-${runId}.json`);
+}
 
 // ── Timestamp helpers ─────────────────────────────────────────────────────────
 
@@ -203,8 +217,10 @@ async function ingestProposal(
 // ── Public seeding entry point ────────────────────────────────────────────────
 
 /**
- * Seed all time-range lineage scenarios, guarded by withArtifactLock so it
- * only actually runs once across the whole test run.
+ * Seed all time-range lineage scenarios, guarded by withArtifactLock on a
+ * run-scoped state file so it only actually runs once across workers in this
+ * Playwright invocation (not across later local runs — timestamps are relative
+ * to Date.now()).
  *
  * Two different spec files (v3-lineage-impact-analysis.spec.ts and
  * v3-lineage-graph.spec.ts) each call this from their own test.beforeAll,
@@ -224,9 +240,10 @@ export async function seedTimeRangeLineage(
   gmsToken: string,
   logger?: DataHubLogger,
 ): Promise<void> {
-  await withArtifactLock(STATE_FILE, async () => {
+  const stateFile = lineageTimeRangeStateFile();
+  await withArtifactLock(stateFile, async () => {
     await doSeedTimeRangeLineage(request, gmsToken, logger);
-    writeJsonAtomic(STATE_FILE, { seededAt: new Date().toISOString() });
+    writeJsonAtomic(stateFile, { seededAt: new Date().toISOString() });
   });
 }
 

--- a/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
+++ b/e2e-test/ui/playwright/utils/lineage-time-seeder.ts
@@ -25,9 +25,13 @@
  *     factor_income → gnp  (created 8 days ago, updated 8 days ago — removed since then)
  */
 
+import * as path from 'path';
 import type { APIRequestContext } from '@playwright/test';
 import { gmsUrl } from './constants';
 import type { DataHubLogger } from './logger';
+import { withArtifactLock, writeJsonAtomic } from '../helpers/seeder-utils';
+
+const STATE_FILE = path.join(__dirname, '../.seeded/lineage-time-range.json');
 
 // ── Timestamp helpers ─────────────────────────────────────────────────────────
 
@@ -199,10 +203,34 @@ async function ingestProposal(
 // ── Public seeding entry point ────────────────────────────────────────────────
 
 /**
- * Seed all time-range lineage scenarios.
- * Safe to call multiple times — each call simply overwrites the aspect.
+ * Seed all time-range lineage scenarios, guarded by withArtifactLock so it
+ * only actually runs once across the whole test run.
+ *
+ * Two different spec files (v3-lineage-impact-analysis.spec.ts and
+ * v3-lineage-graph.spec.ts) each call this from their own test.beforeAll,
+ * on the — previously correct only under workers:1 — assumption that
+ * "once per describe block" means "once, period". Under workers_per_shard
+ * > 1 (or just fullyParallel scheduling these two files onto different
+ * workers), both beforeAll hooks can run concurrently, each doing its own
+ * delete-then-recreate of the SAME shared dataJobInputOutput/upstreamLineage
+ * aspects (see doSeedTimeRangeLineage). Deletes and the graph-edge writes
+ * they gate on propagate asynchronously, so interleaving two independent
+ * delete/recreate sequences can leave a partially-overwritten, wrong-
+ * timestamp result even though each sequence alone is correct -- exactly
+ * the class of bug the seeding fixture's global-data race was.
  */
 export async function seedTimeRangeLineage(
+  request: APIRequestContext,
+  gmsToken: string,
+  logger?: DataHubLogger,
+): Promise<void> {
+  await withArtifactLock(STATE_FILE, async () => {
+    await doSeedTimeRangeLineage(request, gmsToken, logger);
+    writeJsonAtomic(STATE_FILE, { seededAt: new Date().toISOString() });
+  });
+}
+
+async function doSeedTimeRangeLineage(
   request: APIRequestContext,
   gmsToken: string,
   logger?: DataHubLogger,


### PR DESCRIPTION
## Summary

Isolates the in-process Playwright worker support from #19018 into a focused PR.

- Add atomic `withArtifactLock` / `writeJsonAtomic` so seeding runs once across workers sharing a filesystem
- Guard shared time-range lineage seeding the same way (run-scoped artifact so relative timestamps stay fresh across local runs)
- Serialize suites that mutate un-namespaced shared state (`v2-manage-policies`, lineage graph/impact analysis)
- Add opt-in `workers_per_shard` to the reusable Playwright workflow and set `workers_per_shard: "2"` for `docker-unified.yml`'s automatic pipeline only

Deliberately excludes duration-weighted sharding and Kafka offset-based writes-sync waits from #19018.

## Results

Measured on `docker-unified.yml` (8 shards, file-count sharding):

| Shard | Master baseline (workers=1) [run 31411754746](https://github.com/datahub-project/datahub/actions/runs/31411754746) | This PR (workers=2) [run 31421665667](https://github.com/datahub-project/datahub/actions/runs/31421665667) | Δ |
|------:|-------:|----------:|--:|
| 1 | 9.4m | 9.0m | −0.5m (−5%) |
| 2 | 11.2m | 8.1m | −3.1m (−28%) |
| 3 | 10.3m | 8.3m | −2.0m (−20%) |
| 4 | 8.7m | 8.8m | +0.1m (+1%) |
| 5 | 16.4m | 11.3m | −5.0m (−31%) |
| 6 | 13.5m | 12.3m | −1.2m (−9%) |
| 7 | 13.2m | 10.1m | −3.1m (−23%) |
| 8 | 12.3m | 9.2m | −3.1m (−25%) |
| **Bottleneck** | **16.4m** | **12.3m** | **−4.1m (−25%)** |
| **Avg** | **11.9m** | **9.6m** | **−2.2m (−19%)** |

7/8 shards got faster; stage wall clock (bottleneck shard) dropped ~25%. Pattern held vs two other recent master runs as well.

## Test plan

- [x] Confirm `docker-unified.yml` passes `workers_per_shard: "2"` and other callers still default to `"1"`
- [x] Confirm seeding fixture uses `withArtifactLock` for token / global / feature artifacts
- [x] Confirm lineage-time seeder is lock-guarded and the three serial suites stay serial
- [x] Automatic Playwright pipeline green at 2 workers/shard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds an opt-in **`workers_per_shard`** knob through the reusable Playwright workflows and passes **`--workers`** from CI. **`docker-unified.yml`** uses **2 workers on the first run attempt** and **1 on retries**; other callers still default to **1**.
> 
> To make multiple Playwright workers per shard safe on a shared filesystem, the PR introduces **`withArtifactLock`** and **`writeJsonAtomic`** in `seeder-utils`, then routes GMS token minting, seeding fixture artifacts, and time-range lineage seeding through them. Seeding now waits for the search index **before** writing the “done” state file, and the seeding fixture timeout is raised to **180s**.
> 
> **`seedTimeRangeLineage`** gets run-scoped lock dedupe so two specs’ `beforeAll` hooks cannot race delete/recreate. Suites that assume single-shot or shared mutable backend state (**manage policies**, lineage graph/impact analysis) are forced to **serial** / **default** worker mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05eb61bb0943fad998c313d89eddf511ba1206c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->