### PR TITLE
ci(playwright): enable no-wait-for-timeout lint check

### DIFF
--- a/e2e-test/ui/playwright/eslint.config.js
+++ b/e2e-test/ui/playwright/eslint.config.js
@@ -65,9 +65,10 @@ module.exports = tseslint.config(
             // --- Intentional overrides (documented) --------------------------------
             // networkidle: GraphQL responses remain in-flight after navigation
             'playwright/no-networkidle': 'off',
-            // force/waitForTimeout: Ant Design component workarounds
+            // force: Ant Design component workarounds
             'playwright/no-force-option': 'off',
-            'playwright/no-wait-for-timeout': 'off',
+            // waitForTimeout: flag new usages; existing ones are annotated with disable comments
+            'playwright/no-wait-for-timeout': 'error',
             // expect-expect: assertions delegated into POM helper methods
             'playwright/expect-expect': 'off',
             'playwright/no-wait-for-selector': 'off',

--- a/e2e-test/ui/playwright/pages/applications.page.ts
+++ b/e2e-test/ui/playwright/pages/applications.page.ts
@@ -124,6 +124,7 @@ export class ApplicationsPage extends BasePage {
     await this.searchInput.fill('');
     await this.searchInput.type(query);
     // Wait for search debounce + network
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
   }
@@ -150,6 +151,7 @@ export class ApplicationsPage extends BasePage {
     // Wait for modal to close and success message
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
     // Wait for refetch to complete
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -180,6 +182,7 @@ export class ApplicationsPage extends BasePage {
   async confirmDeletion(): Promise<void> {
     await this.deleteConfirmButton.click();
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
@@ -204,6 +207,7 @@ export class ApplicationsPage extends BasePage {
   async verifyAssetInList(assetName: string): Promise<void> {
     // Wait for GraphQL search query to complete and render assets
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     const assetElement = this.getAssetElement(assetName);
@@ -255,6 +259,7 @@ export class ApplicationsPage extends BasePage {
 
   async clickSelectApplicationDropdown(): Promise<void> {
     await this.applicationSelectDropdown.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS); // Wait for modal to fully stabilize
     await this.applicationSelectDropdown.click({ timeout: TIMEOUTS.MEDIUM });
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
@@ -266,10 +271,12 @@ export class ApplicationsPage extends BasePage {
 
     // Wait for input to be ready
     await searchInput.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
 
     // Fill the search input with application name
     await searchInput.fill(appName);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
@@ -277,6 +284,7 @@ export class ApplicationsPage extends BasePage {
     const option = this.getDropdownOption(appName);
     await option.click();
     // Small wait for dropdown to close
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 

--- a/e2e-test/ui/playwright/pages/assertion-list.page.ts
+++ b/e2e-test/ui/playwright/pages/assertion-list.page.ts
@@ -21,6 +21,7 @@ export class AssertionListPage extends BasePage {
 
   async search(value: string): Promise<void> {
     await this.searchInput.fill(value);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(600);
   }
 

--- a/e2e-test/ui/playwright/pages/autocomplete.page.ts
+++ b/e2e-test/ui/playwright/pages/autocomplete.page.ts
@@ -51,6 +51,7 @@ export class AutocompletePage extends BasePage {
     this.logger?.step('typeInSearchBar', { query });
     await this.searchInput.click();
     await this.searchInput.type(query);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 

--- a/e2e-test/ui/playwright/pages/browse-v2.page.ts
+++ b/e2e-test/ui/playwright/pages/browse-v2.page.ts
@@ -48,6 +48,7 @@ export class BrowseV2Page extends BasePage {
 
   async expectSidebarCollapsed(): Promise<void> {
     // Wait for sidebar to actually collapse (width change)
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
     const width = await this.browseV2Container.evaluate((el) => window.getComputedStyle(el).width);
     // Collapsed state should have width ~63px
@@ -62,8 +63,10 @@ export class BrowseV2Page extends BasePage {
     await this.browseV2Toggle.click();
     // Wait for CSS transition animation and state change to propagate
     // The sidebar animates for 200ms, plus buffer for state updates
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
     // Give React state a moment to update
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
@@ -71,6 +74,7 @@ export class BrowseV2Page extends BasePage {
     const platformHeader = this.browsePlatformHeaderLocator(platformName);
     await platformHeader.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await platformHeader.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
@@ -79,6 +83,7 @@ export class BrowseV2Page extends BasePage {
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
     // Wait for animation and DOM updates
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 
@@ -86,6 +91,7 @@ export class BrowseV2Page extends BasePage {
     const locator = this.browseNodeLocator(nodeName);
     await locator.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await locator.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
   }
 

--- a/e2e-test/ui/playwright/pages/description-editor.page.ts
+++ b/e2e-test/ui/playwright/pages/description-editor.page.ts
@@ -81,6 +81,7 @@ export default class DescriptionEditorPage extends BasePage {
       await this.uploadFileButton.click();
       await this.fileUploadInput.waitFor({ state: 'attached', timeout: TIMEOUTS.MEDIUM });
       await this.fileUploadInput.setInputFiles(tempFilePath);
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(TABLE_LOAD_DELAY);
       // For invalid files, backend validation rejects silently - verify file wasn't added
       const fileNode = this.editorFileNodesContainer.getByTestId(this.getFileNodeTestId(fileName));
@@ -155,6 +156,7 @@ export default class DescriptionEditorPage extends BasePage {
     }
     await this.clearDescription();
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TABLE_LOAD_DELAY);
   }
 }

--- a/e2e-test/ui/playwright/pages/domains/domains.page.ts
+++ b/e2e-test/ui/playwright/pages/domains/domains.page.ts
@@ -61,6 +61,7 @@ export class DomainsPage extends BasePage {
     await this.createDomainConfirmButton.click();
     await expect(this.page.getByText(name).first()).toBeVisible({ timeout: 15000 });
     // Allow ES to index the new domain before subsequent tests search for it
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(5000);
   }
 
@@ -78,6 +79,7 @@ export class DomainsPage extends BasePage {
     // On the flat-list layout, search to ensure the domain is visible before clicking
     if (await this.domainSearchInput.isVisible({ timeout: 2000 }).catch(() => false)) {
       await this.domainSearchInput.fill(name);
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(500);
     }
     // Use link role to skip hidden aria-live spans that also match the text
@@ -102,6 +104,7 @@ export class DomainsPage extends BasePage {
       await this.modalSearchInput.click({ clickCount: 3 }); // select-all any existing text
       await this.modalSearchInput.pressSequentially(searchTerm);
       // Wait for the debounce (300ms) + search result render before checking the checkbox
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(800);
       await expect(checkbox).toBeVisible({ timeout: 10000 });
     }).toPass({ timeout: 90000, intervals: [3000] });
@@ -129,6 +132,7 @@ export class DomainsPage extends BasePage {
     await this.page.getByRole('button', { name: 'Yes' }).click();
     await this.page.waitForLoadState('networkidle', { timeout: 15000 });
     // Allow ES to de-index the deleted domain before asserting it's gone
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(5000);
   }
 

--- a/e2e-test/ui/playwright/pages/entity-documentation.page.ts
+++ b/e2e-test/ui/playwright/pages/entity-documentation.page.ts
@@ -167,6 +167,7 @@ export class EntityDocumentationPage extends BasePage {
         }
         // Dismiss a stuck modal before retrying the drawer → edit flow.
         await this.page.keyboard.press('Escape').catch(() => undefined);
+        // eslint-disable-next-line playwright/no-wait-for-timeout
         await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS * attempt);
       }
     }
@@ -176,8 +177,10 @@ export class EntityDocumentationPage extends BasePage {
 
   async openAddLinkForm(): Promise<void> {
     await this.addRelatedButton.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
     await this.page.getByText('Add link').click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
   }
 

--- a/e2e-test/ui/playwright/pages/entity/document.page.ts
+++ b/e2e-test/ui/playwright/pages/entity/document.page.ts
@@ -118,6 +118,7 @@ export class DocumentPage extends BasePage {
 
   async createDocumentWithTitle(title: string): Promise<string> {
     const docUrn = await this.createNewDocumentViaButton();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
     await this.navigateToDocument(docUrn);
     await this.setDocumentTitle(title);
@@ -137,12 +138,15 @@ export class DocumentPage extends BasePage {
     await expect(this.titleInput).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     // Triple-click selects all text in textarea reliably
     await this.titleInput.click({ clickCount: 3 });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await this.titleInput.pressSequentially(title, { delay: DELAYS.SEQUENTIAL });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     // Press Enter to save the title (triggers blur/save handler)
     await this.page.keyboard.press(KEYS.ENTER);
     // Wait for title update to persist in the backend
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -183,10 +187,13 @@ export class DocumentPage extends BasePage {
     const editor = this.getEditorTextbox();
     await expect(editor).toBeVisible();
     await editor.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await editor.clear({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
     await editor.fill(text);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -201,11 +208,13 @@ export class DocumentPage extends BasePage {
     const trigger = this.getStatusSelectTrigger();
     await expect(trigger).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await trigger.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     const option = this.getDropdownOption(status);
     await expect(option).toBeVisible({ timeout: TIMEOUTS.LONG });
     await option.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     // Verify optimistic update with case-insensitive match
@@ -213,6 +222,7 @@ export class DocumentPage extends BasePage {
 
     // Wait for network and database persistence before allowing reload
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
   }
 
@@ -226,11 +236,13 @@ export class DocumentPage extends BasePage {
     const trigger = this.getTypeSelectTrigger();
     await expect(trigger).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await trigger.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     const option = this.getDropdownOption(type);
     await expect(option).toBeVisible({ timeout: TIMEOUTS.LONG });
     await option.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
 
     // Verify optimistic update with case-insensitive match
@@ -238,6 +250,7 @@ export class DocumentPage extends BasePage {
 
     // Wait for network and database persistence before allowing reload
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.MEDIUM);
   }
 
@@ -248,6 +261,7 @@ export class DocumentPage extends BasePage {
   async searchForDocument(query: string): Promise<void> {
     await this.searchInput.click();
     await this.searchInput.fill(query);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -257,6 +271,7 @@ export class DocumentPage extends BasePage {
 
   async closeSearchAndVerifyClosed(): Promise<void> {
     await this.searchInput.clear();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
     await expect(this.searchResults).not.toBeVisible({ timeout: TIMEOUTS.SHORT });
   }
@@ -291,6 +306,7 @@ export class DocumentPage extends BasePage {
     await expect(searchInput).toBeVisible();
     await searchInput.clear();
     await searchInput.fill(text);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -313,6 +329,7 @@ export class DocumentPage extends BasePage {
     await expect(this.actionsMenuButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await expect(this.actionsMenuButton).toBeEnabled({ timeout: TIMEOUTS.MEDIUM });
     await this.actionsMenuButton.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -320,6 +337,7 @@ export class DocumentPage extends BasePage {
     const deleteMenuItem = this.getDeleteMenuOption();
     await expect(deleteMenuItem).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await deleteMenuItem.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -411,6 +429,7 @@ export class DocumentPage extends BasePage {
     await expandButton.hover({ force: true });
     await expect(expandButton).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
     await expandButton.click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -437,6 +456,7 @@ export class DocumentPage extends BasePage {
     await button.click();
     // Expand-all can take a while on large libraries; wait for the control to unlock.
     await expect(button).toBeEnabled({ timeout: 60_000 });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
   }
 
@@ -449,6 +469,7 @@ export class DocumentPage extends BasePage {
     if (/collapse/i.test(label)) {
       await button.click();
       await expect(button).toBeEnabled({ timeout: TIMEOUTS.LONG });
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(TIMEOUTS.OPERATION);
     }
   }

--- a/e2e-test/ui/playwright/pages/incidents.page.ts
+++ b/e2e-test/ui/playwright/pages/incidents.page.ts
@@ -122,6 +122,7 @@ export class IncidentsPage extends BasePage {
       const row = this.getIncidentRow(incidentTitle);
       const isRowVisible = await row.isVisible().catch(() => false);
       if (!isRowVisible) {
+        // eslint-disable-next-line playwright/no-wait-for-timeout
         if (attempt < maxRetries) await this.page.waitForTimeout(retryDelayMs);
         continue;
       }
@@ -137,6 +138,7 @@ export class IncidentsPage extends BasePage {
 
       if (attempt < maxRetries) {
         // The incident is indexed but relationships are not yet — wait and retry.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
         await this.page.waitForTimeout(retryDelayMs);
       }
     }
@@ -296,6 +298,7 @@ export class IncidentsPage extends BasePage {
         .isVisible()
         .catch(() => false);
       if (confirmed) return;
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(300);
     }
   }

--- a/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
+++ b/e2e-test/ui/playwright/pages/ingestion/base/tabs/sources-base.tab.ts
@@ -438,6 +438,7 @@ export abstract class SourcesBaseTab extends BaseTab {
 
   async expectSourceStatusContains(sourceName: string, status: string): Promise<void> {
     // Wait briefly for executor to pick up the request
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.SHORT);
     const row = this.getSourceRow(sourceName);
     // Ingestion source execution completion

--- a/e2e-test/ui/playwright/pages/lineage-base.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-base.page.ts
@@ -388,6 +388,7 @@ export class LineageBasePage extends BasePage {
   /** Open the column selector dropdown and pick a column by name. */
   async selectColumnFromDropdown(columnName: string): Promise<void> {
     await this.page.getByText('Select column').click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(1000);
     await this.columnDropdownVirtualList.getByText(columnName, { exact: true }).click();
   }

--- a/e2e-test/ui/playwright/pages/lineage-v3.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-v3.page.ts
@@ -87,6 +87,7 @@ export class LineageV3Page extends LineageBasePage {
     await this.clickFilterByDescription();
     await this.typeFilterText(text);
     await this.confirmFilterText();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.SHORT);
   }
 

--- a/e2e-test/ui/playwright/pages/policies.page.ts
+++ b/e2e-test/ui/playwright/pages/policies.page.ts
@@ -21,11 +21,13 @@ export class PoliciesPage extends BasePage {
     await expect(this.searchInput).toBeVisible();
     await this.searchInput.clear();
     await this.searchInput.fill(policyName);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
   }
 
   async openRowMenu(policyName: string): Promise<void> {
     await this.page.getByRole('row').filter({ hasText: policyName }).getByRole('button').last().click({ force: true });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(300);
   }
 
@@ -42,6 +44,7 @@ export class PoliciesPage extends BasePage {
       const roleText = await row.getByRole('cell').nth(3).textContent();
       if (roleText?.includes('All Users')) {
         await row.getByRole('button').last().click({ force: true });
+        // eslint-disable-next-line playwright/no-wait-for-timeout
         await this.page.waitForTimeout(300);
         const deactivateItem = this.page.getByRole('menuitem').getByText('Deactivate');
         if ((await deactivateItem.count()) > 0) {

--- a/e2e-test/ui/playwright/pages/search.page.ts
+++ b/e2e-test/ui/playwright/pages/search.page.ts
@@ -83,6 +83,7 @@ export class SearchPage extends BasePage {
   async search(query: string): Promise<void> {
     await this.searchInput.fill(query);
     await this.searchInput.press('Enter');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(2000);
   }
 
@@ -91,6 +92,7 @@ export class SearchPage extends BasePage {
     await this.searchInput.fill(query);
     await this.searchInput.press('Enter');
     await this.page.waitForLoadState('networkidle');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(waitTime);
   }
 
@@ -144,6 +146,7 @@ export class SearchPage extends BasePage {
     if (!(await moreFiltersBtn.isVisible())) return false;
 
     await moreFiltersBtn.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(300);
     const moreFilterOption = this.page.getByTestId(`more-filter-${filterName}`);
     const found = await moreFilterOption.isVisible();
@@ -163,11 +166,13 @@ export class SearchPage extends BasePage {
       const moreFiltersVisible = await moreFiltersBtn.isVisible();
       if (moreFiltersVisible) {
         await moreFiltersBtn.click();
+        // eslint-disable-next-line playwright/no-wait-for-timeout
         await this.page.waitForTimeout(500);
         const moreFilterOption = this.page.getByTestId(`more-filter-${filterName}`);
         const moreFilterVisible = await moreFilterOption.isVisible();
         if (moreFilterVisible) {
           await moreFilterOption.click();
+          // eslint-disable-next-line playwright/no-wait-for-timeout
           await this.page.waitForTimeout(500);
           // After clicking the more-filter option, select the option within
           // the sub-dropdown that appears. Fall through to the selection logic.
@@ -184,6 +189,7 @@ export class SearchPage extends BasePage {
     await filterDropdown.click({ force: true });
 
     // Wait for the dropdown menu to appear
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(1000);
 
     await this.selectFilterValue(optionLabel);
@@ -225,6 +231,7 @@ export class SearchPage extends BasePage {
     const dropdownSearchInput = dropdownMenu.getByTestId('search-input').last();
     if (await dropdownSearchInput.isVisible()) {
       await dropdownSearchInput.fill(optionLabel);
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(500);
 
       if (await tryCheckbox()) {

--- a/e2e-test/ui/playwright/pages/settings/base.settings.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/base.settings.page.ts
@@ -61,6 +61,7 @@ export class BaseSettingsPage extends BasePage {
       await searchInput.clear();
       await searchInput.fill(value);
       // Wait for filter results to appear
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(ANIMATION_TIMEOUT);
     }
 
@@ -85,6 +86,7 @@ export class BaseSettingsPage extends BasePage {
   async logout(): Promise<void> {
     if ((await this.modalDialog.count()) > 0) {
       await this.page.keyboard.press('Escape');
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(ANIMATION_TIMEOUT);
     }
     await this.navSignOut.click();

--- a/e2e-test/ui/playwright/pages/siblings.page.ts
+++ b/e2e-test/ui/playwright/pages/siblings.page.ts
@@ -138,10 +138,12 @@ export class SiblingsPage extends BasePage {
     await this.addTermsButton.click();
     await this.tagTermModalTrigger.click();
     await this.tagTermInput.waitFor({ state: 'visible', timeout: TIMEOUTS.LONG });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     await this.tagTermInput.click();
     await this.tagTermInput.fill(termName);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     const termOption = this.getTermOption(termName);
@@ -150,6 +152,7 @@ export class SiblingsPage extends BasePage {
     await termOption.click({ force: true });
 
     await this.tagTermModalTrigger.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
     await this.addTagTermConfirmButton.click();
     await this.page.waitForLoadState(LOAD_STATES.NETWORKIDLE);

--- a/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
+++ b/e2e-test/ui/playwright/pages/stats-v2/change-history-chart.page.ts
@@ -129,6 +129,7 @@ export class ChangeHistoryChart extends BasePage {
   async closeDayDrawer(timeout: number = TIMEOUTS.SHORT): Promise<void> {
     this.logger?.step('closeDayDrawer');
     await this.closeDrawerButton.click({ timeout });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
@@ -151,6 +152,7 @@ export class ChangeHistoryChart extends BasePage {
     const dayCell = this.getDayCell(dateString);
     await dayCell.scrollIntoViewIfNeeded();
     await dayCell.hover({ timeout });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 
@@ -159,6 +161,7 @@ export class ChangeHistoryChart extends BasePage {
    */
   async toggleOperationType(opType: string, timeout: number = TIMEOUTS.SHORT): Promise<void> {
     await this.getOperationTypeOption(opType).click({ timeout });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
   }
 

--- a/e2e-test/ui/playwright/pages/views/view-select.page.ts
+++ b/e2e-test/ui/playwright/pages/views/view-select.page.ts
@@ -196,12 +196,14 @@ export class ViewSelectPage extends BasePage {
   async openViewDropdown(viewName: string): Promise<void> {
     await this.viewsButton.click();
     await this.waitForPopoverOpen();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
 
     const selectedViewItem = this.getSelectedViewItem(viewName);
     await selectedViewItem.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
 
     await selectedViewItem.hover();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.QUICK);
 
     const dropdownTrigger = this.getViewDropdownTrigger(selectedViewItem);

--- a/e2e-test/ui/playwright/pages/welcome-modal.page.ts
+++ b/e2e-test/ui/playwright/pages/welcome-modal.page.ts
@@ -118,11 +118,13 @@ export class WelcomeModalPage extends BasePage {
     await this.page.keyboard.press('ArrowRight');
     // react-slick afterChange fires via setTimeout(speed=500ms). Match the
     // wait used by clickCarouselDot for consistency.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
   }
 
   async pressArrowLeft(): Promise<void> {
     await this.page.keyboard.press('ArrowLeft');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
   }
 
@@ -136,6 +138,7 @@ export class WelcomeModalPage extends BasePage {
     await this.carouselDots.nth(index).click();
     // react-slick does not emit a DOM signal when the slide CSS transition finishes (~300 ms).
     // There is no reliable locator to await, so a short fixed delay is the least-fragile option.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(500);
   }
 
@@ -174,6 +177,7 @@ export class WelcomeModalPage extends BasePage {
       // react-slick's default animation speed is 500 ms, so 700 ms covers the
       // setTimeout(afterChange, speed) call with margin.
       await this.waitForSlideChange(0, 5000).catch(() => {});
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await this.page.waitForTimeout(700);
       await this.lastCarouselDot.click({ force: true });
       await this.getStartedButton.waitFor({ state: 'attached', timeout: 20000 });

--- a/e2e-test/ui/playwright/tests/application/application-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/application/application-management.spec.ts
@@ -63,6 +63,7 @@ test.describe('Application Management Page', () => {
 
     // Wait for async create operation to complete before checking table
     logger?.info('Waiting for refetch after create');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -73,6 +74,7 @@ test.describe('Application Management Page', () => {
 
     // Wait for async delete operation to complete before checking table
     logger?.info('Waiting for refetch after delete');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 

--- a/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
+++ b/e2e-test/ui/playwright/tests/application/application-sidebar.spec.ts
@@ -119,6 +119,7 @@ test.describe('Application Sidebar Integration', () => {
     logger?.info(`Navigating to dataset: ${DATASET_WITHOUT_APP_NAME}`);
     await applicationsPage.navigateToDataset(DATASET_WITHOUT_APP_URN);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.OPERATION);
 
     logger?.info(`Adding application: ${TEST_APP_NAME}`);

--- a/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
+++ b/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
@@ -155,6 +155,7 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after expanding');
@@ -162,6 +163,7 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
 
     logger?.step('collapse BigQuery platform');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify sidebar remains visible after collapsing');
@@ -193,6 +195,7 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('verify PlaywrightBrowseEntity browse path is visible');
@@ -218,10 +221,12 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     logger?.step('expand BigQuery platform');
     await browseV2Page.expectBrowsePlatformExists(PLATFORM.BIGQUERY, TIMEOUTS.EXTRA_LONG);
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('expand PlaywrightBrowseEntity path');
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     logger?.step('click test_schema node to apply filters');
@@ -250,8 +255,10 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
 
     logger?.step('apply browse path filter');
     await browseV2Page.clickBrowsePlatform(PLATFORM.BIGQUERY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.expandBrowseNode(BROWSE_PATHS.PROJECT);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
     await browseV2Page.clickBrowseNode(BROWSE_PATHS.SCHEMA);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);

--- a/e2e-test/ui/playwright/tests/change-history/change-history.spec.ts
+++ b/e2e-test/ui/playwright/tests/change-history/change-history.spec.ts
@@ -503,6 +503,7 @@ test.describe('sidebar keyboard and close interactions', () => {
     // (or show only matching entries). We type something nonsensical.
     await searchInput.fill('xyzzy_no_match_12345');
     // Give the filter a moment to apply (synchronous state update)
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(300);
 
     // After filtering with a non-matching term, version milestones and change events
@@ -515,6 +516,7 @@ test.describe('sidebar keyboard and close interactions', () => {
 
     // Clear the search and entries should re-appear
     await searchInput.clear();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(300);
   });
 });
@@ -936,6 +938,7 @@ test.describe('Types filter per category', () => {
     await expect(docOption).toBeVisible({ timeout: TIMEOUTS.SHORT });
     await docOption.click();
     await page.keyboard.press('Escape');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(400);
 
     // Tag and owner events should now be hidden
@@ -958,6 +961,7 @@ test.describe('Types filter per category', () => {
     await expect(ownershipOption).toBeVisible({ timeout: TIMEOUTS.SHORT });
     await ownershipOption.click();
     await page.keyboard.press('Escape');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(400);
 
     await expect(sidebar.getByText(/Documentation (added|updated)/, { exact: false })).toHaveCount(0);
@@ -1045,11 +1049,13 @@ test.describe('edge cases', () => {
 
     // Type a specific term we know will match version events
     await searchInput.fill('Version');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(300);
     const afterFilter = sidebar.getByText('Version created');
 
     // Clear search — the entries should be back
     await searchInput.clear();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(300);
     // After clear, "Version created" milestone should return if it was there before
     const afterClear = sidebar.getByText('Version created');

--- a/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
+++ b/e2e-test/ui/playwright/tests/documents/document-management.spec.ts
@@ -95,6 +95,7 @@ test.describe('Document Management', () => {
     cleanup.track(docUrn);
     await documentPage.clickEditorAndType(testContent);
     await page.keyboard.press(KEYS.ESCAPE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.OPERATION);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
@@ -149,10 +150,12 @@ test.describe('Document Management', () => {
     await documentPage.expectSidebarContains('Documents');
 
     await documentPage.clickCollapseButton();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
     await documentPage.expectCreateButtonHidden();
 
     await documentPage.clickCollapseButton();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
     await documentPage.expectSidebarContains('Documents');
     await documentPage.expectCreateButtonEnabled();
@@ -167,6 +170,7 @@ test.describe('Document Management', () => {
     cleanup.track(docUrn);
     await documentPage.expectSidebarVisible();
 
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.OPERATION);
 
     await documentPage.searchForDocument(searchTitle);
@@ -205,6 +209,7 @@ test.describe('Document Management', () => {
     await documentPage.clickDeleteMenuItem();
     await documentPage.confirmDelete();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await documentPage.navigateToDocuments();
@@ -231,6 +236,7 @@ test.describe('Document Management', () => {
     await documentPage.clickDeleteMenuItem();
     await documentPage.confirmDelete();
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await documentPage.navigateToDocuments();

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-impact-analysis.spec.ts
@@ -129,6 +129,7 @@ test.describe('impact analysis', () => {
     const columnParam = encodeURIComponent('[version=2.0].[type=boolean].field_bar');
     await page.goto(`/dataset/${DATASET_URN}/Lineage?column=${columnParam}&is_lineage_mode=false`);
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await lineagePage.clickImpactAnalysis();
@@ -140,6 +141,7 @@ test.describe('impact analysis', () => {
 
     // Toggle off column-level impact analysis
     await lineagePage.clickColumnLineageToggle();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT);
 
     await lineagePage.expectResultTextVisible(UI_TEXT.HDFS_DATASET, TIMEOUTS.MEDIUM);
@@ -153,6 +155,7 @@ test.describe('impact analysis', () => {
       `/dataset/${DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${JAN_1_2021_TIMESTAMP}&end_time_millis=${JAN_1_2022_TIMESTAMP}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await lineagePage.clickImpactAnalysis();
@@ -172,6 +175,7 @@ test.describe('impact analysis', () => {
       `/tasks/${TRANSACTION_ETL_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_14_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await lineagePage.clickSidebarLineageTab();
@@ -187,6 +191,7 @@ test.describe('impact analysis', () => {
       `/tasks/${TRANSACTION_ETL_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_NOW}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.MEDIUM);
 
     await lineagePage.clickSidebarLineageTab();
@@ -204,6 +209,7 @@ test.describe('impact analysis', () => {
       `/dataset/${MONTHLY_TEMPERATURE_DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_14_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT);
 
     await lineagePage.clickSidebarLineageTab();
@@ -216,6 +222,7 @@ test.describe('impact analysis', () => {
       `/dataset/${MONTHLY_TEMPERATURE_DATASET_URN}/Lineage?filter_degree___false___EQUAL___0=1&is_lineage_mode=false&page=1&unionType=0&start_time_millis=${TIMESTAMP_MILLIS_7_DAYS_AGO}&end_time_millis=${TIMESTAMP_MILLIS_NOW}`,
     );
     await page.waitForLoadState(LOAD_STATES.DOMCONTENTLOADED);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.SHORT);
 
     await lineagePage.clickSidebarLineageTab();

--- a/e2e-test/ui/playwright/tests/mutations-v2/v2-edit-documentation.spec.ts
+++ b/e2e-test/ui/playwright/tests/mutations-v2/v2-edit-documentation.spec.ts
@@ -84,6 +84,7 @@ test.describe('edit documentation and link to dataset', () => {
 
     // Verify link is visible in entity header from the search page too
     await page.goto(`/search?query=${SAMPLE_DATASET_NAME}`);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(3000);
     await expect(page.getByText(SAMPLE_DATASET_NAME).first()).toBeVisible({ timeout: 30000 });
     await docPage.expectLinkInEntityHeader(sample);

--- a/e2e-test/ui/playwright/tests/mutations/dataset-ownership.spec.ts
+++ b/e2e-test/ui/playwright/tests/mutations/dataset-ownership.spec.ts
@@ -84,6 +84,7 @@ test.describe.skip('add, remove ownership for dataset', () => {
       await expect(page.getByText(DATASET_NAME)).toBeVisible({ timeout: 30000 });
       await datasetPage.addOwner(username, ownerType);
       // Verify in owned assets
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(3000);
       await page.getByText(username).click();
       await expect(page.getByText(DATASET_NAME)).toBeVisible({ timeout: 30000 });
@@ -100,6 +101,7 @@ test.describe.skip('add, remove ownership for dataset', () => {
       await datasetPage.navigateToDataset(DATASET_URN);
       await expect(page.getByText(DATASET_NAME)).toBeVisible({ timeout: 30000 });
       await datasetPage.addOwner(groupName, ownerType);
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(3000);
       await page.getByText(groupName).click();
       await expect(page.getByText(DATASET_NAME)).toBeVisible({ timeout: 30000 });

--- a/e2e-test/ui/playwright/tests/mutations/manage-ingestion-secret-privilege.spec.ts
+++ b/e2e-test/ui/playwright/tests/mutations/manage-ingestion-secret-privilege.spec.ts
@@ -47,6 +47,7 @@ test.describe.skip('Manage Ingestion and Secret Privileges', () => {
     // Filter to show all policies
     await page.getByTestId('policy-filter').click();
     await page.getByTestId('option-ALL').click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(500);
 
     // Deactivate any existing "All Users" policies that might conflict
@@ -69,6 +70,7 @@ test.describe.skip('Manage Ingestion and Secret Privileges', () => {
     // eslint-disable-next-line playwright/no-raw-locators -- rc-virtual-list internal class; no data-testid available
     await page.locator('.rc-virtual-list').getByText('Manage Metadata Ingestion').click({ force: true });
     await page.getByTestId('privileges').blur();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(1000);
     // eslint-disable-next-line playwright/no-raw-locators -- React-generated HTML id; no data-testid on this button
     await page.locator('#nextButton').click();
@@ -143,6 +145,7 @@ test.describe.skip('Manage Ingestion and Secret Privileges', () => {
     await page.locator('[id="home-page-ingestion"]').scrollIntoViewIfNeeded();
     // eslint-disable-next-line playwright/no-raw-locators -- React-generated HTML id on home page nav item; no data-testid available
     await page.locator('[id="home-page-ingestion"]').click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(1000);
     // eslint-disable-next-line playwright/no-raw-locators -- clicking body to dismiss popovers; no semantic Playwright equivalent
     await page.locator('body').click();

--- a/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
+++ b/e2e-test/ui/playwright/tests/onboarding/welcome-modal.spec.ts
@@ -193,6 +193,7 @@ test.describe('Welcome to DataHub Modal', () => {
       });
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(1000);
       const viewEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalViewEvent');
       expect(viewEvent).toBeDefined();
@@ -208,6 +209,7 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.clickCarouselDot(1);
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(1000);
       const interactEvents = trackRequests.filter((r) => r['type'] === 'WelcomeToDataHubModalInteractEvent');
       expect(interactEvents.length).toBeGreaterThan(0);
@@ -223,6 +225,7 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.closeViaButton();
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(1000);
       const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
       expect(exitEvent).toBeDefined();
@@ -239,6 +242,7 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.navigateToHome();
       await welcomeModalPage.expectModalVisible();
       await welcomeModalPage.closeViaEscape();
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(1000);
       const exitEvent = trackRequests.find((r) => r['type'] === 'WelcomeToDataHubModalExitEvent');
       expect(exitEvent).toBeDefined();
@@ -257,6 +261,7 @@ test.describe('Welcome to DataHub Modal', () => {
       await welcomeModalPage.clickLastCarouselDot();
       await welcomeModalPage.expectFinalSlideVisible();
       await welcomeModalPage.docsLink.click();
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(1000);
       const linkClickEvent = trackRequests.find(
         (r) => r['type'] === 'WelcomeToDataHubModalClickViewDocumentationEvent',

--- a/e2e-test/ui/playwright/tests/search/searchv2.spec.ts
+++ b/e2e-test/ui/playwright/tests/search/searchv2.spec.ts
@@ -26,6 +26,7 @@ test.describe('SearchV2 Features', () => {
 
   test('should perform autocomplete search', async ({ page }) => {
     await searchPage.searchInput.fill('playwright');
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(1000);
     await expect(searchPage.autocompleteDropdown).toBeVisible();
   });
@@ -57,6 +58,7 @@ test.describe('SearchV2 Features', () => {
     const moreFiltersBtn = searchPage.moreFiltersDropdown;
     await expect(moreFiltersBtn).toBeVisible({ timeout: 10000 });
     await moreFiltersBtn.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(500);
     // eslint-disable-next-line playwright/no-raw-locators -- data-testid prefix selector (^=); getByTestId requires exact match
     const moreFilterOption = page.locator('[data-testid^="more-filter-"]').first();
@@ -108,6 +110,7 @@ test.describe('SearchV2 Features', () => {
     const facetCount = await expandFacetIcon.count();
     if (facetCount > 0) {
       await expandFacetIcon.click();
+      // eslint-disable-next-line playwright/no-wait-for-timeout
       await page.waitForTimeout(500);
       await page.waitForLoadState('networkidle');
     }

--- a/e2e-test/ui/playwright/tests/stats-v2/v2-change-history.spec.ts
+++ b/e2e-test/ui/playwright/tests/stats-v2/v2-change-history.spec.ts
@@ -201,6 +201,7 @@ test.describe('Change History Calendar', () => {
 
     // Open dropdown
     await historyHelper.typesSelect.click({ timeout: TIMEOUTS.SHORT });
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.QUICK);
 
     // Toggle all 6 standard operation types OFF
@@ -212,6 +213,7 @@ test.describe('Change History Calendar', () => {
     // Close dropdown by clicking it again
     await historyHelper.typesSelect.click({ timeout: TIMEOUTS.SHORT });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     // ──────────────────────────────────────────────────────────
@@ -306,6 +308,7 @@ test.describe('Change History Calendar', () => {
     const customPill = historyHelper.getSummaryPill(CUSTOM_OPERATION_DISPLAY);
     await expect(customPill).toBeVisible();
     await historyHelper.toggleSummaryPill(CUSTOM_OPERATION_DISPLAY);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     // ──────────────────────────────────────────────────────────
@@ -478,6 +481,7 @@ test.describe('Change History Calendar', () => {
     // Wait for calendar to be visible
     await historyHelper.calendar.waitFor({ state: 'visible', timeout: TIMEOUTS.MEDIUM });
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await page.waitForTimeout(TIMEOUTS.BETWEEN_OPS);
 
     const day0DateStr = getDateString(0);


### PR DESCRIPTION
## Summary
- Enables the `playwright/no-wait-for-timeout` ESLint rule (was `off`) in `e2e-test/ui/playwright/eslint.config.js` so new `page.waitForTimeout()` calls get flagged going forward.
- Adds `// eslint-disable-next-line playwright/no-wait-for-timeout` above each of the 123 pre-existing `waitForTimeout` call sites across 31 files so the lint check passes without changing existing test behavior.

## Test plan
- [x] `eslint .` in `e2e-test/ui/playwright` reports 0 errors for `playwright/no-wait-for-timeout` (previously 123)
- [x] `prettier --check` passes on all touched files
- [x] No test logic changed — only comments and the lint config were added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `playwright/no-wait-for-timeout` rule to prevent new `page.waitForTimeout()` calls in Playwright E2E tests. Added `// eslint-disable-next-line playwright/no-wait-for-timeout` to 123 existing sites across 31 files so tests keep working with no behavior changes.

<sup>Written for commit a4e7a89f99913da1deb17a7a93ce91f1511706c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

