### PR TITLE
docs(managed-datahub): release notes for v2.1.2

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -54,7 +54,6 @@ This release rolls up hotfixes on top of v2.1.1.
 #### Security / Dependencies
 
 - **Spring Framework**: bumped 7.0.7 → 7.0.8 to address CVE-2026-41842, CVE-2026-41845, and CVE-2026-41850.
-- **sentry-sdk**: bumped to 2.63.0 to stop executor coordinator restart loops under FastAPI health-probe load.
 
 #### Bug Fixes
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -39,8 +39,6 @@ This release rolls up hotfixes on top of v2.1.1.
 - **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
 
 #### Platform
-
-- **Support SSO base URL** — optional `AUTH_OIDC_SUPPORT_BASE_URL` overrides the OIDC callback base URL for support SSO (falls back to `AUTH_OIDC_BASE_URL`).
 - **Prometheus on consumers** — Micrometer Prometheus actuator is exposed on MCE/MAE consumers for shared monitoring scrapes.
 - **Structured-property type-mismatch reindex** — system-update can detect locked-in Elasticsearch/OpenSearch type mismatches for structured properties and trigger a `BuildIndices` reindex when structured-property system update and type-mismatch reindex are enabled.
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,71 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.2
+
+This release rolls up hotfixes on top of v2.1.1.
+
+#### Release Availability Date
+
+12-Aug-2026
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
+#### Product
+
+- **Batch lineage propagation** — configure multi-direction tag/term lineage propagation from a single automation in the UI, with optional tag and term filters.
+- **Domain-scoped entity create for writers** — writers can create entities into domains they can edit without broad platform create privileges; authorization failures return HTTP 403.
+- **Configurable search and view entity-type lists** — default GraphQL search, autocomplete, browse, and quick-filter entity-type lists are configurable via env/config, and view authorization unrestricted entity types are configurable for tighter SAC.
+- **Structured-property search ranking (opt-in)** — structured properties can contribute curated count-based ranking when `useAsRankFeature` is set and `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED` is enabled (default off). Existing assets need a `RestoreIndices` document backfill before values start ranking.
+- **Per-property opt-out from structured-property full-text indexing** — optional `excludeFromFullTextSearch` on structured-property search config keeps selected properties out of the aggregated full-text field (takes effect on the next index build for that property).
+- **Dataplex sync-back** — sync-back covers all six ingested Dataplex platforms and skips overwriting externally owned metadata.
+
+#### AI / Ask DataHub
+
+- **Ask DataHub tool-approval card** — human-in-the-loop approval cards use plain-language titles with entity links, collapsed details by default, and clearer handling of stale pending approvals.
+- **MCP chunked initialize** — MCP clients that send chunked `initialize` POSTs no longer fail the handshake with HTTP 400.
+
+#### Platform
+
+- **Support SSO base URL** — optional `AUTH_OIDC_SUPPORT_BASE_URL` overrides the OIDC callback base URL for support SSO (falls back to `AUTH_OIDC_BASE_URL`).
+- **Prometheus on consumers** — Micrometer Prometheus actuator is exposed on MCE/MAE consumers for shared monitoring scrapes.
+- **RFC 8693 token-exchange client registration** — authenticated OAuth client registration accepts the canonical token-exchange grant (anonymous DCR still rejects it).
+- **Structured-property type-mismatch reindex** — system-update can detect locked-in Elasticsearch/OpenSearch type mismatches for structured properties and trigger a `BuildIndices` reindex when structured-property system update and type-mismatch reindex are enabled.
+
+#### Ingestion
+
+- **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
+
+#### Breaking Changes
+
+- **MCP server: the `?token=` query parameter no longer works.** Every MCP endpoint — `/mcp`, `/mcp/<slug>`, and the older `/integrations/ai/mcp` and `/integrations/ai-legacy/mcp` paths — now takes the access token in the `Authorization: Bearer <token>` header only. Requests that include a `token` query parameter get a `400 Bad Request` explaining the header form. Point any MCP client that uses a `?token=…` URL at the plain URL and send the header instead. Clients that can't set headers themselves can use `mcp-remote` with `--header "Authorization: Bearer <token>"`. See [MCP → Connecting & Authenticating](https://docs.datahub.com/docs/features/feature-guides/mcp#connecting--authenticating).
+
+#### Security / Dependencies
+
+- **Spring Framework**: bumped 7.0.7 → 7.0.8 to address CVE-2026-41842, CVE-2026-41845, and CVE-2026-41850.
+- **sentry-sdk**: bumped to 2.63.0 to stop executor coordinator restart loops under FastAPI health-probe load.
+
+#### Bug Fixes
+
+- Fixed lineage graphs for view-restricted users hanging or failing when a neighbor was unviewable; restricted neighbors now render as Restricted nodes instead of blocking the batch.
+- Fixed URN-typed structured-property search facets and filters after v2.1.0 index rebuilds (no reindex required).
+- Fixed free-text search missing structured-property values that mix letters and digits in a single token when custom full-text search is enabled for structured-property values.
+- Fixed Structured Properties management search missing properties that only have a `qualifiedName` (no `displayName`).
+- Fixed the structured-property "Show in Search Filters" toggle silently disabling filters on Update after reopening the edit drawer.
+- Fixed duplicate tags, terms, and owners rendering when the same attribution was applied both manually and via propagation.
+- Fixed column-level lineage highlighting on data-product lineage graphs where the same entity appears under multiple data products.
+- Fixed smart volume assertions producing noisy alerts on cumulative/sub-daily schedules, and restored reliable bootstrap for new volume assertions (14 days of history before predictions).
+- Fixed bridge documents for semantic search inflating platform analytics counts.
+- Fixed Ask DataHub `draft_sql_for_tables` (and related tools) failing under Sonnet 5 when list arguments were serialized as schema-shaped XML.
+- Fixed compliance forms not refreshing correctly after submit/verify, and group usernames appearing as URNs in forms analytics.
+- Fixed MCP proxying so chunked client requests are not rejected with an invalid HTTP framing error.
+
 ### v2.1.1
 
 This release rolls up hotfixes on top of v2.1.0. There are no breaking changes or deprecations.

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -39,6 +39,7 @@ This release rolls up hotfixes on top of v2.1.1.
 - **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
 
 #### Platform
