### PR TITLE
fix: allow config probes to use separate retry limits

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -476,6 +476,7 @@ class DataHubRestEmitter(Closeable, Emitter):
     _gms_server: str
     _token: Optional[str]
     _session: requests.Session
+    _config_session: Optional[requests.Session]
     _openapi_ingestion: Optional[bool]
     _server_config: Optional[RestServiceConfig]
 
@@ -502,6 +503,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         client_mode: Optional[ClientMode] = None,
         datahub_component: Optional[str] = None,
         server_config_refresh_interval: Optional[int] = None,
+        server_config_retry_max_times: Optional[int] = None,
         tcp_keepalive: Optional[bool] = None,
         default_emit_mode: Optional[EmitMode] = None,
     ):
@@ -550,6 +552,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         # mutator/validator, or an upstream processing step).
         self.respect_mcp_sync_marker = respect_mcp_sync_marker is True
         self._server_config_refresh_interval = server_config_refresh_interval
+        self._server_config_retry_max_times = server_config_retry_max_times
         self._server_config: Optional[RestServiceConfig] = None
         self._config_fetch_time: Optional[float] = None
 
@@ -614,6 +617,14 @@ class DataHubRestEmitter(Closeable, Emitter):
         self._session = self._session_config.build_session()
         if auth is not None:
             self._session.auth = auth
+        self._config_session = None
+        if server_config_retry_max_times is not None:
+            config_session_config = self._session_config.model_copy(
+                update={"retry_max_times": server_config_retry_max_times}
+            )
+            self._config_session = config_session_config.build_session()
+            if auth is not None:
+                self._config_session.auth = auth
 
     @property
     def session(self) -> requests.Session:
@@ -654,7 +665,8 @@ class DataHubRestEmitter(Closeable, Emitter):
                 )
 
             url = f"{self._gms_server}/config"
-            response = self._session.get(url)
+            config_session = self._config_session or self._session
+            response = config_session.get(url)
 
             if response.status_code == 200:
                 raw_config = response.json()
@@ -1392,6 +1404,8 @@ class DataHubRestEmitter(Closeable, Emitter):
 
     def close(self) -> None:
         self._session.close()
+        if self._config_session is not None:
+            self._config_session.close()
 
 
 """This class exists as a pass-through for backwards compatibility"""

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -193,6 +193,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             client_mode=config.client_mode,
             datahub_component=config.datahub_component,
             server_config_refresh_interval=config.server_config_refresh_interval,
+            server_config_retry_max_times=config.server_config_retry_max_times,
             tcp_keepalive=self.config.tcp_keepalive,
         )
         self.server_id: str = _MISSING_SERVER_ID
@@ -308,6 +309,9 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 client_mode=session_config.client_mode,
                 datahub_component=session_config.datahub_component,
                 server_config_refresh_interval=emitter._server_config_refresh_interval,
+                server_config_retry_max_times=(
+                    emitter._server_config_retry_max_times
+                ),
                 tcp_keepalive=session_config.tcp_keepalive,
                 # Preserve the source emitter's default emit mode so converting an
                 # emitter to a graph (e.g. emitter.to_graph()) doesn't silently
@@ -2381,10 +2385,12 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
 def get_default_graph(
     client_mode: Optional[ClientMode] = None,
     datahub_component: Optional[str] = None,
+    server_config_retry_max_times: Optional[int] = None,
 ) -> DataHubGraph:
     graph_config = config_utils.load_client_config()
     graph_config.client_mode = client_mode
     graph_config.datahub_component = datahub_component
+    graph_config.server_config_retry_max_times = server_config_retry_max_times
     graph = DataHubGraph(graph_config)
     graph.test_connection()
     telemetry_instance.set_context(server=graph)

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -309,9 +309,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
                 client_mode=session_config.client_mode,
                 datahub_component=session_config.datahub_component,
                 server_config_refresh_interval=emitter._server_config_refresh_interval,
-                server_config_retry_max_times=(
-                    emitter._server_config_retry_max_times
-                ),
+                server_config_retry_max_times=emitter._server_config_retry_max_times,
                 tcp_keepalive=session_config.tcp_keepalive,
                 # Preserve the source emitter's default emit mode so converting an
                 # emitter to a graph (e.g. emitter.to_graph()) doesn't silently
