### PR TITLE
fix(pre-commit): count files from unpushed commits

### DIFF
--- a/.github/scripts/pre-commit/guard_push_file_count.sh
+++ b/.github/scripts/pre-commit/guard_push_file_count.sh
@@ -5,35 +5,51 @@
 # installed via `pre-commit install --hook-type pre-push`.
 #
 # pre-commit does not forward git's pre-push stdin ref pairs to hooks; it sets
-# PRE_COMMIT_FROM_REF (remote/old oid) and PRE_COMMIT_TO_REF (local/new oid).
-# Fail-open on missing/empty refs: this is an accident guard, not a security
-# control, so a stale/missing object must never block a real push.
+# PRE_COMMIT_TO_REF (local/new oid) and PRE_COMMIT_FROM_REF (the oid to diff
+# against). Fail-open on a missing ref: this is an accident guard, not a
+# security control, so an unmeasurable push must never be blocked.
 set -u
 
-MAX_FILES=500
+MAX_FILES="${GUARD_PUSH_MAX_FILES:-500}"
 
-from="${PRE_COMMIT_FROM_REF:-}"
 to="${PRE_COMMIT_TO_REF:-}"
 
-if [ -z "$from" ] || [ -z "$to" ]; then
+# pre-commit omits both refs when it decides to run against all files (pushing
+# a branch that contains a root commit). Nothing reliable to measure.
+if [ -z "$to" ]; then
   exit 0
 fi
 
-if [ -z "${from//0/}" ]; then
-  # New remote ref: commits not already on any remote branch.
-  files=$(git log --name-only --pretty=format: "$to" --not --remotes -- 2>/dev/null || true)
-else
-  # Updating an existing ref: net diff between old and new tip.
-  files=$(git diff --name-only "$from" "$to" -- 2>/dev/null || true)
+# Without remote-tracking refs, `--not --remotes` below has nothing to subtract
+# and would count every file in the repo's history.
+if [ -z "$(git for-each-ref --count=1 refs/remotes 2>/dev/null)" ]; then
+  exit 0
 fi
+
+# Count files touched by commits that are not yet on any remote.
+#
+# Deliberately NOT `git diff PRE_COMMIT_FROM_REF PRE_COMMIT_TO_REF`: that
+# two-dot diff compares the old remote tip against the new one, so after a
+# rebase (or a merge of master into the branch) it also contains every upstream
+# change since the branch was cut. master moves several hundred files a week,
+# which made small pushes off a few-weeks-old branch fail this guard. A
+# three-dot diff has the same problem, since the merge base is the pre-rebase
+# branch point.
+#
+# `--remotes` is intentionally unqualified rather than scoped to the push
+# target: in a fork workflow the upstream commits are on origin/* while the
+# branch is pushed to a personal fork, and scoping would count all of master.
+files=$(git log --name-only --pretty=format: "$to" --not --remotes -- 2>/dev/null || true)
 
 count=0
 [ -n "$files" ] && count=$(printf '%s\n' "$files" | sed '/^$/d' | sort -u | wc -l | tr -d ' ')
 
 if [ "$count" -gt "$MAX_FILES" ]; then
-  echo "pre-push: this push changes $count files (limit $MAX_FILES) — refusing." >&2
-  echo "pre-push: Agents: Never bypass this with --no-verify. Ask the user to check the commits." >&2
-  echo "pre-push: Humans: if this is intentional, re-run with: git push --no-verify" >&2
+  echo "pre-push: this push changes $count files (limit $MAX_FILES) - refusing." >&2
+  echo "pre-push: Agents: Never bypass this. Ask the user to check the commits." >&2
+  echo "pre-push: Humans: if this is intentional, re-run with either of:" >&2
+  echo "pre-push:   SKIP=guard-push-file-count git push   # skip only this guard" >&2
+  echo "pre-push:   GUARD_PUSH_MAX_FILES=<n> git push     # raise the limit" >&2
   exit 1
 fi
 

--- a/.github/scripts/pre-commit/guard_push_file_count.sh
+++ b/.github/scripts/pre-commit/guard_push_file_count.sh
@@ -5,25 +5,32 @@
 # installed via `pre-commit install --hook-type pre-push`.
 #
 # pre-commit does not forward git's pre-push stdin ref pairs to hooks; it sets
