### PR TITLE
fix(smoke-test): put search fixture namespace in name/title fields

### DIFF
--- a/smoke-test/tests/cli/search_cmd/search_test_data.json
+++ b/smoke-test/tests/cli/search_cmd/search_test_data.json
@@ -6,8 +6,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
       "json": {
-        "name": "orders",
-        "description": "Search smoke test: Snowflake orders dataset",
+        "name": "search_smoke_test.orders",
+        "description": "Search smoke test: Snowflake search_smoke_test.orders dataset",
         "customProperties": {}
       }
     }
@@ -19,8 +19,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
       "json": {
-        "name": "customers",
-        "description": "Search smoke test: Snowflake customers dataset",
+        "name": "search_smoke_test.customers",
+        "description": "Search smoke test: Snowflake search_smoke_test.customers dataset",
         "customProperties": {}
       }
     }
@@ -32,8 +32,8 @@
     "aspectName": "datasetProperties",
     "aspect": {
       "json": {
-        "name": "revenue",
-        "description": "Search smoke test: BigQuery revenue dataset",
+        "name": "search_smoke_test.revenue",
+        "description": "Search smoke test: BigQuery search_smoke_test.revenue dataset",
         "customProperties": {}
       }
     }
@@ -45,8 +45,8 @@
     "aspectName": "chartInfo",
     "aspect": {
       "json": {
-        "title": "Revenue Chart",
-        "description": "Search smoke test: Looker revenue chart",
+        "title": "search_smoke_test Revenue Chart",
+        "description": "Search smoke test: Looker search_smoke_test.revenue_chart",
         "lastModified": {
           "created": { "time": 0, "actor": "urn:li:corpuser:datahub" },
           "lastModified": { "time": 0, "actor": "urn:li:corpuser:datahub" }
@@ -62,8 +62,8 @@
     "aspectName": "dashboardInfo",
     "aspect": {
       "json": {
-        "title": "Sales Dashboard",
-        "description": "Search smoke test: Looker sales dashboard",
+        "title": "search_smoke_test Sales Dashboard",
+        "description": "Search smoke test: Looker search_smoke_test.sales_dashboard",
         "charts": [],
         "datasets": [],
         "lastModified": {

--- a/smoke-test/tests/cli/search_cmd/test_search_cmd.py
+++ b/smoke-test/tests/cli/search_cmd/test_search_cmd.py
@@ -11,8 +11,10 @@ Test data (search_test_data.json) contains:
   - 1 chart on looker (revenue_chart)
   - 1 dashboard on looker (sales_dashboard)
 
-All URNs use a run-unique ``search_smoke_test-<suffix>`` namespace (see
-``materialize_with_unique_name``) so parallel xdist modules cannot collide.
+All URNs and searchable name/title/description fields use a run-unique
+``search_smoke_test-<suffix>`` namespace (see ``materialize_with_unique_name``)
+so parallel xdist modules cannot collide and free-text ``ns`` queries match
+on both OSS and Acryl search configs.
 CorpUser filter tests rely on built-in DataHub system users (always present).
 """
 


### PR DESCRIPTION
## Summary
- Embed the `search_smoke_test` namespace token in dataset `name`, chart/dashboard `title`, and related descriptions so free-text `--where` / `ns` queries match searchable properties, not just URNs.
- Keeps search CLI smoke tests reliable under Acryl search scoring as well as OSS.

## Test plan
- [ ] `AGENT_MODE=1 scripts/dev/datahub-dev.sh test tests/cli/search_cmd/test_search_cmd.py`
- [ ] Confirm namespace-scoped search assertions still pass after fixture materialization


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make search CLI smoke tests robust across OSS and Acryl by embedding the run-unique `search_smoke_test-<suffix>` namespace in searchable fields. Previously the namespace was only in URNs, so free-text `--where`/`ns` queries could miss; now dataset names, chart/dashboard titles, and descriptions include it with no change to URNs.

- Updates `smoke-test/tests/cli/search_cmd/search_test_data.json` to prefix dataset names and adjust chart/dashboard titles and descriptions.
- Updates the test module docstring to note the namespace in searchable fields.
- Test fixtures only; no product code changes. No migration or actions required.

<sup>Written for commit 284c9a64b3261135421281157880be2ae7ed4d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

