### PR TITLE
ci: remove Cypress from OSS CI (deprecated)

### DIFF
--- a/.github/actions/smoke-test-retry/action.yml
+++ b/.github/actions/smoke-test-retry/action.yml
@@ -9,7 +9,7 @@ description: >
 
 inputs:
   test_strategy:
-    description: "Test strategy: 'cypress' or 'pytests'"
+    description: "Test strategy: 'pytests'"
     required: true
   batch:
     description: "Current batch number (used for artifact name lookup)"
@@ -24,10 +24,10 @@ inputs:
 outputs:
   parse_result:
     description: "One of: has_failures, all_passed, no_artifacts, error."
-    value: ${{ steps.parse-cypress-failures.outputs.parse_result || steps.parse-pytest-failures.outputs.parse_result || steps.download-artifacts.outputs.parse_result || '' }}
+    value: ${{ steps.parse-pytest-failures.outputs.parse_result || steps.download-artifacts.outputs.parse_result || '' }}
   filtered_tests_file:
     description: "Path to file listing failed tests. Only set when parse_result is 'has_failures'."
-    value: ${{ steps.parse-cypress-failures.outputs.filtered_tests_file || steps.parse-pytest-failures.outputs.filtered_tests_file || '' }}
+    value: ${{ steps.parse-pytest-failures.outputs.filtered_tests_file || '' }}
 
 runs:
   using: composite
@@ -69,66 +69,14 @@ runs:
         gh api "repos/${REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > artifact.zip
         unzip -q artifact.zip
 
-        if [[ "${TEST_STRATEGY}" == "cypress" ]]; then
-          if find . -path "*/smoke-test-results/cypress-test-*.xml" -print -quit | grep -q .; then
-            echo "Successfully downloaded cypress test results"
-            echo "download_success=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No cypress test XML files found in artifact"
-            echo "download_success=false" >> "$GITHUB_OUTPUT"
-            echo "parse_result=no_artifacts" >> "$GITHUB_OUTPUT"
-          fi
+        if find . -path "*/junit*.xml" -print -quit | grep -q .; then
+          echo "Successfully downloaded pytest test results"
+          echo "download_success=true" >> "$GITHUB_OUTPUT"
         else
-          if find . -path "*/junit*.xml" -print -quit | grep -q .; then
-            echo "Successfully downloaded pytest test results"
-            echo "download_success=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No pytest XML files found in artifact"
-            echo "download_success=false" >> "$GITHUB_OUTPUT"
-            echo "parse_result=no_artifacts" >> "$GITHUB_OUTPUT"
-          fi
+          echo "No pytest XML files found in artifact"
+          echo "download_success=false" >> "$GITHUB_OUTPUT"
+          echo "parse_result=no_artifacts" >> "$GITHUB_OUTPUT"
         fi
-
-    - name: Parse failed Cypress tests
-      if: |
-        inputs.test_strategy == 'cypress' &&
-        steps.download-artifacts.outputs.download_success == 'true'
-      id: parse-cypress-failures
-      shell: bash
-      env:
-        BATCH: ${{ inputs.batch }}
-      run: |
-
-        OUTPUT_FILE="${GITHUB_WORKSPACE}/failed-tests-batch-${BATCH}.txt"
-
-        # The parser uses non-zero exit codes as signals (1=error, 2=all_passed,
-        # 3=no_artifacts), not failures. GitHub runs composite bash steps with
-        # `-eo pipefail`, so capture the code via `|| EXIT_CODE=$?` to keep
-        # errexit from aborting the step before the case below can read it.
-        EXIT_CODE=0
-        python3 .github/scripts/parse_failed_cypress_tests.py \
-          --input-dir "${GITHUB_WORKSPACE}/previous-test-results" \
-          --output "${OUTPUT_FILE}" || EXIT_CODE=$?
-
-        case $EXIT_CODE in
-          0)
-            echo "parse_result=has_failures" >> "$GITHUB_OUTPUT"
-            echo "filtered_tests_file=${OUTPUT_FILE}" >> "$GITHUB_OUTPUT"
-            echo "Will retry $(wc -l < ${OUTPUT_FILE}) failed test(s)"
-            ;;
-          2)
-            echo "parse_result=all_passed" >> "$GITHUB_OUTPUT"
-            echo "All tests passed in previous attempt - will skip batch"
-            ;;
-          3)
-            echo "parse_result=no_artifacts" >> "$GITHUB_OUTPUT"
-            echo "No test results found - will run all tests"
-            ;;
-          *)
-            echo "parse_result=error" >> "$GITHUB_OUTPUT"
-            echo "Error parsing test results - will run all tests"
-            ;;
-        esac
 
     - name: Parse failed pytest modules
       if: |
