### PR TITLE
fix(ingest/snowflake): stop paginating database-wide SHOW commands

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
@@ -66,6 +66,16 @@ class SnowflakeObjectDomain(StrEnum):
     PIPE = "pipe"
 
 
+# The plural keyword naming an object class in a SHOW statement, e.g. `SHOW DYNAMIC TABLES`.
+# Deliberately separate from SnowflakeObjectDomain, which carries the singular lowercase
+# objectDomain values ACCESS_HISTORY reports ("dynamic table") - the two vocabularies differ
+# in both number and case, so neither can stand in for the other.
+class SnowflakeShowKind(StrEnum):
+    VIEWS = "VIEWS"
+    STREAMS = "STREAMS"
+    DYNAMIC_TABLES = "DYNAMIC TABLES"
+
+
 GENERIC_PERMISSION_ERROR_KEY = "permission-error"
 LINEAGE_PERMISSION_ERROR = "lineage-permission-error"
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -475,12 +475,15 @@ class SnowflakeV2Config(
 
     fetch_views_from_information_schema: bool = Field(
         default=False,
-        description="If enabled, uses information_schema.views to fetch view definitions instead of SHOW VIEWS command. "
-        "This alternative method can be more reliable for databases with large numbers of views (> 10K views), as the "
-        "SHOW VIEWS approach has proven unreliable and can lead to missing views in such scenarios. However, this method "
-        "requires OWNERSHIP privileges on views to retrieve their definitions. For views without ownership permissions "
-        "(where VIEW_DEFINITION is null/empty), the system will automatically fall back to using batched SHOW VIEWS queries "
-        "to populate the missing definitions.",
+        description="If enabled, uses information_schema.views to fetch views instead of the SHOW VIEWS command. "
+        "Enable this if you need `view_pattern` pushdown (see `push_down_metadata_patterns`, which cannot push a "
+        "pattern list into SHOW VIEWS) or an accurate `last_altered`, which SHOW VIEWS does not report. "
+        "Trade-offs: information_schema.views only exposes VIEW_DEFINITION to a view's owner, so definitions for "
+        "views you don't own are backfilled with batched SHOW VIEWS queries; it needs a running warehouse, whereas "
+        "SHOW VIEWS does not; and it does not report materialized views, which are absent from "
+        "information_schema.views and not covered by the default `table_types`. "
+        "This option is no longer needed for databases with more than 10K views - the SHOW VIEWS path now "
+        "paginates per schema and is exact at any scale.",
     )
 
     include_technical_schema: bool = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -4,7 +4,10 @@ from typing import AbstractSet, List, Optional
 
 from datahub.configuration.common import AllowDenyPattern
 from datahub.configuration.time_window_config import BucketDuration
-from datahub.ingestion.source.snowflake.constants import SnowflakeObjectDomain
+from datahub.ingestion.source.snowflake.constants import (
+    SnowflakeObjectDomain,
+    SnowflakeShowKind,
+)
 from datahub.ingestion.source.snowflake.snowflake_config import (
     DEFAULT_TEMP_TABLES_PATTERNS,
 )
@@ -555,34 +558,70 @@ class SnowflakeQuery:
         """
 
     @staticmethod
+    def show_objects_for_database(
+        kind: SnowflakeShowKind,
+        db_name: str,
+        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
+    ) -> str:
+        """A single database-wide SHOW. Deliberately NOT paginated.
+
+        The output is "ordered lexicographically by database, schema, and name", but the
+        `LIMIT ... FROM '<name>'` cursor matches on the object *name* alone - so the cursor
+        key is not the sort key and the result cannot be continued. Measured against a live
+        account, paging it fails in one of two ways depending on the page's last row:
+          - a real object name: the cursor acts as a global `name > marker` filter, so every
+            object in a LATER schema whose name sorts below the marker is silently dropped,
+            while earlier schemas' higher-sorting objects are returned again;
+          - an INFORMATION_SCHEMA view name: the cursor is ignored outright and the next
+            page comes back identical, so the loop never terminates.
+
+        When this single page comes back full the caller must page per schema instead - see
+        show_objects_for_schema. This is THE explanation of the cursor rule; elsewhere refer
+        here rather than restating it.
+
+        SHOW returns at most 10000 rows:
+        https://docs.snowflake.com/en/sql-reference/sql/show-views#usage-notes
+        """
+        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
+        return f"""SHOW {kind} IN DATABASE "{db_name}" LIMIT {limit};"""
+
+    @staticmethod
+    def show_objects_for_schema(
+        kind: SnowflakeShowKind,
+        db_name: str,
+        schema_name: str,
+        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
+        marker: Optional[str] = None,
+    ) -> str:
+        """One schema's SHOW, optionally continuing after `marker`.
+
+        Scoped to a single schema the output is ordered by name alone, which is exactly what
+        the `FROM '<name>'` cursor matches on, so the cursor key IS the whole sort key and
+        paging is exact - unlike show_objects_for_database.
+        """
+        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
+
+        # A quoted Snowflake identifier may contain a quote or a backslash, and the marker
+        # is embedded in a string literal - escape it or the next page is malformed SQL.
+        from_clause = (
+            f"""FROM '{_escape_sql_string_literal(marker)}'""" if marker else ""
+        )
+        return (
+            f"""SHOW {kind} IN SCHEMA "{db_name}"."{schema_name}" """
+            f"""LIMIT {limit} {from_clause};"""
+        )
+
+    @staticmethod
     def show_views_for_database(
         db_name: str,
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
     ) -> str:
-        # While there is an information_schema.views view, that only shows the view definition if the role
-        # is an owner of the view. That doesn't work for us.
+        # information_schema.views only exposes a definition to the view's owner, which is
+        # why SHOW is the default path here:
         # https://community.snowflake.com/s/article/Is-it-possible-to-see-the-view-definition-in-information-schema-views-from-a-non-owner-role
-
-        # SHOW VIEWS can return a maximum of 10000 rows.
-        # https://docs.snowflake.com/en/sql-reference/sql/show-views#usage-notes
-        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
-
-        # Deliberately not paginated. This output is "ordered lexicographically by
-        # database, schema, and view name", but the `LIMIT ... FROM '<name>'` cursor
-        # matches on the object *name* alone - so the cursor key is not the sort key and
-        # the result cannot be continued. Measured against a live account, paging it
-        # fails in one of two ways depending on what the last row of the page is:
-        #   - a real object name: the cursor acts as a global `name > marker` filter, so
-        #     every view in a LATER schema whose name sorts below the marker is silently
-        #     dropped, while earlier schemas' higher-sorting views are returned again;
-        #   - an INFORMATION_SCHEMA view name: the cursor is ignored outright and the
-        #     next page comes back identical, so the loop never terminates.
-        # When this single page comes back full, the caller must page per schema
-        # instead - see show_views_for_schema.
-        return f"""\
-SHOW VIEWS IN DATABASE "{db_name}"
-LIMIT {limit};
-"""
+        return SnowflakeQuery.show_objects_for_database(
+            SnowflakeShowKind.VIEWS, db_name, limit=limit
+        )
 
     @staticmethod
     def show_views_for_schema(
@@ -591,22 +630,13 @@ LIMIT {limit};
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
         view_pagination_marker: Optional[str] = None,
     ) -> str:
-        # Scoped to a single schema, the output is ordered by view name only - which is
-        # exactly what the `FROM '<name>'` cursor matches on. The cursor key is then the
-        # whole sort key, so paging is exact (unlike show_views_for_database).
-        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
-
-        # A quoted Snowflake identifier may contain a quote or a backslash, and the marker
-        # is embedded in a string literal - escape it or the next page is malformed SQL.
-        from_clause = (
-            f"""FROM '{_escape_sql_string_literal(view_pagination_marker)}'"""
-            if view_pagination_marker
-            else ""
+        return SnowflakeQuery.show_objects_for_schema(
+            SnowflakeShowKind.VIEWS,
+            db_name,
+            schema_name,
+            limit=limit,
+            marker=view_pagination_marker,
         )
-        return f"""\
-SHOW VIEWS IN SCHEMA "{db_name}"."{schema_name}"
-LIMIT {limit} {from_clause};
-"""
 
     @staticmethod
     def get_views_for_database(db_name: str, view_filter: str = "") -> str:
@@ -1562,14 +1592,10 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         db_name: str,
         limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
     ) -> str:
-        # SHOW STREAMS can return a maximum of 10000 rows.
-        # https://docs.snowflake.com/en/sql-reference/sql/show-streams#usage-notes
         assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
-
-        # Deliberately not paginated; see show_views_for_database for why a
-        # database-wide SHOW cannot be paged safely. When this page comes back full the
-        # caller must page per schema instead - see streams_for_schema.
-        return f"""SHOW STREAMS IN DATABASE "{db_name}" LIMIT {limit};"""
+        return SnowflakeQuery.show_objects_for_database(
+            SnowflakeShowKind.STREAMS, db_name, limit=limit
+        )
 
     @staticmethod
     def streams_for_schema(
@@ -1578,33 +1604,23 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
         stream_pagination_marker: Optional[str] = None,
     ) -> str:
-        # Scoped to one schema the output is ordered by name alone, so the
-        # `FROM '<name>'` cursor is the whole sort key and paging is exact.
         assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
-
-        # Escaped for the same reason as in show_views_for_schema.
-        from_clause = (
-            f"""FROM '{_escape_sql_string_literal(stream_pagination_marker)}'"""
-            if stream_pagination_marker
-            else ""
+        return SnowflakeQuery.show_objects_for_schema(
+            SnowflakeShowKind.STREAMS,
+            db_name,
+            schema_name,
+            limit=limit,
+            marker=stream_pagination_marker,
         )
-        return f"""SHOW STREAMS IN SCHEMA "{db_name}"."{schema_name}" LIMIT {limit} {from_clause};"""
 
     @staticmethod
     def show_dynamic_tables_for_database(
         db_name: str,
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
     ) -> str:
-        """Get dynamic table definitions using SHOW DYNAMIC TABLES."""
-        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
-
-        # Deliberately not paginated; see show_views_for_database for why a
-        # database-wide SHOW cannot be paged safely. When this page comes back full the
-        # caller must page per schema instead - see show_dynamic_tables_for_schema.
-        return f"""\
-    SHOW DYNAMIC TABLES IN DATABASE "{db_name}"
-    LIMIT {limit};
-    """
+        return SnowflakeQuery.show_objects_for_database(
+            SnowflakeShowKind.DYNAMIC_TABLES, db_name, limit=limit
+        )
 
     @staticmethod
     def show_dynamic_tables_for_schema(
@@ -1613,20 +1629,13 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
         dynamic_table_pagination_marker: Optional[str] = None,
     ) -> str:
-        # Scoped to one schema the output is ordered by name alone, so the
-        # `FROM '<name>'` cursor is the whole sort key and paging is exact.
-        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
-
-        # Escaped for the same reason as in show_views_for_schema.
-        from_clause = (
-            f"""FROM '{_escape_sql_string_literal(dynamic_table_pagination_marker)}'"""
-            if dynamic_table_pagination_marker
-            else ""
+        return SnowflakeQuery.show_objects_for_schema(
+            SnowflakeShowKind.DYNAMIC_TABLES,
+            db_name,
+            schema_name,
+            limit=limit,
+            marker=dynamic_table_pagination_marker,
         )
-        return f"""\
-    SHOW DYNAMIC TABLES IN SCHEMA "{db_name}"."{schema_name}"
-    LIMIT {limit} {from_clause};
-    """
 
     @staticmethod
     def get_dynamic_table_graph_history(db_name: str) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -1639,18 +1639,20 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
     @staticmethod
     def get_dynamic_table_graph_history(db_name: str) -> str:
         """Get dynamic table dependency information from information schema."""
-        # schema_name is selected because callers key this data by the fully qualified
-        # name: two schemas in one database may hold dynamic tables of the same name, and
-        # keying on the bare name would cross-wire their inputs.
+        # This function is ACCOUNT-scoped, not database-scoped: invoked from one database's
+        # INFORMATION_SCHEMA it returns rows for every database in the account. Measured on a
+        # live account - 12 rows spanning three other databases and none from the one it was
+        # invoked from. So filter on database_name, and select it so callers can key each row
+        # by its own database rather than the one they asked about; a same-named schema.table
+        # elsewhere would otherwise supply this database's lineage.
         #
-        # valid_to IS NULL keeps only the current version of each graph entry. This is a
-        # *history* function - a live account returned 13 rows for one existing dynamic
-        # table, the rest being versions of dropped ones - so without the filter the row
-        # retained per table is whichever the scan happened to see last.
+        # valid_to IS NULL keeps the current version of each entry, since the function
+        # reports history and superseded rows would otherwise compete for the same key.
         return f"""
             SELECT
-                name,
+                database_name,
                 schema_name,
+                name,
                 inputs,
                 target_lag_type,
                 target_lag_sec,
@@ -1658,6 +1660,7 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
                 alter_trigger
             FROM TABLE("{db_name}".INFORMATION_SCHEMA.DYNAMIC_TABLE_GRAPH_HISTORY())
             WHERE valid_to IS NULL
+              AND database_name = '{_escape_sql_string_literal(db_name)}'
             ORDER BY name
         """
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -558,7 +558,6 @@ class SnowflakeQuery:
     def show_views_for_database(
         db_name: str,
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-        view_pagination_marker: Optional[str] = None,
     ) -> str:
         # While there is an information_schema.views view, that only shows the view definition if the role
         # is an owner of the view. That doesn't work for us.
@@ -568,12 +567,40 @@ class SnowflakeQuery:
         # https://docs.snowflake.com/en/sql-reference/sql/show-views#usage-notes
         assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
 
-        # To work around this, we paginate through the results using the FROM clause.
+        # Deliberately not paginated. This output is "ordered lexicographically by
+        # database, schema, and view name", but the `LIMIT ... FROM '<name>'` cursor
+        # matches on the object *name* alone - so the cursor key is not the sort key and
+        # the result cannot be continued. Measured against a live account, paging it
+        # fails in one of two ways depending on what the last row of the page is:
+        #   - a real object name: the cursor acts as a global `name > marker` filter, so
+        #     every view in a LATER schema whose name sorts below the marker is silently
+        #     dropped, while earlier schemas' higher-sorting views are returned again;
+        #   - an INFORMATION_SCHEMA view name: the cursor is ignored outright and the
+        #     next page comes back identical, so the loop never terminates.
+        # When this single page comes back full, the caller must page per schema
+        # instead - see show_views_for_schema.
+        return f"""\
+SHOW VIEWS IN DATABASE "{db_name}"
+LIMIT {limit};
+"""
+
+    @staticmethod
+    def show_views_for_schema(
+        db_name: str,
+        schema_name: str,
+        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
+        view_pagination_marker: Optional[str] = None,
+    ) -> str:
+        # Scoped to a single schema, the output is ordered by view name only - which is
+        # exactly what the `FROM '<name>'` cursor matches on. The cursor key is then the
+        # whole sort key, so paging is exact (unlike show_views_for_database).
+        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
+
         from_clause = (
             f"""FROM '{view_pagination_marker}'""" if view_pagination_marker else ""
         )
         return f"""\
-SHOW VIEWS IN DATABASE "{db_name}"
+SHOW VIEWS IN SCHEMA "{db_name}"."{schema_name}"
 LIMIT {limit} {from_clause};
 """
 
@@ -1530,25 +1557,57 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
     def streams_for_database(
         db_name: str,
         limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
-        stream_pagination_marker: Optional[str] = None,
     ) -> str:
         # SHOW STREAMS can return a maximum of 10000 rows.
         # https://docs.snowflake.com/en/sql-reference/sql/show-streams#usage-notes
         assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
 
-        # To work around this, we paginate through the results using the FROM clause.
+        # Deliberately not paginated; see show_views_for_database for why a
+        # database-wide SHOW cannot be paged safely. When this page comes back full the
+        # caller must page per schema instead - see streams_for_schema.
+        return f"""SHOW STREAMS IN DATABASE "{db_name}" LIMIT {limit};"""
+
+    @staticmethod
+    def streams_for_schema(
+        db_name: str,
+        schema_name: str,
+        limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
+        stream_pagination_marker: Optional[str] = None,
+    ) -> str:
+        # Scoped to one schema the output is ordered by name alone, so the
+        # `FROM '<name>'` cursor is the whole sort key and paging is exact.
+        assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
+
         from_clause = (
             f"""FROM '{stream_pagination_marker}'""" if stream_pagination_marker else ""
         )
-        return f"""SHOW STREAMS IN DATABASE "{db_name}" LIMIT {limit} {from_clause};"""
+        return f"""SHOW STREAMS IN SCHEMA "{db_name}"."{schema_name}" LIMIT {limit} {from_clause};"""
 
     @staticmethod
     def show_dynamic_tables_for_database(
         db_name: str,
         limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-        dynamic_table_pagination_marker: Optional[str] = None,
     ) -> str:
         """Get dynamic table definitions using SHOW DYNAMIC TABLES."""
+        assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
+
+        # Deliberately not paginated; see show_views_for_database for why a
+        # database-wide SHOW cannot be paged safely. When this page comes back full the
+        # caller must page per schema instead - see show_dynamic_tables_for_schema.
+        return f"""\
+    SHOW DYNAMIC TABLES IN DATABASE "{db_name}"
+    LIMIT {limit};
+    """
+
+    @staticmethod
+    def show_dynamic_tables_for_schema(
+        db_name: str,
+        schema_name: str,
+        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
+        dynamic_table_pagination_marker: Optional[str] = None,
+    ) -> str:
+        # Scoped to one schema the output is ordered by name alone, so the
+        # `FROM '<name>'` cursor is the whole sort key and paging is exact.
         assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
 
         from_clause = (
@@ -1557,7 +1616,7 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
             else ""
         )
         return f"""\
-    SHOW DYNAMIC TABLES IN DATABASE "{db_name}"
+    SHOW DYNAMIC TABLES IN SCHEMA "{db_name}"."{schema_name}"
     LIMIT {limit} {from_clause};
     """
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -620,33 +620,6 @@ class SnowflakeQuery:
         return f"""SHOW {kind} IN SCHEMA {schema} LIMIT {limit} {from_clause};"""
 
     @staticmethod
-    def show_views_for_database(
-        db_name: str,
-        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-    ) -> str:
-        # information_schema.views only exposes a definition to the view's owner, which is
-        # why SHOW is the default path here:
-        # https://community.snowflake.com/s/article/Is-it-possible-to-see-the-view-definition-in-information-schema-views-from-a-non-owner-role
-        return SnowflakeQuery.show_objects_for_database(
-            SnowflakeShowKind.VIEWS, db_name, limit=limit
-        )
-
-    @staticmethod
-    def show_views_for_schema(
-        db_name: str,
-        schema_name: str,
-        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-        view_pagination_marker: Optional[str] = None,
-    ) -> str:
-        return SnowflakeQuery.show_objects_for_schema(
-            SnowflakeShowKind.VIEWS,
-            db_name,
-            schema_name,
-            limit=limit,
-            marker=view_pagination_marker,
-        )
-
-    @staticmethod
     def get_views_for_database(db_name: str, view_filter: str = "") -> str:
         # We've seen some issues with the `SHOW VIEWS` query,
         # particularly when it requires pagination.
@@ -1619,30 +1592,6 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
             schema_name,
             limit=limit,
             marker=stream_pagination_marker,
-        )
-
-    @staticmethod
-    def show_dynamic_tables_for_database(
-        db_name: str,
-        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-    ) -> str:
-        return SnowflakeQuery.show_objects_for_database(
-            SnowflakeShowKind.DYNAMIC_TABLES, db_name, limit=limit
-        )
-
-    @staticmethod
-    def show_dynamic_tables_for_schema(
-        db_name: str,
-        schema_name: str,
-        limit: int = SHOW_COMMAND_MAX_PAGE_SIZE,
-        dynamic_table_pagination_marker: Optional[str] = None,
-    ) -> str:
-        return SnowflakeQuery.show_objects_for_schema(
-            SnowflakeShowKind.DYNAMIC_TABLES,
-            db_name,
-            schema_name,
-            limit=limit,
-            marker=dynamic_table_pagination_marker,
         )
 
     @staticmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -1569,32 +1569,6 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         return """SELECT name as "NAME", email as "EMAIL" FROM SNOWFLAKE.ACCOUNT_USAGE.USERS"""
 
     @staticmethod
-    def streams_for_database(
-        db_name: str,
-        limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
-    ) -> str:
-        assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
-        return SnowflakeQuery.show_objects_for_database(
-            SnowflakeShowKind.STREAMS, db_name, limit=limit
-        )
-
-    @staticmethod
-    def streams_for_schema(
-        db_name: str,
-        schema_name: str,
-        limit: int = SHOW_STREAM_MAX_PAGE_SIZE,
-        stream_pagination_marker: Optional[str] = None,
-    ) -> str:
-        assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
-        return SnowflakeQuery.show_objects_for_schema(
-            SnowflakeShowKind.STREAMS,
-            db_name,
-            schema_name,
-            limit=limit,
-            marker=stream_pagination_marker,
-        )
-
-    @staticmethod
     def get_dynamic_table_graph_history(db_name: str) -> str:
         """Get dynamic table dependency information from information schema."""
         # This function is ACCOUNT-scoped, not database-scoped: invoked from one database's

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -575,9 +575,8 @@ class SnowflakeQuery:
           - an INFORMATION_SCHEMA view name: the cursor is ignored outright and the next
             page comes back identical, so the loop never terminates.
 
-        When this single page comes back full the caller must page per schema instead - see
-        show_objects_for_schema. This is THE explanation of the cursor rule; elsewhere refer
-        here rather than restating it.
+        When this page comes back full the caller must page per schema instead - see
+        show_objects_for_schema. Other sites refer here rather than restating this.
 
         SHOW returns at most 10000 rows:
         https://docs.snowflake.com/en/sql-reference/sql/show-views#usage-notes

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -1640,15 +1640,25 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
     @staticmethod
     def get_dynamic_table_graph_history(db_name: str) -> str:
         """Get dynamic table dependency information from information schema."""
+        # schema_name is selected because callers key this data by the fully qualified
+        # name: two schemas in one database may hold dynamic tables of the same name, and
+        # keying on the bare name would cross-wire their inputs.
+        #
+        # valid_to IS NULL keeps only the current version of each graph entry. This is a
+        # *history* function - a live account returned 13 rows for one existing dynamic
+        # table, the rest being versions of dropped ones - so without the filter the row
+        # retained per table is whichever the scan happened to see last.
         return f"""
             SELECT
                 name,
+                schema_name,
                 inputs,
                 target_lag_type,
                 target_lag_sec,
                 scheduling_state,
                 alter_trigger
             FROM TABLE("{db_name}".INFORMATION_SCHEMA.DYNAMIC_TABLE_GRAPH_HISTORY())
+            WHERE valid_to IS NULL
             ORDER BY name
         """
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -11,6 +11,9 @@ from datahub.ingestion.source.snowflake.constants import (
 from datahub.ingestion.source.snowflake.snowflake_config import (
     DEFAULT_TEMP_TABLES_PATTERNS,
 )
+from datahub.ingestion.source.snowflake.snowflake_utils import (
+    SnowflakeIdentifierBuilder,
+)
 from datahub.utilities.prefix_batch_builder import PrefixGroup
 
 logger = logging.getLogger(__name__)
@@ -582,7 +585,10 @@ class SnowflakeQuery:
         https://docs.snowflake.com/en/sql-reference/sql/show-views#usage-notes
         """
         assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
-        return f"""SHOW {kind} IN DATABASE "{db_name}" LIMIT {limit};"""
+        database = SnowflakeIdentifierBuilder.get_quoted_identifier_for_database(
+            db_name
+        )
+        return f"""SHOW {kind} IN DATABASE {database} LIMIT {limit};"""
 
     @staticmethod
     def show_objects_for_schema(
@@ -605,10 +611,13 @@ class SnowflakeQuery:
         from_clause = (
             f"""FROM '{_escape_sql_string_literal(marker)}'""" if marker else ""
         )
-        return (
-            f"""SHOW {kind} IN SCHEMA "{db_name}"."{schema_name}" """
-            f"""LIMIT {limit} {from_clause};"""
+        # The identifiers need escaping for the same reason, by the other rule: inside a
+        # double-quoted identifier a literal quote is doubled, so a schema named a"b
+        # closes the identifier early without this.
+        schema = SnowflakeIdentifierBuilder.get_quoted_identifier_for_schema(
+            db_name, schema_name
         )
+        return f"""SHOW {kind} IN SCHEMA {schema} LIMIT {limit} {from_clause};"""
 
     @staticmethod
     def show_views_for_database(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -596,8 +596,12 @@ LIMIT {limit};
         # whole sort key, so paging is exact (unlike show_views_for_database).
         assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
 
+        # A quoted Snowflake identifier may contain a quote or a backslash, and the marker
+        # is embedded in a string literal - escape it or the next page is malformed SQL.
         from_clause = (
-            f"""FROM '{view_pagination_marker}'""" if view_pagination_marker else ""
+            f"""FROM '{_escape_sql_string_literal(view_pagination_marker)}'"""
+            if view_pagination_marker
+            else ""
         )
         return f"""\
 SHOW VIEWS IN SCHEMA "{db_name}"."{schema_name}"
@@ -1578,8 +1582,11 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         # `FROM '<name>'` cursor is the whole sort key and paging is exact.
         assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
 
+        # Escaped for the same reason as in show_views_for_schema.
         from_clause = (
-            f"""FROM '{stream_pagination_marker}'""" if stream_pagination_marker else ""
+            f"""FROM '{_escape_sql_string_literal(stream_pagination_marker)}'"""
+            if stream_pagination_marker
+            else ""
         )
         return f"""SHOW STREAMS IN SCHEMA "{db_name}"."{schema_name}" LIMIT {limit} {from_clause};"""
 
@@ -1610,8 +1617,9 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         # `FROM '<name>'` cursor is the whole sort key and paging is exact.
         assert limit <= SHOW_COMMAND_MAX_PAGE_SIZE
 
+        # Escaped for the same reason as in show_views_for_schema.
         from_clause = (
-            f"""FROM '{dynamic_table_pagination_marker}'"""
+            f"""FROM '{_escape_sql_string_literal(dynamic_table_pagination_marker)}'"""
             if dynamic_table_pagination_marker
             else ""
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -125,6 +125,12 @@ class SnowflakeV2Report(
     num_upstream_lineage_edge_parsing_failed: int = 0
     num_secure_views_missing_definition: int = 0
     num_dynamic_tables_missing_definition: int = 0
+    # No DYNAMIC_TABLE_GRAPH_HISTORY row matched the dynamic table's qualified name, so its
+    # INPUTS upstreams and target_lag fallback are unavailable. Counted because that loss is
+    # otherwise invisible: this equalling the dynamic-table count is the signature of the
+    # keying bug fixed in #19143, and of the graph-history query's filters excluding
+    # everything on an edition whose output differs from the documented one.
+    num_dynamic_tables_missing_graph_info: int = 0
     num_structured_property_templates_created: int = 0
     # sqlglot parse failures while resolving metric-to-metric derivedFrom refs;
     # best-effort, the metric is still emitted without those edges.

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -1048,6 +1048,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
     def _get_views_for_database_using_show(
         self, db_name: str
     ) -> Optional[Dict[str, List[SnowflakeView]]]:
+        # SHOW is the default path for views because information_schema.views only exposes a
+        # definition to the view's owner:
+        # https://community.snowflake.com/s/article/Is-it-possible-to-see-the-view-definition-in-information-schema-views-from-a-non-owner-role
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
 
         views = self._probe_database_wide_show(
@@ -2565,9 +2568,14 @@ class SnowflakeDataDictionary(SupportsAsObj):
         target_lag = row.get("target_lag")
         upstream_tables: List[SnowflakeDynamicTableInput] = []
 
-        if dt_graph_info:
-            qualified_name = f"{db_name}.{schema_name}.{dt_name}"
-            graph_info = dt_graph_info.get(qualified_name, {})
+        qualified_name = f"{db_name}.{schema_name}.{dt_name}"
+        graph_info = dt_graph_info.get(qualified_name, {})
+        if not graph_info:
+            # Counted, not warned: on a database whose dynamic tables are all outside the
+            # graph history's 7-day window this is expected and per-table noise would drown
+            # the report. The count is what makes a total miss legible.
+            self.report.num_dynamic_tables_missing_graph_info += 1
+        else:
             if not target_lag:
                 if graph_info.get("target_lag_type") and graph_info.get(
                     "target_lag_sec"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -884,10 +884,15 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 ),
             )
         except Exception as e:
+            # Debug, not a warning: the expected error here is "Information schema query
+            # returned too much data", which is this path's normal signal to page per
+            # schema, and a lossless run must not raise an alarm. Tried reporting it and
+            # backed out - it turns a benign overflow into a pipeline warning, which the
+            # failure tests correctly reject. Telling a real fault apart from the overflow
+            # would mean matching Snowflake's error text.
             logger.debug(
                 f"Failed to get all tables for database - {db_name}", exc_info=e
             )
-            # Error - Information schema query returned too much data. Please repeat query with more selective predicates.
             return None
 
         for table in cur:
@@ -982,10 +987,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
     def _probe_database_wide_show(
         self,
         *,
-        build_query: Callable[[int], str],
-        page_limit: int,
         object_kind: SnowflakeShowKind,
         db_name: str,
+        page_limit: int,
         mapper: Callable[[Dict[str, Any]], _ShowRowT],
     ) -> Optional[Dict[str, List[_ShowRowT]]]:
         """Run one database-wide SHOW and group the rows by schema, or give up.
@@ -1011,7 +1015,13 @@ class SnowflakeDataDictionary(SupportsAsObj):
         place rather than being restated for each object type.
         """
         try:
-            rows = list(self.connection.query(build_query(page_limit)))
+            rows = list(
+                self.connection.query(
+                    SnowflakeQuery.show_objects_for_database(
+                        object_kind, db_name, limit=page_limit
+                    )
+                )
+            )
         except Exception as e:
             self.report.warning(
                 message="Database-wide SHOW failed; retrying per schema",
@@ -1042,12 +1052,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
 
         views = self._probe_database_wide_show(
-            build_query=lambda limit: SnowflakeQuery.show_views_for_database(
-                db_name, limit=limit
-            ),
-            page_limit=page_limit,
             object_kind=SnowflakeShowKind.VIEWS,
             db_name=db_name,
+            page_limit=page_limit,
             mapper=self._map_show_view,
         )
         if views is None:
@@ -1076,15 +1083,12 @@ class SnowflakeDataDictionary(SupportsAsObj):
     def _iter_show_rows_for_schema(
         self,
         *,
-        build_query: Callable[[Optional[str], int], str],
-        page_limit: int,
         object_kind: SnowflakeShowKind,
-        context: str,
+        db_name: str,
+        schema_name: str,
+        page_limit: int,
     ) -> Iterable[Dict[str, Any]]:
         """Yield rows of a schema-scoped SHOW, paging by object name.
-
-        The builder is handed the page limit so that the statement's LIMIT and the size
-        compared against the row count come from the same value at the same moment.
 
         Schema-scoped output is ordered by name alone, which is exactly what the
         `FROM '<name>'` cursor matches on, so paging here is exact - unlike the
@@ -1098,13 +1102,17 @@ class SnowflakeDataDictionary(SupportsAsObj):
         Python and, on mixed-case identifiers, could call a perfectly good cursor stalled
         and truncate the schema. A short result plus a warning beats a hung ingestion.
         """
+        context = f"{db_name}.{schema_name}"
         seen_names: Set[str] = set()
         marker: Optional[str] = None
         while True:
             rows_in_page = 0
             new_in_page = 0
             last_name: Optional[str] = None
-            for row in self.connection.query(build_query(marker, page_limit)):
+            query = SnowflakeQuery.show_objects_for_schema(
+                object_kind, db_name, schema_name, limit=page_limit, marker=marker
+            )
+            for row in self.connection.query(query):
                 rows_in_page += 1
                 last_name = row["name"]
                 if last_name in seen_names:
@@ -1137,15 +1145,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
         return [
             self._map_show_view(row)
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker, limit: SnowflakeQuery.show_views_for_schema(
-                    db_name,
-                    schema_name,
-                    limit=limit,
-                    view_pagination_marker=marker,
-                ),
-                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
                 object_kind=SnowflakeShowKind.VIEWS,
-                context=f"{db_name}.{schema_name}",
+                db_name=db_name,
+                schema_name=schema_name,
+                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
             )
         ]
 
@@ -1274,8 +1277,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 SnowflakeQuery.get_views_for_database(db_name, view_filter),
             )
         except Exception as e:
+            # Debug for the same reason as get_tables_for_database: "returned too much
+            # data" is this path's normal overflow signal, not a fault.
             logger.debug(f"Failed to get all views for database {db_name}", exc_info=e)
-            # Error - Information schema query returned too much data. Please repeat query with more selective predicates.
             return None
 
         views: Dict[str, List[SnowflakeView]] = {}
@@ -2353,12 +2357,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
         page_limit = SHOW_STREAM_MAX_PAGE_SIZE
 
         return self._probe_database_wide_show(
-            build_query=lambda limit: SnowflakeQuery.streams_for_database(
-                db_name, limit=limit
-            ),
-            page_limit=page_limit,
             object_kind=SnowflakeShowKind.STREAMS,
             db_name=db_name,
+            page_limit=page_limit,
             mapper=self._map_show_stream,
         )
 
@@ -2368,15 +2369,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
         return [
             self._map_show_stream(row)
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker, limit: SnowflakeQuery.streams_for_schema(
-                    db_name,
-                    schema_name,
-                    limit=limit,
-                    stream_pagination_marker=marker,
-                ),
-                page_limit=SHOW_STREAM_MAX_PAGE_SIZE,
                 object_kind=SnowflakeShowKind.STREAMS,
-                context=f"{db_name}.{schema_name}",
+                db_name=db_name,
+                schema_name=schema_name,
+                page_limit=SHOW_STREAM_MAX_PAGE_SIZE,
             )
         ]
 
@@ -2501,12 +2497,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
         # as "this database genuinely has no dynamic tables" and silently drop every
         # definition.
         return self._probe_database_wide_show(
-            build_query=lambda limit: SnowflakeQuery.show_dynamic_tables_for_database(
-                db_name, limit=limit
-            ),
-            page_limit=page_limit,
             object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
             db_name=db_name,
+            page_limit=page_limit,
             mapper=lambda row: self._map_show_dynamic_table(
                 db_name, row, dt_graph_info
             ),
@@ -2520,17 +2513,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
         dynamic_tables: List[SnowflakeDynamicTable] = []
         try:
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker, limit: (
-                    SnowflakeQuery.show_dynamic_tables_for_schema(
-                        db_name,
-                        schema_name,
-                        limit=limit,
-                        dynamic_table_pagination_marker=marker,
-                    )
-                ),
-                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
                 object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
-                context=f"{db_name}.{schema_name}",
+                db_name=db_name,
+                schema_name=schema_name,
+                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
             ):
                 dynamic_tables.append(
                     self._map_show_dynamic_table(db_name, row, dt_graph_info)
@@ -2588,9 +2574,14 @@ class SnowflakeDataDictionary(SupportsAsObj):
                         if isinstance(inp, dict) and inp.get("name")
                     ]
                 except json.JSONDecodeError as e:
-                    logger.warning(
-                        f"Failed to parse INPUTS for dynamic table "
-                        f"{db_name}.{schema_name}.{dt_name}: {e}"
+                    # Every upstream edge for this dynamic table is lost, so this belongs in
+                    # the report rather than only in the log - the same reasoning as the
+                    # fetch failures above.
+                    self.report.warning(
+                        message="Failed to parse dynamic table inputs; "
+                        "upstream lineage will be missing",
+                        context=f"{db_name}.{schema_name}.{dt_name}",
+                        exc=e,
                     )
 
         return SnowflakeDynamicTable(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -970,7 +970,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
     def _probe_database_wide_show(
         self,
         *,
-        query: str,
+        build_query: Callable[[int], str],
         page_limit: int,
         object_kind: SnowflakeShowKind,
         db_name: str,
@@ -990,8 +990,14 @@ class SnowflakeDataDictionary(SupportsAsObj):
 
         Shared by views, streams and dynamic tables so the page-boundary rule lives in one
         place rather than being restated for each object type.
+
+        Takes a query *builder* rather than a query so that the LIMIT in the statement and
+        the page_limit compared against the row count cannot disagree. Were they passed
+        separately, a query built with a smaller LIMIT would never reach page_limit, the
+        fallback would never fire, and objects would be dropped with no warning - the very
+        bug this method exists to prevent.
         """
-        cur = self.connection.query(query)
+        cur = self.connection.query(build_query(page_limit))
 
         grouped: Dict[str, List[_ShowRowT]] = {}
         result_set_size = 0
@@ -1015,7 +1021,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
 
         views = self._probe_database_wide_show(
-            query=SnowflakeQuery.show_views_for_database(db_name, limit=page_limit),
+            build_query=lambda limit: SnowflakeQuery.show_views_for_database(
+                db_name, limit=limit
+            ),
             page_limit=page_limit,
             object_kind=SnowflakeShowKind.VIEWS,
             db_name=db_name,
@@ -1047,12 +1055,17 @@ class SnowflakeDataDictionary(SupportsAsObj):
     def _iter_show_rows_for_schema(
         self,
         *,
-        build_query: Callable[[Optional[str]], str],
+        build_query: Callable[[Optional[str], int], str],
         page_limit: int,
         object_kind: SnowflakeShowKind,
         context: str,
     ) -> Iterable[Dict[str, Any]]:
         """Yield rows of a schema-scoped SHOW, paging by object name.
+
+        The builder is handed the page limit rather than being called with one already
+        baked in, so the statement's LIMIT always matches the size this method compares
+        against - a smaller LIMIT would otherwise look like a short final page and
+        silently truncate the schema after one query.
 
         Schema-scoped output is ordered by name alone, which is exactly what the
         `FROM '<name>'` cursor matches on, so paging here is exact - unlike the
@@ -1068,7 +1081,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         marker: Optional[str] = None
         first_iteration = True
         while first_iteration or marker is not None:
-            cur = self.connection.query(build_query(marker))
+            cur = self.connection.query(build_query(marker, page_limit))
 
             first_iteration = False
             previous_marker = marker
@@ -1105,10 +1118,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
         return [
             self._map_show_view(row)
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker: SnowflakeQuery.show_views_for_schema(
+                build_query=lambda marker, limit: SnowflakeQuery.show_views_for_schema(
                     db_name,
                     schema_name,
-                    limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                    limit=limit,
                     view_pagination_marker=marker,
                 ),
                 page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
@@ -2321,7 +2334,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
         page_limit = SHOW_STREAM_MAX_PAGE_SIZE
 
         return self._probe_database_wide_show(
-            query=SnowflakeQuery.streams_for_database(db_name, limit=page_limit),
+            build_query=lambda limit: SnowflakeQuery.streams_for_database(
+                db_name, limit=limit
+            ),
             page_limit=page_limit,
             object_kind=SnowflakeShowKind.STREAMS,
             db_name=db_name,
@@ -2334,10 +2349,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
         return [
             self._map_show_stream(row)
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker: SnowflakeQuery.streams_for_schema(
+                build_query=lambda marker, limit: SnowflakeQuery.streams_for_schema(
                     db_name,
                     schema_name,
-                    limit=SHOW_STREAM_MAX_PAGE_SIZE,
+                    limit=limit,
                     stream_pagination_marker=marker,
                 ),
                 page_limit=SHOW_STREAM_MAX_PAGE_SIZE,
@@ -2464,8 +2479,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
 
         try:
             return self._probe_database_wide_show(
-                query=SnowflakeQuery.show_dynamic_tables_for_database(
-                    db_name, limit=page_limit
+                build_query=lambda limit: (
+                    SnowflakeQuery.show_dynamic_tables_for_database(
+                        db_name, limit=limit
+                    )
                 ),
                 page_limit=page_limit,
                 object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
@@ -2478,9 +2495,13 @@ class SnowflakeDataDictionary(SupportsAsObj):
             # None, not an empty mapping: {} would read as "this database genuinely has no
             # dynamic tables" and silently drop every definition. None sends the caller
             # down the per-schema path, which can still succeed when only the
-            # database-wide statement failed (a timeout, or too large a result set) and
-            # which degrades quietly on its own if the failure is systemic.
-            logger.debug(f"Failed to get dynamic tables for database {db_name}: {e}")
+            # database-wide statement failed (a timeout, or too large a result set).
+            self.report.warning(
+                message="Failed to get dynamic tables for database; "
+                "retrying per schema",
+                context=db_name,
+                exc=e,
+            )
             return None
 
     def get_dynamic_tables_for_schema_using_show(
@@ -2491,11 +2512,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
         dynamic_tables: List[SnowflakeDynamicTable] = []
         try:
             for row in self._iter_show_rows_for_schema(
-                build_query=lambda marker: (
+                build_query=lambda marker, limit: (
                     SnowflakeQuery.show_dynamic_tables_for_schema(
                         db_name,
                         schema_name,
-                        limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                        limit=limit,
                         dynamic_table_pagination_marker=marker,
                     )
                 ),
@@ -2507,8 +2528,15 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     self._map_show_dynamic_table(db_name, row, dt_graph_info)
                 )
         except Exception as e:
-            logger.debug(
-                f"Failed to get dynamic tables for {db_name}.{schema_name}: {e}"
+            # This is the last resort - there is no further fallback - so a failure here
+            # loses every definition and its lineage for the schema. `dynamic_tables` may
+            # also hold a partial page, which the caller cannot distinguish from a
+            # complete one, so the count has to be reported rather than logged.
+            self.report.warning(
+                message="Failed to get dynamic tables for schema; "
+                "definitions may be incomplete",
+                context=f"{db_name}.{schema_name} (kept {len(dynamic_tables)})",
+                exc=e,
             )
 
         return dynamic_tables
@@ -2580,13 +2608,21 @@ class SnowflakeDataDictionary(SupportsAsObj):
             dt_with_definitions = self.get_dynamic_tables_with_definitions(db_name)
 
             if dt_with_definitions is None:
-                # The database-wide SHOW filled its page and cannot be paged safely.
-                # Fetch only the schemas we actually need, paging each one exactly.
+                # The database-wide SHOW filled its page and cannot be paged safely, so
+                # page per schema instead - but only for schemas that actually hold a
+                # dynamic table still missing its definition, since that is all the loop
+                # below consumes. Visiting every schema in the database would cost one
+                # query per schema to answer a question about a handful of them.
                 dt_with_definitions = {
                     schema_name: self.get_dynamic_tables_for_schema_using_show(
                         db_name=db_name, schema_name=schema_name
                     )
-                    for schema_name in tables
+                    for schema_name, table_list in tables.items()
+                    if any(
+                        isinstance(table, SnowflakeDynamicTable)
+                        and table.definition is None
+                        for table in table_list
+                    )
                 }
 
             for schema_name, table_list in tables.items():
@@ -2604,8 +2640,10 @@ class SnowflakeDataDictionary(SupportsAsObj):
                                 table.upstream_tables = show_dt.upstream_tables
                                 break
         except Exception as e:
-            logger.debug(
-                f"Failed to populate dynamic table definitions for {db_name}: {e}"
+            self.report.warning(
+                message="Failed to populate dynamic table definitions",
+                context=db_name,
+                exc=e,
             )
 
     def get_stages_for_schema(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -2464,7 +2464,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 # _map_show_dynamic_table looks it up. Keying on the bare NAME silently
                 # dropped every dynamic table's upstream lineage and its fallback target
                 # lag - the lookup simply never hit.
-                dt_name = f"{db_name}.{row['SCHEMA_NAME']}.{row['NAME']}"
+                #
+                # The database comes from the row, not from db_name: the underlying function
+                # is account-scoped, so stamping the caller's database would let a same-named
+                # schema.table in another database claim this one's key.
+                dt_name = f"{row['DATABASE_NAME']}.{row['SCHEMA_NAME']}.{row['NAME']}"
                 dt_graph_info[dt_name] = {
                     "inputs": row.get("INPUTS"),
                     "target_lag_type": row.get("TARGET_LAG_TYPE"),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeVar,
 )
 
 import sqlglot
@@ -53,6 +54,9 @@ class SnowflakeTaskState(StrEnum):
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+# Row type produced by a database-wide SHOW mapper (a view, stream or dynamic table).
+_ShowRowT = TypeVar("_ShowRowT")
 
 SCHEMA_PARALLELISM = get_snowflake_schema_parallelism()
 
@@ -962,36 +966,61 @@ class SnowflakeDataDictionary(SupportsAsObj):
         else:
             return self._get_views_for_database_using_show(db_name)
 
+    def _probe_database_wide_show(
+        self,
+        *,
+        query: str,
+        page_limit: int,
+        object_kind: str,
+        db_name: str,
+        mapper: Callable[[Dict[str, Any]], _ShowRowT],
+    ) -> Optional[Dict[str, List[_ShowRowT]]]:
+        """Run one database-wide SHOW and group the rows by schema, or give up.
+
+        A full page means there is more to fetch, and a database-wide SHOW cannot be
+        continued: its `FROM '<name>'` cursor keys on the object name alone while the
+        output is ordered by (schema, name). Measured against a live account, continuing
+        drops every object in a later schema whose name sorts below the marker while
+        re-returning earlier schemas' higher-sorting ones — and if the marker happens to
+        name an INFORMATION_SCHEMA view the cursor is ignored entirely and the loop spins
+        forever. Returning None tells the caller to page per schema instead, where name
+        *is* the whole sort key and paging is exact (verified against a 16k-view schema:
+        two pages, no gaps, no duplicates).
+
+        Shared by views, streams and dynamic tables so the page-boundary rule lives in one
+        place rather than being restated for each object type.
+        """
+        cur = self.connection.query(query)
+
+        grouped: Dict[str, List[_ShowRowT]] = {}
+        result_set_size = 0
+        for row in cur:
+            result_set_size += 1
+            grouped.setdefault(row["schema_name"], []).append(mapper(row))
+
+        if result_set_size >= page_limit:
+            logger.info(
+                f"Database-wide 'SHOW {object_kind}' for {db_name} filled its "
+                f"{page_limit}-row page; falling back to per-schema queries, which "
+                "paginate reliably."
+            )
+            return None
+
+        return grouped
+
     def _get_views_for_database_using_show(
         self, db_name: str
     ) -> Optional[Dict[str, List[SnowflakeView]]]:
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
 
-        cur = self.connection.query(
-            SnowflakeQuery.show_views_for_database(db_name, limit=page_limit)
+        views = self._probe_database_wide_show(
+            query=SnowflakeQuery.show_views_for_database(db_name, limit=page_limit),
+            page_limit=page_limit,
+            object_kind="VIEWS",
+            db_name=db_name,
+            mapper=self._map_show_view,
         )
-
-        views: Dict[str, List[SnowflakeView]] = {}
-        result_set_size = 0
-        for view in cur:
-            result_set_size += 1
-            views.setdefault(view["schema_name"], []).append(self._map_show_view(view))
-
-        if result_set_size >= page_limit:
-            # A full page means there are more views than one `SHOW VIEWS IN DATABASE`
-            # can return, and that result cannot be continued: its `FROM '<name>'` cursor
-            # keys on the object name alone while the output is ordered by
-            # (schema, name). Measured live, continuing drops every view in a later
-            # schema whose name sorts below the marker while re-returning earlier
-            # schemas' higher-sorting views - and if the marker happens to name an
-            # INFORMATION_SCHEMA view the cursor is ignored entirely and the loop spins
-            # forever. Give up on the database-wide query and let the caller page per
-            # schema, where name *is* the whole sort key and paging is exact (verified
-            # against a 16k-view schema: two pages, no gaps, no duplicates).
-            logger.info(
-                f"Database-wide 'SHOW VIEWS' for {db_name} filled its {page_limit}-row "
-                "page; falling back to per-schema queries, which paginate reliably."
-            )
+        if views is None:
             return None
 
         # Because this is in a cached function, this will only log once per database.
@@ -2290,28 +2319,13 @@ class SnowflakeDataDictionary(SupportsAsObj):
     ) -> Optional[Dict[str, List[SnowflakeStream]]]:
         page_limit = SHOW_STREAM_MAX_PAGE_SIZE
 
-        cur = self.connection.query(
-            SnowflakeQuery.streams_for_database(db_name, limit=page_limit)
+        return self._probe_database_wide_show(
+            query=SnowflakeQuery.streams_for_database(db_name, limit=page_limit),
+            page_limit=page_limit,
+            object_kind="STREAMS",
+            db_name=db_name,
+            mapper=self._map_show_stream,
         )
-
-        streams: Dict[str, List[SnowflakeStream]] = {}
-        result_set_size = 0
-        for stream in cur:
-            result_set_size += 1
-            streams.setdefault(stream["schema_name"], []).append(
-                self._map_show_stream(stream)
-            )
-
-        if result_set_size >= page_limit:
-            # A full page cannot be continued safely - see
-            # _get_views_for_database_using_show for the cursor-vs-sort-key reasoning.
-            logger.info(
-                f"Database-wide 'SHOW STREAMS' for {db_name} filled its {page_limit}-row "
-                "page; falling back to per-schema queries, which paginate reliably."
-            )
-            return None
-
-        return streams
 
     def get_streams_for_schema_using_show(
         self, *, db_name: str, schema_name: str
@@ -2443,39 +2457,27 @@ class SnowflakeDataDictionary(SupportsAsObj):
     ) -> Optional[Dict[str, List[SnowflakeDynamicTable]]]:
         """Get dynamic tables with their definitions using SHOW DYNAMIC TABLES."""
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
-        dynamic_tables: Dict[str, List[SnowflakeDynamicTable]] = {}
 
         # Get graph/dependency information (pass db_name)
         dt_graph_info = self.get_dynamic_table_graph_info(db_name)
 
         try:
-            cur = self.connection.query(
-                SnowflakeQuery.show_dynamic_tables_for_database(
+            return self._probe_database_wide_show(
+                query=SnowflakeQuery.show_dynamic_tables_for_database(
                     db_name, limit=page_limit
-                )
+                ),
+                page_limit=page_limit,
+                object_kind="DYNAMIC TABLES",
+                db_name=db_name,
+                mapper=lambda row: self._map_show_dynamic_table(
+                    db_name, row, dt_graph_info
+                ),
             )
-
-            result_set_size = 0
-            for dt in cur:
-                result_set_size += 1
-                dynamic_tables.setdefault(dt["schema_name"], []).append(
-                    self._map_show_dynamic_table(db_name, dt, dt_graph_info)
-                )
         except Exception as e:
+            # An empty mapping (rather than None) keeps the caller on the database-wide
+            # path with no definitions, degrading gracefully instead of failing the scan.
             logger.debug(f"Failed to get dynamic tables for database {db_name}: {e}")
-            return dynamic_tables
-
-        if result_set_size >= page_limit:
-            # A full page cannot be continued safely - see
-            # _get_views_for_database_using_show for the cursor-vs-sort-key reasoning.
-            logger.info(
-                f"Database-wide 'SHOW DYNAMIC TABLES' for {db_name} filled its "
-                f"{page_limit}-row page; falling back to per-schema queries, which "
-                "paginate reliably."
-            )
-            return None
-
-        return dynamic_tables
+            return {}
 
     def get_dynamic_tables_for_schema_using_show(
         self, *, db_name: str, schema_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -15,6 +15,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeGuard,
     TypeVar,
 )
 
@@ -55,6 +56,17 @@ class SnowflakeTaskState(StrEnum):
 
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _needs_definition(table: "SnowflakeTable") -> TypeGuard["SnowflakeDynamicTable"]:
+    """Whether a table is a dynamic table still awaiting its SHOW-derived definition.
+
+    Used both to choose which schemas the per-schema fallback visits and to decide which
+    tables the results are applied to - the two must agree, or the fallback either queries
+    schemas it has no use for or skips schemas it needed.
+    """
+    return isinstance(table, SnowflakeDynamicTable) and table.definition is None
+
 
 # Row type produced by a database-wide SHOW mapper (a view, stream or dynamic table).
 _ShowRowT = TypeVar("_ShowRowT")
@@ -2614,19 +2626,12 @@ class SnowflakeDataDictionary(SupportsAsObj):
                         db_name=db_name, schema_name=schema_name
                     )
                     for schema_name, table_list in tables.items()
-                    if any(
-                        isinstance(table, SnowflakeDynamicTable)
-                        and table.definition is None
-                        for table in table_list
-                    )
+                    if any(_needs_definition(table) for table in table_list)
                 }
 
             for schema_name, table_list in tables.items():
                 for table in table_list:
-                    if (
-                        isinstance(table, SnowflakeDynamicTable)
-                        and table.definition is None
-                    ):
+                    if _needs_definition(table):
                         # Find matching dynamic table from SHOW results
                         show_dt_list = dt_with_definitions.get(schema_name, [])
                         for show_dt in show_dt_list:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -988,30 +988,39 @@ class SnowflakeDataDictionary(SupportsAsObj):
         *is* the whole sort key and paging is exact (verified against a 16k-view schema:
         two pages, no gaps, no duplicates).
 
+        A failure is reported and also answered with None, so a database-wide SHOW that
+        cannot run at all (a missing grant, a statement timeout) still reaches the exact
+        per-schema path instead of losing the whole database. Catching here rather than in
+        each caller keeps one failure policy for views, streams and dynamic tables - and
+        matters because serialized_lru_cache does not cache exceptions, so an uncaught
+        failure would re-run this query once per schema.
+
         Shared by views, streams and dynamic tables so the page-boundary rule lives in one
         place rather than being restated for each object type.
-
-        Takes a query *builder* rather than a query so that the LIMIT in the statement and
-        the page_limit compared against the row count cannot disagree. Were they passed
-        separately, a query built with a smaller LIMIT would never reach page_limit, the
-        fallback would never fire, and objects would be dropped with no warning - the very
-        bug this method exists to prevent.
         """
-        cur = self.connection.query(build_query(page_limit))
+        try:
+            rows = list(self.connection.query(build_query(page_limit)))
+        except Exception as e:
+            self.report.warning(
+                message="Database-wide SHOW failed; retrying per schema",
+                context=f"{object_kind} in {db_name}",
+                exc=e,
+            )
+            return None
 
-        grouped: Dict[str, List[_ShowRowT]] = {}
-        result_set_size = 0
-        for row in cur:
-            result_set_size += 1
-            grouped.setdefault(row["schema_name"], []).append(mapper(row))
-
-        if result_set_size >= page_limit:
+        # Check the page size before mapping: on a full page every mapped object is
+        # discarded, and for dynamic tables each one parses JSON.
+        if len(rows) >= page_limit:
             logger.info(
                 f"Database-wide 'SHOW {object_kind}' for {db_name} filled its "
                 f"{page_limit}-row page; falling back to per-schema queries, which "
                 "paginate reliably."
             )
             return None
+
+        grouped: Dict[str, List[_ShowRowT]] = {}
+        for row in rows:
+            grouped.setdefault(row["schema_name"], []).append(mapper(row))
 
         return grouped
 
@@ -1062,10 +1071,8 @@ class SnowflakeDataDictionary(SupportsAsObj):
     ) -> Iterable[Dict[str, Any]]:
         """Yield rows of a schema-scoped SHOW, paging by object name.
 
-        The builder is handed the page limit rather than being called with one already
-        baked in, so the statement's LIMIT always matches the size this method compares
-        against - a smaller LIMIT would otherwise look like a short final page and
-        silently truncate the schema after one query.
+        The builder is handed the page limit so that the statement's LIMIT and the size
+        compared against the row count come from the same value at the same moment.
 
         Schema-scoped output is ordered by name alone, which is exactly what the
         `FROM '<name>'` cursor matches on, so paging here is exact - unlike the
@@ -1073,44 +1080,44 @@ class SnowflakeDataDictionary(SupportsAsObj):
 
         Snowflake does not honour that cursor for every object class, though: for its
         built-in INFORMATION_SCHEMA views, `FROM` is ignored and every page repeats the
-        first, which would spin forever. So stop as soon as the marker fails to advance,
-        and dedupe by name so a misbehaving cursor can never emit an object twice. A
-        short result plus a warning beats a hung ingestion.
+        first, which would spin forever. Termination is therefore decided by whether a
+        full page produced any name not already seen - deliberately not by comparing the
+        new marker against the old one, which would re-derive Snowflake's collation in
+        Python and, on mixed-case identifiers, could call a perfectly good cursor stalled
+        and truncate the schema. A short result plus a warning beats a hung ingestion.
         """
         seen_names: Set[str] = set()
         marker: Optional[str] = None
-        first_iteration = True
-        while first_iteration or marker is not None:
-            cur = self.connection.query(build_query(marker, page_limit))
-
-            first_iteration = False
-            previous_marker = marker
-            marker = None
-
-            result_set_size = 0
+        while True:
+            rows_in_page = 0
+            new_in_page = 0
             last_name: Optional[str] = None
-            for row in cur:
-                result_set_size += 1
+            for row in self.connection.query(build_query(marker, page_limit)):
+                rows_in_page += 1
                 last_name = row["name"]
                 if last_name in seen_names:
                     continue
                 seen_names.add(last_name)
+                new_in_page += 1
                 yield row
 
-            if result_set_size >= page_limit and last_name is not None:
-                if previous_marker is not None and last_name <= previous_marker:
-                    self.report.warning(
-                        message=f"Paginated 'SHOW {object_kind}' stopped early because "
-                        "Snowflake did not honour the pagination cursor; some objects "
-                        "may be missing.",
-                        context=f"{context} after {previous_marker}",
-                    )
-                    return
-                logger.info(
-                    f"Fetching next page of {object_kind.lower()} for {context} - "
-                    f"after {last_name}"
+            if rows_in_page < page_limit or last_name is None:
+                return
+
+            if new_in_page == 0:
+                self.report.warning(
+                    message=f"Paginated 'SHOW {object_kind}' stopped early because "
+                    "Snowflake did not honour the pagination cursor; some objects "
+                    "may be missing.",
+                    context=f"{context} after {marker}",
                 )
-                marker = last_name
+                return
+
+            logger.info(
+                f"Fetching next page of {object_kind.lower()} for {context} - "
+                f"after {last_name}"
+            )
+            marker = last_name
 
     def get_views_for_schema_using_show(
         self, *, db_name: str, schema_name: str
@@ -2477,32 +2484,21 @@ class SnowflakeDataDictionary(SupportsAsObj):
         # Get graph/dependency information (pass db_name)
         dt_graph_info = self.get_dynamic_table_graph_info(db_name)
 
-        try:
-            return self._probe_database_wide_show(
-                build_query=lambda limit: (
-                    SnowflakeQuery.show_dynamic_tables_for_database(
-                        db_name, limit=limit
-                    )
-                ),
-                page_limit=page_limit,
-                object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
-                db_name=db_name,
-                mapper=lambda row: self._map_show_dynamic_table(
-                    db_name, row, dt_graph_info
-                ),
-            )
-        except Exception as e:
-            # None, not an empty mapping: {} would read as "this database genuinely has no
-            # dynamic tables" and silently drop every definition. None sends the caller
-            # down the per-schema path, which can still succeed when only the
-            # database-wide statement failed (a timeout, or too large a result set).
-            self.report.warning(
-                message="Failed to get dynamic tables for database; "
-                "retrying per schema",
-                context=db_name,
-                exc=e,
-            )
-            return None
+        # No try/except here: _probe_database_wide_show reports a failure and answers None,
+        # which is the caller's signal to page per schema. Returning {} instead would read
+        # as "this database genuinely has no dynamic tables" and silently drop every
+        # definition.
+        return self._probe_database_wide_show(
+            build_query=lambda limit: SnowflakeQuery.show_dynamic_tables_for_database(
+                db_name, limit=limit
+            ),
+            page_limit=page_limit,
+            object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
+            db_name=db_name,
+            mapper=lambda row: self._map_show_dynamic_table(
+                db_name, row, dt_graph_info
+            ),
+        )
 
     def get_dynamic_tables_for_schema_using_show(
         self, *, db_name: str, schema_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -1083,7 +1083,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         views it is ignored and every page repeats the first - so termination is decided by
         whether a full page yielded a name not already seen. Deliberately not by comparing
         markers: that re-derives Snowflake's collation in Python and could call a working
-        cursor stalled on mixed-case identifiers. A short result plus a warning beats a hang.
+        cursor stalled on mixed-case identifiers. A short result plus a failure beats a hang.
         """
         context = f"{db_name}.{schema_name}"
         seen_names: Set[str] = set()
@@ -1102,10 +1102,17 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 # earlier one - but the caller cannot tell a truncated schema from a small
                 # one, so the count has to be reported. Handled here so views, streams and
                 # dynamic tables share one policy.
-                self.report.warning(
-                    message=f"Paginated 'SHOW {object_kind}' failed for schema; "
+                #
+                # failure, not warning: this returns a knowingly incomplete object list, and
+                # stale-entity removal only skips soft-deletion when the source reported a
+                # failure (stale_entity_removal_handler: `if self.report.failures`). A warning
+                # would let the schema's missing objects be soft-deleted as if they were gone
+                # from Snowflake - and the fail-safe threshold (75% by default) is far too
+                # coarse to catch one schema out of hundreds.
+                self.report.failure(
+                    message="Paginated 'SHOW' failed for schema; "
                     "results may be incomplete",
-                    context=f"{context} (kept {len(seen_names)})",
+                    context=f"SHOW {object_kind} in {context} (kept {len(seen_names)})",
                     exc=e,
                 )
                 return
@@ -1123,11 +1130,12 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 return
 
             if new_in_page == 0:
-                self.report.warning(
-                    message=f"Paginated 'SHOW {object_kind}' stopped early because "
-                    "Snowflake did not honour the pagination cursor; some objects "
-                    "may be missing.",
-                    context=f"{context} after {marker}",
+                # Same incompleteness, same severity as the failed-page case above: a cursor
+                # Snowflake ignores leaves objects unlisted, so soft-deletion must not run.
+                self.report.failure(
+                    message="Paginated 'SHOW' stopped early because Snowflake did not "
+                    "honour the pagination cursor; some objects may be missing.",
+                    context=f"SHOW {object_kind} in {context} after {marker}",
                 )
                 return
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -1095,7 +1095,22 @@ class SnowflakeDataDictionary(SupportsAsObj):
             query = SnowflakeQuery.show_objects_for_schema(
                 object_kind, db_name, schema_name, limit=page_limit, marker=marker
             )
-            for row in self.connection.query(query):
+            try:
+                page = list(self.connection.query(query))
+            except Exception as e:
+                # Rows already yielded stand - a later page failing does not invalidate an
+                # earlier one - but the caller cannot tell a truncated schema from a small
+                # one, so the count has to be reported. Handled here so views, streams and
+                # dynamic tables share one policy.
+                self.report.warning(
+                    message=f"Paginated 'SHOW {object_kind}' failed for schema; "
+                    "results may be incomplete",
+                    context=f"{context} (kept {len(seen_names)})",
+                    exc=e,
+                )
+                return
+
+            for row in page:
                 rows_in_page += 1
                 last_name = row["name"]
                 if last_name in seen_names:
@@ -2497,30 +2512,17 @@ class SnowflakeDataDictionary(SupportsAsObj):
     ) -> List[SnowflakeDynamicTable]:
         dt_graph_info = self.get_dynamic_table_graph_info(db_name)
 
-        dynamic_tables: List[SnowflakeDynamicTable] = []
-        try:
+        # No handler here: _iter_show_rows_for_schema reports a failure with the count it
+        # kept, so all three object kinds degrade identically.
+        return [
+            self._map_show_dynamic_table(db_name, row, dt_graph_info)
             for row in self._iter_show_rows_for_schema(
                 object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
                 db_name=db_name,
                 schema_name=schema_name,
                 page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
-            ):
-                dynamic_tables.append(
-                    self._map_show_dynamic_table(db_name, row, dt_graph_info)
-                )
-        except Exception as e:
-            # This is the last resort - there is no further fallback - so a failure here
-            # loses every definition and its lineage for the schema. `dynamic_tables` may
-            # also hold a partial page, which the caller cannot distinguish from a
-            # complete one, so the count has to be reported rather than logged.
-            self.report.warning(
-                message="Failed to get dynamic tables for schema; "
-                "definitions may be incomplete",
-                context=f"{db_name}.{schema_name} (kept {len(dynamic_tables)})",
-                exc=e,
             )
-
-        return dynamic_tables
+        ]
 
     def _map_show_dynamic_table(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -30,6 +30,7 @@ from datahub.ingestion.source.snowflake.constants import (
 from datahub.ingestion.source.snowflake.snowflake_connection import SnowflakeConnection
 from datahub.ingestion.source.snowflake.snowflake_query import (
     SHOW_COMMAND_MAX_PAGE_SIZE,
+    SHOW_STREAM_MAX_PAGE_SIZE,
     SnowflakeQuery,
 )
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
@@ -963,52 +964,35 @@ class SnowflakeDataDictionary(SupportsAsObj):
 
     def _get_views_for_database_using_show(
         self, db_name: str
-    ) -> Dict[str, List[SnowflakeView]]:
+    ) -> Optional[Dict[str, List[SnowflakeView]]]:
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
 
+        cur = self.connection.query(
+            SnowflakeQuery.show_views_for_database(db_name, limit=page_limit)
+        )
+
         views: Dict[str, List[SnowflakeView]] = {}
+        result_set_size = 0
+        for view in cur:
+            result_set_size += 1
+            views.setdefault(view["schema_name"], []).append(self._map_show_view(view))
 
-        first_iteration = True
-        view_pagination_marker: Optional[str] = None
-        while first_iteration or view_pagination_marker is not None:
-            cur = self.connection.query(
-                SnowflakeQuery.show_views_for_database(
-                    db_name,
-                    limit=page_limit,
-                    view_pagination_marker=view_pagination_marker,
-                )
+        if result_set_size >= page_limit:
+            # A full page means there are more views than one `SHOW VIEWS IN DATABASE`
+            # can return, and that result cannot be continued: its `FROM '<name>'` cursor
+            # keys on the object name alone while the output is ordered by
+            # (schema, name). Measured live, continuing drops every view in a later
+            # schema whose name sorts below the marker while re-returning earlier
+            # schemas' higher-sorting views - and if the marker happens to name an
+            # INFORMATION_SCHEMA view the cursor is ignored entirely and the loop spins
+            # forever. Give up on the database-wide query and let the caller page per
+            # schema, where name *is* the whole sort key and paging is exact (verified
+            # against a 16k-view schema: two pages, no gaps, no duplicates).
+            logger.info(
+                f"Database-wide 'SHOW VIEWS' for {db_name} filled its {page_limit}-row "
+                "page; falling back to per-schema queries, which paginate reliably."
             )
-
-            first_iteration = False
-            view_pagination_marker = None
-
-            result_set_size = 0
-            for view in cur:
-                result_set_size += 1
-
-                view_name = view["name"]
-                schema_name = view["schema_name"]
-                if schema_name not in views:
-                    views[schema_name] = []
-                views[schema_name].append(
-                    SnowflakeView(
-                        name=view_name,
-                        created=view["created_on"],
-                        comment=view["comment"],
-                        view_definition=view["text"],
-                        last_altered=view["created_on"],  # TODO: This is not correct.
-                        materialized=(
-                            view.get("is_materialized", "false").lower() == "true"
-                        ),
-                        is_secure=(view.get("is_secure", "false").lower() == "true"),
-                    )
-                )
-
-            if result_set_size >= page_limit:
-                logger.info(
-                    f"Fetching next page of views for {db_name} - after {view_name}"
-                )
-                view_pagination_marker = view_name
+            return None
 
         # Because this is in a cached function, this will only log once per database.
         view_counts = {schema_name: len(views[schema_name]) for schema_name in views}
@@ -1016,6 +1000,103 @@ class SnowflakeDataDictionary(SupportsAsObj):
             f"Finished fetching views in {db_name}; counts by schema {view_counts}"
         )
         return views
+
+    def get_views_for_schema(
+        self, *, db_name: str, schema_name: str, view_filter: str = ""
+    ) -> List[SnowflakeView]:
+        """Fetch one schema's views, for when the database-wide fetch cannot return a
+        complete result. Mirrors the strategy chosen by get_views_for_database."""
+        if self._fetch_views_from_information_schema:
+            return self.get_views_for_schema_using_information_schema(
+                db_name=db_name, schema_name=schema_name, view_filter=view_filter
+            )
+        return self.get_views_for_schema_using_show(
+            db_name=db_name, schema_name=schema_name
+        )
+
+    def _iter_show_rows_for_schema(
+        self,
+        *,
+        build_query: Callable[[Optional[str]], str],
+        page_limit: int,
+        object_kind: str,
+        context: str,
+    ) -> Iterable[Dict[str, Any]]:
+        """Yield rows of a schema-scoped SHOW, paging by object name.
+
+        Schema-scoped output is ordered by name alone, which is exactly what the
+        `FROM '<name>'` cursor matches on, so paging here is exact - unlike the
+        database-wide form (see _get_views_for_database_using_show).
+
+        Snowflake does not honour that cursor for every object class, though: for its
+        built-in INFORMATION_SCHEMA views, `FROM` is ignored and every page repeats the
+        first, which would spin forever. So stop as soon as the marker fails to advance,
+        and dedupe by name so a misbehaving cursor can never emit an object twice. A
+        short result plus a warning beats a hung ingestion.
+        """
+        seen_names: Set[str] = set()
+        marker: Optional[str] = None
+        first_iteration = True
+        while first_iteration or marker is not None:
+            cur = self.connection.query(build_query(marker))
+
+            first_iteration = False
+            previous_marker = marker
+            marker = None
+
+            result_set_size = 0
+            last_name: Optional[str] = None
+            for row in cur:
+                result_set_size += 1
+                last_name = row["name"]
+                if last_name in seen_names:
+                    continue
+                seen_names.add(last_name)
+                yield row
+
+            if result_set_size >= page_limit and last_name is not None:
+                if previous_marker is not None and last_name <= previous_marker:
+                    self.report.warning(
+                        message=f"Paginated 'SHOW {object_kind}' stopped early because "
+                        "Snowflake did not honour the pagination cursor; some objects "
+                        "may be missing.",
+                        context=f"{context} after {previous_marker}",
+                    )
+                    return
+                logger.info(
+                    f"Fetching next page of {object_kind.lower()} for {context} - "
+                    f"after {last_name}"
+                )
+                marker = last_name
+
+    def get_views_for_schema_using_show(
+        self, *, db_name: str, schema_name: str
+    ) -> List[SnowflakeView]:
+        return [
+            self._map_show_view(row)
+            for row in self._iter_show_rows_for_schema(
+                build_query=lambda marker: SnowflakeQuery.show_views_for_schema(
+                    db_name,
+                    schema_name,
+                    limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                    view_pagination_marker=marker,
+                ),
+                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                object_kind="VIEWS",
+                context=f"{db_name}.{schema_name}",
+            )
+        ]
+
+    def _map_show_view(self, row: Dict[str, Any]) -> SnowflakeView:
+        return SnowflakeView(
+            name=row["name"],
+            created=row["created_on"],
+            comment=row["comment"],
+            view_definition=row["text"],
+            last_altered=row["created_on"],  # TODO: This is not correct.
+            materialized=(row.get("is_materialized", "false").lower() == "true"),
+            is_secure=(row.get("is_secure", "false").lower() == "true"),
+        )
 
     def _map_view(self, db_name: str, row: Dict[str, Any]) -> Tuple[str, SnowflakeView]:
         schema_name = row["VIEW_SCHEMA"]
@@ -2206,61 +2287,69 @@ class SnowflakeDataDictionary(SupportsAsObj):
     @serialized_lru_cache(maxsize=1)
     def get_streams_for_database(
         self, db_name: str
-    ) -> Dict[str, List[SnowflakeStream]]:
-        page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
+    ) -> Optional[Dict[str, List[SnowflakeStream]]]:
+        page_limit = SHOW_STREAM_MAX_PAGE_SIZE
+
+        cur = self.connection.query(
+            SnowflakeQuery.streams_for_database(db_name, limit=page_limit)
+        )
 
         streams: Dict[str, List[SnowflakeStream]] = {}
-
-        first_iteration = True
-        stream_pagination_marker: Optional[str] = None
-        while first_iteration or stream_pagination_marker is not None:
-            cur = self.connection.query(
-                SnowflakeQuery.streams_for_database(
-                    db_name,
-                    limit=page_limit,
-                    stream_pagination_marker=stream_pagination_marker,
-                )
+        result_set_size = 0
+        for stream in cur:
+            result_set_size += 1
+            streams.setdefault(stream["schema_name"], []).append(
+                self._map_show_stream(stream)
             )
 
-            first_iteration = False
-            stream_pagination_marker = None
-
-            result_set_size = 0
-            for stream in cur:
-                result_set_size += 1
-
-                stream_name = stream["name"]
-                schema_name = stream["schema_name"]
-                if schema_name not in streams:
-                    streams[schema_name] = []
-                streams[stream["schema_name"]].append(
-                    SnowflakeStream(
-                        name=stream["name"],
-                        created=stream["created_on"],
-                        owner=stream["owner"],
-                        comment=stream["comment"],
-                        source_type=stream["source_type"],
-                        type=stream["type"],
-                        stale=stream["stale"],
-                        mode=stream["mode"],
-                        database_name=stream["database_name"],
-                        schema_name=stream["schema_name"],
-                        invalid_reason=stream["invalid_reason"],
-                        owner_role_type=stream["owner_role_type"],
-                        stale_after=stream["stale_after"],
-                        table_name=stream["table_name"],
-                        base_tables=stream["base_tables"],
-                        last_altered=stream["created_on"],
-                    )
-                )
-
-            if result_set_size >= page_limit:
-                logger.info(
-                    f"Fetching next page of streams for {db_name} - after {stream_name}"
-                )
-                stream_pagination_marker = stream_name
+        if result_set_size >= page_limit:
+            # A full page cannot be continued safely - see
+            # _get_views_for_database_using_show for the cursor-vs-sort-key reasoning.
+            logger.info(
+                f"Database-wide 'SHOW STREAMS' for {db_name} filled its {page_limit}-row "
+                "page; falling back to per-schema queries, which paginate reliably."
+            )
+            return None
 
         return streams
+
+    def get_streams_for_schema_using_show(
+        self, *, db_name: str, schema_name: str
+    ) -> List[SnowflakeStream]:
+        return [
+            self._map_show_stream(row)
+            for row in self._iter_show_rows_for_schema(
+                build_query=lambda marker: SnowflakeQuery.streams_for_schema(
+                    db_name,
+                    schema_name,
+                    limit=SHOW_STREAM_MAX_PAGE_SIZE,
+                    stream_pagination_marker=marker,
+                ),
+                page_limit=SHOW_STREAM_MAX_PAGE_SIZE,
+                object_kind="STREAMS",
+                context=f"{db_name}.{schema_name}",
+            )
+        ]
+
+    def _map_show_stream(self, row: Dict[str, Any]) -> SnowflakeStream:
+        return SnowflakeStream(
+            name=row["name"],
+            created=row["created_on"],
+            owner=row["owner"],
+            comment=row["comment"],
+            source_type=row["source_type"],
+            type=row["type"],
+            stale=row["stale"],
+            mode=row["mode"],
+            database_name=row["database_name"],
+            schema_name=row["schema_name"],
+            invalid_reason=row["invalid_reason"],
+            owner_role_type=row["owner_role_type"],
+            stale_after=row["stale_after"],
+            table_name=row["table_name"],
+            base_tables=row["base_tables"],
+            last_altered=row["created_on"],
+        )
 
     @serialized_lru_cache(maxsize=1)
     def get_procedures_for_database(
@@ -2351,7 +2440,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
     @serialized_lru_cache(maxsize=1)
     def get_dynamic_tables_with_definitions(
         self, db_name: str
-    ) -> Dict[str, List[SnowflakeDynamicTable]]:
+    ) -> Optional[Dict[str, List[SnowflakeDynamicTable]]]:
         """Get dynamic tables with their definitions using SHOW DYNAMIC TABLES."""
         page_limit = SHOW_COMMAND_MAX_PAGE_SIZE
         dynamic_tables: Dict[str, List[SnowflakeDynamicTable]] = {}
@@ -2359,97 +2448,122 @@ class SnowflakeDataDictionary(SupportsAsObj):
         # Get graph/dependency information (pass db_name)
         dt_graph_info = self.get_dynamic_table_graph_info(db_name)
 
-        first_iteration = True
-        dt_pagination_marker: Optional[str] = None
-
-        while first_iteration or dt_pagination_marker is not None:
-            try:
-                cur = self.connection.query(
-                    SnowflakeQuery.show_dynamic_tables_for_database(
-                        db_name,
-                        limit=page_limit,
-                        dynamic_table_pagination_marker=dt_pagination_marker,
-                    )
+        try:
+            cur = self.connection.query(
+                SnowflakeQuery.show_dynamic_tables_for_database(
+                    db_name, limit=page_limit
                 )
+            )
 
-                first_iteration = False
-                dt_pagination_marker = None
-                result_set_size = 0
-
-                for dt in cur:
-                    result_set_size += 1
-
-                    dt_name = dt["name"]
-                    schema_name = dt["schema_name"]
-
-                    if schema_name not in dynamic_tables:
-                        dynamic_tables[schema_name] = []
-
-                    definition = dt.get("text")
-                    target_lag = dt.get("target_lag")
-                    upstream_tables: List[SnowflakeDynamicTableInput] = []
-                    if dt_graph_info:
-                        qualified_name = f"{db_name}.{schema_name}.{dt_name}"
-                        graph_info = dt_graph_info.get(qualified_name, {})
-                        if not target_lag:
-                            if graph_info.get("target_lag_type") and graph_info.get(
-                                "target_lag_sec"
-                            ):
-                                target_lag = f"{graph_info['target_lag_sec']} {graph_info['target_lag_type']}"
-                        raw_inputs = graph_info.get("inputs")
-                        if raw_inputs:
-                            # INPUTS is ARRAY of OBJECTs [{name, kind}, ...]; may be a JSON string.
-                            try:
-                                if isinstance(raw_inputs, str):
-                                    raw_inputs = json.loads(raw_inputs)
-                                # Coerce non-list JSON values (e.g. "null" -> None,
-                                # single object -> dict) so the comprehension below
-                                # doesn't crash the whole database scan.
-                                if not isinstance(raw_inputs, list):
-                                    raw_inputs = []
-                                upstream_tables = [
-                                    SnowflakeDynamicTableInput(
-                                        name=inp["name"],
-                                        kind=inp.get("kind", "Table"),
-                                    )
-                                    for inp in raw_inputs
-                                    if isinstance(inp, dict) and inp.get("name")
-                                ]
-                            except json.JSONDecodeError as e:
-                                logger.warning(
-                                    f"Failed to parse INPUTS for dynamic table "
-                                    f"{db_name}.{schema_name}.{dt_name}: {e}"
-                                )
-
-                    dynamic_tables[schema_name].append(
-                        SnowflakeDynamicTable(
-                            name=dt_name,
-                            created=dt["created_on"],
-                            last_altered=dt.get("created_on"),
-                            size_in_bytes=dt.get("bytes", 0),
-                            rows_count=dt.get("rows", 0),
-                            comment=dt.get("comment"),
-                            definition=definition,
-                            target_lag=target_lag,
-                            upstream_tables=upstream_tables,
-                            is_dynamic=True,
-                            type="DYNAMIC TABLE",
-                        )
-                    )
-
-                if result_set_size >= page_limit:
-                    logger.info(
-                        f"Fetching next page of dynamic tables for {db_name} - after {dt_name}"
-                    )
-                    dt_pagination_marker = dt_name
-
-            except Exception as e:
-                logger.debug(
-                    f"Failed to get dynamic tables for database {db_name}: {e}"
+            result_set_size = 0
+            for dt in cur:
+                result_set_size += 1
+                dynamic_tables.setdefault(dt["schema_name"], []).append(
+                    self._map_show_dynamic_table(db_name, dt, dt_graph_info)
                 )
-                break
+        except Exception as e:
+            logger.debug(f"Failed to get dynamic tables for database {db_name}: {e}")
+            return dynamic_tables
+
+        if result_set_size >= page_limit:
+            # A full page cannot be continued safely - see
+            # _get_views_for_database_using_show for the cursor-vs-sort-key reasoning.
+            logger.info(
+                f"Database-wide 'SHOW DYNAMIC TABLES' for {db_name} filled its "
+                f"{page_limit}-row page; falling back to per-schema queries, which "
+                "paginate reliably."
+            )
+            return None
 
         return dynamic_tables
+
+    def get_dynamic_tables_for_schema_using_show(
+        self, *, db_name: str, schema_name: str
+    ) -> List[SnowflakeDynamicTable]:
+        dt_graph_info = self.get_dynamic_table_graph_info(db_name)
+
+        dynamic_tables: List[SnowflakeDynamicTable] = []
+        try:
+            for row in self._iter_show_rows_for_schema(
+                build_query=lambda marker: (
+                    SnowflakeQuery.show_dynamic_tables_for_schema(
+                        db_name,
+                        schema_name,
+                        limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                        dynamic_table_pagination_marker=marker,
+                    )
+                ),
+                page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
+                object_kind="DYNAMIC TABLES",
+                context=f"{db_name}.{schema_name}",
+            ):
+                dynamic_tables.append(
+                    self._map_show_dynamic_table(db_name, row, dt_graph_info)
+                )
+        except Exception as e:
+            logger.debug(
+                f"Failed to get dynamic tables for {db_name}.{schema_name}: {e}"
+            )
+
+        return dynamic_tables
+
+    def _map_show_dynamic_table(
+        self,
+        db_name: str,
+        row: Dict[str, Any],
+        dt_graph_info: Dict[str, Dict[str, Any]],
+    ) -> SnowflakeDynamicTable:
+        dt_name = row["name"]
+        schema_name = row["schema_name"]
+        target_lag = row.get("target_lag")
+        upstream_tables: List[SnowflakeDynamicTableInput] = []
+
+        if dt_graph_info:
+            qualified_name = f"{db_name}.{schema_name}.{dt_name}"
+            graph_info = dt_graph_info.get(qualified_name, {})
+            if not target_lag:
+                if graph_info.get("target_lag_type") and graph_info.get(
+                    "target_lag_sec"
+                ):
+                    target_lag = f"{graph_info['target_lag_sec']} {graph_info['target_lag_type']}"
+            raw_inputs = graph_info.get("inputs")
+            if raw_inputs:
+                # INPUTS is ARRAY of OBJECTs [{name, kind}, ...]; may be a JSON string.
+                try:
+                    if isinstance(raw_inputs, str):
+                        raw_inputs = json.loads(raw_inputs)
+                    # Coerce non-list JSON values (e.g. "null" -> None,
+                    # single object -> dict) so the comprehension below
+                    # doesn't crash the whole database scan.
+                    if not isinstance(raw_inputs, list):
+                        raw_inputs = []
+                    upstream_tables = [
+                        SnowflakeDynamicTableInput(
+                            name=inp["name"],
+                            kind=inp.get("kind", "Table"),
+                        )
+                        for inp in raw_inputs
+                        if isinstance(inp, dict) and inp.get("name")
+                    ]
+                except json.JSONDecodeError as e:
+                    logger.warning(
+                        f"Failed to parse INPUTS for dynamic table "
+                        f"{db_name}.{schema_name}.{dt_name}: {e}"
+                    )
+
+        return SnowflakeDynamicTable(
+            name=dt_name,
+            created=row["created_on"],
+            last_altered=row.get("created_on"),
+            size_in_bytes=row.get("bytes", 0),
+            rows_count=row.get("rows", 0),
+            comment=row.get("comment"),
+            definition=row.get("text"),
+            target_lag=target_lag,
+            upstream_tables=upstream_tables,
+            is_dynamic=True,
+            type="DYNAMIC TABLE",
+        )
 
     def populate_dynamic_table_definitions(
         self, tables: Dict[str, List[SnowflakeTable]], db_name: str
@@ -2458,6 +2572,16 @@ class SnowflakeDataDictionary(SupportsAsObj):
         try:
             # Get dynamic tables with definitions from SHOW command
             dt_with_definitions = self.get_dynamic_tables_with_definitions(db_name)
+
+            if dt_with_definitions is None:
+                # The database-wide SHOW filled its page and cannot be paged safely.
+                # Fetch only the schemas we actually need, paging each one exactly.
+                dt_with_definitions = {
+                    schema_name: self.get_dynamic_tables_for_schema_using_show(
+                        db_name=db_name, schema_name=schema_name
+                    )
+                    for schema_name in tables
+                }
 
             for schema_name, table_list in tables.items():
                 for table in table_list:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -2462,7 +2462,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 SnowflakeQuery.get_dynamic_table_graph_history(db_name)
             )
             for row in cur:
-                dt_name = row["NAME"]
+                # Keyed by the fully qualified name because that is how
+                # _map_show_dynamic_table looks it up. Keying on the bare NAME silently
+                # dropped every dynamic table's upstream lineage and its fallback target
+                # lag - the lookup simply never hit.
+                dt_name = f"{db_name}.{row['SCHEMA_NAME']}.{row['NAME']}"
                 dt_graph_info[dt_name] = {
                     "inputs": row.get("INPUTS"),
                     "target_lag_type": row.get("TARGET_LAG_TYPE"),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -30,7 +30,10 @@ from datahub.ingestion.source.snowflake.constants import (
     SnowflakeObjectDomain,
     SnowflakeShowKind,
 )
-from datahub.ingestion.source.snowflake.snowflake_connection import SnowflakeConnection
+from datahub.ingestion.source.snowflake.snowflake_connection import (
+    SnowflakeConnection,
+    SnowflakePermissionError,
+)
 from datahub.ingestion.source.snowflake.snowflake_query import (
     SHOW_COMMAND_MAX_PAGE_SIZE,
     SHOW_STREAM_MAX_PAGE_SIZE,
@@ -998,7 +1001,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
 
         Failures are caught here rather than per caller so all three object kinds share one
         policy, and because serialized_lru_cache does not cache exceptions - an uncaught one
-        would re-run this query once per schema.
+        would re-run this query once per schema. The mapping runs inside the same try for
+        that second reason: a row that breaks the mapper would otherwise escape the cached
+        caller and re-issue this whole page-sized query per schema.
+
+        A permission error is the exception, and propagates: see the handler.
         """
         try:
             rows = list(
@@ -1008,6 +1015,28 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     )
                 )
             )
+
+            # Check the page size before mapping: on a full page every mapped object is
+            # discarded, and for dynamic tables each one parses JSON.
+            if len(rows) >= page_limit:
+                logger.info(
+                    f"Database-wide 'SHOW {object_kind}' for {db_name} filled its "
+                    f"{page_limit}-row page; falling back to per-schema queries, which "
+                    "paginate reliably."
+                )
+                return None
+
+            grouped: Dict[str, List[_ShowRowT]] = {}
+            for row in rows:
+                grouped.setdefault(row["schema_name"], []).append(mapper(row))
+
+            return grouped
+        except SnowflakePermissionError:
+            # Not a size problem, so the per-schema fallback cannot help: it would be denied
+            # too, once per schema. Propagate instead, so the caller reports it as a
+            # permission error with actionable guidance - the classification the callers
+            # already implement, and which swallowing this downgraded to a generic warning.
+            raise
         except Exception as e:
             self.report.warning(
                 message="Database-wide SHOW failed; retrying per schema",
@@ -1015,22 +1044,6 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 exc=e,
             )
             return None
-
-        # Check the page size before mapping: on a full page every mapped object is
-        # discarded, and for dynamic tables each one parses JSON.
-        if len(rows) >= page_limit:
-            logger.info(
-                f"Database-wide 'SHOW {object_kind}' for {db_name} filled its "
-                f"{page_limit}-row page; falling back to per-schema queries, which "
-                "paginate reliably."
-            )
-            return None
-
-        grouped: Dict[str, List[_ShowRowT]] = {}
-        for row in rows:
-            grouped.setdefault(row["schema_name"], []).append(mapper(row))
-
-        return grouped
 
     def _get_views_for_database_using_show(
         self, db_name: str
@@ -1097,6 +1110,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
             )
             try:
                 page = list(self.connection.query(query))
+            except SnowflakePermissionError:
+                # As in _probe_database_wide_show: a denial is reported by the caller as a
+                # permission error, which names the missing grant. Reporting it here as an
+                # incomplete listing would be true but far less actionable.
+                raise
             except Exception as e:
                 # Rows already yielded stand - a later page failing does not invalidate an
                 # earlier one - but the caller cannot tell a truncated schema from a small

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -884,12 +884,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 ),
             )
         except Exception as e:
-            # Debug, not a warning: the expected error here is "Information schema query
-            # returned too much data", which is this path's normal signal to page per
-            # schema, and a lossless run must not raise an alarm. Tried reporting it and
-            # backed out - it turns a benign overflow into a pipeline warning, which the
-            # failure tests correctly reject. Telling a real fault apart from the overflow
-            # would mean matching Snowflake's error text.
+            # Debug, not a warning: "returned too much data" is this path's normal
+            # signal to page per schema, so reporting it would alarm on a lossless run.
+            # The cost is that a genuine fault here is also quiet.
             logger.debug(
                 f"Failed to get all tables for database - {db_name}", exc_info=e
             )
@@ -992,27 +989,16 @@ class SnowflakeDataDictionary(SupportsAsObj):
         page_limit: int,
         mapper: Callable[[Dict[str, Any]], _ShowRowT],
     ) -> Optional[Dict[str, List[_ShowRowT]]]:
-        """Run one database-wide SHOW and group the rows by schema, or give up.
+        """Run one database-wide SHOW and group the rows by schema, or answer None.
 
-        A full page means there is more to fetch, and a database-wide SHOW cannot be
-        continued: its `FROM '<name>'` cursor keys on the object name alone while the
-        output is ordered by (schema, name). Measured against a live account, continuing
-        drops every object in a later schema whose name sorts below the marker while
-        re-returning earlier schemas' higher-sorting ones — and if the marker happens to
-        name an INFORMATION_SCHEMA view the cursor is ignored entirely and the loop spins
-        forever. Returning None tells the caller to page per schema instead, where name
-        *is* the whole sort key and paging is exact (verified against a 16k-view schema:
-        two pages, no gaps, no duplicates).
+        None means "this result is unusable, page per schema instead", for either reason: a
+        full page (the statement cannot be continued - see
+        SnowflakeQuery.show_objects_for_database) or a failure. An empty mapping means the
+        database genuinely holds none.
 
-        A failure is reported and also answered with None, so a database-wide SHOW that
-        cannot run at all (a missing grant, a statement timeout) still reaches the exact
-        per-schema path instead of losing the whole database. Catching here rather than in
-        each caller keeps one failure policy for views, streams and dynamic tables - and
-        matters because serialized_lru_cache does not cache exceptions, so an uncaught
-        failure would re-run this query once per schema.
-
-        Shared by views, streams and dynamic tables so the page-boundary rule lives in one
-        place rather than being restated for each object type.
+        Failures are caught here rather than per caller so all three object kinds share one
+        policy, and because serialized_lru_cache does not cache exceptions - an uncaught one
+        would re-run this query once per schema.
         """
         try:
             rows = list(
@@ -1090,17 +1076,14 @@ class SnowflakeDataDictionary(SupportsAsObj):
     ) -> Iterable[Dict[str, Any]]:
         """Yield rows of a schema-scoped SHOW, paging by object name.
 
-        Schema-scoped output is ordered by name alone, which is exactly what the
-        `FROM '<name>'` cursor matches on, so paging here is exact - unlike the
-        database-wide form (see _get_views_for_database_using_show).
+        Paging is exact here because a schema's output is ordered by name alone, which is
+        what the cursor matches on (see SnowflakeQuery.show_objects_for_schema).
 
-        Snowflake does not honour that cursor for every object class, though: for its
-        built-in INFORMATION_SCHEMA views, `FROM` is ignored and every page repeats the
-        first, which would spin forever. Termination is therefore decided by whether a
-        full page produced any name not already seen - deliberately not by comparing the
-        new marker against the old one, which would re-derive Snowflake's collation in
-        Python and, on mixed-case identifiers, could call a perfectly good cursor stalled
-        and truncate the schema. A short result plus a warning beats a hung ingestion.
+        Snowflake does not honour that cursor for every object class - for INFORMATION_SCHEMA
+        views it is ignored and every page repeats the first - so termination is decided by
+        whether a full page yielded a name not already seen. Deliberately not by comparing
+        markers: that re-derives Snowflake's collation in Python and could call a working
+        cursor stalled on mixed-case identifiers. A short result plus a warning beats a hang.
         """
         context = f"{db_name}.{schema_name}"
         seen_names: Set[str] = set()

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -2474,10 +2474,13 @@ class SnowflakeDataDictionary(SupportsAsObj):
                 ),
             )
         except Exception as e:
-            # An empty mapping (rather than None) keeps the caller on the database-wide
-            # path with no definitions, degrading gracefully instead of failing the scan.
+            # None, not an empty mapping: {} would read as "this database genuinely has no
+            # dynamic tables" and silently drop every definition. None sends the caller
+            # down the per-schema path, which can still succeed when only the
+            # database-wide statement failed (a timeout, or too large a result set) and
+            # which degrades quietly on its own if the failure is systemic.
             logger.debug(f"Failed to get dynamic tables for database {db_name}: {e}")
-            return {}
+            return None
 
     def get_dynamic_tables_for_schema_using_show(
         self, *, db_name: str, schema_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -27,6 +27,7 @@ from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.snowflake.constants import (
     SemanticViewColumnSubtype,
     SnowflakeObjectDomain,
+    SnowflakeShowKind,
 )
 from datahub.ingestion.source.snowflake.snowflake_connection import SnowflakeConnection
 from datahub.ingestion.source.snowflake.snowflake_query import (
@@ -971,7 +972,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         *,
         query: str,
         page_limit: int,
-        object_kind: str,
+        object_kind: SnowflakeShowKind,
         db_name: str,
         mapper: Callable[[Dict[str, Any]], _ShowRowT],
     ) -> Optional[Dict[str, List[_ShowRowT]]]:
@@ -1016,7 +1017,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         views = self._probe_database_wide_show(
             query=SnowflakeQuery.show_views_for_database(db_name, limit=page_limit),
             page_limit=page_limit,
-            object_kind="VIEWS",
+            object_kind=SnowflakeShowKind.VIEWS,
             db_name=db_name,
             mapper=self._map_show_view,
         )
@@ -1048,7 +1049,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         *,
         build_query: Callable[[Optional[str]], str],
         page_limit: int,
-        object_kind: str,
+        object_kind: SnowflakeShowKind,
         context: str,
     ) -> Iterable[Dict[str, Any]]:
         """Yield rows of a schema-scoped SHOW, paging by object name.
@@ -1111,7 +1112,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     view_pagination_marker=marker,
                 ),
                 page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
-                object_kind="VIEWS",
+                object_kind=SnowflakeShowKind.VIEWS,
                 context=f"{db_name}.{schema_name}",
             )
         ]
