### PR TITLE
docs(snowflake): fix external MCP server setup for Snowflake CoWork

### DIFF
--- a/docs/dev-guides/agent-context/snowflake.md
+++ b/docs/dev-guides/agent-context/snowflake.md
@@ -4,11 +4,16 @@ Give [Snowflake Cortex Agents](https://www.snowflake.com/en/developers/guides/ge
 
 Snowflake connects to the [DataHub MCP Server](../../features/feature-guides/mcp.md) as an **External MCP Server**, using OAuth2 with [Dynamic Client Registration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591). Each user signs in with their own DataHub credentials (including SSO), and tokens are scoped per-user and refreshed automatically.
 
+:::note
+Snowflake Intelligence was renamed **Snowflake CoWork** in June 2026. The Cortex Agent and MCP connector objects are unchanged — only the end-user interface was rebranded.
+:::
+
 ## Prerequisites
 
 - DataHub Cloud v1.0.2+ (required for OAuth2 + DCR on the MCP endpoint)
-- A Snowflake account with Cortex Agents / Snowflake Intelligence enabled
+- A Snowflake account with Cortex Agents / Snowflake CoWork enabled
 - A Snowflake user with the `ACCOUNTADMIN` role (for initial setup of the API integration and MCP server object)
+- A database and schema to hold the external MCP server object
 
 ## Setup
 
@@ -22,31 +27,57 @@ CREATE API INTEGRATION datahub_mcp_api_integration
   API_ALLOWED_PREFIXES = ('https://mcp.datahub.com')
   API_USER_AUTHENTICATION = (
     TYPE = OAUTH_DYNAMIC_CLIENT,
-    OAUTH_RESOURCE_URL = 'https://mcp.datahub.com/mcp'
+    OAUTH_RESOURCE_URL = 'https://mcp.datahub.com'
   )
   ENABLED = TRUE;
 ```
 
-If you prefer to point directly at your tenant URL, replace both `https://mcp.datahub.com` values with `https://<tenant>.acryl.io` and `https://<tenant>.acryl.io/integrations/ai/mcp` respectively.
+`OAUTH_RESOURCE_URL` is where Snowflake looks for DataHub's OAuth metadata. It must match the `resource` value DataHub advertises at `/.well-known/oauth-protected-resource`, which is the **origin only** — no `/mcp` path. The MCP server `URL` in the next step still uses the full endpoint.
+
+To point at your tenant instead of the global endpoint, use `https://<tenant>.acryl.io` for both `API_ALLOWED_PREFIXES` and `OAUTH_RESOURCE_URL`, and `https://<tenant>.acryl.io/integrations/ai/mcp` for the MCP server `URL`.
 
 ### 2. Create the External MCP Server
 
+The MCP server is a schema-level object. Create it in a database and schema your agent users can reach, and note the fully qualified name — later steps need it.
+
 ```sql
-CREATE EXTERNAL MCP SERVER datahub_mcp_server
+CREATE EXTERNAL MCP SERVER <db>.<schema>.datahub_mcp_server
   WITH DISPLAY_NAME = 'DataHub'
   URL = 'https://mcp.datahub.com/mcp'
   API_INTEGRATION = datahub_mcp_api_integration;
 ```
 
-### 3. Add the connector to your agent
+### 3. Grant access to your agent users
 
-1. In Snowsight, navigate to **AI & ML → Agents** and open (or create) your agent.
-2. Choose **MCP Connectors** and add the DataHub connector.
-3. Customize the agent's prompt, model, and tools as needed.
+**Don't skip this step.** By default only account admins can use the MCP server, and Snowflake hides objects a role isn't authorized for rather than raising an error — so without these grants the connector simply never appears in CoWork, with no error message anywhere.
 
-### 4. Connect and sign in
+Grant `USAGE` on both the MCP server and its API integration to every role that will use the agent:
 
-Open [Snowflake Intelligence](https://ai.snowflake.com/) and select your agent. Click **Connect** next to the DataHub connector — Snowflake walks each user through the DataHub OAuth flow once, then reuses the credential on subsequent calls.
+```sql
+GRANT USAGE ON EXTERNAL MCP SERVER <db>.<schema>.datahub_mcp_server TO ROLE <role>;
+GRANT USAGE ON INTEGRATION datahub_mcp_api_integration TO ROLE <role>;
+```
+
+### 4. Add the connector to your agent
+
+In Snowsight, navigate to **AI & ML → Agents**, select your agent, choose **MCP Connectors**, select DataHub from **Available Connectors**, and select **Add to agent**. Customize the agent's prompt, model, and tools as needed.
+
+Or via SQL:
+
+```sql
+ALTER AGENT <agent_name> MODIFY LIVE VERSION SET SPECIFICATION $$
+    <previous_spec>
+    mcp_servers:
+      - server_spec:
+         name: "<db>.<schema>.datahub_mcp_server"
+$$;
+```
+
+### 5. Connect and sign in
+
+Open [Snowflake CoWork](https://ai.snowflake.com/) and select your agent. Open the sources panel, select **Connectors**, then select **Connect** next to DataHub. Snowflake walks each user through the DataHub OAuth flow once, then reuses the credential on subsequent calls.
+
+The connector shows as **Connected** when it's ready. Connectors that aren't in the connected state are excluded from the agent's orchestration.
 
 <p align="center">
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/ai/agent-context/snowflake/snowflake-cortex-agent.png"/>
@@ -54,9 +85,24 @@ Open [Snowflake Intelligence](https://ai.snowflake.com/) and select your agent. 
 
 ## Troubleshooting
 
-- **Permission denied creating the integration?** `CREATE API INTEGRATION` and `CREATE EXTERNAL MCP SERVER` both require `ACCOUNTADMIN`.
+- **Permission denied creating the objects?** `CREATE API INTEGRATION` requires `ACCOUNTADMIN`; `CREATE EXTERNAL MCP SERVER` requires the matching privilege on the target schema.
+- **DataHub doesn't appear in the CoWork connectors list?** This is almost always the missing `GRANT USAGE` from step 3 — Snowflake hides unauthorized objects instead of returning an error. Sign in as the role your agent users actually use and confirm the object is visible:
+
+  ```sql
+  SHOW EXTERNAL MCP SERVERS IN ACCOUNT;
+  ```
+
+- **Connector listed, but the OAuth flow never starts?** Check that Snowflake can resolve DataHub's OAuth metadata:
+
+  ```sql
+  SELECT SYSTEM$START_USER_OAUTH_FLOW('datahub_mcp_api_integration');
+  ```
+
+  This returns an authorization URL. If it errors instead, `OAUTH_RESOURCE_URL` is wrong — see step 1.
+
+- **Does DataHub need to allowlist Snowflake's callback URL?** No. DataHub's OAuth server supports Dynamic Client Registration, so Snowflake registers itself and supplies `https://identity.snowflake.com/oauth2/callback` automatically. There is no redirect URI allowlist to configure on the DataHub side.
+- **OAuth flow fails?** Confirm your DataHub Cloud instance is on v1.0.2+.
 - **Agent not using DataHub tools?** Update the agent system prompt to explicitly mention DataHub tools (search, lineage, schema lookup, etc.).
-- **OAuth flow fails?** Confirm your DataHub Cloud instance is on v1.0.2+ and that the `OAUTH_RESOURCE_URL` exactly matches the MCP endpoint (`https://mcp.datahub.com/mcp` or `https://<tenant>.acryl.io/integrations/ai/mcp`).
 - **Empty results?** The signed-in user's DataHub permissions apply — check that they can see the entities in the DataHub UI.
 
 **Links:** [Cortex Agents Docs](https://www.snowflake.com/en/developers/guides/getting-started-with-snowflake-intelligence) · [Agent Context Kit](./agent-context.md) · [MCP Server Guide](../../features/feature-guides/mcp.md)
@@ -114,7 +160,7 @@ Drop `--execute` and `--sf-password` to generate SQL files instead. Then run the
 
 ### Configure and Use
 
-Customize the agent's prompt, model, and tools in the Snowflake UI, then open [Snowflake Intelligence](https://ai.snowflake.com/) and select the DataHub Agent.
+Customize the agent's prompt, model, and tools in the Snowflake UI, then open [Snowflake CoWork](https://ai.snowflake.com/) and select the DataHub Agent.
 
 ### Updating UDFs
 

--- a/docs/dev-guides/agent-context/snowflake.md
+++ b/docs/dev-guides/agent-context/snowflake.md
@@ -12,7 +12,7 @@ Snowflake Intelligence was renamed **Snowflake CoWork** in June 2026. The Cortex
 
 - DataHub Cloud v1.0.2+ (required for OAuth2 + DCR on the MCP endpoint)
 - A Snowflake account with Cortex Agents / Snowflake CoWork enabled
-- A Snowflake user with the `ACCOUNTADMIN` role (for initial setup of the API integration and MCP server object)
+- A Snowflake user with the `ACCOUNTADMIN` role for the initial setup. `CREATE API INTEGRATION` requires it; the MCP server object needs `CREATE EXTERNAL MCP SERVER` on the target schema, which by default only account admins hold.
 - A database and schema to hold the external MCP server object
 
 ## Setup

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -261,11 +261,11 @@ Custom MCP connectors require **Developer Mode** and are available on **Plus, Pr
 </details>
 
 <details>
-  <summary>Snowflake Cortex Agents / Snowflake Intelligence</summary>
+  <summary>Snowflake Cortex Agents / Snowflake CoWork</summary>
 
-Snowflake exposes external MCP servers to Cortex Agents through an **API Integration** + **External MCP Server** object pair. Both are created via SQL by an `ACCOUNTADMIN`, then the resulting connector is added to an agent in Snowsight.
+Snowflake exposes external MCP servers to Cortex Agents through an **API Integration** + **External MCP Server** object pair. Both are created via SQL by an `ACCOUNTADMIN`, then the resulting connector is granted to your agent users and added to an agent in Snowsight.
 
-1. Create an API integration using DCR (run as `ACCOUNTADMIN`):
+1. Create an API integration using DCR (run as `ACCOUNTADMIN`). `OAUTH_RESOURCE_URL` must be the origin only — no `/mcp` path — because that is the `resource` value DataHub advertises at `/.well-known/oauth-protected-resource`:
 
    ```sql
    CREATE API INTEGRATION datahub_mcp_api_integration
@@ -273,24 +273,31 @@ Snowflake exposes external MCP servers to Cortex Agents through an **API Integra
      API_ALLOWED_PREFIXES = ('https://mcp.datahub.com')
      API_USER_AUTHENTICATION = (
        TYPE = OAUTH_DYNAMIC_CLIENT,
-       OAUTH_RESOURCE_URL = 'https://mcp.datahub.com/mcp'
+       OAUTH_RESOURCE_URL = 'https://mcp.datahub.com'
      )
      ENABLED = TRUE;
    ```
 
-2. Create the MCP server object:
+2. Create the MCP server object. It is schema-level, so place it where your agent users can reach it:
 
    ```sql
-   CREATE EXTERNAL MCP SERVER datahub_mcp_server
+   CREATE EXTERNAL MCP SERVER <db>.<schema>.datahub_mcp_server
      WITH DISPLAY_NAME = 'DataHub'
      URL = 'https://mcp.datahub.com/mcp'
      API_INTEGRATION = datahub_mcp_api_integration;
    ```
 
-3. In Snowsight, navigate to **AI & ML → Agents**, open your agent, choose **MCP Connectors**, and add the DataHub connector.
-4. In Snowflake Intelligence, click **Connect** next to the DataHub connector — Snowflake walks each user through the DataHub OAuth flow and reuses the credential on subsequent calls.
+3. Grant `USAGE` to every role that will use the agent. Without this the connector silently never appears — Snowflake hides unauthorized objects rather than raising an error:
 
-See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake.md) for end-to-end setup, or use your tenant URL (`https://<tenant>.acryl.io/integrations/ai/mcp`) in place of `mcp.datahub.com` if you prefer.
+   ```sql
+   GRANT USAGE ON EXTERNAL MCP SERVER <db>.<schema>.datahub_mcp_server TO ROLE <role>;
+   GRANT USAGE ON INTEGRATION datahub_mcp_api_integration TO ROLE <role>;
+   ```
+
+4. In Snowsight, navigate to **AI & ML → Agents**, select your agent, choose **MCP Connectors**, and add the DataHub connector.
+5. In Snowflake CoWork (formerly Snowflake Intelligence), open the sources panel, select **Connectors**, then **Connect** next to DataHub — Snowflake walks each user through the DataHub OAuth flow and reuses the credential on subsequent calls.
+
+See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake.md) for end-to-end setup, or use your tenant URL (`https://<tenant>.acryl.io` for `OAUTH_RESOURCE_URL`, `https://<tenant>.acryl.io/integrations/ai/mcp` for the server URL) in place of `mcp.datahub.com` if you prefer.
 
 </details>
 

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -297,7 +297,7 @@ Snowflake exposes external MCP servers to Cortex Agents through an **API Integra
 4. In Snowsight, navigate to **AI & ML → Agents**, select your agent, choose **MCP Connectors**, and add the DataHub connector.
 5. In Snowflake CoWork (formerly Snowflake Intelligence), open the sources panel, select **Connectors**, then **Connect** next to DataHub — Snowflake walks each user through the DataHub OAuth flow and reuses the credential on subsequent calls.
 
-See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake.md) for end-to-end setup, or use your tenant URL (`https://<tenant>.acryl.io` for `OAUTH_RESOURCE_URL`, `https://<tenant>.acryl.io/integrations/ai/mcp` for the server URL) in place of `mcp.datahub.com` if you prefer.
+See the [Snowflake agent context guide](../../dev-guides/agent-context/snowflake.md) for end-to-end setup. To point at your tenant instead of the global endpoint, use `https://<tenant>.acryl.io` for both `API_ALLOWED_PREFIXES` and `OAUTH_RESOURCE_URL`, and `https://<tenant>.acryl.io/integrations/ai/mcp` for the MCP server `URL`.
 
 </details>
 


### PR DESCRIPTION
## Summary

The Snowflake Cortex Agent setup instructions had drifted from Snowflake's current behavior, and the most common failure mode produced no error message anywhere — the connector just never appears, so there is nothing to search for.

Reported symptom: the external MCP server is created successfully, the agent knows the DataHub connector exists, but it never becomes connectable in the Snowflake CoWork connectors panel.

## Changes

**`OAUTH_RESOURCE_URL` is now the origin, not the `/mcp` path.**

```diff
-  OAUTH_RESOURCE_URL = 'https://mcp.datahub.com/mcp'
+  OAUTH_RESOURCE_URL = 'https://mcp.datahub.com'
```

Snowflake resolves DataHub's OAuth metadata from this URL. Per [RFC 9728 §3.3](https://datatracker.ietf.org/doc/html/rfc9728) the client inserts the well-known suffix after the host and then verifies that the returned `resource` value is identical to the resource URL it used — "if these values are not identical, the data contained in the response MUST NOT be used." DataHub advertises `resource: https://mcp.datahub.com`, so the path form fails that check and discovery never completes. The MCP server `URL` still uses the full endpoint.

**Added the required `GRANT USAGE` statements.** Snowflake requires `USAGE` on both the external MCP server and its underlying API integration, and by default only account admins have it. Snowflake hides objects a role isn't authorized for rather than raising an error, so skipping this makes the connector silently invisible with no diagnostic. This step was missing entirely.

**Other corrections:**

- The MCP server is a schema-level object — create it fully qualified and reference that name in the agent spec (`ALTER AGENT ... mcp_servers`).
- Updated the Snowsight and end-user UI paths; end-user connect is now CoWork → sources panel → **Connectors** → **Connect**.
- Noted the Snowflake Intelligence → Snowflake CoWork rename (June 2026).
- New troubleshooting entries: connector visibility (`SHOW EXTERNAL MCP SERVERS IN ACCOUNT`), OAuth discovery (`SYSTEM$START_USER_OAUTH_FLOW`), and an explicit answer to "does DataHub need to allowlist `https://identity.snowflake.com/oauth2/callback`?" — no, DCR supplies it automatically. That question comes up because agents guess at it when the connector fails to appear.

Both the agent-context guide and the matching snippet in the MCP feature guide are updated so they stay in sync.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Docs updated
- [ ] Tests added/updated — n/a, docs only
- [ ] Breaking changes documented — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Snowflake CoWork MCP connector setup so OAuth discovery completes and the connector appears. Previously, `OAUTH_RESOURCE_URL` used the `/mcp` path and required grants/privileges were missing; now the resource URL is origin-only, required grants are documented, schema scope is explicit, and tenant config is correct.

- `OAUTH_RESOURCE_URL`: change from https://mcp.datahub.com/mcp to https://mcp.datahub.com. Keep the MCP server URL at https://mcp.datahub.com/mcp.
- Tenant config: use https://<tenant>.acryl.io for both `API_ALLOWED_PREFIXES` and `OAUTH_RESOURCE_URL`; use https://<tenant>.acryl.io/integrations/ai/mcp for the MCP server URL.
- Access and privileges: grant USAGE on the external MCP server and its API integration to every role that will use the agent. `ACCOUNTADMIN` is required for `CREATE API INTEGRATION`; `CREATE EXTERNAL MCP SERVER` is required on the target schema.
- Object scope: create the external MCP server as a fully qualified schema-level object and reference that name in the agent spec.
- UI updates: rename Snowflake Intelligence to Snowflake CoWork and update the connector path.
- Troubleshooting: add `SHOW EXTERNAL MCP SERVERS IN ACCOUNT`, `SYSTEM$START_USER_OAUTH_FLOW`, note no callback allowlist is needed with DCR, and call out the minimum DataHub Cloud version.

**Migration**
- Update existing API integrations to use the origin-only `OAUTH_RESOURCE_URL` (or recreate them).
- Grant USAGE on the external MCP server and API integration to all user roles that use the agent.
- If your MCP server was created unqualified, recreate it with a fully qualified name and update the agent spec.

<sup>Written for commit cdef3c2a4cf6a5e7a4b0288c2e881dcf25bff71f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

