### PR TITLE
fix(ingest/fabric): wire _paginate() into all unpaginated OneLake call sites

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, Optional, Set
+from typing import Dict, Iterator, Optional, Set, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -15,6 +15,24 @@ logger = logging.getLogger(__name__)
 
 # Fabric REST API base URL
 FABRIC_API_BASE_URL = "https://api.fabric.microsoft.com/v1"
+
+# Fabric REST API pagination token. The same name is used as the response
+# field and the request parameter; it is read and written in several places,
+# and a typo in any one of them silently degrades pagination to a single
+# page, so every site goes through this constant.
+CONTINUATION_TOKEN_KEY = "continuationToken"
+
+# Response keys that belong to the pagination envelope rather than the
+# payload. A terminal page may legitimately omit the items array and carry
+# only these (e.g. {"next_page_token": null} from the Unity Catalog-style
+# OneLake Table API, or {"continuationToken": null, "continuationUri": null}
+# from the Fabric REST API) — such a page is empty, not malformed.
+# "next_page_token" is the OneLake Table API field (see onelake/client.py's
+# NEXT_PAGE_TOKEN_FIELD); duplicated here as a literal to avoid a circular
+# import.
+PAGINATION_ENVELOPE_KEYS = frozenset(
+    {CONTINUATION_TOKEN_KEY, "continuationUri", "next_page_token"}
+)
 
 # Retry configuration
 RETRY_MAX_TIMES = 3
@@ -160,13 +178,15 @@ class BaseFabricClient(ABC):
     def _is_repeated_pagination_token(
         self, token: Optional[str], seen_tokens: Set[str], context: str
     ) -> bool:
-        """Return True (and warn) if a pagination token has already been seen.
+        """Return True if a pagination token has already been followed.
 
         A well-behaved endpoint issues a fresh token per page and finally omits
-        it. An endpoint that ignores the page/continuation-token request parameter
-        echoes the same token on every call; detecting a repeat lets the caller
-        stop before re-issuing the request and re-yielding the same page, instead
-        of looping forever.
+        it. An endpoint that ignores the page/continuation-token request
+        parameter echoes the same token on every call; detecting a repeat lets
+        the caller stop instead of looping forever. A repeat is recorded on the
+        client report as a pagination truncation (results may be incomplete)
+        in addition to the log warning, so it is visible in the run summary
+        and the JSON report, not only in the console log.
 
         Args:
             token: The next-page token from the current response (may be falsy)
@@ -177,6 +197,10 @@ class BaseFabricClient(ABC):
             True if ``token`` is truthy and already in ``seen_tokens``.
         """
         if token and token in seen_tokens:
+            self.report.report_pagination_truncated(
+                f"{context}: repeated pagination token; stopped after "
+                f"{len(seen_tokens) + 1} page(s), results may be incomplete"
+            )
             logger.warning(
                 f"{context} returned a repeated pagination token; stopping "
                 "pagination to avoid an infinite loop. Results may be incomplete — "
@@ -185,92 +209,188 @@ class BaseFabricClient(ABC):
             return True
         return False
 
+    def _extract_page_items(
+        self,
+        data: dict,
+        items_key: str,
+        fallback_items_keys: Tuple[str, ...],
+        context: str,
+        warned_fallback_keys: Optional[Set[str]] = None,
+    ) -> list:
+        """Return one page's items array from a response body.
+
+        Reads ``items_key`` first, then each of ``fallback_items_keys``; the
+        first key present in the response wins. An explicit ``null`` value is
+        treated as an empty page rather than raising. Two shapes are surfaced
+        instead of silently returning nothing:
+
+        - the items came from a fallback key: warn (once per pagination run,
+          when ``warned_fallback_keys`` is passed), so we learn which key the
+          endpoint actually serves rather than relying on the fallback forever;
+        - none of the expected keys are present in a response that carries
+          more than the pagination envelope: the page doesn't match the
+          documented contract at all, which would otherwise ingest zero items
+          with no signal — recorded as an API parse failure on the client
+          report. A page carrying only envelope keys (e.g.
+          ``{"next_page_token": null}``) is a legitimate empty page, not a
+          parse failure.
+        """
+        for key in (items_key, *fallback_items_keys):
+            if key in data:
+                if key != items_key and (
+                    warned_fallback_keys is None or key not in warned_fallback_keys
+                ):
+                    logger.warning(
+                        f"{context}: response served items under fallback key "
+                        f"'{key}' rather than expected key '{items_key}'."
+                    )
+                    if warned_fallback_keys is not None:
+                        warned_fallback_keys.add(key)
+                # Tolerate an explicit null (e.g. {"data": null}) as an
+                # empty page.
+                return data.get(key) or []
+        if data and not set(data).issubset(PAGINATION_ENVELOPE_KEYS):
+            self.report.report_parse_failure(
+                f"{context}: response has none of the expected items keys "
+                f"{[items_key, *fallback_items_keys]}; keys present: {sorted(data)}"
+            )
+        return []
+
     def _paginate(
         self,
         endpoint: str,
         params: Optional[Dict[str, str]] = None,
         items_key: str = "value",
+        fallback_items_keys: Tuple[str, ...] = (),
     ) -> Iterator[dict]:
         """Yield all items from a paginated Fabric API endpoint.
 
-        Handles continuation token pagination transparently — callers
-        just iterate and get all items across all pages.
+        Handles continuation token pagination transparently — callers just
+        iterate and get all items across all pages. The caller's ``params``
+        dict is never mutated; each page's request gets its own dict.
+
+        A page that has been fetched is always yielded, even if the endpoint
+        then turns out to repeat a pagination token: re-emitting a page at
+        worst duplicates idempotent-per-URN metadata, while dropping one
+        loses entities. The repeated-token guard stops the loop *after* the
+        yield and records the truncation on the client report.
 
         Args:
             endpoint: API endpoint (relative to base URL)
             params: Initial query parameters
             items_key: Response JSON key holding the items array (default "value")
+            fallback_items_keys: Alternative items keys to read (with a warning)
+                when ``items_key`` is absent from the response
 
         Yields:
             Item dictionaries from each page's items array
         """
-        request_params: Dict[str, str] = dict(params or {})
+        context = f"Fabric API endpoint '{endpoint}'"
+        base_params: Dict[str, str] = dict(params or {})
         seen_tokens: Set[str] = set()
-        page = 1
+        warned_fallback_keys: Set[str] = set()
+        next_token: Optional[str] = None
+        page = 0
+        total = 0
         while True:
-            response = self.get(endpoint, params=dict(request_params))
+            # A fresh dict per page: base_params (and the caller's dict) are
+            # never written to.
+            request_params = (
+                base_params
+                if next_token is None
+                else {**base_params, CONTINUATION_TOKEN_KEY: next_token}
+            )
+            response = self.get(endpoint, params=request_params)
             data = response.json()
+            page += 1
 
-            continuation_token = data.get("continuationToken")
-            # Check for a repeated token before yielding, so a non-advancing
-            # cursor doesn't emit the same page twice.
-            if self._is_repeated_pagination_token(
-                continuation_token, seen_tokens, f"Fabric API endpoint '{endpoint}'"
-            ):
-                break
-
-            items = data.get(items_key, [])
+            items = self._extract_page_items(
+                data, items_key, fallback_items_keys, context, warned_fallback_keys
+            )
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
+            total += len(items)
             yield from items
 
-            if not continuation_token:
+            next_token = data.get(CONTINUATION_TOKEN_KEY)
+            if not next_token:
                 break
-            seen_tokens.add(continuation_token)
-            request_params["continuationToken"] = continuation_token
-            page += 1
+            if self._is_repeated_pagination_token(next_token, seen_tokens, context):
+                break
+            seen_tokens.add(next_token)
+
+        # Not reached when the consumer stops iterating early or a request
+        # raises — the absence of this line in a log is not itself a bug.
+        logger.info(f"{endpoint}: fetched {total} item(s) across {page} page(s)")
 
     def _paginate_post(
         self,
         endpoint: str,
         body: dict,
         items_key: str = "value",
+        fallback_items_keys: Tuple[str, ...] = (),
     ) -> Iterator[dict]:
         """Yield all items from a paginated Fabric POST API endpoint.
 
         Some Fabric APIs (e.g. queryActivityRuns) use POST with a
         continuationToken in both the request and response body.
 
+        The caller's ``body`` dict is never mutated; each page's request gets
+        its own dict. (The per-page copy is shallow — nested values are shared
+        with the caller but never written to.) As in :meth:`_paginate`, a
+        fetched page is always yielded and the repeated-token guard stops the
+        loop after the yield, recording the truncation on the client report.
+
         Args:
             endpoint: API endpoint (relative to base URL)
             body: JSON request body
             items_key: Response JSON key holding the items array (default "value")
+            fallback_items_keys: Alternative items keys to read (with a warning)
+                when ``items_key`` is absent from the response
 
         Yields:
             Item dictionaries from each page's items array
         """
+        context = f"Fabric API endpoint '{endpoint}'"
+        base_body = dict(body)
         seen_tokens: Set[str] = set()
-        page = 1
+        warned_fallback_keys: Set[str] = set()
+        next_token: Optional[str] = None
+        page = 0
+        total = 0
         while True:
-            response = self.post(endpoint, json=dict(body))
-            data = response.json()
-
-            continuation_token = (
-                data.get("continuationToken") if isinstance(data, dict) else None
+            request_body = (
+                base_body
+                if next_token is None
+                else {**base_body, CONTINUATION_TOKEN_KEY: next_token}
             )
-            if self._is_repeated_pagination_token(
-                continuation_token, seen_tokens, f"Fabric API endpoint '{endpoint}'"
-            ):
-                break
+            response = self.post(endpoint, json=request_body)
+            data = response.json()
+            page += 1
 
-            items = data if isinstance(data, list) else data.get(items_key, [])
+            if isinstance(data, list):
+                # Some endpoints return a bare array with no pagination
+                # envelope; yield it and stop.
+                items = data
+            else:
+                items = self._extract_page_items(
+                    data, items_key, fallback_items_keys, context, warned_fallback_keys
+                )
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
+            total += len(items)
             yield from items
 
-            if not continuation_token:
+            next_token = (
+                data.get(CONTINUATION_TOKEN_KEY) if isinstance(data, dict) else None
+            )
+            if not next_token:
                 break
-            seen_tokens.add(continuation_token)
-            body["continuationToken"] = continuation_token
-            page += 1
+            if self._is_repeated_pagination_token(next_token, seen_tokens, context):
+                break
+            seen_tokens.add(next_token)
+
+        # Not reached when the consumer stops iterating early or a request
+        # raises — the absence of this line in a log is not itself a bug.
+        logger.info(f"{endpoint}: fetched {total} item(s) across {page} page(s)")
 
     def _list_workspaces_raw(self) -> Iterator[dict]:
         """List all accessible Fabric workspaces (raw data).

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
@@ -161,6 +161,7 @@ class BaseFabricClient(ABC):
         self,
         endpoint: str,
         params: Optional[Dict[str, str]] = None,
+        items_key: str = "value",
     ) -> Iterator[dict]:
         """Yield all items from a paginated Fabric API endpoint.
 
@@ -170,16 +171,17 @@ class BaseFabricClient(ABC):
         Args:
             endpoint: API endpoint (relative to base URL)
             params: Initial query parameters
+            items_key: Response JSON key holding the items array (default "value")
 
         Yields:
-            Item dictionaries from each page's "value" array
+            Item dictionaries from each page's items array
         """
         request_params: Dict[str, str] = dict(params or {})
         page = 1
         while True:
