### PR TITLE
fix(ui): Decode schema field names when displaying in the UI

### DIFF
--- a/datahub-web-react/src/app/entityV2/schemaField/SchemaFieldEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/schemaField/SchemaFieldEntity.tsx
@@ -134,11 +134,12 @@ export class SchemaFieldEntity implements Entity<SchemaField> {
     getLineageVizConfig = (entity: SchemaField): FetchedEntity => {
         const parent =
             entity.parent && globalEntityRegistryV2.getGenericEntityProperties(entity.parent.type, entity.parent);
+        const decodedFieldPath = decodeSchemaField(downgradeV2FieldPath(entity?.fieldPath) || '');
         return {
             urn: entity.urn,
             type: EntityType.SchemaField,
-            name: entity?.fieldPath,
-            expandedName: `${parent?.name}.${entity?.fieldPath}`,
+            name: decodedFieldPath,
+            expandedName: `${parent?.name}.${decodedFieldPath}`,
             icon: parent?.platform?.properties?.logoUrl ?? undefined,
             parent: parent ?? undefined,
         };

--- a/datahub-web-react/src/app/entityV2/schemaField/SchemaFieldEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/schemaField/SchemaFieldEntity.tsx
@@ -105,7 +105,7 @@ export class SchemaFieldEntity implements Entity<SchemaField> {
                 data={genericProperties}
                 previewType={previewType}
                 datasetUrn={data.parent.urn}
-                name={downgradeV2FieldPath(data.fieldPath) || data.urn}
+                name={this.displayName(data)}
                 parent={data?.parent as GenericEntityProperties}
             />
         );
@@ -134,7 +134,7 @@ export class SchemaFieldEntity implements Entity<SchemaField> {
     getLineageVizConfig = (entity: SchemaField): FetchedEntity => {
         const parent =
             entity.parent && globalEntityRegistryV2.getGenericEntityProperties(entity.parent.type, entity.parent);
-        const decodedFieldPath = decodeSchemaField(downgradeV2FieldPath(entity?.fieldPath) || '');
+        const decodedFieldPath = this.displayName(entity);
         return {
             urn: entity.urn,
             type: EntityType.SchemaField,

--- a/datahub-web-react/src/app/entityV2/schemaField/__tests__/SchemaFieldEntity.test.ts
+++ b/datahub-web-react/src/app/entityV2/schemaField/__tests__/SchemaFieldEntity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SchemaFieldEntity } from '@app/entityV2/schemaField/SchemaFieldEntity';
+
+import { EntityType, SchemaFieldEntity as SchemaField } from '@types';
+
+vi.mock('@app/globalEntityRegistryV2', () => ({
+    default: {
+        getGenericEntityProperties: () => ({ name: 'my_dataset' }),
+    },
+}));
+
+describe('SchemaFieldEntity', () => {
+    describe('getLineageVizConfig', () => {
+        it('decodes percent-encoded characters in the field path for the lineage node name', () => {
+            const entity = {
+                urn: 'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_table,PROD),Revenue %28Net%29)',
+                type: EntityType.SchemaField,
+                fieldPath: 'Revenue %28Net%29',
+                parent: {
+                    urn: 'urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_table,PROD)',
+                    type: EntityType.Dataset,
+                },
+            } as unknown as SchemaField;
+
+            const config = new SchemaFieldEntity().getLineageVizConfig(entity);
+
+            expect(config.name).toBe('Revenue (Net)');
+            expect(config.expandedName).toBe('my_dataset.Revenue (Net)');
+        });
+    });
+});

--- a/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameComponent.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameComponent.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import { IconStyleType } from '@app/entity/Entity';
+import { decodeSchemaField } from '@app/lineage/utils/columnLineageUtils';
+import { downgradeV2FieldPath } from '@app/lineageV3/utils/lineageUtils';
 import { EntityPreviewTag } from '@app/recommendations/renderer/component/EntityPreviewTag';
 import { HoverEntityTooltip } from '@app/recommendations/renderer/component/HoverEntityTooltip';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -51,7 +53,7 @@ export const CompactEntityNameComponent = ({
     if (entity.type === EntityType.SchemaField) {
         const { parent, fieldPath } = entity as SchemaFieldEntity;
         processedEntity = parent;
-        columnName = fieldPath;
+        columnName = decodeSchemaField(downgradeV2FieldPath(fieldPath) || '');
     }
 
     const genericProps = entityRegistry.getGenericEntityProperties(processedEntity.type, processedEntity);

--- a/datahub-web-react/src/app/recommendations/renderer/component/__tests__/CompactEntityNameComponent.test.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/__tests__/CompactEntityNameComponent.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CompactEntityNameComponent } from '@app/recommendations/renderer/component/CompactEntityNameComponent';
+import CustomThemeProvider from '@src/CustomThemeProvider';
+
+import { Entity, EntityType } from '@types';
+
+const mockEntityRegistry = {
+    getGenericEntityProperties: () => ({ platform: null }),
+    getDisplayName: () => 'my_dataset',
+    getIcon: () => null,
+    getEntityUrl: () => '/dataset/urn:li:dataset:test',
+    renderPreview: () => null,
+};
+
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistry: () => mockEntityRegistry,
+    useEntityRegistryV2: () => mockEntityRegistry,
+}));
+
+const renderWithProviders = (ui: React.ReactElement) =>
+    render(
+        <CustomThemeProvider>
+            <MemoryRouter>{ui}</MemoryRouter>
+        </CustomThemeProvider>,
+    );
+
+describe('CompactEntityNameComponent', () => {
+    it('decodes percent-encoded characters in a schema field name instead of showing them raw', () => {
+        const schemaFieldEntity = {
+            urn: 'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_table,PROD),Revenue %28Net%29)',
+            type: EntityType.SchemaField,
+            fieldPath: 'Revenue %28Net%29',
+            parent: {
+                urn: 'urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_table,PROD)',
+                type: EntityType.Dataset,
+            },
+        } as unknown as Entity;
+
+        renderWithProviders(<CompactEntityNameComponent entity={schemaFieldEntity} />);
+
+        expect(screen.getByText('Revenue (Net)')).toBeInTheDocument();
+        expect(screen.queryByText('Revenue %28Net%29')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
This fixes a small bug where schema field names could have encoded values when rendering in the UI if their name has reserved characters for urns (ie. `(` and `)`) - so when we render that schema field name we should decode it first.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode URL-encoded schema field names before rendering so users see human-readable names. Previously names with URN-reserved characters (e.g., parentheses) appeared percent-encoded in lineage and recommendations; now they display decoded text while URNs and links remain unchanged.

- Use decoded field paths in `SchemaFieldEntity`: schema field preview names and `getLineageVizConfig` now set `name` and `expandedName` from the decoded field path.
- Decode schema field names in `CompactEntityNameComponent` when rendering recommendations.
- Add tests for both components to ensure percent-encoded names render as decoded.

<sup>Written for commit 566f9195e541e0d21a2df2eb32060a5d709e1a06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

