### PR TITLE
fix(ci): fall back unrouted PRs/issues to OSS Linear team

### DIFF
--- a/.github/workflows/pr-to-linear-routing-test.yml
+++ b/.github/workflows/pr-to-linear-routing-test.yml
@@ -44,6 +44,12 @@ env:
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
         "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
         "description": "Data Quality and Assertions. Any PR touching the Assertions/Monitors or Incidents codebase belongs to this team."
+      },
+      {
+        "key": "OSS",
+        "team_id": "952ee4f2-e3eb-4580-98e3-67c2b73a5c51",
+        "assignee_id": "48f94188-01fa-4ab6-bcbd-153bf769198f",
+        "description": "Fallback for PRs/issues that do not clearly belong to an engineering team (docs, community, misc). Assigned to DevRel for triage."
       }
     ]
 
@@ -164,7 +170,8 @@ jobs:
             FILES_LIST=""
           fi
 
-          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | "- " + .key + ": " + .description')
+          # Exclude OSS from LLM choices — it is the code-side fallback only
+          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | select(.key != "OSS") | "- " + .key + ": " + .description')
 
           PROMPT=$(cat <<PROMPT_EOF
           You are routing a GitHub PR to the correct engineering team for review. Based on the PR details below, respond with ONLY the team key (e.g. ING, CAT, PFP), or NONE if it doesn't clearly belong to any team.
@@ -203,21 +210,27 @@ jobs:
           echo ""
 
           if [ -z "$TEAM_KEY" ] || [ "$TEAM_KEY" = "NONE" ] || [ "$TEAM_KEY" = "NULL" ]; then
-            echo "🤷 Would route to: NONE (no matching team)"
+            echo "⚠️  No matching engineering team — would fall back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+          fi
+
+          TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "⚠️  Claude returned unrecognized key: $TEAM_KEY — would fall back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          fi
+
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "❌ OSS fallback config missing from LINEAR_TEAM_CONFIG"
             echo "team_key=" >> "$GITHUB_OUTPUT"
           else
-            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
-            if [ -z "$TEAM_CONFIG" ]; then
-              echo "⚠️  Claude returned unrecognized key: $TEAM_KEY"
-              echo "team_key=" >> "$GITHUB_OUTPUT"
-            else
-              echo "✅ Would route to: $TEAM_KEY"
-              {
-                echo "team_key=$TEAM_KEY"
-                echo "team_id=$(echo "$TEAM_CONFIG" | jq -r '.team_id')"
-                echo "assignee_id=$(echo "$TEAM_CONFIG" | jq -r '.assignee_id')"
-              } >> "$GITHUB_OUTPUT"
-            fi
+            echo "✅ Would route to: $TEAM_KEY"
+            {
+              echo "team_key=$TEAM_KEY"
+              echo "team_id=$(echo "$TEAM_CONFIG" | jq -r '.team_id')"
+              echo "assignee_id=$(echo "$TEAM_CONFIG" | jq -r '.assignee_id')"
+            } >> "$GITHUB_OUTPUT"
           fi
 
           echo ""
@@ -414,7 +427,8 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | "- " + .key + ": " + .description')
+          # Exclude OSS from LLM choices — it is the code-side fallback only
+          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | select(.key != "OSS") | "- " + .key + ": " + .description')
 
           PROMPT=$(cat <<PROMPT_EOF
           You are routing a GitHub issue to the correct engineering team. Based on the issue details below, respond with ONLY the team key (e.g. ING, CAT, PFP), or NONE if it doesn't clearly belong to any team.
@@ -450,21 +464,27 @@ jobs:
           echo ""
 
           if [ -z "$TEAM_KEY" ] || [ "$TEAM_KEY" = "NONE" ] || [ "$TEAM_KEY" = "NULL" ]; then
-            echo "🤷 Would route to: NONE (no matching team)"
+            echo "⚠️  No matching engineering team — would fall back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+          fi
+
+          TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "⚠️  Claude returned unrecognized key: $TEAM_KEY — would fall back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          fi
+
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "❌ OSS fallback config missing from LINEAR_TEAM_CONFIG"
             echo "team_key=" >> "$GITHUB_OUTPUT"
           else
-            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
-            if [ -z "$TEAM_CONFIG" ]; then
-              echo "⚠️  Claude returned unrecognized key: $TEAM_KEY"
-              echo "team_key=" >> "$GITHUB_OUTPUT"
-            else
-              echo "✅ Would route to: $TEAM_KEY"
-              {
-                echo "team_key=$TEAM_KEY"
-                echo "team_id=$(echo "$TEAM_CONFIG" | jq -r '.team_id')"
-                echo "assignee_id=$(echo "$TEAM_CONFIG" | jq -r '.assignee_id')"
-              } >> "$GITHUB_OUTPUT"
-            fi
+            echo "✅ Would route to: $TEAM_KEY"
+            {
+              echo "team_key=$TEAM_KEY"
+              echo "team_id=$(echo "$TEAM_CONFIG" | jq -r '.team_id')"
+              echo "assignee_id=$(echo "$TEAM_CONFIG" | jq -r '.assignee_id')"
+            } >> "$GITHUB_OUTPUT"
           fi
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 

--- a/.github/workflows/pr-to-linear.yml
+++ b/.github/workflows/pr-to-linear.yml
@@ -38,6 +38,12 @@ env:
         "team_id": "1a592e48-d6ba-4b92-a241-8172b568e9bb",
         "assignee_id": "f81f2754-6338-467c-9c91-a12e727b4c36",
         "description": "Data Quality and Assertions. Any PR touching the Assertions/Monitors or Incidents codebase belongs to this team."
+      },
+      {
+        "key": "OSS",
+        "team_id": "952ee4f2-e3eb-4580-98e3-67c2b73a5c51",
+        "assignee_id": "48f94188-01fa-4ab6-bcbd-153bf769198f",
+        "description": "Fallback for PRs/issues that do not clearly belong to an engineering team (docs, community, misc). Assigned to DevRel for triage."
       }
     ]
 
