### PR TITLE
fix(gms): skip the aliases aspect when the URN is already lowercased

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffect.java
@@ -28,6 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Derives the system-computed {@code aliases.lowercasedUrn} field from the entity's URN. Keyed on
  * the dataset key aspect so it runs once, at creation.
+ *
+ * <p>Skipped when the URN already equals its lowercased form, so a lookup has to match {@code urn}
+ * OR {@code lowercasedUrn}.
  */
 @Slf4j
 @Getter
@@ -64,6 +67,10 @@ public class AliasesSideEffect extends MCPSideEffect {
       lowercasedUrn = AliasesUtils.lowercaseDatasetUrn(urn);
     } catch (URISyntaxException e) {
       log.warn("Unable to compute lowercasedUrn for {}", urn, e);
+      return Stream.empty();
+    }
+
+    if (lowercasedUrn.equals(urn)) {
       return Stream.empty();
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aliases/sideeffects/AliasesSideEffectTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.metadata.Constants.DATASET_KEY_ASPECT_NAME;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.context.OperationFingerprint;
 import com.linkedin.common.Aliases;
@@ -64,26 +65,31 @@ public class AliasesSideEffectTest {
     sideEffect = new AliasesSideEffect().setConfig(CONFIG);
   }
 
+  private ChangeItemImpl keyItem(Urn urn) {
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    return ChangeItemImpl.builder()
+        .urn(urn)
+        .aspectName(DATASET_KEY_ASPECT_NAME)
+        .entitySpec(entitySpec)
+        .aspectSpec(entitySpec.getKeyAspectSpec())
+        .recordTemplate(EntityKeyUtils.convertUrnToEntityKey(urn, entitySpec.getKeyAspectSpec()))
+        .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+        .build(mockAspectRetriever);
+  }
+
+  private List<MCPItem> applyTo(Urn urn) {
+    return sideEffect
+        .applyMCPSideEffect(
+            mockOpContext, Collections.singletonList(keyItem(urn)), retrieverContext)
+        .collect(Collectors.toList());
+  }
+
   @Test
   public void testDerivesLowercasedUrnFromKeyAspect() {
     Urn urn =
         UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.TABLE,PROD)");
-    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
-    ChangeItemImpl keyItem =
-        ChangeItemImpl.builder()
-            .urn(urn)
-            .aspectName(DATASET_KEY_ASPECT_NAME)
-            .entitySpec(entitySpec)
-            .aspectSpec(entitySpec.getKeyAspectSpec())
-            .recordTemplate(
-                EntityKeyUtils.convertUrnToEntityKey(urn, entitySpec.getKeyAspectSpec()))
-            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
-            .build(mockAspectRetriever);
 
-    List<MCPItem> results =
-        sideEffect
-            .applyMCPSideEffect(mockOpContext, Collections.singletonList(keyItem), retrieverContext)
-            .collect(Collectors.toList());
+    List<MCPItem> results = applyTo(urn);
 
     assertEquals(results.size(), 1, "Expected a single aliases MCP");
     MCPItem out = results.get(0);
@@ -94,5 +100,14 @@ public class AliasesSideEffectTest {
     assertEquals(
         aspect.getLowercasedUrn().toString(),
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
+  }
+
+  @Test
+  public void testSkipsUrnThatIsAlreadyItsOwnLowercasedForm() {
+    // Uppercase env is deliberate: only the name is lowercased.
+    Urn urn =
+        UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
+
+    assertTrue(applyTo(urn).isEmpty(), "Expected no aliases MCP for an all-lowercase name");
   }
 }


### PR DESCRIPTION
## Summary

`AliasesSideEffect` wrote `aliases.lowercasedUrn` for every dataset, including the ones whose URN already equals its own lowercased form — for those the aspect only restated the URN.

It now skips those, so the aspect is only written where the lowercased URN actually differs.

```java
if (lowercasedUrn.equals(urn)) {
  return Stream.empty();
}
```


## Consequence for readers

`lowercasedUrn` is no longer a complete index. A case-insensitive lookup has to match **`urn` OR `lowercasedUrn`** — a dataset with an all-lowercase name is only findable under its own URN. Coverage of the two-clause form is identical to the previous always-write behaviour: for a key `K = lower(name)`, the aspect clause returns every stored URN with `lower(S) == K` and `lower(S) != S`, and the `urn` clause returns the one where `S == K`, which is exactly the remaining case. `urn` is already a keyword field in the entity index, so the extra clause needs no mapping change.

Nothing on `master` reads the aspect yet, so there is no read-side change to make here. #18679 applies the same skip to the backfill, so the two stay in agreement about which datasets carry the aspect.

Note that the platform instance is part of the dataset name in the URN and is lowercased along with it, so a deployment with a mixed-case `platform_instance` still gets an aspect for every dataset.

## Testing

- New `testSkipsUrnThatIsAlreadyItsOwnLowercasedForm` — a lowercase name with a `PROD` env, which also pins down that the URN's uppercase scaffolding is not a casing difference.
- Existing mixed-case test unchanged. `:metadata-io:test --tests AliasesSideEffectTest` → 2 passing.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs — no user-facing surface yet; the aspect is system-owned and has no readers on `master`
- [ ] Breaking changes — none externally; the read-side contract is documented in the class javadoc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip writing `aliases.lowercasedUrn` when the entity URN is already lowercase to avoid redundant aspects and writes. If you rely on this aspect, use `urn` OR `lowercasedUrn` for case-insensitive lookups.

- **Bug Fixes**
  - Skip write when `lowercasedUrn.equals(urn)`, using `Urn` equality (not string comparison) to avoid false differences.
  - Added `testSkipsUrnThatIsAlreadyItsOwnLowercasedForm`.

- **Migration**
  - For case-insensitive search, match `urn` OR `lowercasedUrn` (no mapping changes needed; `urn` is keyword-indexed).

<sup>Written for commit e9727ee86c0cd6a2fb1cac432453bc3c839300e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Stops writing the system `aliases.lowercasedUrn` aspect for datasets whose URN already matches its lowercased form, avoiding redundant aspect upserts.
> 
> `AliasesSideEffect` now returns an empty stream when `lowercasedUrn.equals(urn)`. Case-insensitive lookups must therefore match **`urn` OR `lowercasedUrn`**. Adds a unit test covering the already-lowercase skip path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9727ee86c0cd6a2fb1cac432453bc3c839300e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
