### PR TITLE
feat(auth): add Micrometer login metrics and session failure usage events

### DIFF
--- a/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
+++ b/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
@@ -32,6 +32,7 @@ import com.linkedin.metadata.auth.LoginIdentityMask;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventType;
 import com.linkedin.metadata.datahubusage.event.LoginSource;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.settings.global.GlobalSettingsInfo;
 import com.linkedin.settings.global.OidcSettings;
 import com.linkedin.settings.global.SsoSettings;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -104,6 +106,11 @@ public class AuthServiceController {
   private static final String REQUIRED_GROUPS = "requiredGroups";
   private static final String ACCESS_DENIED_MESSAGE = "accessDeniedMessage";
   private static final String ACCESS_DENIED_REDIRECT_URL = "accessDeniedRedirectUrl";
+
+  private static final String LOGIN_OUTCOME_SUCCESS = "success";
+  private static final String LOGIN_OUTCOME_FAILURE = "failure";
+  private static final String LOGIN_DENIAL_REASON_NONE = "none";
+  private static final String LOGIN_SOURCE_UNKNOWN = "unknown";
 
   @Autowired private StatelessTokenService _statelessTokenService;
 
@@ -200,17 +207,26 @@ public class AuthServiceController {
                   _configProvider.getAuthentication().isVerboseAuthFailureLogging();
               final boolean enforceExistence =
                   _configProvider.getAuthentication().isEnforceExistenceEnabled();
+              final String loginSource =
+                  resolveLoginSource(httpEntity.getHeaders(), LOGIN_SOURCE_UNKNOWN);
               final Optional<LoginDenialReason> eligibilityDenial =
                   _userSessionEligibilityChecker.checkEligibility(
                       opContext, userId.asText(), enforceExistence);
               if (eligibilityDenial.isPresent()) {
+                final LoginDenialReason denialReason = eligibilityDenial.get();
+                recordFailedLoginUsageEvent(
+                    httpEntity,
+                    new CorpuserUrn(userId.asText()).toString(),
+                    denialReason,
+                    "failedLoginSessionEligibility",
+                    loginSource);
                 emitLoginDenialLog(
                     verboseAuthFailureLogging,
                     userId.asText(),
-                    eligibilityDenial.get(),
+                    denialReason,
                     "generateSessionTokenForUser");
                 return new ResponseEntity<>(
-                    buildLoginDenialJsonBody(eligibilityDenial.get()), HttpStatus.FORBIDDEN);
+                    buildLoginDenialJsonBody(denialReason), HttpStatus.FORBIDDEN);
               }
 
               // 2. Generate a new DataHub JWT
@@ -233,16 +249,16 @@ public class AuthServiceController {
                         USER_ID_ATTR, new CorpuserUrn(userId.asText()).toString());
                     loginEventAttributes.put(
                         EVENT_TYPE_ATTR, DataHubUsageEventType.LOG_IN_EVENT.getType());
-                    List<String> loginSource =
-                        httpEntity.getHeaders().getOrEmpty(DATAHUB_LOGIN_SOURCE_HEADER_NAME);
-                    if (!loginSource.isEmpty()) {
-                      loginEventAttributes.put(LOGIN_SOURCE_ATTR, loginSource.get(0));
+                    if (!LOGIN_SOURCE_UNKNOWN.equals(loginSource)) {
+                      loginEventAttributes.put(LOGIN_SOURCE_ATTR, loginSource);
                     }
                     List<String> sourceIP = httpEntity.getHeaders().getOrEmpty(X_FORWARDED_FOR);
                     if (!sourceIP.isEmpty()) {
                       loginEventAttributes.put(SOURCE_IP, sourceIP.get(0));
                     }
                     Span.current().addEvent(LOGIN_EVENT, loginEventAttributes.build());
+                    incrementLoginMetric(
+                        LOGIN_OUTCOME_SUCCESS, loginSource, LOGIN_DENIAL_REASON_NONE);
                     return new ResponseEntity<>(buildTokenResponse(token), HttpStatus.OK);
                   });
             } catch (Exception e) {
@@ -512,20 +528,27 @@ public class AuthServiceController {
               }
             }
 
