### PR TITLE
feat(ingest/kafka): link topics to Confluent Cloud

### DIFF
--- a/metadata-ingestion/docs/sources/kafka/kafka_post.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka_post.md
@@ -39,6 +39,22 @@ sink:
   # sink configs
 ```
 
+##### Linking topics to the Confluent Cloud console
+
+Set `confluent_cloud_environment_id` to give every topic a **View in Kafka** link that opens that topic in the Confluent Cloud console:
+
+```yml
+source:
+  type: "kafka"
+  config:
+    confluent_cloud_environment_id: "env-xyz123"
+    # ...connection block
+```
+
+The link is `https://confluent.cloud/environments/<environment_id>/clusters/<cluster_id>/topics/<topic>`. The cluster ID is read from Kafka cluster metadata over the connection the source already has, so the environment ID is the only thing you need to supply. Nothing is emitted unless the bootstrap servers are `confluent.cloud` endpoints and the cluster reports a Confluent Cloud cluster ID; the run reports a warning if you set the environment ID on a cluster that is neither.
+
+Setting `external_url_base` overrides this entirely - use it for any other Kafka console (Aiven, Redpanda, a self-hosted UI), or for a Confluent Cloud console fronted at a different address.
+
 If you are trying to add domains to your topics you can use a configuration like below.
 
 ```yml

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
@@ -379,7 +379,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
         # would be re-emitted without its catalog tags, deleting them. Warn once.
         self._warned_partial_catalog = False
         # Resolved once from the cluster metadata the run already fetches; stays
-        # None on anything that is not a verified Confluent Cloud cluster.
+        # None on anything that is not a verified Confluent Cloud cluster. It is
+        # still None until get_workunits_internal resolves it, which is safe
+        # because the only reader runs downstream of that; a reader added ahead
+        # of it would silently see no cluster and emit no link.
         self._confluent_cloud_cluster_id: Optional[str] = None
         self.consumer: confluent_kafka.Consumer = get_kafka_consumer(
             self.source_config.connection

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
@@ -1391,6 +1391,11 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
         link that renders perfectly and 404s. Both the endpoint and the id's
         shape therefore have to check out before it is used.
         """
+        # Nothing derived is ever used when an explicit base is set, so resolving
+        # here would only produce a warning about links that were emitted anyway.
+        if self.source_config.external_url_base:
+            return None
+
         environment_id = self.source_config.confluent_cloud_environment_id
         if not environment_id:
             return None

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka.py
@@ -25,6 +25,8 @@ from typing import (
 from typing_extensions import LiteralString
 
 from datahub.ingestion.source.kafka.kafka_constants import (
+    CONFLUENT_CLOUD_CLUSTER_ID_PATTERN,
+    CONFLUENT_CLOUD_CONSOLE_URL,
     CONFLUENT_MAGIC_BYTE,
     CONFLUENT_WIRE_HEADER_LENGTH,
     DEFAULT_CONSUMER_TIMEOUT_SECONDS,
@@ -55,6 +57,7 @@ import confluent_kafka
 import confluent_kafka.admin
 from confluent_kafka.admin import (
     AdminClient,
+    ClusterMetadata,
     ConfigEntry,
     ConfigResource,
     TopicMetadata,
@@ -87,6 +90,9 @@ from datahub.ingestion.api.source import (
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
+from datahub.ingestion.source.confluent.constants import (
+    CONFLUENT_CLOUD_DOMAIN_SUFFIX,
+)
 from datahub.ingestion.source.confluent.models import (
     BM_COLLISION_WITH_BROKER_TOPIC_PROPERTIES,
     non_colliding_business_metadata,
@@ -131,6 +137,15 @@ warnings.filterwarnings(
     module="avro.schema",
     message=".*Unknown .*, using .*",
 )
+
+
+def is_confluent_cloud_bootstrap(bootstrap: str) -> bool:
+    """Whether every broker in a bootstrap list is a Confluent Cloud endpoint."""
+    hosts = [host.strip() for host in bootstrap.split(",") if host.strip()]
+    return bool(hosts) and all(
+        host.rsplit(":", 1)[0].lower().endswith(CONFLUENT_CLOUD_DOMAIN_SUFFIX)
+        for host in hosts
+    )
 
 
 def _needs_schema_resolution(schema_and_fields: Optional[SchemaAndFields]) -> bool:
@@ -363,6 +378,9 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
         # globalTags is a replacement aspect: a topic dropped by a partial catalog read
         # would be re-emitted without its catalog tags, deleting them. Warn once.
         self._warned_partial_catalog = False
+        # Resolved once from the cluster metadata the run already fetches; stays
+        # None on anything that is not a verified Confluent Cloud cluster.
+        self._confluent_cloud_cluster_id: Optional[str] = None
         self.consumer: confluent_kafka.Consumer = get_kafka_consumer(
             self.source_config.connection
         )
@@ -437,9 +455,13 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
         return cls(config, ctx)
 
     def get_workunits_internal(self) -> Iterable[Union[MetadataWorkUnit, Entity]]:
-        topics = self.consumer.list_topics(
+        cluster_metadata = self.consumer.list_topics(
             timeout=self.source_config.connection.client_timeout_seconds
-        ).topics
+        )
+        self._confluent_cloud_cluster_id = self._resolve_confluent_cloud_cluster_id(
+            cluster_metadata
+        )
+        topics = cluster_metadata.topics
         extra_topic_details = self.fetch_extra_topic_details(topics.keys())
 
         # Filter allowed topics upfront
@@ -1282,10 +1304,10 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
 
         if not is_subject:
             self._apply_catalog_metadata(topic, all_tags, custom_props)
-
-        if self.source_config.external_url_base:
-            base_url = self.source_config.external_url_base.rstrip("/")
-            external_url = f"{base_url}/{dataset_name}"
+            # Only a topic has somewhere to link to. A Schema Registry subject is
+            # not addressable under a broker's topic path, so a link built for one
+            # 404s.
+            external_url = self._get_topic_external_url(topic)
 
         domain_urn: Optional[str] = None
         for domain, pattern in self.source_config.domain.items():
@@ -1356,6 +1378,62 @@ class KafkaSource(StatefulIngestionSourceBase, TestableSource):
             if properties:
                 custom_props.update(properties)
                 self.report.catalog_topics_with_business_metadata += 1
+
+    def _resolve_confluent_cloud_cluster_id(
+        self, cluster_metadata: ClusterMetadata
+    ) -> Optional[str]:
+        """The Confluent Cloud logical cluster id for this connection, if it has one.
+
+        Read from the cluster metadata the run already fetched (KIP-78), so no
+        extra call and no extra credential. `cluster_id` is a generic Kafka
+        field, though: open-source brokers and MSK fill it with their own opaque
+        identifiers, and one of those spliced into a confluent.cloud URL yields a
+        link that renders perfectly and 404s. Both the endpoint and the id's
+        shape therefore have to check out before it is used.
+        """
+        environment_id = self.source_config.confluent_cloud_environment_id
+        if not environment_id:
+            return None
+
+        if not is_confluent_cloud_bootstrap(self.source_config.connection.bootstrap):
+            self.report.warning(
+                title="No Confluent Cloud links emitted",
+                message="confluent_cloud_environment_id is set, but the bootstrap servers are not Confluent Cloud endpoints. Use external_url_base to link topics to another console.",
+                context=self.source_config.connection.bootstrap,
+            )
+            return None
+
+        cluster_id = cluster_metadata.cluster_id
+        if not cluster_id or not CONFLUENT_CLOUD_CLUSTER_ID_PATTERN.match(cluster_id):
+            self.report.warning(
+                title="No Confluent Cloud links emitted",
+                message="confluent_cloud_environment_id is set, but the cluster reported an id that is not a Confluent Cloud cluster id. Use external_url_base to link topics explicitly.",
+                context=str(cluster_id),
+            )
+            return None
+
+        return cluster_id
+
+    def _get_topic_external_url(self, topic: str) -> Optional[str]:
+        # An explicit base always wins: it is the only way to point at a console
+        # served from another address, so a deliberate setting must not be
+        # overridden by anything derived.
+        if self.source_config.external_url_base:
+            base_url = self.source_config.external_url_base.rstrip("/")
+            return f"{base_url}/{topic}"
+
+        if self._confluent_cloud_cluster_id is None:
+            return None
+
+        # No /overview or query string: the console redirects a bare topic path to
+        # whichever tab it currently defaults to, and naming one freezes that
+        # choice here.
+        return (
+            f"{CONFLUENT_CLOUD_CONSOLE_URL}"
+            f"/environments/{self.source_config.confluent_cloud_environment_id}"
+            f"/clusters/{self._confluent_cloud_cluster_id}"
+            f"/topics/{topic}"
+        )
 
     def build_custom_properties(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
@@ -154,7 +154,11 @@ class KafkaSourceConfig(
     )
     external_url_base: Optional[str] = Field(
         default=None,
-        description="Base URL for external platform (e.g. Aiven) where topics can be viewed. The topic name will be appended to this base URL.",
+        description="Base URL for external platform (e.g. Aiven) where topics can be viewed. The topic name will be appended to this base URL. Takes precedence over the Confluent Cloud console link derived from `confluent_cloud_environment_id`.",
+    )
+    confluent_cloud_environment_id: Optional[str] = Field(
+        default=None,
+        description="Confluent Cloud environment ID (e.g. 'env-xyz123'). When set, each topic gets an external URL pointing at that topic in the Confluent Cloud console. The Kafka cluster ID is read from cluster metadata, so only the environment ID is needed. Ignored unless the cluster is reached over a `confluent.cloud` endpoint, and ignored entirely when `external_url_base` is set.",
     )
     profiling: ProfilerConfig = Field(
         default_factory=ProfilerConfig,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_constants.py
@@ -1,3 +1,5 @@
+import re
+
 from datahub.utilities.str_enum import StrEnum
 
 DEFAULT_CPU_COUNT_FALLBACK = 4
@@ -30,6 +32,18 @@ MAX_DISTINCT_VALUE_FREQUENCIES = 10
 DEFAULT_MAX_FIELDS_TO_PROFILE = 10
 
 SCHEMA_REGISTRY_BASIC_AUTH_KEY = "basic.auth.user.info"
+
+# The console that fronts Confluent Cloud brokers. Fixed by Confluent, so a
+# deployment that reaches the console at some other address uses
+# external_url_base instead. The broker domain those brokers are reached
+# through is CONFLUENT_CLOUD_DOMAIN_SUFFIX, in
+# datahub.ingestion.source.confluent.constants.
+CONFLUENT_CLOUD_CONSOLE_URL = "https://confluent.cloud"
+# A Confluent Cloud logical Kafka cluster id, e.g. "lkc-a1b2c3". Every broker
+# since Kafka 0.10.1 reports some cluster id (KIP-78), but only Confluent Cloud
+# reports one that addresses anything in the console, so the value has to be
+# shape-checked before it is spliced into a URL.
+CONFLUENT_CLOUD_CLUSTER_ID_PATTERN = re.compile(r"^lkc-[a-z0-9]+$")
 
 # Schema types
 SCHEMA_TYPE_AVRO = "AVRO"

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
@@ -1,0 +1,192 @@
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from datahub.emitter.mce_builder import make_data_platform_urn
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.kafka.kafka import KafkaSource, KafkaSourceConfig
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    KafkaSchemaClass,
+    SchemaMetadataClass,
+)
+from datahub.sdk.dataset import Dataset
+
+NO_LINKS_WARNING = "No Confluent Cloud links emitted"
+TOPIC = "orders"
+ENVIRONMENT_ID = "env-xxxxx"
+CLUSTER_ID = "lkc-xxxxx"
+CONFLUENT_CLOUD_BOOTSTRAP = "pkc-xxxxx.us-east-1.aws.confluent.cloud:9092"
+SELF_HOSTED_BOOTSTRAP = "broker.example.com:9092"
+# What an open-source broker reports for the same generic KIP-78 field.
+OPAQUE_CLUSTER_ID = "MkU3OEVBNTcwNTJENDM2Qk"
+CONSOLE_URL = (
+    f"https://confluent.cloud/environments/{ENVIRONMENT_ID}"
+    f"/clusters/{CLUSTER_ID}/topics/{TOPIC}"
+)
+EXTERNAL_URL_BASE = "https://console.aiven.io/project/p/kafka/topics"
+
+
+@pytest.fixture
+def mock_admin_client():
+    with patch(
+        "datahub.ingestion.source.kafka.kafka.AdminClient", autospec=True
+    ) as mock:
+        yield mock
+
+
+def build_source(
+    mock_kafka: Mock,
+    bootstrap: str = CONFLUENT_CLOUD_BOOTSTRAP,
+    cluster_id: Optional[str] = CLUSTER_ID,
+    **config_overrides: Any,
+) -> KafkaSource:
+    cluster_metadata = MagicMock()
+    cluster_metadata.topics = {TOPIC: None}
+    cluster_metadata.cluster_id = cluster_id
+    mock_kafka.return_value.list_topics.return_value = cluster_metadata
+
+    config: Dict[str, Any] = {"connection": {"bootstrap": bootstrap}}
+    config.update(config_overrides)
+    return KafkaSource(
+        KafkaSourceConfig.model_validate(config),
+        PipelineContext(run_id="test"),
+    )
+
+
+def no_links_warnings(source: KafkaSource) -> List[str]:
+    return [
+        warning.title
+        for warning in source.report.warnings
+        if warning.title == NO_LINKS_WARNING
+    ]
+
+
+def external_urls_of(workunits: List[MetadataWorkUnit]) -> List[Optional[str]]:
+    return [
+        properties.externalUrl
+        for properties in (
+            workunit.get_aspect_of_type(DatasetPropertiesClass)
+            for workunit in workunits
+        )
+        if properties is not None
+    ]
+
+
+@patch("datahub.ingestion.source.kafka.kafka.confluent_kafka.Consumer", autospec=True)
+class TestConfluentCloudExternalUrl:
+    def test_topic_links_to_the_confluent_cloud_console(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = build_source(mock_kafka, confluent_cloud_environment_id=ENVIRONMENT_ID)
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert CONSOLE_URL in external_urls
+
+    def test_no_link_when_the_cluster_is_not_confluent_cloud(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = build_source(
+            mock_kafka,
+            bootstrap=SELF_HOSTED_BOOTSTRAP,
+            confluent_cloud_environment_id=ENVIRONMENT_ID,
+        )
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert external_urls
+        assert not any(external_urls)
+        assert no_links_warnings(source)
+
+    def test_no_link_when_the_cluster_id_is_not_a_confluent_cloud_id(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        # Every broker since Kafka 0.10.1 reports a cluster id, so a
+        # confluent.cloud endpoint is not on its own enough to trust its shape.
+        source = build_source(
+            mock_kafka,
+            cluster_id=OPAQUE_CLUSTER_ID,
+            confluent_cloud_environment_id=ENVIRONMENT_ID,
+        )
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert external_urls
+        assert not any(external_urls)
+        assert no_links_warnings(source)
+
+    def test_no_link_without_an_environment_id(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = build_source(mock_kafka)
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert external_urls
+        assert not any(external_urls)
+        assert not no_links_warnings(source)
+
+    def test_an_explicit_external_url_base_wins(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = build_source(
+            mock_kafka,
+            confluent_cloud_environment_id=ENVIRONMENT_ID,
+            external_url_base=EXTERNAL_URL_BASE,
+        )
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert f"{EXTERNAL_URL_BASE}/{TOPIC}" in external_urls
+        assert CONSOLE_URL not in external_urls
+
+    def test_external_url_base_still_works_on_its_own(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        source = build_source(
+            mock_kafka,
+            bootstrap=SELF_HOSTED_BOOTSTRAP,
+            cluster_id=None,
+            external_url_base=f"{EXTERNAL_URL_BASE}/",
+        )
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert f"{EXTERNAL_URL_BASE}/{TOPIC}" in external_urls
+
+    def test_subjects_get_no_external_url(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        # A subject is not addressable under a topic path, so neither link applies.
+        source = build_source(
+            mock_kafka,
+            confluent_cloud_environment_id=ENVIRONMENT_ID,
+            external_url_base=EXTERNAL_URL_BASE,
+            ingest_schemas_as_entities=True,
+        )
+
+        subjects = list(
+            source._emit_dataset(
+                topic=f"{TOPIC}-value",
+                is_subject=True,
+                topic_detail=None,
+                extra_topic_config=None,
+                schema_metadata=SchemaMetadataClass(
+                    schemaName=f"{TOPIC}-value",
+                    platform=make_data_platform_urn("kafka"),
+                    version=0,
+                    hash="",
+                    platformSchema=KafkaSchemaClass(documentSchema=""),
+                    fields=[],
+                ),
+            )
+        )
+
+        assert subjects
+        assert all(
+            isinstance(subject, Dataset) and subject.external_url is None
+            for subject in subjects
+        )

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
@@ -98,7 +98,7 @@ class TestConfluentCloudExternalUrl:
         external_urls = external_urls_of(list(source.get_workunits()))
 
         assert external_urls
-        assert not any(external_urls)
+        assert all(url is None for url in external_urls)
         assert no_links_warnings(source)
 
     def test_no_link_when_the_cluster_id_is_not_a_confluent_cloud_id(
@@ -115,7 +115,7 @@ class TestConfluentCloudExternalUrl:
         external_urls = external_urls_of(list(source.get_workunits()))
 
         assert external_urls
-        assert not any(external_urls)
+        assert all(url is None for url in external_urls)
         assert no_links_warnings(source)
 
     def test_no_link_without_an_environment_id(
@@ -126,7 +126,7 @@ class TestConfluentCloudExternalUrl:
         external_urls = external_urls_of(list(source.get_workunits()))
 
         assert external_urls
-        assert not any(external_urls)
+        assert all(url is None for url in external_urls)
         assert not no_links_warnings(source)
 
     def test_an_explicit_external_url_base_wins(
@@ -142,6 +142,24 @@ class TestConfluentCloudExternalUrl:
 
         assert f"{EXTERNAL_URL_BASE}/{TOPIC}" in external_urls
         assert CONSOLE_URL not in external_urls
+
+    def test_no_warning_when_an_explicit_base_covers_a_failed_guard(
+        self, mock_kafka: Mock, mock_admin_client: Mock
+    ) -> None:
+        # Setting both on a cluster that fails the Confluent guards still yields
+        # links, from the base. Warning that none were emitted would contradict
+        # what the run actually produced.
+        source = build_source(
+            mock_kafka,
+            bootstrap=SELF_HOSTED_BOOTSTRAP,
+            confluent_cloud_environment_id=ENVIRONMENT_ID,
+            external_url_base=EXTERNAL_URL_BASE,
+        )
+
+        external_urls = external_urls_of(list(source.get_workunits()))
+
+        assert f"{EXTERNAL_URL_BASE}/{TOPIC}" in external_urls
+        assert not no_links_warnings(source)
 
     def test_external_url_base_still_works_on_its_own(
         self, mock_kafka: Mock, mock_admin_client: Mock

--- a/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
+++ b/metadata-ingestion/tests/unit/kafka/test_kafka_external_url.py
@@ -6,7 +6,11 @@ import pytest
 from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.ingestion.source.kafka.kafka import KafkaSource, KafkaSourceConfig
+from datahub.ingestion.source.kafka.kafka import (
+    KafkaSource,
+    KafkaSourceConfig,
+    is_confluent_cloud_bootstrap,
+)
 from datahub.metadata.schema_classes import (
     DatasetPropertiesClass,
     KafkaSchemaClass,
@@ -27,6 +31,27 @@ CONSOLE_URL = (
     f"/clusters/{CLUSTER_ID}/topics/{TOPIC}"
 )
 EXTERNAL_URL_BASE = "https://console.aiven.io/project/p/kafka/topics"
+
+
+@pytest.mark.parametrize(
+    "bootstrap,expected",
+    [
+        (CONFLUENT_CLOUD_BOOTSTRAP, True),
+        ("PKC-XXXXX.US-EAST-1.AWS.CONFLUENT.CLOUD:9092", True),
+        (f"{CONFLUENT_CLOUD_BOOTSTRAP},pkc-yyyyy.confluent.cloud:9092", True),
+        (SELF_HOSTED_BOOTSTRAP, False),
+        # One broker outside Confluent Cloud means the run is not addressing a
+        # Confluent Cloud cluster, whichever order the list is given in.
+        (f"{CONFLUENT_CLOUD_BOOTSTRAP},{SELF_HOSTED_BOOTSTRAP}", False),
+        (f"{SELF_HOSTED_BOOTSTRAP},{CONFLUENT_CLOUD_BOOTSTRAP}", False),
+        # A suffix match on the whole string would accept this.
+        ("evil-confluent.cloud.example.com:9092", False),
+        ("", False),
+        (",", False),
+    ],
+)
+def test_is_confluent_cloud_bootstrap(bootstrap: str, expected: bool) -> None:
+    assert is_confluent_cloud_bootstrap(bootstrap) is expected
 
 
 @pytest.fixture


### PR DESCRIPTION
DataHub's **View in Kafka** pill on a dataset is driven solely by `datasetProperties.externalUrl`. The only way a Kafka topic could get one was `external_url_base`, which appends the topic name to a string the user hand-assembles. On Confluent Cloud that string has to carry both the environment id and the Kafka cluster id, so anyone who wants the link has to read two ids out of the console and keep the copy of them in the recipe in step with reality.

One of those ids is already on the wire. `list_topics()` returns `ClusterMetadata`, whose `cluster_id` is the cluster's `lkc-` id, and the source already makes that call to enumerate topics. So this derives the console URL from metadata the run already has: no extra request, no new credential, no Confluent Cloud REST or management API.

The environment id cannot be derived the same way - resolving it from a cluster requires the Cloud management API and therefore a Cloud API key, which this source has no concept of. It is the single new config field, `confluent_cloud_environment_id`, named to match the key the `kafka-connect` source already uses.

```yml
source:
  type: kafka
  config:
    confluent_cloud_environment_id: "env-xxxxx"
    # ...connection block
