### PR TITLE
fix(ingest/airbyte): make integration-test ID rewrite reliable and loud

### DIFF
--- a/metadata-ingestion/tests/integration/airbyte/airbyte_test_setup.py
+++ b/metadata-ingestion/tests/integration/airbyte/airbyte_test_setup.py
@@ -208,7 +208,7 @@ def diagnose_airbyte_proxy_issue() -> None:
                 "get",
                 "pods",
                 "-n",
-                "airbyte-abctl",
+                AIRBYTE_NAMESPACE,
             ],
             capture_output=True,
             text=True,
@@ -246,7 +246,7 @@ def check_airbyte_pods_ready() -> bool:
                 "get",
                 "pods",
                 "-n",
-                "airbyte-abctl",
+                AIRBYTE_NAMESPACE,
                 "-o",
                 "json",
             ],
@@ -288,7 +288,7 @@ def get_airbyte_version() -> Optional[str]:
                 "deployment",
                 "airbyte-server",
                 "-n",
-                "airbyte-abctl",
+                AIRBYTE_NAMESPACE,
                 "-o",
                 "jsonpath={.spec.template.spec.containers[0].image}",
             ],
@@ -389,6 +389,22 @@ def _exec_psql(kubeconfig_path: Path, sql: str) -> "subprocess.CompletedProcess[
     )
 
 