+            final String loginSource =
+                resolveLoginSource(httpEntity.getHeaders(), LoginSource.PASSWORD_LOGIN.getSource());
             if (!doesPasswordMatch) {
-              recordFailedNativeLoginUsageEvent(
+              recordFailedLoginUsageEvent(
                   httpEntity,
                   userUrnString,
                   LoginDenialReason.INVALID_CREDENTIALS,
-                  "failedPasswordLogin");
+                  "failedPasswordLogin",
+                  loginSource);
               emitLoginDenialLog(
                   verboseAuthFailureLogging,
                   userUrnString,
                   LoginDenialReason.INVALID_CREDENTIALS,
                   "verifyNativeUserCredentials");
             } else if (sessionDenial != null) {
-              recordFailedNativeLoginUsageEvent(
-                  httpEntity, userUrnString, sessionDenial, "failedLoginSessionEligibility");
+              recordFailedLoginUsageEvent(
+                  httpEntity,
+                  userUrnString,
+                  sessionDenial,
+                  "failedLoginSessionEligibility",
+                  loginSource);
               emitLoginDenialLog(
                   verboseAuthFailureLogging,
                   userUrnString,
@@ -706,11 +729,46 @@ public class AuthServiceController {
     return json.toString();
   }
 
-  private void recordFailedNativeLoginUsageEvent(
+  @Nonnull
+  private String resolveLoginSource(
+      @Nonnull final HttpHeaders headers, @Nonnull final String defaultSource) {
+    final List<String> loginSourceHeader = headers.getOrEmpty(DATAHUB_LOGIN_SOURCE_HEADER_NAME);
+    if (loginSourceHeader.isEmpty()) {
+      return defaultSource;
+    }
+    // Allow-list against LoginSource to keep Micrometer tag cardinality bounded.
+    final LoginSource knownSource = LoginSource.getSource(loginSourceHeader.get(0));
+    if (knownSource != null) {
+      return knownSource.getSource();
+    }
+    return LOGIN_SOURCE_UNKNOWN;
+  }
+
+  private void incrementLoginMetric(
+      @Nonnull final String outcome,
+      @Nonnull final String loginSource,
+      @Nonnull final String denialReason) {
+    systemOperationContext
+        .getMetricUtils()
+        .ifPresent(
+            metrics ->
+                metrics.incrementMicrometer(
+                    MetricUtils.DATAHUB_LOGIN,
+                    1,
+                    "outcome",
+                    outcome,
+                    "login_source",
+                    loginSource,
+                    "denial_reason",
+                    denialReason));
+  }
+
+  private void recordFailedLoginUsageEvent(
       final HttpEntity<String> httpEntity,
       final String userUrnString,
       final LoginDenialReason denialReason,
-      final String spanName) {
+      final String spanName,
+      @Nonnull final String loginSource) {
     // Uses systemOperationContext for span telemetry only; no entity reads/writes are performed
     // here.
     systemOperationContext.withSpan(
@@ -720,7 +778,7 @@ public class AuthServiceController {
           loginEventAttributes.put(USER_ID_ATTR, UrnUtils.getUrn(userUrnString).toString());
           loginEventAttributes.put(
               EVENT_TYPE_ATTR, DataHubUsageEventType.FAILED_LOGIN_EVENT.getType());
-          loginEventAttributes.put(LOGIN_SOURCE_ATTR, LoginSource.PASSWORD_LOGIN.getSource());
+          loginEventAttributes.put(LOGIN_SOURCE_ATTR, loginSource);
           loginEventAttributes.put(LOGIN_DENIAL_REASON_ATTR, denialReason.name());
           List<String> sourceIP = httpEntity.getHeaders().getOrEmpty(X_FORWARDED_FOR);
           if (!sourceIP.isEmpty()) {
@@ -728,6 +786,7 @@ public class AuthServiceController {
           }
           Span.current().addEvent(LOGIN_EVENT, loginEventAttributes.build());
         });
+    incrementLoginMetric(LOGIN_OUTCOME_FAILURE, loginSource, denialReason.name());
   }
 
   private void emitLoginDenialLog(

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
@@ -1,8 +1,10 @@
 package com.datahub.auth.authentication;
 
 import static com.datahub.auth.authentication.AuthServiceTestConfiguration.SYSTEM_CLIENT_ID;
+import static com.linkedin.metadata.Constants.DATAHUB_LOGIN_SOURCE_HEADER_NAME;
 import static com.linkedin.metadata.Constants.GLOBAL_SETTINGS_INFO_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.GLOBAL_SETTINGS_URN;
+import static com.linkedin.metadata.utils.metrics.MetricUtils.DATAHUB_LOGIN;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,7 +31,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.datahubusage.event.LoginSource;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.settings.global.GlobalSettingsInfo;
 import com.linkedin.settings.global.OidcSettings;
 import com.linkedin.settings.global.SsoSettings;
@@ -46,6 +50,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
@@ -71,6 +76,7 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   @BeforeMethod
   public void stubSessionEligibility() {
     reset(mockUserSessionEligibilityChecker);
+    reset(mockMetricUtils);
     when(mockUserSessionEligibilityChecker.checkEligibility(
             any(OperationContext.class), anyString(), anyBoolean()))
         .thenReturn(Optional.empty());
@@ -95,6 +101,7 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   @Autowired private SpanContext mockSpanContext;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private TrackingService mockTrackingService;
+  @Autowired private MetricUtils mockMetricUtils;
 
   @Autowired private UserSessionEligibilityChecker mockUserSessionEligibilityChecker;
 
@@ -201,6 +208,63 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
 
     Actor capturedActor = actorCaptor.getValue();
     assertEquals(userId, capturedActor.getId());
+    verifyLoginMetric("success", "unknown", "none");
+  }
+
+  @Test
+  public void testGenerateSessionTokenForUserSuccessWithLoginSource() throws Exception {
+    String userId = "ssoUser";
+    String generatedToken = "sso-token";
+
+    Authentication systemAuth = mock(Authentication.class);
+    Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
+    when(systemAuth.getActor()).thenReturn(systemActor);
+    AuthenticationContext.setAuthentication(systemAuth);
+
+    when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
+        .thenReturn(generatedToken);
+    when(mockConfigProvider.getAuthentication()).thenReturn(new AuthenticationConfiguration());
+
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", userId);
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(DATAHUB_LOGIN_SOURCE_HEADER_NAME, LoginSource.SSO_LOGIN.getSource());
+    HttpEntity<String> httpEntity =
+        new HttpEntity<>(objectMapper.writeValueAsString(requestBody), headers);
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    verifyLoginMetric("success", LoginSource.SSO_LOGIN.getSource(), "none");
+  }
+
+  @Test
+  public void testGenerateSessionTokenForUserUnknownLoginSourceHeader() throws Exception {
+    String userId = "testUser";
+    String generatedToken = "test-token";
+
+    Authentication systemAuth = mock(Authentication.class);
+    Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
+    when(systemAuth.getActor()).thenReturn(systemActor);
+    AuthenticationContext.setAuthentication(systemAuth);
+
+    when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
+        .thenReturn(generatedToken);
+    when(mockConfigProvider.getAuthentication()).thenReturn(new AuthenticationConfiguration());
+
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", userId);
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(DATAHUB_LOGIN_SOURCE_HEADER_NAME, "not-a-real-source");
+    HttpEntity<String> httpEntity =
+        new HttpEntity<>(objectMapper.writeValueAsString(requestBody), headers);
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    verifyLoginMetric("success", "unknown", "none");
   }
 
   @Test(expectedExceptions = CompletionException.class)
@@ -259,7 +323,10 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
 
     ObjectNode requestBody = objectMapper.createObjectNode();
     requestBody.put("userId", userId);
-    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(DATAHUB_LOGIN_SOURCE_HEADER_NAME, LoginSource.SSO_LOGIN.getSource());
+    HttpEntity<String> httpEntity =
+        new HttpEntity<>(objectMapper.writeValueAsString(requestBody), headers);
 
     ResponseEntity<String> response =
         authServiceController.generateSessionTokenForUser(request, httpEntity).join();
@@ -270,6 +337,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
         LoginDenialReason.SOFT_DELETED.name(), responseJson.get("loginDenialReason").asText());
     verify(mockTokenService, never())
         .generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong());
+    verifyLoginMetric(
+        "failure", LoginSource.SSO_LOGIN.getSource(), LoginDenialReason.SOFT_DELETED.name());
   }
 
   @Test
@@ -300,6 +369,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     assertTrue(responseJson.get("doesPasswordMatch").asBoolean());
     assertEquals(
         LoginDenialReason.SUSPENDED.name(), responseJson.get("loginDenialReason").asText());
+    verifyLoginMetric(
+        "failure", LoginSource.PASSWORD_LOGIN.getSource(), LoginDenialReason.SUSPENDED.name());
   }
 
   @Test
@@ -589,6 +660,10 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     assertEquals(
         LoginDenialReason.INVALID_CREDENTIALS.name(),
         responseJson.get("loginDenialReason").asText());
+    verifyLoginMetric(
+        "failure",
+        LoginSource.PASSWORD_LOGIN.getSource(),
+        LoginDenialReason.INVALID_CREDENTIALS.name());
   }
 
   @Test