-            response = self.get(endpoint, params=request_params)
+            response = self.get(endpoint, params=dict(request_params))
             data = response.json()
-            items = data.get("value", [])
+            items = data.get(items_key, [])
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
             yield from items
 
@@ -193,6 +195,7 @@ class BaseFabricClient(ABC):
         self,
         endpoint: str,
         body: dict,
+        items_key: str = "value",
     ) -> Iterator[dict]:
         """Yield all items from a paginated Fabric POST API endpoint.
 
@@ -201,17 +204,18 @@ class BaseFabricClient(ABC):
 
         Args:
             endpoint: API endpoint (relative to base URL)
-            body: JSON request body (will be mutated to add continuationToken)
+            body: JSON request body
+            items_key: Response JSON key holding the items array (default "value")
 
         Yields:
-            Item dictionaries from each page's "value" array
+            Item dictionaries from each page's items array
         """
         page = 1
         while True:
-            response = self.post(endpoint, json=body)
+            response = self.post(endpoint, json=dict(body))
             data = response.json()
 
-            items = data if isinstance(data, list) else data.get("value", [])
+            items = data if isinstance(data, list) else data.get(items_key, [])
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
             yield from items
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, Optional, Set
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -177,6 +177,7 @@ class BaseFabricClient(ABC):
             Item dictionaries from each page's items array
         """
         request_params: Dict[str, str] = dict(params or {})
+        seen_tokens: Set[str] = set()
         page = 1
         while True:
             response = self.get(endpoint, params=dict(request_params))
@@ -188,6 +189,13 @@ class BaseFabricClient(ABC):
             continuation_token = data.get("continuationToken")
             if not continuation_token:
                 break
+            if continuation_token in seen_tokens:
+                logger.warning(
+                    f"Fabric API returned a repeated continuationToken for {endpoint}; "
+                    "stopping pagination to avoid an infinite loop. Results may be incomplete."
+                )
+                break
+            seen_tokens.add(continuation_token)
             request_params["continuationToken"] = continuation_token
             page += 1
 
@@ -210,6 +218,7 @@ class BaseFabricClient(ABC):
         Yields:
             Item dictionaries from each page's items array
         """
+        seen_tokens: Set[str] = set()
         page = 1
         while True:
             response = self.post(endpoint, json=dict(body))
@@ -224,6 +233,13 @@ class BaseFabricClient(ABC):
             )
             if not continuation_token:
                 break
+            if continuation_token in seen_tokens:
+                logger.warning(
+                    f"Fabric API returned a repeated continuationToken for {endpoint}; "
+                    "stopping pagination to avoid an infinite loop. Results may be incomplete."
+                )
+                break
+            seen_tokens.add(continuation_token)
             body["continuationToken"] = continuation_token
             page += 1
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/common/base_client.py
@@ -157,6 +157,34 @@ class BaseFabricClient(ABC):
             logger.error(f"Request error for {method} {url}: {e}")
             raise
 
+    def _is_repeated_pagination_token(
+        self, token: Optional[str], seen_tokens: Set[str], context: str
+    ) -> bool:
+        """Return True (and warn) if a pagination token has already been seen.
+
+        A well-behaved endpoint issues a fresh token per page and finally omits
+        it. An endpoint that ignores the page/continuation-token request parameter
+        echoes the same token on every call; detecting a repeat lets the caller
+        stop before re-issuing the request and re-yielding the same page, instead
+        of looping forever.
+
+        Args:
+            token: The next-page token from the current response (may be falsy)
+            seen_tokens: Tokens already followed on this pagination run
+            context: Human-readable endpoint/url for the warning message
+
+        Returns:
+            True if ``token`` is truthy and already in ``seen_tokens``.
+        """
+        if token and token in seen_tokens:
+            logger.warning(
+                f"{context} returned a repeated pagination token; stopping "
+                "pagination to avoid an infinite loop. Results may be incomplete — "
+                "the endpoint may not honor the pagination-token parameter."
+            )
+            return True
+        return False
+
     def _paginate(
         self,
         endpoint: str,
@@ -182,18 +210,20 @@ class BaseFabricClient(ABC):
         while True:
             response = self.get(endpoint, params=dict(request_params))
             data = response.json()
+
+            continuation_token = data.get("continuationToken")
+            # Check for a repeated token before yielding, so a non-advancing
+            # cursor doesn't emit the same page twice.
+            if self._is_repeated_pagination_token(
+                continuation_token, seen_tokens, f"Fabric API endpoint '{endpoint}'"
+            ):
+                break
+
             items = data.get(items_key, [])
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
             yield from items
 
-            continuation_token = data.get("continuationToken")
             if not continuation_token:
-                break
-            if continuation_token in seen_tokens:
-                logger.warning(
-                    f"Fabric API returned a repeated continuationToken for {endpoint}; "
-                    "stopping pagination to avoid an infinite loop. Results may be incomplete."
-                )
                 break
             seen_tokens.add(continuation_token)
             request_params["continuationToken"] = continuation_token
@@ -224,20 +254,19 @@ class BaseFabricClient(ABC):
             response = self.post(endpoint, json=dict(body))
             data = response.json()
 
+            continuation_token = (
+                data.get("continuationToken") if isinstance(data, dict) else None
+            )
+            if self._is_repeated_pagination_token(
+                continuation_token, seen_tokens, f"Fabric API endpoint '{endpoint}'"
+            ):
+                break
+
             items = data if isinstance(data, list) else data.get(items_key, [])
             logger.debug(f"Page {page}: got {len(items)} item(s) from {endpoint}")
             yield from items
 
-            continuation_token = (
-                data.get("continuationToken") if isinstance(data, dict) else None
-            )
             if not continuation_token:
-                break
-            if continuation_token in seen_tokens:
-                logger.warning(
-                    f"Fabric API returned a repeated continuationToken for {endpoint}; "
-                    "stopping pagination to avoid an infinite loop. Results may be incomplete."
-                )
                 break
             seen_tokens.add(continuation_token)
             body["continuationToken"] = continuation_token

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/common/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/common/report.py
@@ -16,6 +16,9 @@ class FabricClientReport:
     request_count: int = 0
     error_count: int = 0
     api_parse_failures: LossyList[str] = field(default_factory=LossyList)
+    # Listings whose pagination stopped before the last page — each entry means
+    # the corresponding results are incomplete.
+    pagination_truncations: LossyList[str] = field(default_factory=LossyList)
 
     def report_request(self) -> None:
         """Track a successful API request."""
@@ -28,3 +31,13 @@ class FabricClientReport:
     def report_parse_failure(self, context: str) -> None:
         """Track an API response that couldn't be parsed due to missing/unexpected fields."""
         self.api_parse_failures.append(context)
+
+    def report_pagination_truncated(self, context: str) -> None:
+        """Record a listing whose pagination stopped early — results are incomplete.
+
+        Recorded when a pagination loop breaks before the endpoint reported the
+        last page (e.g. a repeated pagination token, or an HTTP error after
+        earlier pages were already consumed). Sources should surface these as
+        report warnings so an operator sees the truncation in the run summary.
+        """
+        self.pagination_truncations.append(context)

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/source.py
@@ -293,6 +293,19 @@ class FabricDataFactorySource(StatefulIngestionSourceBase):
         finally:
             self.client.close()
 
+        # Promote client-level pagination truncations into the run summary: a
+        # truncated listing means the emitted metadata is incomplete, which
+        # must be visible in the report's Warnings section, not only in the
+        # nested client report. (Same promotion as the OneLake source.)
+        for truncation_context in self.client_report.pagination_truncations:
+            self.report.warning(
+                title="Listing Truncated",
+                message="A Fabric API listing stopped before all pages were "
+                "fetched; the ingested metadata is incomplete.",
+                context=truncation_context,
+                log=False,
+            )
+
     def _fetch_pipeline_activities(self, workspace_id: str) -> list[FabricItem]:
         """Fetch pipelines and their activities for a workspace into cache.
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
@@ -23,6 +23,13 @@ logger = logging.getLogger(__name__)
 # OneLake Delta Table APIs base URL
 ONELAKE_TABLE_API_BASE_URL = "https://onelake.table.fabric.microsoft.com"
 
+# OneLake Table API (Unity Catalog-compatible) pagination fields. The names
+# are asymmetric — the response carries "next_page_token" and the request
+# sends it back as "page_token" — so a transposition is easy and silently
+# degrades pagination to a single page; both sites go through these constants.
+PAGE_TOKEN_PARAM = "page_token"
+NEXT_PAGE_TOKEN_FIELD = "next_page_token"
+
 
 def _parse_table_name(full_name: str) -> tuple[str, str]:
     """Parse schema and table name from fully qualified name.
@@ -198,63 +205,92 @@ class OneLakeClient(BaseFabricClient):
     ) -> Iterator[dict]:
         """Yield all items from a paginated OneLake Table API endpoint.
 
-        The OneLake Table API for Delta exposes a Unity Catalog-compatible surface,
-        so it uses page_token / next_page_token pagination rather than the
-        continuationToken used by the Fabric REST API. The request parameter
-        "page_token" and response field "next_page_token" are both defined by the
-        Unity Catalog API spec that the OneLake Table API implements (listSchemas /
-        listTables), and next_page_token is shown in Microsoft's docs:
+        The OneLake Table API for Delta exposes a Unity Catalog-compatible
+        surface, so it uses page_token / next_page_token pagination rather than
+        the continuationToken used by the Fabric REST API. Both names are
+        defined by the Unity Catalog API spec that the OneLake Table API
+        implements (listSchemas / listTables), and next_page_token is shown in
+        Microsoft's docs:
         https://learn.microsoft.com/en-us/fabric/onelake/table-apis/delta-table-apis-get-started
 
         Should an endpoint ignore page_token, it would return the same
-        next_page_token on every call; the seen-token guard below breaks the loop
-        (with a warning) as soon as a token repeats, so a misbehaving endpoint
-        truncates loudly instead of looping forever.
+        next_page_token on every call; the seen-token guard breaks the loop as
+        soon as a token repeats, *after* yielding the page (a fetched page is
+        never dropped), and records the truncation on the client report so it
+        is visible in the run summary.
+
+        The Authorization header is fetched per page: the auth helper caches
+        the token with a pre-expiry margin, so this is a timestamp check in
+        the common case — and it is the only chance a near-expiry token has to
+        refresh during a long pagination run instead of failing with a 401
+        partway through. Requests on this path are also counted on the client
+        report (this URL is absolute, so it cannot go through ``_request``).
 
         Args:
             url: Full URL for the API endpoint
-            params: Initial query parameters
+            params: Initial query parameters (never mutated)
             items_key: Response JSON key holding the items array (e.g. "schemas", "tables")
 
         Yields:
             Item dictionaries
         """
-        headers: Dict[str, str] = {}
-        try:
-            headers["Authorization"] = self.auth_helper.get_authorization_header(
-                scope=ONELAKE_STORAGE_SCOPE
-            )
-        except Exception as e:
-            logger.error(f"Failed to get authorization header: {e}")
-            raise
-
-        request_params = dict(params)
+        context = f"OneLake Table API '{url}'"
+        base_params = dict(params)
         seen_page_tokens: Set[str] = set()
-        page = 1
+        warned_fallback_keys: Set[str] = set()
+        next_token: Optional[str] = None
+        page = 0
+        total = 0
         while True:
