### PR TITLE
feat(ingest/kafka-connect): emit externalUrl on Confluent Cloud connector DataFlows

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -4,6 +4,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, ClassVar, Dict, Final, List, Optional
+from urllib.parse import quote
 
 from pydantic import model_validator
 from pydantic.fields import Field
@@ -79,6 +80,17 @@ _JTDS_RE: Final = re.compile(
 
 # Default connection settings
 DEFAULT_CONNECT_URI: Final[str] = "http://localhost:8083/"
+
+# Confluent Cloud web console. Connector pages live under a per-type path
+# segment, e.g.
+#   https://confluent.cloud/environments/env-xxxxx/clusters/lkc-xxxxx
+#       /connectors/sinks/<connector-name>
+# The console keys on the connector name rather than on its lcc-* id.
+CONFLUENT_CLOUD_CONSOLE_URI: Final[str] = "https://confluent.cloud"
+CONFLUENT_CLOUD_CONSOLE_CONNECTOR_PATHS: Final[Dict[str, str]] = {
+    SINK: "sinks",
+    SOURCE: "sources",
+}
 
 _QUOTED_IDENTIFIER_RE: Final = re.compile(r'"([^"]+)"')
 _VALID_TOPIC_NAME_RE: Final = re.compile(r'^[a-zA-Z0-9._\-"\s]+$')
@@ -596,6 +608,41 @@ class ConnectorManifest:
         )
 
         return ConnectorRegistry.get_topics_from_config(self, config, report)
+
+
+def get_connector_external_url(
+    config: "KafkaConnectSourceConfig", connector: ConnectorManifest
+) -> Optional[str]:
+    """Build a credential-free console URL for a connector, if one exists.
+
+    Only Confluent Cloud is handled. The console URL is assembled from the
+    configured environment and cluster ids plus the connector name, so it can
+    never leak a secret. The Connect REST URI is deliberately not used as a
+    fallback for self-hosted deployments: `connect_uri` may embed basic-auth
+    credentials, which would then be published on the DataFlow.
+
+    Returns None when the deployment is self-hosted, when either Confluent
+    Cloud id is unset, or when the connector type is neither source nor sink.
+    """
+    if not config.is_confluent_cloud():
+        return None
+
+    environment_id = config.confluent_cloud_environment_id
+    cluster_id = config.confluent_cloud_cluster_id
+    if not environment_id or not cluster_id:
+        # Confluent Cloud was detected from connect_uri alone, so the ids the
+        # console URL needs were never configured.
+        return None
+
+    connector_path = CONFLUENT_CLOUD_CONSOLE_CONNECTOR_PATHS.get(connector.type)
+    if not connector_path:
+        return None
+
+    return (
+        f"{CONFLUENT_CLOUD_CONSOLE_URI}/environments/{environment_id}"
+        f"/clusters/{cluster_id}/connectors/{connector_path}"
+        f"/{quote(connector.name, safe='')}"
+    )
 
 
 def remove_prefix(text: str, prefix: str) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
@@ -51,6 +51,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KafkaConnectLineage,
     KafkaConnectSourceConfig,
     KafkaConnectSourceReport,
+    get_connector_external_url,
     get_platform_instance,
     transform_connector_config,
 )
@@ -961,7 +962,13 @@ class KafkaConnectSource(StatefulIngestionSourceBase):
         connector_type = connector.type
         connector_class = connector.config.get(CONNECTOR_CLASS)
         flow_property_bag = connector.flow_property_bag
-        # connector_url = connector.url  # NOTE: this will expose connector credential when used
+        # NOTE: connector.url is still not used as the externalUrl. It is derived
+        # from connect_uri, which for a self-hosted Connect cluster can embed
+        # basic-auth credentials that would then be published on the DataFlow.
+        # get_connector_external_url only returns a Confluent Cloud console URL,
+        # which is assembled from the configured environment and cluster ids plus
+        # the connector name and so carries no credentials.
+        external_url = get_connector_external_url(self.config, connector)
         flow_urn = builder.make_data_flow_urn(
             self.platform,
             connector_name,
@@ -975,7 +982,7 @@ class KafkaConnectSource(StatefulIngestionSourceBase):
                 name=connector_name,
                 description=f"{connector_type.capitalize()} connector using `{connector_class}` plugin.",
                 customProperties=flow_property_bag,
-                # externalUrl=connector_url, # NOTE: this will expose connector credential when used
+                externalUrl=external_url,
             ),
         ).as_workunit()
 

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_mces_golden.json
@@ -10,6 +10,7 @@
                 "team": "data-platform",
                 "tier": "1"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/source_postgres_cdc_01",
             "name": "source_postgres_cdc_01",
             "description": "Source connector using `PostgresCdcSource` plugin."
         }
