### PR TITLE
chore(ingest/kafka-connect): normalise the Cloud golden format

### DIFF
--- a/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka_connect/confluent-cloud/kafka_connect_confluent_cloud_mces_golden.json
@@ -1,892 +1,892 @@
 [
-  {
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataFlowInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "source_postgres_cdc_01",
-        "description": "Source connector using `PostgresCdcSource` plugin."
-      }
+        "json": {
+            "customProperties": {},
+            "name": "source_postgres_cdc_01",
+            "description": "Source connector using `PostgresCdcSource` plugin."
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.public.customer_addresses)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "source_postgres_cdc_01:ecommerce_db.public.customer_addresses",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "source_postgres_cdc_01:ecommerce_db.public.customer_addresses",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.public.customer_addresses)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.public.customer_addresses)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,ecommerce_db.public.customer_addresses,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,public.customer_addresses,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,ecommerce_db.public.customer_addresses,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,public.customer_addresses,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.customer_profiles)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.customer_profiles)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.customer_profiles)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,public.customer_profiles,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.customer_profiles,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,public.customer_profiles,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.customer_profiles,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "source_postgres_cdc_01:ecommerce_db.analytics.order_events",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "source_postgres_cdc_01:ecommerce_db.analytics.order_events",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,ecommerce_db.analytics.order_events,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.order_events,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,ecommerce_db.analytics.order_events,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.order_events,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataFlowInfo",
     "aspect": {
-      "json": {
-        "customProperties": {
-          "Transform.Transform": "Transform",
-          "Transform.Transform0 ": "Transform0 ",
-          "cloud.environment": "prod",
-          "cloud.provider": "aws",
-          "connection.host": "postgres-replica.us-west-2.rds.amazonaws.com",
-          "connection.port": "5432",
-          "connector.class": "PostgresSink",
-          "db.name": "reporting_db",
-          "delete.enabled": "true",
-          "input.data.format": "AVRO",
-          "input.key.format": "AVRO",
-          "insert.mode": "UPSERT",
-          "kafka.auth.mode": "****************",
-          "kafka.endpoint": "SASL_SSL://***.aws.confluent.cloud:9092",
-          "kafka.region": "us-east-1",
-          "kafka.service.account.id": "****************",
-          "name": "sink_postgres_01",
-          "pk.mode": "record_key",
-          "ssl.mode": "require",
-          "tasks.max": "5",
-          "topics": "public.customer_profiles,public.product_catalog",
-          "transforms": "Transform,Transform0 ",
-          "transforms.Transform.exclude": "__deleted",
-          "transforms.Transform.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
-          "transforms.Transform0.exclude": "audit_timestamp, audit_user, audit_txn_id, version_range",
-          "transforms.Transform0.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
-          "connection.url": "postgres://postgres-replica.us-west-2.rds.amazonaws.com:5432/reporting_db"
-        },
-        "name": "sink_postgres_01",
-        "description": "Sink connector using `PostgresSink` plugin."
-      }
+        "json": {
+            "customProperties": {
+                "Transform.Transform": "Transform",
+                "Transform.Transform0 ": "Transform0 ",
+                "cloud.environment": "prod",
+                "cloud.provider": "aws",
+                "connection.host": "postgres-replica.us-west-2.rds.amazonaws.com",
+                "connection.port": "5432",
+                "connector.class": "PostgresSink",
+                "db.name": "reporting_db",
+                "delete.enabled": "true",
+                "input.data.format": "AVRO",
+                "input.key.format": "AVRO",
+                "insert.mode": "UPSERT",
+                "kafka.auth.mode": "****************",
+                "kafka.endpoint": "SASL_SSL://***.aws.confluent.cloud:9092",
+                "kafka.region": "us-east-1",
+                "kafka.service.account.id": "****************",
+                "name": "sink_postgres_01",
+                "pk.mode": "record_key",
+                "ssl.mode": "require",
+                "tasks.max": "5",
+                "topics": "public.customer_profiles,public.product_catalog",
+                "transforms": "Transform,Transform0 ",
+                "transforms.Transform.exclude": "__deleted",
+                "transforms.Transform.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
+                "transforms.Transform0.exclude": "audit_timestamp, audit_user, audit_txn_id, version_range",
+                "transforms.Transform0.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
+                "connection.url": "postgres://postgres-replica.us-west-2.rds.amazonaws.com:5432/reporting_db"
+            },
+            "name": "sink_postgres_01",
+            "description": "Sink connector using `PostgresSink` plugin."
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.customer_profiles)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "sink_postgres_01:public.customer_profiles",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "sink_postgres_01:public.customer_profiles",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataFlowInfo",
     "aspect": {
-      "json": {
-        "customProperties": {
-          "cloud.environment": "prod",
-          "cloud.provider": "aws",
-          "connector.class": "SnowflakeSink",
-          "input.data.format": "AVRO",
-          "input.key.format": "AVRO",
-          "kafka.auth.mode": "****************",
-          "kafka.endpoint": "SASL_SSL://***.aws.confluent.cloud:9092",
-          "kafka.region": "us-east-1",
-          "kafka.service.account.id": "****************",
-          "name": "sink_snowflake_01",
-          "snowflake.database.name": "ANALYTICS_DB",
-          "snowflake.schema.name": "public",
-          "snowflake.topic2table.map": "analytics.transactions:analytics_transactions, analytics.order_events:analytics_order_events",
-          "snowflake.url.name": "https://account123.us-east-1.snowflakecomputing.com",
-          "snowflake.user.name": "kafka_connect_user",
-          "tasks.max": "5",
-          "topics": "analytics.transactions, analytics.order_events"
-        },
-        "name": "sink_snowflake_01",
-        "description": "Sink connector using `SnowflakeSink` plugin."
-      }
+        "json": {
+            "customProperties": {
+                "cloud.environment": "prod",
+                "cloud.provider": "aws",
+                "connector.class": "SnowflakeSink",
+                "input.data.format": "AVRO",
+                "input.key.format": "AVRO",
+                "kafka.auth.mode": "****************",
+                "kafka.endpoint": "SASL_SSL://***.aws.confluent.cloud:9092",
+                "kafka.region": "us-east-1",
+                "kafka.service.account.id": "****************",
+                "name": "sink_snowflake_01",
+                "snowflake.database.name": "ANALYTICS_DB",
+                "snowflake.schema.name": "public",
+                "snowflake.topic2table.map": "analytics.transactions:analytics_transactions, analytics.order_events:analytics_order_events",
+                "snowflake.url.name": "https://account123.us-east-1.snowflakecomputing.com",
+                "snowflake.user.name": "kafka_connect_user",
+                "tasks.max": "5",
+                "topics": "analytics.transactions, analytics.order_events"
+            },
+            "name": "sink_snowflake_01",
+            "description": "Sink connector using `SnowflakeSink` plugin."
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.order_events,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:snowflake,ANALYTICS_DB.public.analytics_order_events,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.order_events,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,ANALYTICS_DB.public.analytics_order_events,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.product_catalog)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "sink_postgres_01:public.product_catalog",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "sink_postgres_01:public.product_catalog",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.product_catalog)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "sink_snowflake_01:analytics.order_events",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "sink_snowflake_01:analytics.order_events",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.product_catalog)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,public.product_catalog,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.product_catalog,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,public.product_catalog,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,reporting_db.public.product_catalog,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.transactions)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "sink_snowflake_01:analytics.transactions",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "sink_snowflake_01:analytics.transactions",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.transactions)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD),public.product_catalog)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.transactions)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.transactions,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:snowflake,ANALYTICS_DB.public.analytics_transactions,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,analytics.transactions,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,ANALYTICS_DB.public.analytics_transactions,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_snowflake_01,PROD),analytics.transactions)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_updated)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "outbox-source-connector:outbox_db.outbox.app.events.order_updated",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "outbox-source-connector:outbox_db.outbox.app.events.order_updated",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_updated)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_created)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "outbox-source-connector:outbox_db.outbox.app.events.order_created",
-        "type": {
-          "string": "COMMAND"
+        "json": {
+            "customProperties": {},
+            "name": "outbox-source-connector:outbox_db.outbox.app.events.order_created",
+            "type": {
+                "string": "COMMAND"
+            }
         }
-      }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_created)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_updated)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:mysql,outbox_db.outbox,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,app.events.order_updated,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,outbox_db.outbox,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,app.events.order_updated,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.sink_postgres_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_created)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInputOutput",
     "aspect": {
-      "json": {
-        "inputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:mysql,outbox_db.outbox,PROD)"
-        ],
-        "outputDatasets": [
-          "urn:li:dataset:(urn:li:dataPlatform:kafka,app.events.order_created,PROD)"
-        ]
-      }
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,outbox_db.outbox,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,app.events.order_created,PROD)"
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataFlowInfo",
     "aspect": {
-      "json": {
-        "customProperties": {},
-        "name": "outbox-source-connector",
-        "description": "Source connector using `MySqlCdcSource` plugin."
-      }
+        "json": {
+            "customProperties": {},
+            "name": "outbox-source-connector",
+            "description": "Source connector using `MySqlCdcSource` plugin."
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
-      "json": {
-        "path": [
-          {
-            "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
-            "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
-          }
-        ]
-      }
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:kafka-connect,confluent-cloud-prod)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_updated)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD),outbox_db.outbox.app.events.order_created)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.outbox-source-connector,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.analytics.order_events)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  },
-  {
+},
+{
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,confluent-cloud-prod.source_postgres_cdc_01,PROD),ecommerce_db.public.customer_addresses)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-      "json": {
-        "removed": false
-      }
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
-      "lastObserved": 1635166800000,
-      "runId": "kafka-connect-confluent-cloud-test",
-      "lastRunId": "no-run-id-provided"
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-confluent-cloud-test",
+        "lastRunId": "no-run-id-provided"
     }