@@ -796,6 +871,19 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     ResponseEntity<String> response = authServiceController.getSsoSettings(request, null).join();
 
     assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+  }
+
+  private void verifyLoginMetric(String outcome, String loginSource, String denialReason) {
+    verify(mockMetricUtils)
+        .incrementMicrometer(
+            eq(DATAHUB_LOGIN),
+            eq(1.0),
+            eq("outcome"),
+            eq(outcome),
+            eq("login_source"),
+            eq(loginSource),
+            eq("denial_reason"),
+            eq(denialReason));
   }
 
   /*

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceTestConfiguration.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceTestConfiguration.java
@@ -12,6 +12,7 @@ import com.datahub.telemetry.TrackingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.SystemTelemetryContext;
@@ -101,10 +102,17 @@ public class AuthServiceTestConfiguration {
     return OpenTelemetry.noop().getTracer("auth-servlet-impl-test");
   }
 
+  @Bean
+  @Primary
+  public MetricUtils metricUtils() {
+    return Mockito.mock(MetricUtils.class);
+  }
+
   @Bean(name = "systemOperationContext")
-  public OperationContext systemOperationContext(ObjectMapper objectMapper, Tracer noopTestTracer) {
+  public OperationContext systemOperationContext(
+      ObjectMapper objectMapper, Tracer noopTestTracer, MetricUtils metricUtils) {
     SystemTelemetryContext mockSystemTelemetryContext =
-        SystemTelemetryContext.builder().tracer(noopTestTracer).build();
+        SystemTelemetryContext.builder().tracer(noopTestTracer).metricUtils(metricUtils).build();
     return TestOperationContexts.systemContextTraceNoSearchAuthorization(
         () -> ObjectMapperContext.builder().objectMapper(objectMapper).build(),
         () -> mockSystemTelemetryContext);

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
@@ -37,6 +37,9 @@ public class MetricUtils {
   public static final String DATAHUB_REQUEST_HOOK_QUEUE_TIME = "datahub.request.hook.queue.time";
   public static final String DATAHUB_REQUEST_COUNT = "datahub_request_count";
 
+  /** Human login attempts (success/failure). Tags: outcome, login_source, denial_reason. */
+  public static final String DATAHUB_LOGIN = "datahub.login";
+
   public static final String MESSAGING_SYSTEM_KAFKA = "kafka";
   public static final String MESSAGING_SYSTEM_PGQUEUE = "pgqueue";
   public static final String MESSAGING_TOPIC = "topic";


