### PR TITLE
fix(lineage): fall back to type icon for hydrated transformation nodes (CAT-2698)

### DIFF
--- a/datahub-web-react/src/app/lineageV3/LineageTransformationNode/LineageTransformationNode.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageTransformationNode/LineageTransformationNode.tsx
@@ -7,6 +7,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { Handle, NodeProps, Position } from 'reactflow';
 import styled from 'styled-components';
 
+import { IconStyleType } from '@app/entityV2/Entity';
 import { DeprecationIcon } from '@app/entityV2/shared/components/styled/DeprecationIcon';
 import HomePill from '@app/lineageV3/LineageEntityNode/HomePill';
 import ManageLineageMenu from '@app/lineageV3/LineageEntityNode/ManageLineageMenu';
@@ -90,7 +91,6 @@ export default function LineageTransformationNode(props: NodeProps<LineageEntity
     const refetch = useRefetchLineage(urn, type);
 
     const isQuery = type === EntityType.Query;
-    const isDataProcessInstance = type === EntityType.DataProcessInstance;
 
     const { rootUrn } = useContext(LineageNodesContext);
     const { cllHighlightedNodes, setHoveredNode, displayedMenuNode, setDisplayedMenuNode } =
@@ -128,9 +128,12 @@ export default function LineageTransformationNode(props: NodeProps<LineageEntity
             )}
             <IconWrapper>
                 {icon && <CustomIcon src={icon} alt={entity?.platform?.name} />}
-                {!icon && isDataProcessInstance && entityRegistry.getIcon(EntityType.DataProcessInstance, 18)}
                 {!icon && isQuery && <Icon icon={Tilde} color="gray" size="inherit" />}