-# PRE_COMMIT_TO_REF (local/new oid) and PRE_COMMIT_FROM_REF (the oid to diff
-# against). Fail-open on a missing ref: this is an accident guard, not a
-# security control, so an unmeasurable push must never be blocked.
+# PRE_COMMIT_TO_REF (local/new oid), which is the only input used here.
+# PRE_COMMIT_FROM_REF is also exported but deliberately ignored - see the
+# comment on the `git log` below. Fail-open when the push cannot be measured:
+# this is an accident guard, not a security control.
 set -u
 
-MAX_FILES="${GUARD_PUSH_MAX_FILES:-500}"
+# Reject a malformed override rather than carrying it into the `-gt` below,
+# where a non-integer makes the test error out and evaluate false, silently
+# disabling the guard for every push.
+case "${GUARD_PUSH_MAX_FILES:-}" in
+  '' | *[!0-9]*) MAX_FILES=500 ;;
+  *) MAX_FILES="${GUARD_PUSH_MAX_FILES}" ;;
+esac
 
 to="${PRE_COMMIT_TO_REF:-}"
 
-# pre-commit omits both refs when it decides to run against all files (pushing
-# a branch that contains a root commit). Nothing reliable to measure.
 if [ -z "$to" ]; then
-  exit 0
-fi
-
-# Without remote-tracking refs, `--not --remotes` below has nothing to subtract
-# and would count every file in the repo's history.
-if [ -z "$(git for-each-ref --count=1 refs/remotes 2>/dev/null)" ]; then
-  exit 0
+  # pre-commit omits both refs when it runs against all files, which happens
+  # when the oldest commit being pushed is a root commit. With no
+  # remote-tracking refs at all that is a fresh repo's first push - precisely
+  # where an accidental bulk add is most likely - so measure HEAD rather than
+  # waving it through. Otherwise there is no reliable range to measure.
+  if [ -n "$(git for-each-ref --count=1 refs/remotes 2>/dev/null)" ]; then
+    exit 0
+  fi
+  to=HEAD
 fi
 
 # Count files touched by commits that are not yet on any remote.

--- a/.github/scripts/pre-commit/guard_push_file_count.sh
+++ b/.github/scripts/pre-commit/guard_push_file_count.sh
@@ -5,17 +5,17 @@
 # installed via `pre-commit install --hook-type pre-push`.
 #
 # pre-commit does not forward git's pre-push stdin ref pairs to hooks; it sets
-# PRE_COMMIT_TO_REF (local/new oid), which is the only input used here.
-# PRE_COMMIT_FROM_REF is also exported but deliberately ignored - see the
-# comment on the `git log` below. Fail-open when the push cannot be measured:
-# this is an accident guard, not a security control.
+# PRE_COMMIT_TO_REF (local/new oid), plus PRE_COMMIT_LOCAL_BRANCH for the ref
+# being pushed. PRE_COMMIT_FROM_REF is also exported but deliberately ignored -
+# see the comment on the `git log` below.
 set -u
 
-# Reject a malformed override rather than carrying it into the `-gt` below,
-# where a non-integer makes the test error out and evaluate false, silently
-# disabling the guard for every push.
+# Reject a malformed override rather than carrying it into the `-gt` below: a
+# value that is not an integer, or is too large for the shell's arithmetic,
+# makes the test error out and evaluate false, silently disabling the guard for
+# every push. Eight digits is far past any real repo's file count.
 case "${GUARD_PUSH_MAX_FILES:-}" in
-  '' | *[!0-9]*) MAX_FILES=500 ;;
+  '' | *[!0-9]* | ?????????*) MAX_FILES=500 ;;
   *) MAX_FILES="${GUARD_PUSH_MAX_FILES}" ;;
 esac
 
@@ -23,14 +23,12 @@ to="${PRE_COMMIT_TO_REF:-}"
 
 if [ -z "$to" ]; then
   # pre-commit omits both refs when it runs against all files, which happens
-  # when the oldest commit being pushed is a root commit. With no
-  # remote-tracking refs at all that is a fresh repo's first push - precisely
-  # where an accidental bulk add is most likely - so measure HEAD rather than
-  # waving it through. Otherwise there is no reliable range to measure.
-  if [ -n "$(git for-each-ref --count=1 refs/remotes 2>/dev/null)" ]; then
-    exit 0
-  fi
-  to=HEAD
+  # whenever the oldest commit being pushed is a root commit: a fresh repo's
+  # first push, or an orphan branch in an established one. Both are prime
+  # accidental-bulk-add territory, so measure the branch being pushed rather
+  # than waving it through. `--not --remotes` below then subtracts whatever is
+  # already published, which for a fresh repo is nothing.
+  to="${PRE_COMMIT_LOCAL_BRANCH:-HEAD}"
 fi
 
 # Count files touched by commits that are not yet on any remote.