-            response = self._session.get(
-                url, headers=headers, params=dict(request_params), timeout=self.timeout
+            request_params = (
+                base_params
+                if next_token is None
+                else {**base_params, PAGE_TOKEN_PARAM: next_token}
             )
-            response.raise_for_status()
-            data = response.json()
+            try:
+                headers = {
+                    "Authorization": self.auth_helper.get_authorization_header(
+                        scope=ONELAKE_STORAGE_SCOPE
+                    )
+                }
+            except Exception as e:
+                logger.error(f"Failed to get authorization header: {e}")
+                raise
 
-            next_page_token = data.get("next_page_token")
-            # Check for a repeated token before yielding, so an endpoint that
-            # ignores page_token doesn't emit the same page twice.
-            if self._is_repeated_pagination_token(
-                next_page_token, seen_page_tokens, f"OneLake Table API '{url}'"
-            ):
-                break
+            self.report.report_request()
+            try:
+                response = self._session.get(
+                    url, headers=headers, params=request_params, timeout=self.timeout
+                )
+                response.raise_for_status()
+                # Inside the counted try: requests raises its own
+                # JSONDecodeError (a RequestException) for a malformed body,
+                # which is a failed request like any other.
+                data = response.json()
+            except requests.exceptions.RequestException:
+                self.report.report_error()
+                raise
+            page += 1
 
-            items = data.get(items_key, [])
+            items = self._extract_page_items(
+                data, items_key, (), context, warned_fallback_keys
+            )
             logger.debug(f"Page {page}: got {len(items)} item(s) from {url}")
+            total += len(items)
             yield from items
 
-            if not next_page_token:
+            next_token = data.get(NEXT_PAGE_TOKEN_FIELD)
+            if not next_token:
                 break
-            seen_page_tokens.add(next_page_token)
-            request_params["page_token"] = next_page_token
-            page += 1
+            if self._is_repeated_pagination_token(
+                next_token, seen_page_tokens, context
+            ):
+                break
+            seen_page_tokens.add(next_token)
+
+        # Not reached when the consumer stops iterating early or a request
+        # raises — the absence of this line in a log is not itself a bug.
+        logger.info(f"{url}: fetched {total} item(s) across {page} page(s)")
 
     def _list_schemas_via_onelake_api(
         self, workspace_id: str, lakehouse_id: str
@@ -286,13 +322,13 @@ class OneLakeClient(BaseFabricClient):
                     yield schema_name
 
         except requests.exceptions.HTTPError as e:
-            self.report.report_error()
+            # Request errors are counted on the client report inside
+            # _paginate_onelake_table_api; only log context here.
             logger.error(
                 f"HTTP error {e.response.status_code} listing schemas for lakehouse {lakehouse_id}: {e.response.text}"
             )
             raise
         except Exception as e:
-            self.report.report_error()
             logger.error(f"Failed to list schemas for lakehouse {lakehouse_id}: {e}")
             raise
 
@@ -337,13 +373,13 @@ class OneLakeClient(BaseFabricClient):
                     )
 
         except requests.exceptions.HTTPError as e:
-            self.report.report_error()
+            # Request errors are counted on the client report inside
+            # _paginate_onelake_table_api; only log context here.
             logger.error(
                 f"HTTP error {e.response.status_code} listing tables in schema {schema_name} for lakehouse {lakehouse_id}: {e.response.text}"
             )
             raise
         except Exception as e:
-            self.report.report_error()
             logger.error(
                 f"Failed to list tables in schema {schema_name} for lakehouse {lakehouse_id}: {e}"
             )
@@ -379,24 +415,37 @@ class OneLakeClient(BaseFabricClient):
                 f"Lakehouse {lakehouse_id} has schemas enabled, using OneLake Delta Table APIs"
             )
             # List schemas, then tables per schema
+            yielded_any = False
             try:
                 for schema_name in self._list_schemas_via_onelake_api(
                     workspace_id, lakehouse_id
                 ):
-                    yield from self._list_tables_per_schema_via_onelake_api(
+                    for table in self._list_tables_per_schema_via_onelake_api(
                         workspace_id, lakehouse_id, schema_name
-                    )
+                    ):
+                        yielded_any = True
+                        yield table
             except requests.exceptions.HTTPError as e:
                 # If OneLake APIs fail with 401/403, it might be an authentication/permission issue
                 # Log warning and return empty (don't fail the entire ingestion)
                 if e.response.status_code in (401, 403):
+                    if yielded_any:
+                        # A permission error after tables have already been
+                        # emitted is not "no access" — it is a listing cut
+                        # short (e.g. a token that expired mid-run). Record
+                        # it as truncation so the run report shows the
+                        # results for this lakehouse are incomplete.
+                        self.report.report_pagination_truncated(
+                            f"lakehouse {lakehouse_id}: OneLake Table API listing "
+                            f"stopped early on HTTP {e.response.status_code}"
+                        )
                     logger.warning(
                         f"OneLake Delta Table APIs require additional permissions or different authentication. "
                         f"Unable to list tables for schemas-enabled lakehouse {lakehouse_id}. "
                         f"Error: {e.response.text}. "
                         f"Please ensure your identity has 'Lakehouse.Read.All' or 'Lakehouse.ReadWrite.All' permissions."
                     )
-                    # Return empty iterator instead of raising
+                    # Return the tables already yielded instead of raising
                     return
                 else:
                     logger.error(
@@ -413,11 +462,20 @@ class OneLakeClient(BaseFabricClient):
                 f"Lakehouse {lakehouse_id} does not have schemas enabled, using Fabric REST API"
             )
             # Use standard REST API endpoint
-            # Tables are in "data" key for schemas-disabled lakehouses, not "value".
-            # Reference: https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables
+            # Tables are in the "data" key for schemas-disabled lakehouses per
+            # the documented contract:
+            # https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables
+            # "value" is kept as a fallback because the pre-pagination code
+            # read both keys and we cannot rule out a tenant/API version that
+            # serves "value"; the fallback warns when it fires (and a response
+            # with neither key is reported as a parse failure) instead of
+            # silently ingesting zero tables.
+            yielded_any = False
             try:
                 endpoint = f"workspaces/{workspace_id}/lakehouses/{lakehouse_id}/tables"
-                for table_data in self._paginate(endpoint, items_key="data"):
+                for table_data in self._paginate(
+                    endpoint, items_key="data", fallback_items_keys=("value",)
+                ):
                     full_name = table_data.get("name", "")
                     # For schemas-disabled lakehouses, table names don't include schema prefix
                     # Use empty string for schema_name so URN generation can skip it
@@ -433,6 +491,7 @@ class OneLakeClient(BaseFabricClient):
                         else f"Processing table: {table_name}"
                     )
 
+                    yielded_any = True
                     yield FabricTable(
                         name=table_name,
                         schema_name=schema_name,
@@ -443,8 +502,15 @@ class OneLakeClient(BaseFabricClient):
 
             except requests.exceptions.HTTPError as e:
                 # Check if error is due to schemas being enabled (but detection failed)
+                # The fallback is only taken from a clean start: this 400
+                # rejects the whole route (schemas-enabled lakehouse), so in
+                # practice it fires on the first request. If it ever fired
+                # after a page was yielded, re-listing via the fallback would
+                # duplicate everything already emitted — treat that as a
+                # truncated listing instead (else branch below).
                 if (
-                    e.response.status_code == 400
+                    not yielded_any
+                    and e.response.status_code == 400
                     and "UnsupportedOperationForSchemasEnabledLakehouse"
                     in e.response.text
                 ):
@@ -466,6 +532,15 @@ class OneLakeClient(BaseFabricClient):
                         )
                         raise
                 else:
+                    if yielded_any:
+                        # The failure happened after earlier pages were
+                        # consumed — the tables already yielded are being
+                        # discarded by whoever catches this, so record that
+                        # the listing was cut short.
+                        self.report.report_pagination_truncated(
+                            f"lakehouse {lakehouse_id}: tables listing stopped "
+                            f"early on HTTP {e.response.status_code}"
+                        )
                     self.report.report_error()
                     logger.error(
                         f"HTTP error {e.response.status_code} listing tables for lakehouse {lakehouse_id}: {e.response.text}"
@@ -494,6 +569,7 @@ class OneLakeClient(BaseFabricClient):
             FabricTable objects
         """
         logger.info(f"Listing tables for warehouse {warehouse_id}")
+        yielded_any = False
         try:
             endpoint = f"workspaces/{workspace_id}/warehouses/{warehouse_id}/tables"
             for table_data in self._paginate(endpoint):
@@ -501,6 +577,7 @@ class OneLakeClient(BaseFabricClient):
                 schema_name, table_name = _parse_table_name(full_name)
                 logger.debug(f"Processing table: {schema_name}.{table_name}")
 
+                yielded_any = True
                 yield FabricTable(
                     name=table_name,
                     schema_name=schema_name,
@@ -511,6 +588,20 @@ class OneLakeClient(BaseFabricClient):
 
         except requests.exceptions.HTTPError as e:
             if e.response is not None and e.response.status_code == 404:
+                if yielded_any:
+                    # A 404 after pages have been emitted is a listing cut
+                    # short, not a staging warehouse with no tables endpoint.
+                    # Keep the tables already yielded (dropping them loses
+                    # entities) and record the truncation on the report.
+                    self.report.report_pagination_truncated(
+                        f"warehouse {warehouse_id}: tables listing stopped "
+                        f"early on HTTP 404"
+                    )
+                    logger.warning(
+                        f"Warehouse {warehouse_id} tables endpoint returned 404 "
+                        "after earlier pages were fetched; results are incomplete."
+                    )
+                    return
                 logger.warning(
                     f"Warehouse {warehouse_id} tables endpoint returned 404 (Not Found). "
                     "Some warehouse types (e.g. staging) do not expose tables via API. "

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
@@ -238,19 +238,19 @@ class OneLakeClient(BaseFabricClient):
             response.raise_for_status()
             data = response.json()
 
+            next_page_token = data.get("next_page_token")
+            # Check for a repeated token before yielding, so an endpoint that
+            # ignores page_token doesn't emit the same page twice.
+            if self._is_repeated_pagination_token(
+                next_page_token, seen_page_tokens, f"OneLake Table API '{url}'"
+            ):
+                break
+
             items = data.get(items_key, [])
             logger.debug(f"Page {page}: got {len(items)} item(s) from {url}")
             yield from items
 
-            next_page_token = data.get("next_page_token")
             if not next_page_token:
-                break
-            if next_page_token in seen_page_tokens:
-                logger.warning(
-                    f"OneLake Table API returned a repeated pagination token for {url}; "
-                    "stopping pagination to avoid an infinite loop. Results may be "
-                    "incomplete — the endpoint may not honor the 'page_token' parameter."
-                )
                 break
             seen_page_tokens.add(next_page_token)
             request_params["page_token"] = next_page_token

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
@@ -1,7 +1,7 @@
 """REST API client for Microsoft Fabric OneLake."""
 
 import logging
-from typing import Callable, Dict, Iterator, Optional, TypeVar
+from typing import Callable, Dict, Iterator, Optional, Set, TypeVar
 
 import requests
 
@@ -198,18 +198,18 @@ class OneLakeClient(BaseFabricClient):
     ) -> Iterator[dict]:
         """Yield all items from a paginated OneLake Table API endpoint.
 
-        The OneLake Table API for Delta (Unity Catalog-compatible surface) uses
-        next_page_token pagination rather than the continuationToken used by the
-        Fabric REST API.  Response field "next_page_token" is confirmed per
-        Microsoft documentation:
-        https://learn.microsoft.com/en-us/fabric/onelake/table-apis/delta-table-apis-overview
-        The request-side parameter name ("page_token") follows the Unity Catalog
-        convention; verify against a live multi-page response if silent truncation
-        is observed.
+        The OneLake Table API for Delta exposes a Unity Catalog-compatible surface,
+        so it uses page_token / next_page_token pagination rather than the
+        continuationToken used by the Fabric REST API. The request parameter
+        "page_token" and response field "next_page_token" are both defined by the
+        Unity Catalog API spec that the OneLake Table API implements (listSchemas /
+        listTables), and next_page_token is shown in Microsoft's docs:
+        https://learn.microsoft.com/en-us/fabric/onelake/table-apis/delta-table-apis-get-started
 
-        If the API doesn't paginate for a given call (or if the request parameter
-        name is wrong), the loop exits after one page — identical to pre-fix
-        behaviour, so there is no regression risk.
+        Should an endpoint ignore page_token, it would return the same
+        next_page_token on every call; the seen-token guard below breaks the loop
+        (with a warning) as soon as a token repeats, so a misbehaving endpoint
+        truncates loudly instead of looping forever.
 
         Args:
             url: Full URL for the API endpoint
