### PR TITLE
fix(event-generator/timeline): report v2 field path type changes as MODIFY

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
@@ -221,7 +221,12 @@ public class EditableSchemaMetadataChangeEventGenerator
                   datasetFieldUrn,
                   baseFieldDescription,
                   targetFieldDescription))
-          .parameters(ImmutableMap.of("description", targetFieldDescription))
+          // The schema history UI diffs the two values, so it cannot render the change without the
+          // previous one. Both are non-null here, as guarded by the condition above.
+          .parameters(
+              ImmutableMap.of(
+                  "description", targetFieldDescription,
+                  "previousDescription", baseFieldDescription))
           .auditStamp(auditStamp)
           .build();
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -430,6 +430,15 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
             .filter(field -> !basePaths.contains(field.getFieldPath()))
             .collect(Collectors.groupingBy(SchemaFieldUtils::downgradeFieldPath));
 
+    // Logical paths that also have a field whose path did not move. A union whose members change
+    // keeps its union node in place, for instance, and the merge-join diffs that node's
+    // documentation, tags and terms already.
+    Set<String> logicalPathsWithStableField =
+        baseFields.stream()
+            .filter(field -> targetPaths.contains(field.getFieldPath()))
+            .map(SchemaFieldUtils::downgradeFieldPath)
+            .collect(Collectors.toSet());
+
     Map<SchemaField, MovedFieldGroup> movedFieldGroups = new HashMap<>();
     baseByLogicalPath.forEach(
         (logicalPath, candidateBaseFields) -> {
@@ -437,7 +446,11 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
           if (candidateTargetFields == null) {
             return;
           }
-          MovedFieldGroup group = new MovedFieldGroup(candidateBaseFields, candidateTargetFields);
+          MovedFieldGroup group =
+              new MovedFieldGroup(
+                  candidateBaseFields,
+                  candidateTargetFields,
+                  logicalPathsWithStableField.contains(logicalPath));
           candidateBaseFields.forEach(field -> movedFieldGroups.put(field, group));
           candidateTargetFields.forEach(field -> movedFieldGroups.put(field, group));
         });
