### PR TITLE
fix(documents): make search-index mode an explicit DocumentService contract

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolver.java
@@ -14,6 +14,7 @@ import com.linkedin.datahub.graphql.generated.CreateDocumentInput;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -121,7 +122,8 @@ public class CreateDocumentResolver implements DataFetcher<CompletableFuture<Str
                     relatedDocumentUrns,
                     settings,
                     owners,
-                    actorUrn);
+                    actorUrn,
+                    SearchIndexMode.SYNC);
 
             return documentUrn.toString();
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -41,7 +42,8 @@ public class DeleteDocumentResolver implements DataFetcher<CompletableFuture<Boo
 
           try {
             // Delete using service
-            _documentService.deleteDocument(context.getOperationContext(), documentUrn);
+            _documentService.deleteDocument(
+                context.getOperationContext(), documentUrn, SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.MoveDocumentInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -55,7 +56,8 @@ public class MoveDocumentResolver implements DataFetcher<CompletableFuture<Boole
                 context.getOperationContext(),
                 documentUrn,
                 newParentUrn,
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentContentsInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -61,7 +62,8 @@ public class UpdateDocumentContentsResolver implements DataFetcher<CompletableFu
                 content,
                 input.getTitle(),
                 subTypes,
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentRelatedEntitiesInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -69,7 +70,8 @@ public class UpdateDocumentRelatedEntitiesResolver
                 documentUrn,
                 relatedAssetUrns,
                 relatedDocumentUrns,
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentSettingsInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -53,7 +54,8 @@ public class UpdateDocumentSettingsResolver implements DataFetcher<CompletableFu
                 context.getOperationContext(),
                 documentUrn,
                 settings,
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentStatusInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -53,7 +54,8 @@ public class UpdateDocumentStatusResolver implements DataFetcher<CompletableFutu
                 context.getOperationContext(),
                 documentUrn,
                 pdlState,
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentSubTypeInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -49,7 +50,8 @@ public class UpdateDocumentSubTypeResolver implements DataFetcher<CompletableFut
                 context.getOperationContext(),
                 documentUrn,
                 input.getSubType(),
-                UrnUtils.getUrn(context.getActorUrn()));
+                UrnUtils.getUrn(context.getActorUrn()),
+                SearchIndexMode.SYNC);
 
             return true;
           } catch (ServiceAuthorizationException e) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolverTest.java
@@ -17,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
@@ -64,7 +65,8 @@ public class CreateDocumentResolverTest {
             any(), // related documents
             any(), // showInGlobalContext
             any(), // owners
-            any(Urn.class))) // actor
+            any(Urn.class),
+            any(SearchIndexMode.class))) // actor
         .thenReturn(TEST_DOCUMENT_URN);
 
     resolver = new CreateDocumentResolver(mockService, mockEntityService);
@@ -101,9 +103,11 @@ public class CreateDocumentResolverTest {
             any(), // related documents
             any(), // showInGlobalContext
             any(), // owners
-            any(Urn.class)); // actor URN
+            any(Urn.class),
+            any(SearchIndexMode.class)); // actor URN
 
-    verify(mockService, never()).setDocumentOwnership(any(), any(), any(), any());
+    verify(mockService, never())
+        .setDocumentOwnership(any(), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -129,7 +133,8 @@ public class CreateDocumentResolverTest {
             any(), // related documents
             any(), // showInGlobalContext
             any(), // owners
-            any()); // actor
+            any(),
+            any(SearchIndexMode.class)); // actor
   }
 
   @Test
@@ -160,7 +165,8 @@ public class CreateDocumentResolverTest {
             any(), // related documents
             any(), // showInGlobalContext
             any(), // owners
-            any()); // actor
+            any(),
+            any(SearchIndexMode.class)); // actor
   }
 
   @Test
@@ -216,8 +222,10 @@ public class CreateDocumentResolverTest {
             any(),
             any(),
             argThat(owners -> owners != null && owners.size() == 2),
-            any(Urn.class));
-    verify(mockService, never()).setDocumentOwnership(any(), any(), any(), any());
+            any(Urn.class),
+            any(SearchIndexMode.class));
+    verify(mockService, never())
+        .setDocumentOwnership(any(), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -240,7 +248,8 @@ public class CreateDocumentResolverTest {
             any(), // related documents
             any(), // showInGlobalContext
             any(), // owners
-            any())) // actor
+            any(),
+            any(SearchIndexMode.class))) // actor
         .thenThrow(new RuntimeException("Service error"));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -265,7 +274,8 @@ public class CreateDocumentResolverTest {
             any(),
             any(),
             any(),
-            any()))
+            any(),
+            any(SearchIndexMode.class)))
         .thenThrow(new ServiceAuthorizationException("denied"));
 
     CompletionException exception =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/CreateDocumentResolverTest.java
@@ -66,7 +66,7 @@ public class CreateDocumentResolverTest {
             any(), // showInGlobalContext
             any(), // owners
             any(Urn.class),
-            any(SearchIndexMode.class))) // actor
+            eq(SearchIndexMode.SYNC))) // actor
         .thenReturn(TEST_DOCUMENT_URN);
 
     resolver = new CreateDocumentResolver(mockService, mockEntityService);
@@ -104,7 +104,7 @@ public class CreateDocumentResolverTest {
             any(), // showInGlobalContext
             any(), // owners
             any(Urn.class),
-            any(SearchIndexMode.class)); // actor URN
+            eq(SearchIndexMode.SYNC)); // actor URN
 
     verify(mockService, never())
         .setDocumentOwnership(any(), any(), any(), any(), any(SearchIndexMode.class));
@@ -166,7 +166,7 @@ public class CreateDocumentResolverTest {
             any(), // showInGlobalContext
             any(), // owners
             any(),
-            any(SearchIndexMode.class)); // actor
+            eq(SearchIndexMode.SYNC)); // actor
   }
 
   @Test
@@ -223,7 +223,7 @@ public class CreateDocumentResolverTest {
             any(),
             argThat(owners -> owners != null && owners.size() == 2),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
     verify(mockService, never())
         .setDocumentOwnership(any(), any(), any(), any(), any(SearchIndexMode.class));
   }
@@ -249,7 +249,7 @@ public class CreateDocumentResolverTest {
             any(), // showInGlobalContext
             any(), // owners
             any(),
-            any(SearchIndexMode.class))) // actor
+            eq(SearchIndexMode.SYNC))) // actor
         .thenThrow(new RuntimeException("Service error"));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -275,7 +275,7 @@ public class CreateDocumentResolverTest {
             any(),
             any(),
             any(),
-            any(SearchIndexMode.class)))
+            eq(SearchIndexMode.SYNC)))
         .thenThrow(new ServiceAuthorizationException("denied"));
 
     CompletionException exception =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolverTest.java