```

Each topic then gets:

```
https://confluent.cloud/environments/<environment_id>/clusters/<cluster_id>/topics/<topic>
```

The path deliberately stops at the topic name. The console redirects a bare topic path to whichever tab it currently defaults to; pinning `/overview` would freeze that choice on our side.

### Two guards, because `cluster_id` is not a Confluent field

`cluster_id` is generic Kafka (KIP-78) and every broker since 0.10.1 populates it. Open-source Kafka reports an opaque string such as `MkU3OEVBNTcwNTJENDM2Qk`; MSK reports something else again. One of those spliced into a `confluent.cloud` URL yields a link that renders perfectly and 404s, which is worse than no link. So the derived URL is emitted only when both hold:

1. every bootstrap host ends with `.confluent.cloud`; and
2. the reported cluster id matches `^lkc-[a-z0-9]+$`.

If the environment id is set and either guard fails, no URL is emitted and the run reports a warning pointing at `external_url_base` - silence there would look like the config had simply been ignored.

### Precedence and scope

- An explicitly configured `external_url_base` always wins. It is the only way to point at a console served from another address, so a deliberate setting is never overridden.
- Nothing is emitted unless the guards pass and `confluent_cloud_environment_id` is set. Recipes that do not set it are byte-for-byte unaffected.

### Behaviour change

Links are now confined to topics. The `external_url_base` block sat outside the `if not is_subject:` guard immediately above it, so with `ingest_schemas_as_entities: true` every Schema Registry subject was handed a `/topics/<subject>` URL that 404s - a subject is not addressable under a broker's topic path. Anyone running that combination loses a link that never worked.

### Testing

- New unit tests in `tests/unit/kafka/test_kafka_external_url.py`: derived URL on a healthy Confluent Cloud cluster; no URL when the bootstrap host is not `confluent.cloud`; no URL when the metadata cluster id is an opaque non-`lkc` value; no URL when the environment id is unset; `external_url_base` wins over the derived URL; `external_url_base` still works standalone; subjects get no `externalUrl` at all.
- Verified end to end against a live Confluent Cloud cluster with a file sink: with `confluent_cloud_environment_id` set, all eight topics emitted a distinct console URL of exactly the shape above, and the derived cluster id matched the cluster's real `lkc-` id. With the field unset, no `datasetProperties` aspect carried an `externalUrl` key at all.
- `./gradlew :metadata-ingestion:lint` clean (ruff check, ruff format --check, mypy).

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://docs.datahub.com/docs/contributing#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link Kafka topics to the Confluent Cloud console using `confluent_cloud_environment_id`, deriving the `lkc-...` cluster ID from Kafka metadata. This removes manual URL assembly while keeping `external_url_base` as an explicit override.

- Build topic URLs as https://confluent.cloud/environments/<env>/clusters/<lkc>/topics/<topic> with no extra API calls.
- Emit links only when all bootstrap hosts end with `.confluent.cloud` and `cluster_id` matches `^lkc-[a-z0-9]+$`; otherwise emit no link and warn.
- `external_url_base` takes precedence and suppresses Confluent-link warnings; use it for non-Confluent consoles or custom domains.
- Stop emitting "View in Kafka" links for Schema Registry subjects; only topics get links.

<sup>Written for commit 8d0c4d746adeeaa941a46834d241e9aeca21d313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

