### PR TITLE
ci(playwright): duration-based bin-packing for Playwright shards

### DIFF
--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -316,6 +316,11 @@ for run_id in "${RUN_ID_ARRAY[@]}"; do
             else
                 artifact_subdir="$RUN_DIR/cypress-0"
             fi
+        elif [[ $artifact_name =~ ^playwright-junit-([0-9]+)$ ]]; then
+            # Each shard's artifact contains a same-named test-results/junit.xml; without a
+            # per-shard subdirectory here, every shard after the first overwrites the last
+            # extracted into the shared "other" dir, silently dropping 7/8 shards' data.
+            artifact_subdir="$RUN_DIR/playwright-${BASH_REMATCH[1]}"
         else
             artifact_subdir="$RUN_DIR/other"
         fi

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -188,6 +188,46 @@ def parse_gradle_results(artifact_dir: Path) -> Dict[str, List[float]]:
     return test_durations
 
 
+def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
+    """
+    Parse Playwright JUnit XML files from multiple runs.
+
+    Playwright's junit reporter emits one flat <testsuite name="path/to/file.spec.ts"
+    time="22.9"> per spec file, relative to testDir -- no nested root suite to unwrap
+    (unlike Cypress).
+
+    Returns:
+        Dictionary mapping spec file paths to lists of durations across runs
+        Example: {"analytics/analytics.spec.ts": [22.9, 21.4, 23.1]}
+    """
+    test_durations: Dict[str, List[float]] = {}
+
+    xml_files = list(artifact_dir.rglob("junit.xml"))
+    print(f"Found {len(xml_files)} Playwright XML files")
+
+    for xml_file in xml_files:
+        try:
+            root = ET.parse(xml_file).getroot()
+            for testsuite in root.findall(".//testsuite"):
+                file_path = testsuite.get("name", "")
+                time_str = testsuite.get("time", "0")
+                if not file_path:
+                    continue
+                try:
+                    duration = float(time_str)
+                except ValueError:
+                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
+                    continue
+                if duration > 0:
+                    test_durations.setdefault(file_path, []).append(duration)
+        except ET.ParseError as e:
+            print(f"Warning: Failed to parse {xml_file}: {e}")
+        except Exception as e:
+            print(f"Warning: Error processing {xml_file}: {e}")
+
+    return test_durations
+
+
 def calculate_median_weights(
     test_durations: Dict[str, List[float]], key_name: str = "filePath"
 ) -> List[Dict]:
@@ -245,11 +285,24 @@ def main():
         required=False,
         help="Output path for Gradle test weights JSON (keyed by FQCN)",
     )
+    parser.add_argument(
+        "--playwright-output",
+        type=Path,
+        required=False,
+        help="Output path for Playwright test weights JSON (keyed by spec file path)",
+    )
 
     args = parser.parse_args()
 
-    if not (args.pytest_output or args.cypress_output or args.gradle_output):
-        parser.error("at least one of --pytest-output/--cypress-output/--gradle-output is required")
+    if not (
+        args.pytest_output
+        or args.cypress_output
+        or args.gradle_output
+        or args.playwright_output
+    ):
+        parser.error(
+            "at least one of --pytest-output/--cypress-output/--gradle-output/--playwright-output is required"
+        )
 
     if not args.input_dir.exists():
         print(f"Error: Input directory does not exist: {args.input_dir}")
@@ -279,6 +332,14 @@ def main():
         gradle_durations = parse_gradle_results(args.input_dir)
         print(f"Found {len(gradle_durations)} unique Gradle tests")
 
+    playwright_durations = {}
+    if args.playwright_output:
+        print("\n" + "=" * 60)
+        print("Parsing Playwright test results...")
+        print("=" * 60)
+        playwright_durations = parse_playwright_results(args.input_dir)
+        print(f"Found {len(playwright_durations)} unique Playwright spec files")
+
     print("\n" + "=" * 60)
     print("Calculating median weights...")
     print("=" * 60)
@@ -298,6 +359,11 @@ def main():
         if args.gradle_output
         else []
     )
+    playwright_weights = (
+        calculate_median_weights(playwright_durations, key_name="filePath")
+        if args.playwright_output
+        else []
+    )
 
     # Write output files
     print("\n" + "=" * 60)
@@ -308,6 +374,7 @@ def main():
         (args.cypress_output, cypress_weights, "Cypress"),
         (args.pytest_output, pytest_weights, "Pytest"),
         (args.gradle_output, gradle_weights, "Gradle"),
+        (args.playwright_output, playwright_weights, "Playwright"),
     ):
         if output_path is None:
             continue

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -13,7 +13,32 @@ import statistics
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+
+def _safe_parse_root(xml_file: Path) -> Optional[ET.Element]:
+    """Parse xml_file, printing a warning and returning None on failure instead of raising.
+    Shared by every parser below so a malformed report from any framework fails the same way."""
+    try:
+        return ET.parse(xml_file).getroot()
+    except ET.ParseError as e:
+        print(f"Warning: Failed to parse {xml_file}: {e}")
+    except Exception as e:
+        print(f"Warning: Error processing {xml_file}: {e}")
+    return None
+
+
+def _parse_finite_duration(time_str: str, xml_file: Path) -> Optional[float]:
+    """Float-convert a duration string, rejecting non-finite/negative values (float() accepts
+    nan/inf, and inf would otherwise pass a later ">0" filter and poison a median)."""
+    try:
+        duration = float(time_str)
+    except ValueError:
+        print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
+        return None
+    if not math.isfinite(duration) or duration < 0:
+        return None
+    return duration
 
 
 def parse_cypress_results(artifact_dir: Path) -> Dict[str, List[float]]:
