### PR TITLE
perf(graphql): Container.entities count-only batching with AST-based selection

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -25,6 +25,7 @@ import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.*;
+import com.linkedin.datahub.graphql.loaders.ContainerEntityCountsBatchLoader;
 import com.linkedin.datahub.graphql.loaders.DomainEntityCountsBatchLoader;
 import com.linkedin.datahub.graphql.plugins.SemanticSearchPlugin;
 import com.linkedin.datahub.graphql.resolvers.MeResolver;
@@ -960,6 +961,9 @@ public class GmsGraphQLEngine {
     builder
         .addDataLoaders(loaderSuppliers(loadableTypes))
         .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
+        .addDataLoader(
+            ContainerEntityCountsBatchLoader.LOADER_NAME,
+            context -> ContainerEntityCountsBatchLoader.create(entityClient, context))
         .addDataLoader(
             DomainEntityCountsBatchLoader.LOADER_NAME,
             context -> DomainEntityCountsBatchLoader.create(entityClient, context))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/ContainerEntityCountsBatchLoader.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/loaders/ContainerEntityCountsBatchLoader.java
@@ -1,0 +1,197 @@
+package com.linkedin.datahub.graphql.loaders;
+
+import static com.linkedin.datahub.graphql.resolvers.container.ContainerEntitiesResolver.CONTAINABLE_ENTITY_NAMES;
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.SearchResult;
+import io.datahubproject.metadata.context.OperationContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
+
+/**
+ * Per-request DataLoader resolving {@code Container.entities.total} for the count-only selections
+ * in the search fragments, collapsing the previous N {@code searchAcrossEntities} calls into a
+ * fixed number of aggregation-only searches.
+ *
+ * <p>Each key is a container urn. Keys are chunked, and each chunk issues one aggregation-only
+ * search faceted on {@code container} and filtered to the chunk's containers. The {@code container}
+ * facet buckets are keyed by container urn, so per-container totals read back unambiguously.
+ *
+ * <p>Unlike the domain equivalent there is no entity-type dimension to group by: {@code
+ * Container.entities} has a single call shape in the UI and the fast path only accepts unfiltered,
+ * count-only requests, so the key is the bare urn.
+ *
+ * <p><b>Bucket-cap caveat.</b> This relies on a terms aggregation whose bucket count is capped at
+ * {@code min(maxAggValues, maxTermBucketSize)}. Because the query is already filtered to the
+ * chunk's containers, the {@code container} bucket only needs to hold those containers. We chunk
+ * conservatively ({@link #MAX_CONTAINERS_PER_AGG}) and raise {@code maxAggValues}.
+ */
+@Slf4j
+public final class ContainerEntityCountsBatchLoader {
+
+  public static final String LOADER_NAME = "ContainerEntityCounts";
+
+  private static final String CONTAINER_FIELD = "container";
+  private static final String CONTAINER_KEYWORD_FIELD = CONTAINER_FIELD + ".keyword";
+  private static final String MATCH_ALL_QUERY = "*";
+
+  // Keep chunks safely under the search-layer terms-bucket cap (default maxTermBucketSize == 60).
+  // An asset has at most one container, so the bucket holds no off-chunk keys, but we leave
+  // headroom rather than sitting on the limit.
+  private static final int MAX_CONTAINERS_PER_AGG = 25;
+  private static final int MAX_AGG_VALUES = 1000;
+
+  private ContainerEntityCountsBatchLoader() {}
+
+  public static DataLoader<String, Long> create(
+      final EntityClient entityClient, final QueryContext queryContext) {
+    final BatchLoaderContextProvider provider = () -> queryContext;
+    final DataLoaderOptions options =
+        DataLoaderOptions.newOptions().setBatchLoaderContextProvider(provider);
+
+    // Parent the batchLoad span under the operation, not the executor thread (see
+    // GmsGraphQLEngine#createDataLoader).
+    final Context batchContext = Context.current();
+
+    return DataLoader.newDataLoader(
+        (keys, env) ->
+            GraphQLConcurrencyUtils.supplyAsync(
+                () -> {
+                  try (Scope ignored = batchContext.makeCurrent()) {
+                    return batchLoad(keys, (QueryContext) env.getContext(), entityClient);
+                  }
+                },
+                LOADER_NAME,
+                "batchLoad"),
+        options);
+  }
+
+  @WithSpan
+  public static List<Long> batchLoad(
+      final List<String> containerUrns,
+      final QueryContext queryContext,
+      final EntityClient entityClient) {
+    // urn -> total, defaulting to zero (a container with no visible children stays zero).
+    final Map<String, Long> resultByUrn = new HashMap<>(containerUrns.size());
+    for (String urn : containerUrns) {
+      resultByUrn.put(urn, 0L);
+    }
+
+    final List<String> distinctUrns =
+        containerUrns.stream().distinct().collect(Collectors.toList());
+
+    for (List<String> chunk : partition(distinctUrns, MAX_CONTAINERS_PER_AGG)) {
+      try {
+        resultByUrn.putAll(loadChunk(queryContext, entityClient, chunk));
+      } catch (Exception e) {
+        // Surface the failure rather than swallowing it: a returned 0 is indistinguishable from a
+        // genuinely empty container and would mask a search outage as "no entities" in the UI
+        // counts. Matches the throw-on-failure contract of the direct resolver path
+        // (ContainerEntitiesResolver#resolveDirect) and the other GMS batch loaders.
+        throw new RuntimeException(
+            String.format("Failed to resolve entity counts associated with Containers %s", chunk),
+            e);
+      }
+    }
+
+    // DataLoader contract: results[i] must correspond to keys[i].
+    final List<Long> ordered = new ArrayList<>(containerUrns.size());
+    for (String urn : containerUrns) {
+      ordered.add(resultByUrn.get(urn));
+    }
+    return ordered;
+  }
+
+  private static Map<String, Long> loadChunk(
+      final QueryContext queryContext,
+      final EntityClient entityClient,
+      final List<String> containerUrns)
+      throws Exception {
+
+    final OperationContext opContext =
+        queryContext
+            .getOperationContext()
+            .withSearchFlags(
+                flags -> flags.setMaxAggValues(MAX_AGG_VALUES).setIncludeDefaultFacets(false));
+
+    final SearchResult searchResult =
+        entityClient.searchAcrossEntities(
+            opContext,
+            CONTAINABLE_ENTITY_NAMES,
+            MATCH_ALL_QUERY,
+            buildFilter(containerUrns),
+            0,
+            0,
+            Collections.emptyList(),
+            Collections.singletonList(CONTAINER_FIELD));
+
+    final Map<String, Long> countsByContainer = new HashMap<>();
+    if (searchResult == null) {
+      return countsByContainer;
+    }
+    // `metadata`, its `aggregations` array (which defaults to []), and each entry's own
+    // `aggregations` map are all required PDL fields, so none can be null here — their getters
+    // throw when absent. A malformed response therefore surfaces as an exception that batchLoad
+    // propagates, rather than as a null to guard against.
+    for (AggregationMetadata agg : searchResult.getMetadata().getAggregations()) {
+      if (!CONTAINER_FIELD.equals(agg.getName())) {
+        continue;
+      }
+      // container-facet bucket keys are container urns; ignore anything outside the chunk.
+      agg.getAggregations()
+          .forEach(
+              (containerUrn, count) -> {
+                if (containerUrns.contains(containerUrn)) {
+                  countsByContainer.merge(containerUrn, count, Long::sum);
+                }
+              });
+    }
+    return countsByContainer;
+  }
+
+  private static Filter buildFilter(final List<String> containerUrns) {
+    final StringArray urnValues = new StringArray();
+    for (String urn : containerUrns) {
+      try {
+        urnValues.add(UrnUtils.getUrn(urn).toString());
+      } catch (Exception e) {
+        log.warn("Skipping malformed container urn '{}' in container entity count batch.", urn, e);
+      }
+    }
+
+    final CriterionArray criteria = new CriterionArray();
+    criteria.add(buildCriterion(CONTAINER_KEYWORD_FIELD, Condition.EQUAL, urnValues));
+    return new Filter()
+        .setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(criteria)));
+  }
+
+  private static <T> List<List<T>> partition(final List<T> list, final int size) {
+    final List<List<T>> chunks = new ArrayList<>();
+    for (int i = 0; i < list.size(); i += size) {
+      chunks.add(list.subList(i, Math.min(i + size, list.size())));
+    }
+    return chunks;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolver.java
@@ -4,11 +4,14 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Container;
 import com.linkedin.datahub.graphql.generated.ContainerEntitiesInput;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.loaders.ContainerEntityCountsBatchLoader;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
@@ -20,16 +23,21 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.SelectedField;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.dataloader.DataLoader;
 
 /** Retrieves a list of historical executions for a particular source. */
 @Slf4j
 public class ContainerEntitiesResolver implements DataFetcher<CompletableFuture<SearchResults>> {
 
-  static final List<String> CONTAINABLE_ENTITY_NAMES =
+  public static final List<String> CONTAINABLE_ENTITY_NAMES =
       ImmutableList.of(
           Constants.DATASET_ENTITY_NAME,
           Constants.CHART_ENTITY_NAME,
@@ -41,6 +49,11 @@ public class ContainerEntitiesResolver implements DataFetcher<CompletableFuture<
   private static final Integer DEFAULT_START = 0;
   private static final Integer DEFAULT_COUNT = 20;
   private static final ContainerEntitiesInput DEFAULT_ENTITIES_INPUT = new ContainerEntitiesInput();
+
+  // Selections answerable from an aggregation alone. Deliberately excludes start/count: those are
+  // echoed from the request rather than reported by the search layer on this path, so we only take
+  // it when the caller cannot observe the difference.
+  private static final Set<String> COUNT_ONLY_FIELDS = ImmutableSet.of("total", "__typename");
 
   static {
     DEFAULT_ENTITIES_INPUT.setQuery(DEFAULT_QUERY);
@@ -66,16 +79,89 @@ public class ContainerEntitiesResolver implements DataFetcher<CompletableFuture<
             ? bindArgument(environment.getArgument(INPUT_ARG_NAME), ContainerEntitiesInput.class)
             : DEFAULT_ENTITIES_INPUT;
 
-    final String query = input.getQuery() != null ? input.getQuery() : "*";
-    final int start = input.getStart() != null ? input.getStart() : 0;
-    final int count = input.getCount() != null ? input.getCount() : 20;
+    final String query = input.getQuery() != null ? input.getQuery() : DEFAULT_QUERY;
+    final int start = input.getStart() != null ? input.getStart() : DEFAULT_START;
+    final int count = input.getCount() != null ? input.getCount() : DEFAULT_COUNT;
 
+    // Fast path: every UI call site selects only `total`, so the hits the search would return are
+    // discarded. Serve those from a batched, request-scoped aggregation instead, so a page of N
+    // containers costs a fixed number of searches rather than N searches plus N primary-store
+    // existence checks. See ContainerEntityCountsBatchLoader.
+    if (canServeFromCounts(environment, query, input.getFilters())) {
+      return resolveCountFromLoader(environment, urn, start, count);
+    }
+
+    return resolveDirect(context, urn, input, query, start, count);
+  }
+
+  private static boolean canServeFromCounts(
+      final DataFetchingEnvironment environment,
+      final String query,
+      @Nullable final List<FacetFilterInput> filters) {
+    // The batched loader forces query "*" and applies no facet filters, so anything relying on a
+    // real query or filters must take the direct path to preserve exact behavior. `count` is not
+    // consulted: the gate below already establishes that no hits are read, and `total` is
+    // independent of paging.
+    if (!DEFAULT_QUERY.equals(query) || (filters != null && !filters.isEmpty())) {
+      return false;
+    }
+    return isCountOnlySelection(environment);
+  }
+
+  /**
+   * True when the caller reads nothing but the total. Uses the flattened selection set so fragment
+   * spreads are resolved, and treats an empty selection as ineligible rather than as trivially
+   * count-only.
+   */
+  private static boolean isCountOnlySelection(final DataFetchingEnvironment environment) {
+    final DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
+    if (selectionSet == null) {
+      return false;
+    }
+    final List<SelectedField> fields = selectionSet.getImmediateFields();
+    return !fields.isEmpty()
+        && fields.stream().allMatch(field -> COUNT_ONLY_FIELDS.contains(field.getName()));
+  }
+
+  private CompletableFuture<SearchResults> resolveCountFromLoader(
+      final DataFetchingEnvironment environment,
+      final String containerUrn,
+      final int start,
+      final int count) {
+    final DataLoader<String, Long> loader =
+        environment.getDataLoader(ContainerEntityCountsBatchLoader.LOADER_NAME);
+    return loader.load(containerUrn).thenApply(total -> toCountOnlyResults(total, start, count));
+  }
+
+  private static SearchResults toCountOnlyResults(
+      final Long total, final int start, final int count) {
+    final SearchResults results = new SearchResults();
+    results.setStart(start);
+    results.setCount(count);
+    results.setTotal(total != null ? total.intValue() : 0);
+    results.setSearchResults(Collections.emptyList());
+    return results;
+  }
+
+  /** The original, unbatched behavior: one search per invocation. */
+  private CompletableFuture<SearchResults> resolveDirect(
+      final QueryContext context,
+      final String urn,
+      final ContainerEntitiesInput input,
+      final String query,
+      final int start,
+      final int count) {
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           try {
 
+            final CriterionArray criteria = new CriterionArray();
             final Criterion filterCriterion =
                 buildCriterion(CONTAINER_FIELD_NAME + ".keyword", Condition.EQUAL, urn);
+            criteria.add(filterCriterion);
+            if (input.getFilters() != null) {
+              input.getFilters().forEach(filter -> criteria.add(criterionFromFilter(filter)));
+            }
 
             return UrnSearchResultsMapper.map(
                 context,
@@ -86,9 +172,7 @@ public class ContainerEntitiesResolver implements DataFetcher<CompletableFuture<
                     new Filter()
                         .setOr(
                             new ConjunctiveCriterionArray(
-                                new ConjunctiveCriterion()
-                                    .setAnd(
-                                        new CriterionArray(ImmutableList.of(filterCriterion))))),
+                                new ConjunctiveCriterion().setAnd(criteria))),
                     start,
                     count,
                     Collections.emptyList()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolver.java
@@ -13,6 +13,7 @@ import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
 import com.linkedin.datahub.graphql.loaders.ContainerEntityCountsBatchLoader;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
+import com.linkedin.datahub.graphql.util.SelectionSetUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.Condition;
@@ -23,8 +24,6 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -109,18 +108,16 @@ public class ContainerEntitiesResolver implements DataFetcher<CompletableFuture<
   }
 
   /**
-   * True when the caller reads nothing but the total. Uses the flattened selection set so fragment
-   * spreads are resolved, and treats an empty selection as ineligible rather than as trivially
-   * count-only.
+   * True when the caller reads nothing but the total.
+   *
+   * <p>Read from the query AST rather than {@code environment.getSelectionSet()}, which would
+   * normalize the whole operation and can trip graphql-java's 100k field cap on the production
+   * search query — see {@link SelectionSetUtils}. The check over-approximates what is selected,
+   * which errs toward the direct path; that is the safe direction, since under-approximating would
+   * serve counts to a caller that asked for hits.
    */
   private static boolean isCountOnlySelection(final DataFetchingEnvironment environment) {
-    final DataFetchingFieldSelectionSet selectionSet = environment.getSelectionSet();
-    if (selectionSet == null) {
-      return false;
-    }
-    final List<SelectedField> fields = selectionSet.getImmediateFields();
-    return !fields.isEmpty()
-        && fields.stream().allMatch(field -> COUNT_ONLY_FIELDS.contains(field.getName()));
+    return SelectionSetUtils.selectsOnly(environment, COUNT_ONLY_FIELDS);
   }
 
   private CompletableFuture<SearchResults> resolveCountFromLoader(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/util/SelectionSetUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/util/SelectionSetUtils.java
@@ -41,10 +41,7 @@ public class SelectionSetUtils {
   public static Set<String> selectedSubFieldNames(
       @Nonnull final DataFetchingEnvironment environment) {
     final Set<String> names = new HashSet<>();
-    final Map<String, FragmentDefinition> fragments = environment.getFragmentsByName();
-    for (Field field : environment.getMergedField().getFields()) {
-      collectFieldNames(field.getSelectionSet(), fragments, names);
-    }
+    walk(environment, names, null);
     return names;
   }
 
@@ -52,31 +49,74 @@ public class SelectionSetUtils {
    * True when the caller selected at least one sub-field and every selected sub-field is in {@code
    * allowed}. An empty selection is treated as ineligible rather than as trivially satisfying the
    * constraint.
+   *
+   * <p>Stops at the first sub-field outside {@code allowed} rather than collecting the whole
+   * selection, since the answer cannot change after that.
    */
   public static boolean selectsOnly(
       @Nonnull final DataFetchingEnvironment environment, @Nonnull final Set<String> allowed) {
-    final Set<String> selected = selectedSubFieldNames(environment);
-    return !selected.isEmpty() && allowed.containsAll(selected);
+    final Set<String> selected = new HashSet<>();
+    final boolean foundDisallowed = walk(environment, selected, allowed);
+    return !foundDisallowed && !selected.isEmpty();
   }
 
-  private static void collectFieldNames(
+  /**
+   * @param allowed when non-null, the walk stops as soon as a field outside this set is selected
+   * @return true if the walk stopped early on a disallowed field
+   */
+  private static boolean walk(
+      final DataFetchingEnvironment environment,
+      final Set<String> out,
+      @Nullable final Set<String> allowed) {
+    final Map<String, FragmentDefinition> fragments = environment.getFragmentsByName();
+    // A fragment reached twice contributes nothing new, and re-expanding it makes a document whose
+    // fragments spread each other repeatedly cost 2^depth to walk. Expanding each at most once
+    // keeps this linear in the size of the document (and makes cycles harmless).
+    final Set<String> visitedFragments = new HashSet<>();
+    for (Field field : environment.getMergedField().getFields()) {
+      if (collectFieldNames(field.getSelectionSet(), fragments, visitedFragments, out, allowed)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean collectFieldNames(
       @Nullable final SelectionSet selectionSet,
       final Map<String, FragmentDefinition> fragments,
-      final Set<String> out) {
+      final Set<String> visitedFragments,
+      final Set<String> out,
+      @Nullable final Set<String> allowed) {
     if (selectionSet == null) {
-      return;
+      return false;
     }
     for (Selection<?> selection : selectionSet.getSelections()) {
       if (selection instanceof Field) {
-        out.add(((Field) selection).getName());
+        final String name = ((Field) selection).getName();
+        out.add(name);
+        if (allowed != null && !allowed.contains(name)) {
+          return true;
+        }
       } else if (selection instanceof InlineFragment) {
-        collectFieldNames(((InlineFragment) selection).getSelectionSet(), fragments, out);
+        if (collectFieldNames(
+            ((InlineFragment) selection).getSelectionSet(),
+            fragments,
+            visitedFragments,
+            out,
+            allowed)) {
+          return true;
+        }
       } else if (selection instanceof FragmentSpread) {
-        final FragmentDefinition fragment = fragments.get(((FragmentSpread) selection).getName());
-        if (fragment != null) {
-          collectFieldNames(fragment.getSelectionSet(), fragments, out);
+        final String name = ((FragmentSpread) selection).getName();
+        final FragmentDefinition fragment = fragments.get(name);
+        if (fragment != null
+            && visitedFragments.add(name)
+            && collectFieldNames(
+                fragment.getSelectionSet(), fragments, visitedFragments, out, allowed)) {
+          return true;
         }
       }
     }
+    return false;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/util/SelectionSetUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/util/SelectionSetUtils.java
@@ -1,0 +1,82 @@
+package com.linkedin.datahub.graphql.util;
+
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Reads what a caller selected on the field currently being resolved, straight from the query AST.
+ *
+ * <p>Use this instead of {@code environment.getSelectionSet()} when a resolver only needs to know
+ * which sub-fields were asked for — typically to skip expensive work nobody reads. {@code
+ * getSelectionSet()} normalizes the <b>whole operation</b>, which graphql-java caps at 100k fields
+ * ({@code ExecutableNormalizedOperationFactory}); on a large recursive query that cap aborts the
+ * entire request rather than degrading the one field. Reading the AST is local to the field and
+ * cheap.
+ *
+ * <p><b>These helpers deliberately over-approximate.</b> They ignore {@code @skip}/{@code @include}
+ * and inline-fragment type conditions, so a sub-field present in the document but not actually
+ * resolved still counts as selected. Callers must be safe in that direction: treat the result as
+ * "everything that might be read", and fall back to the complete, always-correct path when in
+ * doubt.
+ */
+public class SelectionSetUtils {
+
+  private SelectionSetUtils() {}
+
+  /**
+   * Names of the immediate sub-fields the caller selected on the field being resolved, resolving
+   * fragment spreads and inline fragments.
+   */
+  @Nonnull
+  public static Set<String> selectedSubFieldNames(
+      @Nonnull final DataFetchingEnvironment environment) {
+    final Set<String> names = new HashSet<>();
+    final Map<String, FragmentDefinition> fragments = environment.getFragmentsByName();
+    for (Field field : environment.getMergedField().getFields()) {
+      collectFieldNames(field.getSelectionSet(), fragments, names);
+    }
+    return names;
+  }
+
+  /**
+   * True when the caller selected at least one sub-field and every selected sub-field is in {@code
+   * allowed}. An empty selection is treated as ineligible rather than as trivially satisfying the
+   * constraint.
+   */
+  public static boolean selectsOnly(
+      @Nonnull final DataFetchingEnvironment environment, @Nonnull final Set<String> allowed) {
+    final Set<String> selected = selectedSubFieldNames(environment);
+    return !selected.isEmpty() && allowed.containsAll(selected);
+  }
+
+  private static void collectFieldNames(
+      @Nullable final SelectionSet selectionSet,
+      final Map<String, FragmentDefinition> fragments,
+      final Set<String> out) {
+    if (selectionSet == null) {
+      return;
+    }
+    for (Selection<?> selection : selectionSet.getSelections()) {
+      if (selection instanceof Field) {
+        out.add(((Field) selection).getName());
+      } else if (selection instanceof InlineFragment) {
+        collectFieldNames(((InlineFragment) selection).getSelectionSet(), fragments, out);
+      } else if (selection instanceof FragmentSpread) {
+        final FragmentDefinition fragment = fragments.get(((FragmentSpread) selection).getName());
+        if (fragment != null) {
+          collectFieldNames(fragment.getSelectionSet(), fragments, out);
+        }
+      }
+    }
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/ContainerEntityCountsBatchLoaderTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/loaders/ContainerEntityCountsBatchLoaderTest.java
@@ -1,0 +1,275 @@
+package com.linkedin.datahub.graphql.loaders;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.testng.Assert.*;
+
+import com.linkedin.data.template.LongMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValueArray;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.dataloader.DataLoader;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ContainerEntityCountsBatchLoaderTest {
+  private static final String SALES = "urn:li:container:sales";
+  private static final String FINANCE = "urn:li:container:finance";
+  private static final String OFF_CHUNK = "urn:li:container:notrequested";
+  private static final String CONTAINER_FACET = "container";
+
+  private EntityClient _entityClient;
+  private QueryContext _context;
+
+  @BeforeMethod
+  public void setup() {
+    _entityClient = Mockito.mock(EntityClient.class);
+    _context = getMockAllowContext();
+  }
+
+  /** A search result carrying a {@code container} facet keyed by container urn. */
+  private static SearchResult resultWithContainerCounts(Map<String, Long> countsByContainerUrn) {
+    final AggregationMetadata agg =
+        new AggregationMetadata()
+            .setName(CONTAINER_FACET)
+            .setAggregations(new LongMap(countsByContainerUrn))
+            .setFilterValues(new FilterValueArray());
+    return new SearchResult()
+        .setEntities(new SearchEntityArray())
+        .setNumEntities(0)
+        .setFrom(0)
+        .setPageSize(0)
+        .setMetadata(new SearchResultMetadata().setAggregations(new AggregationMetadataArray(agg)));
+  }
+
+  private void stubSearch(SearchResult result) throws Exception {
+    Mockito.when(
+            _entityClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any(),
+                any()))
+        .thenReturn(result);
+  }
+
+  private void verifySearchCount(int times) throws Exception {
+    Mockito.verify(_entityClient, Mockito.times(times))
+        .searchAcrossEntities(
+            any(),
+            any(),
+            any(),
+            nullable(Filter.class),
+            anyInt(),
+            nullable(Integer.class),
+            any(),
+            any());
+  }
+
+  @Test
+  public void testCountsDistributedByContainerUrn() throws Exception {
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 18L, FINANCE, 5L)));
+
+    final List<Long> results =
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of(SALES, FINANCE), _context, _entityClient);
+
+    assertEquals(results, List.of(18L, 5L));
+    // One chunk covers the whole page of containers, so one aggregation answers all of them.
+    verifySearchCount(1);
+  }
+
+  @Test
+  public void testResultsInKeyOrderWithAbsentContainerZeroed() throws Exception {
+    // FINANCE has no matching assets, so the facet omits it entirely.
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 3L)));
+
+    final List<Long> results =
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of(FINANCE, SALES), _context, _entityClient);
+
+    assertEquals(results, List.of(0L, 3L));
+  }
+
+  @Test
+  public void testDuplicateKeysShareOneLookupAndBothResolve() throws Exception {
+    // The same container can appear many times in one response (e.g. repeated across lineage
+    // paths). It must be queried once but answered at every key position.
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 7L)));
+
+    final List<Long> results =
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of(SALES, SALES, SALES), _context, _entityClient);
+
+    assertEquals(results, List.of(7L, 7L, 7L));
+    verifySearchCount(1);
+  }
+
+  @Test
+  public void testOffChunkContainersIgnored() throws Exception {
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 4L, OFF_CHUNK, 99L)));
+
+    final List<Long> results =
+        ContainerEntityCountsBatchLoader.batchLoad(List.of(SALES), _context, _entityClient);
+
+    assertEquals(results, List.of(4L));
+  }
+
+  @Test
+  public void testSearchFailurePropagatesInsteadOfYieldingZero() throws Exception {
+    // A backend search failure must surface as an error, not a fabricated 0 that reads as an empty
+    // container and would silently mask a search outage behind wrong UI counts. The cause is
+    // preserved so the underlying failure remains diagnosable.
+    Mockito.when(
+            _entityClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any(),
+                any()))
+        .thenThrow(new RuntimeException("search is down"));
+
+    final RuntimeException thrown =
+        expectThrows(
+            RuntimeException.class,
+            () ->
+                ContainerEntityCountsBatchLoader.batchLoad(
+                    List.of(SALES, FINANCE), _context, _entityClient));
+
+    assertNotNull(thrown.getCause());
+  }
+
+  @Test
+  public void testLargeFanOutIsChunkedAcrossMultipleSearches() throws Exception {
+    stubSearch(resultWithContainerCounts(Map.of()));
+
+    final List<String> keys = new ArrayList<>();
+    for (int i = 0; i < 60; i++) {
+      keys.add("urn:li:container:c" + i);
+    }
+
+    final List<Long> results =
+        ContainerEntityCountsBatchLoader.batchLoad(keys, _context, _entityClient);
+
+    assertEquals(results.size(), 60);
+    // 60 containers at 25 per aggregation → 3 searches: a constant factor, not 60.
+    verifySearchCount(3);
+  }
+
+  @Test
+  public void testCreatedDataLoaderResolvesThroughBatchFunction() throws Exception {
+    // Exercises create() — the path GmsGraphQLEngine actually registers — rather than calling
+    // batchLoad directly, so the DataLoader wiring and context provider are covered too.
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 9L, FINANCE, 2L)));
+
+    final DataLoader<String, Long> loader =
+        ContainerEntityCountsBatchLoader.create(_entityClient, _context);
+    final CompletableFuture<Long> sales = loader.load(SALES);
+    final CompletableFuture<Long> finance = loader.load(FINANCE);
+    loader.dispatch();
+
+    assertEquals(sales.get(30, TimeUnit.SECONDS), Long.valueOf(9L));
+    assertEquals(finance.get(30, TimeUnit.SECONDS), Long.valueOf(2L));
+    // Both keys coalesced into a single batch, hence a single aggregation.
+    verifySearchCount(1);
+  }
+
+  @Test
+  public void testNullSearchResultYieldsZeros() throws Exception {
+    // Defensive: a null result from the search layer must not NPE.
+    stubSearch(null);
+
+    assertEquals(
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of(SALES, FINANCE), _context, _entityClient),
+        List.of(0L, 0L));
+  }
+
+  @Test
+  public void testUnrelatedFacetIsIgnoredWhileContainerFacetIsCounted() throws Exception {
+    // A same-named bucket on a different facet must not leak into container counts. Asserting
+    // FINANCE's real count alongside proves the unrelated facet was skipped rather than the
+    // whole aggregation block being discarded.
+    final AggregationMetadata unrelated =
+        new AggregationMetadata()
+            .setName("platform")
+            .setAggregations(new LongMap(Map.of(SALES, 77L)))
+            .setFilterValues(new FilterValueArray());
+    final AggregationMetadata containers =
+        new AggregationMetadata()
+            .setName(CONTAINER_FACET)
+            .setAggregations(new LongMap(Map.of(FINANCE, 3L)))
+            .setFilterValues(new FilterValueArray());
+    stubSearch(
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(
+                new SearchResultMetadata()
+                    .setAggregations(new AggregationMetadataArray(unrelated, containers))));
+
+    // SALES appears only under the platform facet, so it must stay 0.
+    assertEquals(
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of(SALES, FINANCE), _context, _entityClient),
+        List.of(0L, 3L));
+  }
+
+  @Test
+  public void testMalformedContainerFacetPropagates() throws Exception {
+    // `aggregations` is a required PDL field, so omitting it makes the getter throw. Like a search
+    // failure, that must surface rather than being reported as a count of zero.
+    final AggregationMetadata empty =
+        new AggregationMetadata().setName(CONTAINER_FACET).setFilterValues(new FilterValueArray());
+    stubSearch(
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(
+                new SearchResultMetadata().setAggregations(new AggregationMetadataArray(empty))));
+
+    assertNotNull(
+        expectThrows(
+                RuntimeException.class,
+                () ->
+                    ContainerEntityCountsBatchLoader.batchLoad(
+                        List.of(SALES), _context, _entityClient))
+            .getCause());
+  }
+
+  @Test
+  public void testMalformedUrnKeyIsSkippedWithoutFailingTheBatch() throws Exception {
+    // A malformed key must be dropped from the filter and answered as zero, while its
+    // well-formed neighbours still resolve.
+    stubSearch(resultWithContainerCounts(Map.of(SALES, 4L)));
+
+    assertEquals(
+        ContainerEntityCountsBatchLoader.batchLoad(
+            List.of("not-a-urn", SALES), _context, _entityClient),
+        List.of(0L, 4L));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolverTest.java
@@ -2,6 +2,8 @@ package com.linkedin.datahub.graphql.resolvers.container;
 
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
@@ -12,6 +14,8 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Container;
 import com.linkedin.datahub.graphql.generated.ContainerEntitiesInput;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.loaders.ContainerEntityCountsBatchLoader;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
@@ -25,8 +29,17 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingFieldSelectionSet;
+import graphql.schema.SelectedField;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import org.dataloader.DataLoader;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -34,14 +47,14 @@ public class ContainerEntitiesResolverTest {
 
   private static final ContainerEntitiesInput TEST_INPUT =
       new ContainerEntitiesInput(null, 0, 20, Collections.emptyList());
+  private static final String CONTAINER_URN = "urn:li:container:test-container";
 
   @Test
   public void testGetSuccess() throws Exception {
-    // Create resolver
     EntityClient mockClient = mock(EntityClient.class);
 
     final String childUrn = "urn:li:dataset:(test,test,test)";
-    final String containerUrn = "urn:li:container:test-container";
+    final String containerUrn = CONTAINER_URN;
 
     final Criterion filterCriterion =
         buildCriterion("container.keyword", Condition.EQUAL, containerUrn);
@@ -75,7 +88,6 @@ public class ContainerEntitiesResolverTest {
 
     ContainerEntitiesResolver resolver = new ContainerEntitiesResolver(mockClient);
 
-    // Execute resolver
     QueryContext mockContext = mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(mock(Authentication.class));
     Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
@@ -87,12 +99,237 @@ public class ContainerEntitiesResolverTest {
     parentContainer.setUrn(containerUrn);
     Mockito.when(mockEnv.getSource()).thenReturn(parentContainer);
 
-    // Data Assertions
     assertEquals((int) resolver.get(mockEnv).get().getStart(), 0);
     assertEquals((int) resolver.get(mockEnv).get().getCount(), 1);
     assertEquals((int) resolver.get(mockEnv).get().getTotal(), 1);
     assertEquals(resolver.get(mockEnv).get().getSearchResults().size(), 1);
     assertEquals(
         resolver.get(mockEnv).get().getSearchResults().get(0).getEntity().getUrn(), childUrn);
+  }
+
+  @Test
+  public void testFiltersAreAppliedToSearch() throws Exception {
+    // Facet filters from the input must be ANDed onto the container criterion rather than dropped.
+    EntityClient mockClient = mock(EntityClient.class);
+    stubEmptySearch(mockClient);
+
+    final FacetFilterInput typeFilter = new FacetFilterInput();
+    typeFilter.setField("_entityType");
+    typeFilter.setValues(ImmutableList.of("DATASET"));
+
+    QueryContext mockContext = mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(mock(Authentication.class));
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input")))
+        .thenReturn(new ContainerEntitiesInput(null, 0, 20, ImmutableList.of(typeFilter)));
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Container parentContainer = new Container();
+    parentContainer.setUrn(CONTAINER_URN);
+    Mockito.when(mockEnv.getSource()).thenReturn(parentContainer);
+
+    new ContainerEntitiesResolver(mockClient).get(mockEnv).get();
+
+    final ArgumentCaptor<Filter> captor = ArgumentCaptor.forClass(Filter.class);
+    Mockito.verify(mockClient)
+        .searchAcrossEntities(
+            any(), any(), any(), captor.capture(), anyInt(), nullable(Integer.class), any());
+
+    final CriterionArray criteria = captor.getValue().getOr().get(0).getAnd();
+    assertEquals(criteria.size(), 2);
+    assertEquals(criteria.get(0).getField(), "container.keyword");
+    assertTrue(criteria.get(0).getValues().contains(CONTAINER_URN));
+    assertEquals(criteria.get(1).getField(), "_entityType");
+    assertTrue(criteria.get(1).getValues().contains("DATASET"));
+  }
+
+  @Test
+  public void testCountOnlySelectionServedFromBatchedLoader() throws Exception {
+    // The search-result fragment shape: `entities(input: {}) { total }`. count falls back to 20,
+    // but no hits are selected, so this must not issue a search.
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv =
+        mockEnv(new ContainerEntitiesInput(null, null, null, null), mockCountLoader(42L), "total");
+
+    ContainerEntitiesResolver resolver = new ContainerEntitiesResolver(mockClient);
+
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 42);
+    assertTrue(resolver.get(mockEnv).get().getSearchResults().isEmpty());
+    verifySearchCount(mockClient, 0);
+  }
+
+  @Test
+  public void testCountOnlySelectionWithNonZeroCountStillBatched() throws Exception {
+    // The container profile shape: `entities(input: { start: 0, count: 1 }) { total }`. `total` is
+    // independent of paging, so a non-zero count must not disqualify the fast path.
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv =
+        mockEnv(new ContainerEntitiesInput(null, 0, 1, null), mockCountLoader(7L), "total");
+
+    ContainerEntitiesResolver resolver = new ContainerEntitiesResolver(mockClient);
+
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 7);
+    verifySearchCount(mockClient, 0);
+  }
+
+  @Test
+  public void testHitSelectionFallsBackToDirectSearch() throws Exception {
+    // Selecting searchResults means hits are actually read — the aggregation cannot serve it.
+    EntityClient mockClient = mock(EntityClient.class);
+    stubEmptySearch(mockClient);
+    DataFetchingEnvironment mockEnv =
+        mockEnv(TEST_INPUT, mockCountLoader(42L), "total", "searchResults");
+
+    new ContainerEntitiesResolver(mockClient).get(mockEnv).get();
+
+    verifySearchCount(mockClient, 1);
+  }
+
+  @Test
+  public void testFiltersFallBackToDirectSearch() throws Exception {
+    // The loader applies no facet filters, so a filtered request must take the direct path.
+    EntityClient mockClient = mock(EntityClient.class);
+    stubEmptySearch(mockClient);
+    final FacetFilterInput filter = new FacetFilterInput();
+    filter.setField("_entityType");
+    filter.setValues(ImmutableList.of("DATASET"));
+    DataFetchingEnvironment mockEnv =
+        mockEnv(
+            new ContainerEntitiesInput(null, 0, 20, ImmutableList.of(filter)),
+            mockCountLoader(42L),
+            "total");
+
+    new ContainerEntitiesResolver(mockClient).get(mockEnv).get();
+
+    verifySearchCount(mockClient, 1);
+  }
+
+  @Test
+  public void testNonDefaultQueryFallsBackToDirectSearch() throws Exception {
+    // The loader forces query "*", so a real query must take the direct path.
+    EntityClient mockClient = mock(EntityClient.class);
+    stubEmptySearch(mockClient);
+    DataFetchingEnvironment mockEnv =
+        mockEnv(new ContainerEntitiesInput("sales", 0, 20, null), mockCountLoader(42L), "total");
+
+    new ContainerEntitiesResolver(mockClient).get(mockEnv).get();
+
+    verifySearchCount(mockClient, 1);
+  }
+
+  @Test
+  public void testMissingInputArgumentFallsBackToDefaults() throws Exception {
+    // `entities` with no argument at all must use DEFAULT_ENTITIES_INPUT (query "*", count 20).
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = mockEnv(null, mockCountLoader(11L), "total");
+
+    assertEquals((int) new ContainerEntitiesResolver(mockClient).get(mockEnv).get().getTotal(), 11);
+    verifySearchCount(mockClient, 0);
+  }
+
+  @Test
+  public void testNullLoaderResultYieldsZeroTotal() throws Exception {
+    // A failed aggregation surfaces as a null count; the resolver must report 0, not NPE.
+    EntityClient mockClient = mock(EntityClient.class);
+    @SuppressWarnings("unchecked")
+    final DataLoader<String, Long> loader = mock(DataLoader.class);
+    Mockito.when(loader.load(Mockito.anyString()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    DataFetchingEnvironment mockEnv =
+        mockEnv(new ContainerEntitiesInput(null, 0, 0, null), loader, "total");
+
+    assertEquals((int) new ContainerEntitiesResolver(mockClient).get(mockEnv).get().getTotal(), 0);
+  }
+
+  @Test
+  public void testDirectSearchFailureIsWrapped() throws Exception {
+    // The direct path must not leak the raw client exception.
+    EntityClient mockClient = mock(EntityClient.class);
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any()))
+        .thenThrow(new RuntimeException("search is down"));
+    DataFetchingEnvironment mockEnv =
+        mockEnv(TEST_INPUT, mockCountLoader(1L), "total", "searchResults");
+
+    final ExecutionException e =
+        expectThrows(
+            ExecutionException.class,
+            () -> new ContainerEntitiesResolver(mockClient).get(mockEnv).get());
+    assertTrue(e.getCause().getMessage().contains(CONTAINER_URN));
+  }
+
+  private static DataLoader<String, Long> mockCountLoader(final long total) {
+    @SuppressWarnings("unchecked")
+    final DataLoader<String, Long> loader = mock(DataLoader.class);
+    Mockito.when(loader.load(Mockito.anyString()))
+        .thenReturn(CompletableFuture.completedFuture(total));
+    return loader;
+  }
+
+  private static DataFetchingEnvironment mockEnv(
+      final ContainerEntitiesInput input,
+      final DataLoader<String, Long> loader,
+      final String... selectedFields) {
+    QueryContext mockContext = mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(mock(Authentication.class));
+    Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
+
+    final List<SelectedField> fields =
+        Arrays.stream(selectedFields)
+            .map(
+                name -> {
+                  final SelectedField field = mock(SelectedField.class);
+                  Mockito.when(field.getName()).thenReturn(name);
+                  return field;
+                })
+            .collect(Collectors.toList());
+    DataFetchingFieldSelectionSet selectionSet = mock(DataFetchingFieldSelectionSet.class);
+    Mockito.when(selectionSet.getImmediateFields()).thenReturn(fields);
+
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
+    Mockito.when(mockEnv.<String, Long>getDataLoader(ContainerEntityCountsBatchLoader.LOADER_NAME))
+        .thenReturn(loader);
+
+    Container parentContainer = new Container();
+    parentContainer.setUrn(CONTAINER_URN);
+    Mockito.when(mockEnv.getSource()).thenReturn(parentContainer);
+    return mockEnv;
+  }
+
+  private static void stubEmptySearch(final EntityClient mockClient) throws Exception {
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                any(),
+                any(),
+                nullable(Filter.class),
+                anyInt(),
+                nullable(Integer.class),
+                any()))
+        .thenReturn(
+            new SearchResult()
+                .setFrom(0)
+                .setPageSize(0)
+                .setNumEntities(0)
+                .setEntities(new SearchEntityArray())
+                .setMetadata(
+                    new SearchResultMetadata().setAggregations(new AggregationMetadataArray())));
+  }
+
+  private static void verifySearchCount(final EntityClient mockClient, final int times)
+      throws Exception {
+    Mockito.verify(mockClient, Mockito.times(times))
+        .searchAcrossEntities(
+            any(), any(), any(), nullable(Filter.class), anyInt(), nullable(Integer.class), any());
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ContainerEntitiesResolverTest.java
@@ -28,16 +28,19 @@ import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
+import graphql.execution.MergedField;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.DataFetchingFieldSelectionSet;
-import graphql.schema.SelectedField;
 import io.datahubproject.metadata.context.OperationContext;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 import org.dataloader.DataLoader;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -94,6 +97,9 @@ public class ContainerEntitiesResolverTest {
     DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getMergedField())
+        .thenReturn(mergedEntitiesField("total", "searchResults"));
+    Mockito.when(mockEnv.getFragmentsByName()).thenReturn(Collections.emptyMap());
 
     Container parentContainer = new Container();
     parentContainer.setUrn(containerUrn);
@@ -169,6 +175,29 @@ public class ContainerEntitiesResolverTest {
     ContainerEntitiesResolver resolver = new ContainerEntitiesResolver(mockClient);
 
     assertEquals((int) resolver.get(mockEnv).get().getTotal(), 7);
+    verifySearchCount(mockClient, 0);
+  }
+
+  @Test
+  public void testFragmentSpreadSelectingOnlyTotalIsBatched() throws Exception {
+    // The production query reaches this field through a fragment, so the walk must resolve spreads
+    // rather than treat them as an unrecognized selection.
+    EntityClient mockClient = mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv =
+        mockEnvWithSelections(
+            mockCountLoader(11L),
+            Collections.singletonList(new FragmentSpread("counts")),
+            Collections.singletonMap(
+                "counts",
+                FragmentDefinition.newFragmentDefinition()
+                    .name("counts")
+                    .selectionSet(
+                        SelectionSet.newSelectionSet()
+                            .selection(Field.newField("total").build())
+                            .build())
+                    .build()));
+
+    assertEquals((int) new ContainerEntitiesResolver(mockClient).get(mockEnv).get().getTotal(), 11);
     verifySearchCount(mockClient, 0);
   }
 
@@ -281,28 +310,57 @@ public class ContainerEntitiesResolverTest {
     Mockito.when(mockContext.getAuthentication()).thenReturn(mock(Authentication.class));
     Mockito.when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
 
-    final List<SelectedField> fields =
-        Arrays.stream(selectedFields)
-            .map(
-                name -> {
-                  final SelectedField field = mock(SelectedField.class);
-                  Mockito.when(field.getName()).thenReturn(name);
-                  return field;
-                })
-            .collect(Collectors.toList());
-    DataFetchingFieldSelectionSet selectionSet = mock(DataFetchingFieldSelectionSet.class);
-    Mockito.when(selectionSet.getImmediateFields()).thenReturn(fields);
-
     DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
-    Mockito.when(mockEnv.getSelectionSet()).thenReturn(selectionSet);
+    Mockito.when(mockEnv.getMergedField()).thenReturn(mergedEntitiesField(selectedFields));
+    Mockito.when(mockEnv.getFragmentsByName()).thenReturn(Collections.emptyMap());
     Mockito.when(mockEnv.<String, Long>getDataLoader(ContainerEntityCountsBatchLoader.LOADER_NAME))
         .thenReturn(loader);
 
     Container parentContainer = new Container();
     parentContainer.setUrn(CONTAINER_URN);
     Mockito.when(mockEnv.getSource()).thenReturn(parentContainer);
+    return mockEnv;
+  }
+
+  /**
+   * Builds a real query AST for {@code entities { <selectedFields> }} so the resolver reads the
+   * selection the same way it does at runtime, exercising the actual code path rather than a mocked
+   * selection set.
+   */
+  private static MergedField mergedEntitiesField(final String... selectedFields) {
+    final SelectionSet.Builder selectionSet = SelectionSet.newSelectionSet();
+    for (String name : selectedFields) {
+      selectionSet.selection(Field.newField(name).build());
+    }
+    return MergedField.newMergedField(
+            Field.newField("entities").selectionSet(selectionSet.build()).build())
+        .build();
+  }
+
+  /** Variant of {@link #mockEnv} taking arbitrary AST selections rather than plain field names. */
+  private static DataFetchingEnvironment mockEnvWithSelections(
+      final DataLoader<String, Long> loader,
+      final List<? extends Selection<?>> selections,
+      final Map<String, FragmentDefinition> fragments) {
+    final SelectionSet.Builder selectionSet = SelectionSet.newSelectionSet();
+    selections.forEach(selectionSet::selection);
+    final MergedField mergedField =
+        MergedField.newMergedField(
+                Field.newField("entities").selectionSet(selectionSet.build()).build())
+            .build();
+    return mockEnvWithMergedField(loader, mergedField, fragments);
+  }
+
+  private static DataFetchingEnvironment mockEnvWithMergedField(
+      final DataLoader<String, Long> loader,
+      final MergedField mergedField,
+      final Map<String, FragmentDefinition> fragments) {
+    final DataFetchingEnvironment mockEnv =
+        mockEnv(new ContainerEntitiesInput(null, null, null, null), loader);
+    Mockito.when(mockEnv.getMergedField()).thenReturn(mergedField);
+    Mockito.when(mockEnv.getFragmentsByName()).thenReturn(fragments);
     return mockEnv;
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/util/SelectionSetUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/util/SelectionSetUtilsTest.java
@@ -1,0 +1,162 @@
+package com.linkedin.datahub.graphql.util;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import graphql.execution.MergedField;
+import graphql.language.Argument;
+import graphql.language.BooleanValue;
+import graphql.language.Directive;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.InlineFragment;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class SelectionSetUtilsTest {
+
+  @Test
+  public void testPlainFieldsAreCollected() {
+    final DataFetchingEnvironment env =
+        env(ImmutableList.of(field("total"), field("__typename")), Collections.emptyMap());
+
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "__typename"));
+  }
+
+  @Test
+  public void testFragmentSpreadsAreResolvedRecursively() {
+    // The production query reaches most fields through nested fragments, so a spread inside a
+    // spread must still surface the leaf field names.
+    final Map<String, FragmentDefinition> fragments =
+        ImmutableMap.of(
+            "outer", fragment("outer", ImmutableList.of(new FragmentSpread("inner"))),
+            "inner", fragment("inner", ImmutableList.of(field("searchResults"))));
+    final DataFetchingEnvironment env =
+        env(ImmutableList.of(field("total"), new FragmentSpread("outer")), fragments);
+
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+  }
+
+  @Test
+  public void testUnknownFragmentSpreadIsIgnored() {
+    final DataFetchingEnvironment env =
+        env(
+            ImmutableList.of(field("total"), new FragmentSpread("missing")),
+            Collections.emptyMap());
+
+    assertEquals(SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total"));
+  }
+
+  @Test
+  public void testInlineFragmentsAreTraversed() {
+    final DataFetchingEnvironment env =
+        env(
+            ImmutableList.of(
+                field("total"),
+                InlineFragment.newInlineFragment()
+                    .selectionSet(selectionSet(ImmutableList.of(field("searchResults"))))
+                    .build()),
+            Collections.emptyMap());
+
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+  }
+
+  @Test
+  public void testAllMergedFieldsAreInspected() {
+    // The same field selected twice merges into one MergedField; reading only the first would miss
+    // what the second asked for.
+    final Field countOnly =
+        Field.newField("entities")
+            .selectionSet(selectionSet(ImmutableList.of(field("total"))))
+            .build();
+    final Field withHits =
+        Field.newField("entities")
+            .selectionSet(selectionSet(ImmutableList.of(field("searchResults"))))
+            .build();
+    final DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+    Mockito.when(env.getMergedField())
+        .thenReturn(MergedField.newMergedField(ImmutableList.of(countOnly, withHits)).build());
+    Mockito.when(env.getFragmentsByName()).thenReturn(Collections.emptyMap());
+
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+  }
+
+  @Test
+  public void testSkipDirectiveIsIgnored() {
+    // Documented over-approximation: a sub-field that will be skipped at runtime still counts as
+    // selected, so callers fall back to their complete path rather than skipping work wrongly.
+    final Field skipped =
+        Field.newField("searchResults")
+            .directives(
+                Collections.singletonList(
+                    Directive.newDirective()
+                        .name("skip")
+                        .argument(
+                            Argument.newArgument("if", BooleanValue.newBooleanValue(true).build())
+                                .build())
+                        .build()))
+            .build();
+    final DataFetchingEnvironment env =
+        env(ImmutableList.of(field("total"), skipped), Collections.emptyMap());
+
+    assertTrue(SelectionSetUtils.selectedSubFieldNames(env).contains("searchResults"));
+    assertFalse(SelectionSetUtils.selectsOnly(env, ImmutableSet.of("total")));
+  }
+
+  @Test
+  public void testSelectsOnly() {
+    final DataFetchingEnvironment subset =
+        env(ImmutableList.of(field("total")), Collections.emptyMap());
+    assertTrue(SelectionSetUtils.selectsOnly(subset, ImmutableSet.of("total", "__typename")));
+
+    final DataFetchingEnvironment superset =
+        env(ImmutableList.of(field("total"), field("searchResults")), Collections.emptyMap());
+    assertFalse(SelectionSetUtils.selectsOnly(superset, ImmutableSet.of("total", "__typename")));
+
+    // An empty selection is ineligible rather than trivially satisfying the constraint.
+    final DataFetchingEnvironment empty = env(Collections.emptyList(), Collections.emptyMap());
+    assertFalse(SelectionSetUtils.selectsOnly(empty, ImmutableSet.of("total", "__typename")));
+  }
+
+  private static Field field(final String name) {
+    return Field.newField(name).build();
+  }
+
+  private static SelectionSet selectionSet(final List<? extends Selection<?>> selections) {
+    final SelectionSet.Builder builder = SelectionSet.newSelectionSet();
+    selections.forEach(builder::selection);
+    return builder.build();
+  }
+
+  private static FragmentDefinition fragment(
+      final String name, final List<? extends Selection<?>> selections) {
+    return FragmentDefinition.newFragmentDefinition()
+        .name(name)
+        .selectionSet(selectionSet(selections))
+        .build();
+  }
+
+  private static DataFetchingEnvironment env(
+      final List<? extends Selection<?>> selections,
+      final Map<String, FragmentDefinition> fragments) {
+    final Field parent = Field.newField("entities").selectionSet(selectionSet(selections)).build();
+    final DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
+    Mockito.when(env.getMergedField()).thenReturn(MergedField.newMergedField(parent).build());
+    Mockito.when(env.getFragmentsByName()).thenReturn(fragments);
+    return env;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/util/SelectionSetUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/util/SelectionSetUtilsTest.java
@@ -18,6 +18,7 @@ import graphql.language.Selection;
 import graphql.language.SelectionSet;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.mockito.Mockito;
@@ -47,6 +48,110 @@ public class SelectionSetUtilsTest {
 
     assertEquals(
         SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+  }
+
+  @Test
+  public void testRepeatedFragmentSpreadsAreExpandedOnce() {
+    // Each fragment spreads the next one twice, so a walk that re-expands every occurrence costs
+    // 2^DEPTH. The document itself is tiny and cycle-free, so it passes validation and reaches the
+    // resolver: without memoisation a request like this pins a thread for minutes. Expanding each
+    // fragment at most once keeps the walk linear, so this returns immediately.
+    final int depth = 30;
+    final Map<String, FragmentDefinition> fragments = new HashMap<>();
+    for (int i = 0; i < depth; i++) {
+      fragments.put(
+          "F" + i,
+          fragment(
+              "F" + i,
+              ImmutableList.of(
+                  new FragmentSpread("F" + (i + 1)), new FragmentSpread("F" + (i + 1)))));
+    }
+    fragments.put("F" + depth, fragment("F" + depth, ImmutableList.of(field("total"))));
+
+    final DataFetchingEnvironment env = env(ImmutableList.of(new FragmentSpread("F0")), fragments);
+
+    assertEquals(SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total"));
+    assertTrue(SelectionSetUtils.selectsOnly(env, ImmutableSet.of("total")));
+  }
+
+  @Test
+  public void testAliasedFieldsUseTheirUnderlyingName() {
+    // The response key is irrelevant; what matters is which field the server must resolve. An
+    // aliased `searchResults` still means hits are being read, so it must disqualify a count-only
+    // caller -- treating the alias as the name would silently serve counts to someone wanting hits.
+    final DataFetchingEnvironment aliasedHits =
+        env(
+            ImmutableList.of(Field.newField("searchResults").alias("count").build()),
+            Collections.emptyMap());
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(aliasedHits), ImmutableSet.of("searchResults"));
+    assertFalse(SelectionSetUtils.selectsOnly(aliasedHits, ImmutableSet.of("total")));
+
+    final DataFetchingEnvironment aliasedTotal =
+        env(
+            ImmutableList.of(Field.newField("total").alias("searchResults").build()),
+            Collections.emptyMap());
+    assertTrue(SelectionSetUtils.selectsOnly(aliasedTotal, ImmutableSet.of("total")));
+  }
+
+  @Test
+  public void testNestedFieldSelectionsAreNotCollected() {
+    // Only the immediate sub-fields matter. Descending into `searchResults { entity { urn } }`
+    // would surface `entity`/`urn` as if the caller had selected them at this level, which would
+    // disqualify every caller and defeat the point of the check.
+    final Field hitsWithSubSelection =
+        Field.newField("searchResults")
+            .selectionSet(
+                selectionSet(
+                    ImmutableList.of(
+                        Field.newField("entity")
+                            .selectionSet(selectionSet(ImmutableList.of(field("urn"))))
+                            .build())))
+            .build();
+    final DataFetchingEnvironment env =
+        env(ImmutableList.of(field("total"), hitsWithSubSelection), Collections.emptyMap());
+
+    assertEquals(
+        SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+  }
+
+  @Test
+  public void testDisallowedFieldIsFoundThroughFragments() {
+    // The early exit has to propagate back up through both recursive branches. If it were dropped,
+    // selectsOnly would wrongly report a count-only selection for a caller reading hits.
+    final DataFetchingEnvironment throughSpread =
+        env(
+            ImmutableList.of(field("total"), new FragmentSpread("outer")),
+            ImmutableMap.of(
+                "outer", fragment("outer", ImmutableList.of(new FragmentSpread("inner"))),
+                "inner", fragment("inner", ImmutableList.of(field("searchResults")))));
+    assertFalse(SelectionSetUtils.selectsOnly(throughSpread, ImmutableSet.of("total")));
+
+    final DataFetchingEnvironment throughInlineFragment =
+        env(
+            ImmutableList.of(
+                field("total"),
+                InlineFragment.newInlineFragment()
+                    .selectionSet(selectionSet(ImmutableList.of(field("searchResults"))))
+                    .build()),
+            Collections.emptyMap());
+    assertFalse(SelectionSetUtils.selectsOnly(throughInlineFragment, ImmutableSet.of("total")));
+  }
+
+  @Test
+  public void testCyclicFragmentsTerminate() {
+    // graphql-java rejects fragment cycles before execution, so this should be unreachable in
+    // practice -- but expanding each fragment once makes the walk terminate anyway rather than
+    // recursing until the stack dies.
+    final DataFetchingEnvironment env =
+        env(
+            ImmutableList.of(new FragmentSpread("a")),
+            ImmutableMap.of(
+                "a", fragment("a", ImmutableList.of(field("total"), new FragmentSpread("b"))),
+                "b", fragment("b", ImmutableList.of(new FragmentSpread("a")))));
+
+    assertEquals(SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total"));
+    assertTrue(SelectionSetUtils.selectsOnly(env, ImmutableSet.of("total")));
   }
 
   @Test
@@ -93,6 +198,9 @@ public class SelectionSetUtilsTest {
 
     assertEquals(
         SelectionSetUtils.selectedSubFieldNames(env), ImmutableSet.of("total", "searchResults"));
+    // The disallowed field is only in the second merged field, so the loop over merged fields must
+    // keep going rather than answering from the first one alone.
+    assertFalse(SelectionSetUtils.selectsOnly(env, ImmutableSet.of("total")));
   }
 
   @Test
@@ -115,6 +223,24 @@ public class SelectionSetUtilsTest {
 
     assertTrue(SelectionSetUtils.selectedSubFieldNames(env).contains("searchResults"));
     assertFalse(SelectionSetUtils.selectsOnly(env, ImmutableSet.of("total")));
+
+    // Same for a directive on the spread itself, which is a separate branch of the walk.
+    final DataFetchingEnvironment skippedSpread =
+        env(
+            ImmutableList.of(
+                field("total"),
+                FragmentSpread.newFragmentSpread("hits")
+                    .directives(Collections.singletonList(skipIfTrue()))
+                    .build()),
+            ImmutableMap.of("hits", fragment("hits", ImmutableList.of(field("searchResults")))));
+    assertFalse(SelectionSetUtils.selectsOnly(skippedSpread, ImmutableSet.of("total")));
+  }
+
+  private static Directive skipIfTrue() {
+    return Directive.newDirective()
+        .name("skip")
+        .argument(Argument.newArgument("if", BooleanValue.newBooleanValue(true).build()).build())
+        .build();
   }
 
   @Test

--- a/smoke-test/tests/containers/container_entities_batching_test.py
+++ b/smoke-test/tests/containers/container_entities_batching_test.py
@@ -1,0 +1,260 @@
+import logging
+import os
+import tempfile
+import uuid
+from typing import Any, Dict, List
+
+import pytest
+
+from conftest import _ingest_cleanup_data_impl
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
+from datahub.ingestion.api.sink import NoopWriteCallback
+from datahub.ingestion.sink.file import FileSink, FileSinkConfig
+from datahub.metadata.schema_classes import (
+    ContainerClass,
+    ContainerPropertiesClass,
+    DatasetPropertiesClass,
+)
+from tests.utils import execute_graphql, with_test_retry
+
+logger = logging.getLogger(__name__)
+
+# Unique per run so the containers are freshly seeded and their counts are deterministic
+# regardless of what else is in the instance.
+_RUN_ID = uuid.uuid4().hex[:8]
+
+_PLATFORM = "snowflake"
+
+
+def _container_urn(label: str) -> str:
+    return f"urn:li:container:batching_{label}_{_RUN_ID}"
+
+
+# Ground truth. C is intentionally empty to cover the zero-count path, which is where a
+# batched loader most easily goes wrong (a missing facet bucket must read as 0, not as a
+# dropped key or a default).
+_CONTAINER_A = _container_urn("a")
+_CONTAINER_B = _container_urn("b")
+_CONTAINER_C = _container_urn("c")
+
+_EXPECTED = {_CONTAINER_A: 2, _CONTAINER_B: 3, _CONTAINER_C: 0}
+
+# The loader chunks keys at MAX_CONTAINERS_PER_AGG (25), issuing one aggregation search per
+# chunk. Requesting more than that in a single GraphQL request is the only way to exercise the
+# multi-chunk path end to end, where the failure modes are chunk results being applied to the
+# wrong keys, later chunks silently reading as 0, and off-by-one key/result alignment.
+_CHUNK_SPAN_COUNT = 30
+
+# Counts cycle 0,1,2 so the expected value differs at every adjacent position: any shift or
+# cross-chunk swap of the key/result alignment changes the assertion, and the zero-count
+# containers land in both chunks (a missing facet bucket must read as 0 in a later chunk too,
+# not as a dropped key).
+_CHUNK_SPAN_EXPECTED = {
+    _container_urn(f"span{i}"): i % 3 for i in range(_CHUNK_SPAN_COUNT)
+}
+
+
+class _FileEmitter:
+    def __init__(self, filename: str) -> None:
+        self.sink: FileSink = FileSink(
+            ctx=PipelineContext(run_id="container_entities_batching"),
+            config=FileSinkConfig(filename=filename),
+        )
+
+    def emit(self, event) -> None:
+        self.sink.write_record_async(
+            record_envelope=RecordEnvelope(record=event, metadata={}),
+            write_callback=NoopWriteCallback(),
+        )
+
+    def close(self) -> None:
+        self.sink.close()
+
+
+def _dataset_in_container(
+    name: str, container_urn: str
+) -> List[MetadataChangeProposalWrapper]:
+    dataset_urn = make_dataset_urn(_PLATFORM, name)
+    return [
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=DatasetPropertiesClass(name=name),
+        ),
+        MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=ContainerClass(container=container_urn),
+        ),
+    ]
+
+
+def _build_test_data(filename: str) -> None:
+    mcps: List[MetadataChangeProposalWrapper] = []
+    for urn, label in ((_CONTAINER_A, "A"), (_CONTAINER_B, "B"), (_CONTAINER_C, "C")):
+        mcps.append(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn,
+                aspect=ContainerPropertiesClass(
+                    name=f"Batching Test {label} {_RUN_ID}"
+                ),
+            )
+        )
+
+    for i in range(_EXPECTED[_CONTAINER_A]):
+        mcps += _dataset_in_container(f"batching_a_{_RUN_ID}_{i}", _CONTAINER_A)
+    for i in range(_EXPECTED[_CONTAINER_B]):
+        mcps += _dataset_in_container(f"batching_b_{_RUN_ID}_{i}", _CONTAINER_B)
+
+    for span_index, (urn, expected) in enumerate(_CHUNK_SPAN_EXPECTED.items()):
+        mcps.append(
+            MetadataChangeProposalWrapper(
+                entityUrn=urn,
+                aspect=ContainerPropertiesClass(
+                    name=f"Batching Span {span_index} {_RUN_ID}"
+                ),
+            )
+        )
+        for i in range(expected):
+            mcps += _dataset_in_container(
+                f"batching_span{span_index}_{_RUN_ID}_{i}", urn
+            )
+
+    emitter = _FileEmitter(filename)
+    for mcp in mcps:
+        emitter.emit(mcp)
+    emitter.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ingest_cleanup_data(auth_session, graph_client):
+    _, filename = tempfile.mkstemp(suffix=".json")
+    try:
+        _build_test_data(filename)
+        yield from _ingest_cleanup_data_impl(
+            auth_session, graph_client, filename, "container_entities_batching"
+        )
+    finally:
+        os.remove(filename)
+
+
+# Mirrors the count-only shape the search fragments issue for a page of containers. Fetching
+# all three as aliased fields in a SINGLE request coalesces the per-container .load() calls
+# into one ContainerEntityCountsBatchLoader.batchLoad, so this exercises the batched fast path
+# and per-container attribution end to end — a single-container query would only prove a
+# one-key batch.
+_BATCHED_COUNTS_QUERY = """
+query containerEntityCounts($a: String!, $b: String!, $c: String!) {
+  a: container(urn: $a) { urn entities(input: {}) { total } }
+  b: container(urn: $b) { urn entities(input: {}) { total } }
+  c: container(urn: $c) { urn entities(input: {}) { total } }
+}
+"""
+
+# Selecting hits disqualifies the fast path, so this must fall back to the direct search and
+# still agree with the batched total.
+_DIRECT_QUERY = """
+query containerEntitiesDirect($urn: String!) {
+  container(urn: $urn) {
+    entities(input: {start: 0, count: 10}) {
+      total
+      searchResults { entity { urn } }
+    }
+  }
+}
+"""
+
+# A facet filter also disqualifies the fast path, and must actually be applied: filtering to
+# CHART excludes the container's datasets entirely.
+_FILTERED_QUERY = """
+query containerEntitiesFiltered($urn: String!) {
+  datasets: container(urn: $urn) {
+    entities(input: {filters: [{field: "_entityType", values: ["DATASET"]}]}) { total }
+  }
+  charts: container(urn: $urn) {
+    entities(input: {filters: [{field: "_entityType", values: ["CHART"]}]}) { total }
+  }
+}
+"""
+
+
+def _chunk_span_query() -> str:
+    """One request aliasing every span container, so all keys coalesce into one batchLoad."""
+    fields = "\n  ".join(
+        f'c{i}: container(urn: "{urn}") {{ urn entities(input: {{}}) {{ total }} }}'
+        for i, urn in enumerate(_CHUNK_SPAN_EXPECTED)
+    )
+    return f"query containerEntityCountsAcrossChunks {{\n  {fields}\n}}"
+
+
+def test_container_entities_counts_are_batched_and_correct(auth_session):
+    variables: Dict[str, Any] = {
+        "a": _CONTAINER_A,
+        "b": _CONTAINER_B,
+        "c": _CONTAINER_C,
+    }
+
+    @with_test_retry()
+    def check() -> None:
+        res = execute_graphql(auth_session, _BATCHED_COUNTS_QUERY, variables)
+        data = res["data"]
+        actual = {
+            data[alias]["urn"]: data[alias]["entities"]["total"] for alias in "abc"
+        }
+        logger.info(f"batched container entity counts: {actual}")
+
+        for alias, urn in (
+            ("a", _CONTAINER_A),
+            ("b", _CONTAINER_B),
+            ("c", _CONTAINER_C),
+        ):
+            assert data[alias]["urn"] == urn
+            expected = _EXPECTED[urn]
+            assert data[alias]["entities"]["total"] == expected, (
+                f"{urn} entities: expected {expected}, "
+                f"got {data[alias]['entities']['total']}"
+            )
+
+    check()
+
+
+def test_container_entities_counts_correct_across_chunk_boundary(auth_session):
+    @with_test_retry()
+    def check() -> None:
+        res = execute_graphql(auth_session, _chunk_span_query(), {})
+        data = res["data"]
+
+        actual = {
+            data[f"c{i}"]["urn"]: data[f"c{i}"]["entities"]["total"]
+            for i in range(_CHUNK_SPAN_COUNT)
+        }
+        logger.info(f"chunk-spanning container entity counts: {actual}")
+
+        # Compare the whole mapping at once so a mis-attributed or zeroed chunk shows up as a
+        # diff rather than passing on the containers that happened to be right.
+        assert actual == _CHUNK_SPAN_EXPECTED
+
+    check()
+
+
+def test_container_entities_direct_path_matches_batched_total(auth_session):
+    @with_test_retry()
+    def check() -> None:
+        res = execute_graphql(auth_session, _DIRECT_QUERY, {"urn": _CONTAINER_B})
+        entities = res["data"]["container"]["entities"]
+        expected = _EXPECTED[_CONTAINER_B]
+        assert entities["total"] == expected
+        assert len(entities["searchResults"]) == expected
+
+    check()
+
+
+def test_container_entities_filters_are_applied(auth_session):
+    @with_test_retry()
+    def check() -> None:
+        res = execute_graphql(auth_session, _FILTERED_QUERY, {"urn": _CONTAINER_B})
+        data = res["data"]
+        assert data["datasets"]["entities"]["total"] == _EXPECTED[_CONTAINER_B]
+        assert data["charts"]["entities"]["total"] == 0
+
+    check()

--- a/smoke-test/tests/containers/container_entities_batching_test.py
+++ b/smoke-test/tests/containers/container_entities_batching_test.py
@@ -1,7 +1,9 @@
 import logging
 import os
+import re
 import tempfile
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
@@ -258,3 +260,110 @@ def test_container_entities_filters_are_applied(auth_session):
         assert data["charts"]["entities"]["total"] == 0
 
     check()
+
+
+_FRONTEND_GRAPHQL_DIR = (
+    Path(__file__).resolve().parents[3] / "datahub-web-react" / "src" / "graphql"
+)
+_PRODUCTION_SEARCH_OPERATION = "getSearchResultsForMultiple"
+
+# The assembled operation is what makes this test meaningful: one copy normalizes to just
+# under graphql-java's 100k field cap, so two copies cross it. If the frontend fragments
+# shrink enough that the document no longer approaches the cap, the test would still pass
+# while checking nothing -- these floors make that drift fail loudly instead.
+_MIN_FRAGMENTS = 40
+_MIN_DOCUMENT_CHARS = 30_000
+_DEFINITION_RE = re.compile(
+    r"^(fragment|query|mutation|subscription)\s+(\w+)[\s\S]*?"
+    r"(?=^(?:fragment|query|mutation|subscription)\s|\Z)",
+    re.MULTILINE,
+)
+
+
+def _assemble_production_search_document() -> str:
+    """Rebuild the real search query, with its transitive fragments, from the frontend sources."""
+    if not _FRONTEND_GRAPHQL_DIR.is_dir():
+        pytest.skip(f"frontend graphql sources not found at {_FRONTEND_GRAPHQL_DIR}")
+
+    fragments: Dict[str, str] = {}
+    operation = None
+    for path in sorted(_FRONTEND_GRAPHQL_DIR.glob("*.graphql")):
+        for match in _DEFINITION_RE.finditer(path.read_text()):
+            kind, name, body = match.group(1), match.group(2), match.group(0)
+            if kind == "fragment":
+                fragments[name] = body
+            elif name == _PRODUCTION_SEARCH_OPERATION:
+                operation = body
+
+    assert operation is not None, (
+        f"{_PRODUCTION_SEARCH_OPERATION} not found under {_FRONTEND_GRAPHQL_DIR}; "
+        "the query this regression test depends on was renamed or removed"
+    )
+
+    needed: List[str] = []
+    seen = set()
+    pending = re.findall(r"\.\.\.(\w+)", operation)
+    while pending:
+        name = pending.pop(0)
+        if name in seen or name not in fragments:
+            continue
+        seen.add(name)
+        needed.append(name)
+        pending.extend(re.findall(r"\.\.\.(\w+)", fragments[name]))
+
+    document = (
+        operation.rstrip()
+        + "\n\n"
+        + "\n\n".join(fragments[name].rstrip() for name in needed)
+    )
+    assert len(needed) >= _MIN_FRAGMENTS and len(document) >= _MIN_DOCUMENT_CHARS, (
+        f"assembled {_PRODUCTION_SEARCH_OPERATION} is smaller than expected "
+        f"({len(needed)} fragments, {len(document)} chars); this test only exercises the "
+        "field-count regression while the document approaches graphql-java's 100k cap"
+    )
+    return document
+
+
+def _with_aliased_copies(document: str, copies: int) -> str:
+    """Alias the operation's root selection N times, multiplying the normalized field count."""
+    split_at = document.index("\nfragment ")
+    operation, fragments = document[:split_at], document[split_at:]
+    match = re.search(r"\{([\s\S]*)\}\s*$", operation)
+    assert match is not None, (
+        f"could not locate the body of {_PRODUCTION_SEARCH_OPERATION}; "
+        "the operation's shape in the frontend sources changed"
+    )
+    header, body = operation[: operation.index("{")], match.group(1)
+    aliased = "\n".join(
+        body.replace("searchAcrossEntities(", f"copy{i}: searchAcrossEntities(", 1)
+        for i in range(copies)
+    )
+    return f"{header}{{\n{aliased}\n}}\n{fragments}"
+
+
+def test_container_entities_survives_large_query_normalization(auth_session):
+    """Regression test for "Maximum field count exceeded. 100001 > 100000".
+
+    ContainerEntitiesResolver used to decide whether it could serve a count-only selection
+    by calling environment.getSelectionSet(), which makes graphql-java normalize the whole
+    operation. Normalization is capped at 100k fields, so once a Container hit reached this
+    resolver from the production search query, the entire request was aborted -- not just
+    this field. The resolver now reads its selection from the AST, which is local to the
+    field and never normalizes.
+    """
+    query = _with_aliased_copies(_assemble_production_search_document(), copies=2)
+    variables: Dict[str, Any] = {
+        "input": {"types": ["CONTAINER"], "query": "*", "start": 0, "count": 5},
+        "skipSiblingsSearch": False,
+        "skipLineage": False,
+    }
+
+    res = execute_graphql(auth_session, query, variables, expect_errors=True)
+
+    messages = [error.get("message", "") for error in res.get("errors") or []]
+    assert not any("Maximum field count" in message for message in messages), (
+        f"the field-count regression is back: {messages}"
+    )
+    assert not messages, f"unexpected GraphQL errors: {messages}"
+    # The seeded containers are CONTAINER entities, so the search must find at least those.
+    assert res["data"]["copy0"]["total"] >= len(_EXPECTED)


### PR DESCRIPTION
Brings back #18640 (which #19104 reverted) with the bug that caused the revert fixed.

## What broke

#18640 made `Container.entities` skip its search when the caller only asks for `total`. To decide that, it asked graphql-java "what did the caller select?" using `environment.getSelectionSet()`.

That call is more expensive than it looks. It makes graphql-java expand the **entire query** into a normalized form, and graphql-java refuses to expand past 100,000 fields. Our main search query is big enough to hit that limit, so the whole request failed:

```
Maximum field count exceeded. 100001 > 100000
```

Not just the one field — the entire response.

## The fix

Ask the same question a cheaper way: read the selected fields straight from the query text (the AST) instead of asking graphql-java to expand the whole query. Reading the AST only looks at this one field, so there is nothing to blow the limit.

Everything else from #18640 is unchanged.

## Where the code lives

The AST reading went into a new shared helper, `SelectionSetUtils`, instead of staying inside the resolver:

```java
Set<String> selectedSubFieldNames(env)      // which sub-fields did the caller ask for?
boolean     selectsOnly(env, allowed)       // did they ask for nothing outside this set?
```

Any resolver that wants to skip work nobody asked for needs this, and using `getSelectionSet()` for it is the trap we just fell into — so the safe version should be the easy one to find.

One thing to know about the helper: it errs on the side of saying "yes, that was selected". It does not evaluate `@skip`/`@include` or fragment type conditions. For this resolver that just means we sometimes run the normal search when we could have skipped it — slower, never wrong. Guessing the other way would be the dangerous one, because we would return counts to someone who asked for actual results.

## How we know it works

Tested against a local instance with the real search query (61 fragments, 3031 lines) pulled from the frontend code. One copy of the query sits just under the limit, so it is doubled to reliably cross it:

| Query | Before | After |
| --- | --- | --- |
| 1 copy | ok | ok |
| 2 copies | `Maximum field count exceeded` | ok |
| 3 copies | `Maximum field count exceeded` | ok |

To confirm this resolver was the cause and not just present, the same query was run against different result types. The query is identical every time, so the field count is identical — only whether this resolver runs changes:

| Results contain | Does the resolver run? | Before the fix |
| --- | --- | --- |
| Containers | yes | **fails** |
| Datasets (no container) | no | ok |
| Users | no | ok |

Counts are still correct: batched totals matched a direct query for every container checked (`0, 1, 0, 2, 0, 9`), including empty ones.

## Commits and tests

Two commits, kept separate on purpose:

1. **Revert of the revert** — plain `git revert`, brings back #18640 exactly as it was reviewed. Nothing hand-edited, so there is nothing new to review here.
2. **The fix** — the only new code.

`:datahub-graphql-core:test` — **1964 passed, 0 failed**.

- `SelectionSetUtilsTest` (new) tests the AST reading itself: fragments inside fragments, unknown fragments, inline fragments, the same field selected twice, ignored `@skip`, and the empty-selection case.
- `ContainerEntitiesResolverTest` now builds a real query instead of a mocked selection, so it runs the same code path production does.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline, particularly PR Title Format
- [x] Links to related issues (if applicable) — brings back #18640, reverted by #19104; related #17854
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated — nothing user-facing changed
- [ ] Breaking change entry in Updating DataHub — not a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
