### PR TITLE
fix(plugins): fix stale plugin loading

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupUpgradeConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupUpgradeConfig.java
@@ -48,8 +48,6 @@ import org.springframework.context.annotation.Import;
 @ComponentScan(
     basePackages = {
       "com.linkedin.datahub.upgrade.sqlsetup.config",
-      "com.linkedin.gms.factory.entityregistry",
-      "com.linkedin.gms.factory.plugins",
       "com.linkedin.gms.factory.system_telemetry"
     },
     excludeFilters =

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfig.java
@@ -7,7 +7,6 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.postgres.DatabaseType;
 import com.linkedin.metadata.config.postgres.JdbcUrlParser;
 import com.linkedin.metadata.config.postgres.PostgresSqlSetupProperties;
-import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.EnvironmentUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
@@ -66,10 +65,10 @@ public class SqlSetupConfig {
 
   @Bean(name = "systemOperationContext")
   @ConditionalOnMissingBean
-  public OperationContext operationContext(EntityRegistry entityRegistry) {
+  public OperationContext operationContext() {
     // Create a minimal OperationContext for SqlSetup that essentially does nothing
     // This avoids the need for complex dependencies like entity services, search, etc.
-    return TestOperationContexts.systemContextNoSearchAuthorization(entityRegistry);
+    return TestOperationContexts.systemContextNoSearchAuthorization();
   }
 
   @Bean(name = "sqlSetupArgs")

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
@@ -83,7 +83,7 @@ public class UpgradeCliApplicationTestConfiguration {
   @Primary
   @Bean
   public EntityRegistry entityRegistry() {
-    return TestOperationContexts.defaultEntityRegistry();
+    return TestOperationContexts.constructNewEntityRegistry();
   }
 
   @Primary

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfigTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfigTest.java
@@ -11,7 +11,6 @@ import com.linkedin.datahub.upgrade.sqlsetup.SqlSetupArgs;
 import com.linkedin.metadata.config.postgres.DatabaseType;
 import com.linkedin.metadata.config.postgres.PgQueueSetupOptions;
 import com.linkedin.metadata.config.postgres.PostgresSqlSetupProperties;
-import com.linkedin.metadata.models.registry.EntityRegistry;
 import io.datahubproject.metadata.context.OperationContext;
 import io.ebean.Database;
 import java.lang.reflect.Field;
@@ -27,7 +26,6 @@ public class SqlSetupConfigTest {
   private static final String BANDS_JSON =
       "[{\"range\":[0,3],\"weight\":70},{\"range\":[4,6],\"weight\":20},{\"range\":[7,9],\"weight\":10}]";
 
-  @Mock private EntityRegistry mockEntityRegistry;
   @Mock private Database mockDatabase;
 
   private SqlSetupConfig sqlSetupConfig;
@@ -62,7 +60,7 @@ public class SqlSetupConfigTest {
 
   @Test
   public void testOperationContext() {
-    OperationContext operationContext = sqlSetupConfig.operationContext(mockEntityRegistry);
+    OperationContext operationContext = sqlSetupConfig.operationContext();
 
     assertNotNull(operationContext);
     assertTrue(operationContext instanceof OperationContext);

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
@@ -575,11 +575,12 @@ public class PluginFactory {
 
   /**
    * Appends late-discovered plugins to the existing plugin lists. Plugins already present (by
-   * identity) are skipped. The same {@link #applyDisable} filtering is applied to the new plugins
-   * before they are appended.
+   * equality — same class and config) are skipped. The full combined list is run through {@link
+   * #applyDisable} so the disable contract is consistent with the constructor path.
    *
    * <p>Intended for post-initialization reconciliation (e.g. Spring beans that were unavailable
-   * during entity registry construction due to circular dependencies).
+   * during entity registry construction due to circular dependencies). Called once during startup
+   * by {@code SmartInitializingSingleton} before any request processing begins.
    */
   public void appendPlugins(
       @Nonnull List<AspectPayloadValidator> newValidators,
@@ -599,7 +600,7 @@ public class PluginFactory {
   private static <T extends PluginSpec> List<T> appendNew(
       @Nonnull List<T> existing, @Nonnull List<T> candidates) {
     List<T> fresh =
-        applyDisable(candidates).stream()
+        candidates.stream()
             .filter(candidate -> !existing.contains(candidate))
             .collect(Collectors.toList());
     if (fresh.isEmpty()) {
@@ -607,7 +608,7 @@ public class PluginFactory {
     }
     List<T> combined = new ArrayList<>(existing);
     combined.addAll(fresh);
-    return combined;
+    return applyDisable(combined);
   }
 
   @Nonnull

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
@@ -9,6 +9,8 @@ import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
 import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
 import com.linkedin.metadata.models.registry.config.EntityRegistryLoadResult;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -570,6 +572,43 @@ public class PluginFactory {
             .collect(Collectors.toList());
 
     return initPlugins(classLoaders, baseClazz, packageNames, nonSpringConfigs);
+  }
+
+  /**
+   * Appends late-discovered plugins to the existing plugin lists. Plugins already present (by
+   * identity) are skipped. The same {@link #applyDisable} filtering is applied to the new plugins
+   * before they are appended.
+   *
+   * <p>Intended for post-initialization reconciliation (e.g. Spring beans that were unavailable
+   * during entity registry construction due to circular dependencies).
+   */
+  public void appendPlugins(
+      @Nonnull List<AspectPayloadValidator> newValidators,
+      @Nonnull List<MutationHook> newMutationHooks,
+      @Nonnull List<MCLSideEffect> newMclSideEffects,
+      @Nonnull List<MCPSideEffect> newMcpSideEffects,
+      @Nonnull List<MCPObserver> newMcpObservers) {
+
+    this.aspectPayloadValidators = appendNew(this.aspectPayloadValidators, newValidators);
+    List<MutationHook> appendedHooks = appendNew(this.mutationHooks, newMutationHooks);
+    this.mutationHooks = sortByPriority(appendedHooks);
+    this.mclSideEffects = appendNew(this.mclSideEffects, newMclSideEffects);
+    this.mcpSideEffects = appendNew(this.mcpSideEffects, newMcpSideEffects);
+    this.mcpObservers = appendNew(this.mcpObservers, newMcpObservers);
+  }
+
+  private static <T extends PluginSpec> List<T> appendNew(
+      @Nonnull List<T> existing, @Nonnull List<T> candidates) {
+    List<T> fresh =
+        applyDisable(candidates).stream()
+            .filter(candidate -> !existing.contains(candidate))
+            .collect(Collectors.toList());
+    if (fresh.isEmpty()) {
+      return existing;
+    }
+    List<T> combined = new ArrayList<>(existing);
+    combined.addAll(fresh);
+    return combined;
   }
 
   @Nonnull

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
@@ -10,7 +10,6 @@ import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
 import com.linkedin.metadata.models.registry.config.EntityRegistryLoadResult;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
@@ -71,9 +71,10 @@ public abstract class PluginSpec {
                         || supported.equalsIgnoreCase(String.valueOf(changeType)));
   }
 
-  // Explicit equals and hash code using abstract fields due to lombok EqualsAndHashCode returning equal for 
+  // Explicit equals and hash code using abstract fields due to lombok EqualsAndHashCode returning
+  // equal for
   // invalid cases
-  
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
@@ -4,13 +4,12 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.models.EntitySpec;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 
 @AllArgsConstructor
-@EqualsAndHashCode
 public abstract class PluginSpec {
   protected static String WILDCARD = "*";
 
@@ -70,5 +69,25 @@ public abstract class PluginSpec {
                 supported ->
                     WILDCARD.equals(supported)
                         || supported.equalsIgnoreCase(String.valueOf(changeType)));
+  }
+
+  // Explicit equals and hash code using abstract fields due to lombok EqualsAndHashCode returning equal for 
+  // invalid cases
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PluginSpec that = (PluginSpec) o;
+    return Objects.equals(getConfig(), that.getConfig());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), getConfig());
   }
 }

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/PluginFactoryMergeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/PluginFactoryMergeTest.java
@@ -377,6 +377,28 @@ public class PluginFactoryMergeTest {
     assertEquals(factory.getMclSideEffects().size(), 2);
     assertEquals(factory.getMcpSideEffects().size(), 2);
     assertEquals(factory.getMcpObservers().size(), 2);
+
+    assertEquals(
+        factory.getAspectPayloadValidators().get(0).getConfig().getClassName(),
+        "ValidatorOriginal");
+    assertTrue(factory.getAspectPayloadValidators().get(1) instanceof LateValidator);
+    assertEquals(
+        factory.getAspectPayloadValidators().get(1).getConfig().getClassName(), "NewPlugin");
+
+    assertEquals(factory.getMutationHooks().get(0).getConfig().getClassName(), "ValidatorOriginal");
+    assertTrue(factory.getMutationHooks().get(1) instanceof LateMutationHook);
+
+    assertEquals(
+        factory.getMclSideEffects().get(0).getConfig().getClassName(), "ValidatorOriginal");
+    assertTrue(factory.getMclSideEffects().get(1) instanceof LateMCLSideEffect);
+
+    assertEquals(
+        factory.getMcpSideEffects().get(0).getConfig().getClassName(), "ValidatorOriginal");
+    assertTrue(factory.getMcpSideEffects().get(1) instanceof LateMCPSideEffect);
+
+    assertEquals(factory.getMcpObservers().get(0).getConfig().getClassName(), "ValidatorOriginal");
+    assertTrue(factory.getMcpObservers().get(1) instanceof LateMCPObserver);
+    assertEquals(factory.getMcpObservers().get(1).getConfig().getClassName(), "NewPlugin");
   }
 
   @Test
@@ -403,6 +425,20 @@ public class PluginFactoryMergeTest {
         Collections.emptyList(),
         Collections.emptyList(),
         List.of(observer));
+
+    assertEquals(factory.getMcpObservers().size(), 1);
+
+    // Distinct instance with the same config exercises the config-equality branch
+    // of PluginSpec.equals rather than the this==o short-circuit
+    MockMCPObserver duplicate = new MockMCPObserver();
+    duplicate.setConfig(config);
+
+    factory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of(duplicate));
 
     assertEquals(factory.getMcpObservers().size(), 1);
   }

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/PluginFactoryMergeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/plugins/PluginFactoryMergeTest.java
@@ -355,6 +355,122 @@ public class PluginFactoryMergeTest {
         List.of((MCPObserver) new MockMCPObserver().setConfig(config)));
   }
 
+  // --- appendPlugins tests ---
+
+  @Test
+  public void testAppendPluginsAddsNewPlugins() {
+    PluginFactory factory = createFactoryWithAllPluginTypes("Original");
+
+    assertEquals(factory.getAspectPayloadValidators().size(), 1);
+    assertEquals(factory.getMcpObservers().size(), 1);
+
+    AspectPluginConfig newConfig = createConfig("NewPlugin", true);
+    factory.appendPlugins(
+        List.of((AspectPayloadValidator) new LateValidator().setConfig(newConfig)),
+        List.of((MutationHook) new LateMutationHook().setConfig(newConfig)),
+        List.of((MCLSideEffect) new LateMCLSideEffect().setConfig(newConfig)),
+        List.of((MCPSideEffect) new LateMCPSideEffect().setConfig(newConfig)),
+        List.of((MCPObserver) new LateMCPObserver().setConfig(newConfig)));
+
+    assertEquals(factory.getAspectPayloadValidators().size(), 2);
+    assertEquals(factory.getMutationHooks().size(), 2);
+    assertEquals(factory.getMclSideEffects().size(), 2);
+    assertEquals(factory.getMcpSideEffects().size(), 2);
+    assertEquals(factory.getMcpObservers().size(), 2);
+  }
+
+  @Test
+  public void testAppendPluginsDeduplicatesSameInstance() {
+    AspectPluginConfig config = createConfig("Observer", true);
+    MockMCPObserver observer = new MockMCPObserver();
+    observer.setConfig(config);
+
+    PluginFactory factory =
+        new PluginFactory(
+            PluginConfiguration.EMPTY,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            List.of(observer));
+
+    assertEquals(factory.getMcpObservers().size(), 1);
+
+    factory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of(observer));
+
+    assertEquals(factory.getMcpObservers().size(), 1);
+  }
+
+  @Test
+  public void testAppendPluginsToEmptyFactory() {
+    PluginFactory factory =
+        new PluginFactory(
+            PluginConfiguration.EMPTY,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+    assertTrue(factory.getMcpObservers().isEmpty());
+
+    AspectPluginConfig config = createConfig("LateObserver", true);
+    factory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of((MCPObserver) new MockMCPObserver().setConfig(config)));
+
+    assertEquals(factory.getMcpObservers().size(), 1);
+    assertEquals(factory.getMcpObservers().get(0).getConfig().getClassName(), "LateObserver");
+  }
+
+  @Test
+  public void testAppendPluginsEmptyListIsNoop() {
+    PluginFactory factory = createFactoryWithAllPluginTypes("Existing");
+    int originalSize = factory.getMcpObservers().size();
+
+    factory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+
+    assertEquals(factory.getMcpObservers().size(), originalSize);
+  }
+
+  @Test
+  public void testAppendPluginsFiltersDisabledPlugins() {
+    PluginFactory factory =
+        new PluginFactory(
+            PluginConfiguration.EMPTY,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList());
+
+    AspectPluginConfig disabledConfig = createConfig("DisabledObserver", false);
+    factory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of((MCPObserver) new MockMCPObserver().setConfig(disabledConfig)));
+
+    assertTrue(factory.getMcpObservers().isEmpty());
+  }
+
   // Mock plugin implementations for testing
 
   private static class MockAspectPayloadValidator extends AspectPayloadValidator {
@@ -475,4 +591,18 @@ public class PluginFactoryMergeTest {
       // no-op for testing
     }
   }
+
+  // Distinct "late" plugin classes for appendPlugins tests. PluginSpec uses @EqualsAndHashCode
+  // which compares by class, so distinct classes are needed to represent different plugin beans
+  // (mirroring production where e.g. IngestionBillingEmitter != IngestionMetricsEmitter).
+
+  private static class LateValidator extends MockAspectPayloadValidator {}
+
+  private static class LateMutationHook extends MockMutationHook {}
+
+  private static class LateMCLSideEffect extends MockMCLSideEffect {}
+
+  private static class LateMCPSideEffect extends MockMCPSideEffect {}
+
+  private static class LateMCPObserver extends MockMCPObserver {}
 }

