### PR TITLE
fix(ingest/powerbi): resolve upstream column casing from DataHub for accessor-based lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -265,6 +265,11 @@ class PowerBiDashboardSourceReport(StaleEntityRemovalSourceReport):
     m_query_resolver_errors: int = 0
     m_query_resolver_no_lineage: int = 0
     m_query_resolver_successes: int = 0
+    # Tables whose upstream schema could not be read back from DataHub, so
+    # column-level lineage had to assume PowerBI and the upstream spell their
+    # columns identically. A high count next to missing column-level lineage
+    # points at the upstream not being ingested (yet) or at no graph connection.
+    m_query_upstream_schema_unresolved: int = 0
 
     def report_dashboards_scanned(self, count: int = 1) -> None:
         self.dashboards_scanned += count

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -55,7 +55,7 @@ from datahub.metadata.schema_classes import (
 from datahub.metadata.urns import DatasetUrn
 from datahub.sql_parsing.schema_resolver import (
     SchemaInfo,
-    _convert_schema_aspect_to_info,
+    convert_schema_aspect_to_info,
     match_columns_to_schema,
 )
 from datahub.sql_parsing.sqlglot_lineage import (
@@ -192,23 +192,40 @@ def urn_to_lowercase(value: str, flag: bool) -> str:
     return value
 
 
-def _fetch_upstream_schema(ctx: PipelineContext, urn: str) -> Optional[SchemaInfo]:
+def _fetch_upstream_schema(
+    ctx: PipelineContext, urn: str, reporter: PowerBiDashboardSourceReport
+) -> Optional[SchemaInfo]:
     """The upstream table's columns as DataHub already stores them.
 
-    Returns None when the pipeline has no graph connection (e.g. a file sink) or
-    the upstream has not been ingested yet — the caller then keeps PowerBI's own
-    casing rather than dropping the edge. Reads the aspect directly instead of
-    going through SchemaResolver, which would add a per-table on-disk cache we
-    have no use for here.
+    Returns None when the pipeline has no graph connection (e.g. a file sink),
+    when the upstream has not been ingested yet, or when the lookup itself fails
+    — the caller then keeps PowerBI's own casing rather than dropping the edge.
+    Reads the aspect directly instead of going through SchemaResolver, which
+    would add a per-table on-disk cache we have no use for here.
     """
     if ctx.graph is None:
         return None
 
-    aspect = ctx.graph.get_aspect(urn, SchemaMetadataClass)
+    try:
+        aspect = ctx.graph.get_aspect(urn, SchemaMetadataClass)
+    except Exception as e:
+        # Callers run inside the parser's catch-all, which discards *all* lineage
+        # for the expression. A flaky or unauthorized read must not cost the
+        # table-level upstream too, so degrade to PowerBI's casing instead.
+        reporter.warning(
+            title="Unable to read upstream schema",
+            message="Could not check how the upstream spells its columns, so "
+            "PowerBI's own column casing was used. Column-level lineage may not "
+            "resolve if the two disagree; table-level lineage is unaffected.",
+            context=f"upstream-urn={urn}",
+            exc=e,
+        )
+        return None
+
     if aspect is None:
         return None
 
-    return _convert_schema_aspect_to_info(aspect)
+    return convert_schema_aspect_to_info(aspect)
 
 
 def _remap_column_lineage_to_pbi_fields(
@@ -512,15 +529,20 @@ class AbstractLineage(ABC):
         # edge pointing at a field that does not exist. Ask DataHub how the
         # upstream actually spells its columns; the SQL-parsing path gets the
         # same correction for free from sqlglot's schema resolver.
-        schema_info = _fetch_upstream_schema(self.ctx, urn)
         pbi_column_names = [column.name for column in self.table.columns]
-        if schema_info:
-            upstream_column_names = match_columns_to_schema(
-                schema_info, pbi_column_names
-            )
-        else:
-            upstream_column_names = pbi_column_names
-            self.reporter.m_query_upstream_schema_unresolved += 1
+        upstream_column_names = pbi_column_names
+
+        # The mapper discards every column edge when the flag is off, so skip a
+        # lookup whose result would be thrown away — and do not count it as a
+        # degraded run, which would only muddy the signal.
+        if self.config.extract_column_level_lineage:
+            schema_info = _fetch_upstream_schema(self.ctx, urn, self.reporter)
+            if schema_info is not None:
+                upstream_column_names = match_columns_to_schema(
+                    schema_info, pbi_column_names
+                )
+            else:
+                self.reporter.m_query_upstream_schema_unresolved += 1
 
         column_lineage = []
         for column, upstream_column_name in zip(

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -48,8 +48,16 @@ from datahub.ingestion.source.powerbi.rest_api_wrapper.data_classes import (
     Column,
     Table,
 )
-from datahub.metadata.schema_classes import SchemaFieldDataTypeClass
+from datahub.metadata.schema_classes import (
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+)
 from datahub.metadata.urns import DatasetUrn
+from datahub.sql_parsing.schema_resolver import (
+    SchemaInfo,
+    _convert_schema_aspect_to_info,
+    match_columns_to_schema,
+)
 from datahub.sql_parsing.sqlglot_lineage import (
     ColumnLineageInfo,
     ColumnRef,
@@ -182,6 +190,25 @@ def urn_to_lowercase(value: str, flag: bool) -> str:
         return value.lower()
 
     return value
+
+
+def _fetch_upstream_schema(ctx: PipelineContext, urn: str) -> Optional[SchemaInfo]:
+    """The upstream table's columns as DataHub already stores them.
+
+    Returns None when the pipeline has no graph connection (e.g. a file sink) or
+    the upstream has not been ingested yet — the caller then keeps PowerBI's own
+    casing rather than dropping the edge. Reads the aspect directly instead of
+    going through SchemaResolver, which would add a per-table on-disk cache we
+    have no use for here.
+    """
+    if ctx.graph is None:
+        return None
+
+    aspect = ctx.graph.get_aspect(urn, SchemaMetadataClass)
+    if aspect is None:
+        return None
+
+    return _convert_schema_aspect_to_info(aspect)
 
 
 def _remap_column_lineage_to_pbi_fields(
@@ -475,34 +502,44 @@ class AbstractLineage(ABC):
         )
 
     def create_table_column_lineage(self, urn: str) -> List[ColumnLineageInfo]:
+        if not self.table.columns:
+            return []
+
+        # This path names the upstream columns from the PowerBI model, which can
+        # disagree in casing with the warehouse — most commonly when the upstream
+        # source was ingested with convert_column_urns_to_lowercase. schemaField
+        # URNs are compared as exact strings, so a mismatch silently yields an
+        # edge pointing at a field that does not exist. Ask DataHub how the
+        # upstream actually spells its columns; the SQL-parsing path gets the
+        # same correction for free from sqlglot's schema resolver.
+        schema_info = _fetch_upstream_schema(self.ctx, urn)
+        pbi_column_names = [column.name for column in self.table.columns]
+        if schema_info:
+            upstream_column_names = match_columns_to_schema(
+                schema_info, pbi_column_names
+            )
+        else:
+            upstream_column_names = pbi_column_names
+            self.reporter.m_query_upstream_schema_unresolved += 1
+
         column_lineage = []
+        for column, upstream_column_name in zip(
+            self.table.columns, upstream_column_names, strict=True
+        ):
+            downstream = DownstreamColumnRef(
+                table=self.table.name,
+                column=column.name,
+                column_type=SchemaFieldDataTypeClass(type=column.datahubDataType),
+                native_column_type=column.dataType or "UNKNOWN",
+            )
 
-        if self.table.columns is not None:
-            for column in self.table.columns:
-                downstream = DownstreamColumnRef(
-                    table=self.table.name,
-                    column=column.name,
-                    column_type=SchemaFieldDataTypeClass(type=column.datahubDataType),
-                    native_column_type=column.dataType or "UNKNOWN",
-                )
+            # Lowercasing of the dataset portion of the URN is governed
+            # separately by convert_lineage_urns_to_lowercase in powerbi.py.
+            upstreams = [ColumnRef(table=urn, column=upstream_column_name)]
 
-                upstreams = [
-                    ColumnRef(
-                        table=urn,
-                        # Preserve the source column casing so the upstream
-                        # schemaField URN matches the warehouse's field, which
-                        # stores columns in their original casing. Lowercasing is
-                        # governed for the dataset portion by
-                        # convert_lineage_urns_to_lowercase downstream in powerbi.py.
-                        column=column.name,
-                    )
-                ]
-
-                column_lineage_info = ColumnLineageInfo(
-                    downstream=downstream, upstreams=upstreams
-                )
-
-                column_lineage.append(column_lineage_info)
+            column_lineage.append(
+                ColumnLineageInfo(downstream=downstream, upstreams=upstreams)
+            )
 
         return column_lineage
 

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver.py
@@ -297,7 +297,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
     def add_schema_metadata(
         self, urn: str, schema_metadata: SchemaMetadataClass
     ) -> None:
-        schema_info = _convert_schema_aspect_to_info(schema_metadata)
+        schema_info = convert_schema_aspect_to_info(schema_metadata)
         self._save_to_cache(urn, schema_info)
 
     def add_schema_metadata_from_fetch(
@@ -306,7 +306,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         # Always stores a result (including None) to prevent repeated API calls
         # for schemas not found in DataHub.
         schema_info = (
-            _convert_schema_aspect_to_info(schema_metadata)
+            convert_schema_aspect_to_info(schema_metadata)
             if schema_metadata is not None
             else None
         )
@@ -347,7 +347,7 @@ class SchemaResolver(Closeable, SchemaResolverInterface):
         if not aspect:
             return None
 
-        return _convert_schema_aspect_to_info(aspect)
+        return convert_schema_aspect_to_info(aspect)
 
     @classmethod
     def convert_graphql_schema_metadata_to_info(
@@ -423,7 +423,7 @@ def _convert_schema_field_list_to_info(
     }
 
 
-def _convert_schema_aspect_to_info(schema_metadata: SchemaMetadataClass) -> SchemaInfo:
+def convert_schema_aspect_to_info(schema_metadata: SchemaMetadataClass) -> SchemaInfo:
     return _convert_schema_field_list_to_info(schema_metadata.fields)
 
 

--- a/metadata-ingestion/tests/integration/powerbi/test_ingest.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_ingest.py
@@ -506,10 +506,9 @@ def test_upstream_column_lineage_uses_the_upstream_casing(
                 if MYSQL_EMPLOYEES_URN in upstream:
                     emitted_upstream_columns.add(upstream.rsplit(",", 1)[1].rstrip(")"))
 
-    assert emitted_upstream_columns, (
-        "no column-level lineage was emitted to the mysql upstream"
-    )
-    # Every emitted column follows the warehouse's casing, not PowerBI's.
-    assert emitted_upstream_columns <= set(upstream_columns), (
-        f"expected upstream casing, got {sorted(emitted_upstream_columns)}"
+    # Exact equality, so this also catches column edges being dropped rather
+    # than merely mis-cased.
+    assert emitted_upstream_columns == set(upstream_columns), (
+        f"expected upstream casing for every column, got "
+        f"{sorted(emitted_upstream_columns)}"
     )

--- a/metadata-ingestion/tests/integration/powerbi/test_ingest.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_ingest.py
@@ -1,15 +1,27 @@
 import datetime
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
 import time_machine
 
+from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.run.pipeline import Pipeline
+from datahub.ingestion.source.powerbi.config import PowerBiDashboardSourceConfig
+from datahub.ingestion.source.powerbi.powerbi import PowerBiDashboardSource
+from datahub.metadata.schema_classes import (
+    OtherSchemaClass,
+    SchemaFieldClass,
+    SchemaFieldDataTypeClass,
+    SchemaMetadataClass,
+    StringTypeClass,
+    UpstreamLineageClass,
+)
 from datahub.testing import mce_helpers
+from tests.test_helpers.graph_helpers import MockDataHubGraph
 
 pytestmark = pytest.mark.integration_batch_2
 FROZEN_TIME = "2022-02-03 07:00:00"
@@ -397,4 +409,107 @@ def test_empty_owner_criteria_includes_all_users(
         pytestconfig,
         output_path=f"{tmp_path}/powerbi_empty_criteria_mces.json",
         golden_path=f"{test_resources_dir}/{golden_file}",
+    )
+
+
+MYSQL_EMPLOYEES_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:mysql,employees.employees,PROD)"
+)
+
+
+class _OfflineGraph(MockDataHubGraph):
+    def get_config(self) -> Dict[str, Any]:
+        # PipelineContext asks the server about URN casing while constructing;
+        # there is no server behind the mock.
+        return {}
+
+
+def _mysql_employees_schema(column_names: List[str]) -> SchemaMetadataClass:
+    return SchemaMetadataClass(
+        schemaName="employees",
+        platform="urn:li:dataPlatform:mysql",
+        version=0,
+        hash="",
+        platformSchema=OtherSchemaClass(rawSchema=""),
+        fields=[
+            SchemaFieldClass(
+                fieldPath=column_name,
+                type=SchemaFieldDataTypeClass(type=StringTypeClass()),
+                nativeDataType="VARCHAR",
+            )
+            for column_name in column_names
+        ],
+    )
+
+
+@time_machine.travel(FROZEN_TIME, tick=False)
+@mock.patch("msal.ConfidentialClientApplication", side_effect=mock_msal_cca)
+@pytest.mark.integration
+def test_upstream_column_lineage_uses_the_upstream_casing(
+    mock_msal: MagicMock,
+    pytestconfig: pytest.Config,
+    mock_time: datetime.datetime,
+    requests_mock: Any,
+) -> None:
+    """Column-level lineage must point at the columns as the upstream spells them.
+
+    The PowerBI model here reports `emp_no`; the warehouse in DataHub stores
+    `Emp_No`. schemaField URNs are compared as exact strings, so emitting
+    PowerBI's casing produces an edge to a field that does not exist and the
+    column-level lineage silently disappears in the UI.
+    """
+    register_mock_api(
+        request_mock=requests_mock,
+        pytestconfig=pytestconfig,
+        override_data=read_mock_data(
+            pytestconfig.rootpath
+            / "tests/integration/powerbi/mock_data/mysql_mock_response.json"
+        ),
+    )
+
+    upstream_columns = [
+        "Emp_No",
+        "Birth_Date",
+        "First_Name",
+        "Last_Name",
+        "Gender",
+        "Hire_Date",
+    ]
+    graph = _OfflineGraph(
+        {
+            MYSQL_EMPLOYEES_URN: {
+                "schemaMetadata": _mysql_employees_schema(upstream_columns)
+            }
+        }
+    )
+
+    source = PowerBiDashboardSource(
+        config=PowerBiDashboardSourceConfig.parse_obj(
+            {
+                "tenant_id": "0b0c960b-fcdf-4d0f-8c45-2e03bb59ddeb",
+                "client_id": "a8d655a6-f521-477e-8c22-255018583bf4",
+                "client_secret": "ababa~cdcdcdcdcdcdcdcdcdcd-abcd.defghijk",
+                "extract_column_level_lineage": True,
+                "workspace_name_pattern": {"allow": ["^Employees$"]},
+            }
+        ),
+        ctx=PipelineContext(run_id="powerbi-test", graph=graph),
+    )
+
+    emitted_upstream_columns = set()
+    for work_unit in source.get_workunits():
+        lineage = work_unit.get_aspect_of_type(UpstreamLineageClass)
+        if lineage is None:
+            continue
+        for fine_grained in lineage.fineGrainedLineages or []:
+            for upstream in fine_grained.upstreams or []:
+                if MYSQL_EMPLOYEES_URN in upstream:
+                    emitted_upstream_columns.add(upstream.rsplit(",", 1)[1].rstrip(")"))
+
+    assert emitted_upstream_columns, (
+        "no column-level lineage was emitted to the mysql upstream"
+    )
+    # Every emitted column follows the warehouse's casing, not PowerBI's.
+    assert emitted_upstream_columns <= set(upstream_columns), (
+        f"expected upstream casing, got {sorted(emitted_upstream_columns)}"
     )

--- a/metadata-ingestion/tests/unit/powerbi/test_upstream_column_casing.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_upstream_column_casing.py
@@ -1,0 +1,91 @@
+from typing import List, Optional
+from unittest.mock import patch
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.powerbi.config import (
+    PowerBiDashboardSourceConfig,
+    PowerBiDashboardSourceReport,
+)
+from datahub.ingestion.source.powerbi.dataplatform_instance_resolver import (
+    ResolvePlatformInstanceFromDatasetTypeMapping,
+)
+from datahub.ingestion.source.powerbi.m_query import pattern_handler
+from datahub.ingestion.source.powerbi.m_query.pattern_handler import MSSqlLineage
+from datahub.ingestion.source.powerbi.rest_api_wrapper.data_classes import (
+    Column,
+    Table,
+)
+from datahub.metadata.schema_classes import StringTypeClass
+from datahub.sql_parsing.schema_resolver import SchemaInfo
+
+UPSTREAM_URN = (
+    "urn:li:dataset:(urn:li:dataPlatform:mssql,warehouse.dbo.fact_orders,PROD)"
+)
+
+
+def _handler(column_names: List[str]) -> MSSqlLineage:
+    table = Table(
+        name="fact_orders",
+        full_name="warehouse.fact_orders",
+        columns=[
+            Column(
+                name=name,
+                dataType="string",
+                isHidden=False,
+                datahubDataType=StringTypeClass(),
+            )
+            for name in column_names
+        ],
+    )
+    return MSSqlLineage(
+        ctx=PipelineContext(run_id="test"),
+        table=table,
+        config=PowerBiDashboardSourceConfig(
+            tenant_id="t", client_id="c", client_secret="s"
+        ),
+        reporter=PowerBiDashboardSourceReport(),
+        platform_instance_resolver=ResolvePlatformInstanceFromDatasetTypeMapping(
+            PowerBiDashboardSourceConfig(
+                tenant_id="t", client_id="c", client_secret="s"
+            )
+        ),
+    )
+
+
+def _upstream_columns(
+    column_names: List[str], schema_info: Optional[SchemaInfo]
+) -> List[str]:
+    with patch.object(
+        pattern_handler, "_fetch_upstream_schema", return_value=schema_info
+    ):
+        cll = _handler(column_names).create_table_column_lineage(UPSTREAM_URN)
+    return [upstream.column for info in cll for upstream in info.upstreams]
+
+
+def test_upstream_casing_follows_the_warehouse_not_powerbi() -> None:
+    # The warehouse was ingested with convert_column_urns_to_lowercase, so its
+    # schemaField URNs are lowercased. Emitting PowerBI's own casing would point
+    # the edge at a field that does not exist.
+    assert _upstream_columns(
+        ["LeadId", "Amount"], {"leadid": "VARCHAR", "amount": "DECIMAL"}
+    ) == ["leadid", "amount"]
+
+
+def test_upstream_casing_wins_over_powerbi_casing() -> None:
+    # PowerBI and the warehouse can disagree on casing in either direction; the
+    # warehouse is the side that owns the schemaField URN.
+    assert _upstream_columns(["Leadid"], {"LeadId": "VARCHAR"}) == ["LeadId"]
+
+
+def test_falls_back_to_powerbi_casing_when_schema_is_unresolvable() -> None:
+    # No graph, or the upstream has not been ingested yet: keep today's behaviour
+    # rather than dropping the edge.
+    assert _upstream_columns(["LeadId"], None) == ["LeadId"]
+
+
+def test_columns_absent_from_the_upstream_schema_are_left_alone() -> None:
+    # A PowerBI-only computed column has no warehouse counterpart to match.
+    assert _upstream_columns(["LeadId", "Computed"], {"leadid": "VARCHAR"}) == [
+        "leadid",
+        "Computed",
+    ]

--- a/metadata-ingestion/tests/unit/powerbi/test_upstream_column_casing.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_upstream_column_casing.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.powerbi.config import (
@@ -23,7 +23,16 @@ UPSTREAM_URN = (
 )
 
 
-def _handler(column_names: List[str]) -> MSSqlLineage:
+def _config(**overrides: object) -> PowerBiDashboardSourceConfig:
+    return PowerBiDashboardSourceConfig(
+        tenant_id="t", client_id="c", client_secret="s", **overrides
+    )
+
+
+def _handler(
+    column_names: List[str], config: Optional[PowerBiDashboardSourceConfig] = None
+) -> MSSqlLineage:
+    config = config or _config()
     table = Table(
         name="fact_orders",
         full_name="warehouse.fact_orders",
@@ -40,14 +49,10 @@ def _handler(column_names: List[str]) -> MSSqlLineage:
     return MSSqlLineage(
         ctx=PipelineContext(run_id="test"),
         table=table,
-        config=PowerBiDashboardSourceConfig(
-            tenant_id="t", client_id="c", client_secret="s"
-        ),
+        config=config,
         reporter=PowerBiDashboardSourceReport(),
         platform_instance_resolver=ResolvePlatformInstanceFromDatasetTypeMapping(
-            PowerBiDashboardSourceConfig(
-                tenant_id="t", client_id="c", client_secret="s"
-            )
+            config
         ),
     )
 
@@ -55,10 +60,17 @@ def _handler(column_names: List[str]) -> MSSqlLineage:
 def _upstream_columns(
     column_names: List[str], schema_info: Optional[SchemaInfo]
 ) -> List[str]:
+    handler = _handler(column_names)
     with patch.object(
         pattern_handler, "_fetch_upstream_schema", return_value=schema_info
     ):
-        cll = _handler(column_names).create_table_column_lineage(UPSTREAM_URN)
+        cll = handler.create_table_column_lineage(UPSTREAM_URN)
+
+    # The counter must track only genuinely unreadable schemas, since it is the
+    # signal operators use to explain missing column-level lineage.
+    assert handler.reporter.m_query_upstream_schema_unresolved == (
+        0 if schema_info is not None else 1
+    )
     return [upstream.column for info in cll for upstream in info.upstreams]
 
 
@@ -88,4 +100,44 @@ def test_columns_absent_from_the_upstream_schema_are_left_alone() -> None:
     assert _upstream_columns(["LeadId", "Computed"], {"leadid": "VARCHAR"}) == [
         "leadid",
         "Computed",
+    ]
+
+
+def test_an_empty_upstream_schema_is_not_reported_as_unresolved() -> None:
+    # Readable but with no fields is a different situation from unreadable, and
+    # conflating them inflates the degraded-run signal.
+    assert _upstream_columns(["LeadId"], {}) == ["LeadId"]
+
+
+def test_a_failing_schema_lookup_does_not_cost_the_table_level_lineage() -> None:
+    # create_table_column_lineage runs inside the parser's catch-all, so an
+    # exception escaping here would discard the upstream table edge as well.
+    handler = _handler(["LeadId"])
+    graph = MagicMock()
+    graph.get_aspect.side_effect = ConnectionError("boom")
+    handler.ctx.graph = graph
+
+    cll = handler.create_table_column_lineage(UPSTREAM_URN)
+
+    assert [upstream.column for info in cll for upstream in info.upstreams] == [
+        "LeadId"
+    ]
+    assert handler.reporter.m_query_upstream_schema_unresolved == 1
+    assert handler.reporter.warnings
+
+
+def test_no_schema_lookup_when_column_level_lineage_is_disabled() -> None:
+    # The mapper drops every column edge in this mode, so the graph read would
+    # buy nothing — and must not be counted as a degraded run either.
+    handler = _handler(["LeadId"], config=_config(extract_column_level_lineage=False))
+    graph = MagicMock()
+    handler.ctx.graph = graph
+
+    cll = handler.create_table_column_lineage(UPSTREAM_URN)
+
+    graph.get_aspect.assert_not_called()
+    assert handler.reporter.m_query_upstream_schema_unresolved == 0
+    # Output is unchanged from before this fix: PowerBI's own casing.
+    assert [upstream.column for info in cll for upstream in info.upstreams] == [
+        "LeadId"
     ]


### PR DESCRIPTION
Power BI builds column-level lineage two different ways, and the two disagreed about how upstream columns are spelled.

The SQL-parsing path (`Value.NativeQuery`, ODBC queries, the two/three-step patterns) runs the query through sqlglot. sqlglot's `normalize_identifiers` folds unquoted identifiers to lower case, but its schema resolver then looks the table up in DataHub and restores the casing the warehouse actually stores:

```
sqlglot alone:             ZipCode -> zipcode
sqlglot + resolved schema: ZipCode -> ZipCode
```

The accessor path has no such lookup. `create_table_column_lineage` — shared by `Sql.Database`, Snowflake, Databricks, Oracle, MySQL, Postgres, Athena and four more handlers — names the upstream columns straight from the Power BI model.

`schemaField` URNs are compared as exact strings, so whenever Power BI and the warehouse disagree on casing the accessor path emits an edge to a field that does not exist. Nothing errors: ingestion is green, warning-free, and the column-level lineage is simply absent in the UI.

### Why no configuration fixes it

The two paths answer to different sources of truth, so the upstream's `convert_column_urns_to_lowercase` setting cannot satisfy both at once. With an upstream ingested lower-cased and a Power BI model that spells columns `LeadId` / `ZipCode`:

| upstream flag | SQL-parsing path | accessor path |
| --- | --- | --- |
| `true` (lower-cased) | `zipcode` = `zipcode` ✅ | `LeadId` ≠ `leadid` ❌ |
| `false` (default) | `ZipCode` = `ZipCode` ✅ | `LeadId` = `LeadId` ✅ |

The failure is quiet and load-bearing: a workspace can have some datasets with working column-level lineage and others silently missing it, with no signal distinguishing them.

### Change

Give the accessor path the same lookup: read the upstream's `schemaMetadata` and match the Power BI columns against it case-insensitively, via the framework's existing `match_columns_to_schema` (already used by the Looker and Cube sources for this).

When the schema cannot be read — no graph connection on the pipeline, the upstream not ingested yet, or the lookup itself failing — the previous behaviour is kept exactly, emitting Power BI's own casing rather than dropping the edge. The first two cases are counted under a new `m_query_upstream_schema_unresolved` report field and the third also raises a warning naming the upstream URN, so a degraded run is visible in the report next to the missing lineage it explains.

Swallowing the failure matters here: the handler runs inside the M-Query parser's catch-all, which discards *all* lineage for an expression and reports it as an unknown M-Query pattern. A read needed only for casing must not be able to cost the table-level edge.

The aspect is read directly rather than through `SchemaResolver`, which would attach a per-table on-disk cache this path has no use for. This costs one aspect fetch per table that produces accessor-path column lineage, and only when a graph is configured and `extract_column_level_lineage` is on — with the flag off the mapper discards every column edge anyway, so the lookup is skipped and what the method returns is left untouched.

### Note for `sql_parsing` reviewers

`_convert_schema_aspect_to_info` in `schema_resolver.py` is renamed to `convert_schema_aspect_to_info` (four internal call sites, no behaviour change) so this source is not reaching into another module's private surface. It sits beside `match_columns_to_schema`, already public for this same cross-source use.

### Testing

- `tests/unit/powerbi/test_upstream_column_casing.py` — upstream casing wins in both directions, unknown columns are left alone, the no-schema fallback preserves today's output, a readable-but-empty schema is not counted as degraded, a failing lookup still yields lineage and warns, and the disabled-flag path makes no graph call. The `m_query_upstream_schema_unresolved` counter is asserted on every path.
- `tests/integration/powerbi/test_ingest.py::test_upstream_column_lineage_uses_the_upstream_casing` — end to end through the real source against a graph seeded with a mixed-case upstream schema, asserting the exact set of emitted upstream `schemaField` URNs, so a dropped column edge fails rather than passing as a subset.
- Verified the tests are not vacuous: with the lookup stubbed out, 6 fail.
- The existing Power BI and `sql_parsing` suites pass unchanged (851 tests). No golden files move, since they run without a graph and therefore take the fallback.

### Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated
- [ ] Links to related issues (n/a)
- [ ] Docs related to the changes have been added/updated (n/a — no user-facing configuration is added)
- [ ] Breaking change entry in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (n/a — see below)

### Compatibility

Not a breaking change. Where the schema resolves, previously-broken edges start pointing at real fields; where it does not, output is byte-identical to before. This follows the same "preserve casing on both sides" regime established by #18181 and completes it for the accessor path.
