### PR TITLE
docs(website): update announcement banner to promote CONTEXT 2026 summit

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -125,7 +125,7 @@ module.exports = {
     announcementBar: {
       id: "announcement-4",
       content:
-        '<div class="shimmer-banner"><span>Build with DataHub: The Agent Hackathon is live</span><a href="https://datahub.devpost.com/" target="_blank" class="button"><div>Learn More<span> →</span></div></a></div>',
+        '<div class="shimmer-banner"><span>CONTEXT 2026: Join the virtual summit on context management, November 4</span><a href="https://datahub.com/context/" target="_blank" class="button"><div>Save my spot<span> →</span></div></a></div>',
       backgroundColor: "transparent",
       textColor: "#ffffff",
       isCloseable: false,


### PR DESCRIPTION
## Summary
- Updates the docs site announcement banner (`docusaurus.config.js`) to promote the CONTEXT 2026 virtual summit
- Text: "CONTEXT 2026: Join the virtual summit on context management, November 4", button: "Save my spot" linking to https://datahub.com/context/

## Test plan
- [ ] Confirm banner renders correctly on docs site preview
- [ ] Confirm link opens https://datahub.com/context/ in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the docs site announcement banner to promote the CONTEXT 2026 virtual summit on November 4. Replaces the hackathon promo with “Save my spot” linking to https://datahub.com/context/ (opens in a new tab).

<sup>Written for commit bf1d71e2f383bd583aa31245ce8a329a682e830a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

