### PR TITLE
chore(ingest/confluent): use ASCII punctuation in new code

### DIFF
--- a/metadata-ingestion/docs/sources/kafka-connect/kafka-connect_post.md
+++ b/metadata-ingestion/docs/sources/kafka-connect/kafka-connect_post.md
@@ -117,19 +117,19 @@ source:
       include_lineage: false
 ```
 
-**Requirements**: Confluent Cloud with the **Stream Governance Advanced** package on the environment — tags and business metadata are an Advanced feature, and the catalog API returns `403` even for reads on Essentials. The Schema Registry API key also needs a role that grants Stream Catalog read access — in practice **DataSteward** on the environment; `EnvironmentAdmin` alone is not enough, as it administers the environment but does not carry the catalog read permission. This has no equivalent on self-hosted Kafka Connect — the block is ignored (with a warning) when `confluent_catalog.schema_registry_url` is not a Confluent Cloud endpoint.
+**Requirements**: Confluent Cloud with the **Stream Governance Advanced** package on the environment - tags and business metadata are an Advanced feature, and the catalog API returns `403` even for reads on Essentials. The Schema Registry API key also needs a role that grants Stream Catalog read access - in practice **DataSteward** on the environment; `EnvironmentAdmin` alone is not enough, as it administers the environment but does not carry the catalog read permission. This has no equivalent on self-hosted Kafka Connect - the block is ignored (with a warning) when `confluent_catalog.schema_registry_url` is not a Confluent Cloud endpoint.
 
 **What each option changes:**
 
-- `include_tags` — catalog tags on a connector are written to its DataHub pipeline (`dataFlow`).
-- `include_business_metadata` — catalog business metadata attributes on a connector become custom properties on the same pipeline.
-- `include_lineage` — for **source** connectors, lineage is taken from the catalog's topic list instead of being predicted by the transform pipeline. Off by default; see the trade-off below.
+- `include_tags` - catalog tags on a connector are written to its DataHub pipeline (`dataFlow`).
+- `include_business_metadata` - catalog business metadata attributes on a connector become custom properties on the same pipeline.
+- `include_lineage` - for **source** connectors, lineage is taken from the catalog's topic list instead of being predicted by the transform pipeline. Off by default; see the trade-off below.
 
-This source only writes the Kafka Connect pipelines it owns. Catalog tags and business metadata on the **topics** are ingested by the [`kafka`](/docs/generated/ingestion/sources/kafka) source, which owns those datasets — enable `confluent_catalog` there to pick them up.
+This source only writes the Kafka Connect pipelines it owns. Catalog tags and business metadata on the **topics** are ingested by the [`kafka`](/docs/generated/ingestion/sources/kafka) source, which owns those datasets - enable `confluent_catalog` there to pick them up.
 
 ##### The `include_lineage` trade-off
 
-Catalog lineage is `connector -> topic` only. The catalog reports topic names _after_ topic-routing SMTs have been applied, so that one edge is exact rather than inferred — but the catalog has no view of the source system, so it cannot say which table a row came from.
+Catalog lineage is `connector -> topic` only. The catalog reports topic names _after_ topic-routing SMTs have been applied, so that one edge is exact rather than inferred, but the catalog has no view of the source system, so it cannot say which table a row came from.
 
 Enabling `include_lineage` therefore changes source connectors from:
 

--- a/metadata-ingestion/docs/sources/kafka/kafka_post.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka_post.md
@@ -106,7 +106,7 @@ Requirements and limitations:
   Tags and business metadata are an Advanced feature: on Essentials the catalog API returns
   `403` even for reads. The catalog does not exist on self-managed Kafka, and the block is
   ignored elsewhere.
-- The Schema Registry API key needs a role that grants catalog read access — in practice
+- The Schema Registry API key needs a role that grants catalog read access - in practice
   **DataSteward** on the environment. `EnvironmentAdmin` alone is not enough: it administers the
   environment but does not carry the catalog read permission.
 - If the key cannot read the catalog, ingestion continues without catalog metadata and records a

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/config.py
@@ -101,7 +101,7 @@ class ConfluentStreamCatalogConfig(ConfigModel):
             return True
         report.warning(
             message="'confluent_catalog' is enabled but the Schema Registry endpoint is "
-            "not a Confluent Cloud one — the Stream Catalog is Confluent Cloud only and "
+            "not a Confluent Cloud one: the Stream Catalog is Confluent Cloud only and "
             "will be skipped",
             context=f"schema_registry_url={self.schema_registry_url}",
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/models.py
@@ -68,7 +68,7 @@ class CatalogEntity(CatalogModel):
         }
 
     def duplicate_business_metadata_names(self) -> List[str]:
-        # Only names with multiple non-null values — null siblings do not overwrite.
+        # Only names with multiple non-null values; null siblings do not overwrite.
         counts = Counter(
             attribute.name
             for attribute in self.business_metadata

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog_constants.py
@@ -3,7 +3,7 @@ from typing import Final
 TOPIC_ROOT_KEY: Final[str] = "kafka_topic"
 
 # Unknown fields fail the whole query. The cluster field is `logical_cluster_id`
-# (not the more intuitive `clusterId` — Confluent Cloud rejects that name).
+# (not the more intuitive `clusterId` - Confluent Cloud rejects that name).
 # Pagination placeholders: see LIMIT_PLACEHOLDER / OFFSET_PLACEHOLDER.
 TOPIC_CATALOG_QUERY: Final[str] = """
 {

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -1542,7 +1542,7 @@ class BaseConnector:
         """
         matcher = JavaRegexMatcher()
 
-        # Distinguish None (unavailable → try DataHub) from [] (empty cluster).
+        # Distinguish None (unavailable -> try DataHub) from [] (empty cluster).
         if available_topics is not None:
             matched_topics = matcher.filter_matches([topics_regex], available_topics)
             if matched_topics:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog_constants.py
@@ -6,7 +6,7 @@ LINEAGE_SOURCE_PROPERTY: Final[str] = "lineage_source"
 LINEAGE_SOURCE_CATALOG: Final[str] = "confluent_stream_catalog"
 
 # cn_connector.topics are post-SMT, so they replace the transform heuristic.
-# Unknown fields fail the whole query — only select live, consumed fields.
+# Unknown fields fail the whole query - only select live, consumed fields.
 # Do not filter by cluster id: on cn_connector that field is the Connect
 # cluster (lcc-*), not the Kafka cluster (lkc-*) from the REST URI.
 CONNECTOR_CATALOG_QUERY: Final[str] = """

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
@@ -190,7 +190,7 @@ class KafkaConnectSource(StatefulIngestionSourceBase):
         if not self.config.confluent_catalog.enabled:
             return None
 
-        # Gate on the catalog SR URL, not connect_uri — independently configurable.
+        # Gate on the catalog SR URL, not connect_uri - independently configurable.
         if not self.config.confluent_catalog.check_confluent_cloud_endpoint(
             self.report
         ):

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -247,7 +247,7 @@ class JdbcParserFactory:
 
 @dataclass
 class ConfluentJDBCSourceConnector(BaseConnector):
-    # Traditional io.confluent.connect.jdbc.JdbcSourceConnector only — Cloud
+    # Traditional io.confluent.connect.jdbc.JdbcSourceConnector only - Cloud
     # Postgres/MySQL CDC classes dispatch to DebeziumSourceConnector instead.
     needs_cluster_topics: ClassVar[bool] = True
 

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/confluent_cloud_mock_api.py
@@ -26,7 +26,7 @@ LIMIT_ARGUMENT_RE = re.compile(r"limit:\s*(\d+)")
 IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 # The live catalog rejects the whole query on a single unknown field, so the stub
-# must too — otherwise a field that 400s in production would pass here.
+# must too - otherwise a field that 400s in production would pass here.
 CONNECTOR_QUERY_KNOWN_FIELDS = frozenset(
     {
         "cn_connector",
@@ -469,7 +469,7 @@ def get_topic(cluster_id, topic_name):
 @app.route("/catalog/graphql", methods=["POST"])
 @require_auth
 def catalog_graphql():
-    """cn_connector stand-in. Variables map → 500, like the live endpoint."""
+    """cn_connector stand-in. Variables map -> 500, like the live endpoint."""
     body = request.get_json(silent=True) or {}
     if "variables" in body:
         return jsonify({"error": "Internal server error"}), 500

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_confluent_catalog.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_confluent_catalog.py
@@ -323,7 +323,7 @@ class TestCatalogLineage:
     def test_unknown_source_with_all_catalog_topics_filtered_is_still_skipped(
         self,
     ) -> None:
-        # Catalog listed topics, but none are on the live cluster — no registry
+        # Catalog listed topics, but none are on the live cluster - no registry
         # handler either, so drop the connector rather than emit an empty flow.
         source = make_cloud_source(
             [{"name": "exotic_source", "topics": [{"name": "stale_topic"}]}]


### PR DESCRIPTION
Follow-on housekeeping for the Stream Catalog branch, in the same spirit as `style(ingest/confluent): strip AI narration comments from catalog PR` and `style(ingest/confluent): drop issue-diary commen
s from catalog code`. Punctuation only.

The branch introduces 19 non-ASCII characters on the lines it adds: 17 em dashes (U+2014) and 2 rightwards arrows (U+2192). Six of them sit in `kafka-connect_post.md` and `kafka_post.md`, which are spliced into the generated connector docs, so they reach users directly. One sits inside the `confluent_catalog` endpoint warning, where a non-ASCII dash makes the message harder to match if someone pastes it out of a log and into a search box. The rest are comments, where the cost is the ordinary one: text that survives a round-trip through the wrong encoding as mojibake, and that no one can type when grepping.

Each dash becomes whatever reads naturally in ASCII - a spaced hyphen where it separates clauses, a comma or colon where the sentence is better for it - and each arrow becomes `->`, which is what the surrounding code already uses in several places. No wording changed and no behaviour changed; the whole diff is 17 lines, one substitution each.

Scope is deliberately narrow: only lines this branch adds are touched. The same files carry a further ~113 non-ASCII characters inherited from `master` (checkmarks and arrows in the Kafka Connect support tables, arrows in `source_connectors.py` docstrings). Those are not this branch's to fix, and folding them in would bury a 17-line diff in a 100-line one.

No test fixture, golden file, or assertion string contains any of these characters, so nothing expected had to move with the code.

**Verification**

```
git diff origin/master...HEAD | grep '^+' | grep -v '^+++' | LC_ALL=C grep -c '[^ -~]'
0
```

`./gradlew :metadata-ingestion:lint` passes (ruff check, ruff format --check, mypy over 2545 source files). `pytest tests/unit/kafka tests/unit/confluent tests/unit/kafka_connect` - 831 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace non-ASCII punctuation in Confluent Stream Catalog code, tests, and docs to keep logs, greps, and generated docs searchable. Old behavior: em dashes and arrow glyphs in one `confluent_catalog` warning, comments, and `kafka`/`kafka-connect` doc fragments; new behavior: spaced hyphen, comma/colon, or `->`. No logic changes.

- Runtime change: only the warning string in `metadata-ingestion/src/datahub/ingestion/source/confluent/config.py` now uses ASCII punctuation; all other edits are comments or docs.
- Update any exact-match log alerts that rely on the old `confluent_catalog` warning text.
- Generated docs now use ASCII-only punctuation in `kafka-connect_post.md` and `kafka_post.md`.
- Scope: only lines added by the Stream Catalog work are touched; preexisting non-ASCII remains unchanged.

<sup>Written for commit dfae4db51bc65c76250a8495eaad9015b59146e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

