### PR TITLE
feat(ingestion): add Convex metadata ingestion source

### DIFF
--- a/metadata-ingestion/docs/sources/convex/README.md
+++ b/metadata-ingestion/docs/sources/convex/README.md
@@ -1,0 +1,15 @@
+## Overview
+
+Convex is a reactive backend platform that pairs a document database with server-side functions, used as the application backend for web and mobile products. Learn more in the [official Convex documentation](https://docs.convex.dev/).
+
+The DataHub integration for Convex extracts one container per deployment and one dataset per table, with schema fields mapped from the JSON Schema that Convex derives from the documents it stores. Row counts are ingested as dataset profiles and can be disabled.
+
+## Concept Mapping
+
+| Source Concept     | DataHub Concept               | Notes                                                                 |
+| ------------------ | ----------------------------- | --------------------------------------------------------------------- |
+| Deployment         | Container (CONVEX_DEPLOYMENT) | One per entry in the `deployments` list, named by its `name` field.   |
+| Table              | Dataset                       | Named `<deployment name>.<table name>`.                               |
+| Document field     | SchemaField                   | Typed from the table's JSON Schema, including `anyOf` unions.         |
+| Document reference | SchemaField description       | Convex reports these as `Id(<table>)`, which becomes the description. |
+| Row count          | Dataset Profile               | Optional, controlled by `include_row_counts`.                         |

--- a/metadata-ingestion/docs/sources/convex/convex_post.md
+++ b/metadata-ingestion/docs/sources/convex/convex_post.md
@@ -1,0 +1,18 @@
+### Capabilities
+
+Use the **Important Capabilities** table above as the source of truth for supported features and whether additional configuration is required.
+
+#### Profiling Details
+
+When `include_row_counts` is enabled, each table is counted by paging through a snapshot of it. `max_count_pages` caps how many pages are read per table; if a table is larger than the cap, the row count is reported as a lower bound (`1234+` in the dataset's custom properties) and the table is listed under `row_counts_capped` in the ingestion report.
+
+### Limitations
+
+- Convex does not expose relationships between tables, so no lineage is emitted. Document references are visible as `Id(<table>)` field descriptions.
+- Schemas come from the JSON Schema that Convex derives from stored documents. A table with no documents yields no fields.
+- Only the tables of the deployment's default component are ingested.
+- Stateful ingestion is not supported, so tables deleted in Convex are not soft-deleted in DataHub.
+
+### Troubleshooting
+
+If ingestion fails at the deployment level, confirm that the deploy key belongs to the deployment named in the same entry and that the URL is the `.convex.cloud` deployment URL rather than the dashboard URL. Row-count failures are reported per table and do not stop the run; set `include_row_counts: false` to skip counting entirely on large deployments.

--- a/metadata-ingestion/docs/sources/convex/convex_pre.md
+++ b/metadata-ingestion/docs/sources/convex/convex_pre.md
@@ -1,0 +1,22 @@
+### Overview
+
+The `convex` module ingests table metadata from one or more Convex deployments. For each deployment it emits a container, and for each table a dataset with schema fields, document-reference descriptions, and an optional row-count profile.
+
+Metadata is read through Convex's [streaming export API](https://docs.convex.dev/http-api/#streaming-export), which is available on every deployment. Nothing needs to be installed or deployed on the Convex side.
+
+### Prerequisites
+
+You need a deploy key for each deployment you want to ingest. A read-only key with the `deployment:data:view` scope is sufficient.
+
+#### Steps to Get the Required Information
+
+1. Open your project in the [Convex dashboard](https://dashboard.convex.dev/).
+2. Go to **Settings** → **Deploy keys** and generate a key, or run `npx convex deployment token create`.
+3. Copy the deployment URL from the same settings page. It looks like `https://happy-animal-123.convex.cloud`.
+4. Expose the key to the ingestion process as an environment variable, and reference it from the recipe rather than writing it inline.
+
+:::note
+
+Convex adds bookkeeping fields (`_table`, `_component`, `_ts`, `_deleted`) to every streaming-export document. They are excluded from the emitted schema so that it matches the table as your application defines it. The `_id` and `_creationTime` fields, which Convex documents genuinely carry, are kept.
+
+:::

--- a/metadata-ingestion/docs/sources/convex/convex_recipe.yml
+++ b/metadata-ingestion/docs/sources/convex/convex_recipe.yml
@@ -1,0 +1,25 @@
+source:
+  type: convex
+  config:
+    # Required: one entry per Convex deployment to ingest
+    deployments:
+      - name: "my-app-prod"
+        url: "https://happy-animal-123.convex.cloud"
+        deploy_key: "${CONVEX_DEPLOY_KEY}"
+
+    # Optional: DataHub environment for the emitted URNs
+    # env: "PROD"
+
+    # Optional: filter tables by "<deployment name>.<table name>"
+    # table_pattern:
+    #   allow:
+    #     - "my-app-prod\\..*"
+    #   deny:
+    #     - ".*\\.scratch_.*"
+
+    # Optional: row counts, emitted as dataset profiles
+    # include_row_counts: true
+    # max_count_pages: 200
+
+sink:
+  # config sinks

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -259,6 +259,10 @@ confluence = [
     "urllib3>=1.26,<3.0",
 ]
 
+convex = [
+    "requests<3.0.0",
+]
+
 cube = [
     "requests<3.0.0",
     "sqlglot[c]==30.12.0",
@@ -1807,6 +1811,7 @@ clickhouse = "datahub.ingestion.source.sql.clickhouse:ClickHouseSource"
 clickhouse-usage = "datahub.ingestion.source.usage.clickhouse_usage:ClickHouseUsageSource"
 cockroachdb = "datahub.ingestion.source.sql.cockroachdb:CockroachDBSource"
 confluence = "datahub.ingestion.source.confluence.confluence_source:ConfluenceSource"
+convex = "datahub.ingestion.source.convex.source:ConvexSource"
 delta-lake = "datahub.ingestion.source.delta_lake:DeltaLakeSource"
 s3 = "datahub.ingestion.source.s3:S3Source"
 db2 = "datahub.ingestion.source.sql.db2:Db2Source"

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -599,6 +599,7 @@ plugins: Dict[str, Set[str]] = {
     | postgres_common
     | aws_common
     | {"sqlalchemy-cockroachdb<2.0.0"},
+    "convex": {"requests<3.0.0"},
     "datahub-lineage-file": set(),
     "datahub-business-glossary": set(),
     "dataplex": dataplex_common | cachetools_lib,
@@ -1117,6 +1118,7 @@ entry_points = {
         "clickhouse-usage = datahub.ingestion.source.usage.clickhouse_usage:ClickHouseUsageSource",
         "cockroachdb = datahub.ingestion.source.sql.cockroachdb:CockroachDBSource",
         "confluence = datahub.ingestion.source.confluence.confluence_source:ConfluenceSource",
+        "convex = datahub.ingestion.source.convex.source:ConvexSource",
         "delta-lake = datahub.ingestion.source.delta_lake:DeltaLakeSource",
         "s3 = datahub.ingestion.source.s3:S3Source",
         "db2 = datahub.ingestion.source.sql.db2:Db2Source",

--- a/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
@@ -108,6 +108,8 @@ class DatasetContainerSubTypes(StrEnum):
     PINECONE_NAMESPACE = "Pinecone Namespace"
     # Cube
     CUBE_DEPLOYMENT = "Cube Deployment"
+    # Convex
+    CONVEX_DEPLOYMENT = "Convex Deployment"
 
 
 class BIContainerSubTypes(StrEnum):

--- a/metadata-ingestion/src/datahub/ingestion/source/convex/__init__.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/convex/__init__.py
@@ -1,0 +1,1 @@
+# Convex source module

--- a/metadata-ingestion/src/datahub/ingestion/source/convex/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/convex/client.py
@@ -1,0 +1,60 @@
+"""Thin client for Convex's streaming export REST API.
+
+See https://docs.convex.dev/http-api/#streaming-export. Two endpoints are used:
+
+- ``GET /api/json_schemas`` returns ``{table_name: JSON Schema}`` for every table.
+- ``GET /api/list_snapshot`` pages through a consistent snapshot of one table.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+# Server-side snapshot page size. Informational only - the server decides how many
+# documents a page holds; we just follow the cursor until it says there is no more.
+PAGE_SIZE_HINT = 1024
+
+
+@dataclass(frozen=True)
+class RowCount:
+    count: int
+    # False when the page cap was reached before the snapshot was exhausted, so
+    # `count` is a lower bound rather than the true row count.
+    exact: bool
+
+
+class ConvexStreamingExportClient:
+    def __init__(self, url: str, deploy_key: str, timeout: int = 60) -> None:
+        self.base_url = url.rstrip("/")
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Convex {deploy_key}"
+        self.timeout = timeout
+
+    def _get(self, path: str, params: Optional[Dict[str, str]] = None) -> Any:
+        response = self.session.get(
+            f"{self.base_url}{path}", params=params, timeout=self.timeout
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def list_schemas(self) -> Dict[str, Dict[str, Any]]:
+        """Return the draft-07 JSON Schema of every table, keyed by table name."""
+        return self._get(
+            "/api/json_schemas", params={"deltaSchema": "true", "format": "json"}
+        )
+
+    def count_rows(self, table: str, max_pages: int) -> RowCount:
+        """Count the rows of a table by paging through a snapshot of it."""
+        count = 0
+        cursor: Optional[str] = None
+        for _ in range(max_pages):
+            params: Dict[str, str] = {"tableName": table}
+            if cursor:
+                params["cursor"] = cursor
+            page = self._get("/api/list_snapshot", params=params)
+            count += len(page.get("values", []))
+            if not page.get("hasMore"):
+                return RowCount(count=count, exact=True)
+            cursor = page.get("cursor")
+        return RowCount(count=count, exact=False)

--- a/metadata-ingestion/src/datahub/ingestion/source/convex/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/convex/config.py
@@ -1,0 +1,38 @@
+"""Configuration models for the Convex source."""
+
+from typing import List
+
+from pydantic import Field, PositiveInt, SecretStr
+
+from datahub.configuration.common import AllowDenyPattern, ConfigModel
+from datahub.configuration.source_common import EnvConfigMixin
+
+
+class ConvexDeploymentConfig(ConfigModel):
+    name: str = Field(
+        description="Human-readable deployment name. Used in dataset URNs and as the container name."
+    )
+    url: str = Field(
+        description="Deployment URL, e.g. `https://happy-animal-123.convex.cloud`."
+    )
+    deploy_key: SecretStr = Field(
+        description="Deploy key for the deployment. A read-only key (scope `deployment:data:view`) is sufficient."
+    )
+
+
+class ConvexSourceConfig(EnvConfigMixin):
+    deployments: List[ConvexDeploymentConfig] = Field(
+        description="Convex deployments to ingest. Each deployment becomes a container."
+    )
+    table_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex patterns for tables to filter in ingestion. Matched against `<deployment name>.<table name>`.",
+    )
+    include_row_counts: bool = Field(
+        default=True,
+        description="Count rows per table by paging the streaming export snapshot, and emit a `datasetProfile` aspect.",
+    )
+    max_count_pages: PositiveInt = Field(
+        default=200,
+        description="Safety cap on the number of snapshot pages (roughly 1024 rows each) read per table when counting rows.",
+    )

--- a/metadata-ingestion/src/datahub/ingestion/source/convex/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/convex/source.py
@@ -1,0 +1,311 @@
+"""Convex metadata ingestion source."""
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from datahub.emitter.mce_builder import make_data_platform_urn, make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.mcp_builder import (
+    ContainerKey,
+    add_dataset_to_container,
+    gen_containers,
+)
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.decorators import (
+    SupportStatus,
+    capability,
+    config_class,
+    platform_name,
+    support_status,
+)
+from datahub.ingestion.api.source import Source, SourceCapability, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
+from datahub.ingestion.source.convex.client import (
+    ConvexStreamingExportClient,
+    RowCount,
+)
+from datahub.ingestion.source.convex.config import (
+    ConvexDeploymentConfig,
+    ConvexSourceConfig,
+)
+from datahub.metadata.schema_classes import (
+    ArrayTypeClass,
+    BooleanTypeClass,
+    DatasetProfileClass,
+    DatasetPropertiesClass,
+    NullTypeClass,
+    NumberTypeClass,
+    OtherSchemaClass,
+    RecordTypeClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    StatusClass,
+    StringTypeClass,
+    SubTypesClass,
+    UnionTypeClass,
+)
+from datahub.utilities.lossy_collections import LossyList
+
+logger = logging.getLogger(__name__)
+
+PLATFORM_NAME = "convex"
+
+# Bookkeeping fields that Convex adds to every streaming-export document. They are
+# not part of the user-defined table schema, so they are dropped from the emitted
+# schema to keep it faithful to what the application actually declares.
+SYSTEM_FIELDS = {"_table", "_component", "_ts", "_deleted"}
+
+
+class ConvexDeploymentKey(ContainerKey):
+    deployment: str
+
+
+@dataclass
+class ConvexSourceReport(SourceReport):
+    deployments_scanned: int = 0
+    tables_scanned: int = 0
+    tables_filtered: LossyList[str] = field(default_factory=LossyList)
+    row_counts_capped: LossyList[str] = field(default_factory=LossyList)
+
+
+def map_json_schema_field(name: str, prop: Dict[str, Any]) -> SchemaFieldClass:
+    """Map one JSON Schema property to a DataHub schema field."""
+    json_type = prop.get("type")
+    field_type: Any
+    if "anyOf" in prop:
+        variants = [variant.get("type", "object") for variant in prop["anyOf"]]
+        field_type = UnionTypeClass()
+        native = f"anyOf({', '.join(str(variant) for variant in variants)})"
+    elif json_type == "string":
+        field_type = StringTypeClass()
+        native = "string"
+    elif json_type in ("number", "integer"):
+        field_type = NumberTypeClass()
+        native = str(json_type)
+    elif json_type == "boolean":
+        field_type = BooleanTypeClass()
+        native = "boolean"
+    elif json_type == "object":
+        field_type = RecordTypeClass()
+        native = "object"
+    elif json_type == "array":
+        item_type = (prop.get("items") or {}).get("type", "any")
+        field_type = ArrayTypeClass(nestedType=[str(item_type)])
+        native = f"array<{item_type}>"
+    else:
+        field_type = NullTypeClass()
+        native = str(json_type)
+
+    return SchemaFieldClass(
+        fieldPath=name,
+        type=SchemaFieldDataTypeClass(type=field_type),
+        nativeDataType=native,
+        # Convex describes document references as `Id(<table>)` in this key.
+        description=prop.get("$description"),
+        nullable=False,  # Overwritten by the caller, which knows the required list.
+    )
+
+
+def schema_fields_from_json_schema(
+    table_schema: Dict[str, Any],
+) -> List[SchemaFieldClass]:
+    """Map a Convex table's JSON Schema to DataHub schema fields."""
+    properties: Dict[str, Any] = table_schema.get("properties", {})
+    required = set(table_schema.get("required", []))
+    fields = []
+    for name, prop in properties.items():
+        if name in SYSTEM_FIELDS:
+            continue
+        schema_field = map_json_schema_field(name, prop)
+        schema_field.nullable = name not in required
+        fields.append(schema_field)
+    return fields
+
+
+@platform_name("Convex")
+@config_class(ConvexSourceConfig)
+@support_status(SupportStatus.TESTING)
+@capability(SourceCapability.CONTAINERS, "One container per Convex deployment")
+@capability(SourceCapability.SCHEMA_METADATA, "Enabled by default")
+@capability(
+    SourceCapability.DESCRIPTIONS,
+    "Document reference fields carry their `Id(<table>)` description",
+)
+@capability(
+    SourceCapability.DATA_PROFILING,
+    "Row counts only, via `include_row_counts` (enabled by default)",
+)
+@capability(
+    SourceCapability.PLATFORM_INSTANCE,
+    "Each deployment is its own container, so platform instances are not used",
+    supported=False,
+)
+@capability(
+    SourceCapability.LINEAGE_COARSE,
+    "Convex does not expose cross-table lineage",
+    supported=False,
+)
+class ConvexSource(Source):
+    """
+    Ingests table metadata from one or more [Convex](https://convex.dev) deployments.
+
+    Convex exposes a [streaming export API](https://docs.convex.dev/http-api/#streaming-export)
+    on every deployment, which this source uses to discover each table, its JSON
+    Schema, and (optionally) its row count. No Convex-side setup is needed beyond a
+    deploy key with read access.
+
+    Each deployment becomes a container, and each table in it becomes a dataset whose
+    schema is mapped from Convex's JSON Schema — including unions (`anyOf`), nested
+    objects, and arrays.
+    """
+
+    report: ConvexSourceReport
+
+    def __init__(self, config: ConvexSourceConfig, ctx: PipelineContext) -> None:
+        super().__init__(ctx)
+        self.config = config
+        self.report = ConvexSourceReport()
+
+    @classmethod
+    def create(cls, config_dict: Dict, ctx: PipelineContext) -> "ConvexSource":
+        return cls(ConvexSourceConfig.parse_obj(config_dict), ctx)
+
+    def get_report(self) -> ConvexSourceReport:
+        return self.report
+
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
+        for deployment in self.config.deployments:
+            yield from self._ingest_deployment(deployment)
+
+    def _ingest_deployment(
+        self, deployment: ConvexDeploymentConfig
+    ) -> Iterable[MetadataWorkUnit]:
+        client = ConvexStreamingExportClient(
+            deployment.url, deployment.deploy_key.get_secret_value()
+        )
+        try:
+            schemas = client.list_schemas()
+        except Exception as e:
+            self.report.failure(
+                title="Cannot reach deployment",
+                message="Failed to list table schemas for a Convex deployment",
+                context=f"{deployment.name} ({deployment.url})",
+                exc=e,
+            )
+            return
+
+        self.report.deployments_scanned += 1
+        logger.info(f"Discovered {len(schemas)} tables in {deployment.name}")
+
+        container_key = ConvexDeploymentKey(
+            platform=PLATFORM_NAME,
+            deployment=deployment.name,
+            env=self.config.env,
+        )
+        yield from gen_containers(
+            container_key=container_key,
+            name=deployment.name,
+            sub_types=[DatasetContainerSubTypes.CONVEX_DEPLOYMENT],
+            description=f"Convex deployment `{deployment.name}` at {deployment.url}",
+        )
+
+        for table, table_schema in sorted(schemas.items()):
+            if not self.config.table_pattern.allowed(f"{deployment.name}.{table}"):
+                self.report.tables_filtered.append(f"{deployment.name}.{table}")
+                continue
+            self.report.tables_scanned += 1
+            yield from self._ingest_table(
+                deployment, client, container_key, table, table_schema
+            )
+
+    def _ingest_table(
+        self,
+        deployment: ConvexDeploymentConfig,
+        client: ConvexStreamingExportClient,
+        container_key: ConvexDeploymentKey,
+        table: str,
+        table_schema: Dict[str, Any],
+    ) -> Iterable[MetadataWorkUnit]:
+        dataset_urn = make_dataset_urn(
+            platform=PLATFORM_NAME,
+            name=f"{deployment.name}.{table}",
+            env=self.config.env,
+        )
+
+        row_count = self._count_rows(client, deployment.name, table)
+
+        custom_properties = {"deployment_url": deployment.url, "table": table}
+        if row_count is not None:
+            custom_properties["row_count"] = (
+                str(row_count.count) if row_count.exact else f"{row_count.count}+"
+            )
+
+        aspects: List[Any] = [
+            StatusClass(removed=False),
+            DatasetPropertiesClass(
+                name=table,
+                description=f"Convex table `{table}` in deployment `{deployment.name}`.",
+                customProperties=custom_properties,
+            ),
+            SubTypesClass(typeNames=[DatasetSubTypes.TABLE]),
+            SchemaMetadataClass(
+                schemaName=f"{deployment.name}.{table}",
+                platform=make_data_platform_urn(PLATFORM_NAME),
+                version=0,
+                hash="",
+                platformSchema=OtherSchemaClass(
+                    rawSchema=json.dumps(table_schema, indent=2)
+                ),
+                fields=schema_fields_from_json_schema(table_schema),
+            ),
+        ]
+        if row_count is not None:
+            aspects.append(
+                DatasetProfileClass(
+                    timestampMillis=int(time.time() * 1000),
+                    rowCount=row_count.count,
+                    columnCount=len(
+                        [
+                            name
+                            for name in table_schema.get("properties", {})
+                            if name not in SYSTEM_FIELDS
+                        ]
+                    ),
+                )
+            )
+
+        for aspect in aspects:
+            yield MetadataChangeProposalWrapper(
+                entityUrn=dataset_urn, aspect=aspect
+            ).as_workunit()
+
+        yield from add_dataset_to_container(
+            container_key=container_key, dataset_urn=dataset_urn
+        )
+
+    def _count_rows(
+        self, client: ConvexStreamingExportClient, deployment_name: str, table: str
+    ) -> Optional[RowCount]:
+        if not self.config.include_row_counts:
+            return None
+        try:
+            row_count = client.count_rows(table, self.config.max_count_pages)
+        except Exception as e:
+            self.report.warning(
+                title="Row count failed",
+                message="Failed to count the rows of a Convex table",
+                context=f"{deployment_name}.{table}",
+                exc=e,
+            )
+            return None
+        if not row_count.exact:
+            self.report.row_counts_capped.append(f"{deployment_name}.{table}")
+        return row_count

--- a/metadata-ingestion/tests/unit/convex/test_convex_source.py
+++ b/metadata-ingestion/tests/unit/convex/test_convex_source.py
@@ -1,0 +1,124 @@
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from datahub.ingestion.source.convex.client import ConvexStreamingExportClient
+from datahub.ingestion.source.convex.source import schema_fields_from_json_schema
+from datahub.metadata.schema_classes import (
+    NumberTypeClass,
+    RecordTypeClass,
+    StringTypeClass,
+    UnionTypeClass,
+)
+
+# Trimmed from a real `/api/json_schemas` response for a `plays` table.
+PLAYS_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "_creationTime": {"type": "number"},
+        "_id": {"$description": "Id(plays)", "type": "string"},
+        "artistRaw": {"type": "string"},
+        "canonicalArtistId": {"$description": "Id(artists)", "type": "string"},
+        "playedAt": {"type": "number"},
+        "raw": {
+            "anyOf": [
+                {"type": "string"},
+                {
+                    "type": "object",
+                    "properties": {"StreamTitle": {"type": "string"}},
+                    "required": ["StreamTitle"],
+                },
+            ]
+        },
+        "nested": {"type": "object", "properties": {"x": {"type": "number"}}},
+        "_table": {"type": "string"},
+        "_ts": {"type": "integer"},
+        "_deleted": {"type": "boolean"},
+    },
+    "required": ["_creationTime", "_id", "artistRaw", "playedAt"],
+}
+
+
+def test_system_fields_excluded() -> None:
+    names = {field.fieldPath for field in schema_fields_from_json_schema(PLAYS_SCHEMA)}
+    assert names == {
+        "_creationTime",
+        "_id",
+        "artistRaw",
+        "canonicalArtistId",
+        "playedAt",
+        "raw",
+        "nested",
+    }
+
+
+def test_type_mapping() -> None:
+    fields = {
+        field.fieldPath: field for field in schema_fields_from_json_schema(PLAYS_SCHEMA)
+    }
+    assert isinstance(fields["artistRaw"].type.type, StringTypeClass)
+    assert isinstance(fields["playedAt"].type.type, NumberTypeClass)
+    assert isinstance(fields["raw"].type.type, UnionTypeClass)
+    assert isinstance(fields["nested"].type.type, RecordTypeClass)
+    assert fields["raw"].nativeDataType == "anyOf(string, object)"
+
+
+def test_reference_descriptions_and_nullability() -> None:
+    fields = {
+        field.fieldPath: field for field in schema_fields_from_json_schema(PLAYS_SCHEMA)
+    }
+    assert fields["canonicalArtistId"].description == "Id(artists)"
+    assert fields["canonicalArtistId"].nullable  # not in the required list
+    assert not fields["artistRaw"].nullable
+
+
+class _FakeClient(ConvexStreamingExportClient):
+    """Client whose snapshot pages come from a list instead of the network."""
+
+    def __init__(self, pages: List[Dict[str, Any]]) -> None:
+        super().__init__("https://example.convex.cloud", "fake-key")
+        self.pages = pages
+        self.requests = 0
+
+    def _get(self, path: str, params: Optional[Dict[str, str]] = None) -> Any:
+        self.requests += 1
+        return self.pages[self.requests - 1]
+
+
+@pytest.mark.parametrize(
+    "pages,max_pages,expected_count,expected_exact",
+    [
+        # Snapshot exhausted within the page cap.
+        ([{"values": [1, 2, 3], "hasMore": False}], 10, 3, True),
+        (
+            [
+                {"values": [1, 2], "hasMore": True, "cursor": "c1"},
+                {"values": [3], "hasMore": False},
+            ],
+            10,
+            3,
+            True,
+        ),
+        # Page cap hit first, so the count is only a lower bound.
+        (
+            [
+                {"values": [1, 2], "hasMore": True, "cursor": "c1"},
+                {"values": [3, 4], "hasMore": True, "cursor": "c2"},
+            ],
+            2,
+            4,
+            False,
+        ),
+    ],
+)
+def test_count_rows(
+    pages: List[Dict[str, Any]],
+    max_pages: int,
+    expected_count: int,
+    expected_exact: bool,
+) -> None:
+    client = _FakeClient(pages)
+    row_count = client.count_rows("plays", max_pages)
+    assert row_count.count == expected_count
+    assert row_count.exact is expected_exact
+    assert client.requests == len(pages)


### PR DESCRIPTION
## Summary

Adds a new ingestion source for [Convex](https://convex.dev), a reactive backend platform whose document database backs a growing number of web and mobile applications. Convex has no DataHub connector today, so teams running it have a gap in their catalog between their application data and everything downstream of it.

The source reads Convex's [streaming export API](https://docs.convex.dev/http-api/#streaming-export), which is available on every deployment and needs no Convex-side setup beyond a read-only deploy key.

## What it does

For each deployment listed in the recipe:

- emits a **container** (`CONVEX_DEPLOYMENT` subtype) named after the deployment;
- emits a **dataset** per table, named `<deployment name>.<table name>`, placed in that container;
- maps each table's JSON Schema to **schema fields**, including `anyOf` unions, nested objects, and arrays, and carries Convex's `Id(<table>)` document-reference annotations through as field descriptions;
- optionally emits a **dataset profile** with an exact row count, obtained by paging a snapshot of the table (`include_row_counts`, on by default; `max_count_pages` caps the work per table and downgrades the count to a reported lower bound rather than running unbounded).

Convex's streaming-export bookkeeping fields (`_table`, `_component`, `_ts`, `_deleted`) are dropped so the emitted schema matches the table as the application declares it. `_id` and `_creationTime`, which real Convex documents carry, are kept.

Configuration follows the conventions in `metadata-ingestion/CLAUDE.md`: `EnvConfigMixin` for `env`, `SecretStr` for the deploy key, an `AllowDenyPattern` named `table_pattern`, and a description on every field.

### Files

| Path | |
| --- | --- |
| `metadata-ingestion/src/datahub/ingestion/source/convex/{__init__,config,client,source}.py` | the source |
| `metadata-ingestion/tests/unit/convex/test_convex_source.py` | unit tests |
| `metadata-ingestion/docs/sources/convex/{README.md,convex_pre.md,convex_post.md,convex_recipe.yml}` | docs |
| `metadata-ingestion/setup.py` | `plugins["convex"]` and the `convex` entry point |
| `metadata-ingestion/pyproject.toml` | regenerated from `setup.py` |
| `metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py` | `CONVEX_DEPLOYMENT` container subtype |

The only new dependency is `requests<3.0.0`.

## How it was built and tested

I should be upfront about the provenance and about what has and has not been verified.

This connector was written and used as a standalone `datahub-convex` package for the **Build with DataHub Agent Hackathon**, where it ingests two production Convex deployments into DataHub for [Liner Notes](https://github.com/tmoody1973/liner-notes) — a music-metadata project at Radio Milwaukee. That repository is the working end-to-end usage: real deployments, real recipes, and the catalog built on top of what this source emits. This PR is the port of that package into the monorepo, restructured to match the conventions of the sources already here.

**What I ran locally, and what it showed:**

- The ported unit tests pass (6 passed) against a released `acryl-datahub` build (1.6.0.17), covering the JSON Schema → `SchemaField` mapping (system-field exclusion, type mapping including `anyOf` unions and nested objects, reference descriptions, required-vs-nullable) and the snapshot row-count paging, including the page-cap path where the count becomes a lower bound.
- An end-to-end smoke run with a stubbed HTTP client produced the expected 12 work units (container aspects plus `status`, `datasetProperties`, `subTypes`, `schemaMetadata`, `datasetProfile`, `container`, `browsePathsV2` for one table), with an empty failure list — and asserted the deploy key does not appear anywhere in the emitted metadata.
- `ruff==0.15.22` (the version this repo pins) `check` and `format --check` pass on the new and modified files.
- `python -m py_compile` passes on every touched Python file.
- `scripts/verify_pyproject_equivalence.py` reports 153/153 checks passed after regenerating `pyproject.toml` with `scripts/generate_pyproject_deps.py`.

**What I could not run, and where that leaves things:**

- **Gradle CI has not run locally.** `AGENTS.md` asks contributors to verify Python changes with `./gradlew :metadata-ingestion:lintFix` rather than invoking `ruff`/`mypy`/`py_compile` directly. I did not have the full repo checked out or a JDK 17 toolchain available, so I substituted the repo-pinned `ruff` and a real-`acryl-datahub` test run. **`mypy` has not been run at all** — that is the most likely source of review findings.
- **`uv.lock` and `constraints.txt` are not regenerated.** They are produced by `./gradlew :metadata-ingestion:updateLockFile`, which I could not run; `checkLockFile` will likely fail until a maintainer (or I, on request) runs it. `pyproject.toml` itself is in sync, generated by the script the gradle task calls.
- **No golden-file integration test.** The source talks to a live Convex deployment, and I did not want to commit a recorded fixture from the deployments I have access to. Happy to add one under `tests/integration/convex/` with a synthetic deployment if that is the bar for merging.
- **No logo or `integrations_catalog.json` entry.** Adding a catalog entry requires a `img/logos/platforms/convex.*` asset that I cannot source without Convex's branding permission, and an entry pointing at a missing image would break the docs site build. Steps 9 and 10 of the adding-a-source guide (logo, `data-platforms.yaml` bootstrap, `sources.json` for UI ingestion) are therefore not done — glad to follow up once maintainers advise on the logo.

**One convention question.** The `adding-source.md` guide describes docs as a single `docs/sources/<platform>/<plugin>.md`, but `docs/sources/AGENTS.md` and every recent connector use the `README.md` + `_pre.md` + `_post.md` + `_recipe.yml` split. I followed the latter. I also could not run `mdPrettierWrite`; I formatted the markdown with `prettier@3.5.3` directly, and deliberately left `convex_recipe.yml` at two-space indentation to match every other `*_recipe.yml` in the tree, since a plain prettier run reindented it to four.

Support status is `TESTING`, which seems right for a connector with production usage in exactly one place.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable) — no existing issue found for Convex; happy to open one
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — not applicable, this is a new opt-in source with no behavior change to existing ones


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `convex` ingestion source that reads Convex’s streaming export API to ingest containers, datasets, schemas, and optional row counts. This lets teams catalog Convex tables alongside downstream assets.

- **New Features**
  - New source `convex`: one container per deployment and one dataset per table named `<deployment>.<table>`.
  - Schema mapping from JSON Schema, including `anyOf`, objects, and arrays; keeps `_id` and `_creationTime`, drops `_table`, `_component`, `_ts`, `_deleted`.
  - Optional row counts via snapshot paging (`include_row_counts` default true, `max_count_pages` cap). Capped counts are reported as lower bounds in custom properties; emits a dataset profile.
  - Config: `deployments` with `name`, `url`, `deploy_key`; `env` via `EnvConfigMixin`; `table_pattern` filtering.
  - Container subtype `CONVEX_DEPLOYMENT`; entry point registered in `setup.py` and `pyproject.toml`; docs and unit tests added.

- **Dependencies**
  - New extra `convex` with `requests<3.0.0`.

<sup>Written for commit 07679e32aae3c46ca230815f82fb1f281aee4e53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

