### PR TITLE
docs(agent-context): document Copilot Studio MCP OAuth for DataHub Cloud

### DIFF
--- a/docs/dev-guides/agent-context/copilot-studio.md
+++ b/docs/dev-guides/agent-context/copilot-studio.md
@@ -31,18 +31,18 @@ From your agent's overview, scroll to **Tools** and click **+ Add tool**. Select
 
 On DataHub Cloud v1.0.2+, Copilot Studio can connect with OAuth2 and [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). Each agent user signs in with their own DataHub account (including SSO such as Okta or Azure AD). No personal access token to mint or paste.
 
-| Field              | Value                                           |
-| ------------------ | ----------------------------------------------- |
-| **Server name**    | `DataHub MCP Server`                            |
-| **Server URL**     | `https://<tenant>.acryl.io/integrations/ai/mcp` |
-| **Authentication** | **OAuth 2.0** · **Dynamic discovery**           |
+| Field              | Value                                 |
+| ------------------ | ------------------------------------- |
+| **Server name**    | `DataHub MCP Server`                  |
+| **Server URL**     | `https://mcp.datahub.com/mcp`         |
+| **Authentication** | **OAuth 2.0** · **Dynamic discovery** |
 
-Use your tenant URL (`https://<tenant>.acryl.io/integrations/ai/mcp`) rather than the shared `https://mcp.datahub.com/mcp` endpoint — Copilot Studio works best when the auth server is discovered from the tenant host directly.
+Click **Create** / **Next**. Copilot Studio discovers DataHub's OAuth metadata and registers itself via DCR. On **Add tool**, choose **Create a new connection**. On first connect, enter your DataHub domain (e.g. `<tenant>` for `https://<tenant>.acryl.io`), complete login (and SSO if your tenant uses it), then **Add to agent**.
 
-Click **Create** / **Next**. Copilot Studio discovers DataHub's OAuth metadata and registers itself via DCR. On **Add tool**, choose **Create a new connection**, complete the DataHub login (and SSO if your tenant uses it), then **Add to agent**.
+Prefer your tenant URL directly? Use `https://<tenant>.acryl.io/integrations/ai/mcp` as the Server URL instead — both endpoints support OAuth2 + DCR.
 
 :::tip Fallback OAuth modes
-If **Dynamic discovery** fails, try **Dynamic** and enter the Authorization and Token URLs from your tenant's `/.well-known/oauth-authorization-server` document. Prefer Dynamic discovery when it works — you should not need a Client ID or Client secret.
+If **Dynamic discovery** fails, try **Dynamic** and enter the Authorization and Token URLs from the auth server's `/.well-known/oauth-authorization-server` document. Prefer Dynamic discovery when it works — you should not need a Client ID or Client secret.
 :::
 
 #### DataHub Cloud — Personal Access Token (v0.3.12+)
@@ -92,7 +92,7 @@ Click **Test** in the top-right corner and try:
 
 ## Troubleshooting
 
-- **Can't connect with OAuth?** Confirm the tenant is on DataHub Cloud v1.0.2+, the Server URL is `https://<tenant>.acryl.io/integrations/ai/mcp`, and authentication is **OAuth 2.0** with **Dynamic discovery**. Complete **Create a new connection** so the browser login can finish.
+- **Can't connect with OAuth?** Confirm the tenant is on DataHub Cloud v1.0.2+, the Server URL is `https://mcp.datahub.com/mcp` (or your tenant MCP URL), and authentication is **OAuth 2.0** with **Dynamic discovery**. Complete **Create a new connection**, enter your DataHub domain when prompted, and finish the browser login.
 - **Can't connect with a PAT?** Verify the DataHub URL, check the token hasn't expired, and confirm auth is set to **API key** (not OAuth). Include the `Bearer ` prefix.
 - **Tools not appearing?** Click refresh on the Tools page. Verify the [MCP server](../../features/feature-guides/mcp.md) is running and the connection has the right permissions.
 - **Empty results?** Check that your DataHub instance has ingested metadata. Try broader search terms.

