### PR TITLE
feat(incidents): add incident support for mlModel and mlFeature entities

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3922,7 +3922,8 @@ public class GmsGraphQLEngine {
 
     // Add incidents attribute to all entities that support it
     final List<String> entitiesWithIncidents =
-        ImmutableList.of("Dataset", "DataJob", "DataFlow", "Dashboard", "Chart");
+        ImmutableList.of(
+            "Dataset", "DataJob", "DataFlow", "Dashboard", "Chart", "MLModel", "MLFeature");
     for (String entity : entitiesWithIncidents) {
       builder.type(
           entity,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -494,6 +494,14 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
         .getResourceType()
         .equals(resourceType)) {
       return EntityType.DATA_PLATFORM_INSTANCE;
+    } else if (com.linkedin.metadata.authorization.PoliciesConfig.ML_MODEL_PRIVILEGES
+        .getResourceType()
+        .equals(resourceType)) {
+      return EntityType.MLMODEL;
+    } else if (com.linkedin.metadata.authorization.PoliciesConfig.ML_FEATURE_PRIVILEGES
+        .getResourceType()
+        .equals(resourceType)) {
+      return EntityType.MLFEATURE;
     } else {
       return null;
     }

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -702,11 +702,11 @@ extend type MLModel {
     """
     state: IncidentState
     """
-    Optional incident stage to filter by, defaults to any state.
+    Optional incident stage to filter by, defaults to any stage.
     """
     stage: IncidentStage
     """
-    Optional incident priority to filter by, defaults to any state.
+    Optional incident priority to filter by, defaults to any priority.
     """
     priority: IncidentPriority
     """
@@ -718,7 +718,7 @@ extend type MLModel {
     """
     start: Int
     """
-    Optional start offset, defaults to 20.
+    Optional number of results to return, defaults to 20.
     """
     count: Int
   ): EntityIncidentsResult
@@ -734,11 +734,11 @@ extend type MLFeature {
     """
     state: IncidentState
     """
-    Optional incident stage to filter by, defaults to any state.
+    Optional incident stage to filter by, defaults to any stage.
     """
     stage: IncidentStage
     """
-    Optional incident priority to filter by, defaults to any state.
+    Optional incident priority to filter by, defaults to any priority.
     """
     priority: IncidentPriority
     """
@@ -750,7 +750,7 @@ extend type MLFeature {
     """
     start: Int
     """
-    Optional start offset, defaults to 20.
+    Optional number of results to return, defaults to 20.
     """
     count: Int
   ): EntityIncidentsResult

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -691,3 +691,67 @@ extend type Chart {
     count: Int
   ): EntityIncidentsResult
 }
+
+extend type MLModel {
+  """
+  Incidents associated with the MLModel
+  """
+  incidents(
+    """
+    Optional incident state to filter by, defaults to any state.
+    """
+    state: IncidentState
+    """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!]
+    """
+    Optional start offset, defaults to 0.
+    """
+    start: Int
+    """
+    Optional start offset, defaults to 20.
+    """
+    count: Int
+  ): EntityIncidentsResult
+}
+
+extend type MLFeature {
+  """
+  Incidents associated with the MLFeature
+  """
+  incidents(
+    """
+    Optional incident state to filter by, defaults to any state.
+    """
+    state: IncidentState
+    """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!]
+    """
+    Optional start offset, defaults to 0.
+    """
+    start: Int
+    """
+    Optional start offset, defaults to 20.
+    """
+    count: Int
+  ): EntityIncidentsResult
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolverTest.java
@@ -15,9 +15,12 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.CorpUser;
 import com.linkedin.datahub.graphql.generated.Dataset;
+import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityIncidentsResult;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.IncidentPriority;
+import com.linkedin.datahub.graphql.generated.MLFeature;
+import com.linkedin.datahub.graphql.generated.MLModel;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspectMap;
@@ -51,11 +54,34 @@ import org.testng.annotations.Test;
 public class EntityIncidentsResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
+    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
+    Dataset parentEntity = new Dataset();
+    parentEntity.setUrn(datasetUrn.toString());
+    assertIncidentsResolvedForSource(datasetUrn, parentEntity);
+  }
+
+  @Test
+  public void testGetSuccessMlModelEntity() throws Exception {
+    Urn mlModelUrn =
+        Urn.createFromString("urn:li:mlModel:(urn:li:dataPlatform:mlflow,test-model,PROD)");
+    MLModel parentEntity = new MLModel();
+    parentEntity.setUrn(mlModelUrn.toString());
+    assertIncidentsResolvedForSource(mlModelUrn, parentEntity);
+  }
+
+  @Test
+  public void testGetSuccessMlFeatureEntity() throws Exception {
+    Urn mlFeatureUrn = Urn.createFromString("urn:li:mlFeature:(test-namespace,test-feature)");
+    MLFeature parentEntity = new MLFeature();
+    parentEntity.setUrn(mlFeatureUrn.toString());
+    assertIncidentsResolvedForSource(mlFeatureUrn, parentEntity);
+  }
+
+  private void assertIncidentsResolvedForSource(Urn entityUrn, Entity source) throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Urn assertionUrn = Urn.createFromString("urn:li:assertion:test");
     Urn userUrn = Urn.createFromString("urn:li:corpuser:test");
-    Urn datasetUrn = Urn.createFromString("urn:li:dataset:(test,test,test)");
     Urn incidentUrn = Urn.createFromString("urn:li:incident:test-guid");
 
     Map<String, com.linkedin.entity.EnvelopedAspect> incidentAspects = new HashMap<>();
@@ -71,7 +97,7 @@ public class EntityIncidentsResolverTest {
             .setDescription("Description")
             .setPriority(5)
             .setTitle("Title")
-            .setEntities(new UrnArray(ImmutableList.of(datasetUrn)))
+            .setEntities(new UrnArray(ImmutableList.of(entityUrn)))
             .setSource(
                 new IncidentSource()
                     .setType(IncidentSourceType.ASSERTION_FAILURE)
@@ -89,7 +115,7 @@ public class EntityIncidentsResolverTest {
 
     final Map<String, List<String>> criterionMap = new HashMap<>();
     criterionMap.put(
-        INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, ImmutableList.of(datasetUrn.toString()));
+        INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, ImmutableList.of(entityUrn.toString()));
     Filter expectedFilter = QueryUtils.newListsFilter(criterionMap);
 
     SortCriterion expectedSort = new SortCriterion();
@@ -139,9 +165,7 @@ public class EntityIncidentsResolverTest {
     Mockito.when(mockEnv.getArgumentOrDefault(Mockito.eq("count"), Mockito.eq(20))).thenReturn(10);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
-    Dataset parentEntity = new Dataset();
-    parentEntity.setUrn(datasetUrn.toString());
-    Mockito.when(mockEnv.getSource()).thenReturn(parentEntity);
+    Mockito.when(mockEnv.getSource()).thenReturn(source);
 
     EntityIncidentsResult result = resolver.get(mockEnv).get();
 

--- a/datahub-web-react/src/graphql/mlFeature.graphql
+++ b/datahub-web-react/src/graphql/mlFeature.graphql
@@ -17,6 +17,9 @@ query getMLFeature($urn: String!, $skipSiblingsSearch: Boolean = false) {
                 ...structuredPropertiesFields
             }
         }
+        activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
+            total
+        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/mlModel.graphql
+++ b/datahub-web-react/src/graphql/mlModel.graphql
@@ -48,6 +48,9 @@ query getMLModel($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
+        activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
+            total
+        }
         ...notes
         ...entityProfileVersionProperties
     }

--- a/metadata-models/docs/entities/mlFeature.md
+++ b/metadata-models/docs/entities/mlFeature.md
@@ -337,7 +337,7 @@ Features are accessible through DataHub's GraphQL API via the `MLFeatureType` cl
 
 ### Incidents
 
-ML Features participate in the shared incidents subsystem. Incidents can be raised on a feature via the `raiseIncident` GraphQL mutation, listed back through the `incidents` field on the `MLFeature` GraphQL type, and the feature carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents change state.
+ML Features participate in the shared incidents subsystem. Incidents can be raised on a feature via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLFeature` GraphQL type, and the feature carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved.
 
 ## Notable Exceptions
 

--- a/metadata-models/docs/entities/mlFeature.md
+++ b/metadata-models/docs/entities/mlFeature.md
@@ -335,6 +335,10 @@ Features are accessible through DataHub's GraphQL API via the `MLFeatureType` cl
 - Batch loading of feature metadata
 - Filtering features by properties and relationships
 
+### Incidents
+
+ML Features participate in the shared incidents subsystem. Incidents can be raised on a feature via the `raiseIncident` GraphQL mutation, listed back through the `incidents` field on the `MLFeature` GraphQL type, and the feature carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents change state.
+
 ## Notable Exceptions
 
 ### Feature Namespace vs Feature Table

--- a/metadata-models/docs/entities/mlModel.md
+++ b/metadata-models/docs/entities/mlModel.md
@@ -331,6 +331,10 @@ The GraphQL API provides rich querying capabilities for ML Models through resolv
 - Navigating relationships to features, groups, and deployments
 - Searching and filtering models by tags, terms, platform, etc.
 
+### Incidents
+
+ML Models participate in the shared incidents subsystem. Incidents can be raised on a model via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLModel` GraphQL type, and the model carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved. Since an incident can reference multiple entities, a single incident can link an upstream dataset and the affected model under one lifecycle.
+
 ### Ingestion Sources
 
 Several ingestion sources automatically extract ML Model metadata:

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -455,6 +455,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - incidentsSummary
       - versionProperties
       - subTypes
       - container
@@ -539,6 +540,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - incidentsSummary
       - subTypes
       - documentation
   - name: mlPrimaryKey

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -992,6 +992,16 @@ public class PoliciesConfig {
           "DataHub Views",
           ImmutableList.of(VIEW_ENTITY_PAGE_PRIVILEGE, EXISTS_ENTITY_PRIVILEGE));
 
+  // ML Model Privileges
+  public static final ResourcePrivileges ML_MODEL_PRIVILEGES =
+      ResourcePrivileges.of(
+          "mlModel", "ML Models", "ML Models indexed by DataHub", COMMON_ENTITY_PRIVILEGES);
+
+  // ML Feature Privileges
+  public static final ResourcePrivileges ML_FEATURE_PRIVILEGES =
+      ResourcePrivileges.of(
+          "mlFeature", "ML Features", "ML Features indexed by DataHub", COMMON_ENTITY_PRIVILEGES);
+
   public static final List<ResourcePrivileges> ENTITY_RESOURCE_PRIVILEGES =
       ImmutableList.of(
           DATASET_PRIVILEGES,
@@ -1017,7 +1027,9 @@ public class PoliciesConfig {
           VERSION_SET_PRIVILEGES,
           PLATFORM_INSTANCE_PRIVILEGES,
           APPLICATION_PRIVILEGES,
-          DATAHUB_VIEW_PRIVILEGES);
+          DATAHUB_VIEW_PRIVILEGES,
+          ML_MODEL_PRIVILEGES,
+          ML_FEATURE_PRIVILEGES);
 
   // Merge all entity specific resource privileges to create a superset of all resource privileges
   public static final ResourcePrivileges ALL_RESOURCE_PRIVILEGES =


### PR DESCRIPTION
Part 1 of the plan agreed with @AdrianMachado on #18911. Related: #18999.

Since #18478 the IncidentOn relationship in IncidentInfo.pdl already allows mlModel and mlFeature, so on master an incident raised on a model is accepted and stored, but incidentsSummary is never maintained on the asset and nothing can read the incident back through GraphQL. This PR closes that gap for the two types that are already in the PDL allowlist.

## Changes

- **entity-registry.yml**: register `incidentsSummary` for mlModel and mlFeature, so IncidentsSummaryHook maintains the rolled-up summary on those assets. The hook itself needs no change, it keys only on incident entity events.
- **incident.graphql**: extend `MLModel` and `MLFeature` with the `incidents` field, same arg set as the existing Dataset block (state, stage, priority, assigneeUrns, start, count).
- **GmsGraphQLEngine.configureIncidentResolvers**: add `MLModel` and `MLFeature` to `entitiesWithIncidents`. `EntityIncidentsResolver` is source-type-agnostic, so no resolver change is needed.
- **PoliciesConfig**: add `ML_MODEL_PRIVILEGES` and `ML_FEATURE_PRIVILEGES` (COMMON_ENTITY_PRIVILEGES, which already includes `EDIT_ENTITY_INCIDENTS`) and register them in `ENTITY_RESOURCE_PRIVILEGES`, so the incident privilege can be granted through per-type policies.
- **AppConfigResolver**: resource type to EntityType mapping for the two new privilege groups.
- **docs**: short Incidents sections in the mlModel and mlFeature entity docs. The supported-types list in docs/incidents/incidents.md is left to #18685 to avoid conflicting there.

## Not in this PR (per the plan on #18911)

- UI completion for the two entity pages (PR2)
- mlFeatureTable and mlModelGroup, which also need the PDL entityTypes addition (PR3)
- Health rollup for ML pages, mlModelDeployment, and schemaField (follow-up issues)

## Notes

- Prior art: #11684 by @jjoyce0510 goes in the same direction but predates #18478 and the entityV2 UI move. This PR follows its approach on current master. If reviving that PR is preferred, happy to rework.
- #19097 adds a consistency test across the three sources of truth. Its KNOWN_GAPS entries for mlModel and mlFeature should be dropped once this merges; I can fold that in here if #19097 lands first.
- @cnpierrepapi @JonathanSolvesProblems this is the patch to test against. Note for 1.5.x instances: the PDL entityTypes widening from #18478 is also needed there and is not part of this PR.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated: covered by existing GraphQL engine schema validation in CI plus the cross-source consistency test proposed in #19097
- [x] Docs related to the changes have been added/updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incident support for `MLModel` and `MLFeature`. Previously incidents on these types were accepted but unreadable and not rolled up; now GraphQL reads are available, `incidentsSummary` is maintained, and ML pages show active incident counts.

- Register `incidentsSummary` for `mlModel`/`mlFeature` and expose `incidents` on `MLModel`/`MLFeature` in GraphQL; wire resolvers in `GmsGraphQLEngine`.
- Add `ML_MODEL_PRIVILEGES` and `ML_FEATURE_PRIVILEGES` and map them in `AppConfigResolver` so `EDIT_ENTITY_INCIDENTS` can be granted per type.
- Request `activeIncidents.total` in `mlModel.graphql` and `mlFeature.graphql` to populate the Incidents tab badge.
- Correct filter and pagination descriptions (stage, priority, count) on the new ML incidents fields.
- Extend `EntityIncidentsResolverTest` for ML entities; update ML docs to cover incidents.

<sup>Written for commit 3d8121d467493e422ac5b7c1719954f65461e9e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