@@ -446,20 +459,28 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
 
   /** The fields on either side of a field path move that share one type-stripped field path. */
   private static final class MovedFieldGroup {
+    // The least qualified path in a group denotes the column itself rather than one of its type
+    // branches: a union node is [type=union].u while its members add a type annotation on top. The
+    // path breaks ties so that the representative, and therefore the URN reported for the change,
+    // does not depend on the order the fields happened to arrive in.
+    private static final Comparator<SchemaField> COLUMN_FIRST =
+        Comparator.comparingInt(
+                (SchemaField field) -> StringUtils.countMatches(field.getFieldPath(), '.'))
+            .thenComparing(SchemaField::getFieldPath, Comparator.naturalOrder());
+
     private final List<SchemaField> baseFields;
     private final List<SchemaField> targetFields;
+    private final boolean hasStableField;
 
-    private MovedFieldGroup(List<SchemaField> baseFields, List<SchemaField> targetFields) {
-      // Sorted so that the representative field, and therefore the URN reported for the change,
-      // does not depend on the order the fields happened to arrive in.
+    private MovedFieldGroup(
+        List<SchemaField> baseFields, List<SchemaField> targetFields, boolean hasStableField) {
       this.baseFields = sortByPath(baseFields);
       this.targetFields = sortByPath(targetFields);
+      this.hasStableField = hasStableField;
     }
 
     private static List<SchemaField> sortByPath(List<SchemaField> fields) {
-      return fields.stream()
-          .sorted(Comparator.comparing(SchemaField::getFieldPath))
-          .collect(Collectors.toList());
+      return fields.stream().sorted(COLUMN_FIRST).collect(Collectors.toList());
     }
 
     private static String describeNativeTypes(List<SchemaField> fields) {
@@ -486,9 +507,12 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       return describeNativeTypes(targetFields);
     }
 
-    /** Whether exactly one field on each side carries this path, so the pairing is unambiguous. */
-    boolean isUnambiguousPair() {
-      return baseFields.size() == 1 && targetFields.size() == 1;
+    /**
+     * Whether a field sharing this logical path kept its path, in which case the merge-join already
+     * diffs that field's documentation, tags and terms and this group must not do so again.
+     */
+    boolean hasStableField() {
+      return hasStableField;
     }
 
     /** Whether the path moved because the declared types changed, rather than moving on its own. */
@@ -521,9 +545,10 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
           movedGroup.getTargetNativeTypes(),
           auditStamp);
     }
-    // Descriptions, tags and terms belong to an individual field, so they can only be diffed when
-    // there is exactly one field to attribute them to.
-    if (movedGroup.isUnambiguousPair()) {
+    // Documentation, tags and terms describe the column, so they are diffed between the fields
+    // denoting it on each side - unless a field sharing this path stayed put, in which case the
+    // merge-join has already diffed them and doing it here would report the change twice.
+    if (!movedGroup.hasStableField()) {
       changeEvents.addAll(
           getFieldPropertyChangeEvents(
               baseField, targetField, datasetUrn, changeCategories, auditStamp));

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.timeline.data.ChangeTransaction;
 import com.linkedin.metadata.timeline.data.SemanticChangeType;
 import com.linkedin.metadata.timeline.data.dataset.DatasetSchemaFieldChangeEvent;
 import com.linkedin.metadata.timeline.data.dataset.SchemaFieldModificationCategory;
+import com.linkedin.metadata.utils.SchemaFieldUtils;
 import com.linkedin.schema.SchemaField;
 import com.linkedin.schema.SchemaFieldArray;
 import com.linkedin.schema.SchemaMetadata;
@@ -26,8 +27,10 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -223,6 +226,16 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     List<ChangeEvent> changeEvents = new ArrayList<>();
     Set<SchemaField> renamedFields = new HashSet<>();
 
+    // Connectors that build field paths through the Avro conversion pipeline (Glue, Hive, Trino,
+    // Iceberg, Kafka, ...) encode the column type into the v2 field path, so changing a column's
+    // type also changes its field path and the merge-join below can no longer align the two
+    // versions of the same column. Pair those up ahead of time so they are reported as a single
+    // MODIFY, matching what connectors emitting plain column names (Snowflake, BigQuery, ...) get.
+    Map<SchemaField, MovedFieldGroup> movedFieldGroups =
+        findMovedFieldGroups(baseFields, targetFields);
+    Set<SchemaField> movedFieldCandidates = movedFieldGroups.keySet();
+    Set<SchemaField> processedMovedFields = new HashSet<>();
+
     // Compares each sorted base field with the target field, tries to reconcile name changes by
     // matching field properties
     while (baseFieldIdx < baseFields.size() && targetFieldIdx < targetFields.size()) {
@@ -233,6 +246,10 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
         baseFieldIdx++;
       } else if (renamedFields.contains(curTargetField)) {
         targetFieldIdx++;
+      } else if (processedMovedFields.contains(curBaseField)) {
+        ++baseFieldIdx;
+      } else if (processedMovedFields.contains(curTargetField)) {
+        ++targetFieldIdx;
       } else if (comparison == 0) {
         // This is the same field. Check for change events from property changes.
         if (!curBaseField.getNativeDataType().equals(curTargetField.getNativeDataType())) {
@@ -252,12 +269,20 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
         // Check for rename, if rename coincides with other modifications we assume drop/add.
         // Assumes that two different fields on the same schema would not have the same description,
         // terms, and tags and share the same type
+        MovedFieldGroup movedGroup = movedFieldGroups.get(curBaseField);
+        if (movedGroup != null) {
+          processMovedFields(changeCategories, changeEvents, datasetUrn, movedGroup, auditStamp);
+          movedGroup.markProcessed(processedMovedFields);
+          ++baseFieldIdx;
+          continue;
+        }
         SchemaField renamedField =
             findRenamedField(
                 curBaseField,
                 new HashSet<>(baseFields.subList(baseFieldIdx, baseFields.size())),
                 targetFields.subList(targetFieldIdx, targetFields.size()),
-                renamedFields);
+                renamedFields,
+                movedFieldCandidates);
         if (renamedField == null) {
           processRemoval(changeCategories, changeEvents, datasetUrn, curBaseField, auditStamp);
           ++baseFieldIdx;
@@ -277,12 +302,20 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       } else {
         // The targetField got added or a renaming occurred. Forward & backwards compatible change +
         // minor version bump for both.
+        MovedFieldGroup movedGroup = movedFieldGroups.get(curTargetField);
+        if (movedGroup != null) {
+          processMovedFields(changeCategories, changeEvents, datasetUrn, movedGroup, auditStamp);
+          movedGroup.markProcessed(processedMovedFields);
+          ++targetFieldIdx;
+          continue;
+        }
         SchemaField renamedField =
             findRenamedField(
                 curTargetField,
                 new HashSet<>(targetFields.subList(targetFieldIdx, targetFields.size())),
                 baseFields.subList(baseFieldIdx, baseFields.size()),
-                renamedFields);
+                renamedFields,
+                movedFieldCandidates);
         if (renamedField == null) {
           processAdd(changeCategories, changeEvents, datasetUrn, curTargetField, auditStamp);
           ++targetFieldIdx;
@@ -304,7 +337,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     while (baseFieldIdx < baseFields.size()) {
       // Handle removed fields. Non-backward compatible change + major version bump
       SchemaField baseField = baseFields.get(baseFieldIdx);
-      if (!renamedFields.contains(baseField)) {
+      if (!renamedFields.contains(baseField) && !processedMovedFields.contains(baseField)) {
         processRemoval(changeCategories, changeEvents, datasetUrn, baseField, auditStamp);
       }
       ++baseFieldIdx;
@@ -312,7 +345,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     while (targetFieldIdx < targetFields.size()) {
       // Newly added fields. Forwards & backwards compatible change + minor version bump.
       SchemaField targetField = targetFields.get(targetFieldIdx);
-      if (!renamedFields.contains(targetField)) {
+      if (!renamedFields.contains(targetField) && !processedMovedFields.contains(targetField)) {
         processAdd(changeCategories, changeEvents, datasetUrn, targetField, auditStamp);
       }
       ++targetFieldIdx;
@@ -344,13 +377,157 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       SchemaField curField,
       Set<SchemaField> baseFields,
       List<SchemaField> targetFields,
-      Set<SchemaField> renamedFields) {
+      Set<SchemaField> renamedFields,
+      Set<SchemaField> retypeCandidates) {
     return targetFields.stream()
         .filter(schemaField -> isRenamed(curField, schemaField))
         .filter(field -> !renamedFields.contains(field))
+        .filter(field -> !retypeCandidates.contains(field)) // Already paired up as a type change
         .filter(field -> !baseFields.contains(field)) // Filter out fields that will match later
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * Pairs up fields that represent the same column before and after their field path moved, which
+   * happens for schemas whose field paths embed the column type (v2 field paths). Changing such a
+   * column's type moves its path, so the field path based merge-join in {@link #computeDiffs} sees
+   * an unrelated removal and addition instead of a modification.
+   *
+   * <p>Fields whose path is unchanged are excluded first, since the merge-join already aligns
+   * those. What remains is grouped by type-stripped path: a group is the same named field on both
+   * sides, and it is a type change only when the two sides declare different native types. A group
+   * whose types match is a field that merely moved - a connector switching between plain column
+   * names and v2 field paths moves every path at once without changing the schema - and reporting
+   * that as a removal plus an addition would be wrong.
+   *
+   * <p>A group usually holds a single field per side. Union types are the reason it can hold more:
+   * a union is stored as one field per member, all sharing the member's name, so several fields
+   * collapse onto the same type-stripped path. When more than one member changes at once there is
+   * no fact about which member became which - neither the field paths nor the source schema can say
+   * - so the whole group is reported as one modification naming every type involved rather than as
+   * a guessed pairing. The collision does not have to involve the union member itself: a union of
+   * structs collides on the struct's children as well, for example {@code
+   * [type=union].[type=struct0].u.[type=int].a} and {@code
+   * [type=union].[type=struct1].u.[type=string].a} both reduce to {@code u.a}.
+   *
+   * @return a map from each participating field, on either side, to the group it belongs to
+   */
+  private static Map<SchemaField, MovedFieldGroup> findMovedFieldGroups(
+      SchemaFieldArray baseFields, SchemaFieldArray targetFields) {
+    Set<String> basePaths =
+        baseFields.stream().map(SchemaField::getFieldPath).collect(Collectors.toSet());
+    Set<String> targetPaths =
+        targetFields.stream().map(SchemaField::getFieldPath).collect(Collectors.toSet());
+
+    // Fields whose path exists on both sides are already aligned by the merge-join.
+    Map<String, List<SchemaField>> baseByLogicalPath =
+        baseFields.stream()
+            .filter(field -> !targetPaths.contains(field.getFieldPath()))
+            .collect(Collectors.groupingBy(SchemaFieldUtils::downgradeFieldPath));
+    Map<String, List<SchemaField>> targetByLogicalPath =
+        targetFields.stream()
+            .filter(field -> !basePaths.contains(field.getFieldPath()))
+            .collect(Collectors.groupingBy(SchemaFieldUtils::downgradeFieldPath));
+
+    Map<SchemaField, MovedFieldGroup> movedFieldGroups = new HashMap<>();
+    baseByLogicalPath.forEach(
+        (logicalPath, candidateBaseFields) -> {
+          List<SchemaField> candidateTargetFields = targetByLogicalPath.get(logicalPath);
+          if (candidateTargetFields == null) {
+            return;
+          }
+          MovedFieldGroup group = new MovedFieldGroup(candidateBaseFields, candidateTargetFields);
+          candidateBaseFields.forEach(field -> movedFieldGroups.put(field, group));
+          candidateTargetFields.forEach(field -> movedFieldGroups.put(field, group));
+        });
+    return movedFieldGroups;
+  }
+
+  /** The fields on either side of a field path move that share one type-stripped field path. */
+  private static final class MovedFieldGroup {
+    private final List<SchemaField> baseFields;
+    private final List<SchemaField> targetFields;
+
+    private MovedFieldGroup(List<SchemaField> baseFields, List<SchemaField> targetFields) {
+      // Sorted so that the representative field, and therefore the URN reported for the change,
+      // does not depend on the order the fields happened to arrive in.
+      this.baseFields = sortByPath(baseFields);
+      this.targetFields = sortByPath(targetFields);
+    }
+
+    private static List<SchemaField> sortByPath(List<SchemaField> fields) {
+      return fields.stream()
+          .sorted(Comparator.comparing(SchemaField::getFieldPath))
+          .collect(Collectors.toList());
+    }
+
+    private static String describeNativeTypes(List<SchemaField> fields) {
+      return fields.stream()
+          .map(SchemaField::getNativeDataType)
+          .distinct()
+          .sorted()
+          .collect(Collectors.joining(", "));
+    }
+
+    SchemaField getRepresentativeBaseField() {
+      return baseFields.get(0);
+    }
+
+    SchemaField getRepresentativeTargetField() {
+      return targetFields.get(0);
+    }
+
+    String getBaseNativeTypes() {
+      return describeNativeTypes(baseFields);
+    }
+
+    String getTargetNativeTypes() {
+      return describeNativeTypes(targetFields);
+    }
+
+    /** Whether exactly one field on each side carries this path, so the pairing is unambiguous. */
+    boolean isUnambiguousPair() {
+      return baseFields.size() == 1 && targetFields.size() == 1;
+    }
+
+    /** Whether the path moved because the declared types changed, rather than moving on its own. */
+    boolean isTypeChange() {
+      return !getBaseNativeTypes().equals(getTargetNativeTypes());
+    }
+
+    void markProcessed(Set<SchemaField> processedRetypes) {
+      processedRetypes.addAll(baseFields);
+      processedRetypes.addAll(targetFields);
+    }
+  }
+
+  private static void processMovedFields(
+      Set<ChangeCategory> changeCategories,
+      List<ChangeEvent> changeEvents,
+      Urn datasetUrn,
+      MovedFieldGroup movedGroup,
+      AuditStamp auditStamp) {
+    SchemaField baseField = movedGroup.getRepresentativeBaseField();
+    SchemaField targetField = movedGroup.getRepresentativeTargetField();
+    if (movedGroup.isTypeChange()) {
+      processNativeTypeChange(
+          changeCategories,
+          changeEvents,
+          datasetUrn,
+          baseField,
+          targetField,
+          movedGroup.getBaseNativeTypes(),
+          movedGroup.getTargetNativeTypes(),
+          auditStamp);
+    }
+    // Descriptions, tags and terms belong to an individual field, so they can only be diffed when
+    // there is exactly one field to attribute them to.
+    if (movedGroup.isUnambiguousPair()) {
+      changeEvents.addAll(
+          getFieldPropertyChangeEvents(
+              baseField, targetField, datasetUrn, changeCategories, auditStamp));
+    }
   }
 
   private static boolean isRenamed(SchemaField curField, SchemaField schemaField) {
@@ -444,6 +621,26 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       SchemaField curBaseField,
       SchemaField curTargetField,
       AuditStamp auditStamp) {
+    processNativeTypeChange(
+        changeCategories,
+        changeEvents,
+        datasetUrn,
+        curBaseField,
+        curTargetField,
+        curBaseField.getNativeDataType(),
+        curTargetField.getNativeDataType(),
+        auditStamp);
+  }
+
+  private static void processNativeTypeChange(
+      Set<ChangeCategory> changeCategories,
+      List<ChangeEvent> changeEvents,
+      Urn datasetUrn,
+      SchemaField curBaseField,
+      SchemaField curTargetField,
+      String baseNativeType,
+      String targetNativeType,
+      AuditStamp auditStamp) {
     // Non-backward compatible change + Major version bump
     if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
@@ -458,8 +655,8 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                       "%s native datatype of the field '%s' changed from '%s' to '%s'.",
                       BACKWARDS_INCOMPATIBLE_DESC,
                       downgradeFieldPath(curTargetField),
-                      curBaseField.getNativeDataType(),
-                      curTargetField.getNativeDataType()))
+                      baseNativeType,
+                      targetNativeType))
               .fieldPath(curBaseField.getFieldPath())
               .fieldUrn(generateSchemaFieldUrn(datasetUrn, curBaseField))
               .nullable(curBaseField.isNullable())

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -100,7 +100,11 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                   baseField.getFieldPath(),
                   baseDescription,
                   targetDescription))
-          .parameters(ImmutableMap.of("description", targetDescription))
+          // The schema history UI diffs the two values, so it cannot render the change without the
+          // previous one. Both are non-null here: the branches above handle either being absent.
+          .parameters(
+              ImmutableMap.of(
+                  "description", targetDescription, "previousDescription", baseDescription))
           .auditStamp(auditStamp)
           .build();
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGeneratorTest.java
@@ -1,0 +1,66 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.mxe.SystemMetadata;
+import com.linkedin.schema.EditableSchemaFieldInfo;
+import com.linkedin.schema.EditableSchemaFieldInfoArray;
+import com.linkedin.schema.EditableSchemaMetadata;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+public class EditableSchemaMetadataChangeEventGeneratorTest
+    extends AbstractTestNGSpringContextTests {
+
+  private static Urn getTestUrn() throws URISyntaxException {
+    return Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)");
+  }
+
+  private static AuditStamp getTestAuditStamp() throws URISyntaxException {
+    return new AuditStamp()
+        .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+        .setTime(1683829509553L);
+  }
+
+  private static Aspect<EditableSchemaMetadata> getEditableSchemaMetadata(
+      String fieldPath, String description) {
+    return new Aspect<>(
+        new EditableSchemaMetadata()
+            .setEditableSchemaFieldInfo(
+                new EditableSchemaFieldInfoArray(
+                    List.of(
+                        new EditableSchemaFieldInfo()
+                            .setFieldPath(fieldPath)
+                            .setDescription(description)))),
+        new SystemMetadata());
+  }
+
+  @Test
+  public void testDocumentationChangeCarriesPreviousValue() throws Exception {
+    // Editing a column's documentation in the UI writes here rather than to schemaMetadata. The
+    // schema history UI renders documentation as a diff between the previous and the new value, so
+    // a MODIFY carrying only the new value cannot be displayed at all.
+    EditableSchemaMetadataChangeEventGenerator test =
+        new EditableSchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "editableSchemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<EditableSchemaMetadata> from = getEditableSchemaMetadata("id", "old doc");
+    Aspect<EditableSchemaMetadata> to = getEditableSchemaMetadata("id", "new doc");
+
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    Map<String, Object> parameters = actual.get(0).getParameters();
+    assertEquals(parameters.get("description"), "new doc");
+    assertEquals(parameters.get("previousDescription"), "old doc");
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
@@ -593,6 +593,48 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
   }
 
   @Test
+  public void testUnionCollapsedToScalarStillReportsDescriptionChange() throws Exception {
+    // Collapsing a union to a plain column moves the union node's own path as well, so unlike a
+    // change confined to the members there is no field left outside the group to carry the
+    // documentation. The group still describes one named field, so its documentation is diffed
+    // between the fields that denote the column on each side.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union")
+                    .setDescription("old doc"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].foo")
+                    .setNativeDataType("string"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=int].foo")
+                    .setNativeDataType("int")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=long].foo")
+                    .setNativeDataType("bigint")
+                    .setDescription("new doc")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(2, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'foo' changed from 'int, string, union' to 'bigint'.",
+            "The description for the field '[version=2.0].[type=union].foo' has been changed from 'old doc' to 'new doc'."),
+        actual);
+  }
+
+  @Test
   public void testSchemaFieldPrimaryKeyChange() throws Exception {
     // When a rename cannot be detected, treated as drop -> add
     SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
@@ -211,6 +211,388 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
   }
 
   @Test
+  public void testV2FieldPathNativeTypeChange() throws Exception {
+    // Connectors that go through the Avro conversion pipeline (Glue, Hive, Trino, ...) encode the
+    // column type inside the v2 field path, so a type change also changes the field path. The
+    // change is still a MODIFY, not a removal followed by an addition.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=string].hash_id")
+                    .setNativeDataType("string")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=long].hash_id")
+                    .setNativeDataType("bigint")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'hash_id' changed from 'string' to 'bigint'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testV2NestedFieldPathNativeTypeChange() throws Exception {
+    // A type change on a nested field changes the leaf's own type annotation while its parent
+    // path stays stable.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=struct].[type=struct].addr")
+                    .setNativeDataType("struct<city:string>"),
+                new SchemaField()
+                    .setFieldPath(
+                        "[version=2.0].[type=struct].[type=struct].addr.[type=string].city")
+                    .setNativeDataType("string")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=struct].[type=struct].addr")
+                    .setNativeDataType("struct<city:int>"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=struct].[type=struct].addr.[type=int].city")
+                    .setNativeDataType("int")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(2, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'addr' changed from 'struct<city:string>' to 'struct<city:int>'.",
+            "A backwards incompatible change due to native datatype of the field 'addr.city' changed from 'string' to 'int'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testV2MultipleUnionMemberTypeChangesReportedAsSingleModify() throws Exception {
+    // Avro unions produce several fields that collapse to the same path once the type annotations
+    // are stripped. Which member became which cannot be known when several change at once, but
+    // they all describe the same named field, so report one modification covering the whole set
+    // rather than a removal and an addition per member.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].foo")
+                    .setNativeDataType("string"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=int].foo")
+                    .setNativeDataType("int")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=long].foo")
+                    .setNativeDataType("long"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=double].foo")
+                    .setNativeDataType("double")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'foo' changed from 'int, string' to 'double, long'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testV2UnionOfStructsChildTypeChangesReportedAsSingleModify() throws Exception {
+    // A union of structs collides on the struct's children too, so the colliding field is not
+    // itself a union member: 'a' below carries a plain [type=int] / [type=string] annotation and
+    // only its ancestors mention the union. Grouping must stay driven by the type-stripped path
+    // that the candidates share, not by whether a field looks like a union member.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].u")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct0].u")
+                    .setNativeDataType("struct"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct0].u.[type=int].a")
+                    .setNativeDataType("int"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct1].u")
+                    .setNativeDataType("struct"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct1].u.[type=string].a")
+                    .setNativeDataType("string")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].u")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct0].u")
+                    .setNativeDataType("struct"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct0].u.[type=long].a")
+                    .setNativeDataType("long"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct1].u")
+                    .setNativeDataType("struct"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=struct1].u.[type=double].a")
+                    .setNativeDataType("double")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'u.a' changed from 'int, string' to 'double, long'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testV2SingleUnionMemberTypeChange() throws Exception {
+    // Only one member changed, so the pairing is unambiguous and is reported as a modification.
+    // The union field itself carries the native type 'union' in both versions and so reports
+    // nothing on its own - without this pairing the change would surface as a drop plus an add.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].u")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].u")
+                    .setNativeDataType("string"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=int].u")
+                    .setNativeDataType("int")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].u")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].u")
+                    .setNativeDataType("string"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=long].u")
+                    .setNativeDataType("long")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'u' changed from 'int' to 'long'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testV2UnionCollapsedToScalarReportedAsSingleModify() throws Exception {
+    // Replacing a union with a plain column drops every member field at once. The members and the
+    // column share a name, so this is one field whose type changed rather than several removals
+    // followed by an addition.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].foo")
+                    .setNativeDataType("string"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=int].foo")
+                    .setNativeDataType("int")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=long].foo")
+                    .setNativeDataType("bigint")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'foo' changed from 'int, string, union' to 'bigint'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testFieldPathVersionMigrationReportsNoChange() throws Exception {
+    // A connector switching from plain column names to v2 field paths moves every path at once
+    // without touching the schema. Nothing changed, so nothing should be reported.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField().setFieldPath("id").setNativeDataType("int"),
+                new SchemaField().setFieldPath("hash_id").setNativeDataType("string")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=int].id")
+                    .setNativeDataType("int"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=string].hash_id")
+                    .setNativeDataType("string")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(0, actual.size());
+  }
+
+  @Test
+  public void testFieldPathVersionMigrationWithTypeChange() throws Exception {
+    // Same migration, but one column also changed type - only that column is reported.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField().setFieldPath("id").setNativeDataType("int"),
+                new SchemaField().setFieldPath("hash_id").setNativeDataType("string")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=int].id")
+                    .setNativeDataType("int"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=long].hash_id")
+                    .setNativeDataType("bigint")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'hash_id' changed from 'string' to 'bigint'."),
+        actual);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.TYPE_CHANGE.toString()), actual);
+  }
+
+  @Test
+  public void testUnionMemberTypeChangesStillReportDescriptionChange() throws Exception {
+    // Union members are not diffed individually for documentation, tags or terms, because a
+    // grouped change has no single field to attribute them to. The union node carries the same
+    // documentation and its path does not move when members change, so the change is still
+    // reported through it rather than lost.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union")
+                    .setDescription("old doc"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=string].foo")
+                    .setNativeDataType("string")
+                    .setDescription("old doc"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=int].foo")
+                    .setNativeDataType("int")
+                    .setDescription("old doc")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].foo")
+                    .setNativeDataType("union")
+                    .setDescription("new doc"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=long].foo")
+                    .setNativeDataType("long")
+                    .setDescription("new doc"),
+                new SchemaField()
+                    .setFieldPath("[version=2.0].[type=union].[type=double].foo")
+                    .setNativeDataType("double")
+                    .setDescription("new doc")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(2, actual.size());
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to native datatype of the field 'foo' changed from 'int, string' to 'double, long'.",
+            "The description for the field '[version=2.0].[type=union].foo' has been changed from 'old doc' to 'new doc'."),
+        actual);
+  }
+
+  @Test
   public void testSchemaFieldPrimaryKeyChange() throws Exception {
     // When a rename cannot be detected, treated as drop -> add
     SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
@@ -635,6 +635,39 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
   }
 
   @Test