-  }
+}
 ]


### PR DESCRIPTION
`kafka_connect_confluent_cloud_mces_golden.json` is indented two spaces, which is not what `write_metadata_file` emits, and it is the only golden under `metadata-ingestion/tests/integration` that differs. It was reformatted in #15270, alongside a real `browsePathsV2` change to the same file. Nothing fails as a result - the content is correct and the whitespace is uniform, no tabs and no line-ending changes - but both golden-update paths rewrite the file wholesale in the canonical format, so the next behaviour change in this suite arrives bundled with about a thousand lines of reformatting, exactly as it did in #15270. This normalises it once so future updates diff cleanly.

Produced by passing the parsed records back through the project's own writer, so the bytes are what an update would have written:

```python
records = json.loads(path.read_text())
write_metadata_file(path, records)
```

Records are unchanged - forty-four aspects before and after, equal under a parsed comparison, 537 insertions against 537 deletions - and `pytest tests/integration/kafka_connect/confluent-cloud/` passes against the result.

Here's a couple of whitespace-ignoring diffs to help compare:

- Original PR: https://github.com/datahub-project/datahub/pull/15270/changes?w=1#diff-539a58a446eb364708cdef80e91c6c7052ddf2f077b4f0e121b908bc187ae7a3
- Our PR: https://github.com/datahub-project/datahub/pull/19156/changes?w=1
