### PR TITLE
test(incidents): fail CI when incident entity support drifts across its three sources

### DIFF
--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentEntitySupportConsistencyTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentEntitySupportConsistencyTest.java
@@ -1,0 +1,377 @@
+package com.linkedin.datahub.graphql.types.incident;
+
+import static com.linkedin.datahub.graphql.Constants.INCIDENTS_SCHEMA_FILE;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.datahub.graphql.GmsGraphQLEngine;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.snapshot.Snapshot;
+import graphql.language.FieldDefinition;
+import graphql.language.ObjectTypeDefinition;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Fails the build when the three places that decide "does this entity support incidents?" disagree.
+ *
+ * <p>They are maintained separately and already drift:
+ *
+ * <ol>
+ *   <li>write allowlist: {@code IncidentInfo.pdl}, the {@code IncidentOn} relationship's
+ *       entityTypes. Decides whether raiseIncident accepts the URN at all.
+ *   <li>summary and health: {@code entity-registry.yml}, entities declaring {@code
+ *       incidentsSummary}. Decides whether the entity carries a rolled-up status.
+ *   <li>read API: {@code incident.graphql}, types with an {@code incidents} field. Decides whether
+ *       anything can list them back.
+ * </ol>
+ *
+ * <p>#18478 widened the PDL list to include mlModel, mlFeature, service and aiAgent, added
+ * incidentsSummary for service and aiAgent only, and wired GraphQL for none of them. The result on
+ * v1.7.0 is that raiseIncident accepts an mlModel URN, stores the incident against the model, and
+ * nothing can read it back. The caller gets an incident URN and no reason to think anything went
+ * wrong, which is worse than a clean rejection. See #18999 and #18911.
+ *
+ * <p>All three sets are derived from the sources themselves, so adding an entity to one layer and
+ * forgetting the other two fails here rather than in production. This test is the guardrail only;
+ * closing the gaps is #18911. Until they close, {@link #KNOWN_GAPS} carries them explicitly, and
+ * that map is meant to shrink to empty.
+ */
+public class IncidentEntitySupportConsistencyTest {
+
+  private static final String INCIDENT_ENTITY = "incident";
+  private static final String INCIDENT_INFO_ASPECT = "incidentInfo";
+  private static final String INCIDENTS_SUMMARY_ASPECT = "incidentsSummary";
+  private static final String INCIDENT_ON_RELATIONSHIP = "IncidentOn";
+  private static final String INCIDENTS_FIELD = "incidents";
+  private static final String ENTITY_REGISTRY_RESOURCE = "entity-registry.yml";
+
+  /**
+   * A few entity types are suffixed in GraphQL to avoid colliding with a non-entity type of the
+   * same name: {@code schemaField} is {@code SchemaFieldEntity} because {@code SchemaField} is
+   * already the struct inside a schema aspect.
+   */
+  private static final String GRAPHQL_ENTITY_SUFFIX = "Entity";
+
+  /** Repo paths, used only to make the failure message actionable. */
+  private static final String PDL_PATH =
+      "metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl";
+
+  private static final String REGISTRY_PATH =
+      "metadata-models/src/main/resources/entity-registry.yml";
+  private static final String GRAPHQL_PATH =
+      "datahub-graphql-core/src/main/resources/" + INCIDENTS_SCHEMA_FILE;
+
+  /**
+   * Types knowingly supported in one layer and not the others, as of this commit.
+   *
+   * <p>Every entry is a bug, not a design decision. Delete entries as #18911 lands. When this map
+   * is empty, drop it and the assertion below becomes strict equality across all three sets.
+   */
+  private static final Map<String, String> KNOWN_GAPS =
+      new TreeMap<>(
+          Map.of(
+              "mlModel", "#18911: writable since #18478, no incidentsSummary, no GraphQL read",
+              "mlFeature", "#18911: writable since #18478, no incidentsSummary, no GraphQL read",
+              "service", "#18478 added incidentsSummary but not the GraphQL read",
+              "aiAgent", "#18478 added incidentsSummary but not the GraphQL read",
+              "schemaField",
+                  "writable in the PDL allowlist, no incidentsSummary, no GraphQL read"));
+
+  private EntityRegistry entityRegistry;
+
+  @BeforeTest
+  public void setup() {
+    // Building the registry runs the Pegasus annotation processor, which trips its own assertions
+    // under -ea. Same guard every other registry-backed test in the repo uses.
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+
+    final InputStream registryStream =
+        Snapshot.class.getClassLoader().getResourceAsStream(ENTITY_REGISTRY_RESOURCE);
+    assertNotNull(
+        registryStream,
+        ENTITY_REGISTRY_RESOURCE
+            + " is not on the test classpath; this test derives its sets from it");
+    entityRegistry = new ConfigEntityRegistry(registryStream);
+  }
+
+  @Test
+  public void incidentSupportIsConsistentAcrossAllThreeLayers() {
+    final EntityRegistry registry = entityRegistry;
+    final Map<String, String> entityNamesByLowerCase = indexEntityNames(registry);
+
+    // Names the test could not map back to an entity. Distinct from drift: it means the test has
+    // gone stale against a convention change, and it must not be reported as a passing schema.
+    final List<String> unmapped = new ArrayList<>();
+
+    final Set<String> writable = writeAllowlist(registry, entityNamesByLowerCase, unmapped);
+    final Set<String> summarised = entitiesDeclaringIncidentsSummary(registry);
+    final Set<String> readable = graphQlReadableEntities(entityNamesByLowerCase, unmapped);
+
+    assertTrue(
+        unmapped.isEmpty(),
+        "This test could not map every incident-bearing name back to an entity in "
+            + REGISTRY_PATH
+            + ". Teach it the new name rather than deleting the check.\n\n"
+            + String.join("\n", unmapped)
+            + "\n");
+
+    // Guards against a source moving or a parse silently yielding nothing, which would make the
+    // equality below vacuously true.
+    assertTrue(
+        writable.size() > 1,
+        "derived an implausible write allowlist from " + PDL_PATH + ": " + writable);
+    assertTrue(
+        readable.size() > 1,
+        "derived an implausible GraphQL read set from " + GRAPHQL_PATH + ": " + readable);
+
+    final Set<String> mentionedAnywhere = new TreeSet<>(writable);
+    mentionedAnywhere.addAll(summarised);
+    mentionedAnywhere.addAll(readable);
+
+    final List<String> problems =
+        mentionedAnywhere.stream()
+            .filter(entity -> !KNOWN_GAPS.containsKey(entity))
+            .map(entity -> describeGap(entity, writable, summarised, readable))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(ArrayList::new));
+
+    // A gap that has closed must come off the allowlist, or the allowlist stops meaning anything.
+    KNOWN_GAPS.forEach(
+        (entity, reason) -> {
+          if (describeGap(entity, writable, summarised, readable) != null) {
+            return;
+          }
+          final String state =
+              mentionedAnywhere.contains(entity)
+                  ? "is consistent across all three layers now"
+                  : "is no longer referenced by any of the three layers";
+          problems.add(
+              "  `"
+                  + entity
+                  + "` "
+                  + state
+                  + ". Remove it from KNOWN_GAPS, where it is currently excused as: "
+                  + reason);
+        });
+
+    assertTrue(
+        problems.isEmpty(),
+        "Incident entity support has drifted between its three sources of truth.\n"
+            + "These must be changed together, or raiseIncident accepts writes that nothing\n"
+            + "can read back.\n\n"
+            + "  write allowlist   "
+            + PDL_PATH
+            + " (IncidentOn entityTypes)\n"
+            + "  summary / health  "
+            + REGISTRY_PATH
+            + " (incidentsSummary aspect)\n"
+            + "  read API          "
+            + GRAPHQL_PATH
+            + " (incidents field)\n\n"
+            + String.join("\n", problems)
+            + "\n");
+  }
+
+  /**
+   * One line per inconsistent type, naming the layer that is missing.
+   *
+   * <p>Phrased as an instruction rather than as a set difference on purpose. Three people hit three
+   * different rejection wordings for this condition and none of them named the layer that was
+   * missing, which is what sent all three digging through the registry by hand.
+   *
+   * @return null when the entity is consistent across all three layers
+   */
+  private static String describeGap(
+      final String entity,
+      final Set<String> writable,
+      final Set<String> summarised,
+      final Set<String> readable) {
+    final boolean isWritable = writable.contains(entity);
+    final boolean isSummarised = summarised.contains(entity);
+    final boolean isReadable = readable.contains(entity);
+    if (isWritable == isSummarised && isSummarised == isReadable) {
+      return null;
+    }
+
+    final Set<String> present = new LinkedHashSet<>();
+    final Set<String> missing = new LinkedHashSet<>();
+    if (isWritable) {
+      present.add("is an IncidentOn destination in " + PDL_PATH);
+    } else {
+      missing.add("the IncidentOn entityTypes list in " + PDL_PATH);
+    }
+    if (isSummarised) {
+      present.add("declares the incidentsSummary aspect in " + REGISTRY_PATH);
+    } else {
+      missing.add("the incidentsSummary aspect in " + REGISTRY_PATH);
+    }
+    if (isReadable) {
+      present.add("exposes an incidents field in " + GRAPHQL_PATH);
+    } else {
+      missing.add("an incidents field on its GraphQL type in " + GRAPHQL_PATH);
+    }
+    return "  `"
+        + entity
+        + "` "
+        + String.join(" and ", present)
+        + ", but is missing "
+        + String.join(" and ", missing);
+  }
+
+  /** Valid destinations of the IncidentOn relationship, off the incidentInfo aspect spec. */
+  private static Set<String> writeAllowlist(
+      final EntityRegistry registry,
+      final Map<String, String> entityNamesByLowerCase,
+      final List<String> unmapped) {
+    final EntitySpec incident = registry.getEntitySpec(INCIDENT_ENTITY);
+    return incident.getAspectSpec(INCIDENT_INFO_ASPECT).getRelationshipFieldSpecs().stream()
+        .filter(spec -> INCIDENT_ON_RELATIONSHIP.equals(spec.getRelationshipName()))
+        .flatMap(spec -> spec.getValidDestinationTypes().stream())
+        .map(
+            destination ->
+                resolveEntity(
+                    destination,
+                    entityNamesByLowerCase,
+                    unmapped,
+                    "  `"
+                        + destination
+                        + "` is an IncidentOn destination in "
+                        + PDL_PATH
+                        + " but is not an entity in "
+                        + REGISTRY_PATH))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toCollection(TreeSet::new));
+  }
+
+  /** Entities whose aspect list includes incidentsSummary. */
+  private static Set<String> entitiesDeclaringIncidentsSummary(final EntityRegistry registry) {
+    return registry.getEntitySpecs().values().stream()
+        .filter(spec -> Boolean.TRUE.equals(spec.hasAspect(INCIDENTS_SUMMARY_ASPECT)))
+        .map(EntitySpec::getName)
+        .collect(Collectors.toCollection(TreeSet::new));
+  }
+
+  /**
+   * Entities whose GraphQL type carries an incidents field.
+   *
+   * <p>Loaded and parsed through the same {@link GmsGraphQLEngine#fileBasedSchema} call and the
+   * same {@link SchemaParser} the engine itself uses, so this reads the schema the way production
+   * does rather than pattern-matching the file. It stops short of {@code makeExecutableSchema}: an
+   * assembled schema object needs every other SDL file plus the full runtime wiring (services and
+   * resolvers), which is a heavier fixture than a schema-consistency check should require, and it
+   * would not answer a different question.
+   *
+   * <p>{@code extend type X} is the shape incident.graphql uses to attach the field, so an
+   * extension that cannot be mapped back to an entity is reported rather than skipped. Plain {@code
+   * type X} declarations in this file are incident-domain types (Incident, EntityIncidentsResult),
+   * so those count only when the name is an entity in its own right.
+   */
+  private static Set<String> graphQlReadableEntities(
+      final Map<String, String> entityNamesByLowerCase, final List<String> unmapped) {
+    final TypeDefinitionRegistry schema =
+        new SchemaParser().parse(GmsGraphQLEngine.fileBasedSchema(INCIDENTS_SCHEMA_FILE));
+
+    final Set<String> readable = new TreeSet<>();
+
+    schema
+        .objectTypeExtensions()
+        .forEach(
+            (typeName, extensions) -> {
+              if (extensions.stream()
+                  .noneMatch(IncidentEntitySupportConsistencyTest::hasIncidents)) {
+                return;
+              }
+              final String entity =
+                  resolveEntity(
+                      typeName,
+                      entityNamesByLowerCase,
+                      unmapped,
+                      "  GraphQL type `"
+                          + typeName
+                          + "` in "
+                          + GRAPHQL_PATH
+                          + " has an incidents field but does not map to an entity in "
+                          + REGISTRY_PATH);
+              if (entity != null) {
+                readable.add(entity);
+              }
+            });
+
+    schema.getTypes(ObjectTypeDefinition.class).stream()
+        .filter(IncidentEntitySupportConsistencyTest::hasIncidents)
+        .map(type -> entityNamesByLowerCase.get(type.getName().toLowerCase(Locale.ROOT)))
+        .filter(Objects::nonNull)
+        .forEach(readable::add);
+
+    return readable;
+  }
+
+  private static boolean hasIncidents(final ObjectTypeDefinition type) {
+    return type.getFieldDefinitions().stream()
+        .map(FieldDefinition::getName)
+        .anyMatch(INCIDENTS_FIELD::equals);
+  }
+
+  /**
+   * Maps a GraphQL type name or a PDL destination type onto the entity name the registry uses,
+   * recording the failure instead of silently dropping it.
+   */
+  private static String resolveEntity(
+      final String name,
+      final Map<String, String> entityNamesByLowerCase,
+      final List<String> unmapped,
+      final String failureMessage) {
+    final String direct = entityNamesByLowerCase.get(name.toLowerCase(Locale.ROOT));
+    if (direct != null) {
+      return direct;
+    }
+    if (name.endsWith(GRAPHQL_ENTITY_SUFFIX)) {
+      final String stripped =
+          name.substring(0, name.length() - GRAPHQL_ENTITY_SUFFIX.length())
+              .toLowerCase(Locale.ROOT);
+      final String suffixed = entityNamesByLowerCase.get(stripped);
+      if (suffixed != null) {
+        return suffixed;
+      }
+    }
+    unmapped.add(failureMessage);
+    return null;
+  }
+
+  /**
+   * Entity names keyed by lower case, so GraphQL's MLModel and the registry's mlModel line up
+   * without a hand-maintained translation table.
+   *
+   * <p>Built from {@link EntitySpec#getName()}, not from the key set: {@link ConfigEntityRegistry}
+   * lower cases its map keys but leaves the spec's own name in the casing entity-registry.yml
+   * declares. Keying off the map would make {@code datajob} the canonical spelling and never match
+   * the {@code dataJob} that the PDL and the yml use.
+   */
+  private static Map<String, String> indexEntityNames(final EntityRegistry registry) {
+    final Map<String, String> index = new TreeMap<>();
+    registry
+        .getEntitySpecs()
+        .values()
+        .forEach(spec -> index.put(spec.getName().toLowerCase(Locale.ROOT), spec.getName()));
+    return index;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentEntitySupportConsistencyTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentEntitySupportConsistencyTest.java
@@ -52,6 +52,16 @@ import org.testng.annotations.Test;
  * forgetting the other two fails here rather than in production. This test is the guardrail only;
  * closing the gaps is #18911. Until they close, {@link #KNOWN_GAPS} carries them explicitly, and
  * that map is meant to shrink to empty.
+ *
+ * <p><b>Known limitation.</b> The read check inspects the SDL only, which is necessary but not
+ * sufficient. Read support is itself two independently maintained things: the {@code extend type X
+ * { incidents }} block in {@code incident.graphql}, and a hardcoded {@code entitiesWithIncidents}
+ * list in {@code GmsGraphQLEngine}. A type present in the SDL but absent from that list resolves
+ * through the default {@code PropertyDataFetcher} and returns null with no error, so this test
+ * would pass on that half-finished state. The two agree today (Dataset, DataJob, DataFlow,
+ * Dashboard, Chart), so nothing is currently misreported; the exposure is future drift. Deriving a
+ * fourth set probably wants runtime resolver registration rather than scraping a Java literal.
+ * Raised by @cnpierrepapi on #18999.
  */
 public class IncidentEntitySupportConsistencyTest {
 


### PR DESCRIPTION
Draft, for #18999. This is the guardrail only. Closing the gaps themselves is #18911.

## Why

Three places independently decide whether an entity supports incidents, and they are already out of sync:

| layer | source | what it controls |
|---|---|---|
| write allowlist | `IncidentInfo.pdl`, the `IncidentOn` relationship's `entityTypes` | whether `raiseIncident` accepts the URN at all |
| summary / health | `entity-registry.yml`, entities declaring `incidentsSummary` | whether the entity carries a rolled-up status |
| read API | `incident.graphql`, types with an `incidents` field | whether anything can list them back |

#18478 widened the PDL list to `mlModel`, `mlFeature`, `service` and `aiAgent`, added `incidentsSummary` for `service` and `aiAgent` only, and wired GraphQL for none of them. On v1.7.0 that means `raiseIncident` accepts an `mlModel` URN, stores the incident against the model, and nothing can read it back. The caller gets an incident URN and no reason to think anything went wrong, which is worse than a clean rejection.

Derived from master, this is the current state:

| entity | IncidentOn (PDL) | incidentsSummary | GraphQL `incidents` |
|---|---|---|---|
| dataset, chart, dashboard, dataFlow, dataJob | yes | yes | yes |
| service, aiAgent | yes | yes | no |
| mlModel, mlFeature | yes | no | no |
| **schemaField** | **yes** | **no** | **no** |

`schemaField` was not in the table on #18999, which makes five affected types rather than four. It fell out of deriving the sets instead of trusting the summary, which is the argument for deriving them. It may widen the scope of #18911.

## What the test does

All three sets are derived from the sources themselves, so there is no hand-maintained list of supported entities anywhere in the test body:

- **write allowlist** from the entity registry, off the `incidentInfo` aspect spec's `IncidentOn` relationship field spec. Destination types are resolved against the registry, so a destination that is not a real entity fails too.
- **summary** from the registry, entities whose aspect list includes `incidentsSummary`.
- **read API** by loading `incident.graphql` through `GmsGraphQLEngine.fileBasedSchema(INCIDENTS_SCHEMA_FILE)` and parsing it with graphql-java's `SchemaParser`, the same loader and parser the engine itself uses.

GraphQL type names map back to entity names by lower case against the registry, with a trailing-`Entity` fallback for the suffixed types (`SchemaFieldEntity`). Anything that fails to resolve is reported rather than silently counted as "not readable", so a naming-convention change breaks the test loudly instead of quietly weakening it.

`KNOWN_GAPS` carries the five open gaps as explicit exceptions and is meant to shrink to empty as #18911 lands. An entry whose gap has closed also fails the test, so the allowlist cannot rot.

The failure message names the missing layer per entity:

```
  `mlModel` is an IncidentOn destination in metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl,
  but is missing the incidentsSummary aspect in metadata-models/src/main/resources/entity-registry.yml
  and an incidents field on its GraphQL type in datahub-graphql-core/src/main/resources/incident.graphql
```

That phrasing is deliberate. Three people hit three different rejection strings for this condition and none of them named the layer that was missing, which is what sent all three digging through the registry by hand.

## The two open questions from the issue thread

**Where should it live?** I put it in `datahub-graphql-core`, not `metadata-io` as I originally proposed. The deciding reason is CI: `:metadata-io:test` is excluded from the main `build-and-test` job, and it runs in `metadata-io.yml`, whose path filters do not include `datahub-graphql-core/**`. A PR that edits only `incident.graphql`, which is one of the three sources this guards, would not have run the guardrail at all. A consistency test that does not execute when one of its sources changes is decoration.

Two supporting reasons: `datahub-graphql-core` is the only module that can see all three sources, since it already depends on `metadata-models` (so `entity-registry.yml` and the compiled `IncidentInfo` relationship annotations are on the classpath) and it owns `incident.graphql` as its own resource. And in `metadata-io` the schema is not on the classpath at all, so the only way to read it was walking up from the working directory to the repo root, which differs between a Gradle run and an IDE run.

Happy to move it if you would rather it sat with the other registry tests, but I would want to fix the CI coverage first.

**Parsing `incident.graphql` versus an assembled schema object?** It no longer pattern-matches the file. It parses the SDL with graphql-java's `SchemaParser` into a `TypeDefinitionRegistry` and reads the object type extensions that declare an `incidents` field, which is the same parser `GraphQLEngine` uses on the same string. It stops short of `makeExecutableSchema` on purpose: an assembled schema needs every other SDL file plus the full runtime wiring (services and resolvers), which is a much heavier fixture, and it would not answer a different question. Whether the field exists is a property of the SDL, not of the wiring.

## Testing

Compiled and run against master locally, on JDK 21:

- **Passes as committed.** `1 passing`, with `--rerun` to defeat Gradle's up-to-date check so it is a real execution rather than a cache hit.
- **Fails when it should.** With `KNOWN_GAPS` emptied and the file otherwise byte-identical to this commit: `0 passing / 1 failing`, naming all five affected types (`aiAgent`, `mlFeature`, `mlModel`, `schemaField`, `service`) with the specific layer missing for each. A guardrail that cannot fail is worse than none.

Two bugs in the test survived review and only died on execution, which is also the argument for the guardrail existing at all:

1. `ConfigEntityRegistry.getEntitySpecs()` keys its map with `entity.getName().toLowerCase()`, while `EntitySpec.getName()` preserves the casing from `entity-registry.yml`. Canonicalising on the key made `datajob` and `dataJob` distinct entities and quietly corrupted the whole comparison. The test now indexes off `EntitySpec::getName()`.
2. Building the registry trips Pegasus's own `assert` statements under `-ea`, intermittently. This would have been a flaky CI failure rather than an honest one. The test now uses the same `PathSpecBasedSchemaAnnotationVisitor` assertion guard that 34 other files in the repo already use, two of them in this module (`MapperUtilsTest`, `ScrollAcrossLineageResolverTest`).

## Checklist

- [x] Conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) and PR title format
- [x] Links to related issues: #18999, #18911, #18478
- [x] Tests added
- [ ] Docs: none needed, this adds no user-facing behaviour
- [ ] Updating DataHub entry: not a breaking change

## Out of scope

ML incident UI support (#18911), the docs table, and unifying the three rejection strings.
