### PR TITLE
docs(mcp): add self-hosted terminal smoke test

### DIFF
--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -512,6 +512,20 @@ The self-hosted server authenticates via environment variables:
 
 These are passed to the `mcp-server-datahub` process at startup (see configuration examples below).
 
+### Verify from the Terminal
+
+Before adding the server to an MCP client, call a read-only tool directly to check the DataHub connection. Replace the example URN and environment variables with values from your instance.
+
+```bash
+uvx --from 'fastmcp-slim[server]' fastmcp call \
+  --command "env DATAHUB_GMS_URL=<your-datahub-url> DATAHUB_GMS_TOKEN=<your-datahub-token> uvx mcp-server-datahub@latest" \
+  --target get_lineage \
+  --input-json '{"urn":"urn:li:dataset:(urn:li:dataPlatform:snowflake,my_database.my_schema.my_table,PROD)","upstream":false,"max_hops":1,"max_results":10}' \
+  --json
+```
+
+The response should contain a `structured_content` object with a `downstreams` result. An empty `searchResults` array means the server connected successfully but found no downstream lineage for that URN. Authentication and connection failures surface as an error or timeout instead.
+
 ### Configure
 
 <details>


### PR DESCRIPTION
While wiring RecallGraph to a local DataHub Core instance, I needed a quick way to separate a DataHub connection failure from an MCP client configuration problem. The self-hosted guide currently goes from environment variables straight into client setup.

This adds one terminal command that calls the read-only `get_lineage` tool before a client is involved. The connection variables are included in `--command` because FastMCP launches the MCP server as a stdio child process. The note also explains how an empty lineage result differs from an authentication error or timeout.

Verification:

- Ran the documented command with the current `mcp-server-datahub` and `fastmcp-slim[server]` packages. The MCP server started and made the configured GMS request; an intentionally unreachable endpoint produced the expected connection timeout.
- Ran the same `get_lineage` flow against local DataHub Core with `mcp-server-datahub==0.6.0`. It returned the two seeded ML model descendants of the source dataset.
- `git diff --check`
- `python3 .github/scripts/check_docusaurus_markdown.py docs/features/feature-guides/mcp.md`

This only changes the documentation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a terminal smoke test to the self-hosted MCP guide to validate the DataHub connection before configuring a client. Provides a one-line `uvx` + `fastmcp` command that launches `mcp-server-datahub` with env vars and calls the read-only `get_lineage` tool, with notes on empty results vs auth/timeout errors.

<sup>Written for commit 8255e1dc19d8867a8a12c84ff2d1ccbf53a723d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