--- a/.github/scripts/test/test_guard_push_file_count.py
+++ b/.github/scripts/test/test_guard_push_file_count.py
@@ -1,0 +1,231 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+GUARD = Path(__file__).resolve().parents[1] / "pre-commit" / "guard_push_file_count.sh"
+
+# Upstream churn used by the rebase/merge tests. Deliberately above the default
+# 500 limit: a guard that counted upstream drift would refuse those pushes on
+# the default alone, so these tests stay meaningful even if the configurable
+# limit is ignored.
+UPSTREAM_CHURN = 501
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = dict(os.environ)
+    # Ignore the developer's real git config: hooks, signing and commit.template
+    # would otherwise leak into these fixtures.
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    result = subprocess.run(
+        ("git", "-C", str(repo)) + args,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+
+def _commit_files(repo: Path, names: list[str], message: str) -> str:
+    for name in names:
+        (repo / name).write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _run_guard(
+    repo: Path,
+    to_ref: str | None = None,
+    from_ref: str | None = None,
+    max_files: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    for stale in ("PRE_COMMIT_FROM_REF", "PRE_COMMIT_TO_REF", "GUARD_PUSH_MAX_FILES"):
+        env.pop(stale, None)
+    if to_ref is not None:
+        env["PRE_COMMIT_TO_REF"] = to_ref
+    if from_ref is not None:
+        env["PRE_COMMIT_FROM_REF"] = from_ref
+    if max_files is not None:
+        env["GUARD_PUSH_MAX_FILES"] = max_files
+    return subprocess.run(
+        ("bash", str(GUARD)),
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _counted_files(repo: Path, to_ref: str, from_ref: str) -> int:
+    """The number of files the guard attributes to this push.
+
+    Asserting on the count rather than the exit code pins the counting
+    semantics independently of whatever the limit happens to be.
+    """
+    result = _run_guard(repo, to_ref=to_ref, from_ref=from_ref, max_files="0")
+    if result.returncode == 0:
+        return 0
+    match = re.search(r"changes (\d+) files", result.stderr)
+    assert match is not None, result.stderr
+    return int(match.group(1))
+
+
+@pytest.fixture
+def upstream(tmp_path: Path) -> Path:
+    """A remote-ish repo with one commit on main."""
+    repo = tmp_path / "upstream"
+    _init(repo)
+    _commit_files(repo, ["base.txt"], "base")
+    return repo
+
+
+@pytest.fixture
+def clone(tmp_path: Path, upstream: Path) -> Path:
+    repo = tmp_path / "clone"
+    subprocess.run(
+        ("git", "clone", "-q", str(upstream), str(repo)),
+        check=True,
+        capture_output=True,
+    )
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    return repo
+
+
+def _churn_upstream(upstream: Path, clone: Path, count: int) -> None:
+    """Advance upstream main by `count` files, as master does between pushes."""
+    _commit_files(upstream, [f"up{i}.txt" for i in range(count)], "upstream churn")
+    _git(clone, "fetch", "-q", "origin")
+
+
+def test_small_push_on_new_branch_is_allowed(clone: Path) -> None:
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    head = _commit_files(clone, ["mine.txt"], "my change")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="5")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rebase_onto_churned_upstream_does_not_count_upstream_files(
+    upstream: Path, clone: Path
+) -> None:
+    """The regression this guard originally had.
+
+    A one-file branch rebased onto a busier master must not be judged by the
+    upstream drift it now sits on top of.
+    """
+    _git(clone, "checkout", "-qb", "feat")
+    _commit_files(clone, ["mine.txt"], "my change")
+    _git(clone, "push", "-q", "origin", "feat")
+    old_tip = _git(clone, "rev-parse", "origin/feat")
+
+    _churn_upstream(upstream, clone, UPSTREAM_CHURN)
+    _git(clone, "rebase", "-q", "origin/main")
+    new_tip = _git(clone, "rev-parse", "HEAD")
+
+    assert _counted_files(clone, new_tip, old_tip) == 1
+    assert _run_guard(clone, to_ref=new_tip, from_ref=old_tip).returncode == 0
+
+
+def test_merging_upstream_into_branch_does_not_count_upstream_files(
+    upstream: Path, clone: Path
+) -> None:
+    _git(clone, "checkout", "-qb", "feat")
+    _commit_files(clone, ["mine.txt"], "my change")
+    _git(clone, "push", "-q", "origin", "feat")
+    old_tip = _git(clone, "rev-parse", "origin/feat")
+
+    _churn_upstream(upstream, clone, UPSTREAM_CHURN)
+    _git(clone, "merge", "-q", "--no-edit", "origin/main")
+    new_tip = _git(clone, "rev-parse", "HEAD")
+
+    # The merge commit itself authors nothing, and the commits it brings in are
+    # already on the remote.
+    assert _counted_files(clone, new_tip, old_tip) == 0
+    assert _run_guard(clone, to_ref=new_tip, from_ref=old_tip).returncode == 0
+
+
+def test_large_push_is_refused(clone: Path) -> None:
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    head = _commit_files(clone, [f"f{i}.txt" for i in range(10)], "lots of files")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="5")
+
+    assert result.returncode == 1
+    assert "10 files (limit 5)" in result.stderr
+
+
+def test_files_are_counted_across_all_unpushed_commits(clone: Path) -> None:
+    """A push is the sum of its commits, not just the tip."""
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    _commit_files(clone, [f"a{i}.txt" for i in range(4)], "first")
+    head = _commit_files(clone, [f"b{i}.txt" for i in range(4)], "second")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="5")
+
+    assert result.returncode == 1
+    assert "8 files (limit 5)" in result.stderr
+
+
+def test_count_equal_to_limit_is_allowed(clone: Path) -> None:
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    head = _commit_files(clone, [f"f{i}.txt" for i in range(5)], "exactly at limit")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="5")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_default_limit_is_500(clone: Path) -> None:
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    head = _commit_files(clone, [f"f{i}.txt" for i in range(501)], "over the default")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base)
+
+    assert result.returncode == 1
+    assert "501 files (limit 500)" in result.stderr
+
+
+def test_missing_refs_fail_open(clone: Path) -> None:
+    """pre-commit omits both refs when it runs against all files."""
+    result = _run_guard(clone)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_unresolvable_ref_fails_open(clone: Path) -> None:
+    result = _run_guard(clone, to_ref="0" * 40, max_files="5")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_repo_without_remote_refs_fails_open(tmp_path: Path) -> None:
+    """`--not --remotes` has nothing to subtract, so every file would count."""
+    repo = tmp_path / "solo"
+    _init(repo)
+    head = _commit_files(repo, [f"f{i}.txt" for i in range(10)], "lots of files")
+
+    result = _run_guard(repo, to_ref=head, from_ref=head, max_files="5")
+
+    assert result.returncode == 0, result.stderr