@@ -229,6 +229,7 @@ class OneLakeClient(BaseFabricClient):
             raise
 
         request_params = dict(params)
+        seen_page_tokens: Set[str] = set()
         page = 1
         while True:
             response = self._session.get(
@@ -244,6 +245,14 @@ class OneLakeClient(BaseFabricClient):
             next_page_token = data.get("next_page_token")
             if not next_page_token:
                 break
+            if next_page_token in seen_page_tokens:
+                logger.warning(
+                    f"OneLake Table API returned a repeated pagination token for {url}; "
+                    "stopping pagination to avoid an infinite loop. Results may be "
+                    "incomplete — the endpoint may not honor the 'page_token' parameter."
+                )
+                break
+            seen_page_tokens.add(next_page_token)
             request_params["page_token"] = next_page_token
             page += 1
 

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/client.py
@@ -1,7 +1,7 @@
 """REST API client for Microsoft Fabric OneLake."""
 
 import logging
-from typing import Callable, Iterator, Optional, TypeVar
+from typing import Callable, Dict, Iterator, Optional, TypeVar
 
 import requests
 
@@ -108,14 +108,9 @@ class OneLakeClient(BaseFabricClient):
         """
         logger.info(f"Listing {item_type}s for workspace {workspace_id}")
         try:
-            response = self.get(f"workspaces/{workspace_id}/{endpoint_suffix}")
-            data = response.json()
-            items = data.get("value", [])
-            logger.info(
-                f"Found {len(items)} {item_type}(s) in workspace {workspace_id}"
-            )
-
-            for item_data in items:
+            for item_data in self._paginate(
+                f"workspaces/{workspace_id}/{endpoint_suffix}"
+            ):
                 logger.debug(
                     f"Processing {item_type}: {item_data.get('displayName', 'Unknown')}"
                 )
@@ -195,6 +190,63 @@ class OneLakeClient(BaseFabricClient):
             )
             return False
 
+    def _paginate_onelake_table_api(
+        self,
+        url: str,
+        params: Dict[str, str],
+        items_key: str,
+    ) -> Iterator[dict]:
+        """Yield all items from a paginated OneLake Table API endpoint.
+
+        The OneLake Table API for Delta (Unity Catalog-compatible surface) uses
+        next_page_token pagination rather than the continuationToken used by the
+        Fabric REST API.  Response field "next_page_token" is confirmed per
+        Microsoft documentation:
+        https://learn.microsoft.com/en-us/fabric/onelake/table-apis/delta-table-apis-overview
+        The request-side parameter name ("page_token") follows the Unity Catalog
+        convention; verify against a live multi-page response if silent truncation
+        is observed.
+
+        If the API doesn't paginate for a given call (or if the request parameter
+        name is wrong), the loop exits after one page — identical to pre-fix
+        behaviour, so there is no regression risk.
+
+        Args:
+            url: Full URL for the API endpoint
+            params: Initial query parameters
+            items_key: Response JSON key holding the items array (e.g. "schemas", "tables")
+
+        Yields:
+            Item dictionaries
+        """
+        headers: Dict[str, str] = {}
+        try:
+            headers["Authorization"] = self.auth_helper.get_authorization_header(
+                scope=ONELAKE_STORAGE_SCOPE
+            )
+        except Exception as e:
+            logger.error(f"Failed to get authorization header: {e}")
+            raise
+
+        request_params = dict(params)
+        page = 1
+        while True:
+            response = self._session.get(
+                url, headers=headers, params=dict(request_params), timeout=self.timeout
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            items = data.get(items_key, [])
+            logger.debug(f"Page {page}: got {len(items)} item(s) from {url}")
+            yield from items
+
+            next_page_token = data.get("next_page_token")
+            if not next_page_token:
+                break
+            request_params["page_token"] = next_page_token
+            page += 1
+
     def _list_schemas_via_onelake_api(
         self, workspace_id: str, lakehouse_id: str
     ) -> Iterator[str]:
@@ -210,31 +262,15 @@ class OneLakeClient(BaseFabricClient):
             Schema names
         """
         url = f"{ONELAKE_TABLE_API_BASE_URL}/delta/{workspace_id}/{lakehouse_id}/api/2.1/unity-catalog/schemas"
-        params = {"catalog_name": lakehouse_id}
-        headers = {}
-        try:
-            # Use Storage audience for OneLake Table APIs
-            headers["Authorization"] = self.auth_helper.get_authorization_header(
-                scope=ONELAKE_STORAGE_SCOPE
-            )
-        except Exception as e:
-            logger.error(f"Failed to get authorization header: {e}")
-            raise
+        params: Dict[str, str] = {"catalog_name": lakehouse_id}
 
         logger.debug(
             f"Listing schemas via OneLake Table API for lakehouse {lakehouse_id}"
         )
         try:
-            response = self._session.get(
-                url, headers=headers, params=params, timeout=self.timeout
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            schemas = data.get("schemas", [])
-            logger.info(f"Found {len(schemas)} schema(s) in lakehouse {lakehouse_id}")
-
-            for schema_data in schemas:
+            for schema_data in self._paginate_onelake_table_api(
+                url, params, items_key="schemas"
+            ):
                 schema_name = schema_data.get("name", "")
                 if schema_name:
                     logger.debug(f"Found schema: {schema_name}")
@@ -267,33 +303,18 @@ class OneLakeClient(BaseFabricClient):
             FabricTable objects
         """
         url = f"{ONELAKE_TABLE_API_BASE_URL}/delta/{workspace_id}/{lakehouse_id}/api/2.1/unity-catalog/tables"
-        params = {"catalog_name": lakehouse_id, "schema_name": schema_name}
-        headers = {}
-        try:
-            # Use Storage audience for OneLake Table APIs
-            headers["Authorization"] = self.auth_helper.get_authorization_header(
-                scope=ONELAKE_STORAGE_SCOPE
-            )
-        except Exception as e:
-            logger.error(f"Failed to get authorization header: {e}")
-            raise
+        params: Dict[str, str] = {
+            "catalog_name": lakehouse_id,
+            "schema_name": schema_name,
+        }
 
         logger.debug(
             f"Listing tables in schema {schema_name} via OneLake Table API for lakehouse {lakehouse_id}"
         )
         try:
-            response = self._session.get(
-                url, headers=headers, params=params, timeout=self.timeout
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            tables = data.get("tables", [])
-            logger.info(
-                f"Found {len(tables)} table(s) in schema {schema_name} of lakehouse {lakehouse_id}"
-            )
-
-            for table_data in tables:
+            for table_data in self._paginate_onelake_table_api(
+                url, params, items_key="tables"
+            ):
                 table_name = table_data.get("name", "")
                 if table_name:
                     logger.debug(f"Processing table: {schema_name}.{table_name}")
@@ -302,9 +323,8 @@ class OneLakeClient(BaseFabricClient):
                         schema_name=schema_name,
                         item_id=lakehouse_id,
                         workspace_id=workspace_id,
-                        description=table_data.get(
-                            "comment"
-                        ),  # OneLake API uses "comment" instead of "description"
+                        # OneLake Table API uses "comment" instead of "description"
+                        description=table_data.get("comment"),
                     )
 
         except requests.exceptions.HTTPError as e:
@@ -384,18 +404,11 @@ class OneLakeClient(BaseFabricClient):
                 f"Lakehouse {lakehouse_id} does not have schemas enabled, using Fabric REST API"
             )
             # Use standard REST API endpoint
+            # Tables are in "data" key for schemas-disabled lakehouses, not "value".
+            # Reference: https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables
             try:
-                response = self.get(
-                    f"workspaces/{workspace_id}/lakehouses/{lakehouse_id}/tables"
-                )
-                data = response.json()
-
-                # For schemas-disabled lakehouses, tables are in "data" key, not "value"
-                # Reference: https://learn.microsoft.com/en-us/rest/api/fabric/lakehouse/tables/list-tables
-                tables = data.get("data", []) or data.get("value", [])
-                logger.info(f"Found {len(tables)} table(s) in lakehouse {lakehouse_id}")
-
-                for table_data in tables:
+                endpoint = f"workspaces/{workspace_id}/lakehouses/{lakehouse_id}/tables"
+                for table_data in self._paginate(endpoint, items_key="data"):
                     full_name = table_data.get("name", "")
                     # For schemas-disabled lakehouses, table names don't include schema prefix
                     # Use empty string for schema_name so URN generation can skip it
@@ -473,15 +486,8 @@ class OneLakeClient(BaseFabricClient):
         """
         logger.info(f"Listing tables for warehouse {warehouse_id}")
         try:
-            response = self.get(
-                f"workspaces/{workspace_id}/warehouses/{warehouse_id}/tables"
-            )
-            data = response.json()
-
-            tables = data.get("value", [])
-            logger.info(f"Found {len(tables)} table(s) in warehouse {warehouse_id}")
-
-            for table_data in tables:
+            endpoint = f"workspaces/{workspace_id}/warehouses/{warehouse_id}/tables"
+            for table_data in self._paginate(endpoint):
                 full_name = table_data.get("name", "")
                 schema_name, table_name = _parse_table_name(full_name)
                 logger.debug(f"Processing table: {schema_name}.{table_name}")

--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/onelake/source.py
@@ -340,6 +340,19 @@ class FabricOneLakeSource(StatefulIngestionSourceBase):
         ):
             self.usage_extractor.update_state_on_success()
 
