### PR TITLE
feat(ingest/kafka): derive Confluent Cloud console URLs for topics

### DIFF
--- a/metadata-ingestion/docs/sources/kafka/kafka_post.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka_post.md
@@ -100,6 +100,21 @@ source:
 Confluent tags become DataHub tags and business metadata attributes become custom properties on
 the topic. Set `include_tags` or `include_business_metadata` to `false` to take only one of the two.
 
+Adding `environment_id` also puts a **View in Kafka** link on every topic, pointing at the topic in
+the Confluent Cloud console:
+
+```yml
+    confluent_catalog:
+      enabled: true
+      environment_id: "env-xxxxx"
+      cluster_id: "lkc-xxxxx" # optional, see below
+```
+
+The link is `https://confluent.cloud/environments/<environment_id>/clusters/<cluster_id>/topics/<topic>`.
+The cluster id comes from `cluster_id` when set, otherwise from the topic's own catalog entry, so a
+single-cluster environment only needs `environment_id`. Setting `external_url_base` overrides the
+derived link entirely, for deployments that front the console at another address.
+
 Requirements and limitations:
 
 - **Confluent Cloud only**, and the environment needs the **Stream Governance Advanced** package.

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/constants.py
@@ -10,6 +10,14 @@ DEFAULT_TIMEOUT_SECONDS: Final[int] = 30
 
 CONFLUENT_CLOUD_DOMAIN_SUFFIX: Final[str] = ".confluent.cloud"
 
+# Confluent Cloud console link for a topic. The path deliberately stops at the
+# topic: the console redirects a bare topic path to whichever tab it currently
+# defaults to, so no tab segment is pinned here.
+CONFLUENT_CLOUD_TOPIC_URL: Final[str] = (
+    "https://confluent.cloud/environments/{environment_id}"
+    "/clusters/{cluster_id}/topics/{topic}"
+)
+
 # Confluent Cloud rejects page sizes above this.
 MAX_PAGE_SIZE: Final[int] = 1000
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
@@ -1277,12 +1277,16 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
                         for tag_association in meta_tags_aspect.tags
                     ]
 
+        # Only topics have somewhere to link to; a Schema Registry subject is not
+        # addressable under a broker's topic path.
         if not is_subject:
-            self._apply_catalog_metadata(topic, all_tags, custom_props)
+            external_url = self._apply_catalog_metadata(topic, all_tags, custom_props)
 
-        if self.source_config.external_url_base:
-            base_url = self.source_config.external_url_base.rstrip("/")
-            external_url = f"{base_url}/{dataset_name}"
+            # An explicitly configured base always wins: it is the only way to point
+            # at a private or non-Confluent console.
+            if self.source_config.external_url_base:
+                base_url = self.source_config.external_url_base.rstrip("/")
+                external_url = f"{base_url}/{dataset_name}"
 
         domain_urn: Optional[str] = None
         for domain, pattern in self.source_config.domain.items():
@@ -1312,15 +1316,19 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
 
     def _apply_catalog_metadata(
         self, topic: str, all_tags: List[str], custom_props: Dict[str, str]
-    ) -> None:
+    ) -> Optional[str]:
+        """Apply Stream Catalog tags and business metadata, and return the topic's
+        Confluent Cloud console URL when it can be derived."""
         if self.topic_catalog is None:
-            return
-
-        catalog_topic = self.topic_catalog.get_topic(topic)
-        if catalog_topic is None:
-            return
+            return None
 
         config = self.source_config.confluent_catalog