@@ -165,7 +171,8 @@ jobs:
             FILES_LIST=""
           fi
 
-          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | "- " + .key + ": " + .description')
+          # Exclude OSS from LLM choices — it is the code-side fallback only
+          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | select(.key != "OSS") | "- " + .key + ": " + .description')
 
           PROMPT=$(cat <<PROMPT_EOF
           You are routing a GitHub PR to the correct engineering team for review. Based on the PR details below, respond with ONLY the team key (e.g. ING, CAT, PFP), or NONE if it doesn't clearly belong to any team.
@@ -197,14 +204,19 @@ jobs:
           TEAM_KEY=$(echo "$CLAUDE_RESPONSE" | jq -r '.content[0].text' 2>/dev/null | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
 
           if [ -z "$TEAM_KEY" ] || [ "$TEAM_KEY" = "NONE" ] || [ "$TEAM_KEY" = "NULL" ]; then
-            echo "⏭️  No matching team found for PR #$PR_NUMBER"
-            echo "team_key=" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "⚠️  No matching engineering team for PR #$PR_NUMBER — falling back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
           fi
 
           TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
           if [ -z "$TEAM_CONFIG" ]; then
-            echo "❌ Unrecognized team key returned: $TEAM_KEY"
+            echo "❌ Unrecognized team key returned: $TEAM_KEY — falling back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          fi
+
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "❌ OSS fallback config missing from LINEAR_TEAM_CONFIG"
             echo "team_key=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -287,7 +299,7 @@ jobs:
             exit 0
           fi
 
-          if [ "$TEAM_KEY" = "PFP" ] || [ "$TEAM_KEY" = "OBS" ]; then
+          if [ "$TEAM_KEY" = "PFP" ] || [ "$TEAM_KEY" = "OBS" ] || [ "$TEAM_KEY" = "OSS" ]; then
             RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
               -H "Authorization: $LINEAR_API_KEY" \
               -H "Content-Type: application/json" \
@@ -400,7 +412,8 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
         run: |
-          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | "- " + .key + ": " + .description')
+          # Exclude OSS from LLM choices — it is the code-side fallback only
+          TEAM_DESCRIPTIONS=$(echo "$LINEAR_TEAM_CONFIG" | jq -r '.[] | select(.key != "OSS") | "- " + .key + ": " + .description')
 
           PROMPT=$(cat <<PROMPT_EOF
           You are routing a GitHub issue to the correct engineering team. Based on the issue details below, respond with ONLY the team key (e.g. ING, CAT, PFP), or NONE if it doesn't clearly belong to any team.
@@ -429,14 +442,19 @@ jobs:
           TEAM_KEY=$(echo "$CLAUDE_RESPONSE" | jq -r '.content[0].text' 2>/dev/null | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
 
           if [ -z "$TEAM_KEY" ] || [ "$TEAM_KEY" = "NONE" ] || [ "$TEAM_KEY" = "NULL" ]; then
-            echo "⏭️  No matching team found for issue #$ISSUE_NUMBER"
-            echo "team_key=" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "⚠️  No matching engineering team for issue #$ISSUE_NUMBER — falling back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
           fi
 
           TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
           if [ -z "$TEAM_CONFIG" ]; then
-            echo "❌ Unrecognized team key returned: $TEAM_KEY"
+            echo "❌ Unrecognized team key returned: $TEAM_KEY — falling back to OSS (DevRel triage)"
+            TEAM_KEY=OSS
+            TEAM_CONFIG=$(echo "$LINEAR_TEAM_CONFIG" | jq --arg key "$TEAM_KEY" '.[] | select(.key == $key)')
+          fi
+
+          if [ -z "$TEAM_CONFIG" ]; then
+            echo "❌ OSS fallback config missing from LINEAR_TEAM_CONFIG"
             echo "team_key=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -498,7 +516,7 @@ jobs:
             exit 0
           fi
 
-          if [ "$TEAM_KEY" = "PFP" ] || [ "$TEAM_KEY" = "OBS" ]; then
+          if [ "$TEAM_KEY" = "PFP" ] || [ "$TEAM_KEY" = "OBS" ] || [ "$TEAM_KEY" = "OSS" ]; then
             RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
               -H "Authorization: $LINEAR_API_KEY" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

- When Claude cannot route a community PR/issue to ING/CAT/PFP/OBS, fall back to the **OSS** (Open Source) Linear team instead of skipping ticket creation
- Assign fallback tickets to Lakshay Nasa (DevRel) for triage/routing
- Mirrored the same behavior in the shadow `pr-to-linear-routing-test` workflow

Without a ticket, docs-only / unroutable community PRs (e.g. #19055) get lost after the workflow returns `NONE`.

## Test plan

- [ ] Confirm Lakshay is (or is added as) a member of the OSS Linear team so `assigneeId` succeeds
- [ ] Open a docs-only fork PR (or re-run routing on a similar PR) and verify a Linear ticket is created under OSS and assigned to Lakshay
- [ ] Confirm a clearly engineering-scoped PR still routes to ING/CAT/PFP/OBS as before
- [ ] Check shadow workflow logs show "would fall back to OSS" instead of NONE


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route unrouted PRs and issues to the OSS Linear team instead of dropping them, assigning to DevRel for triage. This prevents docs-only and misc community contributions from being lost when routing returns NONE.

- **Bug Fixes**
  - Added `OSS` team config (team_id, assignee_id) to the routing env.
  - Excluded `OSS` from LLM choices; use it only as a code fallback.
  - Fallback to `OSS` on NONE/null or unknown team keys.
  - Allowed Linear issue creation for `OSS` alongside `PFP` and `OBS`.
  - Improved logs and guards for missing `OSS` config.
  - Mirrored the same behavior in `pr-to-linear-routing-test`.

- **Migration**
  - Ensure the DevRel assignee is a member of the OSS Linear team so `assigneeId` works.

<sup>Written for commit fbd241c16a5bcc73a34f17e22a78bda4bd32807c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