-                {!icon && !isQuery && !isDataProcessInstance && (
+                {/* After hydration, fall back to the type icon when there is no platform logo
+                    (common for DataJobs under a Dataset root). Otherwise the node stays a
+                    permanent Skeleton.Avatar. */}
+                {!icon && !isQuery && entity && entityRegistry.getIcon(type, 18)}
+                {!icon && !isQuery && !entity && (
                     <Skeleton.Avatar active shape="circle" size={TRANSFORMATION_NODE_SIZE} />
                 )}
             </IconWrapper>
@@ -193,6 +196,7 @@ export default function LineageTransformationNode(props: NodeProps<LineageEntity
                     )
                 }
                 properties={entity?.genericEntityProperties}
+                typeIcon={entityRegistry.getIcon(type, 16, IconStyleType.ACCENT)}
                 platformIcons={icon ? [icon] : []}
                 childrenOpen={false}
                 menuActions={menuActions}

--- a/datahub-web-react/src/app/lineageV3/LineageTransformationNode/__tests__/LineageTransformationNode.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageTransformationNode/__tests__/LineageTransformationNode.test.tsx
@@ -1,0 +1,168 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { NodeProps, ReactFlowProvider } from 'reactflow';
+
+import LineageTransformationNode from '@app/lineageV3/LineageTransformationNode/LineageTransformationNode';
+import LineageVisualizationContext from '@app/lineageV3/LineageVisualizationContext';
+import { FetchStatus, LineageDisplayContext, LineageEntity, LineageNodesContext } from '@app/lineageV3/common';
+import { FetchedEntityV2 } from '@app/lineageV3/types';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType, LineageDirection } from '@types';
+
+vi.mock('@graphql/query.generated', () => ({
+    useGetQueryQuery: () => ({ data: undefined }),
+}));
+
+vi.mock('../../queries/useRefetchLineage', () => ({
+    default: () => vi.fn(),
+}));
+
+const mockGetIcon = vi.fn().mockReturnValue(<span data-testid="type-icon">type-icon</span>);
+
+vi.mock('../../../useEntityRegistry', () => ({
+    useEntityRegistry: () => ({
+        getIcon: mockGetIcon,
+        getEntityUrl: vi.fn().mockReturnValue('/entity/test'),
+    }),
+    useEntityRegistryV2: () => ({
+        getIcon: mockGetIcon,
+        getEntityUrl: vi.fn().mockReturnValue('/entity/test'),
+    }),
+}));
+
+function emptyFilters(): LineageEntity['filters'] {
+    return {
+        [LineageDirection.Upstream]: { facetFilters: new Map() },
+        [LineageDirection.Downstream]: { facetFilters: new Map() },
+    };
+}
+
+function buildNodeData(args: {
+    urn: string;
+    type: EntityType;
+    entity?: Pick<FetchedEntityV2, 'name' | 'icon'>;
+}): LineageEntity {
+    const entity: FetchedEntityV2 | undefined = args.entity
+        ? {
+              urn: args.urn,
+              type: args.type,
+              name: args.entity.name,
+              icon: args.entity.icon,
+          }
+        : undefined;
+
+    return {
+        id: args.urn,
+        urn: args.urn,
+        type: args.type,
+        entity,
+        fetchStatus: {
+            [LineageDirection.Upstream]: FetchStatus.COMPLETE,
+            [LineageDirection.Downstream]: FetchStatus.COMPLETE,
+        },
+        isExpanded: {
+            [LineageDirection.Upstream]: true,
+            [LineageDirection.Downstream]: true,
+        },
+        filters: emptyFilters(),
+    };
+}
+
+function buildNodeProps(nodeData: LineageEntity): NodeProps<LineageEntity> {
+    return {
+        id: nodeData.urn,
+        type: 'lineage-transformation',
+        data: nodeData,
+        selected: false,
+        dragging: false,
+        zIndex: 1,
+        isConnectable: false,
+        xPos: 0,
+        yPos: 0,
+    };
+}
+
+function RenderWithLineageContexts({ nodeData }: { nodeData: LineageEntity }) {
+    const defaultNodesContext = useContext(LineageNodesContext);
+    const defaultDisplayContext = useContext(LineageDisplayContext);
+    const defaultVisualizationContext = useContext(LineageVisualizationContext);
+
+    return (
+        <ReactFlowProvider>
+            <LineageNodesContext.Provider
+                value={{
+                    ...defaultNodesContext,
+                    rootUrn: 'urn:li:dataset:home',
+                    rootType: EntityType.Dataset,
+                    nodes: new Map([[nodeData.urn, nodeData]]),
+                }}
+            >
+                <LineageDisplayContext.Provider
+                    value={{
+                        ...defaultDisplayContext,
+                        shownUrns: [nodeData.urn],
+                    }}
+                >
+                    <LineageVisualizationContext.Provider value={defaultVisualizationContext}>
+                        <LineageTransformationNode {...buildNodeProps(nodeData)} />
+                    </LineageVisualizationContext.Provider>
+                </LineageDisplayContext.Provider>
+            </LineageNodesContext.Provider>
+        </ReactFlowProvider>
+    );
+}
+
+function renderNode(args: { urn: string; type: EntityType; entity?: Pick<FetchedEntityV2, 'name' | 'icon'> }) {
+    const nodeData = buildNodeData(args);
+
+    return render(
+        <MockedProvider>
+            <TestPageContainer>
+                <RenderWithLineageContexts nodeData={nodeData} />
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+}
+
+describe('LineageTransformationNode', () => {
+    beforeEach(() => {
+        mockGetIcon.mockClear();
+    });
+
+    it('shows a type icon fallback for hydrated DataJobs without a platform logo', () => {
+        renderNode({
+            urn: 'urn:li:dataJob:(urn:li:dataFlow:(kafkaconnect,flow,PROD),task)',
+            type: EntityType.DataJob,
+            entity: { name: 'task' },
+        });
+
+        expect(screen.getAllByTestId('type-icon').length).toBeGreaterThan(0);
+        expect(mockGetIcon).toHaveBeenCalledWith(EntityType.DataJob, 18);
+        expect(document.querySelector('.ant-skeleton-avatar')).toBeNull();
+    });
+
+    it('keeps the loading skeleton until the DataJob entity hydrates', () => {
+        renderNode({
+            urn: 'urn:li:dataJob:(urn:li:dataFlow:(kafkaconnect,flow,PROD),task)',
+            type: EntityType.DataJob,
+        });
+
+        expect(document.querySelector('.ant-skeleton-avatar')).not.toBeNull();
+        expect(screen.queryByTestId('type-icon')).toBeNull();
+    });
+
+    it('prefers the platform logo over the type icon when present', () => {
+        renderNode({
+            urn: 'urn:li:dataJob:(urn:li:dataFlow:(airflow,flow,PROD),task)',
+            type: EntityType.DataJob,
+            entity: { name: 'task', icon: 'assets/platforms/airflowlogo.png' },
+        });
+
+        expect(screen.getByRole('img')).toHaveAttribute('src', 'assets/platforms/airflowlogo.png');
+        // Node contents use the logo; popover LineageCard still requests a typeIcon fallback.
+        expect(mockGetIcon).not.toHaveBeenCalledWith(EntityType.DataJob, 18);
+        expect(document.querySelector('.ant-skeleton-avatar')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Hydrated lineage transformation nodes (notably DataJobs under a Dataset root) that had no platform logo were stuck showing a permanent `Skeleton.Avatar`.

This change:
- Falls back to the entity type icon once the node is hydrated and no platform logo is available
- Keeps the loading skeleton only while the entity has not hydrated yet
- Passes `typeIcon` into the popover `LineageCard`, matching `LineageEntityNode` / `LineageBoundingBoxNode`

## Before
 
<img width="702" height="605" alt="cat2698-before" src="https://github.com/user-attachments/assets/92aab8c2-d0d4-4bda-9a2a-4fb92ef1ea29" />

 https://deploy-test.acryl.io/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Ahive%2Cfct_users_created%2CPROD%29/Lineage


## After
<img width="702" height="605" alt="cat2698-after" src="https://github.com/user-attachments/assets/2c33f6df-de68-47d2-9a39-97b58273e447" />
  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lineage transformation nodes without platform logos showing a permanent loading avatar. After hydration, nodes now fall back to the entity type icon; the skeleton remains only while loading. Also passes a type icon to the popover LineageCard for consistency.

- Affects hydrated non-query transforms (notably DataJobs under a Dataset root); Query nodes are unchanged.
- Prefers a platform logo when present; otherwise shows the type icon.
- Adds unit tests for type-icon fallback, pre-hydration skeleton, and logo preference.

<sup>Written for commit ab0b7ea1a42c349391bff84ca47afb8b2932ccc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

