### PR TITLE
ci(playwright): seed all feature fixture data globally per shard in CI

### DIFF
--- a/.github/scripts/download_test_artifacts.sh
+++ b/.github/scripts/download_test_artifacts.sh
@@ -316,6 +316,11 @@ for run_id in "${RUN_ID_ARRAY[@]}"; do
             else
                 artifact_subdir="$RUN_DIR/cypress-0"
             fi
+        elif [[ $artifact_name =~ ^playwright-junit-([0-9]+)$ ]]; then
+            # Each shard's artifact contains a same-named test-results/junit.xml; without a
+            # per-shard subdirectory here, every shard after the first overwrites the last
+            # extracted into the shared "other" dir, silently dropping 7/8 shards' data.
+            artifact_subdir="$RUN_DIR/playwright-${BASH_REMATCH[1]}"
         else
             artifact_subdir="$RUN_DIR/other"
         fi

--- a/.github/scripts/generate_test_weights.py
+++ b/.github/scripts/generate_test_weights.py
@@ -188,6 +188,46 @@ def parse_gradle_results(artifact_dir: Path) -> Dict[str, List[float]]:
     return test_durations
 
 
+def parse_playwright_results(artifact_dir: Path) -> Dict[str, List[float]]:
+    """
+    Parse Playwright JUnit XML files from multiple runs.
+
+    Playwright's junit reporter emits one flat <testsuite name="path/to/file.spec.ts"
+    time="22.9"> per spec file, relative to testDir -- no nested root suite to unwrap
+    (unlike Cypress).
+
+    Returns:
+        Dictionary mapping spec file paths to lists of durations across runs
+        Example: {"analytics/analytics.spec.ts": [22.9, 21.4, 23.1]}
+    """
+    test_durations: Dict[str, List[float]] = {}
+
+    xml_files = list(artifact_dir.rglob("junit.xml"))
+    print(f"Found {len(xml_files)} Playwright XML files")
+
+    for xml_file in xml_files:
+        try:
+            root = ET.parse(xml_file).getroot()
+            for testsuite in root.findall(".//testsuite"):
+                file_path = testsuite.get("name", "")
+                time_str = testsuite.get("time", "0")
+                if not file_path:
+                    continue
+                try:
+                    duration = float(time_str)
+                except ValueError:
+                    print(f"Warning: Invalid duration '{time_str}' in {xml_file}")
+                    continue
+                if duration > 0:
+                    test_durations.setdefault(file_path, []).append(duration)
+        except ET.ParseError as e:
+            print(f"Warning: Failed to parse {xml_file}: {e}")
+        except Exception as e:
+            print(f"Warning: Error processing {xml_file}: {e}")
+
+    return test_durations
+
+
 def calculate_median_weights(
     test_durations: Dict[str, List[float]], key_name: str = "filePath"
 ) -> List[Dict]:
@@ -245,11 +285,24 @@ def main():
         required=False,
         help="Output path for Gradle test weights JSON (keyed by FQCN)",
     )
+    parser.add_argument(
+        "--playwright-output",
+        type=Path,
+        required=False,
+        help="Output path for Playwright test weights JSON (keyed by spec file path)",
+    )
 
     args = parser.parse_args()
 
-    if not (args.pytest_output or args.cypress_output or args.gradle_output):
-        parser.error("at least one of --pytest-output/--cypress-output/--gradle-output is required")
+    if not (
+        args.pytest_output
+        or args.cypress_output
+        or args.gradle_output
+        or args.playwright_output
+    ):
+        parser.error(
+            "at least one of --pytest-output/--cypress-output/--gradle-output/--playwright-output is required"
+        )
 
     if not args.input_dir.exists():
         print(f"Error: Input directory does not exist: {args.input_dir}")
@@ -279,6 +332,14 @@ def main():
         gradle_durations = parse_gradle_results(args.input_dir)
         print(f"Found {len(gradle_durations)} unique Gradle tests")
 
+    playwright_durations = {}
+    if args.playwright_output:
+        print("\n" + "=" * 60)
+        print("Parsing Playwright test results...")
+        print("=" * 60)
+        playwright_durations = parse_playwright_results(args.input_dir)
+        print(f"Found {len(playwright_durations)} unique Playwright spec files")
+
     print("\n" + "=" * 60)
     print("Calculating median weights...")
     print("=" * 60)
@@ -298,6 +359,11 @@ def main():
         if args.gradle_output
         else []
     )
+    playwright_weights = (
+        calculate_median_weights(playwright_durations, key_name="filePath")
+        if args.playwright_output
+        else []
+    )
 
     # Write output files
     print("\n" + "=" * 60)
@@ -308,6 +374,7 @@ def main():
         (args.cypress_output, cypress_weights, "Cypress"),
         (args.pytest_output, pytest_weights, "Pytest"),
         (args.gradle_output, gradle_weights, "Gradle"),
+        (args.playwright_output, playwright_weights, "Playwright"),
     ):
         if output_path is None:
             continue