+        catalog_topic = self.topic_catalog.get_topic(topic)
+        if catalog_topic is None:
+            # The console URL is addressed by ids alone, so it still holds for a
+            # topic the catalog has no entry for.
+            return config.get_topic_external_url(topic)
+
         if config.include_tags and catalog_topic.tags:
             all_tags.extend(
                 self.source_config.tag_prefix + tag for tag in catalog_topic.tags
@@ -1338,6 +1346,8 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
             if properties:
                 custom_props.update(properties)
                 self.report.catalog_topics_with_business_metadata += 1
+
+        return config.get_topic_external_url(topic, catalog_topic.cluster_id)
 
     def build_custom_properties(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
@@ -9,6 +9,7 @@ from datahub.configuration.source_common import (
     LowerCaseDatasetUrnConfigMixin,
 )
 from datahub.ingestion.source.confluent.config import ConfluentStreamCatalogConfig
+from datahub.ingestion.source.confluent.constants import CONFLUENT_CLOUD_TOPIC_URL
 from datahub.ingestion.source.ge_profiling_config import GEProfilingConfig
 from datahub.ingestion.source.kafka.kafka_constants import (
     DEFAULT_BATCH_SIZE,
@@ -73,7 +74,17 @@ class KafkaConfluentCatalogConfig(ConfluentStreamCatalogConfig):
         default=None,
         description="Kafka cluster id, e.g. `lkc-xxxxx`. Only needed when the environment "
         "behind this Schema Registry holds more than one Kafka cluster, since the catalog "
-        "covers the whole environment and topic names can repeat across clusters.",
+        "covers the whole environment and topic names can repeat across clusters. Also used, "
+        "together with `environment_id`, to build the Confluent Cloud console link on each "
+        "topic; when it is not set the cluster id carried by the topic's own catalog entry "
+        "is used instead.",
+    )
+    environment_id: Optional[str] = Field(
+        default=None,
+        description="Confluent Cloud environment id, e.g. `env-xxxxx`. Only needed to build the "
+        "Confluent Cloud console link emitted as each topic's `externalUrl` (the 'View in Kafka' "
+        "link in DataHub); the catalog itself does not require it. An explicitly configured "
+        "`external_url_base` takes precedence over the link derived from this.",
     )
     include_tags: bool = Field(
         default=True,
@@ -84,6 +95,21 @@ class KafkaConfluentCatalogConfig(ConfluentStreamCatalogConfig):
         description="Emit Confluent Cloud business metadata attributes on topics as DataHub "
         "custom properties.",
     )
+
+    def get_topic_external_url(
+        self, topic: str, catalog_cluster_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Confluent Cloud console URL for a topic, or None if the ids are unknown."""
+        if not self.enabled or not self.environment_id:
+            return None
+        cluster_id = self.cluster_id or catalog_cluster_id
+        if not cluster_id:
+            return None
+        return CONFLUENT_CLOUD_TOPIC_URL.format(
+            environment_id=self.environment_id,
+            cluster_id=cluster_id,
+            topic=topic,
+        )
 
 
 class KafkaSourceConfig(
@@ -153,7 +179,7 @@ class KafkaSourceConfig(
     )
     external_url_base: Optional[str] = Field(
         default=None,
-        description="Base URL for external platform (e.g. Aiven) where topics can be viewed. The topic name will be appended to this base URL.",
+        description="Base URL for external platform (e.g. Aiven) where topics can be viewed. The topic name will be appended to this base URL. When set, it also overrides the Confluent Cloud console link that `confluent_catalog` would otherwise derive.",
     )
     profiling: ProfilerConfig = Field(
         default_factory=ProfilerConfig,

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_confluent_catalog.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.confluent.client import ConfluentStreamCatalogClient
@@ -12,11 +13,23 @@ from datahub.ingestion.source.kafka.confluent_catalog import (
 )
 from datahub.ingestion.source.kafka.kafka import KafkaSource, KafkaSourceConfig
 from datahub.ingestion.source.kafka.kafka_report import KafkaSourceReport
-from datahub.metadata.schema_classes import DatasetPropertiesClass, GlobalTagsClass
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    GlobalTagsClass,
+    KafkaSchemaClass,
+    SchemaMetadataClass,
+)
+from datahub.sdk.dataset import Dataset
 
 CONFLUENT_SCHEMA_REGISTRY_URL = "https://psrc-abc123.us-east-1.aws.confluent.cloud"
 SCHEMA_REGISTRY_URL = "http://localhost:8081"
 TOPIC = "orders"
+ENVIRONMENT_ID = "env-abc12"
+CLUSTER_ID = "lkc-def34"
+CONSOLE_URL = (
+    f"https://confluent.cloud/environments/{ENVIRONMENT_ID}"
+    f"/clusters/{CLUSTER_ID}/topics/{TOPIC}"
+)
 
 
 @pytest.fixture
@@ -31,6 +44,7 @@ def make_source_config(
     catalog: Optional[Dict[str, object]] = None,
     schema_registry_config: Optional[Dict[str, str]] = None,
     schema_registry_url: str = CONFLUENT_SCHEMA_REGISTRY_URL,
+    external_url_base: Optional[str] = None,
 ) -> KafkaSourceConfig:
     return KafkaSourceConfig.model_validate(
         {
@@ -40,6 +54,7 @@ def make_source_config(
                 "schema_registry_config": schema_registry_config or {},
             },
             "confluent_catalog": catalog or {},
+            "external_url_base": external_url_base,
         }
     )
 
@@ -157,6 +172,16 @@ class TestCatalogConnectionInheritance:
         assert "confluent_catalog.api_key" in message
         assert "confluent_catalog.api_secret" in message
 
+    def test_a_disabled_catalog_derives_no_console_url(self) -> None:
+        catalog = make_source_config(
+            catalog={
+                "environment_id": ENVIRONMENT_ID,
+                "cluster_id": CLUSTER_ID,
+            }
+        ).confluent_catalog
+
+        assert catalog.get_topic_external_url(TOPIC) is None
+
     def test_inherited_schema_registry_url_must_be_http(self) -> None:
         with pytest.raises(ValueError, match="schema_registry_url"):
             make_source_config(
@@ -248,6 +273,14 @@ class TestTopicLookup:
         )
 
 
+def external_urls_of(workunits: List[MetadataWorkUnit]) -> List[Optional[str]]:
+    return [
+        aspect.externalUrl
+        for aspect in aspects_of(workunits, "datasetProperties")
+        if isinstance(aspect, DatasetPropertiesClass)
+    ]
+
+
 @patch("datahub.ingestion.source.kafka.kafka.confluent_kafka.Consumer", autospec=True)
 class TestCatalogMetadataOnTopics:
     def build_source(
@@ -255,6 +288,7 @@ class TestCatalogMetadataOnTopics:
         mock_kafka: Mock,
         topics: List[CatalogKafkaTopic],
         topic_detail: Optional[object] = None,
+        external_url_base: Optional[str] = None,
         **catalog_overrides: object,
     ) -> KafkaSource:
         cluster_metadata = MagicMock()
@@ -265,6 +299,7 @@ class TestCatalogMetadataOnTopics:
             make_source_config(
                 catalog=enabled_catalog_config(**catalog_overrides),
                 schema_registry_url=SCHEMA_REGISTRY_URL,
+                external_url_base=external_url_base,
             ),
             PipelineContext(run_id="test"),
         )
@@ -395,6 +430,148 @@ class TestCatalogMetadataOnTopics:
         assert any(
             "Partitions" in warning.context[0] for warning in source.report.warnings
         )
+
+    def test_console_url_is_derived_from_the_configured_ids(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id=CLUSTER_ID)],
+            environment_id=ENVIRONMENT_ID,
+            cluster_id=CLUSTER_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert CONSOLE_URL in external_urls_of(workunits)
+
+    def test_console_url_uses_the_cluster_id_from_the_catalog_entry(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id=CLUSTER_ID)],
+            environment_id=ENVIRONMENT_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert CONSOLE_URL in external_urls_of(workunits)
+
+    def test_a_topic_missing_from_the_catalog_still_gets_a_console_url(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name="some_other_topic", logical_cluster_id=CLUSTER_ID)],
+            environment_id=ENVIRONMENT_ID,
+            cluster_id=CLUSTER_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert CONSOLE_URL in external_urls_of(workunits)
+
+    def test_no_console_url_without_an_environment_id(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id=CLUSTER_ID)],
+            cluster_id=CLUSTER_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert external_urls_of(workunits)
+        assert not any(external_urls_of(workunits))
+
+    def test_no_console_url_when_no_cluster_id_is_known(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC)],
+            environment_id=ENVIRONMENT_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert external_urls_of(workunits)
+        assert not any(external_urls_of(workunits))
+
+    def test_an_explicit_external_url_base_wins_over_the_derived_url(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id=CLUSTER_ID)],
+            external_url_base="https://console.aiven.io/project/p/kafka/topics/",
+            environment_id=ENVIRONMENT_ID,
+            cluster_id=CLUSTER_ID,
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert (
+            f"https://console.aiven.io/project/p/kafka/topics/{TOPIC}"
+            in external_urls_of(workunits)
+        )
+        assert CONSOLE_URL not in external_urls_of(workunits)
+
+    def test_subjects_get_no_external_url(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = self.build_source(
+            mock_kafka,
+            [CatalogKafkaTopic(name=TOPIC, logical_cluster_id=CLUSTER_ID)],
+            external_url_base="https://console.aiven.io/project/p/kafka/topics/",
+            environment_id=ENVIRONMENT_ID,
+            cluster_id=CLUSTER_ID,
+        )
+
+        subjects = list(
+            source._emit_dataset(
+                topic=TOPIC,
+                is_subject=True,
+                topic_detail=None,
+                extra_topic_config=None,
+                schema_metadata=SchemaMetadataClass(
+                    schemaName=f"{TOPIC}-value",
+                    platform=make_data_platform_urn("kafka"),
+                    version=0,
+                    hash="",
+                    platformSchema=KafkaSchemaClass(documentSchema=""),
+                    fields=[],
+                ),
+            )
+        )
+
+        assert subjects
+        assert all(
+            isinstance(subject, Dataset) and subject.external_url is None
+            for subject in subjects
+        )
+
+    def test_external_url_base_still_applies_with_the_catalog_off(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        cluster_metadata = MagicMock()
+        cluster_metadata.topics = {TOPIC: None}
+        mock_kafka.return_value.list_topics.return_value = cluster_metadata
+
+        source = KafkaSource(
+            make_source_config(
+                schema_registry_url=SCHEMA_REGISTRY_URL,
+                external_url_base="https://console.aiven.io/topics",
+            ),
+            PipelineContext(run_id="test"),
+        )
+
+        workunits = list(source.get_workunits())
+
+        assert source.topic_catalog is None
+        assert f"https://console.aiven.io/topics/{TOPIC}" in external_urls_of(workunits)
 
     def test_non_confluent_cloud_endpoint_skips_the_catalog(
         self, mock_kafka: Mock, mock_admin_client: Mock


### PR DESCRIPTION
DataHub's "View in Kafka" pill on a dataset page is driven solely by `datasetProperties.externalUrl`. Today the only way a Kafka topic gets one is `external_url_base`, which appends the topic name to a base string the user hand-assembles. For Confluent Cloud that string has to carry the environment and cluster ids, so every recipe repeats ids the source already holds once `confluent_catalog` is enabled, and any copy of them can drift without anything noticing.

This adds `confluent_catalog.environment_id` - the one id the catalog leg does not already know - and derives the console link from it:

```
https://confluent.cloud/environments/{environment_id}/clusters/{cluster_id}/topics/{topic}
```

The cluster id comes from `confluent_catalog.cluster_id` when set, otherwise from the topic's own Stream Catalog entry, so a single-cluster environment needs nothing but `environment_id`. The path deliberately stops at the topic name: the console redirects a bare topic path to whichever tab it currently defaults to, and pinning `/overview` would freeze that choice on our side.

Precedence and scope:

- An explicitly configured `external_url_base` always wins. It is the only way to point at a console served from another address, so a deliberate setting is never overridden.
- Nothing is emitted unless the catalog leg is enabled and both ids are known, so existing recipes are unaffected.
- Deriving the link does not require the topic to be present in the catalog - the URL is addressed by ids alone - so it still lands on topics the catalog has no entry for.

Also fixes a pre-existing bug in the same function: the `external_url_base` block sat outside the `if not is_subject:` guard immediately above it, so with `ingest_schemas_as_entities: true` every Schema Registry subject was handed a `/topics/<subject>` URL that 404s. Both the configured and the derived link are now confined to topics.

### Testing

Unit tests cover derivation from configured ids, the catalog-entry cluster-id fallback, topics absent from the catalog, both "id missing" cases, `external_url_base` precedence, `external_url_base` with the catalog off, and subjects getting no link.

Verified end to end against a live Confluent Cloud cluster (kafka source -> file sink). For a topic in that cluster the emitted `datasetProperties.externalUrl` was exactly the console URL for that topic, character for character:

```
https://confluent.cloud/environments/env-xxxxx/clusters/lkc-xxxxx/topics/<topic>
```

and it resolves in a browser to the topic's page. The same run was repeated with `cluster_id` omitted, confirming the cluster id is picked up from the topic's Stream Catalog entry and the URL comes out identical.

`./gradlew :metadata-ingestion:lint` (ruff check + ruff format --check + mypy, tree-wide) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically builds Confluent Cloud console URLs for Kafka topics using `confluent_catalog` ids. Also tightens external URL logic to apply only to topics.

- **New Features**
  - Adds `confluent_catalog.environment_id` and derives topic URLs as `https://confluent.cloud/environments/{environment_id}/clusters/{cluster_id}/topics/{topic}`.
  - Uses `confluent_catalog.cluster_id` if set, else the topic’s catalog entry; only when the catalog is enabled and ids are known; works even if the topic is missing from the catalog; `external_url_base` still overrides.

- **Bug Fixes**
  - External URLs are now emitted only for topics; Schema Registry subjects no longer get `/topics/<subject>` links.
  - Keeps `external_url_base` precedence while restricting it to topics.

<sup>Written for commit 294dce094d822d6c3c9e2b1cff9da19e0046f53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