@@ -2322,7 +2323,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
         return self._probe_database_wide_show(
             query=SnowflakeQuery.streams_for_database(db_name, limit=page_limit),
             page_limit=page_limit,
-            object_kind="STREAMS",
+            object_kind=SnowflakeShowKind.STREAMS,
             db_name=db_name,
             mapper=self._map_show_stream,
         )
@@ -2340,7 +2341,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     stream_pagination_marker=marker,
                 ),
                 page_limit=SHOW_STREAM_MAX_PAGE_SIZE,
-                object_kind="STREAMS",
+                object_kind=SnowflakeShowKind.STREAMS,
                 context=f"{db_name}.{schema_name}",
             )
         ]
@@ -2467,7 +2468,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     db_name, limit=page_limit
                 ),
                 page_limit=page_limit,
-                object_kind="DYNAMIC TABLES",
+                object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
                 db_name=db_name,
                 mapper=lambda row: self._map_show_dynamic_table(
                     db_name, row, dt_graph_info
@@ -2499,7 +2500,7 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     )
                 ),
                 page_limit=SHOW_COMMAND_MAX_PAGE_SIZE,
-                object_kind="DYNAMIC TABLES",
+                object_kind=SnowflakeShowKind.DYNAMIC_TABLES,
                 context=f"{db_name}.{schema_name}",
             ):
                 dynamic_tables.append(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -2759,10 +2759,12 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
             # Some schemas may not have any views
             return views.get(schema_name, [])
 
-        # Usually this fails when there are too many views in the schema.
-        # Fall back to per-schema queries.
+        # The database-wide fetch could not return a complete result — either the
+        # information_schema query returned too much data, or a database-wide
+        # `SHOW VIEWS` filled its page and cannot be paged safely. Per-schema queries
+        # are exact in both modes.
         self.report.num_get_views_for_schema_queries += 1
-        return self.data_dictionary.get_views_for_schema_using_information_schema(
+        return self.data_dictionary.get_views_for_schema(
             db_name=db_name,
             schema_name=schema_name,
             view_filter=view_filter,
@@ -2886,7 +2888,14 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
     ) -> List[SnowflakeStream]:
         streams = self.data_dictionary.get_streams_for_database(db_name)
 
-        return streams.get(schema_name, [])
+        if streams is not None:
+            return streams.get(schema_name, [])
+
+        # The database-wide `SHOW STREAMS` filled its page and cannot be paged safely.
+        # Per-schema queries paginate exactly.
+        return self.data_dictionary.get_streams_for_schema_using_show(
+            db_name=db_name, schema_name=schema_name
+        )
 
     def fetch_procedures_for_schema(
         self, snowflake_schema: SnowflakeSchema, db_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -2873,15 +2873,24 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
             snowflake_schema.streams = [stream.name for stream in streams]
             return streams
         except Exception as e:
-            self.structured_reporter.warning(
-                title="Failed to get streams for schema",
-                message="Please check permissions"
-                if isinstance(e, SnowflakePermissionError)
-                else "",
-                context=f"{db_name}.{snowflake_schema.name}",
-                exc=e,
-            )
-            return []
+            if isinstance(e, SnowflakePermissionError):
+                # As fetch_views_for_schema does, and for the same reason: returning [] here
+                # drops the schema's streams from the run while it still exits successfully,
+                # so stateful ingestion soft-deletes them as though they had been dropped in
+                # Snowflake. Only a failure makes stale-entity removal stand down, and the
+                # 75% fail_safe_threshold will not notice one schema out of hundreds.
+                # Ideal implementation would use PEP 678 - Enriching Exceptions with Notes
+                error_msg = f"Failed to get streams for schema {db_name}.{snowflake_schema.name}. Please check permissions."
+
+                raise SnowflakePermissionError(error_msg) from e.__cause__
+            else:
+                self.structured_reporter.warning(
+                    title="Failed to get streams for schema",
+                    message="",
+                    context=f"{db_name}.{snowflake_schema.name}",
+                    exc=e,
+                )
+                return []
 
     def get_streams_for_schema(
         self, schema_name: str, db_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -511,12 +511,12 @@ class SnowflakeIdentifierBuilder:
         return name.replace('"', '""')
 
     @staticmethod
-    def get_quoted_identifier_for_database(db_name):
+    def get_quoted_identifier_for_database(db_name: str) -> str:
         db_name = SnowflakeIdentifierBuilder._escape_identifier(db_name)
         return f'"{db_name}"'
 
     @staticmethod
-    def get_quoted_identifier_for_schema(db_name, schema_name):
+    def get_quoted_identifier_for_schema(db_name: str, schema_name: str) -> str:
         db_name = SnowflakeIdentifierBuilder._escape_identifier(db_name)
         schema_name = SnowflakeIdentifierBuilder._escape_identifier(schema_name)
         return f'"{db_name}"."{schema_name}"'

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -7,7 +7,10 @@ from datahub.configuration.time_window_config import BucketDuration
 from datahub.ingestion.source.snowflake import snowflake_query
 from datahub.ingestion.source.snowflake.constants import SnowflakeShowKind
 from datahub.ingestion.source.snowflake.snowflake_queries import QueryLogQueryBuilder
-from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
+from datahub.ingestion.source.snowflake.snowflake_query import (
+    SHOW_STREAM_MAX_PAGE_SIZE,
+    SnowflakeQuery,
+)
 from datahub.utilities.prefix_batch_builder import PrefixGroup
 
 NUM_TABLES = 10
@@ -594,7 +597,9 @@ def default_query_results(  # noqa: C901
                 "NUMERIC_SCALE": 0,
             },
         ]
-    elif query == SnowflakeQuery.streams_for_database("TEST_DB"):
+    elif query == SnowflakeQuery.show_objects_for_database(
+        SnowflakeShowKind.STREAMS, "TEST_DB", limit=SHOW_STREAM_MAX_PAGE_SIZE
+    ):
         # TODO: Add tests for stream pagination.
         return [
             {
@@ -617,8 +622,14 @@ def default_query_results(  # noqa: C901
             for stream_idx in range(1, num_streams + 1)
         ]
     elif (
-        query == SnowflakeQuery.streams_for_database("DEMO_DATABASE")
-        or query == SnowflakeQuery.streams_for_database("CUSTOMER_360")
+        query
+        == SnowflakeQuery.show_objects_for_database(
+            SnowflakeShowKind.STREAMS, "DEMO_DATABASE", limit=SHOW_STREAM_MAX_PAGE_SIZE
+        )
+        or query
+        == SnowflakeQuery.show_objects_for_database(
+            SnowflakeShowKind.STREAMS, "CUSTOMER_360", limit=SHOW_STREAM_MAX_PAGE_SIZE
+        )
         or query
         in (
             SnowflakeQuery.use_database("TEST_DB"),

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from datahub.configuration.common import AllowDenyPattern
 from datahub.configuration.time_window_config import BucketDuration
 from datahub.ingestion.source.snowflake import snowflake_query
+from datahub.ingestion.source.snowflake.constants import SnowflakeShowKind
 from datahub.ingestion.source.snowflake.snowflake_queries import QueryLogQueryBuilder
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 from datahub.utilities.prefix_batch_builder import PrefixGroup
@@ -411,7 +412,9 @@ def default_query_results(  # noqa: C901
             }
             for tbl_idx in range(1, num_tables + 1)
         ]
-    elif query == SnowflakeQuery.show_views_for_database("TEST_DB"):
+    elif query == SnowflakeQuery.show_objects_for_database(
+        SnowflakeShowKind.VIEWS, "TEST_DB"
+    ):
         # TODO: Add tests for view pagination.
         return [
             {
@@ -1164,7 +1167,9 @@ def default_query_results(  # noqa: C901
         ]
     elif query == SnowflakeQuery.show_pipes_for_schema("TEST2_SCHEMA", "TEST_DB"):
         return []
-    elif query == SnowflakeQuery.show_dynamic_tables_for_database("TEST_DB"):
+    elif query == SnowflakeQuery.show_objects_for_database(
+        SnowflakeShowKind.DYNAMIC_TABLES, "TEST_DB"
+    ):
         # Return dynamic table definitions for TABLE_2 which should be a dynamic table
         return [
             {
@@ -1184,9 +1189,11 @@ def default_query_results(  # noqa: C901
                 "owner_role_type": "ROLE",
             }
         ]
-    elif query == SnowflakeQuery.show_dynamic_tables_for_database(
-        "DEMO_DATABASE"
-    ) or query == SnowflakeQuery.show_dynamic_tables_for_database("CUSTOMER_360"):
+    elif query == SnowflakeQuery.show_objects_for_database(
+        SnowflakeShowKind.DYNAMIC_TABLES, "DEMO_DATABASE"
+    ) or query == SnowflakeQuery.show_objects_for_database(
+        SnowflakeShowKind.DYNAMIC_TABLES, "CUSTOMER_360"
+    ):
         return []
     elif query == "SHOW AVAILABLE LISTINGS IS_ORGANIZATION = TRUE":
         # SHOW AVAILABLE LISTINGS returns lowercase column names

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
@@ -471,7 +471,12 @@ def test_snowflake_dynamic_table_inputs_lineage_without_ddl(
             [snowflake_query.SnowflakeQuery.get_dynamic_table_graph_history("TEST_DB")],
             [
                 {
-                    "NAME": "TEST_DB.TEST_SCHEMA.TABLE_2",
+                    # DYNAMIC_TABLE_GRAPH_HISTORY reports NAME unqualified, with
+                    # DATABASE_NAME and SCHEMA_NAME as separate columns. A fully qualified
+                    # NAME here used to look right while leaving the row unmatched.
+                    "NAME": "TABLE_2",
+                    "SCHEMA_NAME": "TEST_SCHEMA",
+                    "DATABASE_NAME": "TEST_DB",
                     "INPUTS": [
                         {"name": "TEST_DB.TEST_SCHEMA.TABLE_1", "kind": "TABLE"}
                     ],
@@ -518,6 +523,13 @@ def test_snowflake_dynamic_table_inputs_lineage_without_ddl(
         assert report.num_dynamic_tables_missing_definition == 1
         assert report.sql_aggregator is not None
         assert report.sql_aggregator.num_known_mapping_lineage >= 1
+        # `>= 1` on a global counter is satisfied by lineage from anywhere in the fixtures,
+        # so it kept passing when a stale graph-history row stopped matching. Assert the
+        # graph history was actually read: a KeyError on a missing column is swallowed into
+        # this warning, leaving the INPUTS path silently untested.
+        assert not [
+            w for w in report.warnings if "dynamic table graph history" in str(w)
+        ], "graph history failed to load, so INPUTS lineage was never exercised"
 
 
 # Tests for known_snowflake_edition config option

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
@@ -15,7 +15,10 @@ from datahub.ingestion.source.snowflake.constants import (
     SnowflakeShowKind,
 )
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
-from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
+from datahub.ingestion.source.snowflake.snowflake_query import (
+    SHOW_STREAM_MAX_PAGE_SIZE,
+    SnowflakeQuery,
+)
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
 from datahub.ingestion.source.snowflake.snowflake_v2 import SnowflakeV2Source
 from tests.integration.snowflake.common import (
@@ -174,7 +177,13 @@ def test_snowflake_no_tables_causes_pipeline_failure(
         )
         sf_cursor.execute.side_effect = query_permission_response_override(
             no_views_fn,
-            [SnowflakeQuery.streams_for_database("TEST_DB")],
+            [
+                SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.STREAMS,
+                    "TEST_DB",
+                    limit=SHOW_STREAM_MAX_PAGE_SIZE,
+                )
+            ],
             [],
         )
 
@@ -224,7 +233,13 @@ def test_snowflake_no_tables_warns_on_no_datasets(
         )
         sf_cursor.execute.side_effect = query_permission_response_override(
             no_views_fn,
-            [SnowflakeQuery.streams_for_database("TEST_DB")],
+            [
+                SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.STREAMS,
+                    "TEST_DB",
+                    limit=SHOW_STREAM_MAX_PAGE_SIZE,
+                )
+            ],
             [],
         )
 

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
@@ -10,7 +10,10 @@ from datahub.configuration.common import AllowDenyPattern, DynamicTypedConfig
 from datahub.ingestion.run.pipeline import Pipeline, PipelineInitError
 from datahub.ingestion.run.pipeline_config import PipelineConfig, SourceConfig
 from datahub.ingestion.source.snowflake import snowflake_query
-from datahub.ingestion.source.snowflake.constants import SnowflakeEdition
+from datahub.ingestion.source.snowflake.constants import (
+    SnowflakeEdition,
+    SnowflakeShowKind,
+)
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
@@ -162,7 +165,11 @@ def test_snowflake_no_tables_causes_pipeline_failure(
         )
         no_views_fn = query_permission_response_override(
             no_tables_fn,
-            [SnowflakeQuery.show_views_for_database("TEST_DB")],
+            [
+                SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.VIEWS, "TEST_DB"
+                )
+            ],
             [],
         )
         sf_cursor.execute.side_effect = query_permission_response_override(
@@ -208,7 +215,11 @@ def test_snowflake_no_tables_warns_on_no_datasets(
         )
         no_views_fn = query_permission_response_override(
             no_tables_fn,
-            [SnowflakeQuery.show_views_for_database("TEST_DB")],
+            [
+                SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.VIEWS, "TEST_DB"
+                )
+            ],
             [],
         )
         sf_cursor.execute.side_effect = query_permission_response_override(
@@ -415,8 +426,8 @@ def test_snowflake_dynamic_table_missing_monitor_privilege_raises_pipeline_warni
         sf_cursor.execute.side_effect = query_permission_response_override(
             default_query_results,
             [
-                snowflake_query.SnowflakeQuery.show_dynamic_tables_for_database(
-                    "TEST_DB"
+                snowflake_query.SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.DYNAMIC_TABLES, "TEST_DB"
                 )
             ],
             [
@@ -490,8 +501,8 @@ def test_snowflake_dynamic_table_inputs_lineage_without_ddl(
         sf_cursor.execute.side_effect = query_permission_response_override(
             base,
             [
-                snowflake_query.SnowflakeQuery.show_dynamic_tables_for_database(
-                    "TEST_DB"
+                snowflake_query.SnowflakeQuery.show_objects_for_database(
+                    SnowflakeShowKind.DYNAMIC_TABLES, "TEST_DB"
                 )
             ],
             [

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
@@ -324,12 +324,16 @@ def test_dynamic_table_subtype():
 
 
 def test_dynamic_table_pagination():
-    # Test the pagination marker handling in show_dynamic_tables_for_database
-    query = SnowflakeQuery.show_dynamic_tables_for_database(
-        db_name="TEST_DB", dynamic_table_pagination_marker="LAST_TABLE"
+    # Pagination is only sound at schema scope, where the output is ordered by name
+    # alone and so matches what the `FROM '<name>'` cursor compares against. The
+    # database-wide variant is ordered by (schema, name) and therefore takes no marker.
+    query = SnowflakeQuery.show_dynamic_tables_for_schema(
+        db_name="TEST_DB",
+        schema_name="TEST_SCHEMA",
+        dynamic_table_pagination_marker="LAST_TABLE",
     )
 
-    # Verify the pagination marker is included in the query
+    assert 'IN SCHEMA "TEST_DB"."TEST_SCHEMA"' in query
     assert "FROM 'LAST_TABLE'" in query
 
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
@@ -31,7 +31,12 @@ def test_get_dynamic_table_graph_info(mock_snowflake_data_dictionary):
     mock_cursor = MagicMock()
     mock_cursor.__iter__.return_value = [
         {
-            "NAME": "TEST_DB.PUBLIC.DYNAMIC_TABLE1",
+            # DYNAMIC_TABLE_GRAPH_HISTORY() reports NAME unqualified, with SCHEMA_NAME and
+            # DATABASE_NAME as separate columns - verified against a live account. The
+            # earlier fixture put a qualified name in NAME, which made a lookup keyed on
+            # the fully qualified name appear to work when it never did.
+            "NAME": "DYNAMIC_TABLE1",
+            "SCHEMA_NAME": "PUBLIC",
             "INPUTS": [{"name": "TEST_DB.PUBLIC.SOURCE_TABLE", "kind": "TABLE"}],
             "TARGET_LAG_TYPE": "INTERVAL",
             "TARGET_LAG_SEC": 60,
@@ -496,7 +501,8 @@ def test_dynamic_table_invalid_response_handling(mock_snowflake_data_dictionary)
     mock_cursor = MagicMock()
     mock_cursor.__iter__.return_value = [
         {
-            "NAME": "TEST_DB.PUBLIC.DYNAMIC_TABLE1",
+            "NAME": "DYNAMIC_TABLE1",
+            "SCHEMA_NAME": "PUBLIC",
             # Missing other required fields
         }
     ]

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
@@ -37,6 +37,7 @@ def test_get_dynamic_table_graph_info(mock_snowflake_data_dictionary):
             # the fully qualified name appear to work when it never did.
             "NAME": "DYNAMIC_TABLE1",
             "SCHEMA_NAME": "PUBLIC",
+            "DATABASE_NAME": "TEST_DB",
             "INPUTS": [{"name": "TEST_DB.PUBLIC.SOURCE_TABLE", "kind": "TABLE"}],
             "TARGET_LAG_TYPE": "INTERVAL",
             "TARGET_LAG_SEC": 60,
@@ -503,6 +504,7 @@ def test_dynamic_table_invalid_response_handling(mock_snowflake_data_dictionary)
         {
             "NAME": "DYNAMIC_TABLE1",
             "SCHEMA_NAME": "PUBLIC",
+            "DATABASE_NAME": "TEST_DB",
             # Missing other required fields
         }
     ]

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
-from datahub.ingestion.source.snowflake.constants import SnowflakeObjectDomain
+from datahub.ingestion.source.snowflake.constants import (
+    SnowflakeObjectDomain,
+    SnowflakeShowKind,
+)
 from datahub.ingestion.source.snowflake.snowflake_connection import SnowflakeConnection
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
@@ -103,6 +106,57 @@ def test_get_dynamic_tables_with_definitions(mock_snowflake_data_dictionary):
     assert dt.upstream_tables == [
         SnowflakeDynamicTableInput("TEST_DB.PUBLIC.SOURCE_TABLE", "TABLE")
     ]
+
+
+@pytest.mark.parametrize(
+    "graph_info,expected_missing,expected_upstreams",
+    [
+        (
+            {
+                "TEST_DB.PUBLIC.DYNAMIC_TABLE1": {
+                    "inputs": [{"name": "TEST_DB.PUBLIC.SOURCE_TABLE", "kind": "TABLE"}]
+                }
+            },
+            0,
+            [SnowflakeDynamicTableInput("TEST_DB.PUBLIC.SOURCE_TABLE", "TABLE")],
+        ),
+        ({}, 1, []),
+    ],
+    ids=["matched", "no_graph_row"],
+)
+def test_a_dynamic_table_without_a_graph_row_is_counted(
+    graph_info, expected_missing, expected_upstreams
+):
+    """Losing the graph row loses INPUTS upstreams and the target_lag fallback silently -
+    which is exactly how the keying bug went unnoticed. The counter is the signal: it
+    equalling the dynamic-table count means every lookup missed, whether from a bad key or
+    from the graph-history query's filters excluding everything on some edition."""
+    report = SnowflakeV2Report()
+    data_dictionary = SnowflakeDataDictionary(
+        cast(SnowflakeConnection, MagicMock()), report
+    )
+    data_dictionary.get_dynamic_table_graph_info = MagicMock(return_value=graph_info)  # type: ignore[method-assign]
+
+    mock_cursor = MagicMock()
+    mock_cursor.__iter__.return_value = [
+        {
+            "name": "DYNAMIC_TABLE1",
+            "schema_name": "PUBLIC",
+            "created_on": "2024-01-01 00:00:00",
+            "text": "SELECT * FROM source_table",
+            "target_lag": "1 minute",
+            "bytes": 1000,
+            "rows": 100,
+            "comment": None,
+        }
+    ]
+    data_dictionary.connection.query.return_value = mock_cursor  # type: ignore[attr-defined]
+
+    result = data_dictionary.get_dynamic_tables_with_definitions("TEST_DB")
+
+    assert result is not None
+    assert result["PUBLIC"][0].upstream_tables == expected_upstreams
+    assert report.num_dynamic_tables_missing_graph_info == expected_missing
 
 
 def test_get_dynamic_tables_with_definitions_inputs_as_json_string(
@@ -333,10 +387,11 @@ def test_dynamic_table_pagination():
     # Pagination is only sound at schema scope, where the output is ordered by name
     # alone and so matches what the `FROM '<name>'` cursor compares against. The
     # database-wide variant is ordered by (schema, name) and therefore takes no marker.
-    query = SnowflakeQuery.show_dynamic_tables_for_schema(
+    query = SnowflakeQuery.show_objects_for_schema(
+        SnowflakeShowKind.DYNAMIC_TABLES,
         db_name="TEST_DB",
         schema_name="TEST_SCHEMA",
-        dynamic_table_pagination_marker="LAST_TABLE",
+        marker="LAST_TABLE",
     )
 
     assert 'IN SCHEMA "TEST_DB"."TEST_SCHEMA"' in query

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_dynamic_tables.py
@@ -351,6 +351,15 @@ def test_dynamic_table_graph_history_query():
     assert "DYNAMIC_TABLE_GRAPH_HISTORY()" in query
     assert "TEST_DB" in query
 
+    # Both filters carry correctness, so assert them rather than just the table function.
+    # The function is account-scoped, so without the database_name predicate this returns
+    # every database's dynamic tables; and it reports history, so without valid_to a
+    # superseded row can win the key.
+    assert "database_name = 'TEST_DB'" in query
+    assert "valid_to IS NULL" in query
+    # The row's own database is needed to key the result; the caller's cannot be assumed.
+    assert "database_name," in query
+
 
 @patch(
     "datahub.ingestion.source.snowflake.snowflake_lineage_v2.SnowflakeLineageExtractor"

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -200,6 +200,19 @@ class FailsEverySchemaConnection(FakeShowConnection):
         return []
 
 
+class FailsAfterFirstPageConnection(FakeShowConnection):
+    """Page 1 succeeds and page 2 raises, so the caller ends up holding a partial result it
+    cannot tell apart from a complete one."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        if SHOW_IN_SCHEMA.search(query) and any(
+            SHOW_IN_SCHEMA.search(q) for q in self.queries
+        ):
+            self.queries.append(query)
+            raise ValueError("page 2 failed")
+        return super().query(query)
+
+
 def _make_schema_gen(connection: FakeShowConnection) -> SnowflakeSchemaGenerator:
     config = SnowflakeV2Config.parse_obj(
         {
@@ -505,6 +518,27 @@ def test_a_failed_database_wide_show_falls_back_per_schema(kind, fetch):
     objects = fetch(_make_schema_gen(connection))
 
     assert [o.name for o in objects] == ["obj_a"]
+
+
+def test_a_mid_paging_failure_reports_how_many_rows_were_kept():
+    """Failing on page 2 leaves a partial result the caller cannot distinguish from a
+    complete one, so the kept count has to reach the report - otherwise a truncated schema
+    looks exactly like a small one."""
+    total = SHOW_COMMAND_MAX_PAGE_SIZE + 10
+    connection = FailsAfterFirstPageConnection(
+        {DYNAMIC_TABLES: [("SCHEMA_A", f"dt_{i:05d}") for i in range(total)]}
+    )
+    data_dictionary = _make_data_dictionary(connection)
+
+    tables = data_dictionary.get_dynamic_tables_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert len(tables) == SHOW_COMMAND_MAX_PAGE_SIZE, "page 1 should still be salvaged"
+    reported = " ".join(str(w) for w in data_dictionary.report.warnings)
+    assert f"kept {SHOW_COMMAND_MAX_PAGE_SIZE}" in reported, (
+        f"the kept row count must be reported; got {reported!r}"
+    )
 
 
 def test_dynamic_table_fallback_skips_schemas_without_dynamic_tables():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -26,6 +26,7 @@ from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Repor
 from datahub.ingestion.source.snowflake.snowflake_schema import (
     SnowflakeDataDictionary,
     SnowflakeDynamicTable,
+    SnowflakeSchema,
     SnowflakeTable,
 )
 from datahub.ingestion.source.snowflake.snowflake_schema_gen import (
@@ -626,6 +627,35 @@ def test_a_denied_show_propagates_instead_of_falling_back_per_schema():
     # generic one, so this handler must stay silent.
     assert not data_dictionary.report.failures
     assert not data_dictionary.report.warnings
+
+
+@pytest.mark.parametrize(
+    "kind,fetch",
+    [
+        (
+            VIEWS,
+            lambda gen, schema: gen.fetch_views_for_schema(
+                schema, "TEST_DB", "SCHEMA_A"
+            ),
+        ),
+        (STREAMS, lambda gen, schema: gen.fetch_streams_for_schema(schema, "TEST_DB")),
+    ],
+    ids=["views", "streams"],
+)
+def test_a_denied_listing_reaches_the_permission_classifier(kind, fetch):
+    """Both kinds must let a denial past, because returning [] drops the schema's objects
+    while the run still exits clean - and stale-entity removal stands down only on a
+    failure, which get_workunits_internal records from this exception. Checked for both
+    because streams silently diverged from views here: it recognised the error class well
+    enough to reword the warning, and still swallowed it."""
+    connection = DeniesEveryShowConnection({kind: [("SCHEMA_A", "obj_a")]})
+    schema_gen = _make_schema_gen(connection)
+    schema = SnowflakeSchema(
+        name="SCHEMA_A", created=None, last_altered=None, comment=None
+    )
+
+    with pytest.raises(SnowflakePermissionError):
+        fetch(schema_gen, schema)
 
 
 def test_an_unmappable_row_does_not_re_issue_the_database_wide_query():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -641,6 +641,50 @@ def test_dynamic_table_upstreams_come_through_the_graph_history():
     assert tables[0].target_lag == "1 hour"
 
 
+def test_dynamic_table_graph_info_does_not_take_another_databases_row():
+    """DYNAMIC_TABLE_GRAPH_HISTORY is account-scoped: invoked from one database's
+    INFORMATION_SCHEMA it returns rows for every database in the account - measured live, 12
+    rows spanning three other databases and none from the one it was invoked from. So a row
+    must be keyed by its own DATABASE_NAME; stamping the caller's would let a same-named
+    schema.table in a different database supply this one's lineage."""
+    connection = GraphHistoryConnection(
+        {DYNAMIC_TABLES: [("SCHEMA_A", "dt_a")]},
+        graph_rows=[
+            {
+                "NAME": "dt_a",
+                "SCHEMA_NAME": "SCHEMA_A",
+                "DATABASE_NAME": "TEST_DB",
+                "INPUTS": '[{"kind": "TABLE", "name": "TEST_DB.SCHEMA_A.right"}]',
+                "TARGET_LAG_TYPE": "USER_DEFINED",
+                "TARGET_LAG_SEC": 3600,
+                "SCHEDULING_STATE": None,
+                "ALTER_TRIGGER": None,
+            },
+            # Listed AFTER the correct row deliberately: with the caller's db_name stamped
+            # on every row the two collide and the last one wins, so this ordering is what
+            # makes the test fail when the key is wrong.
+            {
+                "NAME": "dt_a",
+                "SCHEMA_NAME": "SCHEMA_A",
+                "DATABASE_NAME": "OTHER_DB",
+                "INPUTS": '[{"kind": "TABLE", "name": "OTHER_DB.SCHEMA_A.wrong"}]',
+                "TARGET_LAG_TYPE": "USER_DEFINED",
+                "TARGET_LAG_SEC": 1,
+                "SCHEDULING_STATE": None,
+                "ALTER_TRIGGER": None,
+            },
+        ],
+    )
+
+    tables = _make_data_dictionary(connection).get_dynamic_tables_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [u.name for u in tables[0].upstream_tables] == ["TEST_DB.SCHEMA_A.right"], (
+        "lineage was taken from a same-named dynamic table in a different database"
+    )
+
+
 def test_per_schema_show_dynamic_tables_pages_through_every_table_exactly_once():
     total = SHOW_COMMAND_MAX_PAGE_SIZE + 2000
     connection = FakeShowConnection(

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -1,12 +1,9 @@
 """Pagination of database-wide ``SHOW`` commands.
 
-Snowflake's ``SHOW <objects> IN DATABASE`` output is "ordered lexicographically by
-database, schema, and name", but its ``LIMIT ... FROM '<name>'`` cursor matches on the
-object *name* alone. The cursor key is therefore not the sort key, and paging a
-database-wide result both skips objects (anything in a later schema whose name sorts
-before the marker) and returns others twice. Views, streams and dynamic tables all
-shared that bug; each must now page per schema instead, where name *is* the whole
-sort key.
+A database-wide ``SHOW`` sorts by (database, schema, name) but its cursor matches on name
+alone, so paging one both skips and duplicates objects - see
+``SnowflakeQuery.show_objects_for_database`` for the full rule. Views, streams and dynamic
+tables all shared the bug and all now page per schema, where name is the whole sort key.
 """
 
 import re
@@ -126,10 +123,8 @@ class FakeShowConnection:
 
     def query(self, query: str) -> List[Dict[str, Any]]:
         self.queries.append(query)
-        # Counts SHOW statements only. Budgeting every query would let an unrelated lookup
-        # (the dynamic-table graph history SELECT) or a legitimately wide fan-out fixture
-        # trip a message that says "the caller is not terminating" - a false diagnosis of a
-        # correct implementation. Only a paging loop can repeat the same SHOW shape.
+        # SHOW statements only: counting every query would let a wide fan-out fixture trip
+        # a message claiming the caller never terminates. Only paging repeats a SHOW shape.
         show_queries = [q for q in self.queries if q.lstrip().startswith("SHOW ")]
         if len(show_queries) > self._max_queries:
             # Fail fast rather than hang: without this, a caller that stops advancing its

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -126,11 +126,16 @@ class FakeShowConnection:
 
     def query(self, query: str) -> List[Dict[str, Any]]:
         self.queries.append(query)
-        if len(self.queries) > self._max_queries:
+        # Counts SHOW statements only. Budgeting every query would let an unrelated lookup
+        # (the dynamic-table graph history SELECT) or a legitimately wide fan-out fixture
+        # trip a message that says "the caller is not terminating" - a false diagnosis of a
+        # correct implementation. Only a paging loop can repeat the same SHOW shape.
+        show_queries = [q for q in self.queries if q.lstrip().startswith("SHOW ")]
+        if len(show_queries) > self._max_queries:
             # Fail fast rather than hang: without this, a caller that stops advancing its
             # cursor pages forever and the test times out CI instead of reporting.
             raise AssertionError(
-                f"Runaway pagination: {len(self.queries)} queries issued for "
+                f"Runaway pagination: {len(show_queries)} SHOW queries issued for "
                 f"{self._max_queries} allowed; the caller is not terminating."
             )
 
@@ -306,28 +311,57 @@ def test_per_schema_show_views_pages_through_every_view_exactly_once():
     assert [v.name for v in views] == [f"view_{i:05d}" for i in range(total)]
 
 
-def test_per_schema_paging_survives_an_object_name_containing_a_quote():
-    """A quoted Snowflake identifier may contain an apostrophe, and the marker is embedded
-    in a single-quoted SQL literal. Unescaped, the second page is malformed SQL and the
-    rest of the schema is lost."""
-    # The awkward name has to be the LAST row of a full page, because that is the row
-    # whose name becomes the cursor for page 2 - anywhere else and the quote is never
-    # embedded in a query.
-    head = [f"view_{i:05d}" for i in range(SHOW_COMMAND_MAX_PAGE_SIZE - 1)]
-    awkward = "w_it's_a_view"
+@pytest.mark.parametrize(
+    "kind,page_size,fetch",
+    [
+        (
+            VIEWS,
+            SHOW_COMMAND_MAX_PAGE_SIZE,
+            lambda dd: dd.get_views_for_schema_using_show(
+                db_name="TEST_DB", schema_name="SCHEMA_A"
+            ),
+        ),
+        (
+            STREAMS,
+            SHOW_STREAM_MAX_PAGE_SIZE,
+            lambda dd: dd.get_streams_for_schema_using_show(
+                db_name="TEST_DB", schema_name="SCHEMA_A"
+            ),
+        ),
+        (
+            DYNAMIC_TABLES,
+            SHOW_COMMAND_MAX_PAGE_SIZE,
+            lambda dd: dd.get_dynamic_tables_for_schema_using_show(
+                db_name="TEST_DB", schema_name="SCHEMA_A"
+            ),
+        ),
+    ],
+    ids=["views", "streams", "dynamic_tables"],
+)
+def test_per_schema_paging_survives_an_object_name_needing_escaping(
+    kind, page_size, fetch
+):
+    """A quoted Snowflake identifier may contain an apostrophe or a backslash, and the
+    marker is embedded in a single-quoted SQL literal. Unescaped, page 2 is malformed SQL
+    and the rest of the schema is lost. Escaping is applied at three call sites, so it is
+    checked at all three - one passing kind would otherwise cover for two broken ones.
+    """
+    # The awkward name has to be the LAST row of a full page, because that is the row whose
+    # name becomes the cursor for page 2 - anywhere else and the quote never reaches a query.
+    head = [f"obj_{i:05d}" for i in range(page_size - 1)]
+    awkward = "w_it's_a\\_name"
     tail = [f"x_{i:02d}" for i in range(10)]
     expected = head + [awkward] + tail
     assert sorted(expected) == expected, "fixture must already be in SHOW order"
 
-    connection = FakeShowConnection({VIEWS: [("SCHEMA_A", n) for n in expected]})
+    connection = FakeShowConnection({kind: [("SCHEMA_A", n) for n in expected]})
 
-    views = _make_data_dictionary(connection).get_views_for_schema_using_show(
-        db_name="TEST_DB", schema_name="SCHEMA_A"
-    )
+    objects = fetch(_make_data_dictionary(connection))
 
-    assert [v.name for v in views] == expected
-    assert "FROM 'w_it''s_a_view'" in connection.show_queries(VIEWS)[1], (
-        "page 2's cursor must carry the name with its quote doubled"
+    assert [o.name for o in objects] == expected
+    # Quote doubled and backslash doubled, in that order.
+    assert "FROM 'w_it''s_a\\\\_name'" in connection.show_queries(kind)[1], (
+        f"page 2's cursor must carry the escaped name; got {connection.show_queries(kind)[1]!r}"
     )
 
 
@@ -500,6 +534,11 @@ def test_dynamic_table_fallback_skips_schemas_without_dynamic_tables():
     per_schema = [
         q for q in connection.show_queries(DYNAMIC_TABLES) if "IN SCHEMA" in q
     ]
+    # The negative alone is vacuously true if the fallback visits nothing at all, so pin
+    # the positive too: the schema that does need definitions must be queried.
+    assert any("SCHEMA_B" in q for q in per_schema), (
+        f"the schema holding a dynamic table was not queried: {per_schema}"
+    )
     assert all("SCHEMA_NO_DT" not in q for q in per_schema), (
         f"queried a schema with no dynamic tables: {per_schema}"
     )

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -249,6 +249,23 @@ class DeniesEveryShowConnection(FakeShowConnection):
         )
 
 
+class DeniesOnlyPerSchemaConnection(FakeShowConnection):
+    """The database-wide SHOW succeeds but fills its page, so the caller falls back per
+    schema - and only there is the denial hit. This is the shape of a role holding USAGE on
+    the database while lacking it on one schema, and the only way to reach the per-schema
+    handler's permission branch: when every query is denied, the database-wide probe raises
+    first and the fallback never runs."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        if SHOW_IN_SCHEMA.search(query):
+            self.queries.append(query)
+            raise SnowflakePermissionError(
+                "002003 (02000): SQL compilation error: "
+                "Schema 'SCHEMA_A' does not exist or not authorized."
+            )
+        return super().query(query)
+
+
 class ReturnsAnUnmappableRowConnection(FakeShowConnection):
     """A row the mapper cannot handle: _map_show_view lowercases is_materialized, which a
     NULL column value breaks."""
@@ -656,6 +673,45 @@ def test_a_denied_listing_reaches_the_permission_classifier(kind, fetch):
 
     with pytest.raises(SnowflakePermissionError):
         fetch(schema_gen, schema)
+
+
+def test_a_denial_only_on_the_per_schema_fallback_still_propagates():
+    """The per-schema handler has its own permission branch, reached when the database-wide
+    query succeeds and only the narrower one is denied - a role with database USAGE but not
+    schema USAGE. Reporting it as an incomplete listing here would hide the missing grant."""
+    connection = DeniesOnlyPerSchemaConnection(
+        {VIEWS: [("SCHEMA_A", f"v_{i:05d}") for i in range(SHOW_COMMAND_MAX_PAGE_SIZE)]}
+    )
+    data_dictionary = _make_data_dictionary(connection)
+
+    with pytest.raises(SnowflakePermissionError):
+        data_dictionary.get_views_for_schema_using_show(
+            db_name="TEST_DB", schema_name="SCHEMA_A"
+        )
+
+    assert not data_dictionary.report.failures, (
+        "the denial must reach the caller's permission classifier, "
+        "not be pre-empted by a generic incomplete-listing failure"
+    )
+
+
+def test_a_non_permission_stream_failure_still_degrades_to_a_warning():
+    """Only a denial escalates. Anything else must stay the warning-and-return-[] it always
+    was, or a transient error would abort the run. Raised from the filter rather than the
+    connection because a failing query is already absorbed by the per-schema pager - this
+    handler only ever sees what gets past it."""
+    connection = FakeShowConnection({STREAMS: [("SCHEMA_A", "stream_a")]})
+    schema_gen = _make_schema_gen(connection)
+    schema_gen.filters.is_dataset_pattern_allowed.side_effect = ValueError("boom")  # type: ignore[attr-defined]
+    schema = SnowflakeSchema(
+        name="SCHEMA_A", created=None, last_altered=None, comment=None
+    )
+
+    assert schema_gen.fetch_streams_for_schema(schema, "TEST_DB") == []
+    titles = [w.title for w in schema_gen.report.warnings]
+    assert "Failed to get streams for schema" in titles, (
+        f"expected the stream warning; got {titles}"
+    )
 
 
 def test_an_unmappable_row_does_not_re_issue_the_database_wide_query():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -37,14 +37,20 @@ DYNAMIC_TABLES = SnowflakeShowKind.DYNAMIC_TABLES
 # connector can ask for - a new kind cannot be paged without this fixture understanding it.
 _KINDS = "|".join(kind.value for kind in SnowflakeShowKind)
 
-SHOW_IN_SCHEMA = re.compile(
-    rf'SHOW (?P<kind>{_KINDS}) IN SCHEMA "(?P<db>[^"]+)"\."(?P<schema>[^"]+)"'
+# The object name is captured loosely, up to the LIMIT that every SHOW this fake sees
+# carries, so that a badly quoted identifier reaches _parse_identifiers as a hard error
+# rather than failing the match and being answered with an empty result set.
+SHOW_IN_SCHEMA = re.compile(rf"SHOW (?P<kind>{_KINDS}) IN SCHEMA (?P<name>.+?) LIMIT ")
+SHOW_IN_DATABASE = re.compile(
+    rf"SHOW (?P<kind>{_KINDS}) IN DATABASE (?P<name>.+?) LIMIT "
 )
-SHOW_IN_DATABASE = re.compile(rf'SHOW (?P<kind>{_KINDS}) IN DATABASE "(?P<db>[^"]+)"')
 LIMIT_CLAUSE = re.compile(r"LIMIT (?P<limit>\d+)")
 # Spans the whole literal, including any doubled quotes, so that a badly escaped marker is
 # visible to _parse_marker rather than being silently truncated at the first quote.
 FROM_CLAUSE = re.compile(r"FROM '(?P<marker>.*)'\s*;", re.DOTALL)
+# A double-quoted identifier: any run of non-quote characters, with a literal quote
+# written doubled.
+LEADING_QUOTED_IDENTIFIER = re.compile(r'"((?:[^"]|"")*)"')
 
 
 def _parse_marker(query: str) -> Optional[str]:
@@ -62,6 +68,30 @@ def _parse_marker(query: str) -> Optional[str]:
     if "'" in literal.replace("''", ""):
         raise ValueError(f"Malformed SQL - unescaped quote in literal: {query!r}")
     return literal.replace("''", "'").replace("\\\\", "\\")
+
+
+def _parse_identifiers(name: str, query: str) -> List[str]:
+    """Split a dot-qualified quoted identifier the way Snowflake would.
+
+    The counterpart to _parse_marker, for the other escaping rule the same statement
+    relies on: inside a double-quoted identifier a literal quote is written doubled, and
+    a bare one ends the identifier early - a syntax error to Snowflake, so a hard error
+    here too. A fake that instead read a truncated schema name would let the connector
+    ship a statement Snowflake rejects and still pass.
+    """
+    identifiers: List[str] = []
+    rest = name
+    while True:
+        match = LEADING_QUOTED_IDENTIFIER.match(rest)
+        if match is None:
+            raise ValueError(f"Malformed SQL - bad quoted identifier in: {query!r}")
+        identifiers.append(match.group(1).replace('""', '"'))
+        rest = rest[match.end() :]
+        if not rest:
+            return identifiers
+        if not rest.startswith("."):
+            raise ValueError(f"Malformed SQL - bad quoted identifier in: {query!r}")
+        rest = rest[1:]
 
 
 def _row(kind: SnowflakeShowKind, schema_name: str, name: str) -> Dict[str, Any]:
@@ -142,13 +172,11 @@ class FakeShowConnection:
         in_database = SHOW_IN_DATABASE.search(effective)
         if in_schema:
             kind = SnowflakeShowKind(in_schema.group("kind"))
-            rows = [
-                o
-                for o in self._objects.get(kind, [])
-                if o[0] == in_schema.group("schema")
-            ]
+            _, schema = _parse_identifiers(in_schema.group("name"), effective)
+            rows = [o for o in self._objects.get(kind, []) if o[0] == schema]
         elif in_database:
             kind = SnowflakeShowKind(in_database.group("kind"))
+            _parse_identifiers(in_database.group("name"), effective)
             rows = list(self._objects.get(kind, []))
         else:
             # Non-SHOW metadata queries (e.g. the dynamic-table graph history) play no
@@ -382,8 +410,27 @@ def test_per_schema_paging_survives_an_object_name_needing_escaping(
     )
 
 
+def test_per_schema_paging_escapes_a_schema_name_containing_a_quote():
+    """The other half of the escaping the same statement depends on. A quoted Snowflake
+    identifier may contain a quote, doubled - so a schema named a"b closes the identifier
+    early unless escaped, and the statement is rejected. The fake enforces that rule (see
+    _parse_identifiers), so an unescaped identifier fails here rather than silently
+    reading a truncated schema name."""
+    schema = 'SCHEMA"A'
+    connection = FakeShowConnection(
+        {VIEWS: [(schema, "view_a"), ("SCHEMA_B", "view_b")]}
+    )
+
+    views = _make_data_dictionary(connection).get_views_for_schema_using_show(
+        db_name='TEST"DB', schema_name=schema
+    )
+
+    assert [v.name for v in views] == ["view_a"]
+    assert 'IN SCHEMA "TEST""DB"."SCHEMA""A"' in connection.show_queries(VIEWS)[0]
+
+
 def test_per_schema_paging_stops_when_the_cursor_does_not_advance():
-    """A broken cursor must produce a bounded, duplicate-free result plus a warning --
+    """A broken cursor must produce a bounded, duplicate-free result plus a failure --
     never an endless loop. Observed live against INFORMATION_SCHEMA views."""
     connection = IgnoresFromClauseConnection(
         {
@@ -403,7 +450,11 @@ def test_per_schema_paging_stops_when_the_cursor_does_not_advance():
     assert len(names) == len(set(names)) == SHOW_COMMAND_MAX_PAGE_SIZE
     issued = connection.show_queries(VIEWS)
     assert len(issued) == 2
-    assert data_dictionary.report.warnings
+    # Must be a failure, not a warning: the result is knowingly short, and stale-entity
+    # removal only skips soft-deletion when the source reported a failure. Asserting the
+    # severity is the point - a warning here would soft-delete the objects left unlisted.
+    assert data_dictionary.report.failures
+    assert not data_dictionary.report.warnings
     # The recorded statement is what the connector built, not what this fake pretended
     # Snowflake acted on: page 2 did carry a cursor, and the server disregarded it.
     assert "FROM '" in issued[1], (
@@ -502,7 +553,7 @@ def test_a_failed_dynamic_table_fetch_is_reported_not_only_logged():
         {"SCHEMA_A": [_dynamic_table("dt_a")]}, "TEST_DB"
     )
 
-    messages = [w.message for w in data_dictionary.report.warnings]
+    messages = [f.message for f in data_dictionary.report.failures]
     # Assert the per-schema handler specifically. The database-wide failure warns first, so
     # a bare `assert report.warnings` passes even with the terminal handler silenced - which
     # is the handler that actually loses data.
@@ -545,7 +596,7 @@ def test_a_mid_paging_failure_reports_how_many_rows_were_kept():
     )
 
     assert len(tables) == SHOW_COMMAND_MAX_PAGE_SIZE, "page 1 should still be salvaged"
-    reported = " ".join(str(w) for w in data_dictionary.report.warnings)
+    reported = " ".join(str(f) for f in data_dictionary.report.failures)
     assert f"kept {SHOW_COMMAND_MAX_PAGE_SIZE}" in reported, (
         f"the kept row count must be reported; got {reported!r}"
     )

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -445,9 +445,32 @@ def test_a_failed_dynamic_table_fetch_is_reported_not_only_logged():
         {"SCHEMA_A": [_dynamic_table("dt_a")]}, "TEST_DB"
     )
 
-    assert data_dictionary.report.warnings, (
-        "a failed dynamic-table fetch must surface in the report"
+    messages = [w.message for w in data_dictionary.report.warnings]
+    # Assert the per-schema handler specifically. The database-wide failure warns first, so
+    # a bare `assert report.warnings` passes even with the terminal handler silenced - which
+    # is the handler that actually loses data.
+    assert any("for schema" in m for m in messages), (
+        f"the terminal per-schema failure must be reported; got {messages}"
     )
+
+
+@pytest.mark.parametrize(
+    "kind,fetch",
+    [
+        (VIEWS, lambda gen: gen.get_views_for_schema("SCHEMA_A", "TEST_DB")),
+        (STREAMS, lambda gen: gen.get_streams_for_schema("SCHEMA_A", "TEST_DB")),
+    ],
+    ids=["views", "streams"],
+)
+def test_a_failed_database_wide_show_falls_back_per_schema(kind, fetch):
+    """A database-wide SHOW that cannot run at all - a missing grant, a statement timeout -
+    must still reach the exact per-schema path. Losing every object in the database because
+    one wide query failed is the outcome this whole fallback exists to avoid."""
+    connection = FailsDatabaseWideConnection({kind: [("SCHEMA_A", "obj_a")]})
+
+    objects = fetch(_make_schema_gen(connection))
+
+    assert [o.name for o in objects] == ["obj_a"]
 
 
 def test_dynamic_table_fallback_skips_schemas_without_dynamic_tables():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -578,6 +578,59 @@ def test_dynamic_table_fallback_skips_schemas_without_dynamic_tables():
     )
 
 
+class GraphHistoryConnection(FakeShowConnection):
+    """Answers the dynamic-table graph-history query as Snowflake does, so the producer of
+    that mapping and the consumer of it are exercised together - the seam where a key-format
+    mismatch hides when each side is tested alone."""
+
+    def __init__(
+        self,
+        objects: Dict[SnowflakeShowKind, List[Tuple[str, str]]],
+        graph_rows: List[Dict[str, Any]],
+    ) -> None:
+        super().__init__(objects)
+        self._graph_rows = graph_rows
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        if "DYNAMIC_TABLE_GRAPH_HISTORY" in query:
+            self.queries.append(query)
+            return self._graph_rows
+        return super().query(query)
+
+
+def test_dynamic_table_upstreams_come_through_the_graph_history():
+    """The graph history carries a dynamic table's INPUTS, which is where its upstream
+    lineage and its fallback target lag come from. Verified against a live account: the
+    function returns NAME, SCHEMA_NAME and DATABASE_NAME per row."""
+    connection = GraphHistoryConnection(
+        {DYNAMIC_TABLES: [("SCHEMA_A", "dt_a")]},
+        graph_rows=[
+            {
+                "NAME": "dt_a",
+                "SCHEMA_NAME": "SCHEMA_A",
+                "DATABASE_NAME": "TEST_DB",
+                "INPUTS": '[{"kind": "TABLE", "name": "TEST_DB.SCHEMA_A.base"}]',
+                "TARGET_LAG_TYPE": "USER_DEFINED",
+                "TARGET_LAG_SEC": 3600,
+                "SCHEDULING_STATE": None,
+                "ALTER_TRIGGER": None,
+            }
+        ],
+    )
+
+    tables = _make_data_dictionary(connection).get_dynamic_tables_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [t.name for t in tables] == ["dt_a"]
+    assert [u.name for u in tables[0].upstream_tables] == ["TEST_DB.SCHEMA_A.base"], (
+        "upstream lineage from the graph history was dropped"
+    )
+    # SHOW already reports a target lag, and it wins; the graph value is only a fallback
+    # for when it doesn't.
+    assert tables[0].target_lag == "1 hour"
+
+
 def test_per_schema_show_dynamic_tables_pages_through_every_table_exactly_once():
     total = SHOW_COMMAND_MAX_PAGE_SIZE + 2000
     connection = FakeShowConnection(

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -1,0 +1,382 @@
+"""Pagination of database-wide ``SHOW`` commands.
+
+Snowflake's ``SHOW <objects> IN DATABASE`` output is "ordered lexicographically by
+database, schema, and name", but its ``LIMIT ... FROM '<name>'`` cursor matches on the
+object *name* alone. The cursor key is therefore not the sort key, and paging a
+database-wide result both skips objects (anything in a later schema whose name sorts
+before the marker) and returns others twice. Views, streams and dynamic tables all
+shared that bug; each must now page per schema instead, where name *is* the whole
+sort key.
+"""
+
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
+from datahub.ingestion.source.snowflake.snowflake_query import (
+    SHOW_COMMAND_MAX_PAGE_SIZE,
+    SHOW_STREAM_MAX_PAGE_SIZE,
+)
+from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_schema import (
+    SnowflakeDataDictionary,
+    SnowflakeDynamicTable,
+)
+from datahub.ingestion.source.snowflake.snowflake_schema_gen import (
+    SnowflakeSchemaGenerator,
+)
+
+VIEWS = "VIEWS"
+STREAMS = "STREAMS"
+DYNAMIC_TABLES = "DYNAMIC TABLES"
+
+SHOW_IN_SCHEMA = re.compile(
+    r'SHOW (?P<kind>VIEWS|STREAMS|DYNAMIC TABLES) IN SCHEMA "(?P<db>[^"]+)"\."(?P<schema>[^"]+)"'
+)
+SHOW_IN_DATABASE = re.compile(
+    r'SHOW (?P<kind>VIEWS|STREAMS|DYNAMIC TABLES) IN DATABASE "(?P<db>[^"]+)"'
+)
+LIMIT_CLAUSE = re.compile(r"LIMIT (?P<limit>\d+)")
+FROM_CLAUSE = re.compile(r"FROM '(?P<marker>[^']+)'")
+
+
+def _row(kind: str, schema_name: str, name: str) -> Dict[str, Any]:
+    created = datetime(2026, 1, 1)
+    if kind == VIEWS:
+        return {
+            "name": name,
+            "schema_name": schema_name,
+            "created_on": created,
+            "comment": None,
+            "text": f"CREATE VIEW {name} AS SELECT 1",
+            "is_materialized": "false",
+            "is_secure": "false",
+        }
+    if kind == STREAMS:
+        return {
+            "name": name,
+            "schema_name": schema_name,
+            "database_name": "TEST_DB",
+            "created_on": created,
+            "owner": "TEST_ROLE",
+            "comment": None,
+            "source_type": "Table",
+            "type": "DELTA",
+            "stale": "false",
+            "mode": "DEFAULT",
+            "invalid_reason": None,
+            "owner_role_type": "ROLE",
+            "stale_after": None,
+            "table_name": f"TEST_DB.{schema_name}.source_table",
+            "base_tables": None,
+        }
+    if kind == DYNAMIC_TABLES:
+        return {
+            "name": name,
+            "schema_name": schema_name,
+            "created_on": created,
+            "comment": None,
+            "text": f"CREATE DYNAMIC TABLE {name} AS SELECT 1",
+            "target_lag": "1 hour",
+            "bytes": 0,
+            "rows": 0,
+        }
+    raise AssertionError(f"Unknown object kind: {kind}")
+
+
+class FakeShowConnection:
+    """Emulates Snowflake's documented ``SHOW`` semantics: output ordered by
+    ``(schema, name)``, and ``FROM '<name>'`` a cursor on the name alone."""
+
+    def __init__(self, objects: Dict[str, List[Tuple[str, str]]]) -> None:
+        self._objects = {kind: sorted(rows) for kind, rows in objects.items()}
+        self.queries: List[str] = []
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        self.queries.append(query)
+
+        in_schema = SHOW_IN_SCHEMA.search(query)
+        in_database = SHOW_IN_DATABASE.search(query)
+        if in_schema:
+            kind = in_schema.group("kind")
+            rows = [
+                o
+                for o in self._objects.get(kind, [])
+                if o[0] == in_schema.group("schema")
+            ]
+        elif in_database:
+            kind = in_database.group("kind")
+            rows = list(self._objects.get(kind, []))
+        else:
+            # Non-SHOW metadata queries (e.g. the dynamic-table graph history) play no
+            # part in pagination; answer them with no rows.
+            return []
+
+        marker = FROM_CLAUSE.search(query)
+        if marker:
+            rows = [o for o in rows if o[1] > marker.group("marker")]
+
+        limit = LIMIT_CLAUSE.search(query)
+        if limit:
+            rows = rows[: int(limit.group("limit"))]
+
+        return [_row(kind, schema_name, name) for schema_name, name in rows]
+
+    def show_queries(self, kind: str) -> List[str]:
+        return [q for q in self.queries if f"SHOW {kind} " in q]
+
+
+class IgnoresFromClauseConnection(FakeShowConnection):
+    """Mimics behaviour observed live: for some object classes (Snowflake's built-in
+    INFORMATION_SCHEMA views) the ``FROM '<name>'`` cursor is ignored outright, so every
+    page repeats the first one and a marker-driven loop never terminates."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        return super().query(FROM_CLAUSE.sub("", query))
+
+
+def _make_schema_gen(connection: FakeShowConnection) -> SnowflakeSchemaGenerator:
+    config = SnowflakeV2Config.parse_obj(
+        {
+            "account_id": "test_account",
+            "username": "test_user",
+            "password": "test_password",
+        }
+    )
+    return SnowflakeSchemaGenerator(
+        config=config,
+        report=SnowflakeV2Report(),
+        connection=connection,  # type: ignore[arg-type]
+        filters=MagicMock(),
+        identifiers=MagicMock(),
+        domain_registry=None,
+        profiler=None,
+        aggregator=None,
+        snowsight_url_builder=None,
+    )
+
+
+def _make_data_dictionary(connection: FakeShowConnection) -> SnowflakeDataDictionary:
+    return SnowflakeDataDictionary(
+        connection=connection,  # type: ignore[arg-type]
+        report=SnowflakeV2Report(),
+        fetch_views_from_information_schema=False,
+    )
+
+
+def _boundary_skips_a_schema(page_size: int) -> List[Tuple[str, str]]:
+    """``SCHEMA_A`` alone fills a full page and its names all sort *after*
+    ``SCHEMA_B``'s, so a name-only cursor taken from the end of page 1 skips every
+    object in ``SCHEMA_B``.
+
+    This is the shape of the reported production failure: the alphabetically earliest
+    views of a later schema went missing while their siblings were ingested.
+    """
+    return [("SCHEMA_A", f"m_{i:05d}") for i in range(page_size)] + [
+        ("SCHEMA_B", f"a_{i:03d}") for i in range(100)
+    ]
+
+
+def _boundary_repeats_a_schema(page_size: int) -> List[Tuple[str, str]]:
+    """Both schemas together fill exactly one page, and that page's last row (in
+    ``SCHEMA_B``) has a name sorting *before* all of ``SCHEMA_A``'s -- so a name-only
+    cursor rewinds into ``SCHEMA_A`` and returns it a second time. This is the
+    inflated ``views_scanned`` counter seen in production."""
+    half = page_size // 2
+    return [("SCHEMA_A", f"z_{i:05d}") for i in range(half)] + [
+        ("SCHEMA_B", f"a_{i:05d}") for i in range(half)
+    ]
+
+
+SKIPPED_NAMES = [f"a_{i:03d}" for i in range(100)]
+
+
+# --- views ---------------------------------------------------------------------
+
+
+def test_views_in_later_schema_survive_a_database_over_the_page_limit():
+    connection = FakeShowConnection(
+        {VIEWS: _boundary_skips_a_schema(SHOW_COMMAND_MAX_PAGE_SIZE)}
+    )
+    schema_gen = _make_schema_gen(connection)
+
+    views = schema_gen.get_views_for_schema("SCHEMA_B", "TEST_DB")
+
+    assert [v.name for v in views] == SKIPPED_NAMES
+
+
+def test_no_view_is_returned_twice_for_a_database_over_the_page_limit():
+    connection = FakeShowConnection(
+        {VIEWS: _boundary_repeats_a_schema(SHOW_COMMAND_MAX_PAGE_SIZE)}
+    )
+    schema_gen = _make_schema_gen(connection)
+
+    names = [v.name for v in schema_gen.get_views_for_schema("SCHEMA_A", "TEST_DB")]
+
+    assert len(names) == len(set(names)) == SHOW_COMMAND_MAX_PAGE_SIZE // 2
+
+
+def test_per_schema_show_views_pages_through_every_view_exactly_once():
+    total = SHOW_COMMAND_MAX_PAGE_SIZE + 2000
+    connection = FakeShowConnection(
+        {VIEWS: [("SCHEMA_A", f"view_{i:05d}") for i in range(total)]}
+    )
+
+    views = _make_data_dictionary(connection).get_views_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [v.name for v in views] == [f"view_{i:05d}" for i in range(total)]
+
+
+def test_per_schema_paging_stops_when_the_cursor_does_not_advance():
+    """A broken cursor must produce a bounded, duplicate-free result plus a warning --
+    never an endless loop. Observed live against INFORMATION_SCHEMA views."""
+    connection = IgnoresFromClauseConnection(
+        {
+            VIEWS: [
+                ("SCHEMA_A", f"view_{i:05d}")
+                for i in range(SHOW_COMMAND_MAX_PAGE_SIZE + 500)
+            ]
+        }
+    )
+    data_dictionary = _make_data_dictionary(connection)
+
+    views = data_dictionary.get_views_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    names = [v.name for v in views]
+    assert len(names) == len(set(names)) == SHOW_COMMAND_MAX_PAGE_SIZE
+    assert len(connection.show_queries(VIEWS)) == 2
+    assert data_dictionary.report.warnings
+
+
+def test_database_under_the_page_limit_uses_a_single_database_wide_view_query():
+    """Regression guard: the cheap one-query-per-database path must stay in place."""
+    connection = FakeShowConnection(
+        {
+            VIEWS: [("SCHEMA_A", f"view_{i:03d}") for i in range(10)]
+            + [("SCHEMA_B", "other")]
+        }
+    )
+    schema_gen = _make_schema_gen(connection)
+
+    assert len(schema_gen.get_views_for_schema("SCHEMA_A", "TEST_DB")) == 10
+    assert len(schema_gen.get_views_for_schema("SCHEMA_B", "TEST_DB")) == 1
+    assert len(connection.show_queries(VIEWS)) == 1
+
+
+# --- streams -------------------------------------------------------------------
+
+
+def test_streams_in_later_schema_survive_a_database_over_the_page_limit():
+    connection = FakeShowConnection(
+        {STREAMS: _boundary_skips_a_schema(SHOW_STREAM_MAX_PAGE_SIZE)}
+    )
+    schema_gen = _make_schema_gen(connection)
+
+    streams = schema_gen.get_streams_for_schema("SCHEMA_B", "TEST_DB")
+
+    assert [s.name for s in streams] == SKIPPED_NAMES
+
+
+def test_per_schema_show_streams_pages_through_every_stream_exactly_once():
+    total = SHOW_STREAM_MAX_PAGE_SIZE + 2000
+    connection = FakeShowConnection(
+        {STREAMS: [("SCHEMA_A", f"stream_{i:05d}") for i in range(total)]}
+    )
+
+    streams = _make_data_dictionary(connection).get_streams_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [s.name for s in streams] == [f"stream_{i:05d}" for i in range(total)]
+
+
+def test_database_under_the_page_limit_uses_a_single_database_wide_stream_query():
+    connection = FakeShowConnection(
+        {STREAMS: [("SCHEMA_A", "stream_a"), ("SCHEMA_B", "stream_b")]}
+    )
+    schema_gen = _make_schema_gen(connection)
+
+    assert len(schema_gen.get_streams_for_schema("SCHEMA_A", "TEST_DB")) == 1
+    assert len(schema_gen.get_streams_for_schema("SCHEMA_B", "TEST_DB")) == 1
+    assert len(connection.show_queries(STREAMS)) == 1
+
+
+# --- dynamic tables ------------------------------------------------------------
+
+
+def _dynamic_table(name: str) -> SnowflakeDynamicTable:
+    return SnowflakeDynamicTable(
+        name=name,
+        comment=None,
+        created=None,
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+        is_dynamic=True,
+    )
+
+
+def test_dynamic_table_definition_is_populated_for_a_later_schema():
+    connection = FakeShowConnection(
+        {DYNAMIC_TABLES: _boundary_skips_a_schema(SHOW_COMMAND_MAX_PAGE_SIZE)}
+    )
+    table = _dynamic_table("a_000")
+
+    _make_data_dictionary(connection).populate_dynamic_table_definitions(
+        {"SCHEMA_B": [table]}, "TEST_DB"
+    )
+
+    assert table.definition == "CREATE DYNAMIC TABLE a_000 AS SELECT 1"
+
+
+def test_per_schema_show_dynamic_tables_pages_through_every_table_exactly_once():
+    total = SHOW_COMMAND_MAX_PAGE_SIZE + 2000
+    connection = FakeShowConnection(
+        {DYNAMIC_TABLES: [("SCHEMA_A", f"dt_{i:05d}") for i in range(total)]}
+    )
+
+    tables = _make_data_dictionary(connection).get_dynamic_tables_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [t.name for t in tables] == [f"dt_{i:05d}" for i in range(total)]
+
+
+def test_database_under_the_page_limit_uses_a_single_database_wide_dynamic_table_query():
+    connection = FakeShowConnection(
+        {DYNAMIC_TABLES: [("SCHEMA_A", "dt_a"), ("SCHEMA_B", "dt_b")]}
+    )
+    data_dictionary = _make_data_dictionary(connection)
+    dt_a = _dynamic_table("dt_a")
+    dt_b = _dynamic_table("dt_b")
+
+    data_dictionary.populate_dynamic_table_definitions(
+        {"SCHEMA_A": [dt_a], "SCHEMA_B": [dt_b]}, "TEST_DB"
+    )
+
+    assert dt_a.definition == "CREATE DYNAMIC TABLE dt_a AS SELECT 1"
+    assert dt_b.definition == "CREATE DYNAMIC TABLE dt_b AS SELECT 1"
+    assert len(connection.show_queries(DYNAMIC_TABLES)) == 1
+
+
+@pytest.mark.parametrize("kind", [VIEWS, STREAMS, DYNAMIC_TABLES])
+def test_empty_database_issues_no_per_schema_queries(kind):
+    connection = FakeShowConnection({kind: []})
+    data_dictionary = _make_data_dictionary(connection)
+
+    if kind == VIEWS:
+        assert data_dictionary.get_views_for_database("TEST_DB") == {}
+    elif kind == STREAMS:
+        assert data_dictionary.get_streams_for_database("TEST_DB") == {}
+    else:
+        assert data_dictionary.get_dynamic_tables_with_definitions("TEST_DB") == {}
+
+    assert len(connection.show_queries(kind)) == 1

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -198,15 +198,32 @@ SKIPPED_NAMES = [f"a_{i:03d}" for i in range(100)]
 # --- views ---------------------------------------------------------------------
 
 
-def test_views_in_later_schema_survive_a_database_over_the_page_limit():
-    connection = FakeShowConnection(
-        {VIEWS: _boundary_skips_a_schema(SHOW_COMMAND_MAX_PAGE_SIZE)}
-    )
-    schema_gen = _make_schema_gen(connection)
+@pytest.mark.parametrize(
+    "kind,page_size,fetch",
+    [
+        (
+            VIEWS,
+            SHOW_COMMAND_MAX_PAGE_SIZE,
+            lambda gen: gen.get_views_for_schema("SCHEMA_B", "TEST_DB"),
+        ),
+        (
+            STREAMS,
+            SHOW_STREAM_MAX_PAGE_SIZE,
+            lambda gen: gen.get_streams_for_schema("SCHEMA_B", "TEST_DB"),
+        ),
+    ],
+    ids=["views", "streams"],
+)
+def test_objects_in_a_later_schema_survive_a_database_over_the_page_limit(
+    kind, page_size, fetch
+):
+    """The page boundary is one rule shared by every object type, so each kind is checked
+    against the same fixture and expectation rather than in a hand-copied test."""
+    connection = FakeShowConnection({kind: _boundary_skips_a_schema(page_size)})
 
-    views = schema_gen.get_views_for_schema("SCHEMA_B", "TEST_DB")
+    objects = fetch(_make_schema_gen(connection))
 
-    assert [v.name for v in views] == SKIPPED_NAMES
+    assert [o.name for o in objects] == SKIPPED_NAMES
 
 
 def test_no_view_is_returned_twice_for_a_database_over_the_page_limit():
@@ -272,17 +289,6 @@ def test_database_under_the_page_limit_uses_a_single_database_wide_view_query():
 
 
 # --- streams -------------------------------------------------------------------
-
-
-def test_streams_in_later_schema_survive_a_database_over_the_page_limit():
-    connection = FakeShowConnection(
-        {STREAMS: _boundary_skips_a_schema(SHOW_STREAM_MAX_PAGE_SIZE)}
-    )
-    schema_gen = _make_schema_gen(connection)
-
-    streams = schema_gen.get_streams_for_schema("SCHEMA_B", "TEST_DB")
-
-    assert [s.name for s in streams] == SKIPPED_NAMES
 
 
 def test_per_schema_show_streams_pages_through_every_stream_exactly_once():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -15,6 +15,9 @@ import pytest
 
 from datahub.ingestion.source.snowflake.constants import SnowflakeShowKind
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
+from datahub.ingestion.source.snowflake.snowflake_connection import (
+    SnowflakePermissionError,
+)
 from datahub.ingestion.source.snowflake.snowflake_query import (
     SHOW_COMMAND_MAX_PAGE_SIZE,
     SHOW_STREAM_MAX_PAGE_SIZE,
@@ -230,6 +233,30 @@ class FailsEverySchemaConnection(FakeShowConnection):
         if SHOW_IN_DATABASE.search(query) or SHOW_IN_SCHEMA.search(query):
             raise ValueError("SHOW failed")
         return []
+
+
+class DeniesEveryShowConnection(FakeShowConnection):
+    """A missing grant. The connection layer classifies Snowflake's "does not exist or not
+    authorized" as SnowflakePermissionError, which is not a size problem - so the per-schema
+    fallback cannot recover it and must not be attempted."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        super().query(query)
+        raise SnowflakePermissionError(
+            "002003 (02000): SQL compilation error: "
+            "Database 'TEST_DB' does not exist or not authorized."
+        )
+
+
+class ReturnsAnUnmappableRowConnection(FakeShowConnection):
+    """A row the mapper cannot handle: _map_show_view lowercases is_materialized, which a
+    NULL column value breaks."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        rows = super().query(query)
+        for row in rows:
+            row["is_materialized"] = None
+        return rows
 
 
 class FailsAfterFirstPageConnection(FakeShowConnection):
@@ -579,6 +606,40 @@ def test_a_failed_database_wide_show_falls_back_per_schema(kind, fetch):
     objects = fetch(_make_schema_gen(connection))
 
     assert [o.name for o in objects] == ["obj_a"]
+
+
+def test_a_denied_show_propagates_instead_of_falling_back_per_schema():
+    """A missing grant is not a size problem, so the fallback cannot recover it. Swallowing
+    it cost the operator the permission classification the callers already implement (see
+    SnowflakeSchemaGenerator.fetch_views_for_schema) and issued one doomed query per schema
+    in a database it could not read."""
+    connection = DeniesEveryShowConnection({VIEWS: [("SCHEMA_A", "view_a")]})
+    data_dictionary = _make_data_dictionary(connection)
+
+    with pytest.raises(SnowflakePermissionError):
+        data_dictionary.get_views_for_database("TEST_DB")
+
+    assert len(connection.queries) == 1, (
+        f"a denial must not be retried per schema; issued {connection.queries}"
+    )
+    # Reporting it here would pre-empt the caller's permission-specific failure with a
+    # generic one, so this handler must stay silent.
+    assert not data_dictionary.report.failures
+    assert not data_dictionary.report.warnings
+
+
+def test_an_unmappable_row_does_not_re_issue_the_database_wide_query():
+    """The mapping runs inside the same try as the query because get_views_for_database is
+    cached and serialized_lru_cache does not cache exceptions - a mapper error escaping it
+    would re-issue the 10,000-row database-wide SHOW once per schema."""
+    connection = ReturnsAnUnmappableRowConnection({VIEWS: [("SCHEMA_A", "view_a")]})
+    data_dictionary = _make_data_dictionary(connection)
+
+    assert data_dictionary.get_views_for_database("TEST_DB") is None, (
+        "an unmappable row must be answered with 'unusable', not raised"
+    )
+    assert len(connection.queries) == 1
+    assert data_dictionary.report.warnings
 
 
 def test_a_mid_paging_failure_reports_how_many_rows_were_kept():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from datahub.ingestion.source.snowflake.constants import SnowflakeShowKind
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub.ingestion.source.snowflake.snowflake_query import (
     SHOW_COMMAND_MAX_PAGE_SIZE,
@@ -30,21 +31,23 @@ from datahub.ingestion.source.snowflake.snowflake_schema_gen import (
     SnowflakeSchemaGenerator,
 )
 
-VIEWS = "VIEWS"
-STREAMS = "STREAMS"
-DYNAMIC_TABLES = "DYNAMIC TABLES"
+VIEWS = SnowflakeShowKind.VIEWS
+STREAMS = SnowflakeShowKind.STREAMS
+DYNAMIC_TABLES = SnowflakeShowKind.DYNAMIC_TABLES
+
+# Built from the enum so the fake connection recognises exactly the object classes the
+# connector can ask for - a new kind cannot be paged without this fixture understanding it.
+_KINDS = "|".join(kind.value for kind in SnowflakeShowKind)
 
 SHOW_IN_SCHEMA = re.compile(
-    r'SHOW (?P<kind>VIEWS|STREAMS|DYNAMIC TABLES) IN SCHEMA "(?P<db>[^"]+)"\."(?P<schema>[^"]+)"'
+    rf'SHOW (?P<kind>{_KINDS}) IN SCHEMA "(?P<db>[^"]+)"\."(?P<schema>[^"]+)"'
 )
-SHOW_IN_DATABASE = re.compile(
-    r'SHOW (?P<kind>VIEWS|STREAMS|DYNAMIC TABLES) IN DATABASE "(?P<db>[^"]+)"'
-)
+SHOW_IN_DATABASE = re.compile(rf'SHOW (?P<kind>{_KINDS}) IN DATABASE "(?P<db>[^"]+)"')
 LIMIT_CLAUSE = re.compile(r"LIMIT (?P<limit>\d+)")
 FROM_CLAUSE = re.compile(r"FROM '(?P<marker>[^']+)'")
 
 
-def _row(kind: str, schema_name: str, name: str) -> Dict[str, Any]:
+def _row(kind: SnowflakeShowKind, schema_name: str, name: str) -> Dict[str, Any]:
     created = datetime(2026, 1, 1)
     if kind == VIEWS:
         return {
@@ -92,7 +95,7 @@ class FakeShowConnection:
     """Emulates Snowflake's documented ``SHOW`` semantics: output ordered by
     ``(schema, name)``, and ``FROM '<name>'`` a cursor on the name alone."""
 
-    def __init__(self, objects: Dict[str, List[Tuple[str, str]]]) -> None:
+    def __init__(self, objects: Dict[SnowflakeShowKind, List[Tuple[str, str]]]) -> None:
         self._objects = {kind: sorted(rows) for kind, rows in objects.items()}
         self.queries: List[str] = []
 
@@ -102,14 +105,14 @@ class FakeShowConnection:
         in_schema = SHOW_IN_SCHEMA.search(query)
         in_database = SHOW_IN_DATABASE.search(query)
         if in_schema:
-            kind = in_schema.group("kind")
+            kind = SnowflakeShowKind(in_schema.group("kind"))
             rows = [
                 o
                 for o in self._objects.get(kind, [])
                 if o[0] == in_schema.group("schema")
             ]
         elif in_database:
-            kind = in_database.group("kind")
+            kind = SnowflakeShowKind(in_database.group("kind"))
             rows = list(self._objects.get(kind, []))
         else:
             # Non-SHOW metadata queries (e.g. the dynamic-table graph history) play no
@@ -126,7 +129,7 @@ class FakeShowConnection:
 
         return [_row(kind, schema_name, name) for schema_name, name in rows]
 
-    def show_queries(self, kind: str) -> List[str]:
+    def show_queries(self, kind: SnowflakeShowKind) -> List[str]:
         return [q for q in self.queries if f"SHOW {kind} " in q]
 
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -139,6 +139,16 @@ class IgnoresFromClauseConnection(FakeShowConnection):
         return super().query(FROM_CLAUSE.sub("", query))
 
 
+class FailsDatabaseWideConnection(FakeShowConnection):
+    """A database-wide ``SHOW`` can fail on its own - a statement timeout, or a result set
+    too large for the account's limits - while the narrower per-schema queries succeed."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        if SHOW_IN_DATABASE.search(query):
+            raise ValueError("SHOW ... IN DATABASE failed")
+        return super().query(query)
+
+
 def _make_schema_gen(connection: FakeShowConnection) -> SnowflakeSchemaGenerator:
     config = SnowflakeV2Config.parse_obj(
         {
@@ -341,6 +351,17 @@ def test_dynamic_table_definition_is_populated_for_a_later_schema():
     )
 
     assert table.definition == "CREATE DYNAMIC TABLE a_000 AS SELECT 1"
+
+
+def test_dynamic_table_definitions_fall_back_per_schema_when_the_database_wide_show_fails():
+    connection = FailsDatabaseWideConnection({DYNAMIC_TABLES: [("SCHEMA_A", "dt_a")]})
+    table = _dynamic_table("dt_a")
+
+    _make_data_dictionary(connection).populate_dynamic_table_definitions(
+        {"SCHEMA_A": [table]}, "TEST_DB"
+    )
+
+    assert table.definition == "CREATE DYNAMIC TABLE dt_a AS SELECT 1"
 
 
 def test_per_schema_show_dynamic_tables_pages_through_every_table_exactly_once():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -676,20 +676,28 @@ def test_a_denied_listing_reaches_the_permission_classifier(kind, fetch):
 
 
 def test_a_denial_only_on_the_per_schema_fallback_still_propagates():
-    """The per-schema handler has its own permission branch, reached when the database-wide
-    query succeeds and only the narrower one is denied - a role with database USAGE but not
-    schema USAGE. Reporting it as an incomplete listing here would hide the missing grant."""
+    """The per-schema handler has its own permission branch, distinct from the database-wide
+    probe's, and it is reached only on the fallback: the database-wide query succeeds and
+    fills its page, then the schema-scoped retry is denied - a role holding database USAGE
+    but not schema USAGE. Driven through get_views_for_schema rather than the per-schema
+    fetch directly, because calling that directly never issues the database-wide query and
+    so never reaches this handler by the route production takes."""
     connection = DeniesOnlyPerSchemaConnection(
         {VIEWS: [("SCHEMA_A", f"v_{i:05d}") for i in range(SHOW_COMMAND_MAX_PAGE_SIZE)]}
     )
-    data_dictionary = _make_data_dictionary(connection)
+    schema_gen = _make_schema_gen(connection)
 
     with pytest.raises(SnowflakePermissionError):
-        data_dictionary.get_views_for_schema_using_show(
-            db_name="TEST_DB", schema_name="SCHEMA_A"
-        )
+        schema_gen.get_views_for_schema("SCHEMA_A", "TEST_DB")
 
-    assert not data_dictionary.report.failures, (
+    issued = connection.show_queries(VIEWS)
+    assert any("IN DATABASE" in q for q in issued), (
+        f"the database-wide probe must have run and filled its page; got {issued}"
+    )
+    assert any("IN SCHEMA" in q for q in issued), (
+        f"the denial must have come from the per-schema fallback; got {issued}"
+    )
+    assert not schema_gen.report.failures, (
         "the denial must reach the caller's permission classifier, "
         "not be pre-empted by a generic incomplete-listing failure"
     )

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -139,8 +139,12 @@ class FakeShowConnection:
                 f"{self._max_queries} allowed; the caller is not terminating."
             )
 
-        in_schema = SHOW_IN_SCHEMA.search(query)
-        in_database = SHOW_IN_DATABASE.search(query)
+        # What Snowflake acts on. A subclass may differ from what was sent (see
+        # IgnoresFromClauseConnection); self.queries always keeps the statement as built.
+        effective = self._effective(query)
+
+        in_schema = SHOW_IN_SCHEMA.search(effective)
+        in_database = SHOW_IN_DATABASE.search(effective)
         if in_schema:
             kind = SnowflakeShowKind(in_schema.group("kind"))
             rows = [
@@ -156,15 +160,20 @@ class FakeShowConnection:
             # part in pagination; answer them with no rows.
             return []
 
-        marker = _parse_marker(query)
+        marker = _parse_marker(effective)
         if marker is not None:
             rows = [o for o in rows if o[1] > marker]
 
-        limit = LIMIT_CLAUSE.search(query)
+        limit = LIMIT_CLAUSE.search(effective)
         if limit:
             rows = rows[: int(limit.group("limit"))]
 
         return [_row(kind, schema_name, name) for schema_name, name in rows]
+
+    def _effective(self, query: str) -> str:
+        """The statement Snowflake behaves as though it received. Overridden to model a
+        server that quietly disregards part of what was sent."""
+        return query
 
     def show_queries(self, kind: SnowflakeShowKind) -> List[str]:
         return [q for q in self.queries if f"SHOW {kind} " in q]
@@ -175,8 +184,8 @@ class IgnoresFromClauseConnection(FakeShowConnection):
     INFORMATION_SCHEMA views) the ``FROM '<name>'`` cursor is ignored outright, so every
     page repeats the first one and a marker-driven loop never terminates."""
 
-    def query(self, query: str) -> List[Dict[str, Any]]:
-        return super().query(FROM_CLAUSE.sub("", query))
+    def _effective(self, query: str) -> str:
+        return FROM_CLAUSE.sub("", query)
 
 
 class FailsDatabaseWideConnection(FakeShowConnection):
@@ -397,8 +406,14 @@ def test_per_schema_paging_stops_when_the_cursor_does_not_advance():
 
     names = [v.name for v in views]
     assert len(names) == len(set(names)) == SHOW_COMMAND_MAX_PAGE_SIZE
-    assert len(connection.show_queries(VIEWS)) == 2
+    issued = connection.show_queries(VIEWS)
+    assert len(issued) == 2
     assert data_dictionary.report.warnings
+    # The recorded statement is what the connector built, not what this fake pretended
+    # Snowflake acted on: page 2 did carry a cursor, and the server disregarded it.
+    assert "FROM '" in issued[1], (
+        f"page 2 should have been built with a cursor: {issued[1]!r}"
+    )
 
 
 def test_database_under_the_page_limit_uses_a_single_database_wide_view_query():

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_show_pagination.py
@@ -11,7 +11,7 @@ sort key.
 
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,6 +26,7 @@ from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Repor
 from datahub.ingestion.source.snowflake.snowflake_schema import (
     SnowflakeDataDictionary,
     SnowflakeDynamicTable,
+    SnowflakeTable,
 )
 from datahub.ingestion.source.snowflake.snowflake_schema_gen import (
     SnowflakeSchemaGenerator,
@@ -44,7 +45,26 @@ SHOW_IN_SCHEMA = re.compile(
 )
 SHOW_IN_DATABASE = re.compile(rf'SHOW (?P<kind>{_KINDS}) IN DATABASE "(?P<db>[^"]+)"')
 LIMIT_CLAUSE = re.compile(r"LIMIT (?P<limit>\d+)")
-FROM_CLAUSE = re.compile(r"FROM '(?P<marker>[^']+)'")
+# Spans the whole literal, including any doubled quotes, so that a badly escaped marker is
+# visible to _parse_marker rather than being silently truncated at the first quote.
+FROM_CLAUSE = re.compile(r"FROM '(?P<marker>.*)'\s*;", re.DOTALL)
+
+
+def _parse_marker(query: str) -> Optional[str]:
+    """Read the ``FROM '<name>'`` cursor the way Snowflake would.
+
+    Snowflake rejects a statement whose string literal contains a bare quote, so an
+    unescaped marker is a hard error here too - not a truncated cursor. Without that,
+    a fake quietly recovers from bad escaping and the test proves nothing.
+    """
+    match = FROM_CLAUSE.search(query)
+    if match is None:
+        return None
+
+    literal = match.group("marker")
+    if "'" in literal.replace("''", ""):
+        raise ValueError(f"Malformed SQL - unescaped quote in literal: {query!r}")
+    return literal.replace("''", "'").replace("\\\\", "\\")
 
 
 def _row(kind: SnowflakeShowKind, schema_name: str, name: str) -> Dict[str, Any]:
@@ -95,12 +115,24 @@ class FakeShowConnection:
     """Emulates Snowflake's documented ``SHOW`` semantics: output ordered by
     ``(schema, name)``, and ``FROM '<name>'`` a cursor on the name alone."""
 
-    def __init__(self, objects: Dict[SnowflakeShowKind, List[Tuple[str, str]]]) -> None:
+    def __init__(
+        self,
+        objects: Dict[SnowflakeShowKind, List[Tuple[str, str]]],
+        max_queries: int = 10,
+    ) -> None:
         self._objects = {kind: sorted(rows) for kind, rows in objects.items()}
         self.queries: List[str] = []
+        self._max_queries = max_queries
 
     def query(self, query: str) -> List[Dict[str, Any]]:
         self.queries.append(query)
+        if len(self.queries) > self._max_queries:
+            # Fail fast rather than hang: without this, a caller that stops advancing its
+            # cursor pages forever and the test times out CI instead of reporting.
+            raise AssertionError(
+                f"Runaway pagination: {len(self.queries)} queries issued for "
+                f"{self._max_queries} allowed; the caller is not terminating."
+            )
 
         in_schema = SHOW_IN_SCHEMA.search(query)
         in_database = SHOW_IN_DATABASE.search(query)
@@ -119,9 +151,9 @@ class FakeShowConnection:
             # part in pagination; answer them with no rows.
             return []
 
-        marker = FROM_CLAUSE.search(query)
-        if marker:
-            rows = [o for o in rows if o[1] > marker.group("marker")]
+        marker = _parse_marker(query)
+        if marker is not None:
+            rows = [o for o in rows if o[1] > marker]
 
         limit = LIMIT_CLAUSE.search(query)
         if limit:
@@ -150,6 +182,17 @@ class FailsDatabaseWideConnection(FakeShowConnection):
         if SHOW_IN_DATABASE.search(query):
             raise ValueError("SHOW ... IN DATABASE failed")
         return super().query(query)
+
+
+class FailsEverySchemaConnection(FakeShowConnection):
+    """Every SHOW fails - the shape of a systemic problem such as a missing grant, where
+    neither the database-wide query nor the per-schema fallback can succeed."""
+
+    def query(self, query: str) -> List[Dict[str, Any]]:
+        super().query(query)
+        if SHOW_IN_DATABASE.search(query) or SHOW_IN_SCHEMA.search(query):
+            raise ValueError("SHOW failed")
+        return []
 
 
 def _make_schema_gen(connection: FakeShowConnection) -> SnowflakeSchemaGenerator:
@@ -263,6 +306,31 @@ def test_per_schema_show_views_pages_through_every_view_exactly_once():
     assert [v.name for v in views] == [f"view_{i:05d}" for i in range(total)]
 
 
+def test_per_schema_paging_survives_an_object_name_containing_a_quote():
+    """A quoted Snowflake identifier may contain an apostrophe, and the marker is embedded
+    in a single-quoted SQL literal. Unescaped, the second page is malformed SQL and the
+    rest of the schema is lost."""
+    # The awkward name has to be the LAST row of a full page, because that is the row
+    # whose name becomes the cursor for page 2 - anywhere else and the quote is never
+    # embedded in a query.
+    head = [f"view_{i:05d}" for i in range(SHOW_COMMAND_MAX_PAGE_SIZE - 1)]
+    awkward = "w_it's_a_view"
+    tail = [f"x_{i:02d}" for i in range(10)]
+    expected = head + [awkward] + tail
+    assert sorted(expected) == expected, "fixture must already be in SHOW order"
+
+    connection = FakeShowConnection({VIEWS: [("SCHEMA_A", n) for n in expected]})
+
+    views = _make_data_dictionary(connection).get_views_for_schema_using_show(
+        db_name="TEST_DB", schema_name="SCHEMA_A"
+    )
+
+    assert [v.name for v in views] == expected
+    assert "FROM 'w_it''s_a_view'" in connection.show_queries(VIEWS)[1], (
+        "page 2's cursor must carry the name with its quote doubled"
+    )
+
+
 def test_per_schema_paging_stops_when_the_cursor_does_not_advance():
     """A broken cursor must produce a bounded, duplicate-free result plus a warning --
     never an endless loop. Observed live against INFORMATION_SCHEMA views."""
@@ -365,6 +433,53 @@ def test_dynamic_table_definitions_fall_back_per_schema_when_the_database_wide_s
     )
 
     assert table.definition == "CREATE DYNAMIC TABLE dt_a AS SELECT 1"
+
+
+def test_a_failed_dynamic_table_fetch_is_reported_not_only_logged():
+    """The fallback is the last resort: if it fails too, every definition and its lineage
+    is lost. That must reach the ingestion report, not just a debug log."""
+    connection = FailsEverySchemaConnection({DYNAMIC_TABLES: [("SCHEMA_A", "dt_a")]})
+    data_dictionary = _make_data_dictionary(connection)
+
+    data_dictionary.populate_dynamic_table_definitions(
+        {"SCHEMA_A": [_dynamic_table("dt_a")]}, "TEST_DB"
+    )
+
+    assert data_dictionary.report.warnings, (
+        "a failed dynamic-table fetch must surface in the report"
+    )
+
+
+def test_dynamic_table_fallback_skips_schemas_without_dynamic_tables():
+    """The per-schema fallback costs one query per schema, so it must only visit schemas
+    that actually hold a dynamic table awaiting a definition."""
+    connection = FakeShowConnection(
+        {DYNAMIC_TABLES: _boundary_skips_a_schema(SHOW_COMMAND_MAX_PAGE_SIZE)}
+    )
+    data_dictionary = _make_data_dictionary(connection)
+
+    plain_table = SnowflakeTable(
+        name="plain",
+        comment=None,
+        created=None,
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+    )
+    data_dictionary.populate_dynamic_table_definitions(
+        {
+            "SCHEMA_B": [_dynamic_table("a_000")],
+            "SCHEMA_NO_DT": [plain_table],
+        },
+        "TEST_DB",
+    )
+
+    per_schema = [
+        q for q in connection.show_queries(DYNAMIC_TABLES) if "IN SCHEMA" in q
+    ]
+    assert all("SCHEMA_NO_DT" not in q for q in per_schema), (
+        f"queried a schema with no dynamic tables: {per_schema}"
+    )
 
 
 def test_per_schema_show_dynamic_tables_pages_through_every_table_exactly_once():


### PR DESCRIPTION
## Summary

`SHOW <objects> IN DATABASE` output is ordered by (database, schema, name), but its `LIMIT ... FROM '<name>'` cursor matches on the **object name alone**. The cursor key is not the sort key, so paginating a database-wide `SHOW` silently loses and duplicates objects. Views, streams and dynamic tables all paginated that way.

## The bug, in five views

Take a database with two schemas, and pretend the page size is 3 instead of 10,000:

| schema | views |
| --- | --- |
| `SCHEMA_A` | `m1`, `m2`, `m3` |
| `SCHEMA_B` | `a1`, `a2` |

`SHOW VIEWS IN DATABASE "DB"` returns them ordered by (schema, name):

```
SCHEMA_A.m1  SCHEMA_A.m2  SCHEMA_A.m3  SCHEMA_B.a1  SCHEMA_B.a2
```

Page 1 (`LIMIT 3`) returns the three `SCHEMA_A` rows. Its last row is `m3`, so the old code asked for page 2 as:

```sql
SHOW VIEWS IN DATABASE "DB" LIMIT 3 FROM 'm3';
```

`FROM 'm3'` means **`name > 'm3'`, across the whole database** — not "continue where the sort left off". `'a1' < 'm3'` and `'a2' < 'm3'`, so page 2 comes back empty and **both `SCHEMA_B` views are lost**. Three of five views ingested, no error, no warning.

Reorder the same views and you get duplicates instead:

| schema | views |
| --- | --- |
| `SCHEMA_A` | `m5` |
| `SCHEMA_B` | `m1`, `m2`, `m3`, `m4` |

Page 1 (`LIMIT 2`) returns `SCHEMA_A.m5`, `SCHEMA_B.m1`; marker `m1`. Page 2 asks for `name > 'm1'` and gets back `SCHEMA_A.m5` **again**, plus `m2`, `m3`, `m4`. One view emitted twice.

That is why the reported symptom was intermittent, and why `views_scanned` was wildly inflated while views went missing: whether you lose anything depends on where the page boundary falls relative to schema ordering, which shifts as views are recreated. A database whose largest schema sorts last loses nothing at all.

**A second failure mode:** if the marker happens to name an `INFORMATION_SCHEMA` view, Snowflake ignores the cursor outright and the next page comes back byte-identical — the loop never terminates. Reproduced live: paging `INFORMATION_SCHEMA` returned the same page indefinitely.

## The fix, in the SQL it emits

A database-wide `SHOW` is now issued **once, un-paginated**. If it comes back full it cannot be continued, so it is discarded and the caller pages per schema — where a schema's output is ordered by name alone, so the cursor *is* the sort key.

Small database — one query, unchanged from before:

```sql
SHOW VIEWS IN DATABASE "DB" LIMIT 10000;   -- 62 rows < 10000 → complete, done
```

Database over the limit — the probe is thrown away, then each schema is paged exactly:

```sql
SHOW VIEWS IN DATABASE "DB" LIMIT 10000;                        -- 10000 rows → unusable
SHOW VIEWS IN SCHEMA "DB"."SCHEMA_A" LIMIT 10000;               -- full page
SHOW VIEWS IN SCHEMA "DB"."SCHEMA_A" LIMIT 10000 FROM 'm9999';  -- continues correctly
SHOW VIEWS IN SCHEMA "DB"."SCHEMA_B" LIMIT 10000;
```

Supporting changes that make that safe:

- **The marker is gone from the database-wide builders**, so the unsound call cannot be reconstructed by accident.
- **One shared per-schema pager** for all three object kinds. It dedupes by name and stops with a failure if a full page yields no new name — so a cursor Snowflake ignores can neither hang ingestion nor emit an object twice. Termination deliberately does *not* compare markers, which would re-derive Snowflake's collation in Python and could call a working cursor stalled on mixed-case identifiers.
- **Both escaping rules the statement needs are applied**, and they are different rules. The marker sits in a **string literal**: a view named `it's` previously produced `FROM 'it's'` — malformed SQL that killed the rest of the schema — and now produces `FROM 'it''s'` via the `_escape_sql_string_literal` helper already in the file (backslash doubled first, then the quote, since Snowflake treats both as escapes). The database and schema names sit in **quoted identifiers**, where only the quote is doubled and a bare one ends the identifier early: a schema named `a"b` produced `SHOW VIEWS IN SCHEMA "DB"."a"b"`, which Snowflake rejects outright. Those now go through `SnowflakeIdentifierBuilder.get_quoted_identifier_for_database` / `_for_schema` — which already implemented the rule and already had unit tests, but until now had no production callers anywhere in the connector.
- **One failure policy.** A database-wide `SHOW` that cannot run at all (a statement timeout, a result set over the account's limits) is reported and answered with "unusable", so it also reaches the per-schema path instead of losing the whole database. Previously only dynamic tables did this; views and streams let the exception escape a cached function, which re-issued the failing query once per schema.
- **A missing grant is not one of those failures.** `connection.query` classifies Snowflake's `002003 … does not exist or not authorized` as `SnowflakePermissionError`, and a denial is not a size problem — the per-schema fallback would be denied too, once per schema, in a database the role cannot read. An earlier revision of this branch caught it with the rest, so both handlers now let it through instead of answering "unusable".

  **Views and streams** now both surface it as the actionable failure `get_workunits_internal` records under `GENERIC_PERMISSION_ERROR_KEY`. Views always did. Streams did not: `fetch_streams_for_schema` recognised `SnowflakePermissionError` well enough to reword its warning and still swallowed it, returning `[]` — so the schema's streams vanished from a run that exited clean, and got soft-deleted. Fixed here by following the views convention.

  That last one was pre-existing (since #12929), but this branch made it worse in passing, which is worth stating plainly. Measured at three states with a connection that denies every `SHOW`:

  | state | `report.failures` | soft-delete of unlisted streams |
  | --- | --- | --- |
  | `master` | 0 | armed |
  | this branch, at the severity commit | 1 | blocked |
  | this branch, at the permission commit | 0 | armed |

  The per-schema pager's `report.failure` had incidentally closed the hole; moving permission errors to a re-raise handed them to a caller that downgraded them again. Net against `master` was neutral, but the fix belongs here rather than in a follow-up, since the branch had already demonstrated it.

  **Dynamic tables deliberately keep warning.** `populate_dynamic_table_definitions` only enriches tables discovered elsewhere, so a denial costs definitions and lineage, not entities — there is no soft-delete exposure, and `num_dynamic_tables_missing_definition` already reports it. Re-raising there would escape `get_tables_for_database` into `fetch_tables_for_schema`, which aborts the source, turning "no dynamic-table definitions" into "no tables at all"; `test_snowflake_dynamic_table_missing_monitor_privilege_raises_pipeline_warning` pins that it must not. Severity tracks what the denial costs, not the error class.
- **The row mapping moved inside the probe's `try`.** The handler is there because `serialized_lru_cache` does not cache exceptions, so an uncaught one re-runs the page-sized query once per schema — but the mapping sat outside it, and `_map_show_view` lowercases `is_materialized`, which a NULL column value breaks. The docstring's guarantee now holds for the mapper too. The page-size check stays ahead of the mapping, so a full page still costs no mapping work.
- **An incomplete schema listing now fails the run.** Both per-schema incompleteness paths — a page that fails outright, and a cursor Snowflake does not honour — return a knowingly short object list, and previously did so under a `warning`, so the run exited clean. Stale-entity removal skips soft-deletion only when the source reported a failure, and the `fail_safe_threshold` (75% by default) is far too coarse to notice one schema out of hundreds — so the objects Snowflake never listed would be soft-deleted as though they had been dropped. Both are now `failure`. Severity tracks whether the loss is recoverable, which is why the database-wide probe above deliberately keeps warning: the per-schema path still returns everything it could not.
- **`SHOW` statements are built from the object kind**, collapsing six near-identical builders — with three different formattings and three copies of the escaping and page-limit rules — onto two. The page limit now reaches the statement and the row-count comparison from one expression, so they cannot disagree. The four per-kind wrappers that were left delegating to them are gone too, since nothing in production called them any more; the tests that mocked them now key on `show_objects_for_*`, the builder production actually calls.

## Also fixed: dynamic table upstream lineage never worked

Found while testing this branch against a live account, and independent of the pagination bug.

`get_dynamic_table_graph_info` keyed its mapping by the `NAME` column, which Snowflake populates **unqualified**, while `_map_show_dynamic_table` looked the entry up by `db.schema.name`. The lookup could never hit:

```
graph history row:  NAME='DT1'  SCHEMA_NAME='PUBLIC'  INPUTS=[{"name": "DB.PUBLIC.BASE"}]

old key   'DT1'              ← lookup 'DB.PUBLIC.DT1'  → miss → upstream_tables=[]
new key   'DB.PUBLIC.DT1'    ← lookup 'DB.PUBLIC.DT1'  → hit  → upstream_tables=['DB.PUBLIC.BASE']
```

So **every dynamic table silently lost its `INPUTS`-derived upstream lineage**, and the graph-derived `target_lag` fallback never applied. Two existing unit tests hid it by putting a fully qualified value in the `NAME` column, which made the broken lookup look correct; their fixtures now match what the function really returns.

Two further corrections to the same query, both found after that first fix:

**The function is account-scoped.** The docs are explicit — "this table function returns information on all dynamic tables in the current account" — and the database qualifier only routes which schema's function you invoke, it does not filter the result.

Measured on the test account, invoking it through three different databases:

```
invoked through DB_1:   13 rows across 3 databases
    DB_2  2      DB_3  10      DB_4  1
    rows from DB_1 itself: none
invoked through DB_2:   13 rows — same 3 databases
invoked through DB_4:   13 rows — same 3 databases
```

The row set is byte-identical through all 64 databases on the account. So the mapping, which stamped the caller's `db_name` onto every row, gave a dynamic table in another database with the same `schema.name` this database's key — and whichever row the scan saw last supplied the lineage and the `target_lag` fallback. A database with no dynamic tables of its own still got 13 rows' worth of foreign keys.

The query now filters on `database_name`, and each row is keyed by its own `DATABASE_NAME` rather than the database that was asked about. Measured effect of the filter: `13 rows across 3 databases` → `2 rows across 1 database`. Either change alone fixes the collision; together the query also stops shipping the whole account across the wire. Reported by Bugbot and by @kyungsoo-datahub on the pushed branch.

**`valid_to IS NULL` — kept as a documented-behaviour guard, not a reproduced fix.** `DATABASE_NAME` and `QUALIFIED_NAME` are both in the output, alongside `VALID_FROM`/`VALID_TO`. The docs describe `VALID_TO` as bounding the window in which a description was accurate, and say the function "provides only descriptions with a `VALID_TO` value within 7 days of the current time" — so a superseded row sharing a key with the current one is the collision this filter guards against.

I tried to produce such a row on a scratch dynamic table and could not:

```
CREATE DYNAMIC TABLE ... TARGET_LAG = '60 minutes'   -> 1 row, current, lag=3600s
ALTER ... SET TARGET_LAG = '120 minutes'             -> 1 row, current, lag=7200s
                                                        (replaced in place, new VALID_FROM;
                                                         no second entry, VALID_TO still null)
45s later                                            -> 1 row, unchanged
DROP DYNAMIC TABLE ...                               -> 0 rows (vanishes; does not linger
                                                        with VALID_TO set)
```

So on this account the predicate is a no-op: the function behaved as a current-state view under both `ALTER` and `DROP`. It is kept because it is cheap and the documented contract allows superseded rows that a different edition or version may well return — not because it fixes a collision I could reproduce.

For the record, an earlier revision of this description justified the filter as "13 rows for one existing dynamic table, the rest versions of dropped ones". That was wrong on both counts: there are 13 rows, but they are 13 *different, current* dynamic tables in three *other* databases — which is the account-scope problem above, not a history problem.

## Verified against a live Snowflake account

Paging a real user schema at several page sizes, checked against `information_schema.views` as independent ground truth:

| page size | pages | result |
| --- | --- | --- |
| 1 | 6 | exact — no gaps, no duplicates |
| 2 | 3 | exact |
| 3 | 2 | exact |
| 1000 | 1 | exact |

- The non-terminating cursor mode **reproduced** on `INFORMATION_SCHEMA`; the guard stopped it after two queries.
- The escaped cursor `zzz_it's_a\_name` was **accepted by Snowflake** on both `SHOW VIEWS` and `SHOW DYNAMIC TABLES`.
- Dynamic tables: created a scratch base table plus two dynamic tables, confirmed definition, `target_lag`, multi-page paging and — after the key fix — upstream lineage, then dropped them.
- `DYNAMIC_TABLE_GRAPH_HISTORY`'s account scope **measured directly**: 13 rows spanning three databases, byte-identical through all 64 databases on the account, including none of its own when invoked through a database that holds no dynamic tables. Adding the `database_name` predicate narrowed it to 2 rows in 1 database.
- Superseded graph-history rows **could not be reproduced** on a scratch dynamic table via `ALTER ... SET TARGET_LAG` or `DROP`; see the `valid_to` note above for why the predicate stays anyway. Scratch schema dropped afterwards. Because that predicate rests on a documented contract rather than a reproduction, `num_dynamic_tables_missing_graph_info` now counts dynamic tables whose graph row did not resolve — so if the assumption is ever wrong, the lineage loss shows up as a number instead of as silence.
- Earlier measurement on a 16,277-view schema: two pages, nothing missing, nothing duplicated.

## `fetch_views_from_information_schema`

This flag was documented as the workaround for this exact bug. That rationale is obsolete, and following it costs materialized views: `information_schema.views` does not list them and the default `table_types` does not cover them, so they are dropped from both paths. The description now states what the flag is still genuinely for (`view_pattern` pushdown, accurate `last_altered`) and its real trade-offs. Behaviour and default (`false`) unchanged.

## Testing

`tests/unit/snowflake/test_snowflake_show_pagination.py` drives a fake that implements Snowflake's documented `SHOW` semantics — ordered by (schema, name), cursor keyed on name alone, and parsers that reject an unescaped quote exactly as Snowflake would, in a string literal *and* in a quoted identifier. Coverage spans all three object kinds: the skip case, the duplicate case, per-schema paging over 12,000 objects, the non-advancing cursor, the escaped marker, an escaped schema name, failure fallback, the fan-out narrowing, and the partial-page report.

The identifier parser matters as a test, not just as fidelity: before it, an unescaped identifier failed the fake's regex and was answered with an empty result set, which is indistinguishable from an empty schema — so the fake silently recovered from exactly the bug it was meant to catch. The incompleteness paths likewise assert the report *severity*, not merely that something was reported, since severity is what stale-entity removal keys on.

The dynamic-table fixes are covered too: a regression test lists the foreign database's row *after* the correct one on purpose, since with the caller's database stamped on both they collide and the last one wins — written the other way round it passes against the broken code. Both graph-history filters are asserted directly.

Every fix in this PR was confirmed by reverting it individually and checking that a named test fails — including four rounds of review findings. Reverting the identifier escaping fails the escaped-schema-name test; reverting the severity change fails three tests, one per incompleteness path plus the kept-count assertion; reverting either the permission carve-out or the mapping move fails exactly its own test and nothing else; restoring the old streams handler fails the streams half of the permission-classifier test and leaves the views half green. The fake also enforces a query budget, so a regression in the termination guard fails in about a second instead of timing out CI.

752 Snowflake unit tests and 39/39 integration tests pass (the integration suite requires `TZ=UTC`; one golden asserts local-timezone timestamps, which is pre-existing on `master`). Cross-repo connector-tests goldens pass.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added
- [ ] Docs added/updated — config description updated in place; no separate doc changes needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Snowflake ingestion no longer paginates `SHOW … IN DATABASE` for views, streams, or dynamic tables.** Database-wide results sort by (schema, name) but the `FROM '<name>'` cursor filters on name only, which dropped objects in later schemas, duplicated others, or looped forever on some `INFORMATION_SCHEMA` views. The connector now runs one unpaginated database-wide `SHOW` when under the 10k cap, otherwise falls back to **per-schema** `SHOW` with reliable name-based paging, shared via `SnowflakeShowKind` and `show_objects_for_*` builders.
> 
> **Operational safety:** Pagination markers and schema/database identifiers are escaped; `SnowflakePermissionError` propagates instead of per-schema retries or empty lists that could trigger stale-entity soft-deletes; incomplete per-schema listings are **`failure`** (not warnings). Streams permission handling is aligned with views.
> 
> **Dynamic tables:** `DYNAMIC_TABLE_GRAPH_HISTORY` rows are keyed by fully qualified `database.schema.name`, filtered by `database_name` and `valid_to IS NULL`; missing graph matches increment `num_dynamic_tables_missing_graph_info`. Config text for `fetch_views_from_information_schema` is updated (large-view workaround no longer applies).
> 
> **Tests:** New `test_snowflake_show_pagination.py` plus fixture updates for graph history column shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae7996c6039be67971107292727fc102f9e85f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->