### PR TITLE
fix(system-update): restore Kubernetes state after successful upgrade

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessor.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessor.java
@@ -329,6 +329,56 @@ public class KubernetesApiAccessor {
             });
   }
 
+  /**
+   * Restores environment variables captured before scale-down. An empty saved value means the
+   * variable did not exist before scale-down, so it is removed instead of restored as an empty
+   * literal.
+   */
+  public void restoreDeploymentEnv(
+      String deploymentName, String namespace, Map<String, String> envVars) {
+    client
+        .apps()
+        .deployments()
+        .inNamespace(namespace)
+        .withName(deploymentName)
+        .edit(
+            dep -> {
+              if (dep.getSpec() == null
+                  || dep.getSpec().getTemplate() == null
+                  || dep.getSpec().getTemplate().getSpec() == null
+                  || dep.getSpec().getTemplate().getSpec().getContainers() == null
+                  || dep.getSpec().getTemplate().getSpec().getContainers().isEmpty()) {
+                return dep;
+              }
+              Container container = dep.getSpec().getTemplate().getSpec().getContainers().get(0);
+              List<EnvVar> env = container.getEnv();
+              if (env == null) {
+                env = new ArrayList<>();
+                container.setEnv(env);
+              }
+              Map<String, EnvVar> existing = new HashMap<>();
+              for (EnvVar current : env) {
+                if (current.getName() != null) {
+                  existing.put(current.getName(), current);
+                }
+              }
+              for (Map.Entry<String, String> saved : envVars.entrySet()) {
+                EnvVar current = existing.get(saved.getKey());
+                if (saved.getValue().isEmpty()) {
+                  if (current != null) {
+                    env.remove(current);
+                  }
+                } else if (current != null) {
+                  current.setValue(saved.getValue());
+                  current.setValueFrom(null);
+                } else {
+                  env.add(new EnvVar(saved.getKey(), saved.getValue(), null));
+                }
+              }
+              return dep;
+            });
+  }
+
   public void waitForRollout(String deploymentName, String namespace) {
     int maxWaitSec = rolloutMaxWaitSeconds();
     int pollSec = rolloutPollSeconds();

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownCleanupStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownCleanupStep.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.upgrade.kubernetes;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.datahub.upgrade.UpgradeCleanupStep;
 import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeResult;
@@ -7,21 +8,34 @@ import com.linkedin.metadata.config.kubernetes.KubernetesScaleDownConfiguration;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Cleanup step that deletes the scale-down state ConfigMap when the upgrade completes successfully.
- * Ensures the next upgrade run starts with no stale state.
+ * Cleanup step that restores the state captured during scale-down when the upgrade completes
+ * successfully, then deletes the state ConfigMap. Ensures the next upgrade run starts with no stale
+ * state.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class KubernetesScaleDownCleanupStep implements UpgradeCleanupStep {
 
   private static final String STEP_ID = "KubernetesScaleDownCleanupStep";
 
   @Nullable private final KubernetesScaleDownConfiguration configuration;
+  @Nullable private final Supplier<Optional<KubernetesApiAccessor>> accessorSupplier;
+
+  public KubernetesScaleDownCleanupStep(
+      @Nullable KubernetesScaleDownConfiguration configuration) {
+    this(configuration, null);
+  }
+
+  KubernetesScaleDownCleanupStep(
+      @Nullable KubernetesScaleDownConfiguration configuration,
+      @Nullable Supplier<Optional<KubernetesApiAccessor>> accessorSupplier) {
+    this.configuration = configuration;
+    this.accessorSupplier = accessorSupplier;
+  }
 
   @Override
   public String id() {
@@ -49,15 +63,35 @@ public class KubernetesScaleDownCleanupStep implements UpgradeCleanupStep {
         log.debug("Kubernetes scale-down Java implementation disabled; skipping cleanup.");
         return;
       }
-      Optional<KubernetesApiAccessor> accessor = KubernetesApiAccessor.createInCluster(config);
-      if (accessor.isEmpty()) {
+      Optional<KubernetesApiAccessor> accessorOpt =
+          accessorSupplier != null
+              ? accessorSupplier.get()
+              : KubernetesApiAccessor.createInCluster(config);
+      if (accessorOpt.isEmpty()) {
         log.warn(
             "Could not create Kubernetes client; skipping scale-down state ConfigMap cleanup.");
         return;
       }
+      KubernetesApiAccessor accessor = accessorOpt.get();
       String namespace = KubernetesApiAccessor.getNamespaceFromEnvironment();
       String configMapName = KubernetesApiAccessor.resolveStateConfigMapName(config, namespace);
-      accessor.get().deleteConfigMap(configMapName, namespace);
+      ObjectMapper objectMapper = context.opContext().getObjectMapper();
+      Optional<ScaleDownState> state =
+          accessor.getConfigMapState(configMapName, namespace, objectMapper);
+      if (state.isEmpty()) {
+        log.debug("No scale-down state ConfigMap found; skipping cleanup.");
+        return;
+      }
+      try {
+        KubernetesScaleDownStep.restore(accessor, state.get(), namespace);
+        accessor.deleteConfigMap(configMapName, namespace);
+      } catch (RuntimeException e) {
+        log.error(
+            "Failed to restore Kubernetes scale-down state; leaving ConfigMap {} for recovery.",
+            configMapName,
+            e);
+        throw e;
+      }
     };
   }
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownStep.java
@@ -332,7 +332,7 @@ public class KubernetesScaleDownStep implements UpgradeStep {
     CompletableFuture.allOf(futures).join();
   }
 
-  private void restore(KubernetesApiAccessor accessor, ScaleDownState state, String namespace) {
+  static void restore(KubernetesApiAccessor accessor, ScaleDownState state, String namespace) {
     List<ScaleDownState.DeploymentReplicas> deployments = state.getDeployments();
     if (deployments != null && !deployments.isEmpty()) {
       runParallel(
@@ -350,7 +350,7 @@ public class KubernetesScaleDownStep implements UpgradeStep {
               .map(
                   e ->
                       (Runnable)
-                          () -> accessor.setDeploymentEnv(e.getKey(), namespace, e.getValue()))
+                          () -> accessor.restoreDeploymentEnv(e.getKey(), namespace, e.getValue()))
               .collect(Collectors.toList()));
     }
     if (deployments != null && !deployments.isEmpty()) {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/ScaleDownState.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/ScaleDownState.java
@@ -39,7 +39,8 @@ public class ScaleDownState {
   /**
    * Last-known env values we overwrote per deployment (for restore). Key = deployment name, value =
    * env vars to restore. Covers all deployments that had env updates applied via
-   * deploymentEnvUpdates.
+   * deploymentEnvUpdates. An empty value means that the env var was absent before scale-down and
+   * must be removed during restore.
    */
   private Map<String, Map<String, String>> envBeforeByDeployment;
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessorTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessorTest.java
@@ -431,6 +431,65 @@ public class KubernetesApiAccessorTest {
   }
 
   @Test
+  public void testRestoreDeploymentEnvRestoresValuesAndRemovesPreviouslyAbsentVariables() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("gms")
+            .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+            .withNewTemplate()
+            .withNewSpec()
+            .addNewContainer()
+            .withName("main")
+            .addToEnv(new EnvVar("MCE_CONSUMER_ENABLED", "false", null))
+            .addToEnv(new EnvVar("PRE_PROCESS_HOOKS_UI_ENABLED", "false", null))
+            .addToEnv(new EnvVar("UNCHANGED", "value", null))
+            .endContainer()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
+            .build();
+
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.edit(any(UnaryOperator.class)))
+        .thenAnswer(inv -> ((UnaryOperator<Deployment>) inv.getArgument(0)).apply(deployment));
+
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client);
+    accessor.restoreDeploymentEnv(
+        "gms",
+        NAMESPACE,
+        Map.of("MCE_CONSUMER_ENABLED", "true", "PRE_PROCESS_HOOKS_UI_ENABLED", ""));
+
+    List<EnvVar> env = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+    assertEquals(
+        env.stream()
+            .filter(e -> "MCE_CONSUMER_ENABLED".equals(e.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getValue(),
+        "true");
+    assertFalse(env.stream().anyMatch(e -> "PRE_PROCESS_HOOKS_UI_ENABLED".equals(e.getName())));
+    assertEquals(
+        env.stream()
+            .filter(e -> "UNCHANGED".equals(e.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getValue(),
+        "value");
+  }
+
+  @Test
   public void testListActiveJobNamesExceptSystemUpdateReturnsActiveJobsOnly() {
     io.fabric8.kubernetes.api.model.batch.v1.Job activeJob =
         new io.fabric8.kubernetes.api.model.batch.v1.JobBuilder()

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownCleanupStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownCleanupStepTest.java
@@ -1,12 +1,27 @@
 package com.linkedin.datahub.upgrade.kubernetes;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeResult;
 import com.linkedin.metadata.config.kubernetes.KubernetesScaleDownConfiguration;
 import com.linkedin.upgrade.DataHubUpgradeState;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -65,5 +80,97 @@ public class KubernetesScaleDownCleanupStepTest {
     when(upgradeResult.result()).thenReturn(DataHubUpgradeState.SUCCEEDED);
 
     step.executable().accept(upgradeContext, upgradeResult);
+  }
+
+  @Test
+  public void testExecutableRestoresSavedStateBeforeDeletingConfigMap() {
+    KubernetesApiAccessor accessor = mock(KubernetesApiAccessor.class);
+    ScaleDownState state =
+        ScaleDownState.builder()
+            .attempt(1)
+            .deployments(
+                List.of(
+                    ScaleDownState.DeploymentReplicas.builder()
+                        .name("datahub-gms")
+                        .replicas(2)
+                        .build()))
+            .envBeforeByDeployment(
+                Map.of(
+                    "datahub-gms",
+                    Map.of(
+                        "MCE_CONSUMER_ENABLED", "true",
+                        "PRE_PROCESS_HOOKS_UI_ENABLED", "")))
+            .build();
+    configureSuccessfulCleanup(accessor, state);
+
+    step.executable().accept(upgradeContext, upgradeResult);
+
+    InOrder order = inOrder(accessor);
+    order.verify(accessor).scaleDeployment("datahub-gms", "default", 2);
+    order
+        .verify(accessor)
+        .restoreDeploymentEnv(
+            "datahub-gms",
+            "default",
+            Map.of(
+                "MCE_CONSUMER_ENABLED", "true", "PRE_PROCESS_HOOKS_UI_ENABLED", ""));
+    order.verify(accessor).waitForRollout("datahub-gms", "default");
+    order.verify(accessor).deleteConfigMap(anyString(), eq("default"));
+  }
+
+  @Test
+  public void testExecutableLeavesConfigMapWhenRestoreFails() {
+    KubernetesApiAccessor accessor = mock(KubernetesApiAccessor.class);
+    ScaleDownState state =
+        ScaleDownState.builder()
+            .attempt(1)
+            .envBeforeByDeployment(Map.of("datahub-gms", Map.of("MCE_CONSUMER_ENABLED", "true")))
+            .build();
+    configureSuccessfulCleanup(accessor, state);
+    doThrow(new RuntimeException("restore failed"))
+        .when(accessor)
+        .restoreDeploymentEnv(anyString(), anyString(), any());
+
+    assertThrows(
+        RuntimeException.class, () -> step.executable().accept(upgradeContext, upgradeResult));
+
+    verify(accessor, never()).deleteConfigMap(anyString(), anyString());
+  }
+
+  @Test
+  public void testExecutableDoesNotDeleteConfigMapWhenStateIsMissing() {
+    KubernetesApiAccessor accessor = mock(KubernetesApiAccessor.class);
+    KubernetesScaleDownConfiguration config = enabledConfig();
+    OperationContext operationContext = mock(OperationContext.class);
+    when(operationContext.getObjectMapper()).thenReturn(new ObjectMapper());
+    when(upgradeContext.opContext()).thenReturn(operationContext);
+    when(upgradeResult.result()).thenReturn(DataHubUpgradeState.SUCCEEDED);
+    when(accessor.getConfigMapState(anyString(), anyString(), any(ObjectMapper.class)))
+        .thenReturn(Optional.empty());
+    step = new KubernetesScaleDownCleanupStep(config, () -> Optional.of(accessor));
+
+    step.executable().accept(upgradeContext, upgradeResult);
+
+    verify(accessor, never()).deleteConfigMap(anyString(), anyString());
+  }
+
+  private void configureSuccessfulCleanup(
+      KubernetesApiAccessor accessor, ScaleDownState state) {
+    KubernetesScaleDownConfiguration config = enabledConfig();
+    OperationContext operationContext = mock(OperationContext.class);
+    when(operationContext.getObjectMapper()).thenReturn(new ObjectMapper());
+    when(upgradeContext.opContext()).thenReturn(operationContext);
+    when(upgradeResult.result()).thenReturn(DataHubUpgradeState.SUCCEEDED);
+    when(accessor.getConfigMapState(anyString(), anyString(), any(ObjectMapper.class)))
+        .thenReturn(Optional.of(state));
+    step = new KubernetesScaleDownCleanupStep(config, () -> Optional.of(accessor));
+  }
+
+  private static KubernetesScaleDownConfiguration enabledConfig() {
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setKubernetesServiceHost("10.0.0.1");
+    config.setEnabled(true);
+    config.setUseJavaImplementation(true);
+    return config;
   }
 }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesScaleDownStepTest.java
@@ -234,7 +234,7 @@ public class KubernetesScaleDownStepTest {
     assertEquals(result.result(), com.linkedin.upgrade.DataHubUpgradeState.FAILED);
     verify(mockAccessor).scaleDeployment(eq("gms"), anyString(), eq(2));
     verify(mockAccessor)
-        .setDeploymentEnv(
+        .restoreDeploymentEnv(
             eq("gms"), anyString(), eq(Map.of("PRE_PROCESS_HOOKS_UI_ENABLED", "true")));
     verify(mockAccessor).waitForRollout(eq("gms"), anyString());
     verify(mockAccessor).deleteConfigMap(anyString(), anyString());


### PR DESCRIPTION
## Summary

- restore Deployment replicas and environment variables after a successful Kubernetes scale-down
- remove environment variables that were absent before scale-down
- delete the state ConfigMap only after restoration succeeds
- retain the ConfigMap when restoration fails so recovery remains possible
- add regression tests for the successful and failed cleanup paths

Fixes #19158

## Testing

```shell
./gradlew :datahub-upgrade:test \
  --tests 'com.linkedin.datahub.upgrade.kubernetes.KubernetesScaleDownCleanupStepTest' \
  --tests 'com.linkedin.datahub.upgrade.kubernetes.KubernetesScaleDownStepTest' \
  --tests 'com.linkedin.datahub.upgrade.kubernetes.KubernetesApiAccessorTest' \
  --tests 'com.linkedin.datahub.upgrade.kubernetes.KubernetesApiAccessorValueFromTest'
  
  107 tests passing.
  ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Kubernetes Deployment replicas and environment variables after a successful system update, then deletes the scale-down state ConfigMap. Previously the cleanup step only deleted the ConfigMap; replicas and env vars could remain altered.

- Introduces `KubernetesApiAccessor.restoreDeploymentEnv` to restore values and remove vars that were absent before scale-down (empty saved value means delete, not set empty).
- Changes `KubernetesScaleDownCleanupStep` to read the state ConfigMap, call `KubernetesScaleDownStep.restore`, wait for rollouts, and delete the ConfigMap only after a successful restore. Retains the ConfigMap if restore fails to allow recovery.
- Makes `KubernetesScaleDownStep.restore` static and switches env restoration to `restoreDeploymentEnv`.
- Adds regression tests for successful cleanup and failure paths; updates existing tests accordingly.

<sup>Written for commit 1bf9dce6176bb0eaf74d864b31b2a8ee0a4777c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