@@ -49,7 +49,7 @@ public class DeleteDocumentResolverTest {
         .deleteDocument(
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class DeleteDocumentResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .deleteDocument(any(OperationContext.class), any(Urn.class), any(SearchIndexMode.class));
+        .deleteDocument(any(OperationContext.class), any(Urn.class), eq(SearchIndexMode.SYNC));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -85,7 +85,7 @@ public class DeleteDocumentResolverTest {
     when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ARTICLE_URN);
     doThrow(new ServiceAuthorizationException("denied"))
         .when(mockService)
-        .deleteDocument(any(OperationContext.class), any(Urn.class), any(SearchIndexMode.class));
+        .deleteDocument(any(OperationContext.class), any(Urn.class), eq(SearchIndexMode.SYNC));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/DeleteDocumentResolverTest.java
@@ -11,6 +11,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
@@ -45,7 +46,10 @@ public class DeleteDocumentResolverTest {
 
     // Verify service was called
     verify(mockService, times(1))
-        .deleteDocument(any(OperationContext.class), eq(UrnUtils.getUrn(TEST_ARTICLE_URN)));
+        .deleteDocument(
+            any(OperationContext.class),
+            eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -57,7 +61,8 @@ public class DeleteDocumentResolverTest {
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
 
     // Verify service was NOT called
-    verify(mockService, times(0)).deleteDocument(any(OperationContext.class), any(Urn.class));
+    verify(mockService, times(0))
+        .deleteDocument(any(OperationContext.class), any(Urn.class), any(SearchIndexMode.class));
   }
 
   @Test
@@ -68,7 +73,7 @@ public class DeleteDocumentResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .deleteDocument(any(OperationContext.class), any(Urn.class));
+        .deleteDocument(any(OperationContext.class), any(Urn.class), any(SearchIndexMode.class));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -80,7 +85,7 @@ public class DeleteDocumentResolverTest {
     when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ARTICLE_URN);
     doThrow(new ServiceAuthorizationException("denied"))
         .when(mockService)
-        .deleteDocument(any(OperationContext.class), any(Urn.class));
+        .deleteDocument(any(OperationContext.class), any(Urn.class), any(SearchIndexMode.class));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolverTest.java
@@ -60,7 +60,7 @@ public class MoveDocumentResolverTest {
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(UrnUtils.getUrn(TEST_PARENT_URN)),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -82,7 +82,7 @@ public class MoveDocumentResolverTest {
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(null),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -106,7 +106,7 @@ public class MoveDocumentResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .moveDocument(any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
+        .moveDocument(any(OperationContext.class), any(), any(), any(), eq(SearchIndexMode.SYNC));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -118,7 +118,7 @@ public class MoveDocumentResolverTest {
     when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     doThrow(new ServiceAuthorizationException("denied"))
         .when(mockService)
-        .moveDocument(any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
+        .moveDocument(any(OperationContext.class), any(), any(), any(), eq(SearchIndexMode.SYNC));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/MoveDocumentResolverTest.java
@@ -12,6 +12,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.MoveDocumentInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
@@ -58,7 +59,8 @@ public class MoveDocumentResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(UrnUtils.getUrn(TEST_PARENT_URN)),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -79,7 +81,8 @@ public class MoveDocumentResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(null),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -91,7 +94,8 @@ public class MoveDocumentResolverTest {
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
 
     // Verify service was NOT called
-    verify(mockService, times(0)).moveDocument(any(OperationContext.class), any(), any(), any());
+    verify(mockService, times(0))
+        .moveDocument(any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -102,7 +106,7 @@ public class MoveDocumentResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .moveDocument(any(OperationContext.class), any(), any(), any());
+        .moveDocument(any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -114,7 +118,7 @@ public class MoveDocumentResolverTest {
     when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     doThrow(new ServiceAuthorizationException("denied"))
         .when(mockService)
-        .moveDocument(any(OperationContext.class), any(), any(), any());
+        .moveDocument(any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolverTest.java
@@ -13,6 +13,7 @@ import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.DocumentContentInput;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentContentsInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import com.linkedin.metadata.service.ServiceAuthorizationException;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
@@ -63,7 +64,8 @@ public class UpdateDocumentContentsResolverTest {
             any(),
             eq(null),
             eq(null),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -86,7 +88,8 @@ public class UpdateDocumentContentsResolverTest {
             any(),
             eq("New Title"),
             eq(null),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -99,7 +102,14 @@ public class UpdateDocumentContentsResolverTest {
 
     // Verify service was NOT called
     verify(mockService, times(0))
-        .updateDocumentContents(any(OperationContext.class), any(), any(), any(), any(), any());
+        .updateDocumentContents(
+            any(OperationContext.class),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -110,7 +120,14 @@ public class UpdateDocumentContentsResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .updateDocumentContents(any(OperationContext.class), any(), any(), any(), any(), any());
+        .updateDocumentContents(
+            any(OperationContext.class),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(SearchIndexMode.class));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -122,7 +139,14 @@ public class UpdateDocumentContentsResolverTest {
     when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     doThrow(new ServiceAuthorizationException("denied"))
         .when(mockService)
-        .updateDocumentContents(any(OperationContext.class), any(), any(), any(), any(), any());
+        .updateDocumentContents(
+            any(OperationContext.class),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(SearchIndexMode.class));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -150,6 +174,7 @@ public class UpdateDocumentContentsResolverTest {
             any(),
             eq(null),
             eq(java.util.Collections.singletonList("FAQ")),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentContentsResolverTest.java
@@ -65,7 +65,7 @@ public class UpdateDocumentContentsResolverTest {
             eq(null),
             eq(null),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -89,7 +89,7 @@ public class UpdateDocumentContentsResolverTest {
             eq("New Title"),
             eq(null),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -127,7 +127,7 @@ public class UpdateDocumentContentsResolverTest {
             any(),
             any(),
             any(),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }
@@ -146,7 +146,7 @@ public class UpdateDocumentContentsResolverTest {
             any(),
             any(),
             any(),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
 
     CompletionException exception =
         expectThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -175,6 +175,6 @@ public class UpdateDocumentContentsResolverTest {
             eq(null),
             eq(java.util.Collections.singletonList("FAQ")),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolverTest.java
@@ -63,7 +63,7 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
             any(),
             any(),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -85,7 +85,7 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
             any(),
             eq(null),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
         .updateDocumentRelatedEntities(
-            any(OperationContext.class), any(), any(), any(), any(), any(SearchIndexMode.class));
+            any(OperationContext.class), any(), any(), any(), any(), eq(SearchIndexMode.SYNC));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentRelatedEntitiesResolverTest.java
@@ -11,6 +11,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentRelatedEntitiesInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Arrays;
@@ -61,7 +62,8 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             any(),
             any(),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -78,7 +80,12 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
 
     verify(mockService, times(1))
         .updateDocumentRelatedEntities(
-            any(OperationContext.class), any(), any(), eq(null), any(Urn.class));
+            any(OperationContext.class),
+            any(),
+            any(),
+            eq(null),
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -105,7 +112,8 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
 
     // Verify service was NOT called
     verify(mockService, times(0))
-        .updateDocumentRelatedEntities(any(OperationContext.class), any(), any(), any(), any());
+        .updateDocumentRelatedEntities(
+            any(OperationContext.class), any(), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -116,7 +124,8 @@ public class UpdateDocumentRelatedEntitiesResolverTest {
 
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .updateDocumentRelatedEntities(any(OperationContext.class), any(), any(), any(), any());
+        .updateDocumentRelatedEntities(
+            any(OperationContext.class), any(), any(), any(), any(), any(SearchIndexMode.class));
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolverTest.java
@@ -68,7 +68,7 @@ public class UpdateDocumentSettingsResolverTest {
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(expectedSettings),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -99,7 +99,7 @@ public class UpdateDocumentSettingsResolverTest {
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(expectedSettings),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -143,7 +143,7 @@ public class UpdateDocumentSettingsResolverTest {
             any(Urn.class),
             any(),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSettingsResolverTest.java
@@ -11,6 +11,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentSettingsInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.concurrent.CompletionException;
@@ -66,7 +67,8 @@ public class UpdateDocumentSettingsResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(expectedSettings),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -96,7 +98,8 @@ public class UpdateDocumentSettingsResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(expectedSettings),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -116,7 +119,8 @@ public class UpdateDocumentSettingsResolverTest {
 
     // Verify service was NOT called
     verify(mockService, times(0))
-        .updateDocumentSettings(any(OperationContext.class), any(), any(), any());
+        .updateDocumentSettings(
+            any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -134,7 +138,12 @@ public class UpdateDocumentSettingsResolverTest {
     // Make service throw exception
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .updateDocumentSettings(any(OperationContext.class), any(Urn.class), any(), any(Urn.class));
+        .updateDocumentSettings(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(),
+            any(Urn.class),
+            any(SearchIndexMode.class));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolverTest.java
@@ -63,7 +63,7 @@ public class UpdateDocumentStatusResolverTest {
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(com.linkedin.knowledge.DocumentState.PUBLISHED),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class UpdateDocumentStatusResolverTest {
             any(Urn.class),
             any(),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentStatusResolverTest.java
@@ -12,6 +12,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.DocumentState;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentStatusInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.concurrent.CompletionException;
@@ -61,7 +62,8 @@ public class UpdateDocumentStatusResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_ARTICLE_URN)),
             eq(com.linkedin.knowledge.DocumentState.PUBLISHED),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -81,7 +83,8 @@ public class UpdateDocumentStatusResolverTest {
 
     // Verify service was NOT called
     verify(mockService, times(0))
-        .updateDocumentStatus(any(OperationContext.class), any(), any(), any());
+        .updateDocumentStatus(
+            any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -99,7 +102,12 @@ public class UpdateDocumentStatusResolverTest {
     // Make service throw exception
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
-        .updateDocumentStatus(any(OperationContext.class), any(Urn.class), any(), any(Urn.class));
+        .updateDocumentStatus(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(),
+            any(Urn.class),
+            any(SearchIndexMode.class));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolverTest.java
@@ -11,6 +11,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.UpdateDocumentSubTypeInput;
 import com.linkedin.metadata.service.DocumentService;
+import com.linkedin.metadata.service.SearchIndexMode;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.concurrent.CompletionException;
@@ -61,7 +62,8 @@ public class UpdateDocumentSubTypeResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(TEST_SUB_TYPE),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 
   @Test
@@ -81,7 +83,8 @@ public class UpdateDocumentSubTypeResolverTest {
 
     // Verify service was NOT called
     verify(mockService, times(0))
-        .updateDocumentSubType(any(OperationContext.class), any(), any(), any());
+        .updateDocumentSubType(
+            any(OperationContext.class), any(), any(), any(), any(SearchIndexMode.class));
   }
 
   @Test
@@ -100,7 +103,11 @@ public class UpdateDocumentSubTypeResolverTest {
     doThrow(new RuntimeException("Service error"))
         .when(mockService)
         .updateDocumentSubType(
-            any(OperationContext.class), any(Urn.class), any(String.class), any(Urn.class));
+            any(OperationContext.class),
+            any(Urn.class),
+            any(String.class),
+            any(Urn.class),
+            any(SearchIndexMode.class));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -130,6 +137,7 @@ public class UpdateDocumentSubTypeResolverTest {
             any(OperationContext.class),
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(customType),
-            any(Urn.class));
+            any(Urn.class),
+            any(SearchIndexMode.class));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/UpdateDocumentSubTypeResolverTest.java
@@ -63,7 +63,7 @@ public class UpdateDocumentSubTypeResolverTest {
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(TEST_SUB_TYPE),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class UpdateDocumentSubTypeResolverTest {
             any(Urn.class),
             any(String.class),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
 
     // Execute and expect exception
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -138,6 +138,6 @@ public class UpdateDocumentSubTypeResolverTest {
             eq(UrnUtils.getUrn(TEST_DOCUMENT_URN)),
             eq(customType),
             any(Urn.class),
-            any(SearchIndexMode.class));
+            eq(SearchIndexMode.SYNC));
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/DocumentService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/DocumentService.java
@@ -67,6 +67,31 @@ public class DocumentService {
   }
 
   /**
+   * Builds an UPSERT proposal honoring the caller's {@link SearchIndexMode}. SYNC proposals are
+   * marked so GMS updates the indices in the request path and the MAE consumer skips them; ASYNC
+   * proposals are indexed by the consumer. Every proposal a mutation emits must use the same mode —
+   * splitting one document's writes across the two index writers is exactly the out-of-order stale
+   * state {@link SearchIndexMode} warns about.
+   */
+  @Nonnull
+  private static MetadataChangeProposal buildProposal(
+      @Nonnull Urn urn,
+      @Nonnull String aspectName,
+      @Nonnull com.linkedin.data.template.RecordTemplate aspect,
+      @Nonnull SearchIndexMode indexMode) {
+    if (indexMode == SearchIndexMode.SYNC) {
+      return AspectUtils.buildSynchronousMetadataChangeProposal(urn, aspectName, aspect);
+    }
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(urn);
+    proposal.setEntityType(urn.getEntityType());
+    proposal.setAspectName(aspectName);
+    proposal.setChangeType(ChangeType.UPSERT);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(aspect));
+    return proposal;
+  }
+
+  /**
    * Creates a new document.
    *
    * @param opContext the operation context
@@ -82,6 +107,7 @@ public class DocumentService {
    * @param settings optional document settings (defaults to showInGlobalContext=true if not
    *     provided)
    * @param actorUrn the URN of the user creating the document
+   * @param indexMode how the write is applied to the search index (one mode per document)
    * @return the URN of the created document
    * @throws Exception if creation fails
    */
@@ -98,7 +124,8 @@ public class DocumentService {
       @Nullable List<Urn> relatedAssetUrns,
       @Nullable List<Urn> relatedDocumentUrns,
       @Nullable com.linkedin.knowledge.DocumentSettings settings,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
     return createDocument(
         opContext,
@@ -113,7 +140,8 @@ public class DocumentService {
         relatedDocumentUrns,
         settings,
         null,
-        actorUrn);
+        actorUrn,
+        indexMode);
   }
 
   /**
@@ -135,7 +163,8 @@ public class DocumentService {
       @Nullable List<Urn> relatedDocumentUrns,
       @Nullable com.linkedin.knowledge.DocumentSettings settings,
       @Nullable List<Owner> owners,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     // Generate document URN
@@ -223,10 +252,9 @@ public class DocumentService {
       documentInfo.setRelatedDocuments(documentsArray, SetMode.IGNORE_NULL);
     }
 
-    // Create synchronous MCP for document info with all relationships embedded
+    // Create MCP for document info with all relationships embedded
     final MetadataChangeProposal infoMcp =
-        AspectUtils.buildSynchronousMetadataChangeProposal(
-            documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, documentInfo);
+        buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, documentInfo, indexMode);
 
     // Prepare list of MCPs to ingest
     final List<MetadataChangeProposal> mcps = new java.util.ArrayList<>();
@@ -238,8 +266,7 @@ public class DocumentService {
       subTypesAspect.setTypeNames(new com.linkedin.data.template.StringArray(subTypes));
 
       final MetadataChangeProposal subTypesMcp =
-          AspectUtils.buildSynchronousMetadataChangeProposal(
-              documentUrn, Constants.SUB_TYPES_ASPECT_NAME, subTypesAspect);
+          buildProposal(documentUrn, Constants.SUB_TYPES_ASPECT_NAME, subTypesAspect, indexMode);
       mcps.add(subTypesMcp);
     }
 
@@ -256,8 +283,8 @@ public class DocumentService {
     finalSettings.setLastModified(settingsAuditStamp, SetMode.IGNORE_NULL);
 
     final MetadataChangeProposal settingsMcp =
-        AspectUtils.buildSynchronousMetadataChangeProposal(
-            documentUrn, Constants.DOCUMENT_SETTINGS_ASPECT_NAME, finalSettings);
+        buildProposal(
+            documentUrn, Constants.DOCUMENT_SETTINGS_ASPECT_NAME, finalSettings, indexMode);
     mcps.add(settingsMcp);
 
     final List<Owner> initialOwners;
@@ -270,8 +297,11 @@ public class DocumentService {
       initialOwners = Collections.singletonList(creatorOwner);
     }
     final MetadataChangeProposal ownershipMcp =
-        AspectUtils.buildSynchronousMetadataChangeProposal(
-            documentUrn, Constants.OWNERSHIP_ASPECT_NAME, buildOwnership(initialOwners, actorUrn));
+        buildProposal(
+            documentUrn,
+            Constants.OWNERSHIP_ASPECT_NAME,
+            buildOwnership(initialOwners, actorUrn),
+            indexMode);
     mcps.add(ownershipMcp);
 
     // Ingest the document with all aspects
@@ -332,9 +362,11 @@ public class DocumentService {
       @Nullable String text,
       @Nullable String title,
       @Nullable List<String> subTypes,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
-    updateDocumentContents(opContext, documentUrn, text, null, title, subTypes, actorUrn);
+    updateDocumentContents(
+        opContext, documentUrn, text, null, title, subTypes, actorUrn, indexMode);
   }
 
   /**
@@ -355,7 +387,8 @@ public class DocumentService {
       @Nullable String semanticText,
       @Nullable String title,
       @Nullable List<String> subTypes,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -390,39 +423,26 @@ public class DocumentService {
     final List<MetadataChangeProposal> mcps = new java.util.ArrayList<>();
 
     // Ingest updated info
-    final MetadataChangeProposal infoMcp = new MetadataChangeProposal();
-    infoMcp.setEntityUrn(documentUrn);
-    infoMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    infoMcp.setAspectName(Constants.DOCUMENT_INFO_ASPECT_NAME);
-    infoMcp.setChangeType(ChangeType.UPSERT);
-    infoMcp.setAspect(GenericRecordUtils.serializeAspect(existingInfo));
-    mcps.add(infoMcp);
+    mcps.add(
+        buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, existingInfo, indexMode));
 
     // semanticText is a standalone aspect. Only write it when the caller opts in so ordinary
     // document body/title mutations leave an existing curated embedding source untouched.
     if (semanticText != null) {
-      final MetadataChangeProposal semanticTextMcp = new MetadataChangeProposal();
-      semanticTextMcp.setEntityUrn(documentUrn);
-      semanticTextMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-      semanticTextMcp.setAspectName(Constants.SEMANTIC_TEXT_ASPECT_NAME);
-      semanticTextMcp.setChangeType(ChangeType.UPSERT);
-      semanticTextMcp.setAspect(
-          GenericRecordUtils.serializeAspect(new SemanticText().setText(semanticText)));
-      mcps.add(semanticTextMcp);
+      mcps.add(
+          buildProposal(
+              documentUrn,
+              Constants.SEMANTIC_TEXT_ASPECT_NAME,
+              new SemanticText().setText(semanticText),
+              indexMode));
     }
 
     // Update subTypes if provided
     if (subTypes != null && !subTypes.isEmpty()) {
       final com.linkedin.common.SubTypes subTypesAspect = new com.linkedin.common.SubTypes();
       subTypesAspect.setTypeNames(new com.linkedin.data.template.StringArray(subTypes));
-
-      final MetadataChangeProposal subTypesMcp = new MetadataChangeProposal();
-      subTypesMcp.setEntityUrn(documentUrn);
-      subTypesMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-      subTypesMcp.setAspectName(Constants.SUB_TYPES_ASPECT_NAME);
-      subTypesMcp.setChangeType(ChangeType.UPSERT);
-      subTypesMcp.setAspect(GenericRecordUtils.serializeAspect(subTypesAspect));
-      mcps.add(subTypesMcp);
+      mcps.add(
+          buildProposal(documentUrn, Constants.SUB_TYPES_ASPECT_NAME, subTypesAspect, indexMode));
     }
 
     // Batch ingest all proposals
@@ -447,7 +467,8 @@ public class DocumentService {
       @Nonnull Urn documentUrn,
       @Nullable List<Urn> relatedAssetUrns,
       @Nullable List<Urn> relatedDocumentUrns,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -498,12 +519,8 @@ public class DocumentService {
     info.setLastModified(lastModified);
 
     // Ingest updated info
-    final MetadataChangeProposal mcp = new MetadataChangeProposal();
-    mcp.setEntityUrn(documentUrn);
-    mcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    mcp.setAspectName(Constants.DOCUMENT_INFO_ASPECT_NAME);
-    mcp.setChangeType(ChangeType.UPSERT);
-    mcp.setAspect(GenericRecordUtils.serializeAspect(info));
+    final MetadataChangeProposal mcp =
+        buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info, indexMode);
 
     entityClient.ingestProposal(opContext, mcp, false);
 
@@ -522,7 +539,8 @@ public class DocumentService {
       @Nonnull OperationContext opContext,
       @Nonnull Urn documentUrn,
       @Nullable Urn newParentUrn,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -574,10 +592,9 @@ public class DocumentService {
     lastModified.setActor(actorUrn);
     info.setLastModified(lastModified);
 
-    // Ingest updated info with synchronous MCP
+    // Ingest updated info
     final MetadataChangeProposal mcp =
-        AspectUtils.buildSynchronousMetadataChangeProposal(
-            documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info);
+        buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info, indexMode);
 
     entityClient.ingestProposal(opContext, mcp, false);
 
@@ -597,7 +614,8 @@ public class DocumentService {
       @Nonnull OperationContext opContext,
       @Nonnull Urn documentUrn,
       @Nonnull com.linkedin.knowledge.DocumentState newState,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -628,12 +646,8 @@ public class DocumentService {
     info.setLastModified(lastModified);
 
     // Ingest updated info
-    final MetadataChangeProposal mcp = new MetadataChangeProposal();
-    mcp.setEntityUrn(documentUrn);
-    mcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    mcp.setAspectName(Constants.DOCUMENT_INFO_ASPECT_NAME);
-    mcp.setChangeType(ChangeType.UPSERT);
-    mcp.setAspect(GenericRecordUtils.serializeAspect(info));
+    final MetadataChangeProposal mcp =
+        buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info, indexMode);
 
     entityClient.ingestProposal(opContext, mcp, false);
 
@@ -653,7 +667,8 @@ public class DocumentService {
       @Nonnull OperationContext opContext,
       @Nonnull Urn documentUrn,
       @Nonnull com.linkedin.knowledge.DocumentSettings settings,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -671,12 +686,8 @@ public class DocumentService {
     settings.setLastModified(lastModified, SetMode.IGNORE_NULL);
 
     // Create metadata change proposal for DocumentSettings
-    final MetadataChangeProposal settingsMcp = new MetadataChangeProposal();
-    settingsMcp.setEntityUrn(documentUrn);
-    settingsMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    settingsMcp.setAspectName(Constants.DOCUMENT_SETTINGS_ASPECT_NAME);
-    settingsMcp.setChangeType(ChangeType.UPSERT);
-    settingsMcp.setAspect(GenericRecordUtils.serializeAspect(settings));
+    final MetadataChangeProposal settingsMcp =
+        buildProposal(documentUrn, Constants.DOCUMENT_SETTINGS_ASPECT_NAME, settings, indexMode);
 
     // Also update lastModified timestamp in DocumentInfo
     final DocumentInfo info = getDocumentInfoWithoutAuthorization(opContext, documentUrn);
@@ -686,12 +697,8 @@ public class DocumentService {
       infoLastModified.setActor(actorUrn);
       info.setLastModified(infoLastModified);
 
-      final MetadataChangeProposal infoMcp = new MetadataChangeProposal();
-      infoMcp.setEntityUrn(documentUrn);
-      infoMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-      infoMcp.setAspectName(Constants.DOCUMENT_INFO_ASPECT_NAME);
-      infoMcp.setChangeType(ChangeType.UPSERT);
-      infoMcp.setAspect(GenericRecordUtils.serializeAspect(info));
+      final MetadataChangeProposal infoMcp =
+          buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info, indexMode);
 
       // Batch ingest both proposals
       entityClient.batchIngestProposals(
@@ -717,7 +724,8 @@ public class DocumentService {
       @Nonnull OperationContext opContext,
       @Nonnull Urn documentUrn,
       @Nullable String subType,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
@@ -739,12 +747,8 @@ public class DocumentService {
     }
 
     // Create metadata change proposal for SubTypes
-    final MetadataChangeProposal subTypesMcp = new MetadataChangeProposal();
-    subTypesMcp.setEntityUrn(documentUrn);
-    subTypesMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    subTypesMcp.setAspectName(Constants.SUB_TYPES_ASPECT_NAME);
-    subTypesMcp.setChangeType(ChangeType.UPSERT);
-    subTypesMcp.setAspect(GenericRecordUtils.serializeAspect(subTypesAspect));
+    final MetadataChangeProposal subTypesMcp =
+        buildProposal(documentUrn, Constants.SUB_TYPES_ASPECT_NAME, subTypesAspect, indexMode);
 
     // Also update lastModified timestamp in DocumentInfo
     final DocumentInfo info = getDocumentInfoWithoutAuthorization(opContext, documentUrn);
@@ -754,12 +758,8 @@ public class DocumentService {
       lastModified.setActor(actorUrn);
       info.setLastModified(lastModified);
 
-      final MetadataChangeProposal infoMcp = new MetadataChangeProposal();
-      infoMcp.setEntityUrn(documentUrn);
-      infoMcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-      infoMcp.setAspectName(Constants.DOCUMENT_INFO_ASPECT_NAME);
-      infoMcp.setChangeType(ChangeType.UPSERT);
-      infoMcp.setAspect(GenericRecordUtils.serializeAspect(info));
+      final MetadataChangeProposal infoMcp =
+          buildProposal(documentUrn, Constants.DOCUMENT_INFO_ASPECT_NAME, info, indexMode);
 
       // Batch ingest both proposals
       entityClient.batchIngestProposals(
@@ -779,7 +779,10 @@ public class DocumentService {
    * @param documentUrn the document URN to soft delete
    * @throws Exception if deletion fails
    */
-  public void deleteDocument(@Nonnull OperationContext opContext, @Nonnull Urn documentUrn)
+  public void deleteDocument(
+      @Nonnull OperationContext opContext,
+      @Nonnull Urn documentUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanDelete(opContext, documentUrn);
@@ -790,13 +793,12 @@ public class DocumentService {
           String.format("Document with URN %s does not exist", documentUrn));
     }
 
-    // Soft delete by setting Status aspect removed = true with synchronous MCP
+    // Soft delete by setting Status aspect removed = true
     final com.linkedin.common.Status status = new com.linkedin.common.Status();
     status.setRemoved(true);
 
     final MetadataChangeProposal statusProposal =
-        AspectUtils.buildSynchronousMetadataChangeProposal(
-            documentUrn, Constants.STATUS_ASPECT_NAME, status);
+        buildProposal(documentUrn, Constants.STATUS_ASPECT_NAME, status, indexMode);
 
     entityClient.ingestProposal(opContext, statusProposal, false);
     log.debug("Soft deleted document {}", documentUrn);
@@ -815,18 +817,19 @@ public class DocumentService {
       @Nonnull OperationContext opContext,
       @Nonnull Urn documentUrn,
       @Nonnull List<Owner> owners,
-      @Nonnull Urn actorUrn)
+      @Nonnull Urn actorUrn,
+      @Nonnull SearchIndexMode indexMode)
       throws Exception {
 
     DocumentAuthorizationUtils.assertCanUpdate(opContext, documentUrn);
 
     // Create MCP for ownership
-    final MetadataChangeProposal mcp = new MetadataChangeProposal();
-    mcp.setEntityUrn(documentUrn);
-    mcp.setEntityType(Constants.DOCUMENT_ENTITY_NAME);
-    mcp.setAspectName(Constants.OWNERSHIP_ASPECT_NAME);
-    mcp.setChangeType(ChangeType.UPSERT);
-    mcp.setAspect(GenericRecordUtils.serializeAspect(buildOwnership(owners, actorUrn)));
+    final MetadataChangeProposal mcp =
+        buildProposal(
+            documentUrn,
+            Constants.OWNERSHIP_ASPECT_NAME,
+            buildOwnership(owners, actorUrn),
+            indexMode);
 
     entityClient.ingestProposal(opContext, mcp, false);
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/DocumentService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/DocumentService.java
@@ -39,6 +39,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nonnull;
@@ -79,6 +80,9 @@ public class DocumentService {
       @Nonnull String aspectName,
       @Nonnull com.linkedin.data.template.RecordTemplate aspect,
       @Nonnull SearchIndexMode indexMode) {
+    // Fail fast rather than silently routing a null mode down the ASYNC path — a caller that
+    // didn't choose a mode must not accidentally split the document across two index writers.
+    Objects.requireNonNull(indexMode, "indexMode is required");
     if (indexMode == SearchIndexMode.SYNC) {
       return AspectUtils.buildSynchronousMetadataChangeProposal(urn, aspectName, aspect);
     }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/SearchIndexMode.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/SearchIndexMode.java
@@ -1,0 +1,23 @@
+package com.linkedin.metadata.service;
+
+/**
+ * How a service-layer write should be applied to the search index.
+ *
+ * <p>{@link #SYNC} marks the write's proposals so that GMS updates the search/graph indices
+ * synchronously in the request path and the MAE consumer skips them. Interactive callers (GraphQL
+ * resolvers backing the UI) should use this so users read their own writes.
+ *
+ * <p>{@link #ASYNC} leaves indexing to the MAE consumer: eventually consistent, but at-least-once
+ * (the change log is replayed from Kafka on consumer failure). Programmatic/bulk callers should
+ * prefer this.
+ *
+ * <p><b>Pick one mode per entity.</b> The two modes are indexed by different processes on
+ * independent bulk-flush timers, so interleaving SYNC and ASYNC writes to the same entity can apply
+ * out of order and leave the index with stale values until the next write to that aspect.
+ */
+public enum SearchIndexMode {
+  /** Index synchronously in GMS; the MAE consumer skips the event. */
+  SYNC,
+  /** Leave indexing to the MAE consumer. */
+  ASYNC
+}

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/DocumentServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/DocumentServiceTest.java
@@ -72,7 +72,8 @@ public class DocumentServiceTest {
                 null,
                 null,
                 null,
-                TEST_USER_URN));
+                TEST_USER_URN,
+                SearchIndexMode.SYNC));
     verifyNoInteractions(mockClient);
   }
 
@@ -104,7 +105,8 @@ public class DocumentServiceTest {
           null,
           null,
           List.of(owner),
-          TEST_USER_URN);
+          TEST_USER_URN,
+          SearchIndexMode.SYNC);
 
       authUtilMock.verify(
           () ->
@@ -154,7 +156,13 @@ public class DocumentServiceTest {
         ServiceAuthorizationException.class,
         () ->
             service.updateDocumentContents(
-                USER_OP_CONTEXT, TEST_DOCUMENT_URN, "Updated content", null, null, TEST_USER_URN));
+                USER_OP_CONTEXT,
+                TEST_DOCUMENT_URN,
+                "Updated content",
+                null,
+                null,
+                TEST_USER_URN,
+                SearchIndexMode.SYNC));
     verifyNoInteractions(mockClient);
   }
 
@@ -165,7 +173,7 @@ public class DocumentServiceTest {
 
     Assert.assertThrows(
         ServiceAuthorizationException.class,
-        () -> service.deleteDocument(USER_OP_CONTEXT, TEST_DOCUMENT_URN));
+        () -> service.deleteDocument(USER_OP_CONTEXT, TEST_DOCUMENT_URN, SearchIndexMode.SYNC));
     verifyNoInteractions(mockClient);
   }
 
@@ -190,7 +198,8 @@ public class DocumentServiceTest {
             null, // no related assets
             null, // no related documents
             null, // showInGlobalContext defaults to true
-            TEST_USER_URN);
+            TEST_USER_URN,
+            SearchIndexMode.SYNC);
 
     // Verify the URN was created
     Assert.assertNotNull(documentUrn);
@@ -222,7 +231,8 @@ public class DocumentServiceTest {
             Arrays.asList(TEST_ASSET_URN),
             Arrays.asList(TEST_DOCUMENT_URN),
             null, // showInGlobalContext defaults to true
-            TEST_USER_URN);
+            TEST_USER_URN,
+            SearchIndexMode.SYNC);
 
     // Verify the URN was created with custom ID
     Assert.assertNotNull(documentUrn);
@@ -254,7 +264,8 @@ public class DocumentServiceTest {
           null,
           null,
           null, // showInGlobalContext
-          TEST_USER_URN);
+          TEST_USER_URN,
+          SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("already exists"));
@@ -304,7 +315,13 @@ public class DocumentServiceTest {
 
     // Test updating document contents
     service.updateDocumentContents(
-        opContext, TEST_DOCUMENT_URN, "New content", "Updated Title", null, TEST_USER_URN);
+        opContext,
+        TEST_DOCUMENT_URN,
+        "New content",
+        "Updated Title",
+        null,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify batch ingest was called
     verify(mockClient, times(1))
@@ -317,7 +334,13 @@ public class DocumentServiceTest {
     final DocumentService service = new DocumentService(mockClient);
 
     service.updateDocumentContents(
-        opContext, TEST_DOCUMENT_URN, "New content", null, null, TEST_USER_URN);
+        opContext,
+        TEST_DOCUMENT_URN,
+        "New content",
+        null,
+        null,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<List<MetadataChangeProposal>> proposalsCaptor =
@@ -355,7 +378,8 @@ public class DocumentServiceTest {
         "User-owned content",
         null,
         null,
-        TEST_USER_URN);
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<List<MetadataChangeProposal>> proposalsCaptor =
@@ -389,7 +413,7 @@ public class DocumentServiceTest {
     // Test updating a non-existent document
     try {
       service.updateDocumentContents(
-          opContext, TEST_DOCUMENT_URN, "Content", null, null, TEST_USER_URN);
+          opContext, TEST_DOCUMENT_URN, "Content", null, null, TEST_USER_URN, SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("does not exist"));
@@ -408,7 +432,8 @@ public class DocumentServiceTest {
         "New content",
         "Updated Title",
         Arrays.asList("FAQ"),
-        TEST_USER_URN);
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify batch ingest was called with 2 proposals (info + subTypes)
     verify(mockClient, times(1))
@@ -422,7 +447,12 @@ public class DocumentServiceTest {
 
     // Test updating related entities
     service.updateDocumentRelatedEntities(
-        opContext, TEST_DOCUMENT_URN, Arrays.asList(TEST_ASSET_URN), null, TEST_USER_URN);
+        opContext,
+        TEST_DOCUMENT_URN,
+        Arrays.asList(TEST_ASSET_URN),
+        null,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify ingest was called
     verify(mockClient, times(1)).ingestProposal(any(OperationContext.class), any(), eq(false));
@@ -436,7 +466,8 @@ public class DocumentServiceTest {
     final DocumentService service = new DocumentService(mockClient);
 
     // Test moving document to new parent
-    service.moveDocument(opContext, TEST_DOCUMENT_URN, TEST_PARENT_URN, TEST_USER_URN);
+    service.moveDocument(
+        opContext, TEST_DOCUMENT_URN, TEST_PARENT_URN, TEST_USER_URN, SearchIndexMode.SYNC);
 
     // Verify ingest was called
     verify(mockClient, times(1)).ingestProposal(any(OperationContext.class), any(), eq(false));
@@ -450,7 +481,7 @@ public class DocumentServiceTest {
     final DocumentService service = new DocumentService(mockClient);
 
     // Test moving document to root (no parent)
-    service.moveDocument(opContext, TEST_DOCUMENT_URN, null, TEST_USER_URN);
+    service.moveDocument(opContext, TEST_DOCUMENT_URN, null, TEST_USER_URN, SearchIndexMode.SYNC);
 
     // Verify ingest was called
     verify(mockClient, times(1)).ingestProposal(any(OperationContext.class), any(), eq(false));
@@ -465,7 +496,8 @@ public class DocumentServiceTest {
 
     // Test moving document to itself (should fail)
     try {
-      service.moveDocument(opContext, TEST_DOCUMENT_URN, TEST_DOCUMENT_URN, TEST_USER_URN);
+      service.moveDocument(
+          opContext, TEST_DOCUMENT_URN, TEST_DOCUMENT_URN, TEST_USER_URN, SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("Cannot move"));
@@ -480,7 +512,7 @@ public class DocumentServiceTest {
     final DocumentService service = new DocumentService(mockClient);
 
     // Test soft deleting a document
-    service.deleteDocument(opContext, TEST_DOCUMENT_URN);
+    service.deleteDocument(opContext, TEST_DOCUMENT_URN, SearchIndexMode.SYNC);
 
     // Verify ingestProposal was called to set Status aspect with removed=true
     verify(mockClient, times(1))
@@ -496,7 +528,7 @@ public class DocumentServiceTest {
 
     // Test deleting a non-existent document
     try {
-      service.deleteDocument(opContext, TEST_DOCUMENT_URN);
+      service.deleteDocument(opContext, TEST_DOCUMENT_URN, SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("does not exist"));
@@ -634,7 +666,8 @@ public class DocumentServiceTest {
         opContext,
         TEST_DOCUMENT_URN,
         com.linkedin.knowledge.DocumentState.PUBLISHED,
-        TEST_USER_URN);
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify ingest was called to update the info
     verify(mockClient, times(1))
@@ -654,7 +687,8 @@ public class DocumentServiceTest {
           opContext,
           TEST_DOCUMENT_URN,
           com.linkedin.knowledge.DocumentState.PUBLISHED,
-          TEST_USER_URN);
+          TEST_USER_URN,
+          SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("does not exist"));
@@ -679,7 +713,8 @@ public class DocumentServiceTest {
     final List<Owner> owners = Arrays.asList(owner1, owner2);
 
     // Test setting ownership
-    service.setDocumentOwnership(opContext, TEST_DOCUMENT_URN, owners, TEST_USER_URN);
+    service.setDocumentOwnership(
+        opContext, TEST_DOCUMENT_URN, owners, TEST_USER_URN, SearchIndexMode.SYNC);
 
     // Verify that ingestProposal was called once with ownership aspect
     verify(mockClient, times(1))
@@ -693,7 +728,11 @@ public class DocumentServiceTest {
 
     // Test setting ownership with empty list (should still work)
     service.setDocumentOwnership(
-        opContext, TEST_DOCUMENT_URN, java.util.Collections.emptyList(), TEST_USER_URN);
+        opContext,
+        TEST_DOCUMENT_URN,
+        java.util.Collections.emptyList(),
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify that ingestProposal was called once
     verify(mockClient, times(1))
@@ -706,7 +745,8 @@ public class DocumentServiceTest {
     final DocumentService service = new DocumentService(mockClient);
 
     // Test updating document subType
-    service.updateDocumentSubType(opContext, TEST_DOCUMENT_URN, "faq", TEST_USER_URN);
+    service.updateDocumentSubType(
+        opContext, TEST_DOCUMENT_URN, "faq", TEST_USER_URN, SearchIndexMode.SYNC);
 
     // Verify batch ingest was called (subTypes + info with updated lastModified)
     verify(mockClient, times(1))
@@ -722,7 +762,8 @@ public class DocumentServiceTest {
 
     // Test updating subType for a non-existent document
     try {
-      service.updateDocumentSubType(opContext, TEST_DOCUMENT_URN, "faq", TEST_USER_URN);
+      service.updateDocumentSubType(
+          opContext, TEST_DOCUMENT_URN, "faq", TEST_USER_URN, SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("does not exist"));
@@ -829,7 +870,7 @@ public class DocumentServiceTest {
     // Test moving doc1 to have parent doc2 (which would create a circular reference doc1 -> doc2 ->
     // doc1)
     try {
-      service.moveDocument(opContext, doc1Urn, doc2Urn, TEST_USER_URN);
+      service.moveDocument(opContext, doc1Urn, doc2Urn, TEST_USER_URN, SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException for circular reference");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("circular"));
@@ -884,7 +925,8 @@ public class DocumentServiceTest {
             null, // no related documents
             new com.linkedin.knowledge.DocumentSettings()
                 .setShowInGlobalContext(false), // showInGlobalContext = false
-            TEST_USER_URN);
+            TEST_USER_URN,
+            SearchIndexMode.SYNC);
 
     // Verify the URN was created
     Assert.assertNotNull(documentUrn);
@@ -916,7 +958,8 @@ public class DocumentServiceTest {
             null, // no related assets
             null, // no related documents
             null, // showInGlobalContext defaults to true
-            TEST_USER_URN);
+            TEST_USER_URN,
+            SearchIndexMode.SYNC);
 
     // Verify the URN was created
     Assert.assertNotNull(documentUrn);
@@ -937,7 +980,8 @@ public class DocumentServiceTest {
         opContext,
         TEST_DOCUMENT_URN,
         new com.linkedin.knowledge.DocumentSettings().setShowInGlobalContext(false),
-        TEST_USER_URN);
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
 
     // Verify batch ingest was called (settings + documentInfo for lastModified)
     verify(mockClient, times(1))
@@ -957,10 +1001,103 @@ public class DocumentServiceTest {
           opContext,
           TEST_DOCUMENT_URN,
           new com.linkedin.knowledge.DocumentSettings().setShowInGlobalContext(true),
-          TEST_USER_URN);
+          TEST_USER_URN,
+          SearchIndexMode.SYNC);
       Assert.fail("Expected IllegalArgumentException");
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains("does not exist"));
     }
+  }
+
+  // SYNC and ASYNC must apply uniformly to every proposal a mutation emits. Splitting one
+  // document's writes across the two index writers (GMS pre-process vs MAE consumer) lets a
+  // stale create-time search document overwrite later updates (e.g. relatedAssets, status).
+  @Test
+  public void testSyncIndexModeStampsAllProposals() throws Exception {
+    final SystemEntityClient mockClient = mock(SystemEntityClient.class);
+    when(mockClient.exists(any(OperationContext.class), any(Urn.class))).thenReturn(false);
+    final DocumentService service = new DocumentService(mockClient);
+
+    service.createDocument(
+        opContext,
+        "sync-mode-document",
+        List.of("tutorial"),
+        "Title",
+        null,
+        null,
+        "Content",
+        null,
+        null,
+        null,
+        null,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<List<MetadataChangeProposal>> proposalsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    verify(mockClient).batchIngestProposals(eq(opContext), proposalsCaptor.capture(), eq(false));
+    for (MetadataChangeProposal proposal : proposalsCaptor.getValue()) {
+      Assert.assertNotNull(
+          proposal.getSystemMetadata(), proposal.getAspectName() + " missing system metadata");
+      Assert.assertEquals(
+          proposal.getSystemMetadata().getProperties().get(Constants.APP_SOURCE),
+          Constants.UI_SOURCE,
+          proposal.getAspectName() + " not marked for synchronous index update");
+    }
+  }
+
+  @Test
+  public void testSyncIndexModeStampsUpdateProposals() throws Exception {
+    final SystemEntityClient mockClient = createMockEntityClientWithInfo();
+    final DocumentService service = new DocumentService(mockClient);
+
+    service.updateDocumentStatus(
+        opContext,
+        TEST_DOCUMENT_URN,
+        com.linkedin.knowledge.DocumentState.PUBLISHED,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
+    service.updateDocumentRelatedEntities(
+        opContext,
+        TEST_DOCUMENT_URN,
+        List.of(TEST_ASSET_URN),
+        null,
+        TEST_USER_URN,
+        SearchIndexMode.SYNC);
+
+    final ArgumentCaptor<MetadataChangeProposal> proposalCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient, times(2)).ingestProposal(eq(opContext), proposalCaptor.capture(), eq(false));
+    for (MetadataChangeProposal proposal : proposalCaptor.getAllValues()) {
+      Assert.assertNotNull(proposal.getSystemMetadata());
+      Assert.assertEquals(
+          proposal.getSystemMetadata().getProperties().get(Constants.APP_SOURCE),
+          Constants.UI_SOURCE);
+    }
+  }
+
+  @Test
+  public void testAsyncIndexModeLeavesProposalsUnstamped() throws Exception {
+    final SystemEntityClient mockClient = createMockEntityClientWithInfo();
+    when(mockClient.exists(any(OperationContext.class), eq(TEST_DOCUMENT_URN))).thenReturn(true);
+    final DocumentService service = new DocumentService(mockClient);
+
+    service.updateDocumentStatus(
+        opContext,
+        TEST_DOCUMENT_URN,
+        com.linkedin.knowledge.DocumentState.PUBLISHED,
+        TEST_USER_URN,
+        SearchIndexMode.ASYNC);
+
+    final ArgumentCaptor<MetadataChangeProposal> proposalCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockClient).ingestProposal(eq(opContext), proposalCaptor.capture(), eq(false));
+    final MetadataChangeProposal proposal = proposalCaptor.getValue();
+    Assert.assertTrue(
+        proposal.getSystemMetadata() == null
+            || proposal.getSystemMetadata().getProperties() == null
+            || !Constants.UI_SOURCE.equals(
+                proposal.getSystemMetadata().getProperties().get(Constants.APP_SOURCE)));
   }
 }


### PR DESCRIPTION
## Problem

`test_related_documents_shows_context_only_documents` has been failing on the first attempt of nearly every master CI run. Root cause (reproduced locally at ~35% per iteration, with OpenSearch indexing slowlog evidence): **DocumentService mutations are split across two search-index writers.**

- `createDocument` builds its proposals via `AspectUtils.buildSynchronousMetadataChangeProposal`, which stamps `appSource=ui` → GMS pre-processes the index update in the request path and the MAE consumer skips it.
- `updateDocumentStatus`, `updateDocumentRelatedEntities`, `updateDocumentContents`, `updateDocumentSettings`, `updateDocumentSubType`, and `setDocumentOwnership` emit plain proposals → indexed by the MAE consumer.

Two JVMs flush the same search document on independent 1s bulk timers with last-writer-wins `docAsUpsert` semantics. When GMS's flush (carrying the create-time `documentInfo`: `UNPUBLISHED`, `relatedAssets: []`) lands after the consumer's flush (publish + relatedAssets), the indexed document is silently reverted — permanently, until the next write to that aspect. No error is logged anywhere: no version conflict, no bulk failure. The `relatedDocuments` filter (`relatedAssets = X AND (PUBLISHED OR owned-unpublished)`) then never matches, which is why the smoke test's retry loop always reports `Found: []`.

This is user-reachable, not test-created: creating a document and immediately publishing it or attaching it to an asset from the UI races the same way.

## Fix

The service-layer can't know whether its caller is the UI, so the index-delivery decision moves to the caller: every DocumentService mutation now takes an explicit `SearchIndexMode`:

- `SYNC` — proposals are marked for request-path index processing (the existing `appSource=ui` regime); the MAE consumer skips them.
- `ASYNC` — plain proposals, indexed by the MAE consumer.

The mode is applied uniformly to **every** proposal a mutation emits (including the auto-ownership write in `createDocument` and the secondary `documentInfo` proposals in settings/subType updates), so all writes to a given document take one path and apply in order. The GraphQL resolvers — currently the only callers — pass `SYNC`, matching the regime `MutationUtils` already applies to other interactive edits.

Wire format for `SYNC` is unchanged from what `createDocument` produced before, so no consumer-side changes are needed.

## Testing

- New unit tests assert `SYNC` stamps every emitted proposal (create batch + update paths) and `ASYNC` leaves them unstamped.
- Existing DocumentService and knowledge-resolver test suites pass.
- `smoke-test/tests/knowledge/document_search_filter_test.py::test_related_documents_shows_context_only_documents` is intentionally left unchanged — it is the e2e regression detector for this race and should now pass its first attempt.

## Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes search indexing mode an explicit `DocumentService` contract to eliminate out‑of‑order writes from split index writers. Previously `createDocument` indexed synchronously while other mutations used the MAE consumer; callers now supply a `SearchIndexMode` and each mutation applies it uniformly.

- Adds `SearchIndexMode` (`SYNC`, `ASYNC`) and a helper that builds proposals honoring the mode; `SYNC` stamps match the prior `appSource=ui` wire format, and a null mode fails fast.
- Updates all `DocumentService` mutations to accept the mode and use it for every proposal, including secondary writes (ownership, settings, subTypes).
- GraphQL resolvers pass `SearchIndexMode.SYNC` for read‑your‑writes; tests pin `SYNC` in resolver verifications and assert `SYNC` stamping/`ASYNC` unstamped behavior.

**Migration**
- Update external callers of `DocumentService` to pass a `SearchIndexMode`. Use `SYNC` for interactive requests and `ASYNC` for bulk writes, and do not mix modes for the same document.

<sup>Written for commit 40fb21d91dbad8624519f6a5b55f01969bb86036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

