### PR TITLE
fix(smoke-test): remove non-deterministic networkidle wait in structured-properties beforeEach

### DIFF
--- a/e2e-test/ui/playwright/tests/structured-properties/entity-level.spec.ts
+++ b/e2e-test/ui/playwright/tests/structured-properties/entity-level.spec.ts
@@ -19,8 +19,6 @@ test.describe('Entity-level Structured Properties', () => {
     structuredPropertiesPage = new StructuredPropertiesPage(page, logger, logDir);
     datasetPage = new DatasetPage(page, logger, logDir);
 
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
     await structuredPropertiesPage.navigate();
   });
 

--- a/e2e-test/ui/playwright/tests/structured-properties/schema-field.spec.ts
+++ b/e2e-test/ui/playwright/tests/structured-properties/schema-field.spec.ts
@@ -19,8 +19,6 @@ test.describe('Schema Field Structured Properties', () => {
     structuredPropertiesPage = new StructuredPropertiesPage(page, logger, logDir);
     datasetPage = new DatasetPage(page, logger, logDir);
 
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
     await structuredPropertiesPage.navigate();
   });
 


### PR DESCRIPTION
## Summary
- The `Entity-level Structured Properties` and `Schema Field Structured Properties` Playwright suites both had a `beforeEach` that visited `/` and waited for `networkidle` before navigating to `/structured-properties`.
- The homepage never reaches `networkidle`: it issues a continuous stream of card-module GraphQL requests and platform-logo fetches with no 500ms quiet gap, so the wait is timing-dependent and causes intermittent CI failures (all four `entity-level` tests timing out in `beforeEach`).
- `structuredPropertiesPage.navigate()` already goes straight to `/structured-properties` and waits for load there deterministically, so the homepage round-trip is unnecessary and has been removed.

## Test plan
- [x] `eslint` and `tsc --noEmit` pass on both changed files
- [ ] Confirm the suite no longer flakes in CI over several runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates a non-deterministic `networkidle` wait in structured-properties Playwright `beforeEach` to stop CI flakes. Previously tests visited `/` and waited for `networkidle`; now they navigate directly to `/structured-properties`, which waits deterministically. This speeds up and stabilizes the suites without changing app behavior.

- Removed `page.goto('/')` and `page.waitForLoadState('networkidle')` in both structured-properties test suites; all other logic stays the same.
- The homepage never reaches `networkidle` due to continuous requests; removing the wait removes a race that caused timeouts.
- `structuredPropertiesPage.navigate()` already handles waiting on `/structured-properties`.
- No config or environment changes; no migration required. Supports CAT-2924 test stability.

<sup>Written for commit 52535b472cfc7cbcab4d5e0328347ffc196e6ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