@@ -224,6 +225,7 @@
                 "transforms.Transform0.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
                 "connection.url": "postgres://postgres-replica.us-west-2.rds.amazonaws.com:5432/reporting_db"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_postgres_01",
             "name": "sink_postgres_01",
             "description": "Sink connector using `PostgresSink` plugin."
         }
@@ -321,6 +323,7 @@
                 "tasks.max": "5",
                 "topics": "analytics.transactions, analytics.order_events"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_snowflake_01",
             "name": "sink_snowflake_01",
             "description": "Sink connector using `SnowflakeSink` plugin."
         }
@@ -588,6 +591,7 @@
     "aspect": {
         "json": {
             "customProperties": {},
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/outbox-source-connector",
             "name": "outbox-source-connector",
             "description": "Source connector using `MySqlCdcSource` plugin."
         }

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_tags_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_catalog_tags_mces_golden.json
@@ -10,6 +10,7 @@
                 "team": "data-platform",
                 "tier": "1"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/source_postgres_cdc_01",
             "name": "source_postgres_cdc_01",
             "description": "Source connector using `PostgresCdcSource` plugin."
         }
@@ -224,6 +225,7 @@
                 "transforms.Transform0.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
                 "connection.url": "postgres://postgres-replica.us-west-2.rds.amazonaws.com:5432/reporting_db"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_postgres_01",
             "name": "sink_postgres_01",
             "description": "Sink connector using `PostgresSink` plugin."
         }
@@ -425,6 +427,7 @@
                 "tasks.max": "5",
                 "topics": "analytics.transactions, analytics.order_events"
             },
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_snowflake_01",
             "name": "sink_snowflake_01",
             "description": "Sink connector using `SnowflakeSink` plugin."
         }
@@ -588,6 +591,7 @@
     "aspect": {
         "json": {
             "customProperties": {},
+            "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/outbox-source-connector",
             "name": "outbox-source-connector",
             "description": "Source connector using `MySqlCdcSource` plugin."
         }

--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
@@ -7,6 +7,7 @@
     "aspect": {
       "json": {
         "customProperties": {},
+        "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/source_postgres_cdc_01",
         "name": "source_postgres_cdc_01",
         "description": "Source connector using `PostgresCdcSource` plugin."
       }
@@ -256,6 +257,7 @@
           "transforms.Transform0.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
           "connection.url": "postgres://postgres-replica.us-west-2.rds.amazonaws.com:5432/reporting_db"
         },
+        "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_postgres_01",
         "name": "sink_postgres_01",
         "description": "Sink connector using `PostgresSink` plugin."
       }
@@ -333,6 +335,7 @@
           "tasks.max": "5",
           "topics": "analytics.transactions, analytics.order_events"
         },
+        "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sinks/sink_snowflake_01",
         "name": "sink_snowflake_01",
         "description": "Sink connector using `SnowflakeSink` plugin."
       }
