### PR TITLE
docs(mcp): use header auth instead of the ?token= URL

### DIFF
--- a/docs/dev-guides/agent-context/claude.md
+++ b/docs/dev-guides/agent-context/claude.md
@@ -92,7 +92,9 @@ Open **Claude Desktop → Settings → Developer → Edit Config** and update `c
       "args": [
         "-y",
         "mcp-remote",
-        "https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>"
+        "https://<tenant>.acryl.io/integrations/ai/mcp/",
+        "--header",
+        "Authorization: Bearer <token>"
       ]
     }
   }

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -346,26 +346,23 @@ Your managed MCP server URL is:
 https://<tenant>.acryl.io/integrations/ai/mcp/
 ```
 
-There are two ways to authenticate:
+Authenticate by passing your token as a Bearer token in the `Authorization` header:
 
-1. **Authorization header** — pass your token as a Bearer token in the `Authorization` header:
+```
+Authorization: Bearer <token>
+```
 
-   ```
-   Authorization: Bearer <token>
-   ```
-
-2. **Token in URL** — append your token as a query parameter:
-
-   ```
-   https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>
-   ```
-
-   This is a convenient alternative when your MCP client doesn't support custom headers.
+:::caution The `?token=` query parameter no longer works
+Requests that include a `token` query parameter get a `400 Bad Request`. A token in the URL
+shows up in proxy and CDN logs, in browser history, and in `Referer` headers. If your MCP
+client can't set headers itself, use `mcp-remote` with `--header` (shown below) and it will
+send the header for you.
+:::
 
 <details>
   <summary>On-Premises DataHub Cloud</summary>
 
-For on-premises DataHub Cloud, replace `<tenant>.acryl.io` with your DataHub FQDN, e.g. `https://datahub.example.com/integrations/ai/mcp/?token=<token>`.
+For on-premises DataHub Cloud, replace `<tenant>.acryl.io` with your DataHub FQDN, e.g. `https://datahub.example.com/integrations/ai/mcp/`.
 
 </details>
 
@@ -385,7 +382,9 @@ For on-premises DataHub Cloud, replace `<tenant>.acryl.io` with your DataHub FQD
       "args": [
         "-y",
         "mcp-remote",
-        "https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>"
+        "https://<tenant>.acryl.io/integrations/ai/mcp/",
+        "--header",
+        "Authorization: Bearer <token>"
       ]
     }
   }
@@ -457,15 +456,17 @@ For a detailed walkthrough, see the [Gemini CLI integration guide](../../dev-gui
 Most AI tools support remote MCP servers. Provide the hosted MCP server URL:
 
 ```
-https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>
+https://<tenant>.acryl.io/integrations/ai/mcp/
 ```
+
+with the header `Authorization: Bearer <token>`.
 
 Make sure authentication mode is _not_ set to "OAuth" (if applicable).
 
 For clients that don't yet support remote MCP servers, use `mcp-remote`:
 
 - Command: `npx`
-- Args: `-y mcp-remote https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>`
+- Args: `-y mcp-remote https://<tenant>.acryl.io/integrations/ai/mcp/ --header "Authorization: Bearer <token>"`
 
 </details>
 


### PR DESCRIPTION
## What

The hosted MCP server no longer accepts the access token as a `?token=` query parameter. Requests that include it now get a `400 Bad Request`. This updates the connection docs to match.

A token in the URL shows up in proxy and CDN logs, in browser history, and in `Referer` headers, where it can't be cleaned up afterwards.

## Changes

`docs/features/feature-guides/mcp.md`

- The "two ways to authenticate" section is now just the `Authorization: Bearer <token>` header, with a caution note explaining that `?token=` returns a 400.
- The on-premises example and the "Other" client section drop the token from the URL.
- The `mcp-remote` examples pass `--header "Authorization: Bearer <token>"`, which covers clients that can't set headers themselves.

`docs/dev-guides/agent-context/claude.md`

- Same `mcp-remote` update for the Claude Desktop config.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates MCP connection docs to use header-based auth. The `?token=` query param is no longer accepted and now returns 400, so examples and guides were switched to `Authorization: Bearer <token>`.

- **Migration**
  - Send `Authorization: Bearer <token>` on all MCP requests.
  - Remove `?token=<token>` from hosted and on‑prem URLs.
  - If your client can’t set headers, use `npx -y mcp-remote https://<tenant>.acryl.io/integrations/ai/mcp/ --header "Authorization: Bearer <token>"`.

<sup>Written for commit 252abd3552ef980fc16da58a196a68105c66a494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