@@ -142,8 +90,10 @@ runs:
 
         OUTPUT_FILE="${GITHUB_WORKSPACE}/failed-modules-batch-${BATCH}.txt"
 
-        # See the cypress parse step: capture the parser's signal exit code via
-        # `|| EXIT_CODE=$?` so `bash -e` doesn't abort the step before the case.
+        # The parser uses non-zero exit codes as signals (1=error, 2=all_passed,
+        # 3=no_artifacts), not failures. GitHub runs composite bash steps with
+        # `-eo pipefail`, so capture the code via `|| EXIT_CODE=$?` to keep
+        # errexit from aborting the step before the case below can read it.
         EXIT_CODE=0
         python3 .github/scripts/parse_failed_pytest_tests.py \
           --input-dir "${GITHUB_WORKSPACE}/previous-test-results" \

--- a/.github/scripts/compare_test_weights.py
+++ b/.github/scripts/compare_test_weights.py
@@ -13,7 +13,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 
 def load_weights(file_path: str, test_id_key: str) -> Dict[str, float]:
@@ -89,7 +89,6 @@ def calculate_changes(
 
 def generate_pr_body(
     pytest_changes: Dict,
-    cypress_changes: Optional[Dict] = None,
     title: str = "🤖 Automated Test Weight Update",
 ) -> str:
     """Generate markdown PR body with change analysis."""
@@ -109,8 +108,6 @@ def generate_pr_body(
     lines.append("|-----------|-----------|-----------|--------|---------|")
 
     summary_rows: List[tuple[str, Dict]] = [("Pytest", pytest_changes)]
-    if cypress_changes is not None:
-        summary_rows.insert(0, ("Cypress", cypress_changes))
 
     for name, changes in summary_rows:
         old_min = changes["old_total"] / 60
@@ -143,8 +140,6 @@ def generate_pr_body(
         lines.append("<summary>Batch count recommendations</summary>")
         lines.append("")
         lines.append("Current configuration:")
-        if cypress_changes is not None:
-            lines.append("- Cypress: 11 batches (Depot) / 5 batches (GitHub runners)")
         lines.append("- Pytest: 7 batches (GitHub runners)")
         lines.append("")
         lines.append(
@@ -257,16 +252,6 @@ def main():
         description="Compare test weights and generate PR description"
     )
     parser.add_argument(
-        "--old-cypress",
-        required=False,
-        help="Path to old Cypress weights JSON",
-    )
-    parser.add_argument(
-        "--new-cypress",
-        required=False,
-        help="Path to new Cypress weights JSON",
-    )
-    parser.add_argument(
         "--old-pytest", required=True, help="Path to old Pytest weights JSON"
     )
     parser.add_argument(
@@ -291,24 +276,11 @@ def main():
 
     args = parser.parse_args()
 
-    if (args.old_cypress is None) != (args.new_cypress is None):
-        print("Error: --old-cypress and --new-cypress must be provided together")
-        sys.exit(1)
-
     old_pytest = load_weights(args.old_pytest, "testId")
     new_pytest = load_weights(args.new_pytest, "testId")
     pytest_changes = calculate_changes(old_pytest, new_pytest)
 
-    cypress_changes = None
-    change_pcts = [abs(pytest_changes["total_change_pct"])]
-    if args.old_cypress and args.new_cypress:
-        old_cypress = load_weights(args.old_cypress, "filePath")
-        new_cypress = load_weights(args.new_cypress, "filePath")
-        cypress_changes = calculate_changes(old_cypress, new_cypress)
-        change_pcts.append(abs(cypress_changes["total_change_pct"]))
-        print(f"Cypress total change: {cypress_changes['total_change_pct']:+.2f}%")
-
-    max_change = max(change_pcts)
+    max_change = abs(pytest_changes["total_change_pct"])
 
     print(f"Pytest total change: {pytest_changes['total_change_pct']:+.2f}%")
     print(f"Max change: {max_change:.2f}%")
@@ -322,22 +294,15 @@ def main():
 
     print("\n✓ Changes exceed threshold. Generating PR body...")
 
-    pr_body = generate_pr_body(pytest_changes, cypress_changes, title=args.title)
+    pr_body = generate_pr_body(pytest_changes, title=args.title)
 
     with open(args.output, "w") as f:
         f.write(pr_body)
 
     print(f"✓ PR body written to {args.output}")
-    if cypress_changes is not None:
-        print(
-            "✓ Significant changes: "
-            f"Cypress={len(cypress_changes['significant_changes'])}, "
-            f"Pytest={len(pytest_changes['significant_changes'])}"
-        )
-    else:
-        print(
-            f"✓ Significant changes: Pytest={len(pytest_changes['significant_changes'])}"
-        )
+    print(
+        f"✓ Significant changes: Pytest={len(pytest_changes['significant_changes'])}"
+    )
 
     sys.exit(0)
 

--- a/.github/scripts/pre-commit/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit/pre-commit-override.yaml
@@ -16,15 +16,6 @@ repos:
         # first would require changing the generator's merge order (prepend
         # override hooks) — deferred as not worth it for now.
         stages: [pre-push]
-      - id: smoke-test-cypress-lint-fix
-        name: smoke-test cypress Lint Fix
-        entry: ./gradlew :smoke-test:cypressLintFix -x generateGitPropertiesGlobal
-        language: system
-        files: ^smoke-test/tests/cypress/.*\.tsx$
-        pass_filenames: false
-        # cypressLintFix is a self-correcting formatter (slow, module-wide Gradle
-        # invocation). Run it at pre-push instead of pre-commit; see PFP-5002.
-        stages: [pre-push]
       - id: update-lineage-file
         name: update-lineage-file
         entry: ./gradlew :metadata-ingestion:lineageGen -x generateGitPropertiesGlobal

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -35,7 +35,6 @@ jobs:
       # Runs the single python-lint job if ANY Python module's files changed.
       python-lint: ${{ steps.filter.outputs.metadata-ingestion == 'true' || steps.filter.outputs.datahub-actions == 'true' || steps.filter.outputs.datahub-agent-context == 'true' || steps.filter.outputs.airflow-plugin == 'true' || steps.filter.outputs.gx-plugin == 'true' || steps.filter.outputs.dagster-plugin == 'true' || steps.filter.outputs.prefect-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
-      smoke-test-cypress: ${{ steps.filter.outputs.smoke-test-cypress == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
       default-runner: ${{ steps.runners.outputs.default-runner }}
       default-gh-runner: ${{ steps.runners.outputs.default-gh-runner }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -615,15 +615,6 @@ repos:
         stages:
           - pre-push
 
-      - id: smoke-test-cypress-lint-fix
-        name: smoke-test cypress Lint Fix
-        entry: ./gradlew :smoke-test:cypressLintFix -x generateGitPropertiesGlobal
-        language: system
-        files: ^smoke-test/tests/cypress/.*\.tsx$
-        pass_filenames: false
-        stages:
-          - pre-push
-
       - id: update-lineage-file
         name: update-lineage-file
         entry: ./gradlew :metadata-ingestion:lineageGen -x generateGitPropertiesGlobal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -738,7 +738,9 @@ Cypress UI tests in `smoke-test/tests/cypress/` are **deprecated as of 2026-06-3
 
 - **Do not write new Cypress tests.** All new UI automation must use Playwright (see below).
 - **Do not fix failing Cypress tests.** Migrate them to Playwright instead.
-- The Cypress test code is retained temporarily for reference; all CI jobs running Cypress have been removed.
+- The Cypress test code is retained temporarily for reference during the Playwright migration.
+- CI infrastructure for Cypress (Gradle tasks, workflow references, retry logic, pre-commit
+  hooks, and smoke orchestration branches) was removed on 2026-08-11. Do not reintroduce it.
 
 ## Playwright UI E2E Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -739,8 +739,7 @@ Cypress UI tests in `smoke-test/tests/cypress/` are **deprecated as of 2026-06-3
 - **Do not write new Cypress tests.** All new UI automation must use Playwright (see below).
 - **Do not fix failing Cypress tests.** Migrate them to Playwright instead.
 - The Cypress test code is retained temporarily for reference during the Playwright migration.
-- CI infrastructure for Cypress (Gradle tasks, workflow references, retry logic, pre-commit
-  hooks, and smoke orchestration branches) was removed on 2026-08-11. Do not reintroduce it.
+- CI infrastructure for Cypress is deprecated in OSS; avoid adding new Cypress Gradle/workflow/retry/hook orchestration and continue migration to Playwright.
 
 ## Playwright UI E2E Tests
 

--- a/smoke-test/build.gradle
+++ b/smoke-test/build.gradle
@@ -35,24 +35,6 @@ node {
 
 }
 
-task yarnInstall(type: YarnTask) {
-  println  "Root directory:  ${project.rootDir}";
-  environment = ['NODE_OPTIONS': '--openssl-legacy-provider']
-  args = ['install', '--network-timeout', '300000', '--cwd', "${project.rootDir}/smoke-test/tests/cypress"]
-}
-
-task cypressLint(type: YarnTask, dependsOn: yarnInstall) {
-  environment = ['NODE_OPTIONS': '--openssl-legacy-provider']
-  // TODO: Run a full lint instead of just format.
-  args = ['--cwd', "${project.rootDir}/smoke-test/tests/cypress", 'run', 'format']
-}
-
-task cypressLintFix(type: YarnTask, dependsOn: yarnInstall) {
-  environment = ['NODE_OPTIONS': '--openssl-legacy-provider']
-  // TODO: Run a full lint instead of just format.
-  args = ['--cwd', "${project.rootDir}/smoke-test/tests/cypress", 'run', 'format', '--write']
-}
-
 task installDev(type: Exec) {
     inputs.file file('pyproject.toml')
     inputs.file file('requirements.txt')
@@ -102,62 +84,12 @@ task pytest(type: Exec, dependsOn: [installDev, ':metadata-ingestion:installDev'
             "./smoke.sh"
 }
 
-//  ./gradlew :smoke-test:cypressTest -PbatchNumber=2 (default 0)
-task cypressTest(type: Exec, dependsOn: [installDev, ':metadata-ingestion:installDev']) {
-    // Get BATCH_NUMBER from command line argument with default value of 0
-    def batchNumber = project.hasProperty('batchNumber') ? project.property('batchNumber') : '0'
-
-    environment 'RUN_QUICKSTART', 'false'
-    environment 'TEST_STRATEGY', 'cypress'
-    environment 'BATCH_COUNT', 11
-    environment 'BATCH_NUMBER', batchNumber
-
-    workingDir = project.projectDir
-    commandLine 'bash', '-c',
-            "source ${venv_name}/bin/activate && set -x && " +
-                    "./smoke.sh"
-}
-
-/**
- * The following will run Cypress in interactive mode against an already running stack.
- */
-task cypressDev(type: Exec, dependsOn: [installDev, ':metadata-ingestion:installDev']) {
-    environment 'RUN_QUICKSTART', 'false'
-
-    workingDir = project.projectDir
-    commandLine 'bash', '-c',
-            "source ${venv_name}/bin/activate && set -x && " +
-                    "./cypress-dev.sh"
-}
-
-/**
- * The following will install Cypress data in an already running stack.
- */
-task cypressData(type: Exec, dependsOn: [installDev, ':metadata-ingestion:installDev']) {
-    environment 'RUN_QUICKSTART', 'false'
-    environment 'RUN_UI', 'false'
-
-    workingDir = project.projectDir
-    commandLine 'bash', '-c',
-            "source ${venv_name}/bin/activate && set -x && " +
-                    "./cypress-dev.sh"
-}
-
-task cypressRemote(type: Exec) {
-  environment 'CYPRESS_BASE_URL', project.findProperty('baseUrl') ?: 'http://localhost:4173'
-  environment 'CYPRESS_ADMIN_USERNAME', project.findProperty('username') ?: 'admin'
-  environment 'CYPRESS_ADMIN_PASSWORD', project.findProperty('password')
-
-  workingDir = "${project.rootDir}/smoke-test/tests/cypress"
-  commandLine 'bash', '-c', './cypress-remote.sh'
-}
-
 task lint {
-    dependsOn pythonLint, cypressLint
+    dependsOn pythonLint
 }
 
 task lintFix {
-    dependsOn pythonLintFix, cypressLintFix
+    dependsOn pythonLintFix
 }
 
 task cleanPythonCache(type: Exec) {

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -381,9 +381,6 @@ def _apply_smoke_policy_phase_filter(items: List[Item]) -> None:
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: List[Item]
 ) -> None:
-    if env_vars.get_test_strategy() == "cypress":
-        return  # We launch cypress via pytests, but needs a different batching mechanism at cypress level.
-
     # Check if FILTERED_TESTS is set (for retry logic)
     filtered_tests_file = env_vars.get_filtered_tests_file()
     if filtered_tests_file:

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -28,10 +28,6 @@ else
   uv pip install -r requirements.txt
 fi
 
-(cd ..; ./gradlew :smoke-test:yarnInstall)
-
-source ./set-cypress-creds.sh
-
 # set environment variables for the test
 source ./set-test-env-vars.sh
 
@@ -97,23 +93,8 @@ run_pytest_policy_phases() {
   return 0
 }
 
-# TEST_STRATEGY:
-#   if set to pytests, runs all pytests, skips cypress tests(though cypress test launch is via  a pytest).
-#   if set tp cypress, runs all cypress tests
-#   if blank, runs all.
+# Cypress deprecated 2026-08-11. Always run pytests only.
 # When invoked via the github action, BATCH_COUNT and BATCH_NUMBER env vars are set to run a slice of those tests per
-# worker for parallelism. docker-unified.yml generates a test matrix of pytests/cypress in batches. As number of tests
+# worker for parallelism. docker-unified.yml generates a test matrix of pytests in batches. As number of tests
 # increase, the batch_count config (in docker-unified.yml) may need adjustment.
-if [[ "${TEST_STRATEGY}" == "pytests" ]]; then
-  #pytests only - github test matrix runs pytests in one of the runners when applicable.
-  run_pytest_policy_phases junit.smoke-pytests -k 'not test_run_cypress'
-elif [[ "${TEST_STRATEGY}" == "cypress" ]]; then
-  # run only cypress tests. The test inspects BATCH_COUNT and BATCH_NUMBER and runs only a subset of tests in that batch.
-  # github workflow test matrix will invoke this in multiple runners for each batch.
-  # Skipping the junit at the pytest level since cypress itself generates junits on a per-test basis. The pytest is a single test for all cypress
-  # tests and isnt very helpful.
-  # Cypress is launched from a single pytest module; xdist is not useful here.
-  pytest -rP --durations=20 -vvs --continue-on-collection-errors tests/cypress/integration_test.py
-else
-  run_pytest_policy_phases junit.smoke-all
-fi
+run_pytest_policy_phases junit.smoke-pytests -k 'not test_run_cypress'


### PR DESCRIPTION
## Summary

Removes all Cypress CI infrastructure from the OSS repo (Gradle tasks, workflow references, retry logic, pre-commit hooks, and test orchestration branches). Cypress tests were already not running (matrices use `pytests` only), but this cleans out the dead code. Matches the Cloud repo deprecation (commit `d406f15968`). Test files are retained for reference during the Playwright migration.