--- a/.github/scripts/split_playwright_tests.py
+++ b/.github/scripts/split_playwright_tests.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Assign individual Playwright spec files to one CI shard, balanced by historical duration.
+
+Vendored + stdlib-only (py3.9+), mirrors split_gradle_tests.py's LPT bin-packing. Reads a
+committed weights snapshot (playwright_test_weights.json, spec-file-path -> median seconds
+from generate_test_weights.py) and bin-packs individual *.spec.ts files across shards. Run
+from / pass the Playwright project root (e2e-test/ui/playwright) so paths resolve correctly.
+
+File-level by design: explicit file args passed to `playwright test` bypass Playwright's
+fullyParallel worker-hash grouping entirely, so per-file duration balancing actually controls
+shard placement (unlike `--shard=N/M`, which balances by test count only). Falls back to an
+even split when no weights exist.
+
+Emits a JSON plan on stdout; with --output-args FILE, also writes spec file paths one-per-line
+for `mapfile -t ARGS < FILE; npx playwright test "${ARGS[@]}"`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+
+
+def _canonical(path: str) -> str:
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _resolve_glob(pattern: str, repo_root: str) -> str:
+    return pattern if os.path.isabs(pattern) else os.path.join(repo_root, pattern)
+
+
+def _relative_to_test_dir(path: str, test_dir: str) -> str | None:
+    rel = os.path.relpath(os.path.abspath(path), test_dir)
+    if rel == ".." or rel.startswith(".." + os.sep):
+        return None
+    return rel.replace(os.sep, "/")
+
+
+def discover_spec_files(glob_pattern: str, exclude_globs: list[str], test_dir: str) -> list[str]:
+    """Spec file paths relative to test_dir, matching the junit reporter's testsuite name."""
+    excluded = {
+        _canonical(p)
+        for pattern in exclude_globs
+        for p in glob.glob(_resolve_glob(pattern, test_dir), recursive=True)
+    }
+    specs = []
+    for path in glob.glob(_resolve_glob(glob_pattern, test_dir), recursive=True):
+        if not os.path.isfile(path) or _canonical(path) in excluded:
+            continue
+        rel = _relative_to_test_dir(path, test_dir)
+        if rel is not None:
+            specs.append(rel)
+    return specs
+
+
+def load_weights(weights_path: str | None) -> dict[str, float]:
+    if not weights_path or not os.path.isfile(weights_path):
+        return {}
+    try:
+        with open(weights_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return {}
+    weights: dict[str, float] = {}
+    for item in data:
+        file_path = item.get("filePath")
+        duration = item.get("duration", "")
+        if not file_path or not isinstance(duration, str) or not duration.endswith("s"):
+            continue
+        try:
+            weights[file_path] = float(duration[:-1])
+        except ValueError:
+            continue
+    return weights
+
+
+def spec_weights(specs: list[str], weights: dict[str, float]) -> dict[str, float]:
+    known = [weights[s] for s in specs if s in weights]
+    fallback = statistics.median(known) if known else 1.0
+    return {spec: weights.get(spec, fallback) for spec in specs}
+
+
+def bin_pack(weighted: dict[str, float], total: int) -> list[list[str]]:
+    """LPT: heaviest spec file into the currently-lightest shard. Deterministic tiebreak by name."""
+    buckets: list[list[str]] = [[] for _ in range(total)]
+    load = [0.0] * total
+    for spec in sorted(weighted, key=lambda p: (-weighted[p], p)):
+        target = min(range(total), key=lambda b: load[b])
+        buckets[target].append(spec)
+        load[target] += weighted[spec]
+    return buckets
+
+
+def plan_for_shard(specs: list[str], weighted: dict[str, float]) -> dict:
+    return {
+        "hasTests": bool(specs),
+        "specs": sorted(specs),
+        "diagnostics": {
+            "specFiles": len(specs),
+            "predictedSeconds": round(sum(weighted.get(s, 0.0) for s in specs), 1),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Assign individual Playwright spec files to one shard.")
+    parser.add_argument("--split-index", "-i", type=int, required=True)
+    parser.add_argument("--split-total", "-t", type=int, required=True)
+    parser.add_argument("--glob", "-g", default="**/*.spec.ts")
+    parser.add_argument("--exclude-glob", "-e", action="append", default=[])
+    parser.add_argument("--weights", help="Path to committed playwright_test_weights.json.")
+    parser.add_argument("--test-dir", default="tests", help="Playwright testDir (relative to --repo-root).")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-args", help="Write spec file paths one-per-line to this file.")
+    args = parser.parse_args()
+
+    if args.split_total < 1:
+        parser.error("--split-total must be >= 1")
+    if not (0 <= args.split_index < args.split_total):
+        parser.error("--split-index must be in [0, --split-total)")
+    repo_root = os.path.abspath(args.repo_root)
+    test_dir = os.path.join(repo_root, args.test_dir)
+
+    specs = discover_spec_files(args.glob, args.exclude_glob, test_dir)
+    if not specs:
+        print("split_playwright_tests: no spec files matched", file=sys.stderr)
+
+    weights = load_weights(args.weights)
+    weighted = spec_weights(specs, weights)
+    buckets = bin_pack(weighted, args.split_total)
+    plan = plan_for_shard(buckets[args.split_index], weighted)
+
+    matched = sum(1 for s in specs if s in weights)
+    mode = "duration-balanced" if weights else "even fallback"
+    d = plan["diagnostics"]
+    print(
+        f"split_playwright_tests: {len(specs)} spec files "
+        f"({matched} weighted, {mode}); shard {args.split_index}/{args.split_total} -> "
+        f"{d['specFiles']} files, predicted {d['predictedSeconds']}s",
+        file=sys.stderr,
+    )
+
+    if args.output_args is not None:
+        with open(args.output_args, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(plan["specs"]))
+    print(json.dumps(plan))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -167,19 +167,42 @@ jobs:
           yarn install --frozen-lockfile
           npx playwright install --with-deps chromium
 
+      - name: Compute this shard's spec files
+        # Individual spec-file args bypass Playwright's fullyParallel worker-hash grouping
+        # (keyed off featureName, used inconsistently across files, not path) entirely, so
+        # duration-balanced file assignment actually controls shard placement here --
+        # --shard=N/M only balances by raw test count.
+        env:
+          SHARD: ${{ inputs.shard }}
+          SHARD_COUNT: ${{ inputs.shard_count }}
+        run: |
+          python3 .github/scripts/split_playwright_tests.py \
+            --split-index "$((SHARD - 1))" --split-total "$SHARD_COUNT" \
+            --repo-root . \
+            --test-dir e2e-test/ui/playwright/tests \
+            --weights e2e-test/ui/playwright/playwright_test_weights.json \
+            --output-args e2e-test/ui/playwright/shard-files.txt
+
       - name: Run Playwright tests
         working-directory: e2e-test/ui/playwright
         env:
           BASE_URL: "http://localhost:9002"
           PLAYWRIGHT_REUSE_SERVER: "1"
-          SHARD: ${{ inputs.shard }}
-          SHARD_COUNT: ${{ inputs.shard_count }}
           WORKERS_PER_SHARD: ${{ inputs.workers_per_shard }}
+          # Blob reporter's default output filename (report.zip) only gets a shard suffix
+          # when --shard is set (see playwright/lib/runner/index.js _defaultReportName). We
+          # no longer pass --shard, so every shard job would collide on the same filename
+          # once reusable-playwright-report.yml flattens blobs into one directory to merge
+          # them -- set this explicitly instead.
+          PLAYWRIGHT_BLOB_OUTPUT_FILE: blob-report/report-${{ inputs.shard }}.zip
         run: |
-          echo "Running Playwright shard $SHARD/$SHARD_COUNT at $WORKERS_PER_SHARD worker(s)"
-          npx playwright test \
-            --shard="$SHARD/$SHARD_COUNT" \
-            --workers="$WORKERS_PER_SHARD"
+          mapfile -t ARGS < shard-files.txt
+          if [ "${#ARGS[@]}" -eq 0 ]; then
+            echo "No spec files assigned to shard ${{ inputs.shard }}/${{ inputs.shard_count }} — skipping."
+            exit 0
+          fi
+          echo "Running Playwright shard ${{ inputs.shard }}/${{ inputs.shard_count }} (${#ARGS[@]} spec files) at $WORKERS_PER_SHARD worker(s)"
+          npx playwright test "${ARGS[@]}" --workers="$WORKERS_PER_SHARD"
 
       - name: Upload Playwright blob report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/update-test-weights.yml
+++ b/.github/workflows/update-test-weights.yml
@@ -62,6 +62,15 @@ jobs:
             --workflow build-and-test.yml \
             --artifact-prefix "build-and-test" \
             --repository ${{ github.repository }}
+
+          echo "Downloading Playwright JUnit artifacts from recent docker-unified runs..."
+          # Named playwright-junit-{shard} by resusable-playwright-tests.yml.
+          bash .github/scripts/download_test_artifacts.sh \
+            --output-dir ./test-artifacts-playwright \
+            --run-count ${{ github.event.inputs.run_count || '3' }} \
+            --workflow docker-unified.yml \
+            --artifact-prefix "playwright-junit" \
+            --repository ${{ github.repository }}
       - name: Download ingestion test artifacts
         id: download-ingestion
         env:
@@ -91,6 +100,8 @@ jobs:
           cp metadata-ingestion/tests/integration_test_weights.json \
             ./weights-backup/integration_test_weights.json || echo "No existing integration weights"
           cp .github/backend_test_weights.json ./weights-backup/gradle_weights.json || echo "No existing Gradle weights"
+          cp e2e-test/ui/playwright/playwright_test_weights.json \
+            ./weights-backup/playwright_weights.json || echo "No existing Playwright weights"
 
       - name: Generate smoke test weights
         run: |
@@ -113,6 +124,13 @@ jobs:
           python .github/scripts/generate_test_weights.py \
             --input-dir ./test-artifacts-gradle \
             --gradle-output .github/backend_test_weights.json
+
+      - name: Generate playwright test weights
+        run: |
+          echo "Generating Playwright weights (keyed by spec file path)..."
+          python .github/scripts/generate_test_weights.py \
+            --input-dir ./test-artifacts-playwright \
+            --playwright-output e2e-test/ui/playwright/playwright_test_weights.json
 
       - name: Compare smoke weights
         id: compare-smoke
@@ -173,10 +191,28 @@ jobs:
             echo "✓ Gradle backend weights unchanged. No PR needed."
           fi
 
+      - name: Compare playwright weights
+        id: compare-playwright
+        run: |
+          # Playwright weights are keyed by spec file path and aren't diffed by
+          # compare_test_weights.py (pytest-only). Trigger a PR whenever the file changed at
+          # all, so its refresh isn't gated on the pytest 5% threshold.
+          if ! cmp -s ./weights-backup/playwright_weights.json e2e-test/ui/playwright/playwright_test_weights.json; then
+            echo "create_pr_playwright=true" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright weights changed. Will create PR."
+            {
+              echo ""
+              echo "- Playwright test weights (\`e2e-test/ui/playwright/playwright_test_weights.json\`) refreshed."
+            } > ./pr-body-playwright.md
+          else
+            echo "create_pr_playwright=false" >> "$GITHUB_OUTPUT"
+            echo "✓ Playwright weights unchanged. No PR needed."
+          fi
+
       - name: Decide PR creation
         id: decide
         run: |
-          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
+          if [ "${{ steps.compare-smoke.outputs.create_pr_smoke }}" == "true" ] || [ "${{ steps.compare-ingestion.outputs.create_pr_ingestion }}" == "true" ] || [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ] || [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
             echo "create_pr=true" >> "$GITHUB_OUTPUT"
             echo "✓ At least one suite exceeded the 5% threshold. Will create PR."
           else
@@ -199,6 +235,7 @@ jobs:
           git add smoke-test/pytest_test_weights.json
           git add metadata-ingestion/tests/integration_test_weights.json
           git add .github/backend_test_weights.json
+          git add e2e-test/ui/playwright/playwright_test_weights.json
 
           git commit -m "chore(test): update test weights from recent CI runs
 
@@ -221,7 +258,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Concatenate whichever PR body sections were generated (empty files contribute nothing)
-          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md 2>/dev/null)
+          PR_BODY=$(cat ./pr-body-smoke.md ./pr-body-ingestion.md ./pr-body-gradle.md ./pr-body-playwright.md 2>/dev/null)
 
           # Create PR (gh pr create prints the PR URL to stdout)
           PR_URL=$(gh pr create \
@@ -254,6 +291,9 @@ jobs:
               fi
               if [ "${{ steps.compare-gradle.outputs.create_pr_gradle }}" == "true" ]; then
                 echo "- gradle (backend)"
+              fi
+              if [ "${{ steps.compare-playwright.outputs.create_pr_playwright }}" == "true" ]; then
+                echo "- playwright"
               fi
             else
               echo "ℹ️ **No PR Created**: Changes below 5% threshold"

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -38,8 +38,9 @@
  * over ~25 features would serialize 6+ minutes of pure waiting per shard,
  * making CI slower. Instead the batch path ingests every pending feature
  * back-to-back with NO per-feature wait (`ingestMcpsNoWait`), then performs
- * ONE 15s index wait for the whole batch, then writes all state files —
- * see `ingestMcps` vs. `ingestMcpsNoWait` below.
+ * ONE index wait for the whole batch (longer than the single-feature default —
+ * see `BATCH_INDEX_CATCH_UP_MS`), then writes all state files — see `ingestMcps`
+ * vs. `ingestMcpsNoWait` below.
  *
  * The whole batch is itself guarded by a single withArtifactLock keyed to a
  * `.seeded/_all-features.json` marker, so only one worker per shard performs
@@ -212,10 +213,21 @@ function dataFilePath(featureName: string): string {
   return path.join(TESTS_DIR, featureName, 'fixtures', 'data.json');
 }
 
-/** Wait for the search index to catch up. Shared by single-feature and batch ingestion. */
-async function waitForIndexCatchUp(logger: DataHubLogger): Promise<void> {
-  logger.info('waiting 15s for search index to catch up before marking seed complete');
-  await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
+/** Default wait for a single feature's (or global-data's) search/graph index catch-up. */
+const INDEX_CATCH_UP_MS = 15_000;
+/**
+ * CI batch seeds ~25 features' worth of MCPs (and their complex-aspects second pass) back
+ * to back in one burst, which backlogs the async MAE/graph-index pipeline more than the old
+ * one-feature-at-a-time pattern did — relationship edges (e.g. glossaryRelatedTerms) were
+ * observed lagging behind plain document search visibility under this load. Give the batch
+ * a longer wait rather than inflating the single-feature default used everywhere else.
+ */
+const BATCH_INDEX_CATCH_UP_MS = 30_000;
+
+/** Wait for the search/graph index to catch up. Shared by single-feature and batch ingestion. */
+async function waitForIndexCatchUp(logger: DataHubLogger, waitMs: number = INDEX_CATCH_UP_MS): Promise<void> {
+  logger.info(`waiting ${waitMs}ms for search index to catch up before marking seed complete`);
+  await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
 }
 
 /** Write the state file marking `featureName` as seeded. */
@@ -232,7 +244,7 @@ function writeSeedState(featureName: string, entityCount: number): void {
  * Ingest MCPs from a data file into the GMS, WITHOUT waiting for the search
  * index or writing the state file. Split out from `ingestMcps` so batch
  * seeding (`seedAllFeaturesForCi`) can ingest many features back-to-back and
- * pay the 15s index-catch-up wait exactly once for the whole batch, instead
+ * pay the index-catch-up wait exactly once for the whole batch, instead
  * of once per feature.
  *
  * @param throwOnFailure - When true (default), throws if any entity fails.
@@ -383,9 +395,9 @@ function discoverFeatureNames(): string[] {
  * single withArtifactLock so only one worker per shard performs it (see
  * module docstring for why CI needs this instead of per-feature lazy
  * seeding). Ingests every not-yet-seeded feature back-to-back with no
- * per-feature wait, pays the 15s search-index wait exactly once for the
- * whole batch, then writes each feature's state file before writing the
- * marker file itself.
+ * per-feature wait, pays the (longer, batch-sized) search/graph-index wait
+ * exactly once for the whole batch, then writes each feature's state file
+ * before writing the marker file itself.
  */
 async function seedAllFeaturesForCi(gmsToken: string, gmsBaseUrl: string, logger: DataHubLogger): Promise<void> {
   await withArtifactLock(ALL_FEATURES_MARKER_FILE, async () => {
@@ -403,7 +415,7 @@ async function seedAllFeaturesForCi(gmsToken: string, gmsBaseUrl: string, logger
         entityCounts.push([featureName, entityCount]);
       }
 
-      await waitForIndexCatchUp(logger);
+      await waitForIndexCatchUp(logger, BATCH_INDEX_CATCH_UP_MS);
 
       for (const [featureName, entityCount] of entityCounts) {
         writeSeedState(featureName, entityCount);
@@ -486,8 +498,8 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
     },
     // Local: worst case one worker produces token + global + one feature, each with
     // ingest + a 15s ES index wait under withArtifactLock. CI: worst case one worker
-    // also produces the full batch seed of every feature (one shared 15s wait, see
-    // seedAllFeaturesForCi) before its own feature's now-instant short-circuit.
+    // also produces the full batch seed of every feature (one shared, longer wait — see
+    // BATCH_INDEX_CATCH_UP_MS) before its own feature's now-instant short-circuit.
     { auto: true, scope: 'worker', timeout: SEED_TIMEOUT_MS },
   ],
 });

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -17,6 +17,38 @@
  * a given feature name, regardless of how many tests request it; across
  * workers sharing a filesystem, exactly one of them actually performs it.
  *
+ * ── Local vs. CI: two different seeding strategies ──────────────────────────
+ *
+ * Locally, the lazy per-feature strategy above is fast for a dev iterating on
+ * one feature: only the current suite's `featureName` gets ingested.
+ *
+ * In CI (`process.env.CI === 'true'`), Playwright's `fullyParallel` scheduler
+ * groups tests onto workers by a hash of worker-scoped options — including
+ * `featureName`, which is set inconsistently across spec files — and shard
+ * assignment is now done per spec file (duration-based bin-packing) rather
+ * than by feature directory. That means a shard/worker can no longer assume
+ * "if a test doesn't declare featureName X, X's data was never needed here":
+ * a test can end up depending on another feature's fixture data purely by
+ * shard placement. So in CI, before the per-feature check above runs, a
+ * worker seeds EVERY feature's `tests/{featureName}/fixtures/data.json` up front —
+ * data locality no longer depends on which shard/worker a test lands on.
+ * See `seedAllFeaturesForCi`.
+ *
+ * Naively looping "ingest feature → wait 15s for the index → write state"
+ * over ~25 features would serialize 6+ minutes of pure waiting per shard,
+ * making CI slower. Instead the batch path ingests every pending feature
+ * back-to-back with NO per-feature wait (`ingestMcpsNoWait`), then performs
+ * ONE 15s index wait for the whole batch, then writes all state files —
+ * see `ingestMcps` vs. `ingestMcpsNoWait` below.
+ *
+ * The whole batch is itself guarded by a single withArtifactLock keyed to a
+ * `.seeded/_all-features.json` marker, so only one worker per shard performs
+ * it; siblings under `workers_per_shard > 1` poll for the marker instead of
+ * duplicating the batch. After the batch, the normal per-feature
+ * `withArtifactLock(stateFile, ...)` check still runs unconditionally — for a
+ * suite that also declares `featureName`, that state file was already
+ * written by the batch, so it short-circuits immediately at no extra cost.
+ *
  * NOTE: This fixture is intentionally worker-scoped.  Worker-scoped fixtures
  * cannot depend on test-scoped fixtures such as `logger`.  A dedicated logger
  * instance is created directly via createLogger() using workerInfo.workerIndex.
@@ -136,6 +168,15 @@ const TESTS_DIR = path.join(__dirname, '../tests');
 const GLOBAL_DATA_FILE = path.join(__dirname, '../test-data/data.json');
 const GLOBAL_FEATURE_NAME = 'global-data';
 
+/**
+ * Playwright fixture timeouts are static per-declaration (evaluated once at
+ * module load), not runtime-conditional on the current test — so the CI vs.
+ * local budget has to be computed here rather than inside the fixture body.
+ * CI seeds every feature in one batch (see module docstring); local dev only
+ * ever seeds the current suite's one feature.
+ */
+const SEED_TIMEOUT_MS = process.env.CI === 'true' ? 600_000 : 180_000;
+
 /** Shape written to the state file after a successful seed. */
 interface SeedState {
   featureName: string;
@@ -171,20 +212,41 @@ function dataFilePath(featureName: string): string {
   return path.join(TESTS_DIR, featureName, 'fixtures', 'data.json');
 }
 
+/** Wait for the search index to catch up. Shared by single-feature and batch ingestion. */
+async function waitForIndexCatchUp(logger: DataHubLogger): Promise<void> {
+  logger.info('waiting 15s for search index to catch up before marking seed complete');
+  await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
+}
+
+/** Write the state file marking `featureName` as seeded. */
+function writeSeedState(featureName: string, entityCount: number): void {
+  const state: SeedState = {
+    featureName,
+    seededAt: new Date().toISOString(),
+    entityCount,
+  };
+  writeJsonAtomic(stateFilePath(featureName), state);
+}
+
 /**
- * Ingest MCPs from a data file into the GMS.
+ * Ingest MCPs from a data file into the GMS, WITHOUT waiting for the search
+ * index or writing the state file. Split out from `ingestMcps` so batch
+ * seeding (`seedAllFeaturesForCi`) can ingest many features back-to-back and
+ * pay the 15s index-catch-up wait exactly once for the whole batch, instead
+ * of once per feature.
  *
  * @param throwOnFailure - When true (default), throws if any entity fails.
  *   Set to false for optional/global data where partial ingestion is acceptable.
+ * @returns the number of MCPs ingested, for the caller to use when writing state.
  */
-async function ingestMcps(
+async function ingestMcpsNoWait(
   featureName: string,
   gmsToken: string,
   gmsBaseUrl: string,
   logger: DataHubLogger,
   explicitDataFile?: string,
   throwOnFailure = true,
-): Promise<void> {
+): Promise<number> {
   const dataFile = explicitDataFile ?? dataFilePath(featureName);
   if (!fs.existsSync(dataFile)) {
     throw new Error(`Seed data file not found: ${dataFile}\n` + `Expected: tests/${featureName}/fixtures/data.json`);
@@ -261,25 +323,92 @@ async function ingestMcps(
       await ingestComplexAspects(apiContext, gmsToken, complexAspects, logger);
     }
 
-    // Wait for the search index to catch up BEFORE marking this seed complete.
-    // The state file's mere existence is the fixture's signal that data is safe
-    // to read; writing it any earlier let workers that reuse it proceed against
-    // not-yet-indexed data.
-    logger.info('waiting 15s for search index to catch up before marking seed complete');
-    await new Promise<void>((resolve) => setTimeout(resolve, 15_000));
-
-    // Write state file so other workers (and next runs) skip re-seeding.
-    // Written even on partial failures (when throwOnFailure=false) so we don't retry endlessly.
-    const state: SeedState = {
-      featureName,
-      seededAt: new Date().toISOString(),
-      entityCount: mcps.length,
-    };
-    writeJsonAtomic(stateFilePath(featureName), state);
-    logger.info('state saved', { featureName });
+    return mcps.length;
   } finally {
     await apiContext.dispose();
   }
+}
+
+/**
+ * Ingest a single feature's MCPs, then wait for the search index and write
+ * its state file. This is the original single-feature seeding path (local
+ * dev, and the CI per-feature short-circuit after the batch below) —
+ * `ingestMcpsNoWait` + `waitForIndexCatchUp` + `writeSeedState` composed for
+ * the one-feature-at-a-time case.
+ *
+ * @param throwOnFailure - When true (default), throws if any entity fails.
+ *   Set to false for optional/global data where partial ingestion is acceptable.
+ */
+async function ingestMcps(
+  featureName: string,
+  gmsToken: string,
+  gmsBaseUrl: string,
+  logger: DataHubLogger,
+  explicitDataFile?: string,
+  throwOnFailure = true,
+): Promise<void> {
+  const entityCount = await ingestMcpsNoWait(featureName, gmsToken, gmsBaseUrl, logger, explicitDataFile, throwOnFailure);
+  // Wait for the search index to catch up BEFORE marking this seed complete.
+  // The state file's mere existence is the fixture's signal that data is safe
+  // to read; writing it any earlier let workers that reuse it proceed against
+  // not-yet-indexed data.
+  await waitForIndexCatchUp(logger);
+  // Write state file so other workers (and next runs) skip re-seeding.
+  // Written even on partial failures (when throwOnFailure=false) so we don't retry endlessly.
+  writeSeedState(featureName, entityCount);
+  logger.info('state saved', { featureName });
+}
+
+/** Marker artifact for the CI batch-seed-everything path (see module docstring). */
+const ALL_FEATURES_MARKER_FILE = path.join(SEEDED_DIR, '_all-features.json');
+
+/** Feature directories under `tests/` that have their own `fixtures/data.json`. */
+function discoverFeatureNames(): string[] {
+  return fs
+    .readdirSync(TESTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => fs.existsSync(dataFilePath(name)));
+}
+
+/**
+ * CI-only: seed every feature's fixture data in one batch, guarded by a
+ * single withArtifactLock so only one worker per shard performs it (see
+ * module docstring for why CI needs this instead of per-feature lazy
+ * seeding). Ingests every not-yet-seeded feature back-to-back with no
+ * per-feature wait, pays the 15s search-index wait exactly once for the
+ * whole batch, then writes each feature's state file before writing the
+ * marker file itself.
+ */
+async function seedAllFeaturesForCi(gmsToken: string, gmsBaseUrl: string, logger: DataHubLogger): Promise<void> {
+  await withArtifactLock(ALL_FEATURES_MARKER_FILE, async () => {
+    const featureNames = discoverFeatureNames();
+    const pending = featureNames.filter((name) => !fs.existsSync(stateFilePath(name)));
+
+    if (pending.length > 0) {
+      logger.info(`CI global seeding: batch-ingesting ${pending.length} feature(s)`, { features: pending });
+
+      const entityCounts: Array<[string, number]> = [];
+      for (const featureName of pending) {
+        // throwOnFailure=false: one bad feature's fixture shouldn't block seeding the rest
+        // for the whole shard — mirrors GLOBAL_DATA_FILE's non-blocking ingest below.
+        const entityCount = await ingestMcpsNoWait(featureName, gmsToken, gmsBaseUrl, logger, undefined, false);
+        entityCounts.push([featureName, entityCount]);
+      }
+
+      await waitForIndexCatchUp(logger);
+
+      for (const [featureName, entityCount] of entityCounts) {
+        writeSeedState(featureName, entityCount);
+      }
+    }
+
+    writeJsonAtomic(ALL_FEATURES_MARKER_FILE, {
+      seededAt: new Date().toISOString(),
+      featureCount: featureNames.length,
+    });
+    logger.info('CI global seeding complete', { featureCount: featureNames.length });
+  });
 }
 
 // ── Fixture ───────────────────────────────────────────────────────────────────
@@ -326,11 +455,21 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
         logger.info('global data ready', { seededAt: state.seededAt, entityCount: state.entityCount });
       }
 
+      // CI: seed every feature up front, regardless of this suite's own featureName —
+      // shard placement can no longer be relied on to co-locate a test with the feature
+      // data it needs (see module docstring). Local dev never takes this branch.
+      if (process.env.CI === 'true') {
+        await seedAllFeaturesForCi(gmsToken, gmsUrl(), logger);
+      }
+
       if (!featureName) {
         await use();
         return;
       }
 
+      // In CI this is a no-op short-circuit: seedAllFeaturesForCi already wrote
+      // this feature's state file, so withArtifactLock's existence check returns
+      // immediately without re-ingesting.
       const stateFile = stateFilePath(featureName);
       await withArtifactLock(stateFile, () => ingestMcps(featureName, gmsToken, gmsUrl(), logger));
       const state = JSON.parse(fs.readFileSync(stateFile, 'utf-8')) as SeedState;
@@ -338,8 +477,10 @@ export const seedingFixture = base.extend<{}, SeedingFixtureOptions>({
 
       await use();
     },
-    // Generous ceiling: worst case one worker produces token + global + feature,
-    // each with ingest + a 15s ES index wait under withArtifactLock.
-    { auto: true, scope: 'worker', timeout: 180_000 },
+    // Local: worst case one worker produces token + global + one feature, each with
+    // ingest + a 15s ES index wait under withArtifactLock. CI: worst case one worker
+    // also produces the full batch seed of every feature (one shared 15s wait, see
+    // seedAllFeaturesForCi) before its own feature's now-instant short-circuit.
+    { auto: true, scope: 'worker', timeout: SEED_TIMEOUT_MS },
   ],
 });

--- a/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
+++ b/e2e-test/ui/playwright/fixtures/seeding.fixture.ts
@@ -347,7 +347,14 @@ async function ingestMcps(
   explicitDataFile?: string,
   throwOnFailure = true,
 ): Promise<void> {
-  const entityCount = await ingestMcpsNoWait(featureName, gmsToken, gmsBaseUrl, logger, explicitDataFile, throwOnFailure);
+  const entityCount = await ingestMcpsNoWait(
+    featureName,
+    gmsToken,
+    gmsBaseUrl,
+    logger,
+    explicitDataFile,
+    throwOnFailure,
+  );
   // Wait for the search index to catch up BEFORE marking this seed complete.
   // The state file's mere existence is the fixture's signal that data is safe
   // to read; writing it any earlier let workers that reuse it proceed against

--- a/e2e-test/ui/playwright/helpers/seeder-utils.ts
+++ b/e2e-test/ui/playwright/helpers/seeder-utils.ts
@@ -220,6 +220,8 @@ export function normalizeMcp(mcp: Mcp): Mcp {
  *   mlPrimaryKey mlPrimaryKeyProperties — strip nulls
  *   mlModel  mlModelProperties          — strip nulls
  *   mlModelGroup mlModelGroupProperties — strip nulls
+ *   glossaryTerm glossaryRelatedTerms   — posted as-is (silently dropped by the legacy endpoint,
+ *                                         same as the other union-typed aspects above)
  */
 export function extractComplexAspects(mcps: Mcp[]): ComplexAspect[] {
   const results: ComplexAspect[] = [];
@@ -353,6 +355,16 @@ export function extractComplexAspects(mcps: Mcp[]): ComplexAspect[] {
               entityType: 'mlModelGroup',
               aspectName: 'mlModelGroupProperties',
               value: stripNulls(aspect[propsKey]),
+            });
+          }
+        } else if (urn.startsWith('urn:li:glossaryTerm:')) {
+          const relatedTermsKey = keys.find((k) => k.includes('GlossaryRelatedTerms'));
+          if (relatedTermsKey) {
+            results.push({
+              urn,
+              entityType: 'glossaryTerm',
+              aspectName: 'glossaryRelatedTerms',
+              value: stripNulls(aspect[relatedTermsKey]),
             });
           }
         }

--- a/e2e-test/ui/playwright/pages/search.page.ts
+++ b/e2e-test/ui/playwright/pages/search.page.ts
@@ -121,6 +121,17 @@ export class SearchPage extends BasePage {
     await this.page.getByText(resultName).first().click();
   }
 
+  /**
+   * Click a specific search result row by URN. Unlike clickResult(), this is safe when
+   * other seeded entities share substrings of the display name — e.g. under CI global
+   * seeding, every feature's fixture data is present simultaneously, so a generic text
+   * match risks landing on an unrelated result. See EntitySearchResults.tsx's
+   * `search-result-row-${urn}` data-testid.
+   */
+  async clickResultByUrn(urn: string): Promise<void> {
+    await this.page.getByTestId(`search-result-row-${urn}`).first().click();
+  }
+
   async clickAdvanced(): Promise<void> {
     await this.advancedButton.click();
   }

--- a/e2e-test/ui/playwright/playwright_test_weights.json
+++ b/e2e-test/ui/playwright/playwright_test_weights.json
@@ -1,0 +1,358 @@
+[
+  {
+    "filePath": "analytics/analytics.spec.ts",
+    "duration": "22.898s"
+  },
+  {
+    "filePath": "application/application-management.spec.ts",
+    "duration": "25.639s"
+  },
+  {
+    "filePath": "application/application-sidebar.spec.ts",
+    "duration": "50.694s"
+  },
+  {
+    "filePath": "auth/login-with-welcome-modal.spec.ts",
+    "duration": "8.260s"
+  },
+  {
+    "filePath": "auth/login.spec.ts",
+    "duration": "19.176s"
+  },
+  {
+    "filePath": "autocomplete-v2/autocomplete.spec.ts",
+    "duration": "27.957s"
+  },
+  {
+    "filePath": "browse-v2/browse-v2.spec.ts",
+    "duration": "85.303s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute-navigation.spec.ts",
+    "duration": "0.209s"
+  },
+  {
+    "filePath": "business-attributes/business-attribute.spec.ts",
+    "duration": "0.564s"
+  },
+  {
+    "filePath": "business-attributes/check-feature-flag.spec.ts",
+    "duration": "0.089s"
+  },
+  {
+    "filePath": "change-history/change-history.spec.ts",
+    "duration": "134.812s"
+  },
+  {
+    "filePath": "containers-v2/v2-containers.spec.ts",
+    "duration": "5.302s"
+  },
+  {
+    "filePath": "documents/document-import.spec.ts",
+    "duration": "14.346s"
+  },
+  {
+    "filePath": "documents/document-management.spec.ts",
+    "duration": "255.744s"
+  },
+  {
+    "filePath": "documents/document-tree-expand.spec.ts",
+    "duration": "50.356s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-advanced.spec.ts",
+    "duration": "33.812s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-core.spec.ts",
+    "duration": "28.047s"
+  },
+  {
+    "filePath": "domains-v2/v2-domains-summary.spec.ts",
+    "duration": "19.591s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-about-section.spec.ts",
+    "duration": "20.346s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-data-product.spec.ts",
+    "duration": "4.841s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-domain.spec.ts",
+    "duration": "5.299s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-node.spec.ts",
+    "duration": "4.781s"
+  },
+  {
+    "filePath": "entity-pages/summary-tab/v2-summary-tab-glossary-term.spec.ts",
+    "duration": "5.024s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-navigation.spec.ts",
+    "duration": "60.362s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-node-tags.spec.ts",
+    "duration": "11.468s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term-tags.spec.ts",
+    "duration": "15.476s"
+  },
+  {
+    "filePath": "glossary/v2-glossary-term.spec.ts",
+    "duration": "17.498s"
+  },
+  {
+    "filePath": "glossary/v2-glossary.spec.ts",
+    "duration": "104.366s"
+  },
+  {
+    "filePath": "home-v2/v2-home.spec.ts",
+    "duration": "4.092s"
+  },
+  {
+    "filePath": "home/homepage-collection-view-all.spec.ts",
+    "duration": "9.003s"
+  },
+  {
+    "filePath": "home/homepage-modules.spec.ts",
+    "duration": "42.231s"
+  },
+  {
+    "filePath": "home/homepage-templates.spec.ts",
+    "duration": "7.452s"
+  },
+  {
+    "filePath": "home/homepage-visibility.spec.ts",
+    "duration": "7.308s"
+  },
+  {
+    "filePath": "incidents-v2/v2-incidents.spec.ts",
+    "duration": "30.166s"
+  },
+  {
+    "filePath": "ingestion-v2/odcs-source.spec.ts",
+    "duration": "9.487s"
+  },
+  {
+    "filePath": "ingestion-v2/run-history.spec.ts",
+    "duration": "17.175s"
+  },
+  {
+    "filePath": "ingestion-v2/secrets-tab.spec.ts",
+    "duration": "45.996s"
+  },
+  {
+    "filePath": "ingestion-v2/sources.spec.ts",
+    "duration": "59.854s"
+  },
+  {
+    "filePath": "ingestion-v3/run-history.spec.ts",
+    "duration": "22.157s"
+  },
+  {
+    "filePath": "ingestion-v3/secrets-tab.spec.ts",
+    "duration": "44.834s"
+  },
+  {
+    "filePath": "ingestion-v3/sources.spec.ts",
+    "duration": "56.406s"
+  },
+  {
+    "filePath": "lineage-v3/v3-download-lineage-results.spec.ts",
+    "duration": "13.362s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-level.spec.ts",
+    "duration": "9.356s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-column-path.spec.ts",
+    "duration": "22.953s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-graph.spec.ts",
+    "duration": "89.433s"
+  },
+  {
+    "filePath": "lineage-v3/v3-lineage-impact-analysis.spec.ts",
+    "duration": "104.879s"
+  },
+  {
+    "filePath": "login-v2/v2-login.spec.ts",
+    "duration": "8.994s"
+  },
+  {
+    "filePath": "manage-tags/assign-unassign-tags.spec.ts",
+    "duration": "16.791s"
+  },
+  {
+    "filePath": "manage-tags/create-edit-remove-tags.spec.ts",
+    "duration": "11.222s"
+  },
+  {
+    "filePath": "manage-tags/search-filter-tags.spec.ts",
+    "duration": "21.308s"
+  },
+  {
+    "filePath": "mfeframework/valid-config-mfe.spec.ts",
+    "duration": "15.533s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-experiment.spec.ts",
+    "duration": "18.669s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-mlflow.spec.ts",
+    "duration": "21.360s"
+  },
+  {
+    "filePath": "ml-entities-v2/v2-model-sagemaker.spec.ts",
+    "duration": "6.630s"
+  },
+  {
+    "filePath": "mutations-v2/v2-domains.spec.ts",
+    "duration": "55.585s"
+  },
+  {
+    "filePath": "mutations-v2/v2-edit-documentation.spec.ts",
+    "duration": "56.546s"
+  },
+  {
+    "filePath": "mutations/dataset-health.spec.ts",
+    "duration": "5.406s"
+  },
+  {
+    "filePath": "mutations/edit-documentation.spec.ts",
+    "duration": "12.141s"
+  },
+  {
+    "filePath": "navbar/navbar.spec.ts",
+    "duration": "23.003s"
+  },
+  {
+    "filePath": "nested-column-stats/nested-column-stats.spec.ts",
+    "duration": "13.448s"
+  },
+  {
+    "filePath": "onboarding/welcome-modal.spec.ts",
+    "duration": "192.936s"
+  },
+  {
+    "filePath": "ownership-v2/v2-manage-ownership.spec.ts",
+    "duration": "13.358s"
+  },
+  {
+    "filePath": "quality/assertion-list.spec.ts",
+    "duration": "8.086s"
+  },
+  {
+    "filePath": "schema-blame/schema-blame.spec.ts",
+    "duration": "10.656s"
+  },
+  {
+    "filePath": "search/query-and-filter-search.spec.ts",
+    "duration": "92.107s"
+  },
+  {
+    "filePath": "search/search-filters.spec.ts",
+    "duration": "42.818s"
+  },
+  {
+    "filePath": "search/search-within-operator.spec.ts",
+    "duration": "15.025s"
+  },
+  {
+    "filePath": "search/search.spec.ts",
+    "duration": "61.694s"
+  },
+  {
+    "filePath": "search/searchv2.spec.ts",
+    "duration": "71.033s"
+  },
+  {
+    "filePath": "settings-v2/v2-home-page-posts.spec.ts",
+    "duration": "56.424s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-access-tokens.spec.ts",
+    "duration": "9.359s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-policies.spec.ts",
+    "duration": "62.260s"
+  },
+  {
+    "filePath": "settings-v2/v2-manage-service-accounts.spec.ts",
+    "duration": "18.516s"
+  },
+  {
+    "filePath": "settings-v2/v2-managing-groups.spec.ts",
+    "duration": "81.543s"
+  },
+  {
+    "filePath": "siblings-v2/siblings.spec.ts",
+    "duration": "30.395s"
+  },
+  {
+    "filePath": "stats-v2/v2-change-history.spec.ts",
+    "duration": "53.096s"
+  },
+  {
+    "filePath": "stats-v2/v2-charts.spec.ts",
+    "duration": "45.847s"
+  },
+  {
+    "filePath": "stats-v2/v2-column-stats.spec.ts",
+    "duration": "9.254s"
+  },
+  {
+    "filePath": "stats-v2/v2-highlights.spec.ts",
+    "duration": "7.856s"
+  },
+  {
+    "filePath": "stats-v2/v2-stats-tab.spec.ts",
+    "duration": "20.798s"
+  },
+  {
+    "filePath": "structured-properties/entity-level.spec.ts",
+    "duration": "50.908s"
+  },
+  {
+    "filePath": "structured-properties/schema-field.spec.ts",
+    "duration": "57.214s"
+  },
+  {
+    "filePath": "structured-properties/structured-properties.spec.ts",
+    "duration": "16.991s"
+  },
+  {
+    "filePath": "structured-properties/structured-props-drawer-font.spec.ts",
+    "duration": "8.149s"
+  },
+  {
+    "filePath": "task-runs-v2/task-runs.spec.ts",
+    "duration": "10.401s"
+  },
+  {
+    "filePath": "upload-files/upload-files.spec.ts",
+    "duration": "49.401s"
+  },
+  {
+    "filePath": "views/v2-manage-views.spec.ts",
+    "duration": "8.428s"
+  },
+  {
+    "filePath": "views/v2-view-select.spec.ts",
+    "duration": "20.105s"
+  },
+  {
+    "filePath": "views/v2-view-within-operator.spec.ts",
+    "duration": "10.654s"
+  }
+]

--- a/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
+++ b/e2e-test/ui/playwright/tests/browse-v2/browse-v2.spec.ts
@@ -49,6 +49,10 @@ const CONTAINER_URNS = {
   SCHEMA: 'urn:li:container:playwright_browse_entity_schema_container',
 };
 
+const DATASET_URNS = {
+  CUSTOMERS: 'urn:li:dataset:(urn:li:dataPlatform:bigquery,PlaywrightBrowseEntity.test_schema.customers,PROD)',
+};
+
 const SEARCH_QUERIES = {
   WILDCARD: '*',
   ENTITY_TYPE: 'dataset',
@@ -284,7 +288,10 @@ test.describe('Browse V2 - Platform Browse Mode', () => {
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
     logger?.step('click on customers dataset to open profile');
-    await searchPage.clickResult(SEARCH_QUERIES.CUSTOMERS);
+    // Match by URN, not clickResult()'s generic text search: under CI global seeding,
+    // other features' fixtures also reference "customers"/"bigquery", so a substring
+    // + .first() match can land on the wrong search result.
+    await searchPage.clickResultByUrn(DATASET_URNS.CUSTOMERS);
     await page.waitForLoadState(LOAD_STATES.NETWORKIDLE);
 
     logger?.step('verify dataset profile page is loaded');

--- a/e2e-test/ui/playwright/tests/business-attributes/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/business-attributes/fixtures/data.json
@@ -69,12 +69,6 @@
             }
           },
           {
-            "com.linkedin.glossary.GlossaryRelatedTerms": {
-              "isRelatedTerms": [],
-              "hasRelatedTerms": []
-            }
-          },
-          {
             "com.linkedin.common.Ownership": {
               "owners": [
                 {


### PR DESCRIPTION
## Summary

- Per-spec-file duration-based shard bin-packing (`split_playwright_tests.py`) means shard placement of a spec file no longer aligns with which `featureName`(s) it depends on, so a shard/worker can no longer assume "if a suite doesn't declare feature X, X's data was never needed here."
- In CI (`process.env.CI === 'true'`), the seeding fixture now seeds every feature's `tests/{feature}/fixtures/data.json` up front in a single batched ingest — one shared search-index wait for the whole batch instead of one 15s wait per feature — guarded by one cross-worker `withArtifactLock` so only one worker per shard performs it.
- Local dev is unaffected: outside CI, the existing fast lazy per-feature seeding runs unchanged.
- Also carries over the already-validated per-spec-file duration-balanced shard splitting from `ci/playwright-duration-bin-packing` (`split_playwright_tests.py`, weight generation, artifact download fix, weekly cron wiring, bootstrapped weights file), since imbalanced shards are what made this seeding change necessary.

## Test plan

- [x] `tsc --noEmit` clean for the Playwright project
- [x] `./gradlew :e2e-test:ui:playwright:lintFix` — 0 errors (pre-existing warnings only)
- [x] Dry-ran `split_playwright_tests.py` for all 8 shard indices locally — all 94 spec files correctly distributed, bin-packing unaffected by the seeding changes
- [ ] Watch the `docker-unified.yml` CI run on this PR to confirm all 94 spec files pass regardless of shard, and that batched global seeding doesn't regress total wall-clock time vs #19140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable duration-balanced Playwright sharding and batch-seed all feature fixtures once per CI shard to avoid missing data and reduce index waits. Adds a longer CI batch index catch-up and fixes cross-feature collisions, including a last-write-wins overwrite in `business-attributes` fixtures.

- **New Features**
  - Duration-based sharding per spec file using `split_playwright_tests.py`; runs `npx playwright test` with explicit file lists instead of `--shard`.
  - CI batch seeding: ingest all features’ `tests/{feature}/fixtures/data.json` once per shard with a single index wait, guarded by one `withArtifactLock` and `_all-features.json`; per-feature state files still short-circuit; local dev unchanged.
  - Playwright test weights at `e2e-test/ui/playwright/playwright_test_weights.json`; `generate_test_weights.py` now parses Playwright JUnit; `update-test-weights.yml` downloads Playwright artifacts and refreshes weights.

- **Bug Fixes**
  - CI batch seeding: longer index/graph catch-up wait (30s) and higher CI seeding fixture timeout to prevent flakiness on relationship edges.
  - Prevent per-shard JUnit overwrites by extracting into `playwright-{shard}` in `download_test_artifacts.sh`.
  - Avoid blob report filename collisions by setting `PLAYWRIGHT_BLOB_OUTPUT_FILE` per shard.
  - Eliminate search-result misclicks under global seeding by adding `clickResultByUrn()` and updating `browse-v2` to use it.
  - Ensure glossary related terms index correctly by handling `glossaryRelatedTerms` in the complex-aspects second pass.
  - Stop last-write-wins clobbering of shared glossary term relationships by removing the empty `GlossaryRelatedTerms` aspect from `business-attributes` fixtures.

<sup>Written for commit 16b3b7dfeff3660b9d070ea8220aa5f4e8aabb41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

