### PR TITLE
fix(lookml): emit empty globalTags instead of None when tag_measures_and_dimensions is False

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -878,7 +878,7 @@ class LookerUtil:
             globalTags=(
                 LookerUtil._get_tags_from_field_type(field, reporter)
                 if tag_measures_and_dimensions is True
-                else None
+                else GlobalTagsClass(tags=[])
             ),
             isPartOfKey=field.is_primary_key,
         )

--- a/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/drop_hive_dot_golden.json
@@ -272,6 +272,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -286,6 +289,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -300,6 +306,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/duplicate_field_ingestion_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/duplicate_field_ingestion_golden.json
@@ -305,6 +305,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -319,6 +322,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -333,6 +339,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -347,6 +356,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -361,6 +373,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -375,6 +390,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/expected_output.json
@@ -294,6 +294,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -308,6 +311,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -322,6 +328,9 @@
                     },
                     "nativeDataType": "yesno",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -336,6 +345,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -350,6 +362,9 @@
                     },
                     "nativeDataType": "average",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -599,6 +614,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -613,6 +631,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -627,6 +648,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -641,6 +665,9 @@
                     },
                     "nativeDataType": "average",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1165,6 +1192,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1695,6 +1725,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1709,6 +1742,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1723,6 +1759,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1953,6 +1992,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1967,6 +2009,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2194,6 +2239,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2208,6 +2256,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2435,6 +2486,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -2449,6 +2503,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2700,6 +2757,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2714,6 +2774,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2728,6 +2791,9 @@
                     },
                     "nativeDataType": "count_distinct",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2742,6 +2808,9 @@
                     },
                     "nativeDataType": "sum",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2958,6 +3027,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/gms_schema_resolution_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/gms_schema_resolution_golden.json
@@ -272,6 +272,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -286,6 +289,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -300,6 +306,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/lkml_col_lineage_looker_api_based_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/lkml_col_lineage_looker_api_based_golden.json
@@ -162,6 +162,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -176,6 +179,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -190,6 +196,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -204,6 +213,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -218,6 +230,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -232,6 +247,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -246,6 +264,9 @@
                     },
                     "nativeDataType": "yesno",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -260,6 +281,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -274,6 +298,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -288,6 +315,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -302,6 +332,9 @@
                     },
                     "nativeDataType": "duration",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -316,6 +349,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -330,6 +366,9 @@
                     },
                     "nativeDataType": "average",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -344,6 +383,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -716,6 +758,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -730,6 +775,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -744,6 +792,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -758,6 +809,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -772,6 +826,9 @@
                     },
                     "nativeDataType": "count_distinct",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1046,6 +1103,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1060,6 +1120,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -1074,6 +1137,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1088,6 +1154,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1102,6 +1171,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1116,6 +1188,9 @@
                     },
                     "nativeDataType": "duration",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1130,6 +1205,9 @@
                     },
                     "nativeDataType": "count_distinct",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1144,6 +1222,9 @@
                     },
                     "nativeDataType": "sum",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1158,6 +1239,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/refinement_include_order_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/refinement_include_order_golden.json
@@ -294,6 +294,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -308,6 +311,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -322,6 +328,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -336,6 +345,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -350,6 +362,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -613,6 +628,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -627,6 +645,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -641,6 +662,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -655,6 +679,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -669,6 +696,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -899,6 +929,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -913,6 +946,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1154,6 +1190,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1168,6 +1207,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1182,6 +1224,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/refinements_ingestion_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/refinements_ingestion_golden.json
@@ -294,6 +294,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -308,6 +311,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -322,6 +328,9 @@
                     },
                     "nativeDataType": "yesno",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -336,6 +345,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -350,6 +362,9 @@
                     },
                     "nativeDataType": "average",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -602,6 +617,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -616,6 +634,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -630,6 +651,9 @@
                     },
                     "nativeDataType": "time",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -644,6 +668,9 @@
                     },
                     "nativeDataType": "average",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1177,6 +1204,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1732,6 +1762,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1746,6 +1779,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1760,6 +1796,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1993,6 +2032,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2007,6 +2049,9 @@
                     },
                     "nativeDataType": "unknown",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2221,6 +2266,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2235,6 +2283,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2476,6 +2527,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -2490,6 +2544,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2504,6 +2561,9 @@
                     },
                     "nativeDataType": "yesno",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2758,6 +2818,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2772,6 +2835,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2786,6 +2852,9 @@
                     },
                     "nativeDataType": "count_distinct",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2800,6 +2869,9 @@
                     },
                     "nativeDataType": "sum",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -3019,6 +3091,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/vv_lineage_liquid_template_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/vv_lineage_liquid_template_golden.json
@@ -250,6 +250,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 }
             ],
@@ -501,6 +504,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -515,6 +521,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -529,6 +538,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -543,6 +555,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -781,6 +796,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -795,6 +813,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -809,6 +830,9 @@
                     },
                     "nativeDataType": "sum",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1047,6 +1071,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1061,6 +1088,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1075,6 +1105,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1313,6 +1346,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1327,6 +1363,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1341,6 +1380,9 @@
                     },
                     "nativeDataType": "sum",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1574,6 +1616,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1588,6 +1633,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1602,6 +1650,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -1616,6 +1667,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -1848,6 +1902,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 }
             ],
@@ -2099,6 +2156,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2113,6 +2173,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2127,6 +2190,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2141,6 +2207,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2363,6 +2432,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2377,6 +2449,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2391,6 +2466,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2629,6 +2707,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -2643,6 +2724,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2657,6 +2741,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],
@@ -2924,6 +3011,9 @@
                     },
                     "nativeDataType": "integer",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -2938,6 +3028,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2952,6 +3045,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -2966,6 +3062,9 @@
                     },
                     "nativeDataType": "count",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],

--- a/metadata-ingestion/tests/integration/looker/lookml/vv_lineage_lookml_constant_golden.json
+++ b/metadata-ingestion/tests/integration/looker/lookml/vv_lineage_lookml_constant_golden.json
@@ -250,6 +250,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 }
             ],
@@ -479,6 +482,9 @@
                     },
                     "nativeDataType": "number",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": true
                 },
                 {
@@ -493,6 +499,9 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
                     "isPartOfKey": false
                 }
             ],


### PR DESCRIPTION
When tag_measures_and_dimensions is False, view_field_to_schema_field sets globalTags=None on SchemaField objects. Pydantic serialises None by omitting the key entirely from the JSON payload, so DataHub treats the absent field as "keep existing tags" rather than "clear tags". This means old Dimension, Measure, and looker:group_label tags are never removed from schema fields after the setting is changed to False.

Fix: emit GlobalTagsClass(tags=[]) instead of None. This serialises as {"globalTags": {"tags": []}} which DataHub correctly interprets as an explicit empty tag set, clearing any previously ingested tags.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit an explicit empty globalTags when tag_measures_and_dimensions is false so DataHub clears previously ingested Looker tags instead of keeping them. Previously, `globalTags=None` made `pydantic` omit the key, causing DataHub to retain tags; now we send {"globalTags": {"tags": []}} to clear them.

<sup>Written for commit 612203bc748639a61783bbba7df7964c2853b696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