+
 - **Prometheus on consumers** — Micrometer Prometheus actuator is exposed on MCE/MAE consumers for shared monitoring scrapes.
 - **Structured-property type-mismatch reindex** — system-update can detect locked-in Elasticsearch/OpenSearch type mismatches for structured properties and trigger a `BuildIndices` reindex when structured-property system update and type-mismatch reindex are enabled.
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -35,17 +35,14 @@ This release rolls up hotfixes on top of v2.1.1.
 
 - **Ask DataHub tool-approval card** — human-in-the-loop approval cards use plain-language titles with entity links, collapsed details by default, and clearer handling of stale pending approvals.
 - **MCP chunked initialize** — MCP clients that send chunked `initialize` POSTs no longer fail the handshake with HTTP 400.
+- **RFC 8693 token-exchange client registration** — authenticated OAuth client registration accepts the canonical token-exchange grant (anonymous DCR still rejects it).
+- **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
 
 #### Platform
 
 - **Support SSO base URL** — optional `AUTH_OIDC_SUPPORT_BASE_URL` overrides the OIDC callback base URL for support SSO (falls back to `AUTH_OIDC_BASE_URL`).
 - **Prometheus on consumers** — Micrometer Prometheus actuator is exposed on MCE/MAE consumers for shared monitoring scrapes.
-- **RFC 8693 token-exchange client registration** — authenticated OAuth client registration accepts the canonical token-exchange grant (anonymous DCR still rejects it).
 - **Structured-property type-mismatch reindex** — system-update can detect locked-in Elasticsearch/OpenSearch type mismatches for structured properties and trigger a `BuildIndices` reindex when structured-property system update and type-mismatch reindex are enabled.
-
-#### Ingestion
-
-- **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
 
 #### Breaking Changes
 


### PR DESCRIPTION
## Summary

- Add the DataHub Cloud **v2.1.2** patch section to `docs/managed-datahub/release-notes/v_2_1_0.md` (release availability **12-Aug-2026**).
- Cover product, Ask DataHub/MCP, platform, ingestion, the MCP `?token=` breaking change, security bumps, and high-impact bug fixes from `v2.1.1-cloud` → `v2.1.2-cloud`.
- Keep **CLI/SDK** (`1.6.0.16`) and **Helm** (`1.6.233`) unchanged; update Remote Executor to include `v2.1.2-cloud`.

## Test plan

- [ ] `### v2.1.2` appears above `### v2.1.1` under Release Changelog
- [ ] CLI/SDK and Helm versions match v2.1.1; Remote Executor lists v2.1.2-cloud first
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Proofread customer-facing wording before marking ready for review


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DataHub Cloud v2.1.2 release notes. Covers product, platform, and Ask DataHub updates, plus security and bug fixes; CLI/SDK and Helm stay the same, the Remote Executor list is updated, and Prettier formatting is applied to the file.

- **Migration**
  - MCP: the `?token=` query parameter is no longer accepted; send tokens via the `Authorization: Bearer <token>` header.

- **Dependencies**
  - Bumped `Spring Framework` to 7.0.8.

<sup>Written for commit 6da86771f35ec68608ed0e3a19ebfc4c7a862149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