+  public void testDescriptionChangeCarriesPreviousValue() throws Exception {
+    // The schema history UI renders documentation as a diff between the previous and the new value,
+    // so a MODIFY carrying only the new value cannot be displayed at all. The dataset properties
+    // generators already emit both.
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("id")
+                    .setNativeDataType("int")
+                    .setDescription("old doc")));
+    Aspect<SchemaMetadata> to =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("id")
+                    .setNativeDataType("int")
+                    .setDescription("new doc")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
+    assertEquals(1, actual.size());
+    Map<String, Object> parameters = actual.get(0).getParameters();
+    assertEquals(parameters.get("description"), "new doc");
+    assertEquals(parameters.get("previousDescription"), "old doc");
+  }
+
+  @Test
   public void testSchemaFieldPrimaryKeyChange() throws Exception {
     // When a rename cannot be detected, treated as drop -> add
     SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
@@ -1011,7 +1011,14 @@ public class PlatformEventGeneratorHookTest {
             ChangeOperation.MODIFY,
             null,
             ImmutableMap.of(
-                "description", "newC2Desc", "fieldPath", "c2", "parentUrn", TEST_DATASET_URN),
+                "description",
+                "newC2Desc",
+                "previousDescription",
+                "oldC2Desc",
+                "fieldPath",
+                "c2",
+                "parentUrn",
+                TEST_DATASET_URN),
             actorUrn),
         false);
 
