### PR TITLE
fix(gms): Finish adding support for applications on glossary nodes

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryNodeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryNodeMapper.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.graphql.types.glossary.mappers;
 import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
 import static com.linkedin.metadata.Constants.*;
 
+import com.linkedin.application.Applications;
 import com.linkedin.common.DisplayProperties;
 import com.linkedin.common.Forms;
 import com.linkedin.common.GlobalTags;
@@ -16,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.GlossaryNode;
 import com.linkedin.datahub.graphql.generated.GlossaryNodeProperties;
 import com.linkedin.datahub.graphql.generated.ResolvedAuditStamp;
+import com.linkedin.datahub.graphql.types.application.ApplicationAssociationMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.AssetSettingsMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DisplayPropertiesMapper;
@@ -80,6 +82,9 @@ public class GlossaryNodeMapper implements ModelMapper<EntityResponse, GlossaryN
                 GlobalTagsMapper.map(context, new GlobalTags(dataMap), entityUrn)));
     mappingHelper.mapToResult(context, DOMAINS_ASPECT_NAME, this::mapDomains);
     mappingHelper.mapToResult(
+        APPLICATION_MEMBERSHIP_ASPECT_NAME,
+        (glossaryNode, dataMap) -> mapApplicationAssociation(context, glossaryNode, dataMap));
+    mappingHelper.mapToResult(
         INSTITUTIONAL_MEMORY_ASPECT_NAME,
         (glossaryNode, dataMap) ->
             glossaryNode.setInstitutionalMemory(
@@ -136,6 +141,17 @@ public class GlossaryNodeMapper implements ModelMapper<EntityResponse, GlossaryN
       @Nonnull DataMap dataMap) {
     final Domains domains = new Domains(dataMap);
     glossaryNode.setDomain(DomainAssociationMapper.map(context, domains, glossaryNode.getUrn()));
+  }
+
+  private static void mapApplicationAssociation(
+      @Nullable final QueryContext context,
+      @Nonnull GlossaryNode glossaryNode,
+      @Nonnull DataMap dataMap) {
+    final Applications applications = new Applications(dataMap);
+    final java.util.List<com.linkedin.datahub.graphql.generated.ApplicationAssociation>
+        applicationAssociations =
+            ApplicationAssociationMapper.mapList(context, applications, glossaryNode.getUrn());
+    glossaryNode.setApplications(applicationAssociations);
   }
 
   private void mapGlossaryNodeKey(@Nonnull GlossaryNode glossaryNode, @Nonnull DataMap dataMap) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -2838,6 +2838,11 @@ type GlossaryNode implements Entity {
   The Domain associated with the glossary node
   """
   domain: DomainAssociation
+
+  """
+  The applications associated with the glossary node
+  """
+  applications: [ApplicationAssociation!]
 }
 
 """

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -38,6 +38,9 @@ fragment glossaryNodeFields on GlossaryNode {
     domain {
         ...entityDomain
     }
+    applications {
+        ...entityApplication
+    }
     parentNodes {
         ...parentNodesFields
     }

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -350,6 +350,7 @@ entities:
       - displayProperties
       - assetSettings
       - domains
+      - applications
       - globalTags
   - name: document
     category: core


### PR DESCRIPTION
We already had a decent amount of the code in and ready for supporting applications on glossary node entities, but were just missing a few pieces of the wiring:
1. register aspect in entity registry
2. support aspect in graphql schema
3. map it back in graphql
4. fetch it from the UI

we were already trying to get this aspect in GlossaryNodeType and we already have the sidebar section on the entity profile.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables application associations on Glossary Nodes end-to-end. Users can now see linked applications in the Glossary Node profile sidebar.

- **New Features**
  - Registered the `applications` aspect for glossary nodes in `entity-registry.yml`.
  - Exposed `applications` on `GlossaryNode` in `entity.graphql`.
  - Mapped `Applications` to `ApplicationAssociation` via `ApplicationAssociationMapper` in `GlossaryNodeMapper`.
  - Fetched `applications` in the UI via `glossaryNode.graphql` fragment.

<sup>Written for commit a673c1f3f09e8dbf13981801b3967831d9c4d4d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

