### PR TITLE
docs(release-notes): add v2.1.2 section

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,22 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.2
+
+This release rolls up hotfixes on top of v2.1.1. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+11-Aug-2026
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
 ### v2.1.1
 
 This release rolls up hotfixes on top of v2.1.0. There are no breaking changes or deprecations.


### PR DESCRIPTION
## Summary

Adds a `### v2.1.2` section to `docs/managed-datahub/release-notes/v_2_1_0.md`.

The deploy pipeline's CLI version-alignment check (`Check CLI version alignment in release notes`) reads this file from `master` and requires a `### v2.1.2` section with a `- **CLI/SDK**:` line matching `rollout-config.json` (`v2.1.2-cloud` → `cli: 1.6.0.16`). The section was missing, so the check failed with `[MISSING SECTION]`.

## Notes

- CLI/SDK `1.6.0.16` matches the rest of the 2.1.0 line (v2.1.1 / v2.1.0).
- Availability date (`11-Aug-2026`) and any bug-fix bullets should be confirmed/filled in by the release owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e97f8b504ca2ccaea1793d2ec2981eacab7cba2f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a v2.1.2 section to the v2.1.0 release notes to align the deploy pipeline’s CLI version check and unblock the release. Sets `CLI/SDK` to 1.6.0.16, adds the availability date, and updates recommended Remote Executor and on‑prem versions.

<sup>Written for commit e97f8b504ca2ccaea1793d2ec2981eacab7cba2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