@@ -762,6 +765,7 @@
     "aspect": {
       "json": {
         "customProperties": {},
+        "externalUrl": "https://confluent.cloud/environments/env-00000/clusters/cluster-123/connectors/sources/outbox-source-connector",
         "name": "outbox-source-connector",
         "description": "Source connector using `MySqlCdcSource` plugin."
       }

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
@@ -6,6 +6,8 @@ import jpype
 import jpype.imports
 import pytest
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+
 # Import the classes we're testing
 from datahub.ingestion.source.kafka_connect.common import (
     CLOUD_JDBC_SOURCE_CLASSES,
@@ -14,6 +16,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KafkaConnectLineage,
     KafkaConnectSourceConfig,
     KafkaConnectSourceReport,
+    get_connector_external_url,
     get_dataset_name,
     has_three_level_hierarchy,
 )
@@ -33,6 +36,7 @@ from datahub.ingestion.source.kafka_connect.source_connectors import (
 from datahub.ingestion.source.kafka_connect.transform_plugins import (
     get_transform_pipeline,
 )
+from datahub.metadata.schema_classes import DataFlowInfoClass
 from datahub.sql_parsing.schema_resolver import SchemaResolverInterface
 
 logger = logging.getLogger(__name__)
@@ -5608,3 +5612,124 @@ class TestPlatformCloudEnvironmentDetection:
         assert "user_events" in target_datasets
         assert "order_events" in target_datasets
         assert "system_events" in target_datasets
+
+
+class TestConnectorExternalUrl:
+    """Test the Confluent Cloud console URL emitted on the connector DataFlow."""
+
+    CLOUD_ENV_ID = "env-xxxxx"
+    CLOUD_CLUSTER_ID = "lkc-xxxxx"
+
+    def cloud_config(self, **overrides: Any) -> KafkaConnectSourceConfig:
+        """Config for a Confluent Cloud deployment with both ids set."""
+        values: Dict[str, Any] = {
+            "confluent_cloud_environment_id": self.CLOUD_ENV_ID,
+            "confluent_cloud_cluster_id": self.CLOUD_CLUSTER_ID,
+            "username": "test-api-key",
+            "password": "test-api-secret",
+        }
+        values.update(overrides)
+        return KafkaConnectSourceConfig(**values)
+
+    def manifest(self, connector_type: str, name: str = "s3-sink") -> ConnectorManifest:
+        return ConnectorManifest(
+            name=name,
+            type=connector_type,
+            config={"connector.class": "S3_SINK"},
+            tasks=[],
+        )
+
+    def test_cloud_sink_connector_url(self) -> None:
+        """Sink connectors get a console URL under the /sinks/ path."""
+        url = get_connector_external_url(
+            self.cloud_config(), self.manifest("sink", "my-sink")
+        )
+
+        assert url == (
+            f"https://confluent.cloud/environments/{self.CLOUD_ENV_ID}"
+            f"/clusters/{self.CLOUD_CLUSTER_ID}/connectors/sinks/my-sink"
+        )
+
+    def test_cloud_source_connector_url(self) -> None:
+        """Source connectors get a console URL under the /sources/ path."""
+        url = get_connector_external_url(
+            self.cloud_config(), self.manifest("source", "my-source")
+        )
+
+        assert url == (
+            f"https://confluent.cloud/environments/{self.CLOUD_ENV_ID}"
+            f"/clusters/{self.CLOUD_CLUSTER_ID}/connectors/sources/my-source"
+        )
+
+    def test_connector_name_is_url_encoded(self) -> None:
+        """Connector names are escaped so they cannot break out of the path."""
+        url = get_connector_external_url(
+            self.cloud_config(), self.manifest("sink", "sink with/space")
+        )
+
+        assert url is not None
+        assert url.endswith("/connectors/sinks/sink%20with%2Fspace")
+
+    def test_unknown_connector_type_has_no_url(self) -> None:
+        """An unrecognised connector type yields no URL rather than a guess."""
+        assert (
+            get_connector_external_url(self.cloud_config(), self.manifest("unknown"))
+            is None
+        )
+
+    def test_self_hosted_has_no_url(self) -> None:
+        """Self-hosted deployments emit nothing - connect_uri may hold secrets."""
+        config = KafkaConnectSourceConfig(connect_uri="http://localhost:8083")
+
+        assert get_connector_external_url(config, self.manifest("sink")) is None
+
+    def test_cloud_without_ids_has_no_url(self) -> None:
+        """Confluent Cloud detected from connect_uri alone lacks the ids."""
+        config = KafkaConnectSourceConfig(
+            connect_uri=(
+                "https://api.confluent.cloud/connect/v1"
+                f"/environments/{self.CLOUD_ENV_ID}/clusters/{self.CLOUD_CLUSTER_ID}"
+            ),
+            username="test-api-key",
+            password="test-api-secret",
+        )
+
+        assert config.is_confluent_cloud() is True
+        assert config.confluent_cloud_environment_id is None
+        assert get_connector_external_url(config, self.manifest("sink")) is None
+
+    def _flow_info(self, config: KafkaConnectSourceConfig) -> DataFlowInfoClass:
+        from datahub.ingestion.source.kafka_connect.kafka_connect import (
+            KafkaConnectSource,
+        )
+
+        with patch("requests.Session.get") as mock_get:
+            mock_response = Mock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = []
+            mock_get.return_value = mock_response
+            source = KafkaConnectSource(config, Mock())
+
+        workunit = source.construct_flow_workunit(self.manifest("sink", "my-sink"))
+        mcp = workunit.metadata
+        assert isinstance(mcp, MetadataChangeProposalWrapper)
+        aspect = mcp.aspect
+        assert isinstance(aspect, DataFlowInfoClass)
+        return aspect
+
+    def test_flow_workunit_carries_external_url(self) -> None:
+        """The DataFlow aspect for a Cloud connector carries the console URL."""
+        aspect = self._flow_info(self.cloud_config())
+
+        assert aspect.externalUrl == (
+            f"https://confluent.cloud/environments/{self.CLOUD_ENV_ID}"
+            f"/clusters/{self.CLOUD_CLUSTER_ID}/connectors/sinks/my-sink"
+        )
+
+    def test_flow_workunit_has_no_external_url_when_self_hosted(self) -> None:
+        """Self-hosted DataFlows are unchanged - no externalUrl is set."""
+        aspect = self._flow_info(
+            KafkaConnectSourceConfig(connect_uri="http://localhost:8083")
+        )
+
+        assert aspect.externalUrl is None


### PR DESCRIPTION
## What

A kafka-connect `DataFlow` (one per connector) now carries an `externalUrl` pointing at the connector's page in the Confluent Cloud console, when - and only when - the source is configured for Confluent Cloud with both `confluent_cloud_environment_id` and `confluent_cloud_cluster_id` set.

```
https://confluent.cloud/environments/env-xxxxx/clusters/lkc-xxxxx/connectors/sinks/<connector-name>
```

Self-hosted Kafka Connect deployments are entirely unaffected: nothing new is emitted for them.

## Why

DataHub renders the "View in ..." pill purely from an entity's `externalUrl` (`entityV2/shared/externalUrl/ViewInPlatform.tsx`, shown in the profile sidebar header, the entity overflow menu, and search preview cards). Without it, a kafka-connect DataFlow is a dead end - someone who spots a connector in the catalog and wants to check its status, tasks, or config has to leave DataHub and find it by hand in the Confluent Cloud console. The DataFlow *is* the connector in this source's model (DataJobs below it are the per-lineage-pair edges), so the console link belongs on the DataFlow.

The field was previously left unset on purpose. `construct_flow_workunit` carried two commented-out lines, both noting that the connector URL "will expose connector credential when used". That is correct for self-managed Kafka Connect, where `connect_uri` can embed basic-auth credentials that would then be published in metadata. It does not apply to Confluent Cloud: the console URL is assembled from two configuration ids and the connector name, and contains no secret material. Those comments are replaced with a comment that keeps the original reasoning and explains why the Cloud case is safe, so the next reader does not have to rediscover why self-hosted is still excluded.

## Evidence for the URL shape

The URL was observed in a browser against a live Confluent Cloud sink connector; the console keys on the connector **name**, not the `lcc-*` id, which is convenient because the source already has the name. I could not find any Confluent documentation that specifies the console's URL structure at all - it appears to be undocumented.

**The `/sinks/` segment is observed. The `/sources/` segment is an inference by symmetry** from the console's own source/sink navigation split. I have chosen to derive the URL for both connector types rather than emit only for sinks, because a source-only asymmetry would be surprising and the type-plural segment is the only variable part of an otherwise verified pattern. **If a reviewer has a Confluent Cloud source connector to hand, please confirm the `/sources/<name>` path resolves** - if it does not, the fix is a one-line change to the `CONFLUENT_CLOUD_CONSOLE_CONNECTOR_PATHS` map (or dropping the `source` entry, which makes the helper return `None` and emit nothing).

## Gating

`get_connector_external_url` returns `None`, and no `externalUrl` is emitted, when any of these hold:

- the deployment is not Confluent Cloud (`is_confluent_cloud()` is false);
- either Confluent Cloud id is unset - this covers a user who reaches Cloud via a hand-written `connect_uri` rather than the recommended id pair, where the ids the console URL needs were never configured;
- the connector type is neither `source` nor `sink`.

The connector name is percent-encoded so an unusual name cannot break out of the path.

## Tests

`TestConnectorExternalUrl` in `tests/unit/kafka_connect/test_kafka_connect.py`:

- sink connectors get the `/connectors/sinks/<name>` URL;
- source connectors get the `/connectors/sources/<name>` URL;
- connector names are URL-encoded;
- an unrecognised connector type yields no URL;
- self-hosted yields no URL;
- Confluent Cloud detected from `connect_uri` alone (ids unset) yields no URL;
- the emitted `DataFlowInfo` aspect carries the URL for Cloud;
- the emitted `DataFlowInfo` aspect has `externalUrl is None` for self-hosted.

## Checklist

- [x] `./gradlew :metadata-ingestion:lint` clean (ruff check, ruff format --check, mypy).
- [x] `pytest tests/unit/kafka_connect` - 535 passed.
- [ ] Confirmation of the `/sources/` path segment from anyone with a Confluent Cloud source connector.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits a credential-free externalUrl on Kafka Connect DataFlows for Confluent Cloud connectors so users can jump to the connector in the Confluent Cloud console. Previously no externalUrl was emitted; now it is set only when both confluent_cloud_environment_id and confluent_cloud_cluster_id are configured and the connector type is source or sink. Self-hosted and Cloud deployments without both IDs remain unchanged.

- URL: https://confluent.cloud/environments/<env>/clusters/<lkc>/connectors/{sources|sinks}/<percent-encoded-connector-name>. Connector names are percent-encoded; we do not use the REST connect_uri to avoid leaking basic-auth. Unknown connector types emit no URL.
- Tests and goldens: unit tests cover source/sink paths, encoding, and gating; all Confluent Cloud integration and catalog goldens now include the externalUrl. Self-managed tests are unchanged.
- Rollout: set confluent_cloud_environment_id and confluent_cloud_cluster_id in the Kafka Connect source to enable links. No action needed for self-hosted.

<sup>Written for commit a38d996695eff7065c7f09332600496de6ed1a5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

