### PR TITLE
fix(ingest/kafka-connect): recognise the Confluent Cloud S3 sink class

### DIFF
--- a/metadata-ingestion/docs/sources/kafka-connect/kafka-connect_post.md
+++ b/metadata-ingestion/docs/sources/kafka-connect/kafka-connect_post.md
@@ -207,6 +207,7 @@ transforms.RegexRouter.replacement: "events.$1"
 | **Snowflake Sink**<br/>`com.snowflake.kafka.connector.SnowflakeSinkConnector`  | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → Table mapping     |
 | **Cloud PostgreSQL Sink**<br/>`PostgresSink`                                   | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → Table mapping     |
 | **Cloud MySQL Sink**<br/>`MySqlSink`                                           | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → Table mapping     |
+| **Cloud S3 Sink**<br/>`S3_SINK`                                                | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → S3 object mapping |
 | **Cloud Snowflake Sink**<br/>`SnowflakeSink`                                   | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → Table mapping     |
 | **Debezium JDBC Sink**<br/>`io.debezium.connector.jdbc.JdbcSinkConnector`      | ✅ Full             | ✅ Partial              | Runtime API / Config-based | Topic → Table mapping     |
 | **ClickHouse Sink**<br/>`com.clickhouse.kafka.connect.ClickHouseSinkConnector` | ✅ Full             | ✅ Full                 | Runtime API / Config-based | Topic → Table mapping     |

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -118,6 +118,7 @@ DEBEZIUM_CONNECTORS_WITH_2_LEVEL_CONTAINER: Final[set] = {
 # - https://docs.confluent.io/cloud/current/connectors/cc-postgresql-sink.html
 # - https://docs.confluent.io/cloud/current/connectors/cc-snowflake-sink.html
 # - https://docs.confluent.io/cloud/current/connectors/cc-snowflake-source.html
+# - https://docs.confluent.io/cloud/current/connectors/cc-s3-sink/cc-s3-sink.html
 POSTGRES_CDC_SOURCE_CLOUD: Final[str] = "PostgresCdcSource"
 POSTGRES_CDC_SOURCE_V2_CLOUD: Final[str] = "PostgresCdcSourceV2"
 POSTGRES_SINK_CLOUD: Final[str] = "PostgresSink"
@@ -127,6 +128,7 @@ MYSQL_SOURCE_CLOUD: Final[str] = "MySqlSource"
 MYSQL_CDC_SOURCE_CLOUD: Final[str] = "MySqlCdcSource"
 MYSQL_CDC_SOURCE_V2_CLOUD: Final[str] = "MySqlCdcSourceV2"
 MYSQL_SINK_CLOUD: Final[str] = "MySqlSink"
+S3_SINK_CLOUD: Final[str] = "S3_SINK"
 
 # Cloud JDBC source connector classes
 CLOUD_JDBC_SOURCE_CLASSES: Final[List[str]] = [
@@ -142,6 +144,7 @@ CLOUD_SINK_CLASSES: Final[List[str]] = [
     POSTGRES_SINK_CLOUD,
     SNOWFLAKE_SINK_CLOUD,
     MYSQL_SINK_CLOUD,
+    S3_SINK_CLOUD,
 ]
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
@@ -12,6 +12,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KAFKA,
     MYSQL_SINK_CLOUD,
     POSTGRES_SINK_CLOUD,
+    S3_SINK_CLOUD,
     SINK,
     SNOWFLAKE_SINK_CLOUD,
     SNOWFLAKE_SOURCE_CLOUD,
@@ -255,8 +256,8 @@ class ConnectorRegistry:
             == "io.confluent.connect.bigquery.BigQuerySinkConnector"
         ):
             return BigQuerySinkConnector(manifest, config, report)
-        # S3 sink connectors
-        elif connector_class_value == S3_SINK_CONNECTOR_CLASS:
+        # S3 sink connectors (self-managed and Confluent Cloud)
+        elif connector_class_value in (S3_SINK_CONNECTOR_CLASS, S3_SINK_CLOUD):
             return ConfluentS3SinkConnector(manifest, config, report)
         # Snowflake sink connectors (classic self-hosted, high-performance v4, and Cloud)
         elif connector_class_value in (

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
@@ -10,6 +10,7 @@ import pytest
 from datahub.ingestion.source.kafka_connect.common import (
     CLOUD_JDBC_SOURCE_CLASSES,
     POSTGRES_CDC_SOURCE_CLOUD,
+    S3_SINK_CLOUD,
     ConnectorManifest,
     KafkaConnectLineage,
     KafkaConnectSourceConfig,
@@ -17,7 +18,9 @@ from datahub.ingestion.source.kafka_connect.common import (
     get_dataset_name,
     has_three_level_hierarchy,
 )
+from datahub.ingestion.source.kafka_connect.connector_registry import ConnectorRegistry
 from datahub.ingestion.source.kafka_connect.sink_connectors import (
+    S3_SINK_CONNECTOR_CLASS,
     BigQuerySinkConnector,
     ClickHouseSinkConnector,
     ConfluentS3SinkConnector,
@@ -334,6 +337,53 @@ class TestS3SinkConnector:
         assert lineage.source_dataset == "user-events"
         assert lineage.source_platform == "kafka"
         assert lineage.target_dataset == "my-data-lake/kafka-data/processed-events"
+        assert lineage.target_platform == "s3"
+
+    @pytest.mark.parametrize(
+        "connector_class", [S3_SINK_CONNECTOR_CLASS, S3_SINK_CLOUD]
+    )
+    def test_s3_sink_lineage_via_registry(self, connector_class: str) -> None:
+        """Both the self-managed and Cloud-managed S3 sink classes get lineage.
+
+        The config shape is the one a Confluent Cloud managed S3 sink reports,
+        which uses the same 's3.bucket.name' and 'topics.dir' keys as the
+        self-managed connector.
+        """
+        connector_config: Dict[str, str] = {
+            "connector.class": connector_class,
+            "topics": "user-events",
+            "s3.bucket.name": "my-data-lake",
+            "topics.dir": "kafka-data",
+            "input.data.format": "AVRO",
+            "output.data.format": "JSON",
+            "path.format": "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH",
+            "time.interval": "HOURLY",
+            "flush.size": "1000",
+            "tasks.max": "1",
+        }
+
+        manifest: ConnectorManifest = self.create_mock_manifest(connector_config)
+        config: Mock = create_mock_kafka_connect_config()
+        # The registry checks explicit generic_connectors overrides before
+        # dispatching on connector.class, so the mock has to expose the field.
+        config.generic_connectors = []
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert isinstance(connector, ConfluentS3SinkConnector)
+        assert connector.get_platform() == "s3"
+        assert connector.get_topics_from_config() == ["user-events"]
+
+        lineages: List = connector.extract_lineages()
+
+        assert len(lineages) == 1
+        lineage = lineages[0]
+        assert lineage.source_dataset == "user-events"
+        assert lineage.source_platform == "kafka"
+        assert lineage.target_dataset == "my-data-lake/kafka-data/user-events"
         assert lineage.target_platform == "s3"
 
 

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
@@ -9,6 +9,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     MYSQL_SINK_CLOUD,
     POSTGRES_CDC_SOURCE_CLOUD,
     POSTGRES_SINK_CLOUD,
+    S3_SINK_CLOUD,
     SINK,
     SNOWFLAKE_SINK_CLOUD,
     SNOWFLAKE_SOURCE_CLOUD,
@@ -194,6 +195,20 @@ class TestConnectorRegistrySinkConnectors:
     def test_s3_sink_connector(self) -> None:
         """Test routing for S3 sink connector."""
         manifest = create_manifest(SINK, S3_SINK_CONNECTOR_CLASS)
+        config = create_mock_config()
+        report = create_mock_report()
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert connector is not None
+        assert isinstance(connector, ConfluentS3SinkConnector)
+        assert connector.get_platform() == "s3"
+
+    def test_s3_sink_connector_cloud(self) -> None:
+        """Test routing for the Confluent Cloud managed S3 sink connector."""
+        manifest = create_manifest(SINK, S3_SINK_CLOUD)
         config = create_mock_config()
         report = create_mock_report()
 


### PR DESCRIPTION
## What

Registers `S3_SINK` - the `connector.class` value a Confluent Cloud fully-managed Amazon S3 sink reports - alongside the existing self-managed `io.confluent.connect.s3.S3SinkConnector`, so both route to `ConfluentS3SinkConnector`.

## Why

The connector registry dispatches on the exact `connector.class` string, and matched only the self-managed Java class. Confluent Cloud fully-managed connectors report a bare plugin name instead. A Cloud-managed S3 sink therefore fell through to `_handle_unsupported_connector`: a DataFlow was still emitted, but with **no DataJobs, no lineage, no topics resolved from config**, and a "Lineage for Sink Connector not supported" warning in the report.

This is a dispatch gap, not a modelling gap. The Cloud connector's own configuration uses the same keys the existing parser already reads - `s3.bucket.name` and `topics.dir` - so once it reaches the parser it produces exactly the lineage the self-managed class does.

The same class of gap is already handled for other Cloud connectors: `SnowflakeSink`, `PostgresSink` and `MySqlSink` are registered under their Cloud plugin names in `common.py` and matched in `connector_registry.py`. That is precisely why a Cloud Snowflake sink produced full lineage while a Cloud S3 sink on the same cluster produced none. This change follows that existing pattern rather than introducing a new mechanism: a `S3_SINK_CLOUD` constant next to its siblings, added to `CLOUD_SINK_CLASSES`, and matched in the sink branch alongside the self-managed class.

## Evidence

- Observed directly on a live Confluent Cloud connector via `GET https://api.confluent.cloud/connect/v1/environments/{env}/clusters/{lkc}/connectors/{name}`: `connector.class` is exactly `S3_SINK`.
- Confluent's own S3 sink tutorial config shows the same, together with the config keys the parser needs:

  ```json
  {
    "connector.class": "S3_SINK",
    "topics": "products",
    "s3.bucket.name": "products-private",
    "topics.dir": "topics",
    "aws.access.key.id": "<AWS_ACCESS_KEY_ID>",
    "aws.secret.access.key": "<AWS_SECRET_ACCESS_KEY>",
    ...
  }
  ```

  (https://developer.confluent.io/confluent-tutorials/confluent-cloud-connector-aws-privatelink/kafka/)

## Parser compatibility - checked, not assumed

- **Destination**: `s3.bucket.name` - present, same key.
- **Directory**: `topics.dir` - present, same key, same `"topics"` default.
- **Topic discovery**: the managed connector uses `topics`, which `get_topics_from_config` already reads. Before this change, topic discovery for a Cloud S3 sink returned nothing at all, since it goes through the same registry lookup.
- **Path format**: the managed connector supports `path.format` / `time.interval` partition directories below the topic directory. The source models the S3 target as the folder `bucket/topics.dir/topic`, above the partition level, so partitioned layouts need no special handling - this matches existing self-managed behaviour.
- **Credentials in flow properties**: `ConfluentS3SinkConnector.extract_flow_property_bag` already strips `aws.access.key.id`, `aws.secret.access.key`, `s3.sse.customer.key` and `s3.proxy.password`. The first two are the managed connector's credential keys as well. Confluent Cloud masks sensitive fields such as `kafka.api.secret` in the Connect API response, and the exposure profile here is identical to the already-registered Cloud Snowflake and JDBC sinks, so the mask list is left unchanged rather than expanded in this PR.

## Tests

- `test_kafka_connect_connector_registry.py::test_s3_sink_connector_cloud` - `S3_SINK` routes to `ConfluentS3SinkConnector` with platform `s3`; the existing `test_s3_sink_connector` still covers the self-managed class.
- `test_kafka_connect.py::TestS3SinkConnector::test_s3_sink_lineage_via_registry` - parametrised over both classes, using a Cloud-managed config shape, asserting topic discovery from config and `topic -> bucket/topics.dir/topic` lineage on the `s3` platform.

## Docs

Adds a `Cloud S3 Sink` / `S3_SINK` row to the supported sink connectors table in `metadata-ingestion/docs/sources/kafka-connect/kafka-connect_post.md`, matching how the other Cloud classes are listed.

## Checklist

- [x] `./gradlew :metadata-ingestion:lint` clean (ruff check, ruff format --check, mypy).
- [x] `pytest tests/unit/kafka_connect` - 530 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes Confluent Cloud S3 sink `connector.class` value `S3_SINK` and routes it to `ConfluentS3SinkConnector`. Previously, Cloud S3 sinks were unsupported (DataFlow only, no DataJobs/lineage/topics, warning); now they produce full topic-to-S3 lineage like `io.confluent.connect.s3.S3SinkConnector`.

- Adds `S3_SINK_CLOUD` in `common.py` and includes it in `CLOUD_SINK_CLASSES`; the registry now routes both `S3_SINK_CONNECTOR_CLASS` and `S3_SINK_CLOUD` to `ConfluentS3SinkConnector`.
- Adds tests for Cloud routing and lineage; updates docs to list “Cloud S3 Sink” (`S3_SINK`) as supported.
- No config or migrations required; parser keys (`s3.bucket.name`, `topics.dir`) and credential masking are unchanged.

<sup>Written for commit cf980fff5343afcab1489a0dc2b1c206899b75f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