@@ -1089,7 +1096,14 @@ public class PlatformEventGeneratorHookTest {
             ChangeOperation.MODIFY,
             null,
             ImmutableMap.of(
-                "description", "newC2Desc", "fieldPath", "c2", "parentUrn", TEST_DATASET_URN),
+                "description",
+                "newC2Desc",
+                "previousDescription",
+                "oldC2Desc",
+                "fieldPath",
+                "c2",
+                "parentUrn",
+                TEST_DATASET_URN),
             actorUrn),
         false);
 


### PR DESCRIPTION
Changing a column's data type on a Glue dataset showed up in the schema timeline as a **removal of the column followed by an addition** (with a major version bump) rather than a single modification. Snowflake reported the same change correctly as one MODIFY. Hive is affected the same way.

### Root cause

The two connectors build `fieldPath` differently.

Connectors emitting plain column names put the type only in `nativeDataType`:

```
before: hash_id   native=string
after:  hash_id   native=bigint
```

Connectors that route columns through the Avro conversion pipeline emit v2 field paths, which **embed the column type in the path itself**:

```
before: [version=2.0].[type=string].hash_id   native=string
after:  [version=2.0].[type=long].hash_id     native=bigint
```

`SchemaMetadataChangeEventGenerator.computeDiffs()` aligns the two versions with a merge-join keyed on the raw `fieldPath`, and only checks `nativeDataType` when the paths compare equal. A type change moves the path, so the two versions never align: the old path falls into the removal branch and the new one into the addition branch. The rename fallback cannot recover it either, since `isRenamed()` requires the native types to be equal — false by construction for a type change.