### PR DESCRIPTION
## Summary
- Emit `FailedLogInEvent` usage/OTEL events for session-token eligibility denials so SSO failures are tracked like native password failures.
- Add Micrometer `datahub.login` counters (`outcome`, `login_source`, `denial_reason`) on login success and failure paths in GMS for PFP-3127 alerting readiness.
- Refactor shared `recordFailedLoginUsageEvent` helper and extend `AuthServiceControllerTest` coverage.

Linear: https://linear.app/acryl-data/issue/PFP-3127/create-login-metrics

## Test plan
- [x] `./gradlew :metadata-service:auth-servlet-impl:spotlessCheck :metadata-utils:spotlessCheck`
- [x] `./gradlew :metadata-service:auth-servlet-impl:test --tests com.datahub.auth.authentication.AuthServiceControllerTest`
- [ ] Optional: scrape Prometheus for `datahub_login_total{outcome=...}` after password fail and soft-deleted SSO/session deny

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Micrometer `datahub.login` counters and emits failed login usage events for session-token eligibility denials, bringing SSO parity with native password failures and enabling PFP-3127 alerting.

- Adds `MetricUtils.DATAHUB_LOGIN` and increments it on success (session token issued) and failure in `AuthServiceController` with tags: `outcome` (success|failure), `login_source` (from `DATAHUB_LOGIN_SOURCE` header; defaults to `password_login` for native and `unknown` for session or unrecognized values; allow-listed to `LoginSource`), and `denial_reason` (enum or `none` on success).
- Emits `FAILED_LOGIN_EVENT` for session-token eligibility denials via a new shared `recordFailedLoginUsageEvent` helper (replacing the native-only variant).
- Extends tests to assert metric increments and event emission; no behavior change to auth flows. Optional: callers can set `DATAHUB_LOGIN_SOURCE` to improve `login_source` attribution.

<sup>Written for commit d26f418478b9ba53de8dd82c634a7953c424fb40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`datahub.login`** Micrometer counters on GMS auth login success and failure paths, tagged with **`outcome`**, **`login_source`**, and **`denial_reason`**, via new **`MetricUtils.DATAHUB_LOGIN`** and **`incrementLoginMetric`**.
> 
> **`resolveLoginSource`** normalizes the `DATAHUB_LOGIN_SOURCE` header against the **`LoginSource`** enum (unknown values map to **`unknown`**) to keep tag cardinality bounded. Session-token generation defaults to **`unknown`** when the header is missing; native password verify defaults to **`password_login`**.
> 
> Renames **`recordFailedNativeLoginUsageEvent`** to **`recordFailedLoginUsageEvent`**, passes the resolved login source into OTEL **`FAILED_LOGIN_EVENT`** attributes, and increments the failure metric. **Session-token eligibility denials** now emit the same failed-login usage events and metrics as password failures (previously only native password paths did).
> 
> Tests wire a mock **`MetricUtils`** into **`systemOperationContext`** and assert metric tags for SSO headers, unknown sources, eligibility denials, and bad passwords.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26f418478b9ba53de8dd82c634a7953c424fb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->