+def _row_exists(kubeconfig_path: Path, table_name: str, row_id: str) -> bool:
+    """Whether `table_name` holds a row with `row_id`.
+
+    Best-effort: a failure here is reported as "not present" so the caller falls
+    through to its own retry and its own loud error, rather than masking that
+    error with this one.
+    """
+    try:
+        result = _exec_psql(
+            kubeconfig_path, f"SELECT 1 FROM {table_name} WHERE id = '{row_id}';"
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0 and "(1 row)" in result.stdout
+
+
 def update_all_ids_atomically(
     kubeconfig_path: Path,
     id_updates: Dict[str, Dict[str, Any]],
@@ -455,21 +471,35 @@ def update_airbyte_database_id(
 
     sql = f"UPDATE {table_name} SET id = '{new_id}' WHERE id = '{old_id}';"
     failure = ""
+    # An attempt can commit server-side and still fail locally — kubectl killed at
+    # the timeout, or an UPDATE that matched nothing because a previous attempt
+    # already renamed the row. Once that is possible, the row's end state rather
+    # than the affected-row count decides whether the rewrite landed.
+    may_have_committed = False
 
     for attempt in range(1, _DB_ID_UPDATE_ATTEMPTS + 1):
         try:
             result = _exec_psql(kubeconfig_path, sql)
         except subprocess.TimeoutExpired:
+            may_have_committed = True
             failure = f"kubectl exec timed out after {_PSQL_TIMEOUT_SECONDS}s"
+        except (subprocess.SubprocessError, OSError) as e:
+            failure = f"kubectl exec failed: {e}"
         else:
             # psql exits 0 for an UPDATE that matched no rows, so the affected-row
             # count is the only trustworthy signal that the rewrite landed.
             if result.returncode == 0 and "UPDATE 1" in result.stdout:
                 return
+            if "UPDATE 0" in result.stdout:
+                may_have_committed = True
             failure = (
                 f"exit={result.returncode} stdout={result.stdout.strip()!r} "
                 f"stderr={result.stderr.strip()!r}"
             )
+
+        if may_have_committed and _row_exists(kubeconfig_path, table_name, new_id):
+            print(f"  {table_name} id already holds {new_id}; rewrite landed")
+            return
 
         print(f"  {table_name} id rewrite attempt {attempt} failed: {failure}")
         if attempt < _DB_ID_UPDATE_ATTEMPTS:
@@ -819,7 +849,7 @@ def _restart_airbyte_server(kubeconfig: Path) -> None:
             "restart",
             "deployment/airbyte-abctl-server",
             "-n",
-            "airbyte-abctl",
+            AIRBYTE_NAMESPACE,
         ]
         restart_result = subprocess.run(
             restart_cmd, capture_output=True, text=True, timeout=30
@@ -834,7 +864,7 @@ def _restart_airbyte_server(kubeconfig: Path) -> None:
                 "status",
                 "deployment/airbyte-abctl-server",
                 "-n",
-                "airbyte-abctl",
+                AIRBYTE_NAMESPACE,
                 "--timeout=120s",
             ]
             subprocess.run(

--- a/metadata-ingestion/tests/integration/airbyte/airbyte_test_setup.py
+++ b/metadata-ingestion/tests/integration/airbyte/airbyte_test_setup.py
@@ -65,6 +65,16 @@ STATIC_MYSQL_SOURCE_ID = "22222222-2222-2222-2222-222222222222"
 STATIC_POSTGRES_DEST_ID = "44444444-4444-4444-4444-444444444444"
 STATIC_MYSQL_TO_PG_CONNECTION_ID = "66666666-6666-6666-6666-666666666666"
 
+AIRBYTE_NAMESPACE = "airbyte-abctl"
+AIRBYTE_DB_POD = "airbyte-db-0"
+
+_PSQL_TIMEOUT_SECONDS = 60
+# The ID rewrites run right after `abctl local install` + onboarding, while the
+# cluster is still churning, so `kubectl exec` into the DB pod can fail or time
+# out transiently. Retry before giving up.
+_DB_ID_UPDATE_ATTEMPTS = 5
+_DB_ID_UPDATE_RETRY_SECONDS = 5
+
 # abctl v0.30.3 deploys Airbyte 1.8+
 ABCTL_VERSION = "v0.30.3"
 
@@ -352,6 +362,33 @@ def wait_for_airbyte_ready(timeout: int = 600) -> bool:
     return False
 
 
+def _exec_psql(kubeconfig_path: Path, sql: str) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [
+            "kubectl",
+            "--kubeconfig",
+            str(kubeconfig_path),
+            "exec",
+            "-n",
+            AIRBYTE_NAMESPACE,
+            AIRBYTE_DB_POD,
+            "--",
+            "psql",
+            "-U",
+            "airbyte",
+            "-d",
+            "db-airbyte",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            sql,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_PSQL_TIMEOUT_SECONDS,
+    )
+
+
 def update_all_ids_atomically(
     kubeconfig_path: Path,
     id_updates: Dict[str, Dict[str, Any]],
@@ -362,8 +399,6 @@ def update_all_ids_atomically(
         return False
 
     try:
-        db_pod_name = "airbyte-db-0"
-
         sql_statements = [
             "BEGIN;",
             "ALTER TABLE connection DISABLE TRIGGER ALL;",
@@ -393,78 +428,57 @@ def update_all_ids_atomically(
             ]
         )
 
-        full_sql = " ".join(sql_statements)
-
-        command = [
-            "kubectl",
-            "--kubeconfig",
-            str(kubeconfig_path),
-            "exec",
-            "-n",
-            "airbyte-abctl",
-            db_pod_name,
-            "--",
-            "psql",
-            "-U",
-            "airbyte",
-            "-d",
-            "db-airbyte",
-            "-c",
-            full_sql,
-        ]
-
-        result = subprocess.run(command, capture_output=True, text=True, timeout=60)
+        result = _exec_psql(kubeconfig_path, " ".join(sql_statements))
+        if result.returncode != 0:
+            print(f"  psql rejected the atomic ID update: {result.stderr.strip()!r}")
         return result.returncode == 0
 
-    except Exception:
+    except Exception as e:
+        print(f"  Atomic ID update failed: {e}")
         return False
 
 
 def update_airbyte_database_id(
     kubeconfig_path: Path, table_name: str, old_id: str, new_id: str
-) -> bool:
+) -> None:
+    """Rewrite a row's primary key in Airbyte's Postgres to one of our static test IDs.
+
+    Raises on failure instead of returning a status. This rewrite runs while the
+    freshly-installed cluster is still settling, so a single attempt is not
+    reliable; swallowing the failure left Airbyte's random workspace UUID in the
+    ingested output and surfaced much later as an unexplained golden-file diff.
+    """
+    if not shutil.which("kubectl"):
+        raise RuntimeError("kubectl not found on PATH; cannot rewrite Airbyte IDs")
     if not kubeconfig_path.exists():
-        return False
+        raise RuntimeError(f"abctl kubeconfig not found at {kubeconfig_path}")
 
-    try:
-        kubectl_check = subprocess.run(
-            ["kubectl", "version", "--client"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if kubectl_check.returncode != 0:
-            return False
-    except (subprocess.SubprocessError, FileNotFoundError):
-        return False
+    sql = f"UPDATE {table_name} SET id = '{new_id}' WHERE id = '{old_id}';"
+    failure = ""
 
-    try:
-        result = subprocess.run(
-            [
-                "kubectl",
-                f"--kubeconfig={kubeconfig_path}",
-                "exec",
-                "-n",
-                "airbyte-abctl",
-                "airbyte-db-0",
-                "--",
-                "psql",
-                "-U",
-                "airbyte",
-                "-d",
-                "db-airbyte",
-                "-c",
-                f"UPDATE {table_name} SET id = '{new_id}' WHERE id = '{old_id}';",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+    for attempt in range(1, _DB_ID_UPDATE_ATTEMPTS + 1):
+        try:
+            result = _exec_psql(kubeconfig_path, sql)
+        except subprocess.TimeoutExpired:
+            failure = f"kubectl exec timed out after {_PSQL_TIMEOUT_SECONDS}s"
+        else:
+            # psql exits 0 for an UPDATE that matched no rows, so the affected-row
+            # count is the only trustworthy signal that the rewrite landed.
+            if result.returncode == 0 and "UPDATE 1" in result.stdout:
+                return
+            failure = (
+                f"exit={result.returncode} stdout={result.stdout.strip()!r} "
+                f"stderr={result.stderr.strip()!r}"
+            )
 
-        return result.returncode == 0
+        print(f"  {table_name} id rewrite attempt {attempt} failed: {failure}")
+        if attempt < _DB_ID_UPDATE_ATTEMPTS:
+            time.sleep(_DB_ID_UPDATE_RETRY_SECONDS)
 
-    except (subprocess.TimeoutExpired, Exception):
-        return False
+    raise RuntimeError(
+        f"Could not rewrite {table_name} id {old_id} -> {new_id} after "
+        f"{_DB_ID_UPDATE_ATTEMPTS} attempts. Last failure: {failure}"
+    )
 
 
 def try_direct_api_setup() -> Optional[str]:
@@ -747,12 +761,12 @@ def setup_airbyte_connections(test_resources_dir: Path) -> Dict[str, Optional[st
 
     kubeconfig = Path.home() / ".airbyte" / "abctl" / "abctl.kubeconfig"
 
-    if update_airbyte_database_id(
+    update_airbyte_database_id(
         kubeconfig, "workspace", workspace_id, STATIC_WORKSPACE_ID
-    ):
-        workspace_id = STATIC_WORKSPACE_ID
-        print(f"Using static workspace ID: {workspace_id}")
-        time.sleep(5)
+    )
+    workspace_id = STATIC_WORKSPACE_ID
+    print(f"Using static workspace ID: {workspace_id}")
+    time.sleep(5)
 
     created_ids = create_airbyte_test_setup(workspace_id)
 

--- a/metadata-ingestion/tests/unit/airbyte/test_airbyte_test_setup.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_airbyte_test_setup.py
@@ -67,6 +67,38 @@ def test_update_matching_no_rows_is_a_failure(kubeconfig: Path) -> None:
             update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
 
 
+def test_rewrite_committed_by_a_timed_out_attempt_is_not_a_false_failure(
+    kubeconfig: Path,
+) -> None:
+    # kubectl can be killed at the timeout after psql already committed server-side.
+    # The retry then matches no rows, so the end state — not the UPDATE count — is
+    # what decides success.
+    row_present = " ?column?\n----------\n        1\n(1 row)"
+    results = [
+        subprocess.TimeoutExpired(cmd="kubectl", timeout=60),
+        _completed(0, stdout=row_present),
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", side_effect=results),
+    ):
+        update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+
+def test_non_timeout_exec_failure_is_retried_and_surfaced(kubeconfig: Path) -> None:
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", side_effect=OSError("exec format error")) as run,
+    ):
+        with pytest.raises(RuntimeError, match="exec format error"):
+            update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+    assert run.call_count > 1
+
+
 def test_timeout_is_retried_then_surfaced(kubeconfig: Path) -> None:
     calls: List[Any] = []
 

--- a/metadata-ingestion/tests/unit/airbyte/test_airbyte_test_setup.py
+++ b/metadata-ingestion/tests/unit/airbyte/test_airbyte_test_setup.py
@@ -1,0 +1,85 @@
+import subprocess
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import patch
+
+import pytest
+
+from tests.integration.airbyte.airbyte_test_setup import (  # type: ignore[import-untyped]
+    update_airbyte_database_id,
+)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> Any:
+    return subprocess.CompletedProcess(
+        args=["kubectl"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.fixture
+def kubeconfig(tmp_path: Path) -> Path:
+    path = tmp_path / "abctl.kubeconfig"
+    path.write_text("")
+    return path
+
+
+def test_transient_kubectl_failure_is_retried(kubeconfig: Path) -> None:
+    results = [
+        _completed(1, stderr="error: unable to upgrade connection: pod not running"),
+        _completed(0, stdout="UPDATE 1"),
+    ]
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", side_effect=results) as run,
+    ):
+        update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+    assert run.call_count == 2
+
+
+def test_psql_error_is_surfaced_after_retries_are_exhausted(kubeconfig: Path) -> None:
+    psql_error = (
+        'ERROR:  update or delete on table "workspace" violates foreign key constraint'
+    )
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", return_value=_completed(1, stderr=psql_error)),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+    assert psql_error in str(exc_info.value)
+
+
+def test_update_matching_no_rows_is_a_failure(kubeconfig: Path) -> None:
+    # psql exits 0 for an UPDATE that matched nothing. Treating that as success is
+    # what let the test continue with Airbyte's random workspace UUID.
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", return_value=_completed(0, stdout="UPDATE 0")),
+    ):
+        with pytest.raises(RuntimeError):
+            update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+
+def test_timeout_is_retried_then_surfaced(kubeconfig: Path) -> None:
+    calls: List[Any] = []
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        calls.append(args)
+        raise subprocess.TimeoutExpired(cmd="kubectl", timeout=30)
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/kubectl"),
+        patch("time.sleep"),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
+        with pytest.raises(RuntimeError, match="timed out"):
+            update_airbyte_database_id(kubeconfig, "workspace", "old-id", "new-id")
+
+    assert len(calls) > 1


### PR DESCRIPTION
The Airbyte integration tests install a real Airbyte via `abctl`, which assigns the workspace a random UUID on every run. Setup rewrites that UUID to `STATIC_WORKSPACE_ID` directly in Postgres so the golden files stay stable.

That rewrite ran **once**, immediately after install while the cluster was still settling, and discarded every error:

```python
if update_airbyte_database_id(kubeconfig, "workspace", workspace_id, STATIC_WORKSPACE_ID):
    workspace_id = STATIC_WORKSPACE_ID
    ...
# on failure: fall through, keep the random UUID
```

When it failed, the run continued with Airbyte's random UUID — which is embedded in `customProperties['workspace_id']` and every `externalUrl` — so the failure surfaced minutes later as an unexplained golden-file diff pointing at the wrong thing entirely.

### Evidence

Roughly 1 in 12 master runs, leaking a different UUID each time. In all three, the `Using static workspace ID:` line is absent from setup output while `update_all_ids_atomically` (the sibling that rewrites actor/connection IDs) succeeded in the same run:

| Run | Leaked workspace UUID |
|---|---|
| [31206535886](https://github.com/datahub-project/datahub/actions/runs/31206535886) | `2612a6d7-…` |
| [31366074012](https://github.com/datahub-project/datahub/actions/runs/31366074012) | `99b596ed-…` |
| [31545064812](https://github.com/datahub-project/datahub/actions/runs/31545064812) | `dcc4741f-…` |

The working sibling runs later, once the cluster has settled, uses a 60s timeout, and wraps its updates in a transaction. The failing one fired at the busiest moment with a 30s timeout and no retry.

### Changes

`update_airbyte_database_id`:

- **Retries** rather than making a single attempt against a still-starting cluster.
- **Raises with psql's exit code, stdout and stderr** instead of `return False`, so a failure stops the run at its real cause. The caller no longer treats the rewrite as best-effort.
- **Requires psql to report `UPDATE 1`.** psql exits `0` for an `UPDATE` that matched no rows, so the return code alone never proved the rewrite landed — this hole could produce the exact symptom with a clean exit code.

Supporting changes: the duplicated `kubectl exec … psql` invocation is extracted into `_exec_psql`, which also gives `update_all_ids_atomically` `ON_ERROR_STOP=1` and an error message on its previously silent failure paths.

### Deliberately not included

`ALTER TABLE ... DISABLE TRIGGER ALL` on the workspace update, as the sibling function uses. Whether a foreign key is the underlying cause is **unverified** — the old code discarded the error that would tell us — and disabling those triggers would leave rows referencing a workspace ID that no longer exists. The stderr this PR surfaces will settle that question the next time it fails, and the follow-up is then a one-liner.

### Testing

New unit tests in `tests/unit/airbyte/test_airbyte_test_setup.py` cover retry-then-succeed, stderr surfacing after retries are exhausted, `UPDATE 0` treated as failure, and timeout handling. Each was run against the old implementation first and failed there.

```
4 new tests: fail before, pass after
202 passed — full tests/unit/airbyte/ + test_integration_batch_balancing.py
ruff check + format clean; mypy: no issues in 2533 source files
```

The integration test itself is not verified locally: it needs `abctl` plus a local Kubernetes cluster, and at a ~8% reproduction rate a single green run would prove little. Real confirmation is master staying green — and any remaining failure now names its own cause.

### Checklist

- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Tests added
- [ ] Docs — n/a, test-infrastructure only
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Hardens Airbyte integration-test setup so the **workspace UUID rewrite in Postgres** cannot fail quietly and poison golden files later.
> 
> **`update_airbyte_database_id`** now **retries** (5 attempts, 5s apart) against transient `kubectl exec`/psql failures right after install, **requires `UPDATE 1` in stdout** (psql can exit 0 on zero rows), and **raises `RuntimeError`** with exit code, stdout, and stderr instead of returning `False`. **`setup_airbyte_connections`** always uses the static workspace ID after a successful rewrite—no best-effort fallthrough to Airbyte’s random UUID.
> 
> Shared **`_exec_psql`** centralizes `kubectl exec` into the DB pod (60s timeout, `ON_ERROR_STOP=1`); **`update_all_ids_atomically`** uses it and logs when psql rejects the transaction.
> 
> New unit tests cover retry-then-succeed, exhausted retries with stderr, `UPDATE 0` as failure, and timeout retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a5b13a6365f913ab564a5929eb1b7e6472f7e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Airbyte integration-test workspace ID rewrite so it can’t fail quietly and break golden files later. Before: a single best‑effort update at cluster startup swallowed errors; After: it retries, handles exec timeouts/errors, and raises with details so failures fail fast at the real cause.

- Retries the Postgres ID update up to 5 times with 5s backoff and a 60s `psql` timeout; retries on `TimeoutExpired`, `OSError`, and other `SubprocessError`s.
- Accepts success only on `UPDATE 1`; if a prior attempt may have committed but the retry matches 0 rows, verifies via a row-exists check and treats that as success.
- Raises with `psql` exit code, stdout, and stderr; the rewrite is no longer optional, so tests now stop immediately on failure.
- Extracts `_exec_psql` with `ON_ERROR_STOP=1`; `update_all_ids_atomically` uses it and logs when `psql` rejects the transaction.
- Replaces inline namespace strings with `AIRBYTE_NAMESPACE` across call sites for consistency.
- Adds unit tests for retry-then-succeed, committed‑but‑timed‑out attempts, `UPDATE 0` as failure, timeout retries, and non-timeout exec errors.
- Deliberately does not disable triggers for the workspace update; any FK errors will now surface for follow‑up.

<sup>Written for commit 0bf4505a78346a0eacc53b8444d58d503b2912a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