--- a/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
@@ -40,7 +40,7 @@ public class MaeConsumerApplicationTestConfiguration {
   @Bean
   @Primary
   public EntityRegistry entityRegistry() {
-    return TestOperationContexts.defaultEntityRegistry();
+    return TestOperationContexts.constructNewEntityRegistry();
   }
 
   @MockitoBean private RestrictedService restrictedService;

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
@@ -59,7 +59,7 @@ public class MCLSpringCommonTestConfiguration {
   @Bean
   @Primary
   public EntityRegistry entityRegistry() {
-    return TestOperationContexts.defaultEntityRegistry();
+    return TestOperationContexts.constructNewEntityRegistry();
   }
 
   @Bean

--- a/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
@@ -80,7 +80,7 @@ public class MceConsumerApplicationTestConfiguration {
   @Bean
   @Primary
   public EntityRegistry entityRegistry() {
-    return TestOperationContexts.defaultEntityRegistry();
+    return TestOperationContexts.constructNewEntityRegistry();
   }
 
   // Use @Bean (no @Primary) to prevent ConfigEntityRegistryFactory from loading

--- a/metadata-operation-context/src/main/java/io/datahubproject/test/metadata/context/TestOperationContexts.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/test/metadata/context/TestOperationContexts.java
@@ -65,21 +65,29 @@ public class TestOperationContexts {
 
   public static EntityRegistry defaultEntityRegistry() {
     if (defaultEntityRegistryInstance == null) {
-      PathSpecBasedSchemaAnnotationVisitor.class
-          .getClassLoader()
-          .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
-      try {
-        SnapshotEntityRegistry snapshotEntityRegistry = new SnapshotEntityRegistry();
-        ConfigEntityRegistry configEntityRegistry =
-            new ConfigEntityRegistry(
-                Snapshot.class.getClassLoader().getResourceAsStream("entity-registry.yml"));
-        defaultEntityRegistryInstance =
-            new MergedEntityRegistry(snapshotEntityRegistry).apply(configEntityRegistry);
-      } catch (EntityRegistryException e) {
-        throw new RuntimeException(e);
-      }
+      defaultEntityRegistryInstance = constructNewEntityRegistry();
     }
     return defaultEntityRegistryInstance;
+  }
+
+  // Created to not share Spring managed entity registries with static instance, this results in
+  // unexpected
+  // modifications to the static instance so instead we use this for Spring config
+  public static EntityRegistry constructNewEntityRegistry() {
+    EntityRegistry entityRegistry;
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+    try {
+      SnapshotEntityRegistry snapshotEntityRegistry = new SnapshotEntityRegistry();
+      ConfigEntityRegistry configEntityRegistry =
+          new ConfigEntityRegistry(
+              Snapshot.class.getClassLoader().getResourceAsStream("entity-registry.yml"));
+      entityRegistry = new MergedEntityRegistry(snapshotEntityRegistry).apply(configEntityRegistry);
+    } catch (EntityRegistryException e) {
+      throw new RuntimeException(e);
+    }
+    return entityRegistry;
   }
 
   public static RetrieverContext emptyActiveUsersRetrieverContext(

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -76,23 +77,31 @@ public class EntityRegistryFactory {
 
       List<AspectPayloadValidator> newValidators =
           findMissing(
-              applicationContext.getBeansOfType(AspectPayloadValidator.class).values(),
+              BeanFactoryUtils.beansOfTypeIncludingAncestors(
+                      applicationContext, AspectPayloadValidator.class)
+                  .values(),
               pluginFactory.getAspectPayloadValidators());
       List<MutationHook> newHooks =
           findMissing(
-              applicationContext.getBeansOfType(MutationHook.class).values(),
+              BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, MutationHook.class)
+                  .values(),
               pluginFactory.getMutationHooks());
       List<MCLSideEffect> newMclEffects =
           findMissing(
-              applicationContext.getBeansOfType(MCLSideEffect.class).values(),
+              BeanFactoryUtils.beansOfTypeIncludingAncestors(
+                      applicationContext, MCLSideEffect.class)
+                  .values(),
               pluginFactory.getMclSideEffects());
       List<MCPSideEffect> newMcpEffects =
           findMissing(
-              applicationContext.getBeansOfType(MCPSideEffect.class).values(),
+              BeanFactoryUtils.beansOfTypeIncludingAncestors(
+                      applicationContext, MCPSideEffect.class)
+                  .values(),
               pluginFactory.getMcpSideEffects());
       List<MCPObserver> newObservers =
           findMissing(
-              applicationContext.getBeansOfType(MCPObserver.class).values(),
+              BeanFactoryUtils.beansOfTypeIncludingAncestors(applicationContext, MCPObserver.class)
+                  .values(),
               pluginFactory.getMcpObservers());
 
       int total =

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
@@ -15,7 +15,6 @@ import com.linkedin.metadata.models.registry.EntityRegistryException;
 import com.linkedin.metadata.models.registry.MergedEntityRegistry;
 import com.linkedin.metadata.models.registry.PluginEntityRegistryLoader;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -66,8 +65,8 @@ public class EntityRegistryFactory {
 
   /**
    * Runs after all singleton beans are created. Picks up any plugin beans that were unavailable
-   * during entity registry construction due to circular dependencies (e.g. plugins that transitively
-   * depend on EntityRegistry via systemOperationContext).
+   * during entity registry construction due to circular dependencies (e.g. plugins that
+   * transitively depend on EntityRegistry via systemOperationContext).
    */
   @Bean
   SmartInitializingSingleton entityRegistryPluginRefresh(
@@ -115,10 +114,16 @@ public class EntityRegistryFactory {
           "Entity registry plugin refresh: appended {} plugin(s) — "
               + "validators={}, mutationHooks={}, mclSideEffects={}, mcpSideEffects={}, mcpObservers={}",
           total,
-          newValidators.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newValidators.stream()
+              .map(p -> p.getClass().getSimpleName())
+              .collect(Collectors.toList()),
           newHooks.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
-          newMclEffects.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
-          newMcpEffects.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newMclEffects.stream()
+              .map(p -> p.getClass().getSimpleName())
+              .collect(Collectors.toList()),
+          newMcpEffects.stream()
+              .map(p -> p.getClass().getSimpleName())
+              .collect(Collectors.toList()),
           newObservers.stream()
               .map(p -> p.getClass().getSimpleName())
               .collect(Collectors.toList()));

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/EntityRegistryFactory.java
@@ -4,16 +4,27 @@ import com.datahub.plugins.metadata.aspect.SpringPluginFactory;
 import com.linkedin.gms.factory.plugins.SpringStandardPluginConfiguration;
 import com.linkedin.metadata.aspect.plugins.PluginFactory;
 import com.linkedin.metadata.aspect.plugins.config.PluginConfiguration;
+import com.linkedin.metadata.aspect.plugins.hooks.MCLSideEffect;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPObserver;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistryException;
 import com.linkedin.metadata.models.registry.MergedEntityRegistry;
 import com.linkedin.metadata.models.registry.PluginEntityRegistryLoader;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -22,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
+@Slf4j
 @Configuration
 @Import({ConfigEntityRegistryFactory.class, PluginEntityRegistryFactory.class})
 public class EntityRegistryFactory {
@@ -50,5 +62,73 @@ public class EntityRegistryFactory {
             .apply(configEntityRegistry);
     pluginEntityRegistryLoader.withBaseRegistry(baseEntityRegistry).start(true);
     return baseEntityRegistry;
+  }
+
+  /**
+   * Runs after all singleton beans are created. Picks up any plugin beans that were unavailable
+   * during entity registry construction due to circular dependencies (e.g. plugins that transitively
+   * depend on EntityRegistry via systemOperationContext).
+   */
+  @Bean
+  SmartInitializingSingleton entityRegistryPluginRefresh(
+      @Qualifier("entityRegistry") EntityRegistry entityRegistry) {
+    return () -> {
+      PluginFactory pluginFactory = entityRegistry.getPluginFactory();
+
+      List<AspectPayloadValidator> newValidators =
+          findMissing(
+              applicationContext.getBeansOfType(AspectPayloadValidator.class).values(),
+              pluginFactory.getAspectPayloadValidators());
+      List<MutationHook> newHooks =
+          findMissing(
+              applicationContext.getBeansOfType(MutationHook.class).values(),
+              pluginFactory.getMutationHooks());
+      List<MCLSideEffect> newMclEffects =
+          findMissing(
+              applicationContext.getBeansOfType(MCLSideEffect.class).values(),
+              pluginFactory.getMclSideEffects());
+      List<MCPSideEffect> newMcpEffects =
+          findMissing(
+              applicationContext.getBeansOfType(MCPSideEffect.class).values(),
+              pluginFactory.getMcpSideEffects());
+      List<MCPObserver> newObservers =
+          findMissing(
+              applicationContext.getBeansOfType(MCPObserver.class).values(),
+              pluginFactory.getMcpObservers());
+
+      int total =
+          newValidators.size()
+              + newHooks.size()
+              + newMclEffects.size()
+              + newMcpEffects.size()
+              + newObservers.size();
+
+      if (total == 0) {
+        log.info("Entity registry plugin refresh: all Spring plugin beans already registered");
+        return;
+      }
+
+      pluginFactory.appendPlugins(
+          newValidators, newHooks, newMclEffects, newMcpEffects, newObservers);
+
+      log.info(
+          "Entity registry plugin refresh: appended {} plugin(s) — "
+              + "validators={}, mutationHooks={}, mclSideEffects={}, mcpSideEffects={}, mcpObservers={}",
+          total,
+          newValidators.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newHooks.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newMclEffects.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newMcpEffects.stream().map(p -> p.getClass().getSimpleName()).collect(Collectors.toList()),
+          newObservers.stream()
+              .map(p -> p.getClass().getSimpleName())
+              .collect(Collectors.toList()));
+    };
+  }
+
+  private static <T> List<T> findMissing(Collection<T> springBeans, List<T> registered) {
+    Set<T> registeredSet = Set.copyOf(registered);
+    return springBeans.stream()
+        .filter(bean -> !registeredSet.contains(bean))
+        .collect(Collectors.toList());
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -261,8 +261,7 @@ public class SpringStandardPluginConfiguration {
   @Bean
   @ConditionalOnProperty(name = "ingestionMetrics.enabled", havingValue = "true")
   public MCPObserver ingestionMetricsEmitter(
-      MeterRegistry meterRegistry,
-      ObjectMapper objectMapper) {
+      MeterRegistry meterRegistry, ObjectMapper objectMapper) {
     AspectPluginConfig config =
         AspectPluginConfig.builder()
             .className(IngestionMetricsEmitter.class.getName())

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -72,7 +72,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -259,18 +258,11 @@ public class SpringStandardPluginConfiguration {
     return new DataProductUnsetSideEffect().setConfig(config);
   }
 
-  // Returns null when MeterRegistry/ObjectMapper unavailable
   @Bean
   @ConditionalOnProperty(name = "ingestionMetrics.enabled", havingValue = "true")
   public MCPObserver ingestionMetricsEmitter(
-      ObjectProvider<MeterRegistry> meterRegistryProvider,
-      ObjectProvider<ObjectMapper> objectMapperProvider) {
-    MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
-    ObjectMapper objectMapper = objectMapperProvider.getIfAvailable();
-    if (meterRegistry == null || objectMapper == null) {
-      log.info("Required beans not available, skipping IngestionMetricsEmitter");
-      return null;
-    }
+      MeterRegistry meterRegistry,
+      ObjectMapper objectMapper) {
     AspectPluginConfig config =
         AspectPluginConfig.builder()
             .className(IngestionMetricsEmitter.class.getName())

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactoryTest.java
@@ -18,6 +18,7 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.plugins.SpringStandardPluginConfiguration;
 import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.gms.factory.search.MappingsBuilderFactory;
+import com.linkedin.metadata.aspect.plugins.PluginFactory;
 import com.linkedin.metadata.connection.ConnectionService;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.versioning.EntityVersioningService;
@@ -262,7 +263,9 @@ public class GraphQLEngineFactoryTest extends AbstractTestNGSpringContextTests {
 
   @MockitoBean private MetricUtils metricUtils;
 
-  @MockitoBean private EntityRegistry entityRegistry;
+  @Autowired
+  @Qualifier("entityRegistry")
+  private EntityRegistry entityRegistry;
 
   @MockitoBean private QueryFilterRewriteChain queryFilterRewriteChain;
 
@@ -546,6 +549,16 @@ public class GraphQLEngineFactoryTest extends AbstractTestNGSpringContextTests {
     @SuppressWarnings("unchecked")
     public EntityService<?> entityService() {
       return Mockito.mock(EntityService.class);
+    }
+
+    // Replaces @MockitoBean so getPluginFactory() can be stubbed before context refresh:
+    // entityRegistryPluginRefresh runs during startup and relies on the @Nonnull contract.
+    @Bean(name = "entityRegistry")
+    @Primary
+    public EntityRegistry entityRegistry() {
+      EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+      Mockito.when(registry.getPluginFactory()).thenReturn(PluginFactory.empty());
+      return registry;
     }
 
     @Bean(name = "baseElasticSearchComponents")

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/AspectMigrationMutatorChainInjectionTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/AspectMigrationMutatorChainInjectionTest.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.plugins;
 
 import static org.testng.Assert.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.aspect.RetrieverContext;
@@ -10,6 +11,7 @@ import com.linkedin.metadata.aspect.hooks.AspectMigrationMutatorChain;
 import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.config.DataHubConfiguration;
 import com.linkedin.metadata.structuredproperties.validation.StructuredPropertyMappingLookup;
+import io.micrometer.core.instrument.MeterRegistry;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.mockito.Answers;
@@ -47,6 +49,10 @@ public class AspectMigrationMutatorChainInjectionTest extends AbstractTestNGSpri
   private ConfigurationProvider configurationProvider;
 
   @MockitoBean private StructuredPropertyMappingLookup structuredPropertyMappingLookup;
+
+  @MockitoBean private MeterRegistry meterRegistry;
+
+  @MockitoBean private ObjectMapper objectMapper;
 
   @BeforeClass
   private void setup() {

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/StandardPluginConfigurationTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/plugins/StandardPluginConfigurationTest.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.plugins;
 
 import static org.testng.Assert.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.aliases.sideeffects.AliasesSideEffect;
 import com.linkedin.metadata.aspect.hooks.AspectMigrationMutatorChain;
@@ -30,6 +31,7 @@ import com.linkedin.metadata.structuredproperties.validation.PropertyDefinitionV
 import com.linkedin.metadata.structuredproperties.validation.ShowPropertyAsBadgeValidator;
 import com.linkedin.metadata.structuredproperties.validation.StructuredPropertiesValidator;
 import com.linkedin.metadata.structuredproperties.validation.StructuredPropertyMappingLookup;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import org.mockito.Answers;
 import org.mockito.Mockito;
@@ -59,6 +61,10 @@ public class StandardPluginConfigurationTest extends AbstractTestNGSpringContext
   private ConfigurationProvider configurationProvider;
 
   @MockitoBean private StructuredPropertyMappingLookup structuredPropertyMappingLookup;
+
+  @MockitoBean private MeterRegistry meterRegistry;
+
+  @MockitoBean private ObjectMapper objectMapper;
 
   @BeforeClass
   private void setup() {

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/ingestion/validation/ExecutionIngestionAuthSystemUserTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/ingestion/validation/ExecutionIngestionAuthSystemUserTest.java
@@ -14,6 +14,7 @@ import com.datahub.authorization.AuthorizationRequest;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizerChain;
 import com.datahub.authorization.EntitySpec;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringMap;
@@ -29,6 +30,7 @@ import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -68,6 +71,10 @@ public class ExecutionIngestionAuthSystemUserTest extends AbstractTestNGSpringCo
   @Autowired private AuthorizerChain authorizerChain;
 
   @Autowired private EntityRegistry entityRegistry;
+
+  @MockitoBean private MeterRegistry meterRegistry;
+
+  @MockitoBean private ObjectMapper objectMapper;
 
   @Test
   public void testAuthInit() {

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
@@ -118,14 +118,15 @@ public class SpringPluginLateRegistrationTest {
     MergedEntityRegistry mergedRegistry = new MergedEntityRegistry(configEntityRegistry);
     PluginFactory pluginFactory = mergedRegistry.getPluginFactory();
 
-    int beforeSize = pluginFactory.getMcpObservers().size();
+    List<MCPObserver> existingObservers = pluginFactory.getMcpObservers();
+    int beforeSize = existingObservers.size();
 
     pluginFactory.appendPlugins(
         Collections.emptyList(),
         Collections.emptyList(),
         Collections.emptyList(),
         Collections.emptyList(),
-        Collections.emptyList());
+        List.copyOf(existingObservers));
 
     assertEquals(pluginFactory.getMcpObservers().size(), beforeSize);
   }

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
@@ -28,8 +28,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
- * Verifies that plugin beans created after {@link SpringPluginFactory} construction (due to circular
- * dependencies during entity registry initialization) can be reconciled via {@link
+ * Verifies that plugin beans created after {@link SpringPluginFactory} construction (due to
+ * circular dependencies during entity registry initialization) can be reconciled via {@link
  * PluginFactory#appendPlugins}.
  *
  * <p>Simulates the production scenario where (an {@link
@@ -99,9 +99,7 @@ public class SpringPluginLateRegistrationTest {
 
     List<MCPObserver> finalObservers = pluginFactory.getMcpObservers();
     Set<String> finalClasses =
-        finalObservers.stream()
-            .map(o -> o.getClass().getSimpleName())
-            .collect(Collectors.toSet());
+        finalObservers.stream().map(o -> o.getClass().getSimpleName()).collect(Collectors.toSet());
     assertTrue(
         finalClasses.contains("LateObserver"),
         "LateObserver should be present after appendPlugins reconciliation");

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
@@ -32,9 +32,9 @@ import org.testng.annotations.Test;
  * circular dependencies during entity registry initialization) can be reconciled via {@link
  * PluginFactory#appendPlugins}.
  *
- * <p>Simulates the production scenario where (an {@link
- * MCPObserver}) transitively depends on {@code EntityRegistry} and is therefore unavailable when
- * {@link SpringPluginFactory#build} queries {@code BeanFactoryUtils.beansOfTypeIncludingAncestors}.
+ * <p>Simulates the production scenario where (an {@link MCPObserver}) transitively depends on
+ * {@code EntityRegistry} and is therefore unavailable when {@link SpringPluginFactory#build}
+ * queries {@code BeanFactoryUtils.beansOfTypeIncludingAncestors}.
  */
 public class SpringPluginLateRegistrationTest {
 

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginLateRegistrationTest.java
@@ -1,0 +1,172 @@
+package com.datahub.plugins.metadata.aspect;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.plugins.PluginFactory;
+import com.linkedin.metadata.aspect.plugins.PluginSpec;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPObserver;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import com.linkedin.metadata.models.registry.MergedEntityRegistry;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that plugin beans created after {@link SpringPluginFactory} construction (due to circular
+ * dependencies during entity registry initialization) can be reconciled via {@link
+ * PluginFactory#appendPlugins}.
+ *
+ * <p>Simulates the production scenario where (an {@link
+ * MCPObserver}) transitively depends on {@code EntityRegistry} and is therefore unavailable when
+ * {@link SpringPluginFactory#build} queries {@code BeanFactoryUtils.beansOfTypeIncludingAncestors}.
+ */
+public class SpringPluginLateRegistrationTest {
+
+  @BeforeTest
+  public void disableAssert() {
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+  }
+
+  /**
+   * Simulates the circular dependency scenario:
+   *
+   * <ol>
+   *   <li>Build a Spring context with an MCPObserver that is NOT registered as a Spring-scanned
+   *       plugin config (simulating the bean being invisible during entity registry construction)
+   *   <li>Construct the entity registry via SpringPluginFactory — the observer is missing
+   *   <li>Run the same reconciliation logic as the SmartInitializingSingleton in
+   *       EntityRegistryFactory
+   *   <li>Verify the observer is now in the registry's plugin factory
+   * </ol>
+   */
+  @Test
+  public void testLateRegisteredObserverPickedUpByAppendPlugins() {
+    AnnotationConfigApplicationContext springContext = new AnnotationConfigApplicationContext();
+    springContext.register(LateObserverConfiguration.class);
+    springContext.refresh();
+
+    ConfigEntityRegistry configEntityRegistry =
+        new ConfigEntityRegistry(
+            SpringPluginLateRegistrationTest.class
+                .getClassLoader()
+                .getResourceAsStream(SpringPluginFactoryTest.REGISTRY_FILE_1));
+
+    MergedEntityRegistry mergedRegistry = new MergedEntityRegistry(configEntityRegistry);
+    PluginFactory pluginFactory = mergedRegistry.getPluginFactory();
+
+    List<MCPObserver> initialObservers = pluginFactory.getMcpObservers();
+    Set<String> initialClasses =
+        initialObservers.stream()
+            .map(o -> o.getClass().getSimpleName())
+            .collect(Collectors.toSet());
+    assertTrue(
+        !initialClasses.contains("LateObserver"),
+        "LateObserver should NOT be in the initial plugin factory (simulates circular dep)");
+
+    Collection<MCPObserver> springObservers =
+        springContext.getBeansOfType(MCPObserver.class).values();
+    List<MCPObserver> missing =
+        springObservers.stream()
+            .filter(bean -> !initialObservers.contains(bean))
+            .collect(Collectors.toList());
+
+    assertEquals(missing.size(), 1, "Should find exactly one missing observer from Spring context");
+
+    pluginFactory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        missing);
+
+    List<MCPObserver> finalObservers = pluginFactory.getMcpObservers();
+    Set<String> finalClasses =
+        finalObservers.stream()
+            .map(o -> o.getClass().getSimpleName())
+            .collect(Collectors.toSet());
+    assertTrue(
+        finalClasses.contains("LateObserver"),
+        "LateObserver should be present after appendPlugins reconciliation");
+
+    springContext.close();
+  }
+
+  @Test
+  public void testAppendPluginsIsNoopWhenAllRegistered() {
+    ConfigEntityRegistry configEntityRegistry =
+        new ConfigEntityRegistry(
+            SpringPluginLateRegistrationTest.class
+                .getClassLoader()
+                .getResourceAsStream(SpringPluginFactoryTest.REGISTRY_FILE_1));
+
+    MergedEntityRegistry mergedRegistry = new MergedEntityRegistry(configEntityRegistry);
+    PluginFactory pluginFactory = mergedRegistry.getPluginFactory();
+
+    int beforeSize = pluginFactory.getMcpObservers().size();
+
+    pluginFactory.appendPlugins(
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList());
+
+    assertEquals(pluginFactory.getMcpObservers().size(), beforeSize);
+  }
+
+  @Configuration
+  static class LateObserverConfiguration {
+    @Bean
+    public MCPObserver lateObserver() {
+      LateObserver observer = new LateObserver();
+      observer.setConfig(
+          AspectPluginConfig.builder()
+              .className(LateObserver.class.getName())
+              .enabled(true)
+              .supportedOperations(List.of("UPSERT", "CREATE"))
+              .supportedEntityAspectNames(
+                  List.of(
+                      AspectPluginConfig.EntityAspectName.builder()
+                          .entityName("dataHubExecutionRequest")
+                          .aspectName("dataHubExecutionRequestResult")
+                          .build()))
+              .build());
+      return observer;
+    }
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  static class LateObserver extends MCPObserver {
+    private AspectPluginConfig config;
+
+    @Override
+    public PluginSpec setConfig(@Nonnull AspectPluginConfig config) {
+      this.config = config;
+      return this;
+    }
+
+    @Override
+    protected void observeMCPs(
+        Collection<? extends BatchItem> items, @Nonnull RetrieverContext retrieverContext) {}
+  }
+}


### PR DESCRIPTION
Fixes issue where customer plugins with circular dependencies got loaded late and were not available to the entityRegistry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale plugin loading so Spring-defined plugins delayed by circular dependencies register in the EntityRegistry before requests. Previously some plugins were missing at startup; now we reconcile late Spring beans, deduplicate by class+config, and decouple SQL setup from the registry.

- Add `PluginFactory.appendPlugins(...)` to append validators, mutation hooks, side effects, and observers post-initialization. Apply disable filtering, sort mutation hooks by priority, and deduplicate via explicit equals/hash in `PluginSpec`.
- In `EntityRegistryFactory`, add a `SmartInitializingSingleton` that finds missing `AspectPayloadValidator`, `MutationHook`, `MCLSideEffect`, `MCPSideEffect`, and `MCPObserver` Spring beans and appends them before serving requests.
- Tighten metrics wiring: when `ingestionMetrics.enabled=true`, the `ingestionMetricsEmitter` now requires `MeterRegistry` and `ObjectMapper` beans (no silent skip).
- Simplify SQL setup to avoid circular deps: stop scanning `com.linkedin.gms.factory.entityregistry` and `com.linkedin.gms.factory.plugins` in `SqlSetupUpgradeConfig`; in `SqlSetupConfig` create a minimal `OperationContext` that does not require `EntityRegistry`.
- Test/infra: avoid sharing a static `EntityRegistry` across Spring contexts via `TestOperationContexts.constructNewEntityRegistry()`. Add coverage for append/dedup and late registration; update tests to provide `MeterRegistry`/`ObjectMapper` when metrics are enabled and ensure `entityRegistry.getPluginFactory()` is available during startup.

- Rollout: if `ingestionMetrics.enabled=true`, provide `MeterRegistry` and `ObjectMapper` beans or disable the property to avoid startup failure.

<sup>Written for commit 8e87095c7d5e4777f5ae0f1ee2dd327db7af0f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

