### PR TITLE
fix(build): give the betterleaks mise pin a resolvable backend

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,11 @@
 [tools]
 actionlint = "1.7.11"
-betterleaks = "1.6.1"
+# betterleaks has no mise registry entry, so it needs its backend named
+# explicitly. A bare `betterleaks = "..."` fails to resolve, mise installs
+# nothing, and the pre-commit secret scan then fails with "Executable
+# `betterleaks` not found" — which reads as a broken hook rather than a
+# missing tool.
+"ubi:betterleaks/betterleaks" = "1.6.1"
 java = "21"
 node = "22"
 python = "3.11"


### PR DESCRIPTION
## Problem

`betterleaks` has no entry in the mise tool registry, so the bare pin resolves to nothing:

```
mise WARN Failed to resolve tool version list for betterleaks:
  [mise.toml] betterleaks@1.6.1: betterleaks not found in mise tool registry
```

mise installs it silently. The failure surfaces later as a pre-commit failure that reads like a broken hook rather than a missing tool:

```
Detect hardcoded secrets....Failed
- hook id: betterleaks
Executable `betterleaks` not found
```

## Change

```diff
-betterleaks = "1.6.1"
+"ubi:betterleaks/betterleaks" = "1.6.1"
```

The project publishes release binaries for macOS, Linux and Windows on both architectures, so `ubi` consumes them directly. The pinned version is unchanged and is a real upstream tag — only the resolution was broken.

## Testing

```
$ mise install
mise all tools are installed
$ mise which betterleaks
~/.local/share/mise/installs/ubi-betterleaks-betterleaks/1.6.1/betterleaks
$ pre-commit run betterleaks --all-files
Detect hardcoded secrets....Passed
```

No warning from `mise ls`. Anyone who worked around this by installing betterleaks themselves keeps working; the mise-provided binary takes precedence where mise is active.

## Checklist

- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format) format
- [x] Tests — verified manually above; no automated coverage exists for the mise config
- [x] Docs — none needed, the change is self-documenting via a comment in `mise.toml`
- [x] `docs/how/updating-datahub.md` — not applicable, developer tooling only


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `betterleaks` resolvable in `mise` by pinning to `ubi:betterleaks/betterleaks`, fixing silent install failures and the missing executable error in the pre-commit `betterleaks` hook. The version stays `1.6.1`; only the resolution backend changed.

<sup>Written for commit a60d630dbafd1655e885a0e15defe3e5811ea75b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