--- a/docs/dev-guides/agent-context/copilot-studio.md
+++ b/docs/dev-guides/agent-context/copilot-studio.md
@@ -31,15 +31,20 @@ From your agent's overview, scroll to **Tools** and click **+ Add tool**. Select
 
 On DataHub Cloud v1.0.2+, Copilot Studio can connect with OAuth2 and [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). Each agent user signs in with their own DataHub account (including SSO such as Okta or Azure AD). No personal access token to mint or paste.
 
-| Field              | Value                                 |
-| ------------------ | ------------------------------------- |
-| **Server name**    | `DataHub MCP Server`                  |
-| **Server URL**     | `https://mcp.datahub.com/mcp`         |
-| **Authentication** | **OAuth 2.0** · **Dynamic discovery** |
+1. Fill in the MCP server fields:
 
-Click **Create** / **Next**. Copilot Studio discovers DataHub's OAuth metadata and registers itself via DCR. On **Add tool**, choose **Create a new connection**. On first connect, enter your DataHub domain (e.g. `<tenant>` for `https://<tenant>.acryl.io`), complete login (and SSO if your tenant uses it), then **Add to agent**.
+   | Field              | Value                                 |
+   | ------------------ | ------------------------------------- |
+   | **Server name**    | `DataHub MCP Server`                  |
+   | **Server URL**     | `https://mcp.datahub.com/mcp`         |
+   | **Authentication** | **OAuth 2.0** · **Dynamic discovery** |
 
-Prefer your tenant URL directly? Use `https://<tenant>.acryl.io/integrations/ai/mcp` as the Server URL instead — both endpoints support OAuth2 + DCR.
+2. Click **Create**. Copilot Studio discovers DataHub's OAuth metadata and registers itself via DCR — leave Client ID / Client secret empty.
+3. On **Add tool**, click **Create a new connection** (or **Connect**). A browser window opens for the DataHub OAuth flow.
+4. Enter your DataHub domain when prompted (e.g. `<tenant>` for `https://<tenant>.acryl.io`), sign in, and approve the connection. Copilot Studio can only retrieve DataHub's tools after this step completes.
+5. Click **Add to agent**.
+
+Prefer your tenant URL directly? Use `https://<tenant>.acryl.io/integrations/ai/mcp` as the Server URL instead — both endpoints support OAuth2 + DCR. With the tenant URL you skip the domain prompt and go straight to login.
 
 :::tip Fallback OAuth modes
 If **Dynamic discovery** fails, try **Dynamic** and enter the Authorization and Token URLs from the auth server's `/.well-known/oauth-authorization-server` document. Prefer Dynamic discovery when it works — you should not need a Client ID or Client secret.
@@ -59,7 +64,7 @@ For service accounts, unattended agents, or DataHub Cloud versions prior to v1.0
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/copilot-studio/copilot_studio_mcp_config.png"/>
 </p>
 
-Include the `Bearer ` prefix in the API key value.
+Include the `Bearer ` prefix in the API key value. Click **Create**, create the connection with your token, then **Add to agent**.
 
 :::note Self-Hosted DataHub
 For self-hosted instances, OAuth DCR for the managed MCP path is a DataHub Cloud capability. Expose the [MCP server](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage) via a publicly accessible URL, use that as the Server URL, and authenticate with a personal access token (API key · Header · `Authorization` · `Bearer <token>`).
@@ -67,11 +72,13 @@ For self-hosted instances, OAuth DCR for the managed MCP path is a DataHub Cloud
 
 ### 4. Enable Tools
 
-Click **Next** — Copilot Studio discovers DataHub's tools automatically. Click **Add and configure**, then toggle on the tools you want.
+After the connection succeeds, Copilot Studio discovers DataHub's tools automatically. Click **Add and configure**, then toggle on the tools you want.
 
 <p align="center">
   <img width="80%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/copilot-studio/copilot_studio_tools_list.png"/>
 </p>
+
+If no tools appear, go back and complete **Connect** / **Create a new connection** — tool discovery requires an authenticated connection.
 
 ### 5. Test
 
@@ -92,9 +99,9 @@ Click **Test** in the top-right corner and try:
 
 ## Troubleshooting
 