@@ -333,6 +331,11 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
             # TODO(oauth): retain the declarative AuthConfig alongside the
             # resolved auth so derived configs keep it.
             graph._session.auth = emitter._session.auth
+            # A dedicated config-probe session is created when
+            # server_config_retry_max_times is set; it needs the same auth or
+            # /config calls from to_graph() would be unauthenticated.
+            if graph._config_session is not None:
+                graph._config_session.auth = emitter._session.auth
         return graph
 
     def _send_restli_request(self, method: str, url: str, **kwargs: Any) -> Dict:
@@ -2390,7 +2393,8 @@ def get_default_graph(
     graph_config = config_utils.load_client_config()
     graph_config.client_mode = client_mode
     graph_config.datahub_component = datahub_component
-    graph_config.server_config_retry_max_times = server_config_retry_max_times
+    if server_config_retry_max_times is not None:
+        graph_config.server_config_retry_max_times = server_config_retry_max_times
     graph = DataHubGraph(graph_config)
     graph.test_connection()
     telemetry_instance.set_context(server=graph)

--- a/metadata-ingestion/src/datahub/ingestion/graph/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/config.py
@@ -51,6 +51,7 @@ class DatahubClientConfig(ConfigModel):
     client_mode: Optional[ClientMode] = None
     datahub_component: Optional[str] = None
     server_config_refresh_interval: Optional[int] = None
+    server_config_retry_max_times: Optional[int] = None
     tcp_keepalive: bool = _DEFAULT_TCP_KEEPALIVE
     # Default emit mode for emit calls that don't pass one. None falls back to the
     # emitter's global default. Not used by the `datahub-rest` sink (it has `mode`).

--- a/metadata-ingestion/src/datahub/sdk/main_client.py
+++ b/metadata-ingestion/src/datahub/sdk/main_client.py
@@ -88,8 +88,8 @@ class DataHubClient:
         Args:
             client_mode: [internal] The client mode to use. Defaults to "SDK".
             datahub_component: [internal] The DataHub component name to include in the user agent.
-            server_config_retry_max_times: Maximum retries for the initial server
-                configuration probe. Other requests retain their configured retry policy.
+            server_config_retry_max_times: Maximum retries for server configuration
+                probes. Other requests retain their configured retry policy.
 
         Returns:
             A DataHubClient instance.

--- a/metadata-ingestion/src/datahub/sdk/main_client.py
+++ b/metadata-ingestion/src/datahub/sdk/main_client.py
@@ -74,6 +74,7 @@ class DataHubClient:
         *,
         client_mode: ClientMode = ClientMode.SDK,
         datahub_component: Optional[str] = None,
+        server_config_retry_max_times: Optional[int] = None,
     ) -> "DataHubClient":
         """Initialize a DataHubClient from the environment variables or ~/.datahubenv file.
 
@@ -87,6 +88,8 @@ class DataHubClient:
         Args:
             client_mode: [internal] The client mode to use. Defaults to "SDK".
             datahub_component: [internal] The DataHub component name to include in the user agent.
+            server_config_retry_max_times: Maximum retries for the initial server
+                configuration probe. Other requests retain their configured retry policy.
 
         Returns:
             A DataHubClient instance.
@@ -98,6 +101,7 @@ class DataHubClient:
         graph = get_default_graph(
             client_mode=client_mode,
             datahub_component=datahub_component,
+            server_config_retry_max_times=server_config_retry_max_times,
         )
 
         return cls(graph=graph)

--- a/metadata-ingestion/tests/unit/cli/test_config_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_config_utils.py
@@ -3,7 +3,6 @@ from unittest.mock import mock_open, patch
 
 import pytest
 import yaml
-
 from datahub.cli import config_utils
 from datahub.cli.config_utils import (
     DATAHUB_CONFIG_PATH,
@@ -267,6 +266,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "server_config_retry_max_times": None,
                     "tcp_keepalive": False,
                     "default_emit_mode": None,
                 }
@@ -322,6 +322,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "server_config_retry_max_times": None,
                     "tcp_keepalive": False,
                     "default_emit_mode": None,
                 },
@@ -357,6 +358,7 @@ class TestConfigUtils:
                     "retry_status_codes": None,
                     "timeout_sec": None,
                     "server_config_refresh_interval": None,
+                    "server_config_retry_max_times": None,
                     "tcp_keepalive": False,
                     "default_emit_mode": None,
                 }

--- a/metadata-ingestion/tests/unit/cli/test_config_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_config_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 import yaml
+
 from datahub.cli import config_utils
 from datahub.cli.config_utils import (
     DATAHUB_CONFIG_PATH,

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -196,6 +196,47 @@ class TestDataHubRestEmitter:
         config_session.get.assert_called_once_with(f"{MOCK_GMS_ENDPOINT}/config")
         emitter._session.get.assert_not_called()
 
+    def test_from_emitter_copies_auth_to_config_session(self) -> None:
+        from datahub.ingestion.graph.client import DataHubGraph
+
+        auth = object()
+        emitter = DatahubRestEmitter(
+            MOCK_GMS_ENDPOINT,
+            server_config_retry_max_times=0,
+        )
+        emitter._session.auth = auth
+
+        graph = DataHubGraph.from_emitter(emitter)
+
+        assert graph._session.auth is auth
+        assert graph._config_session is not None
+        assert graph._config_session.auth is auth
+
+    def test_get_default_graph_preserves_config_retry_limit(self) -> None:
+        from datahub.ingestion.graph.client import DataHubGraph, get_default_graph
+        from datahub.ingestion.graph.config import DatahubClientConfig
+
+        loaded = DatahubClientConfig(
+            server=MOCK_GMS_ENDPOINT,
+            server_config_retry_max_times=3,
+        )
+        get_default_graph.cache_clear()
+        with (
+            patch(
+                "datahub.ingestion.graph.client.config_utils.load_client_config",
+                return_value=loaded,
+            ),
+            patch.object(DataHubGraph, "test_connection"),
+            patch("datahub.ingestion.graph.client.telemetry_instance"),
+        ):
+            graph = get_default_graph(server_config_retry_max_times=None)
+            assert graph._server_config_retry_max_times == 3
+
+            get_default_graph.cache_clear()
+            graph = get_default_graph(server_config_retry_max_times=0)
+            assert graph._server_config_retry_max_times == 0
+        get_default_graph.cache_clear()
+
     def test_datahub_client_from_env_passes_config_retry_limit(self) -> None:
         with patch("datahub.sdk.main_client.get_default_graph") as get_default_graph:
             DataHubClient.from_env(server_config_retry_max_times=0)

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -199,7 +199,7 @@ class TestDataHubRestEmitter:
     def test_from_emitter_copies_auth_to_config_session(self) -> None:
         from datahub.ingestion.graph.client import DataHubGraph
 
-        auth = object()
+        auth = MagicMock(name="oauth-auth")
         emitter = DatahubRestEmitter(
             MOCK_GMS_ENDPOINT,
             server_config_retry_max_times=0,

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -174,9 +174,7 @@ class TestDataHubRestEmitter:
             server_config_retry_max_times=0,
         )
 
-        assert (
-            emitter._session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total == 42
-        )
+        assert emitter._session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total == 42
         assert emitter._config_session is not None
         assert (
             emitter._config_session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -8,29 +8,15 @@ from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 import requests
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+
 from datahub.configuration.common import (
     ConfigurationError,
     OperationalError,
     TraceTimeoutError,
     TraceValidationError,
 )
-from datahub.metadata.com.linkedin.pegasus2avro.common import (
-    Status,
-)
-from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
-    DatasetProfile,
-    DatasetProperties,
-)
-from datahub.metadata.schema_classes import (
-    KEY_ASPECT_NAMES,
-    KEY_ASPECTS,
-    ChangeTypeClass,
-)
-from datahub.specific.dataset import DatasetPatchBuilder
-from datahub.utilities.server_config_util import RestServiceConfig
-from requests import Response, Session
-from requests.adapters import HTTPAdapter
-
 from datahub.emitter import rest_emitter
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.response_helper import TraceData
@@ -48,7 +34,21 @@ from datahub.emitter.rest_emitter import (
 )
 from datahub.errors import APITracingWarning
 from datahub.ingestion.graph.config import ClientMode
+from datahub.metadata.com.linkedin.pegasus2avro.common import (
+    Status,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
+    DatasetProfile,
+    DatasetProperties,
+)
+from datahub.metadata.schema_classes import (
+    KEY_ASPECT_NAMES,
+    KEY_ASPECTS,
+    ChangeTypeClass,
+)
 from datahub.sdk.main_client import DataHubClient
+from datahub.specific.dataset import DatasetPatchBuilder
+from datahub.utilities.server_config_util import RestServiceConfig
 
 MOCK_GMS_ENDPOINT = "http://fakegmshost:8080"
 

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -46,6 +46,7 @@ from datahub.metadata.schema_classes import (
     KEY_ASPECTS,
     ChangeTypeClass,
 )
+from datahub.sdk.main_client import DataHubClient
 from datahub.specific.dataset import DatasetPatchBuilder
 from datahub.utilities.server_config_util import RestServiceConfig
 
@@ -165,6 +166,42 @@ class TestDataHubRestEmitter:
         )
         assert emitter._session_config.retry_status_codes == [418]
         assert emitter._session_config.retry_max_times == 42
+
+    def test_server_config_uses_dedicated_retry_policy(self, mock_response) -> None:
+        emitter = DatahubRestEmitter(
+            MOCK_GMS_ENDPOINT,
+            retry_max_times=42,
+            server_config_retry_max_times=0,
+        )
+
+        assert (
+            emitter._session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total == 42
+        )
+        assert emitter._config_session is not None
+        assert (
+            emitter._config_session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total
+            == 0
+        )
+
+        config_session = MagicMock(spec=Session)
+        config_session.get.return_value = mock_response
+        emitter._config_session = config_session
+        emitter._session = MagicMock(spec=Session)
+
+        emitter.fetch_server_config()
+
+        config_session.get.assert_called_once_with(f"{MOCK_GMS_ENDPOINT}/config")
+        emitter._session.get.assert_not_called()
+
+    def test_datahub_client_from_env_passes_config_retry_limit(self) -> None:
+        with patch("datahub.sdk.main_client.get_default_graph") as get_default_graph:
+            DataHubClient.from_env(server_config_retry_max_times=0)
+
+        get_default_graph.assert_called_once_with(
+            client_mode=ClientMode.SDK,
+            datahub_component=None,
+            server_config_retry_max_times=0,
+        )
 
     def test_datahub_rest_emitter_extra_params(self) -> None:
         emitter = DatahubRestEmitter(

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -221,21 +221,23 @@ class TestDataHubRestEmitter:
             server_config_retry_max_times=3,
         )
         get_default_graph.cache_clear()
-        with (
-            patch(
-                "datahub.ingestion.graph.client.config_utils.load_client_config",
-                return_value=loaded,
-            ),
-            patch.object(DataHubGraph, "test_connection"),
-            patch("datahub.ingestion.graph.client.telemetry_instance"),
-        ):
-            graph = get_default_graph(server_config_retry_max_times=None)
-            assert graph._server_config_retry_max_times == 3
+        try:
+            with (
+                patch(
+                    "datahub.ingestion.graph.client.config_utils.load_client_config",
+                    return_value=loaded,
+                ),
+                patch.object(DataHubGraph, "test_connection"),
+                patch("datahub.ingestion.graph.client.telemetry_instance"),
+            ):
+                graph = get_default_graph(server_config_retry_max_times=None)
+                assert graph._server_config_retry_max_times == 3
 
+                get_default_graph.cache_clear()
+                graph = get_default_graph(server_config_retry_max_times=0)
+                assert graph._server_config_retry_max_times == 0
+        finally:
             get_default_graph.cache_clear()
-            graph = get_default_graph(server_config_retry_max_times=0)
-            assert graph._server_config_retry_max_times == 0
-        get_default_graph.cache_clear()
 
     def test_datahub_client_from_env_passes_config_retry_limit(self) -> None:
         with patch("datahub.sdk.main_client.get_default_graph") as get_default_graph:

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -3,20 +3,34 @@ import os
 import time
 import warnings
 from datetime import timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 import requests
-from requests import Response, Session
-from requests.adapters import HTTPAdapter
-
 from datahub.configuration.common import (
     ConfigurationError,
     OperationalError,
     TraceTimeoutError,
     TraceValidationError,
 )
+from datahub.metadata.com.linkedin.pegasus2avro.common import (
+    Status,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
+    DatasetProfile,
+    DatasetProperties,
+)
+from datahub.metadata.schema_classes import (
+    KEY_ASPECT_NAMES,
+    KEY_ASPECTS,
+    ChangeTypeClass,
+)
+from datahub.specific.dataset import DatasetPatchBuilder
+from datahub.utilities.server_config_util import RestServiceConfig
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+
 from datahub.emitter import rest_emitter
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.response_helper import TraceData
@@ -34,21 +48,7 @@ from datahub.emitter.rest_emitter import (
 )
 from datahub.errors import APITracingWarning
 from datahub.ingestion.graph.config import ClientMode
-from datahub.metadata.com.linkedin.pegasus2avro.common import (
-    Status,
-)
-from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
-    DatasetProfile,
-    DatasetProperties,
-)
-from datahub.metadata.schema_classes import (
-    KEY_ASPECT_NAMES,
-    KEY_ASPECTS,
-    ChangeTypeClass,
-)
 from datahub.sdk.main_client import DataHubClient
-from datahub.specific.dataset import DatasetPatchBuilder
-from datahub.utilities.server_config_util import RestServiceConfig
 
 MOCK_GMS_ENDPOINT = "http://fakegmshost:8080"
 
@@ -167,19 +167,24 @@ class TestDataHubRestEmitter:
         assert emitter._session_config.retry_status_codes == [418]
         assert emitter._session_config.retry_max_times == 42
 
-    def test_server_config_uses_dedicated_retry_policy(self, mock_response) -> None:
+    def test_server_config_uses_dedicated_retry_policy(
+        self, mock_response: Response
+    ) -> None:
         emitter = DatahubRestEmitter(
             MOCK_GMS_ENDPOINT,
             retry_max_times=42,
             server_config_retry_max_times=0,
         )
 
-        assert emitter._session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total == 42
-        assert emitter._config_session is not None
-        assert (
-            emitter._config_session.get_adapter(MOCK_GMS_ENDPOINT).max_retries.total
-            == 0
+        session_adapter = cast(
+            HTTPAdapter, emitter._session.get_adapter(MOCK_GMS_ENDPOINT)
         )
+        assert session_adapter.max_retries.total == 42
+        assert emitter._config_session is not None
+        config_adapter = cast(
+            HTTPAdapter, emitter._config_session.get_adapter(MOCK_GMS_ENDPOINT)
+        )
+        assert config_adapter.max_retries.total == 0
 
         config_session = MagicMock(spec=Session)
         config_session.get.return_value = mock_response


### PR DESCRIPTION
## Summary
- Add an explicit retry limit for the initial GMS `/config` capability probe
- Leave the existing ingestion retry policy unchanged for all other requests
- Expose the option through `DatahubClientConfig` / `DataHubClient.from_env` so interactive clients (MCP server startup) can fail fast when GMS is unreachable

Fixes #18904.

## Why
`mcp-server-datahub` uses the shared Rest emitter for its initial `/config` check. That path currently inherits ingestion-oriented retries, so a missing GMS can take 60s+ before the client sees a failure. Interactive tools need a short probe; batch ingestion still needs the long retries.

## Test plan
- [x] `python -m py_compile` on the touched modules
- [x] Unit coverage added in `metadata-ingestion/tests/unit/sdk/test_rest_emitter.py` for the config-probe retry limit
- [ ] Full `pytest metadata-ingestion/tests/unit/sdk/test_rest_emitter.py` in CI (needs generated metadata modules)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a separate retry limit for the `/config` capability probe so startup checks can fail fast without changing ingestion retry behavior. The limit is configurable via `server_config_retry_max_times` and available through `DataHubClient.from_env`.

- **New Features**
  - Added `server_config_retry_max_times` with a dedicated `/config` session; other requests keep existing `retry_max_times`.
  - Wired through `DatahubClientConfig`, `DataHubGraph` (`get_default_graph`), and `DataHubClient.from_env`.
  - Added tests for the dedicated retry policy, OAuth carryover, `get_default_graph(None)` preservation, and env wiring.

- **Bug Fixes**
  - Preserve OAuth/auth on the `/config` session when deriving a graph via `from_emitter`, ensuring authenticated probes.
  - Keep file-based retry config unless `server_config_retry_max_times` is explicitly overridden (treat `None` as “preserve”).
  - Stabilized the retry-limit test by always clearing the `get_default_graph` cache; updated config snapshot expectations and fixed mypy/ruff in tests.

<sup>Written for commit 68134d5db1502a68b5a58cb60082c79aad37301f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

