### PR TITLE
chore(quickstart): remap v1.6.0 to v1.6.0.1

### DIFF
--- a/docker/quickstart/quickstart_version_mapping.yaml
+++ b/docker/quickstart/quickstart_version_mapping.yaml
@@ -44,6 +44,12 @@ quickstart_version_map:
     docker_tag: quickstart
     mysql_tag: "8.2"
 
+  # Remap minor release label to the latest patch (security + bugfixes).
+  v1.6.0:
+    composefile_git_ref: v1.6.0.1
+    docker_tag: v1.6.0.1
+    mysql_tag: "8.2"
+
   # Must be v1.4.0.3+ so datahub-upgrade runs SqlSetup when DATAHUB_SQL_SETUP_ENABLED=true.
   v1.4.0:
     composefile_git_ref: v1.4.0.3


### PR DESCRIPTION
## Summary
- Remap `datahub docker quickstart --version v1.6.0` to the **v1.6.0.1** patch (`composefile_git_ref` + `docker_tag`), following the same pattern as `v1.4.0` → `v1.4.0.3` and `v1.3.0` → `v1.3.0.1`.
- Default quickstart remains on **v1.7.0**; this only affects callers who pin/request the `v1.6.0` label.

## Test plan
- [ ] Confirm `v1.6.0.1` GitHub release/tag and Docker Hub images exist
- [ ] After merge, `datahub docker quickstart --version v1.6.0` resolves to `v1.6.0.1` via `quickstart_version_mapping.yaml` on master
- [ ] Spot-check that `default` / `head` / `quickstart` entries are unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remaps the `datahub` quickstart label `v1.6.0` to patch `v1.6.0.1` to deliver security and bugfix updates without changing default `v1.7.0` behavior. Previously, `--version v1.6.0` pulled `v1.6.0` images/compose; now it resolves to `v1.6.0.1`.

**Review notes**
- Confirm the `v1.6.0.1` GitHub tag and Docker Hub images exist.
- Verify `datahub docker quickstart --version v1.6.0` resolves to `v1.6.0.1` via `docker/quickstart/quickstart_version_mapping.yaml`.
- Check that default `v1.7.0` and other mappings are unchanged.

<sup>Written for commit 33d7e304caa4c62bf5a02dc1eda6e7cfda6acfdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