@@ -27,7 +52,7 @@ def parse_cypress_results(artifact_dir: Path) -> Dict[str, List[float]]:
         Dictionary mapping test file paths to lists of durations across runs
         Example: {"glossaryV2/v2_glossary_navigation.js": [94.8, 95.2, 94.5]}
     """
-    test_durations = {}
+    test_durations: Dict[str, List[float]] = {}
 
     # Find all cypress-test-*.xml files
     xml_files = list(artifact_dir.rglob("cypress-test-*.xml"))
@@ -35,48 +60,34 @@ def parse_cypress_results(artifact_dir: Path) -> Dict[str, List[float]]:
     print(f"Found {len(xml_files)} Cypress XML files")
 
     for xml_file in xml_files:
-        try:
-            tree = ET.parse(xml_file)
-            root = tree.getroot()
+        root = _safe_parse_root(xml_file)
+        if root is None:
+            continue
 
-            # Find the root suite with file attribute
-            root_suite = root.find(".//testsuite[@file]")
-            if root_suite is None:
+        # Find the root suite with file attribute
+        root_suite = root.find(".//testsuite[@file]")
+        if root_suite is None:
+            continue
+
+        file_path = root_suite.get("file")
+
+        # Strip "cypress/e2e/" prefix to get relative path
+        if file_path.startswith("cypress/e2e/"):
+            relative_path = file_path.replace("cypress/e2e/", "")
+        else:
+            relative_path = file_path
+
+        # Find all other testsuites (not the root suite) to get actual test durations
+        for testsuite in root.findall(".//testsuite"):
+            # Skip if this is the root suite with file attribute
+            if testsuite.get("file"):
                 continue
 
-            file_path = root_suite.get("file")
-
-            # Strip "cypress/e2e/" prefix to get relative path
-            if file_path.startswith("cypress/e2e/"):
-                relative_path = file_path.replace("cypress/e2e/", "")
-            else:
-                relative_path = file_path
-
-            # Find all other testsuites (not the root suite) to get actual test durations
-            all_testsuites = root.findall(".//testsuite")
-            for testsuite in all_testsuites:
-                # Skip if this is the root suite with file attribute
-                if testsuite.get("file"):
-                    continue
-
-                time_str = testsuite.get("time", "0")
-                try:
-                    duration = float(time_str)
-
-                    # Only add if duration is non-zero
-                    if duration > 0:
-                        if relative_path not in test_durations:
-                            test_durations[relative_path] = []
-                        test_durations[relative_path].append(duration)
-                        # Only take the first non-zero duration per file
-                        break
-                except ValueError:
-                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
-
-        except ET.ParseError as e:
-            print(f"Warning: Failed to parse {xml_file}: {e}")
-        except Exception as e:
-            print(f"Warning: Error processing {xml_file}: {e}")
+            duration = _parse_finite_duration(testsuite.get("time", "0"), xml_file)
+            if duration is not None and duration > 0:
+                test_durations.setdefault(relative_path, []).append(duration)
+                # Only take the first non-zero duration per file
+                break
 
     return test_durations
 
@@ -92,51 +103,33 @@ def parse_pytest_results(artifact_dir: Path) -> Dict[str, List[float]]:
         Dictionary mapping test IDs to lists of durations across runs
         Example: {"test_e2e::test_gms_get_dataset": [262.8, 265.3, 260.1]}
     """
-    test_durations = {}
+    test_durations: Dict[str, List[float]] = {}
 
-    # Find all junit.*.xml files (exclude cypress ones)
-    xml_files = []
-    for xml_file in artifact_dir.rglob("junit*.xml"):
-        # Exclude Cypress JUnit files
-        if "cypress" not in xml_file.name:
-            xml_files.append(xml_file)
+    # Find all junit.*.xml files (exclude Cypress ones)
+    xml_files = [f for f in artifact_dir.rglob("junit*.xml") if "cypress" not in f.name]
 
     print(f"Found {len(xml_files)} Pytest XML files")
 
     for xml_file in xml_files:
-        try:
-            tree = ET.parse(xml_file)
-            root = tree.getroot()
+        root = _safe_parse_root(xml_file)
+        if root is None:
+            continue
 
-            # Find all testcase elements
-            for testcase in root.findall(".//testcase"):
-                classname = testcase.get("classname", "")
-                name = testcase.get("name", "")
-                time_str = testcase.get("time", "0")
+        for testcase in root.findall(".//testcase"):
+            classname = testcase.get("classname", "")
+            name = testcase.get("name", "")
 
-                # Build test ID
-                if classname and name:
-                    test_id = f"{classname}::{name}"
-                elif name:
-                    test_id = name
-                else:
-                    continue
+            # Build test ID
+            if classname and name:
+                test_id = f"{classname}::{name}"
+            elif name:
+                test_id = name
+            else:
+                continue
 
-                try:
-                    duration = float(time_str)
-
-                    # Only add if duration is non-zero
-                    if duration > 0:
-                        if test_id not in test_durations:
-                            test_durations[test_id] = []
-                        test_durations[test_id].append(duration)
-                except ValueError:
-                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
-
-        except ET.ParseError as e:
-            print(f"Warning: Failed to parse {xml_file}: {e}")
-        except Exception as e:
-            print(f"Warning: Error processing {xml_file}: {e}")
+            duration = _parse_finite_duration(testcase.get("time", "0"), xml_file)
+            if duration is not None and duration > 0:
+                test_durations.setdefault(test_id, []).append(duration)
 
     return test_durations
 
@@ -160,30 +153,22 @@ def parse_gradle_results(artifact_dir: Path) -> Dict[str, List[float]]:
     print(f"Found {len(xml_files)} Gradle XML files")
 
     for xml_file in xml_files:
-        try:
-            root = ET.parse(xml_file).getroot()
-            per_class: Dict[str, float] = {}
-            for testcase in root.findall(".//testcase"):
-                classname = testcase.get("classname", "")
-                time_str = testcase.get("time", "0")
-                if not classname:
-                    continue
-                try:
-                    duration = float(time_str)
-                except ValueError:
-                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
-                    continue
-                # Reject non-finite/negative (float() accepts nan/inf, and inf passes ">0").
-                if not math.isfinite(duration) or duration < 0:
-                    continue
-                per_class[classname] = per_class.get(classname, 0.0) + duration
-            for classname, total in per_class.items():
-                if total > 0:
-                    test_durations.setdefault(classname, []).append(total)
-        except ET.ParseError as e:
-            print(f"Warning: Failed to parse {xml_file}: {e}")
-        except Exception as e:
-            print(f"Warning: Error processing {xml_file}: {e}")
+        root = _safe_parse_root(xml_file)
+        if root is None:
+            continue
+
+        per_class: Dict[str, float] = {}
+        for testcase in root.findall(".//testcase"):
+            classname = testcase.get("classname", "")
+            if not classname:
+                continue
+            duration = _parse_finite_duration(testcase.get("time", "0"), xml_file)
+            if duration is None:
+                continue
+            per_class[classname] = per_class.get(classname, 0.0) + duration
+        for classname, total in per_class.items():
+            if total > 0:
+                test_durations.setdefault(classname, []).append(total)
 
     return test_durations
 