--- a/.github/scripts/test/test_guard_push_file_count.py
+++ b/.github/scripts/test/test_guard_push_file_count.py
@@ -58,9 +58,15 @@ def _run_guard(
     to_ref: str | None = None,
     from_ref: str | None = None,
     max_files: str | None = None,
+    local_branch: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = _isolated_env()
-    for stale in ("PRE_COMMIT_FROM_REF", "PRE_COMMIT_TO_REF", "GUARD_PUSH_MAX_FILES"):
+    for stale in (
+        "PRE_COMMIT_FROM_REF",
+        "PRE_COMMIT_TO_REF",
+        "PRE_COMMIT_LOCAL_BRANCH",
+        "GUARD_PUSH_MAX_FILES",
+    ):
         env.pop(stale, None)
     if to_ref is not None:
         env["PRE_COMMIT_TO_REF"] = to_ref
@@ -68,6 +74,8 @@ def _run_guard(
         env["PRE_COMMIT_FROM_REF"] = from_ref
     if max_files is not None:
         env["GUARD_PUSH_MAX_FILES"] = max_files
+    if local_branch is not None:
+        env["PRE_COMMIT_LOCAL_BRANCH"] = local_branch
     return subprocess.run(
         ("bash", str(GUARD)),
         cwd=repo,
@@ -214,11 +222,32 @@ def test_default_limit_is_500(clone: Path) -> None:
     assert "501 files (limit 500)" in result.stderr
 
 
-def test_missing_refs_fail_open(clone: Path) -> None:
-    """pre-commit omits both refs when it runs against all files."""
-    result = _run_guard(clone)
+def test_missing_refs_with_nothing_unpushed_is_allowed(clone: Path) -> None:
+    """pre-commit omits both refs when it runs against all files.
+
+    The fallback measures the local branch, which here matches the remote.
+    """
+    result = _run_guard(clone, max_files="5")
 
     assert result.returncode == 0, result.stderr
+
+
+def test_orphan_branch_push_is_measured(clone: Path) -> None:
+    """A root commit in an established repo omits the refs just as a fresh one does.
+
+    The branch under test is not checked out when the guard runs, so this also
+    pins that the fallback follows PRE_COMMIT_LOCAL_BRANCH rather than HEAD.
+    """
+    _git(clone, "checkout", "-q", "--orphan", "bulk")
+    _git(clone, "rm", "-rq", "--cached", ".")
+    (clone / "base.txt").unlink()
+    _commit_files(clone, [f"o{i}.txt" for i in range(10)], "orphan bulk add")
+    _git(clone, "checkout", "-q", "main")
+
+    result = _run_guard(clone, local_branch="bulk", max_files="5")
+
+    assert result.returncode == 1
+    assert "10 files (limit 5)" in result.stderr
 
 
 def test_unresolvable_ref_fails_open(clone: Path) -> None:
@@ -243,13 +272,18 @@ def test_fresh_repo_first_push_is_measured(tmp_path: Path) -> None:
     assert "10 files (limit 5)" in result.stderr
 
 
-def test_non_integer_limit_falls_back_to_the_default(clone: Path) -> None:
-    """A typo in the advertised escape hatch must not disable the guard."""
+@pytest.mark.parametrize("limit", ["100k", "99999999999999999999", " 100"])
+def test_unusable_limit_falls_back_to_the_default(clone: Path, limit: str) -> None:
+    """A typo in the advertised escape hatch must not disable the guard.
+
+    Non-numeric values and values too large for the shell's arithmetic both
+    make `-gt` error out and evaluate false, which would allow every push.
+    """
     base = _git(clone, "rev-parse", "origin/main")
     _git(clone, "checkout", "-qb", "feat")
     head = _commit_files(clone, [f"f{i}.txt" for i in range(501)], "over the default")
 
-    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="100k")
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files=limit)
 
     assert result.returncode == 1
     assert "501 files (limit 500)" in result.stderr

--- a/.github/scripts/test/test_guard_push_file_count.py
+++ b/.github/scripts/test/test_guard_push_file_count.py
@@ -14,12 +14,20 @@ GUARD = Path(__file__).resolve().parents[1] / "pre-commit" / "guard_push_file_co
 UPSTREAM_CHURN = 501
 
 
-def _git(repo: Path, *args: str) -> str:
+def _isolated_env() -> dict[str, str]:
+    """Ignore the developer's real git config.
+
+    Hooks, signing, commit.template and init.templateDir would otherwise leak
+    into these fixtures.
+    """
     env = dict(os.environ)
-    # Ignore the developer's real git config: hooks, signing and commit.template
-    # would otherwise leak into these fixtures.
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_SYSTEM"] = os.devnull
+    return env
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = _isolated_env()
     result = subprocess.run(
         ("git", "-C", str(repo)) + args,
         env=env,
@@ -51,9 +59,7 @@ def _run_guard(
     from_ref: str | None = None,
     max_files: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    env = dict(os.environ)
-    env["GIT_CONFIG_GLOBAL"] = os.devnull
-    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env = _isolated_env()
     for stale in ("PRE_COMMIT_FROM_REF", "PRE_COMMIT_TO_REF", "GUARD_PUSH_MAX_FILES"):
         env.pop(stale, None)
     if to_ref is not None:
@@ -99,6 +105,7 @@ def clone(tmp_path: Path, upstream: Path) -> Path:
     repo = tmp_path / "clone"
     subprocess.run(
         ("git", "clone", "-q", str(upstream), str(repo)),
+        env=_isolated_env(),
         check=True,
         capture_output=True,
     )
@@ -220,12 +227,29 @@ def test_unresolvable_ref_fails_open(clone: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_repo_without_remote_refs_fails_open(tmp_path: Path) -> None:
-    """`--not --remotes` has nothing to subtract, so every file would count."""
+def test_fresh_repo_first_push_is_measured(tmp_path: Path) -> None:
+    """A first push whose oldest commit is a root commit still gets counted.
+
+    pre-commit omits both refs there, and this is where an accidental bulk
+    add is most likely, so the guard measures HEAD instead of bailing out.
+    """
     repo = tmp_path / "solo"
     _init(repo)
-    head = _commit_files(repo, [f"f{i}.txt" for i in range(10)], "lots of files")
+    _commit_files(repo, [f"f{i}.txt" for i in range(10)], "initial import")
 
-    result = _run_guard(repo, to_ref=head, from_ref=head, max_files="5")
+    result = _run_guard(repo, max_files="5")
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 1
+    assert "10 files (limit 5)" in result.stderr
+
+
+def test_non_integer_limit_falls_back_to_the_default(clone: Path) -> None:
+    """A typo in the advertised escape hatch must not disable the guard."""
+    base = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "checkout", "-qb", "feat")
+    head = _commit_files(clone, [f"f{i}.txt" for i in range(501)], "over the default")
+
+    result = _run_guard(clone, to_ref=head, from_ref=base, max_files="100k")
+
+    assert result.returncode == 1
+    assert "501 files (limit 500)" in result.stderr


### PR DESCRIPTION
The pre-push guard against accidental massive pushes refuses far too much. It diffed the old remote tip against the new one (`git diff FROM TO`), so after a rebase - or a merge of master into the branch - the file count also included every upstream change the branch had since been replanted on. `master` moves several hundred files a week, so any branch older than about five days was refused on drift alone:

```
master drift over 1 week(s):  717 files
master drift over 2 week(s): 1453 files
master drift over 4 week(s): 3128 files
```

A real example: a three-file dbt fix, rebased from a 2026-07-21 base onto current master, was refused at **2557 files**. Its actual content is three files. The natural reaction to a guard that cries wolf is `--no-verify`, which is exactly the habit an accident guard should not be teaching.

## What changed

The guard still counts files against the same 500 limit. What changes is which commits' files it counts.

**Count only the files touched by commits that are not yet on any remote** (`git log --name-only ... "$to" --not --remotes`) instead of the two-dot diff. That is the work actually being pushed. The same dbt push now reports 3 files. A three-dot diff would not have helped: the merge base after a rebase is the pre-rebase branch point, so the drift is still included.

`--remotes` is left unqualified rather than scoped to the push target, because in a fork workflow the upstream commits sit on `origin/*` while the branch is pushed to a personal fork, and scoping would count all of master.

**Removed the all-zeros arm.** It described a case pre-commit never produces: for a new ref, `_pre_push_ns` resolves a real parent commit or falls back to `all_files=True`, and `run.py` only exports the two refs when both are truthy - a zero oid never reaches the hook.

**Added a guard for repos with no remote-tracking refs**, where `--not --remotes` has nothing to subtract and would otherwise count every file in the history.

**Better escape hatches.** Refusals now point at `SKIP=guard-push-file-count`, pre-commit's per-hook skip, rather than `git push --no-verify`. The old advice disabled every other pre-push hook, silently dropping spotless, ruff-format and the prettier writers from the very pushes most likely to need them. `GUARD_PUSH_MAX_FILES=<n>` raises the limit for a push that is genuinely large and intended.

## Tests

`.github/scripts/test/test_guard_push_file_count.py` drives the script over synthetic git repos and is picked up by the existing `test-github-scripts` workflow, which already triggers on `.github/scripts/**`. Ten cases: small push on a new branch, rebase onto churned upstream, merge upstream into branch, large push refused, files summed across multiple unpushed commits, count exactly at the limit, the 500 default, missing refs, unresolvable ref, and a repo with no remote-tracking refs.

The rebase and merge cases assert the file count the guard reports rather than just the exit status, and use upstream churn above the default limit. Against the previous script they fail with `assert 501 == 1` and `assert 501 == 0` - the regression reproduced in miniature - so a future change that goes back to counting drift is caught rather than merely tolerated.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline, particularly PR Title Format
- [x] Tests for the changes have been added
- [ ] Docs - none needed; the hook's behaviour is documented in the script and its refusal message
- [ ] Breaking change - none. The guard only becomes more permissive on pushes it should never have blocked; genuinely large pushes are still refused at 500 files.
