### PR TITLE
fix(incidents): populate incident count on Data Job pages

### DIFF
--- a/datahub-web-react/src/graphql/dataJob.graphql
+++ b/datahub-web-react/src/graphql/dataJob.graphql
@@ -22,6 +22,9 @@ query getDataJob($urn: String!) {
         browsePathV2 {
             ...browsePathV2Fields
         }
+        activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
+            total
+        }
         ...notes
         platform {
             ...platformFields


### PR DESCRIPTION
Data Jobs show an Incidents tab with a permanently empty count. Found while reviewing #19112, where the same shape of bug affects the ML entities; @Danishlynx has fixed those there in a3d1d80. This one is separate and predates both PRs, so it is its own change.

## The bug

`DataJobEntity.tsx:140` registers the tab like every other entity that supports incidents:

```tsx
getCount: (_, dataJob) => {
    return dataJob?.dataJob?.activeIncidents?.total;
},
```

`activeIncidents` is not a field in the GraphQL schema. Grep the SDL and it does not exist anywhere. It is a client side alias, declared per entity in the frontend query documents, as in `dataset.graphql`:

```graphql
activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
    total
}
```

Which documents declare it, on master:

| query document | declares `activeIncidents` | tab reads it |
| --- | --- | --- |
| `dataset.graphql` | yes | yes |
| `chart.graphql` | yes | yes |
| `dashboard.graphql` | yes | yes |
| `dataFlow.graphql` | yes | yes |
| `dataJob.graphql` | **no** | **yes** |

So `getCount` reads `undefined` and the badge renders empty. Nothing throws and no query fails, which is presumably why it has survived: `dataJob` has had incident support at every backend layer all along, so the feature looks supported everywhere you would think to check.

Only the count is affected, not the tab contents. `IncidentList` runs its own `useGetEntityIncidentsQuery` off the urn and entity type from `useEntityData`, so opening the tab has always worked. It is the badge on the closed tab that is wrong, which is the part that tells a user whether it is worth opening.

## The fix

Declares the alias in `getDataJob`, in the same shape and position as the other four documents. Three lines.

The generated hooks are not committed: `datahub-web-react/.gitignore` ignores `*.generated.ts` and none are tracked, so codegen picks this up at build time with nothing further to commit. Same conclusion @Danishlynx reached on #19112.

## Verification

I validated the change against the real schema rather than eyeballing it. Assembling all 35 SDL files the way `GmsGraphQLEngine` does, building the schema with graphql-js, then validating every document in `datahub-web-react/src/graphql` against it:

```
                 validation errors   getDataJob selects
master           2                   ..., browsePathV2, platform
this PR          2                   ..., browsePathV2, activeIncidents:incidents, platform
```

The two errors are identical before and after and are artifacts of concatenating all documents into one (`There can be only one operation named "createPost"` / `"updatePost"`). No new error, and the alias resolves against `DataJob.incidents`.

Formatting checked with prettier 3.5.3 under `datahub-web-react/.prettierrc.js`: the file is clean before and after.

What I have not run: `yarn generate`, `yarn type-check` or the vitest suite. The change is three lines of GraphQL in a document whose four siblings already carry the identical selection, so I do not expect movement there, but CI is the first real run.

## Checklist

- [x] PR conforms to the Contributing Guideline, including PR Title Format
- [x] Links to related issues: #19112, #18999
- [ ] No test added: this is a declaration in a query document, and the generated hooks are not committed
- [ ] No docs change needed
- [ ] Not a breaking change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty incident count on Data Job pages by adding the missing `activeIncidents` alias to the `getDataJob` query. The Incidents tab badge now shows the correct active incident total.

- **Bug Fixes**
  - Added `activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) { total }` to `datahub-web-react/src/graphql/dataJob.graphql`.
  - Only the badge count was affected; the tab contents already loaded correctly via `useGetEntityIncidentsQuery`.

<sup>Written for commit ad39eeec9a189ce9b36f3ddf36f350a18e536168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