@@ -220,28 +205,20 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
     print(f"Found {len(xml_files)} Playwright XML files")
 
     for xml_file in xml_files:
+        root = _safe_parse_root(xml_file)
+        if root is None:
+            continue
+
         run_dir = _run_dir(xml_file)
-        try:
-            root = ET.parse(xml_file).getroot()
-            for testsuite in root.findall(".//testsuite"):
-                file_path = testsuite.get("name", "")
-                time_str = testsuite.get("time", "0")
-                if not file_path:
-                    continue
-                try:
-                    duration = float(time_str)
-                except ValueError:
-                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
-                    continue
-                # Reject non-finite/negative (float() accepts nan/inf, and inf passes ">0").
-                if not math.isfinite(duration) or duration < 0:
-                    continue
-                totals = per_run_totals.setdefault(run_dir, {})
-                totals[file_path] = totals.get(file_path, 0.0) + duration
-        except ET.ParseError as e:
-            print(f"Warning: Failed to parse {xml_file}: {e}")
-        except Exception as e:
-            print(f"Warning: Error processing {xml_file}: {e}")
+        for testsuite in root.findall(".//testsuite"):
+            file_path = testsuite.get("name", "")
+            if not file_path:
+                continue
+            duration = _parse_finite_duration(testsuite.get("time", "0"), xml_file)
+            if duration is None:
+                continue
+            totals = per_run_totals.setdefault(run_dir, {})
+            totals[file_path] = totals.get(file_path, 0.0) + duration
 
     test_durations: Dict[str, List[float]] = {}
     for totals in per_run_totals.values():

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -188,24 +188,39 @@ def parse_gradle_results(artifact_dir: Path) -> Dict[str, List[float]]:
     return test_durations
 
 
+def _run_dir(xml_file: Path) -> Path:
+    """Nearest ancestor directory named run-<id> (download_test_artifacts.sh's convention),
+    falling back to the file's own parent if none is found."""
+    for parent in xml_file.parents:
+        if parent.name.startswith("run-"):
+            return parent
+    return xml_file.parent
+
+
 def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
     """
     Parse Playwright JUnit XML files from multiple runs.
 
     Playwright's junit reporter emits one flat <testsuite name="path/to/file.spec.ts"
     time="22.9"> per spec file, relative to testDir -- no nested root suite to unwrap
-    (unlike Cypress).
+    (unlike Cypress). But Playwright's --shard=N/M splits by test *count*, not by file,
+    so one file's tests can land in two different shards' junit.xml within the same run.
+    Sum a file's duration across all of a run's shard XMLs before treating it as one
+    sample -- otherwise each fragment is counted as an independent (much smaller) sample,
+    silently halving that file's median weight. Mirrors parse_gradle_results()'s per-class,
+    per-run summing for the same reason.
 
     Returns:
         Dictionary mapping spec file paths to lists of durations across runs
         Example: {"analytics/analytics.spec.ts": [22.9, 21.4, 23.1]}
     """
-    test_durations: Dict[str, List[float]] = {}
+    per_run_totals: Dict[Path, Dict[str, float]] = {}
 
     xml_files = list(artifact_dir.rglob("junit.xml"))
     print(f"Found {len(xml_files)} Playwright XML files")
 
     for xml_file in xml_files:
+        run_dir = _run_dir(xml_file)
         try:
             root = ET.parse(xml_file).getroot()
             for testsuite in root.findall(".//testsuite"):
@@ -219,11 +234,17 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
                     print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
                     continue
                 if duration > 0:
-                    test_durations.setdefault(file_path, []).append(duration)
+                    totals = per_run_totals.setdefault(run_dir, {})
+                    totals[file_path] = totals.get(file_path, 0.0) + duration
         except ET.ParseError as e:
             print(f"Warning: Failed to parse {xml_file}: {e}")
         except Exception as e:
             print(f"Warning: Error processing {xml_file}: {e}")
+
+    test_durations: Dict[str, List[float]] = {}
+    for totals in per_run_totals.values():
+        for file_path, total in totals.items():
+            test_durations.setdefault(file_path, []).append(total)
 
     return test_durations
 

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -233,9 +233,11 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
                 except ValueError:
                     print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
                     continue
-                if duration > 0:
-                    totals = per_run_totals.setdefault(run_dir, {})
-                    totals[file_path] = totals.get(file_path, 0.0) + duration
+                # Reject non-finite/negative (float() accepts nan/inf, and inf passes ">0").
+                if not math.isfinite(duration) or duration < 0:
+                    continue
+                totals = per_run_totals.setdefault(run_dir, {})
+                totals[file_path] = totals.get(file_path, 0.0) + duration
         except ET.ParseError as e:
             print(f"Warning: Failed to parse {xml_file}: {e}")
         except Exception as e:
@@ -244,7 +246,8 @@ def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
     test_durations: Dict[str, List[float]] = {}
     for totals in per_run_totals.values():
         for file_path, total in totals.items():
-            test_durations.setdefault(file_path, []).append(total)
+            if total > 0:
+                test_durations.setdefault(file_path, []).append(total)
 
     return test_durations
 

