### PR TITLE
feat(incidents): complete incident UI for mlModel and mlFeature

### DIFF
--- a/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
@@ -7,7 +7,6 @@ import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
 import i18next from 'i18next';
 import * as React from 'react';
 
-import { IncidentTab } from '@app/entity/shared/tabs/Incident/IncidentTab';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import { Preview } from '@app/entityV2/mlFeature/preview/Preview';
@@ -27,6 +26,7 @@ import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/ut
 import SidebarNotesSection from '@app/entityV2/shared/sidebarSection/SidebarNotesSection';
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
+import { IncidentTab } from '@app/entityV2/shared/tabs/Incident/IncidentTab';
 import { LineageTab } from '@app/entityV2/shared/tabs/Lineage/LineageTab';
 import { FeatureTableTab } from '@app/entityV2/shared/tabs/ML/MlFeatureFeatureTableTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';

--- a/datahub-web-react/src/graphql/incident.graphql
+++ b/datahub-web-react/src/graphql/incident.graphql
@@ -75,6 +75,11 @@ fragment incidentLinkedAssetPreview on Entity {
             ...platformFields
         }
     }
+    ... on MLFeature {
+        name
+        featureNamespace
+        description
+    }
     ... on MLFeatureTable {
         urn
         type
@@ -267,6 +272,22 @@ query getEntityIncidents(
             }
         }
         ... on Chart {
+            incidents(start: $start, count: $count, state: $state) {
+                ...incidentResultFields
+            }
+            privileges {
+                canEditIncidents
+            }
+        }
+        ... on MLModel {
+            incidents(start: $start, count: $count, state: $state) {
+                ...incidentResultFields
+            }
+            privileges {
+                canEditIncidents
+            }
+        }
+        ... on MLFeature {
             incidents(start: $start, count: $count, state: $state) {
                 ...incidentResultFields
             }


### PR DESCRIPTION
PR2 of the plan agreed on #18911. **Stacked on #19112: only the last commit (fa4769d) is new; the rest is PR1 and this will be rebased once it merges.** Draft until then.

### Why the tab still would not have worked after PR1

Reviewing the UI surfaces turned up a sixth place the incident entity list is written down, one layer past the activeIncidents badge alias found by @cnpierrepapi: the tab body's own query. `getEntityIncidents` in `src/graphql/incident.graphql` selects `incidents` and `privileges { canEditIncidents }` through per-type inline fragments, and only Dataset, DataJob, DataFlow, Dashboard and Chart have them. On an MLModel or MLFeature page the query runs, selects nothing, the list renders empty and the create button stays disabled, with no error anywhere. So the earlier read that the tab body works off the context urn alone was half right: the query is keyed off the urn, but its selection set is still per type.

### Changes (one commit)

- `src/graphql/incident.graphql`: add `... on MLModel` and `... on MLFeature` to `getEntityIncidents`, same shape as the DataJob fragment (no sibling handling, matching the backend where only datasets have siblings)
- same file: add the missing `... on MLFeature` case to `incidentLinkedAssetPreview` (MLFeatureTable, MLModel and MLModelGroup were already covered; MLFeature has no platform or deprecation fields, so it selects name, featureNamespace, description)
- `src/app/entityV2/mlFeature/MLFeatureEntity.tsx`: import the entityV2 `IncidentTab` instead of the legacy `entity/shared` one. It was the only entityV2 page still importing the v1 tab, so MLFeature rendered the old antd list while MLModel rendered the v2 drawer UI

Generated hooks are gitignored and regenerate at build.

### Verified while scoping, no change needed

- The v1 entity tree has no entity classes anymore and only `buildEntityRegistryV2` is ever used, so there is no second tree to update
- The header Raise Incident action (`RaiseIncidentMenuAction`) is fully generic and both ML entities already opt in via `headerDropdownItems`, so raising from the header works with PR1 alone
- `IncidentTab`/`IncidentList` internals are entity-agnostic (no type switches, no per-type urn parsing)

### Out of scope

- mlFeatureTable and mlModelGroup surfaces (no tab, no alias, no menu item, no `getEntityIncidents` fragment): PR3, together with their backend
- Pre-existing nit, noting for whoever wants it: `RaiseIncidentMenuAction` redirects using the hardcoded English tab name `Incidents` while tab names are i18n-translated, which looks like a wrong route under non-English locales

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Links to related issues: #18911, #19112, #18999
- [x] Tests: covered by the resolver tests in #19112 plus frontend type generation in CI; the UI change is declarative wiring
- [x] Docs: covered in #19112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Incidents tab for ML Model and ML Feature pages so incidents render and users can raise incidents when permitted. Previously the tab showed no items and the create button was disabled because `getEntityIncidents` lacked ML fragments.

- GraphQL: add `... on MLModel` and `... on MLFeature` to `getEntityIncidents` to fetch `incidents` and `privileges`; add `... on MLFeature` to `incidentLinkedAssetPreview` (name, featureNamespace, description).
- UI: switch `datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx` to the v2 `IncidentTab` for consistency with other entityV2 pages.
- Rollout: no migration. Permissions unchanged; ensure policies allow editing incidents on ML entities to enable creation.

<sup>Written for commit 06eb37b848606f50db7cdd139eb76a07c02dc366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

