### PR TITLE
fix(elasticsearch): reject conflicting authentication settings

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -9,7 +9,7 @@ from hashlib import md5
 from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Type, Union
 
 from opensearchpy import OpenSearch
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic.fields import Field
 
 from datahub.configuration.common import (
@@ -343,6 +343,16 @@ class ElasticsearchSourceConfig(
                     entry = entry[: -len(suffix)]
             validate_host_port(entry)
         return host_val
+
+    @model_validator(mode="after")
+    def validate_authentication(self) -> "ElasticsearchSourceConfig":
+        if self.api_key is not None and (
+            self.username is not None or self.password is not None
+        ):
+            raise ValueError(
+                "Set either api_key or username/password authentication, not both."
+            )
+        return self
 
     @property
     def http_auth(self) -> Optional[Tuple[str, str]]:

--- a/metadata-ingestion/tests/unit/test_elasticsearch_source.py
+++ b/metadata-ingestion/tests/unit/test_elasticsearch_source.py
@@ -2575,6 +2575,18 @@ def test_api_key_authorization_passes_through_encoded_string() -> None:
     assert _api_key_authorization("already-encoded") == "ApiKey already-encoded"
 
 
+def test_api_key_authentication_is_mutually_exclusive_with_basic_auth() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        ElasticsearchSourceConfig.model_validate(
+            {
+                "host": "localhost:9200",
+                "api_key": ["id", "key"],
+                "username": "user",
+                "password": "password",
+            }
+        )
+
+
 @patch("datahub.ingestion.source.elastic_search.OpenSearch")
 def test_api_key_list_sets_authorization_header(mock_opensearch: Any) -> None:
     ElasticsearchSource.create(


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->



Summary

- Reject Elasticsearch/OpenSearch source configurations that set `api_key` together with `username` or `password`.
- Prevent `opensearch-py` from silently replacing the requested API-key authorization with Basic authentication.
- Add a regression test for the conflicting configuration.

## Problem

The source builds an API-key `Authorization` header when `api_key` is configured, but also passes `http_auth` whenever `username` is set. `opensearch-py` normalizes the latter into a Basic authorization header, so a mixed recipe authenticates differently from what the user configured.

## Root cause

The source configuration did not enforce mutual exclusion between its two authentication modes, and the client constructor allowed both credential mechanisms to be supplied at once.

## Fix

Add a Pydantic model validator to `ElasticsearchSourceConfig`. A configuration containing API-key credentials and either Basic-auth field now fails before the `OpenSearch` client is constructed. API-key-only and Basic-auth-only configurations retain their existing behavior.

## Test plan

- Added `test_api_key_authentication_is_mutually_exclusive_with_basic_auth`.
- Verified in an isolated runtime that mixed configuration raises `ValidationError`.
- Verified that API-key-only configuration remains valid and exposes no Basic-auth tuple.
- `git diff --check` passes.

### Local verification note

The repository Gradle lint/test tasks could not run in the local environment because no Java runtime was initially available. The fallback targeted pytest collection also requires the generated `datahub.metadata` package that Gradle normally creates. CI should run the standard DataHub tasks before merge:

```bash
./gradlew :metadata-ingestion:lintFix
./gradlew :metadata-ingestion:testQuick
```

## Scope

This PR changes configuration validation and tests only. It does not change the API-key format, Basic-auth format, TLS settings, or request behavior for valid single-mode configurations.

## Checklist

- [x] PR title follows DataHub’s conventional format.
- [ ] Related issue linked: replace `#ISSUE_NUMBER` after the issue is opened.
- [x] Regression test added.
- [x] No documentation or migration note is required for this bug fix.
- [x] No customer-specific identifiers or credentials are included.

Related issue: `Fixes #19092


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject mixed API-key and Basic auth in the Elasticsearch/OpenSearch source to prevent unintended Basic auth fallback in `opensearch-py`. Valid single-mode configs are unchanged.

- **Bug Fixes**
  - Added a `pydantic` model validator to block configs that set `api_key` together with `username` or `password`.
  - Fail fast with a clear validation error before the `OpenSearch` client is created.
  - Added regression test: `test_api_key_authentication_is_mutually_exclusive_with_basic_auth`.

<sup>Written for commit 4be20a890fcd5785e1eb39d14a2a3877b401f527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

