### PR TITLE
feat(lineage): Support `parent` filtering on lightning path; add useLightningMode lineage flag

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -56,8 +56,8 @@ public class LineageFlagsInputMapper
     if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
       result.setEntitiesExploredPerHopLimit(lineageFlags.getEntitiesExploredPerHopLimit());
     }
-    if (lineageFlags.getIncludeGhostEntities() != null) {
-      result.setIncludeGhostEntities(lineageFlags.getIncludeGhostEntities());
+    if (lineageFlags.getUseLightningMode() != null) {
+      result.setUseLightningMode(lineageFlags.getUseLightningMode());
     }
     return result;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -56,6 +56,9 @@ public class LineageFlagsInputMapper
     if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
       result.setEntitiesExploredPerHopLimit(lineageFlags.getEntitiesExploredPerHopLimit());
     }
+    if (lineageFlags.getIncludeGhostEntities() != null) {
+      result.setIncludeGhostEntities(lineageFlags.getIncludeGhostEntities());
+    }
     return result;
   }
 

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -220,7 +220,16 @@ input LineageFlags {
   """
   Whether to include lineage results for entities that have no entity of their own, rather than
   dropping them. Such entities are returned as a urn and entity type only, as there is nothing to
-  hydrate them from, and filters evaluated by the search index cannot be applied to them.
+  hydrate them from.
+
+  Not recommended for general use. Results have to come off the lineage graph rather than the
+  search index, since the index has nothing to return for an entity that does not exist, and that
+  is only possible under narrow conditions: the query must be "*", no sort may be requested, and
+  filters are limited to the few fields derivable from a urn alone (platform, origin, parent).
+  A request that sets this flag and meets none of those conditions is rejected rather than quietly
+  answered without the entities it asked for. Prefer leaving it unset unless you specifically need
+  to count lineage that points at entities which were never materialized -- most commonly schema
+  fields connected by fine-grained lineage.
   """
   includeGhostEntities: Boolean
 }

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -216,6 +216,13 @@ input LineageFlags {
   a large amount of additional hops to occur and should be used with caution.
   """
   ignoreAsHops: [EntityTypeToPlatforms!]
+
+  """
+  Whether to include lineage results for entities that have no entity of their own, rather than
+  dropping them. Such entities are returned as a urn and entity type only, as there is nothing to
+  hydrate them from, and filters evaluated by the search index cannot be applied to them.
+  """
+  includeGhostEntities: Boolean
 }
 
 input EntityTypeToPlatforms {

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -218,20 +218,18 @@ input LineageFlags {
   ignoreAsHops: [EntityTypeToPlatforms!]
 
   """
-  Whether to include lineage results for entities that have no entity of their own, rather than
-  dropping them. Such entities are returned as a urn and entity type only, as there is nothing to
-  hydrate them from.
+  Read results off the lineage graph rather than by looking each one up in the entity search index.
+  Chiefly this returns entities that have no entity of their own, which the index has nothing to
+  return for -- lineage graphs point at those constantly, since fine-grained lineage writes graph
+  edges without materializing the schema fields it connects. They cannot be hydrated, so they come
+  back as a urn and entity type only.
 
-  Not recommended for general use. Results have to come off the lineage graph rather than the
-  search index, since the index has nothing to return for an entity that does not exist, and that
-  is only possible under narrow conditions: the query must be "*", no sort may be requested, and
-  filters are limited to the few fields derivable from a urn alone (platform, origin, parent).
-  A request that sets this flag and meets none of those conditions is rejected rather than quietly
-  answered without the entities it asked for. Prefer leaving it unset unless you specifically need
-  to count lineage that points at entities which were never materialized -- most commonly schema
-  fields connected by fine-grained lineage.
+  Use with care. It is only possible under narrow conditions: the query must be "*", no sort may be
+  requested, and filters are limited to the few fields derivable from a urn alone (platform, origin,
+  parent). Endpoints that cannot serve it reject the request rather than quietly answering without
+  the entities it asked for; scrollAcrossLineage does not support it at all.
   """
-  includeGhostEntities: Boolean
+  useLightningMode: Boolean
 }
 
 input EntityTypeToPlatforms {

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/validation/ValidationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/validation/ValidationUtils.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.EntityLineageResult;
 import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.graph.LineageRelationshipArray;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.search.LineageScrollResult;
 import com.linkedin.metadata.search.LineageSearchEntity;
@@ -23,6 +24,7 @@ import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -200,13 +202,20 @@ public class ValidationUtils {
                       lineageSearchResult.getLineageSearchPath(), SetMode.IGNORE_NULL)
                   .setNumEntities(lineageSearchResult.getNumEntities());
 
+          // Ghost entities have nothing in SQL to exist, so enforcing existence would drop exactly
+          // the results the caller asked to keep
+          boolean includeGhostEntities =
+              Optional.ofNullable(opContext.getSearchContext().getLineageFlags())
+                  .map(LineageFlags::isIncludeGhostEntities)
+                  .orElse(false);
+
           LineageSearchEntityArray validatedEntities =
               validateSearchUrns(
                       opContext,
                       lineageSearchResult.getEntities(),
                       LineageSearchEntity::getEntity,
                       entityService,
-                      true,
+                      !includeGhostEntities,
                       true)
                   .collect(Collectors.toCollection(LineageSearchEntityArray::new));
           validatedLineageSearchResult.setEntities(validatedEntities);

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/validation/ValidationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/validation/ValidationUtils.java
@@ -202,11 +202,11 @@ public class ValidationUtils {
                       lineageSearchResult.getLineageSearchPath(), SetMode.IGNORE_NULL)
                   .setNumEntities(lineageSearchResult.getNumEntities());
 
-          // Ghost entities have nothing in SQL to exist, so enforcing existence would drop exactly
-          // the results the caller asked to keep
-          boolean includeGhostEntities =
+          // Lightning mode reads results off the graph, which points at entities that were never
+          // materialized, so enforcing existence would drop exactly what the caller asked to keep
+          boolean useLightningMode =
               Optional.ofNullable(opContext.getSearchContext().getLineageFlags())
-                  .map(LineageFlags::isIncludeGhostEntities)
+                  .map(LineageFlags::isUseLightningMode)
                   .orElse(false);
 
           LineageSearchEntityArray validatedEntities =
@@ -215,7 +215,7 @@ public class ValidationUtils {
                       lineageSearchResult.getEntities(),
                       LineageSearchEntity::getEntity,
                       entityService,
-                      !includeGhostEntities,
+                      !useLightningMode,
                       true)
                   .collect(Collectors.toCollection(LineageSearchEntityArray::new));
           validatedLineageSearchResult.setEntities(validatedEntities);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtils.java
@@ -6,6 +6,7 @@ import static com.linkedin.metadata.graph.elastic.utils.GraphQueryConstants.*;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.UrnArrayArray;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.IntegerArray;
@@ -202,14 +203,20 @@ public final class GraphQueryUtils {
     return (path.size() != urnSet.size());
   }
 
-  /** Check if a URN's platform matches any of the provided platforms. */
+  /**
+   * Check if a URN's platform matches any of the provided platforms. Entity types that have no
+   * platform to read match nothing, rather than failing the lineage query they are part of.
+   */
   public static boolean platformMatches(Urn urn, UrnArray platforms) {
+    final DataPlatformUrn platform;
+    try {
+      platform = DataPlatformInstanceUtils.getDataPlatform(urn);
+    } catch (IllegalArgumentException e) {
+      log.warn("Could not read a platform from {}, treating it as unmatched", urn, e);
+      return false;
+    }
     return platforms.stream()
-        .anyMatch(
-            platform ->
-                DataPlatformInstanceUtils.getDataPlatform(urn)
-                    .toString()
-                    .equals(platform.toString()));
+        .anyMatch(candidate -> platform.toString().equals(candidate.toString()));
   }
 
   /** Clone a path by creating a new UrnArray with the same contents. */

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -259,13 +259,13 @@ public class LineageSearchService {
           SearchUtils.removeCriteria(
               inputFilters, criterion -> criterion.getField().equals(DEGREE_FILTER));
 
-      boolean includeGhostEntities =
+      boolean useLightningMode =
           Optional.ofNullable(finalOpContext.getSearchContext().getLineageFlags())
-              .map(LineageFlags::isIncludeGhostEntities)
+              .map(LineageFlags::isUseLightningMode)
               .orElse(false);
 
       if (canDoLightning(
-          lineageRelationships, finalInput, reducedFilters, sortCriteria, includeGhostEntities)) {
+          lineageRelationships, finalInput, reducedFilters, sortCriteria, useLightningMode)) {
         codePath = "lightning";
         // use lightning approach to return lineage search results
         LineageSearchResult lineageSearchResult =
@@ -282,19 +282,12 @@ public class LineageSearchService {
           lineageSearchResult.setIsPartial(lineageResult.isPartial());
         }
         return lineageSearchResult;
-      } else if (includeGhostEntities) {
+      } else if (useLightningMode) {
         // Falling through would answer from the entity index, which has nothing to return for an
-        // entity that does not exist -- so the caller would silently get a short count rather than
-        // the results it asked for
+        // entity that does not exist -- so the caller would silently get a short result rather than
+        // what it asked for
         throw new IllegalArgumentException(
-            String.format(
-                "includeGhostEntities requires the graph-only lineage path, which cannot serve this "
-                    + "query. It needs a '*' query, no sort criteria, and filters only on %s, but "
-                    + "got query '%s', %d sort criteria, and filters on %s.",
-                LIGHTNING_FILTER_FIELDS,
-                finalInput,
-                sortCriteria == null ? 0 : sortCriteria.size(),
-                filterFields(reducedFilters)));
+            unservableLightningMessage(finalInput, sortCriteria, reducedFilters));
       } else {
         codePath = "tortoise";
         LineageSearchResult lineageSearchResult =
@@ -328,7 +321,7 @@ public class LineageSearchService {
       String input,
       Filter inputFilters,
       List<SortCriterion> sortCriteria,
-      boolean includeGhostEntities) {
+      boolean useLightningMode) {
     boolean simpleFilters =
         inputFilters == null
             || inputFilters.getOr() == null
@@ -339,15 +332,28 @@ public class LineageSearchService {
                             .allMatch(
                                 criterion1 ->
                                     LIGHTNING_FILTER_FIELDS.contains(criterion1.getField())));
-    // Use lightning path when including ghost entities -- it gives us the exact results we want
+    // Use lightning path when the caller asks for it -- it gives us the exact results we want
     boolean worthwhile =
-        includeGhostEntities
+        useLightningMode
             || lineageRelationships.size()
                 > appConfig.getCache().getSearch().getLineage().getLightningThreshold();
     return worthwhile
         && input.equals("*")
         && simpleFilters
         && CollectionUtils.isEmpty(sortCriteria);
+  }
+
+  /** Explains why lightning mode cannot be served, naming what the request actually asked for. */
+  private static String unservableLightningMessage(
+      String input, @Nullable List<SortCriterion> sortCriteria, @Nullable Filter filters) {
+    return String.format(
+        "useLightningMode reads results off the lineage graph, which cannot serve this query. It "
+            + "needs a '*' query, no sort criteria, and filters only on %s, but got query '%s', %d "
+            + "sort criteria, and filters on %s.",
+        LIGHTNING_FILTER_FIELDS,
+        input,
+        sortCriteria == null ? 0 : sortCriteria.size(),
+        filterFields(filters));
   }
 
   /** The distinct fields the filters constrain, for reporting what a query asked for. */
@@ -890,6 +896,17 @@ public class LineageSearchService {
       Filter reducedFilters =
           SearchUtils.removeCriteria(
               inputFilters, criterion -> criterion.getField().equals(DEGREE_FILTER));
+
+      // Scrolling has no graph-only path: paging is done by the entity index, which has nothing to
+      // return for an entity that does not exist
+      if (Optional.ofNullable(opContext.getSearchContext().getLineageFlags())
+          .map(LineageFlags::isUseLightningMode)
+          .orElse(false)) {
+        throw new IllegalArgumentException(
+            "useLightningMode is not supported when scrolling across lineage; use "
+                + "searchAcrossLineage instead.");
+      }
+
       LineageScrollResult scrollResult =
           getScrollResultInBatches(
               opContext,

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -282,6 +282,19 @@ public class LineageSearchService {
           lineageSearchResult.setIsPartial(lineageResult.isPartial());
         }
         return lineageSearchResult;
+      } else if (includeGhostEntities) {
+        // Falling through would answer from the entity index, which has nothing to return for an
+        // entity that does not exist -- so the caller would silently get a short count rather than
+        // the results it asked for
+        throw new IllegalArgumentException(
+            String.format(
+                "includeGhostEntities requires the graph-only lineage path, which cannot serve this "
+                    + "query. It needs a '*' query, no sort criteria, and filters only on %s, but "
+                    + "got query '%s', %d sort criteria, and filters on %s.",
+                LIGHTNING_FILTER_FIELDS,
+                finalInput,
+                sortCriteria == null ? 0 : sortCriteria.size(),
+                filterFields(reducedFilters)));
       } else {
         codePath = "tortoise";
         LineageSearchResult lineageSearchResult =
@@ -335,6 +348,18 @@ public class LineageSearchService {
         && input.equals("*")
         && simpleFilters
         && CollectionUtils.isEmpty(sortCriteria);
+  }
+
+  /** The distinct fields the filters constrain, for reporting what a query asked for. */
+  private static Set<String> filterFields(@Nullable Filter filters) {
+    if (filters == null || filters.getOr() == null) {
+      return Set.of();
+    }
+    return filters.getOr().stream()
+        .map(ConjunctiveCriterion::getAnd)
+        .flatMap(CriterionArray::stream)
+        .map(Criterion::getField)
+        .collect(Collectors.toCollection(java.util.TreeSet::new));
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -326,8 +326,7 @@ public class LineageSearchService {
                             .allMatch(
                                 criterion1 ->
                                     LIGHTNING_FILTER_FIELDS.contains(criterion1.getField())));
-    // Ghost entities are only reachable here: every other path answers from the entity index,
-    // which by definition has nothing to return for them. Take it whatever the result size.
+    // Use lightning path when including ghost entities -- it gives us the exact results we want
     boolean worthwhile =
         includeGhostEntities
             || lineageRelationships.size()

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -28,13 +28,16 @@ import com.linkedin.metadata.query.GroupingCriterionArray;
 import com.linkedin.metadata.query.GroupingSpec;
 import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
+import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.cache.CachedEntityLineageResult;
 import com.linkedin.metadata.search.utils.FilterUtils;
 import com.linkedin.metadata.search.utils.SearchUtils;
+import com.linkedin.metadata.utils.SchemaFieldUtils;
 import com.linkedin.metadata.utils.metrics.CascadeOperationContext;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
@@ -45,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -92,6 +96,12 @@ public class LineageSearchService {
   @Setter @Nullable private MetricUtils metricUtils;
 
   private static final String DEGREE_FILTER = "degree";
+  private static final String PARENT_FILTER = "parent";
+
+  /** Filter fields the graph-only path can answer from a urn, without the entity index. */
+  private static final Set<String> LIGHTNING_FILTER_FIELDS =
+      Set.of("platform", "origin", PARENT_FILTER);
+
   private static final AggregationMetadata DEGREE_FILTER_GROUP =
       new AggregationMetadata()
           .setName(DEGREE_FILTER)
@@ -249,7 +259,13 @@ public class LineageSearchService {
           SearchUtils.removeCriteria(
               inputFilters, criterion -> criterion.getField().equals(DEGREE_FILTER));
 
-      if (canDoLightning(lineageRelationships, finalInput, reducedFilters, sortCriteria)) {
+      boolean includeGhostEntities =
+          Optional.ofNullable(finalOpContext.getSearchContext().getLineageFlags())
+              .map(LineageFlags::isIncludeGhostEntities)
+              .orElse(false);
+
+      if (canDoLightning(
+          lineageRelationships, finalInput, reducedFilters, sortCriteria, includeGhostEntities)) {
         codePath = "lightning";
         // use lightning approach to return lineage search results
         LineageSearchResult lineageSearchResult =
@@ -298,7 +314,8 @@ public class LineageSearchService {
       List<LineageRelationship> lineageRelationships,
       String input,
       Filter inputFilters,
-      List<SortCriterion> sortCriteria) {
+      List<SortCriterion> sortCriteria,
+      boolean includeGhostEntities) {
     boolean simpleFilters =
         inputFilters == null
             || inputFilters.getOr() == null
@@ -308,13 +325,60 @@ public class LineageSearchService {
                         criterion.getAnd().stream()
                             .allMatch(
                                 criterion1 ->
-                                    "platform".equals(criterion1.getField())
-                                        || "origin".equals(criterion1.getField())));
-    return (lineageRelationships.size()
-            > appConfig.getCache().getSearch().getLineage().getLightningThreshold())
+                                    LIGHTNING_FILTER_FIELDS.contains(criterion1.getField())));
+    // Ghost entities are only reachable here: every other path answers from the entity index,
+    // which by definition has nothing to return for them. Take it whatever the result size.
+    boolean worthwhile =
+        includeGhostEntities
+            || lineageRelationships.size()
+                > appConfig.getCache().getSearch().getLineage().getLightningThreshold();
+    return worthwhile
         && input.equals("*")
         && simpleFilters
         && CollectionUtils.isEmpty(sortCriteria);
+  }
+
+  /**
+   * Whether a urn passes the `parent` criteria in the filters. A schema field nests its parent
+   * inside its own urn, so this is answerable without the entity. Entities with no parent to read
+   * pass only negated criteria.
+   *
+   * <p>Unlike the platform and origin criteria, negation is honored: excluding columns that the
+   * graph draws folded into some other node is expressed that way.
+   */
+  @VisibleForTesting
+  static boolean passesParentCriteria(Urn urn, @Nullable Filter inputFilters) {
+    if (inputFilters == null || inputFilters.getOr() == null) {
+      return true;
+    }
+    List<Criterion> parentCriteria =
+        inputFilters.getOr().stream()
+            .map(ConjunctiveCriterion::getAnd)
+            .flatMap(CriterionArray::stream)
+            .filter(criterion -> PARENT_FILTER.equals(criterion.getField()))
+            .collect(Collectors.toList());
+    if (parentCriteria.isEmpty()) {
+      return true;
+    }
+
+    String parent =
+        SchemaFieldUtils.parseSchemaFieldUrn(urn)
+            .map(parsed -> parsed.getFirst().toString())
+            .orElse(null);
+    for (Criterion criterion : parentCriteria) {
+      boolean matches =
+          parent != null
+              && criterion.getValues().stream()
+                  .anyMatch(
+                      value ->
+                          Condition.CONTAIN.equals(criterion.getCondition())
+                              ? parent.contains(value)
+                              : parent.equals(value));
+      if (matches == Boolean.TRUE.equals(criterion.isNegated())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @VisibleForTesting
@@ -382,7 +446,8 @@ public class LineageSearchService {
               && (CollectionUtils.isEmpty(platformCriteriaValues)
                   || (platform != null && platformCriteriaValues.contains(platform)))
               && (CollectionUtils.isEmpty(originCriteriaValues)
-                  || (environment != null && originCriteriaValues.contains(environment)));
+                  || (environment != null && originCriteriaValues.contains(environment)))
+              && passesParentCriteria(entityUrn, inputFilters);
 
       if (isNotFiltered) {
         start++;

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/utils/GraphQueryUtilsTest.java
@@ -188,6 +188,32 @@ public class GraphQueryUtilsTest {
   }
 
   @Test
+  public void testPlatformMatchesSchemaField() {
+    // A schema field takes the platform of the dataset it is a field of, so that ignoreAsHops can
+    // be scoped by platform for columns the same way it is for datasets
+    Urn dbtColumn =
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,db.orders,PROD),order_id)");
+    Urn warehouseColumn =
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,db.orders,PROD),order_id)");
+    UrnArray dbt = new UrnArray();
+    dbt.add(UrnUtils.getUrn("urn:li:dataPlatform:dbt"));
+
+    assertTrue(GraphQueryUtils.platformMatches(dbtColumn, dbt));
+    assertFalse(GraphQueryUtils.platformMatches(warehouseColumn, dbt));
+  }
+
+  @Test
+  public void testPlatformMatchesEntityWithoutPlatform() {
+    // Rather than failing the whole lineage query it is part of
+    UrnArray dbt = new UrnArray();
+    dbt.add(UrnUtils.getUrn("urn:li:dataPlatform:dbt"));
+
+    assertFalse(GraphQueryUtils.platformMatches(UrnUtils.getUrn("urn:li:domain:marketing"), dbt));
+  }
+
+  @Test
   public void testClonePath() {
     UrnArray originalPath = new UrnArray();
     originalPath.add(TEST_URN_1);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
@@ -1025,16 +1025,16 @@ public class LineageSearchServiceTest {
   }
 
   @Test
-  public void testCanDoLightningForGhostEntities() {
+  public void testCanDoLightningWhenRequested() {
     List<LineageRelationship> tinyResult = oneRelationship();
     Filter filter = QueryUtils.newFilter("platform", "urn:li:dataPlatform:kafka");
 
     // Below the threshold the entity index path is still preferred...
     assertFalse(_lineageSearchService.canDoLightning(tinyResult, "*", filter, null, false));
-    // ...but ghost entities are only reachable here, so take it whatever the result size
+    // ...but a caller can ask for it whatever the result size
     assertTrue(_lineageSearchService.canDoLightning(tinyResult, "*", filter, null, true));
 
-    // Filters this path cannot answer from a urn keep it off, ghosts or not
+    // Filters this path cannot answer from a urn keep it off, requested or not
     Filter unsupported = QueryUtils.newFilter("description", "anything");
     assertFalse(_lineageSearchService.canDoLightning(tinyResult, "*", unsupported, null, true));
   }
@@ -1067,14 +1067,14 @@ public class LineageSearchServiceTest {
   }
 
   @Test
-  public void testGhostEntitiesRejectedWhenLightningUnavailable() throws Exception {
-    // A query string forces the entity-index path, which cannot return entities that do not exist,
-    // so asking for ghosts there has to fail rather than quietly come back short
+  public void testLightningModeRejectedWhenUnservable() throws Exception {
+    // A query string cannot be served off the graph, so asking for lightning mode there has to fail
+    // rather than quietly fall back to the entity index and come back short
     Urn sourceUrn = UrnUtils.getUrn("urn:li:dataset:test-dataset");
     List<String> entities = Collections.singletonList(DATASET_ENTITY_NAME);
 
     OperationContext ghostContext =
-        _operationContext.withLineageFlags(f -> new LineageFlags().setIncludeGhostEntities(true));
+        _operationContext.withLineageFlags(f -> new LineageFlags().setUseLightningMode(true));
 
     EntityLineageResult mockLineageResult = new EntityLineageResult();
     mockLineageResult.setTotal(0);
@@ -1113,6 +1113,23 @@ public class LineageSearchServiceTest {
             null,
             0,
             10));
+
+    // Scrolling has no graph-only path at all, so it refuses regardless of the query
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            _lineageSearchService.scrollAcrossLineage(
+                ghostContext,
+                sourceUrn,
+                LineageDirection.DOWNSTREAM,
+                entities,
+                null,
+                1,
+                null,
+                null,
+                null,
+                "5m",
+                10));
   }
 
   private EntityLineageResult createMockEntityLineageResult() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.common.urn.Urn;
@@ -1063,6 +1064,55 @@ public class LineageSearchServiceTest {
             Condition.EQUAL, true, "urn:li:dataset:(urn:li:dataPlatform:dbt,db.orders,PROD)");
     assertFalse(LineageSearchService.passesParentCriteria(dbtColumn, notSibling));
     assertTrue(LineageSearchService.passesParentCriteria(warehouseColumn, notSibling));
+  }
+
+  @Test
+  public void testGhostEntitiesRejectedWhenLightningUnavailable() throws Exception {
+    // A query string forces the entity-index path, which cannot return entities that do not exist,
+    // so asking for ghosts there has to fail rather than quietly come back short
+    Urn sourceUrn = UrnUtils.getUrn("urn:li:dataset:test-dataset");
+    List<String> entities = Collections.singletonList(DATASET_ENTITY_NAME);
+
+    OperationContext ghostContext =
+        _operationContext.withLineageFlags(f -> new LineageFlags().setIncludeGhostEntities(true));
+
+    EntityLineageResult mockLineageResult = new EntityLineageResult();
+    mockLineageResult.setTotal(0);
+    mockLineageResult.setRelationships(new LineageRelationshipArray());
+    when(_graphService.getImpactLineage(
+            eq(ghostContext), eq(sourceUrn), any(LineageGraphFilters.class), anyInt()))
+        .thenReturn(mockLineageResult);
+    when(_lineageRegistry.getEntitiesWithLineageToEntityType(DATASET_ENTITY_NAME))
+        .thenReturn(Collections.singleton(DATASET_ENTITY_NAME));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            _lineageSearchService.searchAcrossLineage(
+                ghostContext,
+                sourceUrn,
+                LineageDirection.DOWNSTREAM,
+                entities,
+                "some query",
+                1,
+                null,
+                null,
+                0,
+                10));
+
+    // The same request without a query string is served by the graph-only path
+    assertNotNull(
+        _lineageSearchService.searchAcrossLineage(
+            ghostContext,
+            sourceUrn,
+            LineageDirection.DOWNSTREAM,
+            entities,
+            null,
+            1,
+            null,
+            null,
+            0,
+            10));
   }
 
   private EntityLineageResult createMockEntityLineageResult() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchServiceTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search;
 
 import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,7 +11,9 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -34,6 +37,12 @@ import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.graph.LineageRelationshipArray;
 import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.query.LineageFlags;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.utils.QueryUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collections;
@@ -994,6 +1003,66 @@ public class LineageSearchServiceTest {
     // should have used null for entitiesExploredPerHopLimit since lineageFlags is null.
     // This is verified by the fact that the method executes successfully
     // and the cache key is created with null for the entitiesExploredPerHopLimit value.
+  }
+
+  /** One relationship, far below the lightning threshold. */
+  private static List<LineageRelationship> oneRelationship() {
+    return Collections.singletonList(
+        new LineageRelationship()
+            .setEntity(UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:kafka,topic,PROD)"))
+            .setType("DownstreamOf")
+            .setDegree(1));
+  }
+
+  private static Filter parentFilter(Condition condition, boolean negated, String value) {
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                new ConjunctiveCriterion()
+                    .setAnd(
+                        new CriterionArray(buildCriterion("parent", condition, negated, value)))));
+  }
+
+  @Test
+  public void testCanDoLightningForGhostEntities() {
+    List<LineageRelationship> tinyResult = oneRelationship();
+    Filter filter = QueryUtils.newFilter("platform", "urn:li:dataPlatform:kafka");
+
+    // Below the threshold the entity index path is still preferred...
+    assertFalse(_lineageSearchService.canDoLightning(tinyResult, "*", filter, null, false));
+    // ...but ghost entities are only reachable here, so take it whatever the result size
+    assertTrue(_lineageSearchService.canDoLightning(tinyResult, "*", filter, null, true));
+
+    // Filters this path cannot answer from a urn keep it off, ghosts or not
+    Filter unsupported = QueryUtils.newFilter("description", "anything");
+    assertFalse(_lineageSearchService.canDoLightning(tinyResult, "*", unsupported, null, true));
+  }
+
+  @Test
+  public void testPassesParentCriteria() {
+    Urn warehouseColumn =
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,db.orders,PROD),id)");
+    Urn dbtColumn =
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,db.orders,PROD),id)");
+    Urn dataset = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.orders,PROD)");
+
+    assertTrue(LineageSearchService.passesParentCriteria(warehouseColumn, null));
+
+    // Excluding columns on dbt nodes, which the graph walks through rather than drawing
+    Filter notDbt = parentFilter(Condition.CONTAIN, true, "urn:li:dataPlatform:dbt");
+    assertTrue(LineageSearchService.passesParentCriteria(warehouseColumn, notDbt));
+    assertFalse(LineageSearchService.passesParentCriteria(dbtColumn, notDbt));
+    // Nothing to read a parent from, so only a negated criterion lets it through
+    assertTrue(LineageSearchService.passesParentCriteria(dataset, notDbt));
+
+    // Excluding one specific node, as siblings drawn folded into another node are
+    Filter notSibling =
+        parentFilter(
+            Condition.EQUAL, true, "urn:li:dataset:(urn:li:dataPlatform:dbt,db.orders,PROD)");
+    assertFalse(LineageSearchService.passesParentCriteria(dbtColumn, notSibling));
+    assertTrue(LineageSearchService.passesParentCriteria(warehouseColumn, notSibling));
   }
 
   private EntityLineageResult createMockEntityLineageResult() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
@@ -1287,7 +1287,8 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
     int size = 10;
     Set<String> entityNames = Collections.emptySet();
 
-    Assert.assertTrue(lineageSearchService.canDoLightning(lineageRelationships, "*", filter, null));
+    Assert.assertTrue(
+        lineageSearchService.canDoLightning(lineageRelationships, "*", filter, null, false));
 
     // Set up filters
     ConjunctiveCriterionArray conCritArr = new ConjunctiveCriterionArray();
@@ -1306,7 +1307,8 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
     from = 500;
     size = 10;
     filter = new Filter().setOr(conCritArr);
-    Assert.assertTrue(lineageSearchService.canDoLightning(lineageRelationships, "*", filter, null));
+    Assert.assertTrue(
+        lineageSearchService.canDoLightning(lineageRelationships, "*", filter, null, false));
   }
 
   @Test

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
@@ -33,8 +33,12 @@ record LineageFlags {
      * edges without materializing the schema fields they connect -- and joining lineage results
      * against the entity index silently discards every one of them.
      *
-     * These entities cannot be hydrated, so they are returned as a urn and entity type only, and
-     * filters that are evaluated by the search index cannot be applied to them.
+     * These entities cannot be hydrated, so they are returned as a urn and entity type only.
+     *
+     * Not recommended for general use. Results have to be read off the graph rather than the entity
+     * index, which is only possible under narrow conditions: a "*" query, no sort criteria, and
+     * filters limited to the fields derivable from a urn alone. A request that sets this and meets
+     * none of those is rejected rather than quietly answered without the entities it asked for.
      */
     includeGhostEntities: optional boolean = false
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
@@ -26,4 +26,15 @@ record LineageFlags {
       * a large amount of additional hops to occur and should be used with caution.
       */
       ignoreAsHops: optional map[string, array[Urn]]
+
+    /**
+     * Include lineage results for entities that have no entity of their own, rather than dropping
+     * them. Lineage graphs routinely point at such entities -- fine-grained lineage writes graph
+     * edges without materializing the schema fields they connect -- and joining lineage results
+     * against the entity index silently discards every one of them.
+     *
+     * These entities cannot be hydrated, so they are returned as a urn and entity type only, and
+     * filters that are evaluated by the search index cannot be applied to them.
+     */
+    includeGhostEntities: optional boolean = false
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
@@ -28,17 +28,15 @@ record LineageFlags {
       ignoreAsHops: optional map[string, array[Urn]]
 
     /**
-     * Include lineage results for entities that have no entity of their own, rather than dropping
-     * them. Lineage graphs routinely point at such entities -- fine-grained lineage writes graph
-     * edges without materializing the schema fields they connect -- and joining lineage results
-     * against the entity index silently discards every one of them.
+     * Read results off the lineage graph rather than by looking each one up in the entity search
+     * index. Chiefly this returns entities that have no entity of their own, which the index has
+     * nothing to return for: lineage graphs point at those constantly, since fine-grained lineage
+     * writes graph edges without materializing the schema fields it connects. They cannot be
+     * hydrated, so they come back as a urn and entity type only.
      *
-     * These entities cannot be hydrated, so they are returned as a urn and entity type only.
-     *
-     * Not recommended for general use. Results have to be read off the graph rather than the entity
-     * index, which is only possible under narrow conditions: a "*" query, no sort criteria, and
-     * filters limited to the fields derivable from a urn alone. A request that sets this and meets
-     * none of those is rejected rather than quietly answered without the entities it asked for.
+     * Use with care. It is only possible under narrow conditions -- a "*" query, no sort criteria,
+     * and filters limited to the fields derivable from a urn alone -- and endpoints that cannot
+     * serve it reject the request rather than quietly answering without the entities it asked for.
      */
-    includeGhostEntities: optional boolean = false
+    useLightningMode: optional boolean = false
 }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -787,6 +787,11 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.filterParam(filter);
     }
     LineageFlags lineageFlags = opContext.getSearchContext().getLineageFlags();
+    if (Boolean.TRUE.equals(lineageFlags.isUseLightningMode())) {
+      throw new IllegalArgumentException(
+          "useLightningMode cannot be requested through the Restli client, which does not carry it "
+              + "to the server.");
+    }
     if (lineageFlags.getStartTimeMillis() != null) {
       requestBuilder.startTimeMillisParam(lineageFlags.getStartTimeMillis());
     }
@@ -838,6 +843,11 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.scrollIdParam(scrollId);
     }
     LineageFlags lineageFlags = opContext.getSearchContext().getLineageFlags();
+    if (Boolean.TRUE.equals(lineageFlags.isUseLightningMode())) {
+      throw new IllegalArgumentException(
+          "useLightningMode cannot be requested through the Restli client, which does not carry it "
+              + "to the server.");
+    }
     if (lineageFlags.getStartTimeMillis() != null) {
       requestBuilder.startTimeMillisParam(lineageFlags.getStartTimeMillis());
     }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/DataPlatformInstanceUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/DataPlatformInstanceUtils.java
@@ -104,6 +104,15 @@ public class DataPlatformInstanceUtils {
                       EntityKeyUtils.convertUrnToEntityKeyInternal(
                           urn, MLModelGroupKey.dataSchema()))
                   .getPlatform());
+        case "schemaField":
+          // A schema field carries no platform of its own; it takes the one from the entity it is a
+          // field of, which is nested inside its urn
+          return SchemaFieldUtils.parseSchemaFieldUrn(urn)
+              .map(parsed -> getDataPlatform(parsed.getFirst()))
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          String.format("Unable to read a parent from schema field urn: %s", urn)));
         default:
           log.error(
               String.format(


### PR DESCRIPTION
In order to support using search across lineage to get proper column lineage counts, when schema fields are not materialized, we add the lineage flag `useLightningMode` as the lightning path doesn't check whether entities exist. And we add support for filtering by `parent`. This is only necessary because schema fields are not always materialized.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `useLightningMode` to `LineageFlags` and added `parent` filtering on the lightning path so lineage search can return column results even when schema fields aren’t materialized. Tightened constraints and error handling for lightning mode, and improved platform detection for schema fields.

- **New Features**
  - `LineageFlags.useLightningMode`: read results from the lineage graph to include ghost schema fields; entities return as urn + type only. Allowed only with a "*" query, no sort, and filters on platform, origin, or parent. Added to GraphQL `LineageFlags` in `search.graphql`.
  - Support `parent` filter on the lightning path, including negation, to include/exclude schema field results by their dataset parent.

- **Bug Fixes**
  - `getDataPlatform` reads a schema field’s platform from its parent urn; `platformMatches` treats entities without a platform as unmatched.
  - Reject `useLightningMode` when the graph-only path cannot serve the request, and on `scrollAcrossLineage`; `RestliEntityClient` disallows passing this flag.
  - Skip SQL existence validation when `useLightningMode` is set to avoid dropping requested ghost entities.

<sup>Written for commit 9e6c7170b00a5812055654f4b2d8774d9b556188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



