### PR TITLE
fix(graphql): preserve double precision for structured property numbers

### DIFF
--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -62,9 +62,15 @@ graphqlCodegen {
     generateParameterizedFieldsResolvers = false
     modelValidationAnnotation = "@javax.annotation.Nonnull"
     addGeneratedAnnotation = false  // Skips timestamps in generated files which forces re-compile
+    // GraphQL Float is IEEE-754 double precision. Keep most historical Float mappings,
+    // but force structured-property number inputs to Double so values like 410258.29 are
+    // not silently narrowed to float32 (410258.28125) before PDL double storage.
+    // See https://github.com/datahub-project/datahub/issues/19078
     customTypesMapping = [
         Long: "Long",
-        Float: "Float"
+        Float: "Float",
+        "PropertyValueInput.numberValue": "Double",
+        "AllowedValueInput.numberValue": "Double",
     ]
 }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/StructuredPropertyUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/StructuredPropertyUtils.java
@@ -15,7 +15,7 @@ public class StructuredPropertyUtils {
     if (valueInput.getStringValue() != null) {
       return PrimitivePropertyValue.create(valueInput.getStringValue());
     } else if (valueInput.getNumberValue() != null) {
-      return PrimitivePropertyValue.create(valueInput.getNumberValue().doubleValue());
+      return PrimitivePropertyValue.create(valueInput.getNumberValue());
     }
     return null;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
@@ -201,7 +201,7 @@ public class CreateStructuredPropertyResolver
                 primitiveValue.setString(allowedValueInput.getStringValue());
               }
               if (allowedValueInput.getNumberValue() != null) {
-                primitiveValue.setDouble(allowedValueInput.getNumberValue().doubleValue());
+                primitiveValue.setDouble(allowedValueInput.getNumberValue());
               }
               value.setValue(primitiveValue);
               value.setDescription(allowedValueInput.getDescription(), SetMode.IGNORE_NULL);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
@@ -261,7 +261,7 @@ public class UpdateStructuredPropertyResolver
                 primitiveValue.setString(allowedValueInput.getStringValue());
               }
               if (allowedValueInput.getNumberValue() != null) {
-                primitiveValue.setDouble(allowedValueInput.getNumberValue().doubleValue());
+                primitiveValue.setDouble(allowedValueInput.getNumberValue());
               }
               value.setValue(primitiveValue);
               value.setDescription(allowedValueInput.getDescription(), SetMode.IGNORE_NULL);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/StructuredPropertyUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/StructuredPropertyUtilsTest.java
@@ -1,0 +1,59 @@
+package com.linkedin.datahub.graphql.resolvers.mutate.util;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.datahub.graphql.generated.AllowedValueInput;
+import com.linkedin.datahub.graphql.generated.PropertyValueInput;
+import com.linkedin.structured.PrimitivePropertyValue;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class StructuredPropertyUtilsTest {
+
+  // Value that cannot be represented exactly in IEEE-754 float32.
+  // float32(410258.29) == 410258.28125; double preserves 410258.29.
+  private static final double FINANCIAL_NUMBER = 410258.29;
+  private static final double FLOAT32_ROUNDED = 410258.28125;
+
+  @Test
+  public void testBindArgumentPreservesDoublePrecisionForNumberValue() {
+    Map<String, Object> rawInput = new HashMap<>();
+    rawInput.put("numberValue", FINANCIAL_NUMBER);
+
+    PropertyValueInput bound = bindArgument(rawInput, PropertyValueInput.class);
+
+    assertNotNull(bound.getNumberValue());
+    assertEquals(bound.getNumberValue(), FINANCIAL_NUMBER);
+    // Guard against regressing to java.lang.Float binding.
+    assertTrue(Math.abs(bound.getNumberValue() - FLOAT32_ROUNDED) > 1e-6);
+  }
+
+  @Test
+  public void testMapPropertyValueInputPreservesDoublePrecision() {
+    Map<String, Object> rawInput = new HashMap<>();
+    rawInput.put("numberValue", FINANCIAL_NUMBER);
+
+    PropertyValueInput bound = bindArgument(rawInput, PropertyValueInput.class);
+    PrimitivePropertyValue mapped = StructuredPropertyUtils.mapPropertyValueInput(bound);
+
+    assertNotNull(mapped);
+    assertTrue(mapped.isDouble());
+    assertEquals(mapped.getDouble(), FINANCIAL_NUMBER);
+  }
+
+  @Test
+  public void testBindArgumentPreservesDoublePrecisionForAllowedValue() {
+    Map<String, Object> rawInput = new HashMap<>();
+    rawInput.put("numberValue", FINANCIAL_NUMBER);
+    rawInput.put("description", "gap usd");
+
+    AllowedValueInput bound = bindArgument(rawInput, AllowedValueInput.class);
+
+    assertNotNull(bound.getNumberValue());
+    assertEquals(bound.getNumberValue(), FINANCIAL_NUMBER);
+  }
+}


### PR DESCRIPTION
## Summary
- GraphQL codegen mapped `PropertyValueInput.numberValue` / `AllowedValueInput.numberValue` to `java.lang.Float`, so values like `410258.29` were silently narrowed to float32 (`410258.28125`) before PDL `double` storage.
- Map those fields to `Double` (GraphQL `Float` is IEEE double) and pass the boxed value through to `PrimitivePropertyValue`.
- Unit-test the `bindArgument` path that mirrors GraphQL → Java input binding.

Fixes https://github.com/datahub-project/datahub/issues/19078

## Test plan
- [x] `./gradlew :datahub-graphql-core:test --tests 'com.linkedin.datahub.graphql.resolvers.mutate.util.StructuredPropertyUtilsTest' --tests 'com.linkedin.datahub.graphql.resolvers.structuredproperties.*'`
- [ ] Upsert structured property `410258.29` via GraphQL / UI and confirm aspect read returns `{"double": 410258.29}` (not `410258.28125`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves double precision for structured property number inputs in GraphQL to prevent silent float32 narrowing. Previously `numberValue` in `PropertyValueInput`/`AllowedValueInput` mapped to `Float`, producing values like 410258.28125; now they map to `Double` and pass through unchanged to PDL double storage.

- Update `datahub-graphql-core` `graphqlCodegen.customTypesMapping` to use `Double` for `PropertyValueInput.numberValue` and `AllowedValueInput.numberValue`; keep other `Float` mappings unchanged.
- Pass the boxed `Double` directly to `PrimitivePropertyValue` and remove `.doubleValue()` in create/update and mapping paths.
- Add tests covering the `bindArgument` path to assert precision is preserved.
- No schema or client changes. Optional verification: upsert `410258.29` and confirm the aspect returns `{"double": 410258.29}`.

<sup>Written for commit 7b0dec113855f4572541925829968a01dc892f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

