### PR TITLE
perf(recommendations): Cache check for existence of usage events index

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
@@ -18,7 +18,6 @@ import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -30,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -83,17 +81,8 @@ public class MostPopularSource implements EntityRecommendationSource {
   @Override
   public boolean isEligible(
       @Nonnull OperationContext opContext, @Nonnull RecommendationRequestContext requestContext) {
-    boolean analyticsEnabled = false;
-    try {
-      analyticsEnabled =
-          _searchClient.indexExists(
-              opContext,
-              new GetIndexRequest(_indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-              RequestOptions.DEFAULT);
-    } catch (IOException e) {
-      log.error("Failed to determine whether DataHub usage index exists");
-    }
-    return requestContext.getScenario() == ScenarioType.HOME && analyticsEnabled;
+    return requestContext.getScenario() == ScenarioType.HOME
+        && UsageEventIndexChecker.usageIndexExists(opContext, _searchClient, _indexConvention);
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
@@ -18,7 +18,6 @@ import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -82,17 +80,8 @@ public class RecentlyEditedSource implements EntityRecommendationSource {
   @Override
   public boolean isEligible(
       @Nonnull OperationContext opContext, @Nonnull RecommendationRequestContext requestContext) {
-    boolean analyticsEnabled = false;
-    try {
-      analyticsEnabled =
-          _searchClient.indexExists(
-              opContext,
-              new GetIndexRequest(_indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-              RequestOptions.DEFAULT);
-    } catch (IOException e) {
-      log.error("Failed to check whether DataHub usage index exists");
-    }
-    return requestContext.getScenario() == ScenarioType.HOME && analyticsEnabled;
+    return requestContext.getScenario() == ScenarioType.HOME
+        && UsageEventIndexChecker.usageIndexExists(opContext, _searchClient, _indexConvention);
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
@@ -18,7 +18,6 @@ import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -82,17 +80,8 @@ public class RecentlyViewedSource implements EntityRecommendationSource {
   @Override
   public boolean isEligible(
       @Nonnull OperationContext opContext, @Nonnull RecommendationRequestContext requestContext) {
-    boolean analyticsEnabled = false;
-    try {
-      analyticsEnabled =
-          _searchClient.indexExists(
-              opContext,
-              new GetIndexRequest(_indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-              RequestOptions.DEFAULT);
-    } catch (IOException e) {
-      log.error("Failed to check whether DataHub usage index exists");
-    }
-    return requestContext.getScenario() == ScenarioType.HOME && analyticsEnabled;
+    return requestContext.getScenario() == ScenarioType.HOME
+        && UsageEventIndexChecker.usageIndexExists(opContext, _searchClient, _indexConvention);
   }
 
   @Override

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlySearchedSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlySearchedSource.java
@@ -15,7 +15,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -26,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
-import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilder;
@@ -63,17 +61,8 @@ public class RecentlySearchedSource implements RecommendationSource {
   @Override
   public boolean isEligible(
       @Nonnull OperationContext opContext, @Nonnull RecommendationRequestContext requestContext) {
-    boolean analyticsEnabled = false;
-    try {
-      analyticsEnabled =
-          _searchClient.indexExists(
-              opContext,
-              new GetIndexRequest(_indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-              RequestOptions.DEFAULT);
-    } catch (IOException e) {
-      log.error("Failed to check whether DataHub usage index exists");
-    }
-    return requestContext.getScenario() == ScenarioType.SEARCH_BAR && analyticsEnabled;
+    return requestContext.getScenario() == ScenarioType.SEARCH_BAR
+        && UsageEventIndexChecker.usageIndexExists(opContext, _searchClient, _indexConvention);
   }
 
   @Override

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
@@ -1,0 +1,51 @@
+package com.linkedin.metadata.recommendation.candidatesource;
+
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import io.datahubproject.metadata.context.OperationContext;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.GetIndexRequest;
+
+/**
+ * Checks whether the DataHub usage event index exists, caching the result for the lifetime of the
+ * process so recommendation candidate sources don't each re-issue the same index check.
+ */
+@Slf4j
+public class UsageEventIndexChecker {
+
+  private static final String DATAHUB_USAGE_INDEX = "datahub_usage_event";
+
+  private static volatile Boolean USAGE_INDEX_EXISTS = null;
+
+  private UsageEventIndexChecker() {}
+
+  public static boolean usageIndexExists(
+      @Nonnull OperationContext opContext,
+      @Nonnull SearchClientShim<?> searchClient,
+      @Nonnull IndexConvention indexConvention) {
+    Boolean cached = USAGE_INDEX_EXISTS;
+    if (cached != null) {
+      return cached;
+    }
+    synchronized (UsageEventIndexChecker.class) {
+      if (USAGE_INDEX_EXISTS != null) {
+        return USAGE_INDEX_EXISTS;
+      }
+      try {
+        boolean exists =
+            searchClient.indexExists(
+                opContext,
+                new GetIndexRequest(indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
+                RequestOptions.DEFAULT);
+        USAGE_INDEX_EXISTS = exists;
+        return exists;
+      } catch (IOException e) {
+        log.error("Failed to check whether DataHub usage index exists");
+        return false;
+      }
+    }
+  }
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
@@ -4,21 +4,26 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.GetIndexRequest;
 
 /**
- * Checks whether the DataHub usage event index exists, caching the result for the lifetime of the
- * process so recommendation candidate sources don't each re-issue the same index check.
+ * Checks whether the DataHub usage event index exists, caching the result per index name for the
+ * lifetime of the process so recommendation candidate sources don't each re-issue the same index
+ * check. Keyed by index name to stay correct across tenants/index prefixes.
  */
 @Slf4j
 public class UsageEventIndexChecker {
 
   private static final String DATAHUB_USAGE_INDEX = "datahub_usage_event";
 
-  private static volatile Boolean USAGE_INDEX_EXISTS = null;
+  private static final int MAX_CACHE_SIZE = 1000;
+
+  private static final ConcurrentHashMap<String, Boolean> USAGE_INDEX_EXISTS_CACHE =
+      new ConcurrentHashMap<>();
 
   private UsageEventIndexChecker() {}
 
@@ -26,17 +31,18 @@ public class UsageEventIndexChecker {
       @Nonnull OperationContext opContext,
       @Nonnull SearchClientShim<?> searchClient,
       @Nonnull IndexConvention indexConvention) {
-    Boolean cached = USAGE_INDEX_EXISTS;
+    String indexName = indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX);
+    Boolean cached = USAGE_INDEX_EXISTS_CACHE.get(indexName);
     if (cached != null) {
       return cached;
     }
     try {
       boolean exists =
           searchClient.indexExists(
-              opContext,
-              new GetIndexRequest(indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-              RequestOptions.DEFAULT);
-      USAGE_INDEX_EXISTS = exists;
+              opContext, new GetIndexRequest(indexName), RequestOptions.DEFAULT);
+      if (USAGE_INDEX_EXISTS_CACHE.size() < MAX_CACHE_SIZE) {
+        USAGE_INDEX_EXISTS_CACHE.put(indexName, exists);
+      }
       return exists;
     } catch (IOException e) {
       log.error("Failed to check whether DataHub usage index exists");

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexChecker.java
@@ -30,22 +30,17 @@ public class UsageEventIndexChecker {
     if (cached != null) {
       return cached;
     }
-    synchronized (UsageEventIndexChecker.class) {
-      if (USAGE_INDEX_EXISTS != null) {
-        return USAGE_INDEX_EXISTS;
-      }
-      try {
-        boolean exists =
-            searchClient.indexExists(
-                opContext,
-                new GetIndexRequest(indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
-                RequestOptions.DEFAULT);
-        USAGE_INDEX_EXISTS = exists;
-        return exists;
-      } catch (IOException e) {
-        log.error("Failed to check whether DataHub usage index exists");
-        return false;
-      }
+    try {
+      boolean exists =
+          searchClient.indexExists(
+              opContext,
+              new GetIndexRequest(indexConvention.getIndexName(opContext, DATAHUB_USAGE_INDEX)),
+              RequestOptions.DEFAULT);
+      USAGE_INDEX_EXISTS = exists;
+      return exists;
+    } catch (IOException e) {
+      log.error("Failed to check whether DataHub usage index exists");
+      return false;
     }
   }
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexCheckerTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexCheckerTest.java
@@ -1,0 +1,78 @@
+package com.linkedin.metadata.recommendation.candidatesource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.client.indices.GetIndexRequest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class UsageEventIndexCheckerTest {
+
+  private final OperationContext opContext =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+  private final SearchClientShim<?> searchClient = mock(SearchClientShim.class);
+  private final IndexConvention indexConvention = mock(IndexConvention.class);
+
+  @BeforeMethod
+  public void setup() {
+    reset(searchClient, indexConvention);
+    when(indexConvention.getIndexName(opContext, "datahub_usage_event"))
+        .thenReturn("prefix_datahub_usage_event");
+  }
+
+  @AfterMethod
+  public void resetCache() throws Exception {
+    Field field = UsageEventIndexChecker.class.getDeclaredField("USAGE_INDEX_EXISTS");
+    field.setAccessible(true);
+    field.set(null, null);
+  }
+
+  @Test
+  public void testReturnsIndexExistsResult() throws IOException {
+    when(searchClient.indexExists(any(), any(GetIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(true);
+
+    assertTrue(UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention));
+  }
+
+  @Test
+  public void testCachesResultAcrossCalls() throws IOException {
+    when(searchClient.indexExists(any(), any(GetIndexRequest.class), any(RequestOptions.class)))
+        .thenReturn(true);
+
+    UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention);
+    UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention);
+    UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention);
+
+    verify(searchClient, times(1))
+        .indexExists(any(), any(GetIndexRequest.class), any(RequestOptions.class));
+  }
+
+  @Test
+  public void testDoesNotCacheOnFailureAndRetriesOnNextCall() throws IOException {
+    when(searchClient.indexExists(any(), any(GetIndexRequest.class), any(RequestOptions.class)))
+        .thenThrow(new IOException("simulated failure"))
+        .thenReturn(true);
+
+    assertFalse(UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention));
+    assertTrue(UsageEventIndexChecker.usageIndexExists(opContext, searchClient, indexConvention));
+
+    verify(searchClient, times(2))
+        .indexExists(any(), any(GetIndexRequest.class), any(RequestOptions.class));
+  }
+}

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexCheckerTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/recommendation/candidatesource/UsageEventIndexCheckerTest.java
@@ -15,6 +15,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Map;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.indices.GetIndexRequest;
 import org.testng.annotations.AfterMethod;
@@ -37,9 +38,9 @@ public class UsageEventIndexCheckerTest {
 
   @AfterMethod
   public void resetCache() throws Exception {
-    Field field = UsageEventIndexChecker.class.getDeclaredField("USAGE_INDEX_EXISTS");
+    Field field = UsageEventIndexChecker.class.getDeclaredField("USAGE_INDEX_EXISTS_CACHE");
     field.setAccessible(true);
-    field.set(null, null);
+    ((Map<?, ?>) field.get(null)).clear();
   }
 
   @Test


### PR DESCRIPTION
## Summary
This is a minor improvement to `listRecommendations`, which currently issues multiple HEAD calls to ES to check if the `datahub_usage_event` index exists and uses this information to conditionally load modules. This check is trivially cacheable given the fact that the existence of this index would not change during the normal course of operations.

## Changes
- Introduce a simple static variable cache `UsageEventIndexChecker` that caches the result for the lifetime of the process after checking for index existence the first time. This relies on the assumption that this index will not be created/deleted outside of upgrade/restart operations.

## Test Plan
- Added a unit test 
- Manually verified that  calling`listRecommendations` no longer results in unnecessary HEAD calls to ES.

## Checklist

- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Linked related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the OpenSearch index-exists check for `datahub_usage_event` in recommendation sources to reduce repeated calls during `listRecommendations`. Previously each source checked ES on every eligibility call; now a shared checker caches the result per process and per resolved index name to support multi-tenant/index prefixes. On IO failure it returns false, does not cache, and retries next call.

- Adds `UsageEventIndexChecker`: process-lifetime cache keyed by index name, bounded to 1000 entries; skips caching on IO failure.
- Replaces ad‑hoc checks in `MostPopularSource`, `RecentlyEditedSource`, `RecentlyViewedSource`, and `RecentlySearchedSource`.
- Adds unit tests for caching, retry behavior, and index-name scoping.

<sup>Written for commit 229cb2ebded9302038b9baa574ea8d7106cf99fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

