### PR TITLE
fix(sdk): allow add_lineage() to set a custom audit stamp

### DIFF
--- a/metadata-ingestion/src/datahub/sdk/lineage_client.py
+++ b/metadata-ingestion/src/datahub/sdk/lineage_client.py
@@ -164,6 +164,7 @@ class LineageClient:
             bool, ColumnLineageMapping, Literal["auto_fuzzy", "auto_strict"]
         ] = False,
         transformation_text: Optional[str] = None,
+        audit_stamp: Optional[models.AuditStampClass] = None,
     ) -> None:
         """Add dataset-to-dataset lineage with column-level mapping."""
 
@@ -217,6 +218,7 @@ class LineageClient:
             bool, ColumnLineageMapping, Literal["auto_fuzzy", "auto_strict"]
         ] = False,
         transformation_text: Optional[str] = None,
+        audit_stamp: Optional[models.AuditStampClass] = None,
     ) -> None:
         """Add lineage between two entities.
 
@@ -236,6 +238,9 @@ class LineageClient:
             column_lineage: Optional boolean to indicate if column-level lineage should be added or a lineage mapping type (auto_fuzzy, auto_strict, or a mapping of column-level lineage)
             transformation_text: Optional SQL query text that defines the transformation
                     (only applicable for dataset-to-dataset lineage)
+            audit_stamp: Optional audit stamp (actor + time) to record on the lineage edge
+                    (only applicable for dataset-to-dataset lineage). Defaults to the
+                    zero-time/unknown-actor stamp DataHub uses when none is provided.
 
         Raises:
             InvalidUrnError: If the URNs provided are invalid
@@ -251,6 +256,11 @@ class LineageClient:
         if key != ("dataset", "dataset") and (column_lineage or transformation_text):
             raise SdkUsageError(
                 "Column lineage and query text are only applicable for dataset-to-dataset lineage"
+            )
+
+        if key != ("dataset", "dataset") and audit_stamp is not None:
+            raise SdkUsageError(
+                "audit_stamp is only applicable for dataset-to-dataset lineage"
             )
 
         lineage_handlers: dict[tuple[str, str], Callable] = {
@@ -272,6 +282,7 @@ class LineageClient:
                 upstream_type=upstream_entity_type,
                 column_lineage=column_lineage,
                 transformation_text=transformation_text,
+                audit_stamp=audit_stamp,
             )
         except KeyError:
             raise SdkUsageError(
@@ -285,6 +296,7 @@ class LineageClient:
         downstream,
         column_lineage,
         transformation_text,
+        audit_stamp=None,
         **_,
     ):
         upstream_urn = DatasetUrn.from_string(upstream)
@@ -302,7 +314,11 @@ class LineageClient:
 
         if transformation_text:
             self._process_transformation_lineage(
-                transformation_text, upstream_urn, downstream_urn, cll
+                transformation_text,
+                upstream_urn,
+                downstream_urn,
+                cll,
+                audit_stamp=audit_stamp,
             )
         else:
             updater = DatasetPatchBuilder(str(downstream_urn))
@@ -310,6 +326,7 @@ class LineageClient:
                 models.UpstreamClass(
                     dataset=str(upstream_urn),
                     type=models.DatasetLineageTypeClass.COPY,
+                    auditStamp=audit_stamp,
                 )
             )
             for cl in cll or []:
@@ -385,7 +402,7 @@ class LineageClient:
         return cll
 
     def _process_transformation_lineage(
-        self, transformation_text, upstream_urn, downstream_urn, cll
+        self, transformation_text, upstream_urn, downstream_urn, cll, audit_stamp=None
     ):
         fields_involved = OrderedSet([str(upstream_urn), str(downstream_urn)])
         if cll is not None:
@@ -424,6 +441,7 @@ class LineageClient:
                 dataset=str(upstream_urn),
                 type=models.DatasetLineageTypeClass.TRANSFORMED,
                 query=query_urn,
+                auditStamp=audit_stamp,
             )
         )
 

--- a/metadata-ingestion/tests/unit/sdk_v2/lineage_client_golden/test_lineage_copy_with_audit_stamp_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/lineage_client_golden/test_lineage_copy_with_audit_stamp_golden.json
@@ -1,0 +1,24 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,downstream_table,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/upstreams/urn:li:dataset:(urn:li:dataPlatform:snowflake,upstream_table,PROD)",
+                "value": {
+                    "auditStamp": {
+                        "time": 1700000000000,
+                        "actor": "urn:li:corpuser:jdoe"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,upstream_table,PROD)",
+                    "type": "COPY"
+                }
+            }
+        ]
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/test_lineage_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_lineage_client.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from datahub.errors import SdkUsageError
+from datahub.metadata.schema_classes import AuditStampClass
 from datahub.sdk.main_client import DataHubClient
 from datahub.sdk.search_filters import FilterDsl as F
 from datahub.sql_parsing.sql_parsing_common import QueryType
@@ -230,6 +231,42 @@ def test_add_lineage_dataset_to_dataset_copy_basic(client: DataHubClient) -> Non
 
     client.lineage.add_lineage(upstream=upstream, downstream=downstream)
     assert_client_golden(client, _GOLDEN_DIR / "test_lineage_copy_basic_golden.json")
+
+
+def test_add_lineage_dataset_to_dataset_with_audit_stamp(
+    client: DataHubClient,
+) -> None:
+    """Test add_lineage records a caller-supplied audit stamp instead of the
+    zero-time/unknown-actor default."""
+    upstream = "urn:li:dataset:(urn:li:dataPlatform:snowflake,upstream_table,PROD)"
+    downstream = "urn:li:dataset:(urn:li:dataPlatform:snowflake,downstream_table,PROD)"
+
+    client.lineage.add_lineage(
+        upstream=upstream,
+        downstream=downstream,
+        audit_stamp=AuditStampClass(
+            time=1700000000000, actor="urn:li:corpuser:jdoe"
+        ),
+    )
+    assert_client_golden(
+        client, _GOLDEN_DIR / "test_lineage_copy_with_audit_stamp_golden.json"
+    )
+
+
+def test_add_lineage_audit_stamp_rejected_for_non_dataset_lineage(
+    client: DataHubClient,
+) -> None:
+    """audit_stamp is only meaningful for dataset-to-dataset lineage, same as
+    column_lineage/transformation_text, and should be rejected the same way."""
+    with pytest.raises(
+        SdkUsageError,
+        match="audit_stamp is only applicable for dataset-to-dataset lineage",
+    ):
+        client.lineage.add_lineage(
+            upstream="urn:li:dataset:(urn:li:dataPlatform:snowflake,source_table,PROD)",
+            downstream="urn:li:dataJob:(urn:li:dataFlow:(airflow,example_dag,PROD),process_job)",
+            audit_stamp=AuditStampClass(time=123, actor="urn:li:corpuser:jdoe"),
+        )
 
 
 def test_add_lineage_dataset_to_dataset_copy_custom_mapping(


### PR DESCRIPTION
client.lineage.add_lineage() always writes auditStamp.time=0 and actor=urn:li:corpuser:unknown on the UpstreamClass it builds. Neither _add_dataset_lineage() nor _process_transformation_lineage() passes anything for the auditStamp field, so the PDL default silently applies every time.

There's no way to set a real timestamp through this API. A caller that needs one — an agent recording when it actually computed a lineage edge, so a downstream consumer can compare that against other metadata to decide if the edge is stale — has to skip add_lineage() entirely and construct a raw MetadataChangeProposalWrapper with an explicit UpstreamClass instead. That's a fair amount of boilerplate for something the convenience method almost does already.

This PR adds an optional audit_stamp parameter to add_lineage() and threads it through both the plain-copy path and the transformation_text path. It's restricted to dataset-to-dataset lineage, same as column_lineage and transformation_text already are, and rejected with the same SdkUsageError for any other entity combination. Leaving it unset keeps the current default behavior exactly as it is.

Testing: added a golden-file test that checks the emitted JSON patch actually carries a custom AuditStampClass, plus a test for the new SdkUsageError guard. I also ran this against the compiled SDK directly — a custom stamp comes through correctly, the default is untouched when the argument is omitted, and the guard fires for a dataset-to-datajob combination as expected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow passing a custom `audit_stamp` to `client.lineage.add_lineage()` for dataset-to-dataset lineage so callers can record real timestamps; default behavior is unchanged when omitted.

- **Bug Fixes**
  - Thread `audit_stamp` through both copy and `transformation_text` paths so emitted patches include the provided `AuditStampClass`.
  - Reject `audit_stamp` for non–dataset-to-dataset lineage with `SdkUsageError`.

<sup>Written for commit fce3a93c6083799783491f5a12fbd73663a65de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