-- **Can't connect with OAuth?** Confirm the tenant is on DataHub Cloud v1.0.2+, the Server URL is `https://mcp.datahub.com/mcp` (or your tenant MCP URL), and authentication is **OAuth 2.0** with **Dynamic discovery**. Complete **Create a new connection**, enter your DataHub domain when prompted, and finish the browser login.
+- **Can't connect with OAuth?** Confirm the tenant is on DataHub Cloud v1.0.2+, the Server URL is `https://mcp.datahub.com/mcp` (or your tenant MCP URL), and authentication is **OAuth 2.0** with **Dynamic discovery**. Click **Create a new connection** / **Connect**, enter your DataHub domain (e.g. `<tenant>`) when prompted, sign in, and approve.
 - **Can't connect with a PAT?** Verify the DataHub URL, check the token hasn't expired, and confirm auth is set to **API key** (not OAuth). Include the `Bearer ` prefix.
-- **Tools not appearing?** Click refresh on the Tools page. Verify the [MCP server](../../features/feature-guides/mcp.md) is running and the connection has the right permissions.
+- **Tools not appearing?** Finish the **Connect** step first — Copilot Studio only lists DataHub tools after the connection authenticates. Then refresh the Tools page. Verify the [MCP server](../../features/feature-guides/mcp.md) is running and the connection has the right permissions.
 - **Empty results?** Check that your DataHub instance has ingested metadata. Try broader search terms.
 
 **Links:** [Copilot Studio Docs](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)