+        # Promote client-level pagination truncations into the run summary: a
+        # truncated listing means the emitted metadata is incomplete, which
+        # must be visible in the report's Warnings section, not only in the
+        # console log or the nested client report.
+        for truncation_context in self.client_report.pagination_truncations:
+            self.report.warning(
+                title="Listing Truncated",
+                message="A Fabric API listing stopped before all pages were "
+                "fetched; the ingested metadata is incomplete.",
+                context=truncation_context,
+                log=False,
+            )
+
     def _create_workspace_container(
         self, workspace: FabricWorkspace
     ) -> Iterable[Container]:

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
@@ -1,0 +1,412 @@
+"""Unit tests for pagination in OneLakeClient and BaseFabricClient."""
+
+from typing import Any, Dict
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import requests
+
+from datahub.ingestion.source.fabric.common.auth import FabricAuthHelper
+from datahub.ingestion.source.fabric.onelake.client import (
+    ONELAKE_TABLE_API_BASE_URL,
+    OneLakeClient,
+)
+from datahub.ingestion.source.fabric.onelake.report import FabricOneLakeClientReport
+
+
+def _make_response(data: Any, status_code: int = 200) -> Mock:
+    """Build a minimal mock requests.Response."""
+    resp = Mock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status = Mock()
+    return resp
+
+
+def _make_http_error(status_code: int, text: str = "") -> requests.exceptions.HTTPError:
+    error_response = Mock()
+    error_response.status_code = status_code
+    error_response.text = text
+    err = requests.exceptions.HTTPError(response=error_response)
+    return err
+
+
+@pytest.fixture
+def mock_auth() -> MagicMock:
+    auth = MagicMock(spec=FabricAuthHelper)
+    auth.get_authorization_header.return_value = "Bearer mock-token"
+    return auth
+
+
+@pytest.fixture
+def mock_report() -> MagicMock:
+    return MagicMock(spec=FabricOneLakeClientReport)
+
+
+@pytest.fixture
+def client(mock_auth: MagicMock, mock_report: MagicMock) -> OneLakeClient:
+    return OneLakeClient(auth_helper=mock_auth, report=mock_report)
+
+
+# ---------------------------------------------------------------------------
+# TestPaginateFabricApi — _paginate() on BaseFabricClient
+# ---------------------------------------------------------------------------
+
+
+class TestPaginateFabricApi:
+    def test_single_page(self, client: OneLakeClient) -> None:
+        page1 = {"value": [{"id": "a"}, {"id": "b"}]}
+        with patch.object(
+            client, "get", return_value=_make_response(page1)
+        ) as mock_get:
+            items = list(client._paginate("workspaces"))
+        assert items == [{"id": "a"}, {"id": "b"}]
+        mock_get.assert_called_once_with("workspaces", params={})
+
+    def test_multi_page(self, client: OneLakeClient) -> None:
+        page1 = {"value": [{"id": "a"}], "continuationToken": "tok1"}
+        page2 = {"value": [{"id": "b"}], "continuationToken": "tok2"}
+        page3 = {"value": [{"id": "c"}]}
+        responses = [
+            _make_response(page1),
+            _make_response(page2),
+            _make_response(page3),
+        ]
+        with patch.object(client, "get", side_effect=responses) as mock_get:
+            items = list(client._paginate("workspaces"))
+        assert items == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        assert mock_get.call_count == 3
+        # Second call must include the continuation token
+        mock_get.assert_any_call("workspaces", params={"continuationToken": "tok1"})
+        mock_get.assert_any_call("workspaces", params={"continuationToken": "tok2"})
+
+    def test_empty_page(self, client: OneLakeClient) -> None:
+        page: Dict[str, Any] = {"value": []}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(client._paginate("workspaces"))
+        assert items == []
+
+    def test_custom_items_key(self, client: OneLakeClient) -> None:
+        page = {"data": [{"name": "tbl1"}, {"name": "tbl2"}]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(client._paginate("some/endpoint", items_key="data"))
+        assert items == [{"name": "tbl1"}, {"name": "tbl2"}]
+
+    def test_custom_items_key_multi_page(self, client: OneLakeClient) -> None:
+        page1 = {"data": [{"name": "tbl1"}], "continuationToken": "ct1"}
+        page2 = {"data": [{"name": "tbl2"}]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            items = list(client._paginate("endpoint", items_key="data"))
+        assert [i["name"] for i in items] == ["tbl1", "tbl2"]
+
+    def test_default_items_key_unchanged(self, client: OneLakeClient) -> None:
+        """Default items_key="value" must keep existing behaviour for workspaces."""
+        page = {"value": [{"id": "ws-1"}]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(client._paginate("workspaces"))
+        assert items == [{"id": "ws-1"}]
+
+
+# ---------------------------------------------------------------------------
+# TestListItemsPagination — _list_items() (lakehouses & warehouses)
+# ---------------------------------------------------------------------------
+
+
+class TestListItemsPagination:
+    def _lakehouse_item(self, n: int) -> Dict[str, str]:
+        return {
+            "id": f"lh-{n}",
+            "displayName": f"Lakehouse{n}",
+            "description": f"desc{n}",
+        }
+
+    def test_list_lakehouses_single_page(self, client: OneLakeClient) -> None:
+        page = {"value": [self._lakehouse_item(1), self._lakehouse_item(2)]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            lakehouses = list(client.list_lakehouses("ws-1"))
+        assert len(lakehouses) == 2
+        assert lakehouses[0].id == "lh-1"
+        assert lakehouses[1].id == "lh-2"
+
+    def test_list_lakehouses_multi_page(self, client: OneLakeClient) -> None:
+        page1 = {
+            "value": [self._lakehouse_item(i) for i in range(1, 4)],
+            "continuationToken": "ct",
+        }
+        page2 = {"value": [self._lakehouse_item(4)]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            lakehouses = list(client.list_lakehouses("ws-1"))
+        assert len(lakehouses) == 4
+        assert [lh.id for lh in lakehouses] == ["lh-1", "lh-2", "lh-3", "lh-4"]
+
+    def test_list_warehouses_multi_page(self, client: OneLakeClient) -> None:
+        def _wh(n: int) -> Dict[str, str]:
+            return {"id": f"wh-{n}", "displayName": f"Warehouse{n}"}
+
+        page1 = {"value": [_wh(1)], "continuationToken": "ct"}
+        page2 = {"value": [_wh(2)]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            warehouses = list(client.list_warehouses("ws-1"))
+        assert [wh.id for wh in warehouses] == ["wh-1", "wh-2"]
+
+
+# ---------------------------------------------------------------------------
+# TestListLakehouseTablesPagination — non-schema branch ("data" key)
+# ---------------------------------------------------------------------------
+
+
+class TestListLakehouseTablesPagination:
+    def _table_item(self, name: str) -> Dict[str, str]:
+        return {"name": name, "description": f"desc_{name}"}
+
+    def _setup_schemas_disabled(self, client: OneLakeClient) -> None:
+        """Patch _is_lakehouse_schemas_enabled to return False."""
+        client._is_lakehouse_schemas_enabled = Mock(return_value=False)  # type: ignore[method-assign]
+
+    def test_single_page(self, client: OneLakeClient) -> None:
+        self._setup_schemas_disabled(client)
+        page = {"data": [self._table_item("my_table")]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        assert len(tables) == 1
+        assert tables[0].name == "my_table"
+
+    def test_multi_page(self, client: OneLakeClient) -> None:
+        self._setup_schemas_disabled(client)
+        page1 = {
+            "data": [self._table_item("tbl1"), self._table_item("tbl2")],
+            "continuationToken": "ct",
+        }
+        page2 = {"data": [self._table_item("tbl3")]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        assert [t.name for t in tables] == ["tbl1", "tbl2", "tbl3"]
+
+    def test_400_schemas_enabled_fallback_still_works(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """400 UnsupportedOperationForSchemasEnabledLakehouse must trigger schema fallback."""
+        self._setup_schemas_disabled(client)
+        http_err = _make_http_error(
+            400, "UnsupportedOperationForSchemasEnabledLakehouse"
+        )
+
+        # First call (tables endpoint) raises the 400 error
+        # Subsequent calls are for OneLake Table API (session.get)
+        schema_resp = _make_response({"schemas": [{"name": "dbo"}]})
+        table_resp = _make_response({"tables": [{"name": "t1"}]})
+
+        with (
+            patch.object(client, "get", side_effect=http_err),
+            patch.object(client._session, "get", side_effect=[schema_resp, table_resp]),
+        ):
+            tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
+
+        assert len(tables) == 1
+        assert tables[0].name == "t1"
+        assert tables[0].schema_name == "dbo"
+
+
+# ---------------------------------------------------------------------------
+# TestListWarehouseTablesPagination
+# ---------------------------------------------------------------------------
+
+
+class TestListWarehouseTablesPagination:
+    def _table_item(self, schema: str, name: str) -> Dict[str, str]:
+        return {"name": f"{schema}.{name}"}
+
+    def test_single_page(self, client: OneLakeClient) -> None:
+        page = {"value": [self._table_item("dbo", "orders")]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            tables = list(client.list_warehouse_tables("ws-1", "wh-1"))
+        assert len(tables) == 1
+        assert tables[0].name == "orders"
+        assert tables[0].schema_name == "dbo"
+
+    def test_multi_page(self, client: OneLakeClient) -> None:
+        page1 = {
+            "value": [self._table_item("dbo", "t1"), self._table_item("dbo", "t2")],
+            "continuationToken": "ct",
+        }
+        page2 = {"value": [self._table_item("sales", "t3")]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            tables = list(client.list_warehouse_tables("ws-1", "wh-1"))
+        assert [t.name for t in tables] == ["t1", "t2", "t3"]
+        assert tables[2].schema_name == "sales"
+
+    def test_404_returns_empty(self, client: OneLakeClient) -> None:
+        """Staging warehouses return 404 — must yield nothing, not raise."""
+        http_err = _make_http_error(404)
+        with patch.object(client, "get", side_effect=http_err):
+            tables = list(client.list_warehouse_tables("ws-1", "staging-wh"))
+        assert tables == []
+
+    def test_non_404_http_error_propagates(self, client: OneLakeClient) -> None:
+        http_err = _make_http_error(500, "internal server error")
+        with patch.object(client, "get", side_effect=http_err):
+            with pytest.raises(requests.exceptions.HTTPError):
+                list(client.list_warehouse_tables("ws-1", "wh-1"))
+
+
+# ---------------------------------------------------------------------------
+# TestOneLakeTableApiPagination — _paginate_onelake_table_api()
+#
+# NOTE: The response-side field "next_page_token" is confirmed by MS docs.
+# The request-side parameter "page_token" follows the Unity Catalog convention
+# but has not been verified against a live multi-page response. Mark accordingly.
+# ---------------------------------------------------------------------------
+
+
+class TestOneLakeTableApiPagination:
+    """Tests for _paginate_onelake_table_api().
+
+    REQUEST PARAMETER STATUS: "page_token" follows Unity Catalog convention.
+    Verify against a live multi-page response before relying on multi-page behaviour.
+    """
+
+    def test_schemas_single_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        resp = _make_response({"schemas": [{"name": "dbo"}, {"name": "sales"}]})
+        with patch.object(client._session, "get", return_value=resp):
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert schemas == ["dbo", "sales"]
+
+    def test_schemas_multi_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """Validate that next_page_token drives a second request."""
+        resp1 = _make_response({"schemas": [{"name": "s1"}], "next_page_token": "pt1"})
+        resp2 = _make_response({"schemas": [{"name": "s2"}]})
+        with patch.object(
+            client._session, "get", side_effect=[resp1, resp2]
+        ) as mock_get:
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+
+        assert schemas == ["s1", "s2"]
+        assert mock_get.call_count == 2
+        # Second call must include page_token
+        second_call_kwargs = mock_get.call_args_list[1]
+        assert second_call_kwargs.kwargs.get("params", {}).get("page_token") == "pt1"
+
+    def test_tables_single_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        resp = _make_response({"tables": [{"name": "orders"}, {"name": "products"}]})
+        with patch.object(client._session, "get", return_value=resp):
+            tables = list(
+                client._list_tables_per_schema_via_onelake_api("ws-1", "lh-1", "dbo")
+            )
+        assert [t.name for t in tables] == ["orders", "products"]
+        assert all(t.schema_name == "dbo" for t in tables)
+
+    def test_tables_multi_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        resp1 = _make_response({"tables": [{"name": "t1"}], "next_page_token": "pt1"})
+        resp2 = _make_response({"tables": [{"name": "t2"}, {"name": "t3"}]})
+        with patch.object(client._session, "get", side_effect=[resp1, resp2]):
+            tables = list(
+                client._list_tables_per_schema_via_onelake_api("ws-1", "lh-1", "sales")
+            )
+        assert [t.name for t in tables] == ["t1", "t2", "t3"]
+
+    def test_tables_uses_comment_field_for_description(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """OneLake Table API uses 'comment' not 'description' for table descriptions."""
+        resp = _make_response({"tables": [{"name": "t1", "comment": "my comment"}]})
+        with patch.object(client._session, "get", return_value=resp):
+            tables = list(
+                client._list_tables_per_schema_via_onelake_api("ws-1", "lh-1", "dbo")
+            )
+        assert tables[0].description == "my comment"
+
+    def test_auth_header_uses_storage_scope(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """_paginate_onelake_table_api must use ONELAKE_STORAGE_SCOPE, not the default scope."""
+        from datahub.ingestion.source.fabric.common.auth import ONELAKE_STORAGE_SCOPE
+
+        resp = _make_response({"schemas": []})
+        with patch.object(client._session, "get", return_value=resp):
+            list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+
+        mock_auth.get_authorization_header.assert_called_with(
+            scope=ONELAKE_STORAGE_SCOPE
+        )
+
+    def test_http_error_propagates(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        err_resp = Mock()
+        err_resp.status_code = 403
+        err_resp.text = "Forbidden"
+        http_err = requests.exceptions.HTTPError(response=err_resp)
+
+        with patch.object(client._session, "get", side_effect=http_err):
+            with pytest.raises(requests.exceptions.HTTPError):
+                list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+
+    def test_no_next_page_token_stops_after_one_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """When next_page_token is absent, exactly one request is made."""
+        resp = _make_response({"schemas": [{"name": "dbo"}]})
+        with patch.object(client._session, "get", return_value=resp) as mock_get:
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert schemas == ["dbo"]
+        assert mock_get.call_count == 1
+
+    def test_null_next_page_token_stops_after_one_page(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """next_page_token=null (None) must also stop pagination."""
+        resp = _make_response({"schemas": [{"name": "dbo"}], "next_page_token": None})
+        with patch.object(client._session, "get", return_value=resp) as mock_get:
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert schemas == ["dbo"]
+        assert mock_get.call_count == 1
+
+    def test_url_construction_schemas(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        resp = _make_response({"schemas": []})
+        with patch.object(client._session, "get", return_value=resp) as mock_get:
+            list(client._list_schemas_via_onelake_api("ws-abc", "lh-xyz"))
+
+        expected_url = (
+            f"{ONELAKE_TABLE_API_BASE_URL}/delta/ws-abc/lh-xyz"
+            "/api/2.1/unity-catalog/schemas"
+        )
+        actual_url = mock_get.call_args[0][0]
+        assert actual_url == expected_url
+
+    def test_url_construction_tables(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        resp = _make_response({"tables": []})
+        with patch.object(client._session, "get", return_value=resp) as mock_get:
+            list(
+                client._list_tables_per_schema_via_onelake_api(
+                    "ws-abc", "lh-xyz", "my_schema"
+                )
+            )
+
+        expected_url = (
+            f"{ONELAKE_TABLE_API_BASE_URL}/delta/ws-abc/lh-xyz"
+            "/api/2.1/unity-catalog/tables"
+        )
+        actual_url = mock_get.call_args[0][0]
+        assert actual_url == expected_url

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
@@ -1,6 +1,19 @@
-"""Unit tests for pagination in OneLakeClient and BaseFabricClient."""
+"""Unit tests for pagination in OneLakeClient and BaseFabricClient.
 
-from typing import Any, Dict
+Design notes shared across these tests:
+
+- The repeated-token guard tests use a *bounded* ``side_effect`` list rather
+  than ``return_value``: if the guard ever regresses, the mock runs dry and
+  the test fails fast with ``StopIteration`` instead of hanging the CI job in
+  an infinite pagination loop.
+- A fetched page is never dropped: when an endpoint repeats a pagination
+  token, the page is yielded *before* the guard breaks the loop. Re-emitting
+  a page at worst duplicates idempotent-per-URN metadata, while dropping one
+  loses entities — so the guard tests deliberately assert the duplicate
+  emission, and assert the truncation is recorded on the client report.
+"""
+
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -76,15 +89,132 @@ class TestPaginateFabricApi:
             items = list(client._paginate("workspaces"))
         assert items == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
         assert mock_get.call_count == 3
-        # Second call must include the continuation token
-        mock_get.assert_any_call("workspaces", params={"continuationToken": "tok1"})
-        mock_get.assert_any_call("workspaces", params={"continuationToken": "tok2"})
+        # Later calls must carry the continuation token — full-dict equality
+        # so a rebuilt/lost params dict cannot slip through.
+        assert mock_get.call_args_list[1].kwargs["params"] == {
+            "continuationToken": "tok1"
+        }
+        assert mock_get.call_args_list[2].kwargs["params"] == {
+            "continuationToken": "tok2"
+        }
 
-    def test_empty_page(self, client: OneLakeClient) -> None:
+    def test_multi_page_preserves_initial_params(self, client: OneLakeClient) -> None:
+        """Page 2+ must carry the caller's original filters alongside the token.
+
+        A regression that rebuilt the params dict instead of extending it would
+        page against the wrong filter — plausible-but-wrong results, which is
+        worse than truncation.
+        """
+        page1 = {"value": [{"id": "a"}], "continuationToken": "tok1"}
+        page2 = {"value": [{"id": "b"}]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ) as mock_get:
+            items = list(
+                client._paginate(
+                    "workspaces/ws-1/items", params={"type": "DataPipeline"}
+                )
+            )
+        assert [i["id"] for i in items] == ["a", "b"]
+        assert mock_get.call_args_list[0].kwargs["params"] == {"type": "DataPipeline"}
+        assert mock_get.call_args_list[1].kwargs["params"] == {
+            "type": "DataPipeline",
+            "continuationToken": "tok1",
+        }
+
+    def test_caller_params_not_mutated(self, client: OneLakeClient) -> None:
+        params = {"type": "DataPipeline"}
+        page1 = {"value": [{"id": "a"}], "continuationToken": "tok1"}
+        page2 = {"value": [{"id": "b"}]}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            list(client._paginate("endpoint", params=params))
+        assert params == {"type": "DataPipeline"}
+
+    def test_empty_page_is_not_a_parse_failure(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A legitimately-empty page ({"value": []}) yields nothing quietly."""
         page: Dict[str, Any] = {"value": []}
         with patch.object(client, "get", return_value=_make_response(page)):
             items = list(client._paginate("workspaces"))
         assert items == []
+        mock_report.report_parse_failure.assert_not_called()
+
+    def test_null_items_value_treated_as_empty(self, client: OneLakeClient) -> None:
+        """{"value": null} must be an empty page, not a TypeError."""
+        page = {"value": None}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(client._paginate("workspaces"))
+        assert items == []
+
+    def test_token_only_terminal_page_is_not_a_parse_failure(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A terminal page carrying only the pagination envelope (items array
+        omitted entirely) is a legitimate empty page — e.g.
+        {"continuationToken": null} — not a malformed response."""
+        page1 = {"value": [{"id": "a"}], "continuationToken": "tok1"}
+        page2: Dict[str, Any] = {"continuationToken": None, "continuationUri": None}
+        with patch.object(
+            client, "get", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            items = list(client._paginate("workspaces"))
+        assert items == [{"id": "a"}]
+        mock_report.report_parse_failure.assert_not_called()
+
+    def test_fallback_warning_fires_once_per_run(
+        self, client: OneLakeClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A multi-page listing served entirely under the fallback key warns
+        once, not once per page."""
+        page1 = {"value": [{"name": "t1"}], "continuationToken": "ct1"}
+        page2 = {"value": [{"name": "t2"}]}
+        with (
+            caplog.at_level("WARNING"),
+            patch.object(
+                client,
+                "get",
+                side_effect=[_make_response(page1), _make_response(page2)],
+            ),
+        ):
+            items = list(
+                client._paginate(
+                    "endpoint", items_key="data", fallback_items_keys=("value",)
+                )
+            )
+        assert [i["name"] for i in items] == ["t1", "t2"]
+        fallback_warnings = [
+            r for r in caplog.records if "fallback key" in r.getMessage()
+        ]
+        assert len(fallback_warnings) == 1
+
+    def test_missing_items_key_reports_parse_failure(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A non-empty response without the expected items key must be loud:
+        it would otherwise ingest zero items with no signal."""
+        page = {"unexpected": [{"id": "a"}]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(client._paginate("workspaces"))
+        assert items == []
+        mock_report.report_parse_failure.assert_called_once()
+
+    def test_fallback_items_key_used(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """When the primary key is absent, a configured fallback key still
+        serves the items (and is not a parse failure)."""
+        page = {"value": [{"name": "tbl1"}]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            items = list(
+                client._paginate(
+                    "endpoint", items_key="data", fallback_items_keys=("value",)
+                )
+            )
+        assert items == [{"name": "tbl1"}]
+        mock_report.report_parse_failure.assert_not_called()
 
     def test_custom_items_key(self, client: OneLakeClient) -> None:
         page = {"data": [{"name": "tbl1"}, {"name": "tbl2"}]}
@@ -101,23 +231,97 @@ class TestPaginateFabricApi:
             items = list(client._paginate("endpoint", items_key="data"))
         assert [i["name"] for i in items] == ["tbl1", "tbl2"]
 
-    def test_default_items_key_unchanged(self, client: OneLakeClient) -> None:
-        """Default items_key="value" must keep existing behaviour for workspaces."""
-        page = {"value": [{"id": "ws-1"}]}
-        with patch.object(client, "get", return_value=_make_response(page)):
-            items = list(client._paginate("workspaces"))
-        assert items == [{"id": "ws-1"}]
-
-    def test_repeated_continuation_token_breaks(self, client: OneLakeClient) -> None:
-        """A non-advancing continuationToken must stop pagination without emitting
-        the repeated page twice."""
+    def test_repeated_continuation_token_breaks(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A non-advancing continuationToken stops pagination after the second
+        request. The second page is yielded before the guard fires (never drop
+        a fetched page; the duplicate is tolerated), and the truncation is
+        recorded on the client report."""
         page: Dict[str, Any] = {"value": [{"id": "a"}], "continuationToken": "stuck"}
-        with patch.object(client, "get", return_value=_make_response(page)) as mock_get:
+        responses = [_make_response(page) for _ in range(5)]
+        with patch.object(client, "get", side_effect=responses) as mock_get:
             items = list(client._paginate("workspaces"))
-        # Page 1 yields and records the token; page 2 detects the repeat before
-        # yielding and breaks, so the item is emitted once.
         assert mock_get.call_count == 2
-        assert items == [{"id": "a"}]
+        assert items == [{"id": "a"}, {"id": "a"}]
+        mock_report.report_pagination_truncated.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestPaginatePostFabricApi — _paginate_post() on BaseFabricClient
+#
+# The only production caller is query_activity_runs (data_factory/client.py),
+# whose integration tests patch the method out wholesale — so the paginator
+# body is pinned here.
+# ---------------------------------------------------------------------------
+
+
+class TestPaginatePostFabricApi:
+    BODY: Dict[str, Any] = {
+        "filters": [],
+        "orderBy": [{"orderBy": "ActivityRunStart", "order": "DESC"}],
+    }
+
+    def test_single_page(self, client: OneLakeClient) -> None:
+        page1 = {"value": [{"activityName": "a"}]}
+        with patch.object(
+            client, "post", return_value=_make_response(page1)
+        ) as mock_post:
+            items = list(client._paginate_post("runs", dict(self.BODY)))
+        assert items == [{"activityName": "a"}]
+        mock_post.assert_called_once_with("runs", json=self.BODY)
+
+    def test_multi_page_body_carries_token_and_original_fields(
+        self, client: OneLakeClient
+    ) -> None:
+        """Page 2's body must be the original body plus the token — full-dict
+        equality so a rebuilt/lost body cannot slip through."""
+        page1 = {"value": [{"activityName": "a"}], "continuationToken": "ct1"}
+        page2 = {"value": [{"activityName": "b"}]}
+        with patch.object(
+            client, "post", side_effect=[_make_response(page1), _make_response(page2)]
+        ) as mock_post:
+            items = list(client._paginate_post("runs", dict(self.BODY)))
+        assert [i["activityName"] for i in items] == ["a", "b"]
+        assert mock_post.call_args_list[0].kwargs["json"] == self.BODY
+        assert mock_post.call_args_list[1].kwargs["json"] == {
+            **self.BODY,
+            "continuationToken": "ct1",
+        }
+
+    def test_caller_body_not_mutated(self, client: OneLakeClient) -> None:
+        """Pagination state must never be written into the caller's dict —
+        a reused body would otherwise carry a stale token into an unrelated
+        request."""
+        body = dict(self.BODY)
+        page1 = {"value": [{"activityName": "a"}], "continuationToken": "ct1"}
+        page2 = {"value": [{"activityName": "b"}]}
+        with patch.object(
+            client, "post", side_effect=[_make_response(page1), _make_response(page2)]
+        ):
+            list(client._paginate_post("runs", body))
+        assert body == self.BODY
+
+    def test_list_shaped_response(self, client: OneLakeClient) -> None:
+        """A bare-array response is yielded as-is and stops after one page."""
+        page: List[Dict[str, str]] = [{"activityName": "a"}, {"activityName": "b"}]
+        with patch.object(
+            client, "post", return_value=_make_response(page)
+        ) as mock_post:
+            items = list(client._paginate_post("runs", dict(self.BODY)))
+        assert items == page
+        assert mock_post.call_count == 1
+
+    def test_repeated_continuation_token_breaks(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        page = {"value": [{"activityName": "a"}], "continuationToken": "stuck"}
+        responses = [_make_response(page) for _ in range(5)]
+        with patch.object(client, "post", side_effect=responses) as mock_post:
+            items = list(client._paginate_post("runs", dict(self.BODY)))
+        assert mock_post.call_count == 2
+        assert items == [{"activityName": "a"}, {"activityName": "a"}]
+        mock_report.report_pagination_truncated.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +372,8 @@ class TestListItemsPagination:
 
 
 # ---------------------------------------------------------------------------
-# TestListLakehouseTablesPagination — non-schema branch ("data" key)
+# TestListLakehouseTablesPagination — non-schema branch ("data" key, with a
+# loud "value" fallback)
 # ---------------------------------------------------------------------------
 
 
@@ -201,6 +406,46 @@ class TestListLakehouseTablesPagination:
             tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
         assert [t.name for t in tables] == ["tbl1", "tbl2", "tbl3"]
 
+    def test_value_key_fallback_still_ingests(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A response serving tables under "value" (the pre-pagination code
+        read both keys) must still ingest every table, not silently zero."""
+        self._setup_schemas_disabled(client)
+        page = {"value": [self._table_item("tbl1"), self._table_item("tbl2")]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        assert [t.name for t in tables] == ["tbl1", "tbl2"]
+        mock_report.report_parse_failure.assert_not_called()
+
+    def test_unrecognized_items_key_reports_parse_failure(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A non-empty response under neither "data" nor "value" must surface
+        as a parse failure instead of quietly ingesting nothing."""
+        self._setup_schemas_disabled(client)
+        page = {"tables": [self._table_item("tbl1")]}
+        with patch.object(client, "get", return_value=_make_response(page)):
+            tables = list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        assert tables == []
+        mock_report.report_parse_failure.assert_called_once()
+
+    def test_http_error_after_first_page_records_truncation(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A failure on page 2+ means earlier pages were already consumed —
+        record the truncation before propagating."""
+        self._setup_schemas_disabled(client)
+        page1 = _make_response(
+            {"data": [self._table_item("tbl1")], "continuationToken": "ct"}
+        )
+        with patch.object(
+            client, "get", side_effect=[page1, _make_http_error(500, "boom")]
+        ):
+            with pytest.raises(requests.exceptions.HTTPError):
+                list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        mock_report.report_pagination_truncated.assert_called_once()
+
     def test_400_schemas_enabled_fallback_still_works(
         self, client: OneLakeClient, mock_auth: MagicMock
     ) -> None:
@@ -224,6 +469,24 @@ class TestListLakehouseTablesPagination:
         assert len(tables) == 1
         assert tables[0].name == "t1"
         assert tables[0].schema_name == "dbo"
+
+    def test_400_after_first_page_is_truncation_not_fallback(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """The schema fallback re-lists the whole lakehouse, so it is only
+        taken from a clean start; after a page has been yielded a 400 is a
+        truncated listing and propagates."""
+        self._setup_schemas_disabled(client)
+        page1 = _make_response(
+            {"data": [self._table_item("tbl1")], "continuationToken": "ct"}
+        )
+        http_err = _make_http_error(
+            400, "UnsupportedOperationForSchemasEnabledLakehouse"
+        )
+        with patch.object(client, "get", side_effect=[page1, http_err]):
+            with pytest.raises(requests.exceptions.HTTPError):
+                list(client.list_lakehouse_tables("ws-1", "lh-1"))
+        mock_report.report_pagination_truncated.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -256,12 +519,29 @@ class TestListWarehouseTablesPagination:
         assert [t.name for t in tables] == ["t1", "t2", "t3"]
         assert tables[2].schema_name == "sales"
 
-    def test_404_returns_empty(self, client: OneLakeClient) -> None:
-        """Staging warehouses return 404 — must yield nothing, not raise."""
+    def test_404_returns_empty(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """Staging warehouses return 404 on the first request — must yield
+        nothing, not raise, and is not a truncation."""
         http_err = _make_http_error(404)
         with patch.object(client, "get", side_effect=http_err):
             tables = list(client.list_warehouse_tables("ws-1", "staging-wh"))
         assert tables == []
+        mock_report.report_pagination_truncated.assert_not_called()
+
+    def test_404_after_first_page_keeps_tables_and_records_truncation(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A 404 on page 2+ is a listing cut short, not a staging warehouse:
+        the tables already yielded are kept and the truncation is recorded."""
+        page1 = _make_response(
+            {"value": [self._table_item("dbo", "t1")], "continuationToken": "ct"}
+        )
+        with patch.object(client, "get", side_effect=[page1, _make_http_error(404)]):
+            tables = list(client.list_warehouse_tables("ws-1", "wh-1"))
+        assert [t.name for t in tables] == ["t1"]
+        mock_report.report_pagination_truncated.assert_called_once()
 
     def test_non_404_http_error_propagates(self, client: OneLakeClient) -> None:
         http_err = _make_http_error(500, "internal server error")
@@ -294,7 +574,8 @@ class TestOneLakeTableApiPagination:
     def test_schemas_multi_page(
         self, client: OneLakeClient, mock_auth: MagicMock
     ) -> None:
-        """Validate that next_page_token drives a second request."""
+        """Validate that next_page_token drives a second request that carries
+        both the original catalog filter and the token."""
         resp1 = _make_response({"schemas": [{"name": "s1"}], "next_page_token": "pt1"})
         resp2 = _make_response({"schemas": [{"name": "s2"}]})
         with patch.object(
@@ -304,9 +585,13 @@ class TestOneLakeTableApiPagination:
 
         assert schemas == ["s1", "s2"]
         assert mock_get.call_count == 2
-        # Second call must include page_token
-        second_call_kwargs = mock_get.call_args_list[1]
-        assert second_call_kwargs.kwargs.get("params", {}).get("page_token") == "pt1"
+        # Full-dict equality: a rebuilt params dict that lost catalog_name
+        # would page against the wrong lakehouse with the suite still green.
+        second_call = mock_get.call_args_list[1]
+        assert second_call.kwargs["params"] == {
+            "catalog_name": "lh-1",
+            "page_token": "pt1",
+        }
 
     def test_tables_single_page(
         self, client: OneLakeClient, mock_auth: MagicMock
@@ -355,8 +640,32 @@ class TestOneLakeTableApiPagination:
             scope=ONELAKE_STORAGE_SCOPE
         )
 
-    def test_http_error_propagates(
+    def test_auth_header_fetched_per_page(
         self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """The Authorization header is fetched once per page (the helper
+        caches, so this is cheap) — a single fetch hoisted above the loop
+        could expire during a long pagination run."""
+        resp1 = _make_response({"schemas": [{"name": "s1"}], "next_page_token": "pt1"})
+        resp2 = _make_response({"schemas": [{"name": "s2"}], "next_page_token": "pt2"})
+        resp3 = _make_response({"schemas": [{"name": "s3"}]})
+        with patch.object(client._session, "get", side_effect=[resp1, resp2, resp3]):
+            list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert mock_auth.get_authorization_header.call_count == 3
+
+    def test_requests_counted_on_report(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """Every page fetched via the OneLake Table API counts toward
+        request_count — this path cannot go through _request()."""
+        resp1 = _make_response({"schemas": [{"name": "s1"}], "next_page_token": "pt1"})
+        resp2 = _make_response({"schemas": [{"name": "s2"}]})
+        with patch.object(client._session, "get", side_effect=[resp1, resp2]):
+            list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert mock_report.report_request.call_count == 2
+
+    def test_http_error_propagates_and_counts_once(
+        self, client: OneLakeClient, mock_report: MagicMock
     ) -> None:
         err_resp = Mock()
         err_resp.status_code = 403
@@ -366,41 +675,62 @@ class TestOneLakeTableApiPagination:
         with patch.object(client._session, "get", side_effect=http_err):
             with pytest.raises(requests.exceptions.HTTPError):
                 list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        # Counted at the request layer inside the paginator, and only there.
+        assert mock_report.report_error.call_count == 1
 
     def test_no_next_page_token_stops_after_one_page(
         self, client: OneLakeClient, mock_auth: MagicMock
     ) -> None:
-        """When next_page_token is absent, exactly one request is made."""
-        resp = _make_response({"schemas": [{"name": "dbo"}]})
-        with patch.object(client._session, "get", return_value=resp) as mock_get:
-            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
-        assert schemas == ["dbo"]
-        assert mock_get.call_count == 1
-
-    def test_null_next_page_token_stops_after_one_page(
-        self, client: OneLakeClient, mock_auth: MagicMock
-    ) -> None:
-        """next_page_token=null (None) must also stop pagination."""
+        """When next_page_token is absent (or null), exactly one request is made."""
         resp = _make_response({"schemas": [{"name": "dbo"}], "next_page_token": None})
         with patch.object(client._session, "get", return_value=resp) as mock_get:
             schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
         assert schemas == ["dbo"]
         assert mock_get.call_count == 1
 
-    def test_repeated_page_token_breaks(
-        self, client: OneLakeClient, mock_auth: MagicMock
+    def test_token_only_terminal_page_is_not_a_parse_failure(
+        self, client: OneLakeClient, mock_report: MagicMock
     ) -> None:
-        """An endpoint that ignores page_token repeats next_page_token; the guard
-        must stop pagination instead of looping forever."""
-        resp = _make_response(
-            {"schemas": [{"name": "dbo"}], "next_page_token": "stuck"}
-        )
-        with patch.object(client._session, "get", return_value=resp) as mock_get:
+        """Unity Catalog-style APIs may omit the items array on an empty/terminal
+        page and serialize only {"next_page_token": null} — that page is empty,
+        not malformed."""
+        resp1 = _make_response({"schemas": [{"name": "s1"}], "next_page_token": "pt1"})
+        resp2 = _make_response({"next_page_token": None})
+        with patch.object(client._session, "get", side_effect=[resp1, resp2]):
             schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
-        # Page 1 yields and records the token; page 2 detects the repeat before
-        # yielding and breaks, so the schema is emitted once.
+        assert schemas == ["s1"]
+        mock_report.report_parse_failure.assert_not_called()
+
+    def test_malformed_json_body_counts_as_error(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """A 200 whose body fails JSON decoding is a failed request: it must
+        count on the report and propagate."""
+        resp = Mock(spec=requests.Response)
+        resp.status_code = 200
+        resp.raise_for_status = Mock()
+        resp.json.side_effect = requests.exceptions.JSONDecodeError(
+            "Expecting value", "not json", 0
+        )
+        with patch.object(client._session, "get", return_value=resp):
+            with pytest.raises(requests.exceptions.JSONDecodeError):
+                list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        assert mock_report.report_error.call_count == 1
+
+    def test_repeated_page_token_breaks(
+        self, client: OneLakeClient, mock_report: MagicMock
+    ) -> None:
+        """An endpoint that ignores page_token repeats next_page_token; the
+        guard stops pagination after the second request. The second page is
+        yielded before the guard fires (never drop a fetched page), and the
+        truncation is recorded on the client report."""
+        resp_data = {"schemas": [{"name": "dbo"}], "next_page_token": "stuck"}
+        responses = [_make_response(resp_data) for _ in range(5)]
+        with patch.object(client._session, "get", side_effect=responses) as mock_get:
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
         assert mock_get.call_count == 2
-        assert schemas == ["dbo"]
+        assert schemas == ["dbo", "dbo"]
+        mock_report.report_pagination_truncated.assert_called_once()
 
     def test_url_construction_schemas(
         self, client: OneLakeClient, mock_auth: MagicMock

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
@@ -108,6 +108,15 @@ class TestPaginateFabricApi:
             items = list(client._paginate("workspaces"))
         assert items == [{"id": "ws-1"}]
 
+    def test_repeated_continuation_token_breaks(self, client: OneLakeClient) -> None:
+        """A non-advancing continuationToken must stop pagination, not loop forever."""
+        page: Dict[str, Any] = {"value": [{"id": "a"}], "continuationToken": "stuck"}
+        with patch.object(client, "get", return_value=_make_response(page)) as mock_get:
+            items = list(client._paginate("workspaces"))
+        # Page 1 records the token; page 2 sees the same token and breaks.
+        assert mock_get.call_count == 2
+        assert items == [{"id": "a"}, {"id": "a"}]
+
 
 # ---------------------------------------------------------------------------
 # TestListItemsPagination — _list_items() (lakehouses & warehouses)
@@ -262,18 +271,15 @@ class TestListWarehouseTablesPagination:
 # ---------------------------------------------------------------------------
 # TestOneLakeTableApiPagination — _paginate_onelake_table_api()
 #
-# NOTE: The response-side field "next_page_token" is confirmed by MS docs.
-# The request-side parameter "page_token" follows the Unity Catalog convention
-# but has not been verified against a live multi-page response. Mark accordingly.
+# Both the request parameter "page_token" and response field "next_page_token"
+# are defined by the Unity Catalog API spec that the OneLake Table API implements
+# (listSchemas / listTables). Should an endpoint ignore page_token, the seen-token
+# guard breaks the loop instead of spinning forever (test_repeated_page_token_breaks).
 # ---------------------------------------------------------------------------
 
 
 class TestOneLakeTableApiPagination:
-    """Tests for _paginate_onelake_table_api().
-
-    REQUEST PARAMETER STATUS: "page_token" follows Unity Catalog convention.
-    Verify against a live multi-page response before relying on multi-page behaviour.
-    """
+    """Tests for _paginate_onelake_table_api()."""
 
     def test_schemas_single_page(
         self, client: OneLakeClient, mock_auth: MagicMock
@@ -378,6 +384,20 @@ class TestOneLakeTableApiPagination:
             schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
         assert schemas == ["dbo"]
         assert mock_get.call_count == 1
+
+    def test_repeated_page_token_breaks(
+        self, client: OneLakeClient, mock_auth: MagicMock
+    ) -> None:
+        """An endpoint that ignores page_token repeats next_page_token; the guard
+        must stop pagination instead of looping forever."""
+        resp = _make_response(
+            {"schemas": [{"name": "dbo"}], "next_page_token": "stuck"}
+        )
+        with patch.object(client._session, "get", return_value=resp) as mock_get:
+            schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
+        # Page 1 records the token; page 2 sees the same token and breaks.
+        assert mock_get.call_count == 2
+        assert schemas == ["dbo", "dbo"]
 
     def test_url_construction_schemas(
         self, client: OneLakeClient, mock_auth: MagicMock

--- a/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
+++ b/metadata-ingestion/tests/unit/fabric_onelake/test_client_pagination.py
@@ -109,13 +109,15 @@ class TestPaginateFabricApi:
         assert items == [{"id": "ws-1"}]
 
     def test_repeated_continuation_token_breaks(self, client: OneLakeClient) -> None:
-        """A non-advancing continuationToken must stop pagination, not loop forever."""
+        """A non-advancing continuationToken must stop pagination without emitting
+        the repeated page twice."""
         page: Dict[str, Any] = {"value": [{"id": "a"}], "continuationToken": "stuck"}
         with patch.object(client, "get", return_value=_make_response(page)) as mock_get:
             items = list(client._paginate("workspaces"))
-        # Page 1 records the token; page 2 sees the same token and breaks.
+        # Page 1 yields and records the token; page 2 detects the repeat before
+        # yielding and breaks, so the item is emitted once.
         assert mock_get.call_count == 2
-        assert items == [{"id": "a"}, {"id": "a"}]
+        assert items == [{"id": "a"}]
 
 
 # ---------------------------------------------------------------------------
@@ -395,9 +397,10 @@ class TestOneLakeTableApiPagination:
         )
         with patch.object(client._session, "get", return_value=resp) as mock_get:
             schemas = list(client._list_schemas_via_onelake_api("ws-1", "lh-1"))
-        # Page 1 records the token; page 2 sees the same token and breaks.
+        # Page 1 yields and records the token; page 2 detects the repeat before
+        # yielding and breaks, so the schema is emitted once.
         assert mock_get.call_count == 2
-        assert schemas == ["dbo", "dbo"]
+        assert schemas == ["dbo"]
 
     def test_url_construction_schemas(
         self, client: OneLakeClient, mock_auth: MagicMock


### PR DESCRIPTION
## Summary

- **`_list_items()`** (backs `list_lakehouses()` + `list_warehouses()`): replaced single `self.get()` + manual parse with `self._paginate()` — fixes silent truncation at 100 lakehouses/warehouses per workspace.
- **`list_lakehouse_tables()` non-schema branch**: replaced single `self.get()` with `self._paginate(endpoint, items_key="data")` — the Fabric "List Tables" endpoint returns items under `"data"`, not `"value"`.
- **`list_warehouse_tables()`**: replaced single `self.get()` with `self._paginate()`.
- **`_list_schemas_via_onelake_api()` / `_list_tables_per_schema_via_onelake_api()`** (schema-enabled branch): added `_paginate_onelake_table_api()` helper which handles `next_page_token` / `page_token` pagination used by the OneLake Delta (Unity Catalog-compatible) API surface — distinct from the `continuationToken` used by the Fabric REST API.
- **`BaseFabricClient._paginate()` / `_paginate_post()`**: added an `items_key` parameter (default `"value"`) so callers can specify the response array key without forking the method.
- **New test file** `tests/unit/fabric_onelake/test_client_pagination.py`: unit tests covering multi-page responses for all four call sites.

## Root Cause

`_paginate()` was wired only to `_list_workspaces_raw()`. The four list endpoints above were left on single-page `self.get()` calls — not a regression, just incomplete wiring from when the connector was added.

## Impact

Any workspace/lakehouse/warehouse with more than 100 items (the Fabric REST API default page size) silently returned only the first 100. Ingestion runs reported SUCCESS with no error, causing undetected data loss. Reported via support.

## Test Plan

- [x] `ruff check` + `ruff format --check` pass on all changed files
- [x] New unit tests in `test_client_pagination.py` cover multi-page responses for `_list_items`, `list_lakehouse_tables` (both branches), and `list_warehouse_tables`
- [x] No behaviour change for the already-working `_list_workspaces_raw()` path

## Notes

- The OneLake Delta Table API response field `next_page_token` is confirmed by [Microsoft's documentation](https://learn.microsoft.com/en-us/fabric/onelake/table-apis/delta-table-apis-overview); the request-side parameter name `page_token` follows the Unity Catalog convention and has not yet been verified against a live multi-page response. If it is wrong, that branch exits after one page — identical to pre-fix behaviour, so there is no regression risk. This caveat is documented in the helper's docstring and in the test module.
- The `list_lakehouse_tables()` non-schema branch now reads only the `"data"` key (via `items_key="data"`) rather than the previous `data.get("data", []) or data.get("value", [])` fallback, matching the documented endpoint contract.

## Non-Goals

- Does not touch schema extraction logic (`sql_analytics_endpoint` path) beyond the table-listing calls it depends on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pages all Fabric OneLake list endpoints and prevents hangs by guarding non-advancing pagination tokens. Previously, listings returned only the first 100 items or could loop forever; now all pages are iterated, and truncated listings surface as warnings in the run summary instead of silently passing.

- `_list_items()` (backs `list_lakehouses()`/`list_warehouses()`) and `list_warehouse_tables()` now use `_paginate()`. `list_lakehouse_tables()` for schemas-disabled lakehouses uses `_paginate(..., items_key="data")`, keeping a "value" fallback that warns when it fires.
- Schema-enabled paths use `_paginate_onelake_table_api()` with `page_token`/`next_page_token`; table descriptions come from `comment`. The auth header is fetched per page so a token can refresh mid-run.
- Shared guard `BaseFabricClient._is_repeated_pagination_token` stops pagination when a token repeats; a fetched page is always yielded before the guard fires. Each request uses a fresh copy of params/body.
- Repeated tokens and errors after pages were fetched are recorded as `pagination_truncations` on the client report and promoted to a "Listing Truncated" warning in both Fabric sources' summaries.
- Unit tests cover multi-page flows, repeated-token guards, fallback keys, and truncation reporting across all updated call sites.

**Rollout and risks**
- No config or migration; expect more API calls on large listings.
- If an endpoint ignores the pagination token, we log a warning and stop; results may be truncated instead of hanging.

<sup>Written for commit d639deee9c576a2fee0caa54dde4fc59ce2e5c1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

