### PR TITLE
perf(gms): Cache result of ActorContext.isActive() for the lifetime of an actor

### DIFF
--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ActorContext.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -93,6 +94,11 @@ public class ActorContext implements ContextInterface {
   @EqualsAndHashCode.Exclude @Builder.Default
   private final Set<Urn> directRoleMembership = Collections.emptySet();
 
+  /** Memoized result of {@link #isActive}; {@code null} until computed. */
+  @EqualsAndHashCode.Exclude
+  @Getter(AccessLevel.NONE)
+  private volatile Boolean isActiveCache;
+
   @EqualsAndHashCode.Exclude private final boolean systemAuth;
 
   public Urn getActorUrn() {
@@ -135,6 +141,10 @@ public class ActorContext implements ContextInterface {
       return true;
     }
 
+    if (isActiveCache != null) {
+      return isActiveCache;
+    }
+
     Urn selfUrn = UrnUtils.getUrn(authentication.getActor().toUrnStr());
     Map<Urn, Map<String, Aspect>> urnAspectMap =
         aspectRetriever.getLatestAspectObjects(
@@ -146,7 +156,8 @@ public class ActorContext implements ContextInterface {
 
     if (enforceExistenceEnabled && !aspectMap.containsKey(CORP_USER_KEY_ASPECT_NAME)) {
       // No corp user key aspect (never provisioned, purged, or inconsistent); not inferrable.
-      return false;
+      isActiveCache = false;
+      return isActiveCache;
     }
 
     Status status =
@@ -157,8 +168,9 @@ public class ActorContext implements ContextInterface {
         Optional.ofNullable(aspectMap.get(CORP_USER_STATUS_ASPECT_NAME))
             .map(a -> new CorpUserStatus(a.data()))
             .orElse(new CorpUserStatus().setStatus(""));
-
-    return !status.isRemoved() && !CORP_USER_STATUS_SUSPENDED.equals(corpUserStatus.getStatus());
+    isActiveCache =
+        !status.isRemoved() && !CORP_USER_STATUS_SUSPENDED.equals(corpUserStatus.getStatus());
+    return isActiveCache;
   }
 
   /**

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/ActorContextTest.java
@@ -3,6 +3,8 @@ package io.datahubproject.metadata.context;
 import static com.linkedin.metadata.Constants.CORP_USER_STATUS_SUSPENDED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -268,5 +270,48 @@ public class ActorContextTest {
                     "status", new Aspect(new Status().setRemoved(false).data()),
                     "corpUserStatus", new Aspect(suspended.data()))));
     assertFalse(ctx.isActive(mock(OperationContext.class), retriever));
+  }
+
+  @Test
+  public void isActiveMemoizesTrueResultAndSkipsRepeatedAspectLookup() {
+    Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:activeone");
+    Authentication userAuth = new Authentication(new Actor(ActorType.USER, "activeone"), "");
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), true);
+    CorpUserKey key = new CorpUserKey().setUsername("activeone");
+    AspectRetriever retriever = mock(AspectRetriever.class);
+    when(retriever.getLatestAspectObjects(any(OperationFingerprint.class), any(), any()))
+        .thenReturn(
+            Map.of(
+                userUrn,
+                Map.of(
+                    "corpUserKey", new Aspect(key.data()),
+                    "status", new Aspect(new Status().setRemoved(false).data()),
+                    "corpUserStatus",
+                        new Aspect(new CorpUserStatus().setStatus("ACTIVE").data()))));
+
+    assertTrue(ctx.isActive(mock(OperationContext.class), retriever));
+    assertTrue(ctx.isActive(mock(OperationContext.class), retriever));
+
+    verify(retriever, times(1))
+        .getLatestAspectObjects(any(OperationFingerprint.class), any(), any());
+  }
+
+  @Test
+  public void isActiveMemoizesFalseResultAndSkipsRepeatedAspectLookup() {
+    Urn userUrn = UrnUtils.getUrn("urn:li:corpuser:nobody");
+    Authentication userAuth = new Authentication(new Actor(ActorType.USER, "nobody"), "");
+    ActorContext ctx =
+        ActorContext.asSessionRestricted(userAuth, Set.of(), List.of(), Set.of(), true);
+    AspectRetriever retriever = mock(AspectRetriever.class);
+    when(retriever.getLatestAspectObjects(any(OperationFingerprint.class), any(), any()))
+        .thenReturn(
+            Map.of(userUrn, Map.of("status", new Aspect(new Status().setRemoved(false).data()))));
+
+    assertFalse(ctx.isActive(mock(OperationContext.class), retriever));
+    assertFalse(ctx.isActive(mock(OperationContext.class), retriever));
+
+    verify(retriever, times(1))
+        .getLatestAspectObjects(any(OperationFingerprint.class), any(), any());
   }
 }


### PR DESCRIPTION
## Summary
We currently make a check to `ActorContext.isActive()` every time `OperationContext.build()` is called. Every `isActive()` check is an uncached call to fetch the latest status aspects for a user. For operations that  internally require a lot of OperationContext rebuilding (e.g. to change searchFlags), this adds up to a lot of unnecessary user fetch queries. Memoizing the result of  the `isActive()`call for every actor helps us avoid this under the assumption that changes to user activity status do not need to be instantly visible to operations that are already running.

## Changes
- Add a simple boolean member to memoize calls to `ActorContext.isActive()`. The cache is valid for the lifetime of the object.

## Test Plan
- Added a unit test
- Manually verified that some operations that rebuild OperationContext multiple times no longer fire unnecessary user status fetches. e.g. query log comparison for a simple `getDomain` below: 

BEFORE:
```
2026-08-13T10:13:00.930497Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:00.951332Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:00.955751Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:00.958179Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserInfo', 0))
2026-08-13T10:13:00.971976Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'ownership', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'forms', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'deprecation', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'institutionalMemory', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'displayProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'structuredProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainKey', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'assetSettings', 0))
2026-08-13T10:13:00.983965Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainProperties', 0))
2026-08-13T10:13:01.003679Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.005927Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.007467Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.027111Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.028919Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.031856Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.184119Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.186899Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.188782Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T10:13:01.206060Z	92154 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserInfo', 0))
```

AFTER:
```
2026-08-13T09:29:26.525101Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T09:29:26.532007Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T09:29:26.533368Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'nativeGroupMembership', 0),('urn:li:corpuser:datahub', 'groupMembership', 0),('urn:li:corpuser:datahub', 'roleMembership', 0))
2026-08-13T09:29:26.534465Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserKey', 0),('urn:li:corpuser:datahub', 'status', 0),('urn:li:corpuser:datahub', 'corpUserStatus', 0))
2026-08-13T09:29:26.535101Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserInfo', 0))
2026-08-13T09:29:26.544454Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'ownership', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'forms', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'deprecation', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'institutionalMemory', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'displayProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'structuredProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainKey', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainProperties', 0),('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'assetSettings', 0))
2026-08-13T09:29:26.548463Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:domain:b2fd91.7d749c3f-cad4-4e7f-b30c-17f9639b652b', 'domainProperties', 0))
2026-08-13T09:29:26.612873Z	90708 Query	select urn, aspect, version, metadata, systemMetadata, createdOn, createdBy, createdFor FROM metadata_aspect_v2 WHERE (urn, aspect, version) IN (('urn:li:corpuser:datahub', 'corpUserInfo', 0))
```


## Checklist

- [x] PR title follows the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)
- [ ] Linked related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches `ActorContext.isActive()` for the lifetime of an `ActorContext` to eliminate redundant user-status lookups during `OperationContext` rebuilds. Previously each call re-fetched status; now the first call stores the boolean and subsequent calls reuse it, improving hot-path performance while delaying visibility of mid-operation status changes until a new `ActorContext` is created.

- Adds a `volatile` `isActiveCache` that is null until first compute; new `ActorContext` instances recompute.
- Short-circuits repeated calls and returns false when no `corpUserKey` aspect exists; system sessions remain always active.
- Reduces calls to `AspectRetriever.getLatestAspectObjects` in rebuild-heavy flows.
- Tests verify memoization for both active and inactive results and assert a single retriever invocation per instance.

<sup>Written for commit 6d110c361d6d56d50bcca50fd24703d1473cf71c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