--- a/docs/dev-guides/agent-context/copilot-studio.md
+++ b/docs/dev-guides/agent-context/copilot-studio.md
@@ -5,8 +5,7 @@ Build [Copilot Studio](https://copilotstudio.microsoft.com/) agents that can fin
 ## Prerequisites
 
 - A [Microsoft Copilot Studio](https://copilotstudio.microsoft.com/) account
-- A DataHub Cloud instance (v0.3.12+) or self-hosted DataHub with the [MCP server](../../features/feature-guides/mcp.md) running
-- A DataHub [personal access token](../../authentication/personal-access-tokens.md)
+- A DataHub instance: [Cloud](../../features/feature-guides/mcp.md#managed-mcp-server-usage) (OAuth on v1.0.2+, PAT on v0.3.12+) or [self-hosted](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage) with the MCP server running
 
 ## Setup
 
@@ -28,6 +27,28 @@ From your agent's overview, scroll to **Tools** and click **+ Add tool**. Select
 
 ### 3. Configure the MCP Connection
 
+#### DataHub Cloud — OAuth (Recommended, v1.0.2+)
+
+On DataHub Cloud v1.0.2+, Copilot Studio can connect with OAuth2 and [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). Each agent user signs in with their own DataHub account (including SSO such as Okta or Azure AD). No personal access token to mint or paste.
+
+| Field              | Value                                           |
+| ------------------ | ----------------------------------------------- |
+| **Server name**    | `DataHub MCP Server`                            |
+| **Server URL**     | `https://<tenant>.acryl.io/integrations/ai/mcp` |
+| **Authentication** | **OAuth 2.0** · **Dynamic discovery**           |
+
+Use your tenant URL (`https://<tenant>.acryl.io/integrations/ai/mcp`) rather than the shared `https://mcp.datahub.com/mcp` endpoint — Copilot Studio works best when the auth server is discovered from the tenant host directly.
+
+Click **Create** / **Next**. Copilot Studio discovers DataHub's OAuth metadata and registers itself via DCR. On **Add tool**, choose **Create a new connection**, complete the DataHub login (and SSO if your tenant uses it), then **Add to agent**.
+
+:::tip Fallback OAuth modes
+If **Dynamic discovery** fails, try **Dynamic** and enter the Authorization and Token URLs from your tenant's `/.well-known/oauth-authorization-server` document. Prefer Dynamic discovery when it works — you should not need a Client ID or Client secret.
+:::
+
+#### DataHub Cloud — Personal Access Token (v0.3.12+)
+
+For service accounts, unattended agents, or DataHub Cloud versions prior to v1.0.2, use a [personal access token](../../authentication/personal-access-tokens.md):
+
 | Field              | Value                                                 |
 | ------------------ | ----------------------------------------------------- |
 | **Server name**    | `DataHub MCP Server`                                  |
@@ -38,8 +59,10 @@ From your agent's overview, scroll to **Tools** and click **+ Add tool**. Select
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/copilot-studio/copilot_studio_mcp_config.png"/>
 </p>
 
+Include the `Bearer ` prefix in the API key value.
+
 :::note Self-Hosted DataHub
-For self-hosted instances, expose the [MCP server](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage) via a publicly accessible URL and use that as the Server URL.
+For self-hosted instances, OAuth DCR for the managed MCP path is a DataHub Cloud capability. Expose the [MCP server](../../features/feature-guides/mcp.md#self-hosted-mcp-server-usage) via a publicly accessible URL, use that as the Server URL, and authenticate with a personal access token (API key · Header · `Authorization` · `Bearer <token>`).
 :::
 
 ### 4. Enable Tools
@@ -65,11 +88,13 @@ Click **Test** in the top-right corner and try:
 
 - Use the **Instructions** field to guide behavior — e.g., _"Always search DataHub before answering data questions."_
 - **Publish** your agent to Teams, your website, or other channels when ready.
+- Prefer OAuth for interactive Copilot agents so each user acts as themselves in DataHub. Keep PATs for service accounts and unattended workflows.
 
 ## Troubleshooting
 
-- **Can't connect?** Verify the DataHub URL, check the token hasn't expired, and confirm auth is set to **API key** (not OAuth). Include the `Bearer ` prefix.
-- **Tools not appearing?** Click refresh on the Tools page. Verify the [MCP server](../../features/feature-guides/mcp.md) is running and the token has the right permissions.
+- **Can't connect with OAuth?** Confirm the tenant is on DataHub Cloud v1.0.2+, the Server URL is `https://<tenant>.acryl.io/integrations/ai/mcp`, and authentication is **OAuth 2.0** with **Dynamic discovery**. Complete **Create a new connection** so the browser login can finish.
+- **Can't connect with a PAT?** Verify the DataHub URL, check the token hasn't expired, and confirm auth is set to **API key** (not OAuth). Include the `Bearer ` prefix.
+- **Tools not appearing?** Click refresh on the Tools page. Verify the [MCP server](../../features/feature-guides/mcp.md) is running and the connection has the right permissions.
 - **Empty results?** Check that your DataHub instance has ingested metadata. Try broader search terms.
 
-**Links:** [Copilot Studio Docs](https://learn.microsoft.com/en-us/microsoft-copilot-studio/) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)
+**Links:** [Copilot Studio Docs](https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -148,7 +148,7 @@ Mutation tools are available in [mcp-server-datahub](https://github.com/acryldat
 
 </details>
 
-# Connecting to Managed MCP Server with OAuth - Recommended
+# Connecting to Managed MCP Server with OAuth - Recommended {#managed-mcp-server-usage}
 
 _Available in DataHub Cloud v1.0.2+_
 


### PR DESCRIPTION
## Summary
- Documents OAuth 2.0 + Dynamic Client Registration as the recommended auth path for connecting Microsoft Copilot Studio to DataHub Cloud MCP (v1.0.2+).
- Keeps the existing personal access token (API key) flow for service accounts, unattended agents, and Cloud versions before v1.0.2.
- Clarifies that managed MCP OAuth DCR is a DataHub Cloud capability; self-hosted setups continue to use a PAT against a publicly reachable MCP URL.

## Test plan
- [ ] Preview the Copilot Studio guide and confirm OAuth and PAT sections render correctly
- [ ] Spot-check links to the MCP server guide and Microsoft Copilot Studio MCP docs
- [ ] Confirm the guide does not imply OAuth DCR for self-hosted DataHub Core

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents OAuth 2.0 + Dynamic Client Registration as the recommended way to connect Microsoft Copilot Studio to DataHub Cloud MCP (v1.0.2+), defaulting to `https://mcp.datahub.com/mcp`, and makes the Connect step explicit; tool discovery occurs only after authentication. Keeps PAT for service accounts, earlier Cloud, and self-hosted; updates prerequisites, tenant URL option, `Bearer ` header usage, OAuth fallback guidance, troubleshooting, links (including Microsoft MCP page), and adds the `#managed-mcp-server-usage` anchor.

<sup>Written for commit 671c6bd5a7abce9bab21cec8809af3791460a1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

