### PR TITLE
fix(docker): start Kafka for the debug-elasticsearch profile

### DIFF
--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -455,6 +455,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      kafka-broker:
+        condition: service_healthy
   system-update-debug-postgres:
     <<: *datahub-system-update-service-dev
     profiles:

--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -120,6 +120,7 @@ x-kafka-broker-profiles: &kafka-broker-profiles
   - debug-consumers
   - debug-consumers-cdc
   - debug-neo4j
+  - debug-elasticsearch
   - debug-backend-aws
   - debug-aws
 

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -224,6 +224,7 @@ services:
     - debug-consumers
     - debug-consumers-cdc
     - debug-neo4j
+    - debug-elasticsearch
     - debug-backend-aws
     - debug-aws
     command:


### PR DESCRIPTION
## Summary
- The `debug-elasticsearch` (ES8) debug stack never started `kafka-broker`, so `system-update` failed with `No resolvable bootstrap urls given in bootstrap.servers` and GMS never came up.
- Include that profile in the Kafka broker profile list and wait for a healthy broker before system-update.

## Test plan
- [x] `./gradlew :docker:quickstartDebugElasticsearch` starts `kafka-broker`, system-update completes, GMS becomes healthy
- [ ] Confirm `./gradlew quickstartDebug` (OpenSearch) is unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts Kafka in the `debug-elasticsearch` profile and makes GMS wait for a healthy broker. Previously, ES8 debug skipped `kafka-broker`, causing `system-update` to fail with missing `bootstrap.servers` and preventing GMS from starting.

- Adds `debug-elasticsearch` to the Kafka broker profile list in `docker/profiles/docker-compose.prerequisites.yml` and `docker/quickstart/docker-compose.quickstart-profile.yml`.
- Adds `depends_on` on `kafka-broker` (condition: `service_healthy`) to GMS in `docker/profiles/docker-compose.gms.yml`.
- No change to `quickstartDebug` (OpenSearch) behavior.

<sup>Written for commit 1e8169d2ac885f9986e1c1a21c4e303dbc047e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