This affects every connector using v2 field paths: Glue, Hive, Trino, Iceberg, Delta Lake, Unity Catalog, Kafka/Avro, and BigQuery's nested columns.

### Fix

Before the merge-join runs, group fields by their type-stripped path (`SchemaFieldUtils.downgradeFieldPath`, already used for descriptions and URNs). Fields whose raw path is unchanged are excluded first, since the merge-join already aligns those.

A group is the same named field on both sides, and what happens next depends on the group:

- **native types differ** → one MODIFY / TYPE_CHANGE, replacing the removal and addition
- **native types match** → the path moved on its own, as when a connector switches between plain column names and v2 field paths. The group is consumed without emitting anything, instead of every column looking dropped and re-added
- **more than one field per side** → unions place several fields on one path. When multiple members change there is no way to tell which member became which, so the group is reported as one MODIFY naming every type involved rather than a guessed pairing

Schemas using plain column names are unaffected by construction: `downgradeFieldPath` is the identity for paths without a `[version=2.0]` prefix, so "type-stripped paths equal" implies "raw paths equal", every field is excluded, no groups form, and the existing merge-join runs unchanged.

The timeline is computed from stored aspects at query time, so existing history renders correctly without re-ingesting.

### Documentation events

Two follow-on fixes, both surfaced by review:

Documentation, tags and terms are diffed per group, gated on whether a field sharing that logical path kept its path. When a union's members change, the union node stays put and the merge-join already diffs its documentation, so the group must not report it again. When the union itself collapses to a plain column, the node's own path moves too and nothing outside the group covers it, so the group diffs it. The representative field for a group is its least qualified path, which denotes the column rather than one of its type branches.

Separately, `getDescriptionChange` emitted MODIFY events carrying only the new description. The schema history UI renders documentation as a diff and skips a MODIFY without `previousDescription`, so field documentation changes never displayed. `EditableSchemaMetadataChangeEventGenerator` had the same gap, and that is the path user-edited column documentation actually takes. Both now emit the previous value, matching `DatasetPropertiesChangeEventGenerator` and `EditableDatasetPropertiesChangeEventGenerator`, which always did. This predates the change above but became reachable in more cases once a moved path is reported as a modification rather than a removal plus an addition.

### Testing

Eleven tests added to `SchemaMetadataChangeEventGeneratorTest` (19 total) covering flat columns, nested structs, unions (single member, multiple members, union of structs, collapse to a scalar), field path version migrations with and without a type change, and the documentation parameters. The v2 field paths used were generated from the actual Hive-to-Avro converter rather than written by hand.

`EditableSchemaMetadataChangeEventGeneratorTest` is new — that generator had no test class.

`PlatformEventGeneratorHookTest` is updated: its schema field documentation cases pinned the old parameter shape. The dataset level cases in the same file already expected a previous value.

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated — internal behaviour fix, no user-facing docs
- [ ] Breaking change entry in Updating DataHub — not a breaking change; the semantic version bump for a type change stays MAJOR, only the event shape changes