--- a/.github/scripts/split_playwright_tests.py
+++ b/.github/scripts/split_playwright_tests.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Assign individual Playwright spec files to one CI shard, balanced by historical duration.
+
+Vendored + stdlib-only (py3.9+), mirrors split_gradle_tests.py's LPT bin-packing. Reads a
+committed weights snapshot (playwright_test_weights.json, spec-file-path -> median seconds
+from generate_test_weights.py) and bin-packs individual *.spec.ts files across shards. Run
+from / pass the Playwright project root (e2e-test/ui/playwright) so paths resolve correctly.
+
+File-level by design: explicit file args passed to `playwright test` bypass Playwright's
+fullyParallel worker-hash grouping entirely, so per-file duration balancing actually controls
+shard placement (unlike `--shard=N/M`, which balances by test count only). Falls back to an
+even split when no weights exist.
+
+Emits a JSON plan on stdout; with --output-args FILE, also writes spec file paths one-per-line
+for `mapfile -t ARGS < FILE; npx playwright test "${ARGS[@]}"`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+
+def _canonical(path: str) -> str:
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _resolve_glob(pattern: str, repo_root: str) -> str:
+    return pattern if os.path.isabs(pattern) else os.path.join(repo_root, pattern)
+
+
+def _relative_to_test_dir(path: str, test_dir: str) -> str | None:
+    rel = os.path.relpath(os.path.abspath(path), test_dir)
+    if rel == ".." or rel.startswith(".." + os.sep):
+        return None
+    return rel.replace(os.sep, "/")
+
+
+def discover_spec_files(glob_pattern: str, exclude_globs: list[str], test_dir: str) -> list[str]:
+    """Spec file paths relative to test_dir, matching the junit reporter's testsuite name."""
+    excluded = {
+        _canonical(p)
+        for pattern in exclude_globs
+        for p in glob.glob(_resolve_glob(pattern, test_dir), recursive=True)
+    }
+    specs = []
+    for path in glob.glob(_resolve_glob(glob_pattern, test_dir), recursive=True):
+        if not os.path.isfile(path) or _canonical(path) in excluded:
+            continue
+        rel = _relative_to_test_dir(path, test_dir)
+        if rel is not None:
+            specs.append(rel)
+    return specs
+
+
+def load_weights(weights_path: str | None) -> dict[str, float]:
+    if not weights_path or not os.path.isfile(weights_path):
+        return {}
+    try:
+        with open(weights_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    weights: dict[str, float] = {}
+    for item in data:
+        file_path = item.get("filePath")
+        duration = item.get("duration", "")
+        if not file_path or not isinstance(duration, str) or not duration.endswith("s"):
+            continue
+        try:
+            weights[file_path] = float(duration[:-1])
+        except ValueError:
+            continue
+    return weights
+
+
+def spec_weights(specs: list[str], weights: dict[str, float]) -> dict[str, float]:
+    known = [weights[s] for s in specs if s in weights]
+    fallback = statistics.median(known) if known else 1.0
+    return {spec: weights.get(spec, fallback) for spec in specs}
+
+
+def bin_pack(weighted: dict[str, float], total: int) -> list[list[str]]:
+    """LPT: heaviest spec file into the currently-lightest shard. Deterministic tiebreak by name."""
+    buckets: list[list[str]] = [[] for _ in range(total)]
+    load = [0.0] * total
+    for spec in sorted(weighted, key=lambda p: (-weighted[p], p)):
+        target = min(range(total), key=lambda b: load[b])
+        buckets[target].append(spec)
+        load[target] += weighted[spec]
+    return buckets
+
+
+def plan_for_shard(specs: list[str], weighted: dict[str, float]) -> dict:
+    return {
+        "hasTests": bool(specs),
+        "specs": sorted(specs),
+        "diagnostics": {
+            "specFiles": len(specs),
+            "predictedSeconds": round(sum(weighted.get(s, 0.0) for s in specs), 1),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Assign individual Playwright spec files to one shard.")
+    parser.add_argument("--split-index", "-i", type=int, required=True)
+    parser.add_argument("--split-total", "-t", type=int, required=True)
+    parser.add_argument("--glob", "-g", default="**/*.spec.ts")
+    parser.add_argument("--exclude-glob", "-e", action="append", default=[])
+    parser.add_argument("--weights", help="Path to committed playwright_test_weights.json.")
+    parser.add_argument("--test-dir", default="tests", help="Playwright testDir (relative to --repo-root).")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-args", help="Write spec file paths one-per-line to this file.")
+    args = parser.parse_args()
+
+    if args.split_total < 1:
+        parser.error("--split-total must be >= 1")
+    if not (0 <= args.split_index < args.split_total):
+        parser.error("--split-index must be in [0, --split-total)")
+    repo_root = os.path.abspath(args.repo_root)
+    test_dir = os.path.join(repo_root, args.test_dir)
+
+    specs = discover_spec_files(args.glob, args.exclude_glob, test_dir)
+    if not specs:
+        print("split_playwright_tests: no spec files matched", file=sys.stderr)
+
+    weights = load_weights(args.weights)
+    weighted = spec_weights(specs, weights)
+    buckets = bin_pack(weighted, args.split_total)
+    plan = plan_for_shard(buckets[args.split_index], weighted)
+
+    matched = sum(1 for s in specs if s in weights)
+    mode = "duration-balanced" if weights else "even fallback"
+    d = plan["diagnostics"]
+    print(
+        f"split_playwright_tests: {len(specs)} spec files "
+        f"({matched} weighted, {mode}); shard {args.split_index}/{args.split_total} -> "
+        f"{d['specFiles']} files, predicted {d['predictedSeconds']}s",
+        file=sys.stderr,
+    )
+
+    if args.output_args is not None:
+        with open(args.output_args, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(plan["specs"]))
+    print(json.dumps(plan))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -167,19 +167,42 @@ jobs:
           yarn install --frozen-lockfile
           npx playwright install --with-deps chromium
 
+      - name: Compute this shard's spec files
+        # Individual spec-file args bypass Playwright's fullyParallel worker-hash grouping
+        # (keyed off featureName, used inconsistently across files, not path) entirely, so
+        # duration-balanced file assignment actually controls shard placement here --
+        # --shard=N/M only balances by raw test count.
+        env:
+          SHARD: ${{ inputs.shard }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          python3 .github/scripts/split_playwright_tests.py \
+            --split-index "$((SHARD - 1))" --split-total "$SHARD_COUNT" \
+            --repo-root . \
+            --test-dir e2e-test/ui/playwright/tests \
+            --weights e2e-test/ui/playwright/playwright_test_weights.json \
+            --output-args e2e-test/ui/playwright/shard-files.txt
+
       - name: Run Playwright tests
         working-directory: e2e-test/ui/playwright
         env:
           BASE_URL: "http://localhost:9002"
           PLAYWRIGHT_REUSE_SERVER: "1"
-          SHARD: ${{ inputs.shard }}
-          SHARD_COUNT: ${{ inputs.shard_count }}
           WORKERS_PER_SHARD: ${{ inputs.workers_per_shard }}
+          # Blob reporter's default output filename (report.zip) only gets a shard suffix
+          # when --shard is set (see playwright/lib/runner/index.js _defaultReportName). We
+          # no longer pass --shard, so every shard job would collide on the same filename
+          # once reusable-playwright-report.yml flattens blobs into one directory to merge
+          # them -- set this explicitly instead.
+          PLAYWRIGHT_BLOB_OUTPUT_FILE: blob-report/report-${{ inputs.shard }}.zip
         run: |
-          echo "Running Playwright shard $SHARD/$SHARD_COUNT at $WORKERS_PER_SHARD worker(s)"
-          npx playwright test \
-            --shard="$SHARD/$SHARD_COUNT" \
-            --workers="$WORKERS_PER_SHARD"
+          mapfile -t ARGS < shard-files.txt
+          if [ "${#ARGS[@]}" -eq 0 ]; then
+            echo "No spec files assigned to shard ${{ inputs.shard }}/${{ inputs.shard_count }} — skipping."
+            exit 0
+          fi
+          echo "Running Playwright shard ${{ inputs.shard }}/${{ inputs.shard_count }} (${#ARGS[@]} spec files) at $WORKERS_PER_SHARD worker(s)"
+          npx playwright test "${ARGS[@]}" --workers="$WORKERS_PER_SHARD"
 
       - name: Upload Playwright blob report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -257,8 +257,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Concatenate whichever PR body sections were generated (empty files contribute nothing)
-          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md ./pr-body-playwright.md 2>/dev/null)
+          # Concatenate whichever PR body sections were generated. gradle/playwright only
+          # write their file when changed, so cat can hit a missing file -- `|| true` keeps
+          # that from failing this step (errexit) when some other suite is what triggered
+          # create_pr, since $(cat ...)'s exit code would otherwise propagate.
+          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md ./pr-body-playwright.md 2>/dev/null || true)
 
           # Create PR (gh pr create prints the PR URL to stdout)
           PR_URL=$(gh pr create \

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -62,6 +62,15 @@ jobs:
             --workflow build-and-test.yml \
             --artifact-prefix "build-and-test" \
             --repository ${{ github.repository }}
+
+          echo "Downloading Playwright JUnit artifacts from recent docker-unified runs..."
+          # Named playwright-junit-{shard} by resusable-playwright-tests.yml.
+          bash .github/scripts/download_test_artifacts.sh \
+            --output-dir ./test-artifacts-playwright \
+            --run-count ${{ github.event.inputs.run_count || '3' }} \
+            --workflow docker-unified.yml \
+            --artifact-prefix "playwright-junit" \
+            --repository ${{ github.repository }}
       - name: Download ingestion test artifacts
         id: download-ingestion
         env:
@@ -91,6 +100,8 @@ jobs:
           cp metadata-ingestion/tests/integration_test_weights.json \
             ./weights-backup/integration_test_weights.json || echo "No existing integration weights"
           cp .github/backend_test_weights.json ./weights-backup/gradle_weights.json || echo "No existing Gradle weights"
+          cp e2e-test/ui/playwright/playwright_test_weights.json \
+            ./weights-backup/playwright_weights.json || echo "No existing Playwright weights"
 
       - name: Generate smoke test weights
         run: |
@@ -113,6 +124,13 @@ jobs:
           python .github/scripts/generate_test_weights.py \
             --input-dir ./test-artifacts-gradle \
             --gradle-output .github/backend_test_weights.json
+
+      - name: Generate playwright test weights
+        run: |
+          echo "Generating Playwright weights (keyed by spec file path)..."
+          python .github/scripts/generate_test_weights.py \
+            --input-dir ./test-artifacts-playwright \
+            --playwright-output e2e-test/ui/playwright/playwright_test_weights.json
 
       - name: Compare smoke weights
         id: compare-smoke
@@ -173,10 +191,28 @@ jobs:
             echo "✓ Gradle backend weights unchanged. No PR needed."
           fi
 
+      - name: Compare playwright weights
+        id: compare-playwright
+        run: |
+          # Playwright weights are keyed by spec file path and aren't diffed by
+          # compare_test_weights.py (pytest-only). Trigger a PR whenever the file changed at
+          # all, so its refresh isn't gated on the pytest 5% threshold.
+          if ! cmp -s ./weights-backup/playwright_weights.json e2e-test/ui/playwright/playwright_test_weights.json; then
+            echo "create_pr_playwright=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright weights changed. Will create PR."
+            {
+              echo ""
+              echo "- Playwright test weights (\`e2e-test/ui/playwright/playwright_test_weights.json\`) refreshed."
+            } > ./pr-body-playwright.md
+          else
+            echo "create_pr_playwright=false" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright weights unchanged. No PR needed."
+          fi
+
       - name: Decide PR creation
         id: decide
         run: |
-          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
+          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ] || [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
             echo "create_pr=true" >> "$GITHUB_OUTPUT"
             echo "✓ At least one suite exceeded the 5% threshold. Will create PR."
           else
@@ -199,6 +235,7 @@ jobs:
           git add smoke-test/pytest_test_weights.json
           git add metadata-ingestion/tests/integration_test_weights.json
           git add .github/backend_test_weights.json
+          git add e2e-test/ui/playwright/playwright_test_weights.json
 
           git commit -m "chore(test): update test weights from recent CI runs
 
@@ -221,7 +258,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Concatenate whichever PR body sections were generated (empty files contribute nothing)
-          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md 2>/dev/null)
+          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md ./pr-body-playwright.md 2>/dev/null)
 
           # Create PR (gh pr create prints the PR URL to stdout)
           PR_URL=$(gh pr create \
@@ -254,6 +291,9 @@ jobs:
               fi
               if [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
                 echo "- gradle (backend)"
+              fi
+              if [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
+                echo "- playwright"
               fi
             else
               echo "ℹ️ **No PR Created**: Changes below 5% threshold"

--- a/e2e-test/ui/playwright/playwright_test_weights.json
+++ b/e2e-test/ui/playwright/playwright_test_weights.json
@@ -1,0 +1,358 @@
+[
+  {
+    "filePath": "analytics/analytics.spec.ts",
+    "duration": "22.898s"
+  },
+  {
+    "filePath": "application/application-management.spec.ts",
+    "duration": "25.639s"
+  },
+  {
+    "filePath": "application/application-sidebar.spec.ts",
+    "duration": "50.694s"
+  },
+  {
+    "filePath": "auth/login-with-welcome-modal.spec.ts",
+    "duration": "8.260s"
+  },
+  {
+    "filePath": "auth/login.spec.ts",
+    "duration": "19.176s"
+  },
+  {
+    "filePath": "autocomplete-v2/autocomplete.spec.ts",
+    "duration": "27.957s"
+  },
+  {
+    "filePath": "browse-v2/browse-v2.spec.ts",
+    "duration": "85.303s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute-navigation.spec.ts",
+    "duration": "0.209s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute.spec.ts",
+    "duration": "0.564s"
+  },
+  {
+    "filePath": "business-attributes/check-feature-flag.spec.ts",
+    "duration": "0.089s"
+  },
+  {
+    "filePath": "change-history/change-history.spec.ts",
+    "duration": "134.812s"
+  },
+  {
+    "filePath": "containers-v2/v2-containers.spec.ts",
+    "duration": "5.302s"
+  },
+  {
+    "filePath": "documents/document-import.spec.ts",
+    "duration": "14.346s"
+  },
+  {
+    "filePath": "documents/document-management.spec.ts",
+    "duration": "255.744s"
+  },
+  {
+    "filePath": "documents/document-tree-expand.spec.ts",
+    "duration": "50.356s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-advanced.spec.ts",
+    "duration": "33.812s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-core.spec.ts",
+    "duration": "28.047s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-summary.spec.ts",
+    "duration": "19.591s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-about-section.spec.ts",
+    "duration": "20.346s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-data-product.spec.ts",
+    "duration": "4.841s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-domain.spec.ts",
+    "duration": "5.299s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-node.spec.ts",
+    "duration": "4.781s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-term.spec.ts",
+    "duration": "5.024s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-navigation.spec.ts",
+    "duration": "60.362s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-node-tags.spec.ts",
+    "duration": "11.468s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term-tags.spec.ts",
+    "duration": "15.476s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term.spec.ts",
+    "duration": "17.498s"
+  },
+  {
+    "filePath": "glossary/v2-glossary.spec.ts",
+    "duration": "104.366s"
+  },
+  {
+    "filePath": "home-v2/v2-home.spec.ts",
+    "duration": "4.092s"
+  },
+  {
+    "filePath": "home/homepage-collection-view-all.spec.ts",
+    "duration": "9.003s"
+  },
+  {
+    "filePath": "home/homepage-modules.spec.ts",
+    "duration": "42.231s"
+  },
+  {
+    "filePath": "home/homepage-templates.spec.ts",
+    "duration": "7.452s"
+  },
+  {
+    "filePath": "home/homepage-visibility.spec.ts",
+    "duration": "7.308s"
+  },
+  {
+    "filePath": "incidents-v2/v2-incidents.spec.ts",
+    "duration": "30.166s"
+  },
+  {
+    "filePath": "ingestion-v2/odcs-source.spec.ts",
+    "duration": "9.487s"
+  },
+  {
+    "filePath": "ingestion-v2/run-history.spec.ts",
+    "duration": "17.175s"
+  },
+  {
+    "filePath": "ingestion-v2/secrets-tab.spec.ts",
+    "duration": "45.996s"
+  },
+  {
+    "filePath": "ingestion-v2/sources.spec.ts",
+    "duration": "59.854s"
+  },
+  {
+    "filePath": "ingestion-v3/run-history.spec.ts",
+    "duration": "22.157s"
+  },
+  {
+    "filePath": "ingestion-v3/secrets-tab.spec.ts",
+    "duration": "44.834s"
+  },
+  {
+    "filePath": "ingestion-v3/sources.spec.ts",
+    "duration": "56.406s"
+  },
+  {
+    "filePath": "lineage-v3/v3-download-lineage-results.spec.ts",
+    "duration": "13.362s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-level.spec.ts",
+    "duration": "9.356s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-path.spec.ts",
+    "duration": "22.953s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-graph.spec.ts",
+    "duration": "89.433s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-impact-analysis.spec.ts",
+    "duration": "104.879s"
+  },
+  {
+    "filePath": "login-v2/v2-login.spec.ts",
+    "duration": "8.994s"
+  },
+  {
+    "filePath": "manage-tags/assign-unassign-tags.spec.ts",
+    "duration": "16.791s"
+  },
+  {
+    "filePath": "manage-tags/create-edit-remove-tags.spec.ts",
+    "duration": "11.222s"
+  },
+  {
+    "filePath": "manage-tags/search-filter-tags.spec.ts",
+    "duration": "21.308s"
+  },
+  {
+    "filePath": "mfeframework/valid-config-mfe.spec.ts",
+    "duration": "15.533s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-experiment.spec.ts",
+    "duration": "18.669s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-mlflow.spec.ts",
+    "duration": "21.360s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-sagemaker.spec.ts",
+    "duration": "6.630s"
+  },
+  {
+    "filePath": "mutations-v2/v2-domains.spec.ts",
+    "duration": "55.585s"
+  },
+  {
+    "filePath": "mutations-v2/v2-edit-documentation.spec.ts",
+    "duration": "56.546s"
+  },
+  {
+    "filePath": "mutations/dataset-health.spec.ts",
+    "duration": "5.406s"
+  },
+  {
+    "filePath": "mutations/edit-documentation.spec.ts",
+    "duration": "12.141s"
+  },
+  {
+    "filePath": "navbar/navbar.spec.ts",
+    "duration": "23.003s"
+  },
+  {
+    "filePath": "nested-column-stats/nested-column-stats.spec.ts",
+    "duration": "13.448s"
+  },
+  {
+    "filePath": "onboarding/welcome-modal.spec.ts",
+    "duration": "192.936s"
+  },
+  {
+    "filePath": "ownership-v2/v2-manage-ownership.spec.ts",
+    "duration": "13.358s"
+  },
+  {
+    "filePath": "quality/assertion-list.spec.ts",
+    "duration": "8.086s"
+  },
+  {
+    "filePath": "schema-blame/schema-blame.spec.ts",
+    "duration": "10.656s"
+  },
+  {
+    "filePath": "search/query-and-filter-search.spec.ts",
+    "duration": "92.107s"
+  },
+  {
+    "filePath": "search/search-filters.spec.ts",
+    "duration": "42.818s"
+  },
+  {
+    "filePath": "search/search-within-operator.spec.ts",
+    "duration": "15.025s"
+  },
+  {
+    "filePath": "search/search.spec.ts",
+    "duration": "61.694s"
+  },
+  {
+    "filePath": "search/searchv2.spec.ts",
+    "duration": "71.033s"
+  },
+  {
+    "filePath": "settings-v2/v2-home-page-posts.spec.ts",
+    "duration": "56.424s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-access-tokens.spec.ts",
+    "duration": "9.359s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-policies.spec.ts",
+    "duration": "62.260s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-service-accounts.spec.ts",
+    "duration": "18.516s"
+  },
+  {
+    "filePath": "settings-v2/v2-managing-groups.spec.ts",
+    "duration": "81.543s"
+  },
+  {
+    "filePath": "siblings-v2/siblings.spec.ts",
+    "duration": "30.395s"
+  },
+  {
+    "filePath": "stats-v2/v2-change-history.spec.ts",
+    "duration": "53.096s"
+  },
+  {
+    "filePath": "stats-v2/v2-charts.spec.ts",
+    "duration": "45.847s"
+  },
+  {
+    "filePath": "stats-v2/v2-column-stats.spec.ts",
+    "duration": "9.254s"
+  },
+  {
+    "filePath": "stats-v2/v2-highlights.spec.ts",
+    "duration": "7.856s"
+  },
+  {
+    "filePath": "stats-v2/v2-stats-tab.spec.ts",
+    "duration": "20.798s"
+  },
+  {
+    "filePath": "structured-properties/entity-level.spec.ts",
+    "duration": "50.908s"
+  },
+  {
+    "filePath": "structured-properties/schema-field.spec.ts",
+    "duration": "57.214s"
+  },
+  {
+    "filePath": "structured-properties/structured-properties.spec.ts",
+    "duration": "16.991s"
+  },
+  {
+    "filePath": "structured-properties/structured-props-drawer-font.spec.ts",
+    "duration": "8.149s"
+  },
+  {
+    "filePath": "task-runs-v2/task-runs.spec.ts",
+    "duration": "10.401s"
+  },
+  {
+    "filePath": "upload-files/upload-files.spec.ts",
+    "duration": "49.401s"
+  },
+  {
+    "filePath": "views/v2-manage-views.spec.ts",
+    "duration": "8.428s"
+  },
+  {
+    "filePath": "views/v2-view-select.spec.ts",
+    "duration": "20.105s"
+  },
+  {
+    "filePath": "views/v2-view-within-operator.spec.ts",
+    "duration": "10.654s"
+  }
+]

--- a/e2e-test/ui/playwright/playwright_test_weights.json
+++ b/e2e-test/ui/playwright/playwright_test_weights.json
@@ -13,7 +13,7 @@
   },
   {
     "filePath": "auth/login-with-welcome-modal.spec.ts",
-    "duration": "8.260s"
+    "duration": "16.305s"
   },
   {
     "filePath": "auth/login.spec.ts",
@@ -41,7 +41,7 @@
   },
   {
     "filePath": "change-history/change-history.spec.ts",
-    "duration": "134.812s"
+    "duration": "270.137s"
   },
   {
     "filePath": "containers-v2/v2-containers.spec.ts",
@@ -141,7 +141,7 @@
   },
   {
     "filePath": "ingestion-v2/run-history.spec.ts",
-    "duration": "17.175s"
+    "duration": "31.733s"
   },
   {
     "filePath": "ingestion-v2/secrets-tab.spec.ts",
@@ -273,7 +273,7 @@
   },
   {
     "filePath": "search/searchv2.spec.ts",
-    "duration": "71.033s"
+    "duration": "132.882s"
   },
   {
     "filePath": "settings-v2/v2-home-page-posts.spec.ts",


### PR DESCRIPTION
## Summary

Replaces `--shard=N/M` count-based sharding for Playwright CI with duration-balanced
bin-packing of individual spec files ("Option C"), the durable fix following the
`ci/rebalance-playwright-shards` stopgap (#19135). Mirrors the pattern already proven for
Gradle backend test sharding (`split_gradle_tests.py` / `backend_test_weights.json`).

On the 8-shard `docker-unified.yml` Playwright run, shards 5-8 currently run ~2x longer than
shards 1-4 (measured: 613s vs 229s of summed test-time on one sampled run; ideal is
~393s/shard across 3142s total / 94 spec files) because `--shard=N/M` balances by raw test
*count*, with no notion of duration. Full analysis:
`e2e-test/ui/playwright/docs/audit-reports/shard-rebalancing-analysis-2026-08-12.md`.

- `generate_test_weights.py`: new `parse_playwright_results()` + `--playwright-output`,
  mirroring the existing Cypress/Pytest/Gradle parsers. Playwright's junit.xml is flat --
  one `<testsuite name="path/to/file.spec.ts" time="22.9">` per spec file -- so no root-suite
  unwrapping is needed. Wired into `update-test-weights.yml`'s weekly cron so weights
  self-refresh with no manual re-tagging ever again.
- `split_playwright_tests.py`: new script adapting `split_gradle_tests.py`'s LPT `bin_pack()`
  almost verbatim, swapped from whole-module to individual-`*.spec.ts`-file granularity.
  File-level args bypass Playwright's `fullyParallel` worker-hash grouping (keyed off
  `featureName`, used inconsistently across files, not path) entirely, so duration data
  actually controls shard placement -- unlike `--shard=N/M`.
- `resusable-playwright-tests.yml`: the "Run Playwright tests" step now computes its shard's
  spec file list via the split script instead of `--shard`, and sets
  `PLAYWRIGHT_BLOB_OUTPUT_FILE` explicitly (the blob reporter's default filename only gets a
  shard suffix when `--shard` is set -- without it, all 8 shards would collide on the same
  blob filename when merged).
- Also fixes a real bug found while bootstrapping weights: `download_test_artifacts.sh`
  dumped every non-pytest/cypress artifact into a shared `other/` subdirectory, so the 8
  `playwright-junit-N` artifacts per run overwrote each other's same-named `junit.xml`,
  silently keeping only 1/8 shards' data.
- Bootstraps `playwright_test_weights.json` from 5 recent `docker-unified.yml` runs so this
  PR isn't merging with an empty/fallback weights file.
- A follow-up fix while iterating on this PR: `parse_playwright_results()` wasn't summing a
  spec file's duration across shards when Playwright's old `--shard` mechanism split that
  file's tests across two shards in the same run, silently halving the weight of the affected
  files (4 of them in the bootstrap data). Fixed by grouping per run before medianing, mirroring
  `parse_gradle_results()`'s existing per-class-per-run summing. Also addressed both issues
  from cubic's review (missing `math.isfinite()` guard, now shared + extended to all four
  parsers; the PR-body `cat` step's crash-on-missing-optional-file bug in `update-test-weights.yml`).

Once this is confirmed green, the `ci/rebalance-playwright-shards` stopgap (g1-g8 directory
prefixes + `shardGroup` tag, #19135) becomes unnecessary and can be reverted in a follow-up.

## Results

Measured directly from `junit.xml` per-shard summed test-time (same method
`generate_test_weights.py` uses), comparing 5 recent `master` runs on the old `--shard=N/M`
sharding against this PR's own CI runs. All numbers below are on the same
`workers_per_shard=2` baseline (from #19081, unrelated to this PR), so the sharding method is
the only variable:

| | min shard | max shard (bottleneck) | spread (max/min) | tests |
|---|---|---|---|---|
| `master` (avg of 5 runs, old `--shard=N/M`) | 246.5s | 692.7s | ~2.81x | -- |
| This PR, run [31583560254](https://github.com/datahub-project/datahub/actions/runs/31583560254) (pre weight-bug-fix) | 345.9s | 504.6s | 1.46x | 408, 0 failures |
| This PR, run [31589319275](https://github.com/datahub-project/datahub/actions/runs/31589319275) (post weight-bug-fix) | 361.1s | 433.9s | 1.20x | 408, 0 failures |
| **This PR, run [31592290855](https://github.com/datahub-project/datahub/actions/runs/31592290855)** (final, post cubic fixes/refactor) | **376.3s** | **426.1s** | **1.13x** | 408, 0 failures |

**Bottleneck shard (the one that actually gates the Playwright stage's wall clock, since all 8
run in parallel) is down from a 692.7s master average to 426.1s -- a ~38.5% reduction.** Shard
spread narrowed from ~2.8x to 1.13x. All three CI runs on this PR passed the full 408-test
suite with 0 failures, confirming duration-based packing doesn't silently drop or skip tests.

The progression across the three runs above (1.46x -> 1.20x -> 1.13x) also isolates the real
effect of fixing the weight-halving bug: correcting the 4 underweighted files' weights measurably
improved live shard balance, not just the local dry-run projection.

## Test plan

- [x] Fixed `download_test_artifacts.sh`'s artifact-routing bug (all 8 shards' junit.xml were
      overwriting each other) and re-verified the bootstrap harvest picks up all 8 shards x 5
      runs (40 junit.xml files).
- [x] Bootstrapped `playwright_test_weights.json` from real CI data (89/94 current spec files
      weighted).
- [x] Found and fixed a second weight-accuracy bug (per-run summing for files split across
      shards by the old `--shard` mechanism) and confirmed it measurably improved the live
      balance (see Results).
- [x] Addressed both issues from cubic's review (finite-duration guard now shared across all
      four parsers; `update-test-weights.yml`'s PR-body concatenation no longer fails when an
      optional section is missing).
- [x] Dry-ran `split_playwright_tests.py` for all 8 shard indices locally: confirmed the 94
      spec files are assigned exactly once across shards (no gaps, no overlaps, verified via
      diff against the actual `find tests -name '*.spec.ts'` listing).
- [x] `npx tsc --noEmit` clean in `e2e-test/ui/playwright`.
- [x] `./gradlew :e2e-test:ui:playwright:lintFix` clean (0 errors; pre-existing warnings only,
      unrelated to this change).
- [x] `./gradlew :datahub-web-react:githubActionsPrettierCheck` clean.
- [x] Confirmed on real CI: all 8 Playwright shards green across three separate runs on this
      PR (408/408 tests, 0 failures each time), with the measured duration spread matching the
      Results section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Playwright CI from count-based `--shard=N/M` to duration-balanced bin-packing of spec files to even shard runtimes. Adds weekly auto-refresh of Playwright test weights and refactors JUnit parsing for safer, consistent weight generation.

- **New Features**
  - Duration-based bin-packing of spec files via `.github/scripts/split_playwright_tests.py`; workflow now passes explicit file args instead of `--shard`.
  - Playwright JUnit parsing in `.github/scripts/generate_test_weights.py` and weekly refresh in `update-test-weights.yml`; committed weights at `e2e-test/ui/playwright/playwright_test_weights.json`.
  - Set `PLAYWRIGHT_BLOB_OUTPUT_FILE` per shard to avoid blob filename collisions during report merge.

- **Bug Fixes**
  - `.github/scripts/generate_test_weights.py`: sum each spec’s duration across all shard JUnit files within a run; extracted shared XML parsing helpers and extended finite/negative duration guards to Cypress and Pytest for consistency; regenerated `playwright_test_weights.json`.
  - `.github/scripts/download_test_artifacts.sh`: route `playwright-junit-{shard}` artifacts into per-shard folders to prevent `junit.xml` overwrites.
  - `update-test-weights.yml`: make PR body concatenation resilient when optional files are missing to avoid job failures.

<sup>Written for commit 6cd4d8e32975f70f91bb29a6f46bf1aaafe15111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
