### PR TITLE
feat(cli): load cloud evals command

### DIFF
--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1276,6 +1276,8 @@ all = [
 
 cloud = ["acryl-datahub-cloud"]
 
+datahub-evals = ["acryl-datahub-cloud[datahub-evals]"]
+
 dev = [
     "acryl-pyhive[hive-pure-sasl]==0.6.18",
     "aerospike>=15.0.0,<20.0.0",

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1276,8 +1276,6 @@ all = [
 
 cloud = ["acryl-datahub-cloud"]
 
-datahub-evals = ["acryl-datahub-cloud"]
-
 dev = [
     "acryl-pyhive[hive-pure-sasl]==0.6.18",
     "aerospike>=15.0.0,<20.0.0",

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1276,6 +1276,8 @@ all = [
 
 cloud = ["acryl-datahub-cloud"]
 
+datahub-evals = ["acryl-datahub-cloud"]
+
 dev = [
     "acryl-pyhive[hive-pure-sasl]==0.6.18",
     "aerospike>=15.0.0,<20.0.0",

--- a/metadata-ingestion/scripts/generate_pyproject_deps.py
+++ b/metadata-ingestion/scripts/generate_pyproject_deps.py
@@ -302,8 +302,10 @@ def generate_pyproject_toml() -> str:
     output_lines.append("all = " + format_toml_list(sort_deps(all_unique)))
     output_lines.append("")
 
-    # Meta extras: cloud, dev, docs, lint, testing-utils, integration-tests, debug
+    # Meta extras: cloud, datahub-evals, dev, docs, lint, testing-utils, integration-tests, debug
     output_lines.append('cloud = ["acryl-datahub-cloud"]')
+    output_lines.append("")
+    output_lines.append('datahub-evals = ["acryl-datahub-cloud"]')
     output_lines.append("")
     output_lines.append("dev = " + format_toml_list(sort_deps(dev_requirements)))
     output_lines.append("")

--- a/metadata-ingestion/scripts/generate_pyproject_deps.py
+++ b/metadata-ingestion/scripts/generate_pyproject_deps.py
@@ -302,10 +302,8 @@ def generate_pyproject_toml() -> str:
     output_lines.append("all = " + format_toml_list(sort_deps(all_unique)))
     output_lines.append("")
 
-    # Meta extras: cloud, datahub-evals, dev, docs, lint, testing-utils, integration-tests, debug
+    # Meta extras: cloud, dev, docs, lint, testing-utils, integration-tests, debug
     output_lines.append('cloud = ["acryl-datahub-cloud"]')
-    output_lines.append("")
-    output_lines.append('datahub-evals = ["acryl-datahub-cloud"]')
     output_lines.append("")
     output_lines.append("dev = " + format_toml_list(sort_deps(dev_requirements)))
     output_lines.append("")

--- a/metadata-ingestion/scripts/generate_pyproject_deps.py
+++ b/metadata-ingestion/scripts/generate_pyproject_deps.py
@@ -302,8 +302,10 @@ def generate_pyproject_toml() -> str:
     output_lines.append("all = " + format_toml_list(sort_deps(all_unique)))
     output_lines.append("")
 
-    # Meta extras: cloud, dev, docs, lint, testing-utils, integration-tests, debug
+    # Meta extras: cloud, datahub-evals, dev, docs, lint, testing-utils, integration-tests, debug
     output_lines.append('cloud = ["acryl-datahub-cloud"]')
+    output_lines.append("")
+    output_lines.append('datahub-evals = ["acryl-datahub-cloud[datahub-evals]"]')
     output_lines.append("")
     output_lines.append("dev = " + format_toml_list(sort_deps(dev_requirements)))
     output_lines.append("")

--- a/metadata-ingestion/scripts/verify_pyproject_equivalence.py
+++ b/metadata-ingestion/scripts/verify_pyproject_equivalence.py
@@ -197,14 +197,6 @@ def main():
     if not compare_sets("cloud", setup_cloud, pyproject_cloud):
         mismatches += 1
 
-    total += 1
-    setup_datahub_evals = {"acryl-datahub-cloud"}
-    pyproject_datahub_evals = resolve_extra(
-        "datahub-evals", optional_deps, resolve_cache
-    )
-    if not compare_sets("datahub-evals", setup_datahub_evals, pyproject_datahub_evals):
-        mismatches += 1
-
     # Non-plugin meta extras are standalone sets
     meta_extras = {
         "dev": ns["dev_requirements"],

--- a/metadata-ingestion/scripts/verify_pyproject_equivalence.py
+++ b/metadata-ingestion/scripts/verify_pyproject_equivalence.py
@@ -197,6 +197,14 @@ def main():
     if not compare_sets("cloud", setup_cloud, pyproject_cloud):
         mismatches += 1
 
+    total += 1
+    setup_datahub_evals = {"acryl-datahub-cloud"}
+    pyproject_datahub_evals = resolve_extra(
+        "datahub-evals", optional_deps, resolve_cache
+    )
+    if not compare_sets("datahub-evals", setup_datahub_evals, pyproject_datahub_evals):
+        mismatches += 1
+
     # Non-plugin meta extras are standalone sets
     meta_extras = {
         "dev": ns["dev_requirements"],

--- a/metadata-ingestion/scripts/verify_pyproject_equivalence.py
+++ b/metadata-ingestion/scripts/verify_pyproject_equivalence.py
@@ -197,6 +197,13 @@ def main():
     if not compare_sets("cloud", setup_cloud, pyproject_cloud):
         mismatches += 1
 
+    # "datahub-evals" extra forwards to the cloud package's own extra
+    total += 1
+    setup_evals = {"acryl-datahub-cloud[datahub-evals]"}
+    pyproject_evals = resolve_extra("datahub-evals", optional_deps, resolve_cache)
+    if not compare_sets("datahub-evals", setup_evals, pyproject_evals):
+        mismatches += 1
+
     # Non-plugin meta extras are standalone sets
     meta_extras = {
         "dev": ns["dev_requirements"],

--- a/metadata-ingestion/scripts/verify_pyproject_equivalence.py
+++ b/metadata-ingestion/scripts/verify_pyproject_equivalence.py
@@ -199,7 +199,7 @@ def main():
 
     # "datahub-evals" extra forwards to the cloud package's own extra
     total += 1
-    setup_evals = {"acryl-datahub-cloud[datahub-evals]"}
+    setup_evals = set(ns["_setup_args"]["extras_require"]["datahub-evals"])
     pyproject_evals = resolve_extra("datahub-evals", optional_deps, resolve_cache)
     if not compare_sets("datahub-evals", setup_evals, pyproject_evals):
         mismatches += 1

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -1363,6 +1363,9 @@ setuptools.setup(
         ),
         "sso": list(framework_common | {"playwright>=1.40.0,<2.0.0"}),
         "cloud": ["acryl-datahub-cloud"],
+        # TODO: add a >= bound once the acryl-datahub-cloud release shipping the
+        # datahub-evals extra is on PyPI. Until then an older installed cloud
+        # release satisfies this and `datahub evals` stays a shim.
         "datahub-evals": ["acryl-datahub-cloud[datahub-evals]"],
         "dev": list(dev_requirements),
         "docs": list(

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -1363,6 +1363,7 @@ setuptools.setup(
         ),
         "sso": list(framework_common | {"playwright>=1.40.0,<2.0.0"}),
         "cloud": ["acryl-datahub-cloud"],
+        "datahub-evals": ["acryl-datahub-cloud[datahub-evals]"],
         "dev": list(dev_requirements),
         "docs": list(
             docs_requirements

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -1363,7 +1363,6 @@ setuptools.setup(
         ),
         "sso": list(framework_common | {"playwright>=1.40.0,<2.0.0"}),
         "cloud": ["acryl-datahub-cloud"],
-        "datahub-evals": ["acryl-datahub-cloud"],
         "dev": list(dev_requirements),
         "docs": list(
             docs_requirements

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -1363,6 +1363,7 @@ setuptools.setup(
         ),
         "sso": list(framework_common | {"playwright>=1.40.0,<2.0.0"}),
         "cloud": ["acryl-datahub-cloud"],
+        "datahub-evals": ["acryl-datahub-cloud"],
         "dev": list(dev_requirements),
         "docs": list(
             docs_requirements

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -1363,9 +1363,11 @@ setuptools.setup(
         ),
         "sso": list(framework_common | {"playwright>=1.40.0,<2.0.0"}),
         "cloud": ["acryl-datahub-cloud"],
-        # TODO: add a >= bound once the acryl-datahub-cloud release shipping the
-        # datahub-evals extra is on PyPI. Until then an older installed cloud
-        # release satisfies this and `datahub evals` stays a shim.
+        # Deliberately unbounded: acryl-datahub-cloud 2.1.x requires
+        # acryl-datahub==1.7.0.3, so any bound selecting it makes uv lock
+        # unresolvable against this project's own version. The cost is that an
+        # older installed cloud release already satisfies this, leaving
+        # `datahub evals` a shim after an install that reported success.
         "datahub-evals": ["acryl-datahub-cloud[datahub-evals]"],
         "dev": list(dev_requirements),
         "docs": list(

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -604,12 +604,12 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
-    if "acryl_datahub_cloud" not in str(e):
-        raise
-    logger.debug(f"Failed to load datahub evals command: {e}")
-    datahub.add_command(
-        make_shim_command("evals", "run `pip install acryl-datahub-cloud`")
-    )
+    if "acryl_datahub_cloud" in str(e):
+        suggestion = "run `pip install acryl-datahub-cloud`"
+    else:
+        logger.warning(f"acryl-datahub-cloud is installed but failed to load: {e}")
+        suggestion = f"fix the acryl-datahub-cloud installation ({e})"
+    datahub.add_command(make_shim_command("evals", suggestion))
 
 try:
     from datahub.cli.iceberg_cli import iceberg

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -57,6 +57,14 @@ _logging_configured: Optional[ContextManager] = None
 
 MAX_CONTENT_WIDTH = 120
 
+
+def _evals_import_suggestion(error: ImportError) -> str:
+    if "acryl_datahub_cloud" in str(error):
+        return "run `pip install acryl-datahub-cloud`"
+    logger.warning(f"acryl-datahub-cloud is installed but failed to load: {error}")
+    return f"fix the acryl-datahub-cloud installation ({error})"
+
+
 if sys.version_info >= (3, 12):
     click.secho(
         "Python versions above 3.11 are not actively tested with yet. Please use Python 3.11 for now.",
@@ -604,12 +612,7 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
-    if "acryl_datahub_cloud" in str(e):
-        suggestion = "run `pip install acryl-datahub-cloud`"
-    else:
-        logger.warning(f"acryl-datahub-cloud is installed but failed to load: {e}")
-        suggestion = f"fix the acryl-datahub-cloud installation ({e})"
-    datahub.add_command(make_shim_command("evals", suggestion))
+    datahub.add_command(make_shim_command("evals", _evals_import_suggestion(e)))
 
 try:
     from datahub.cli.iceberg_cli import iceberg

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -600,6 +600,16 @@ datahub.add_command(api)
 datahub.add_command(agent_skill)
 
 try:
+    from acryl_datahub_cloud.cli.evals import evals
+
+    datahub.add_command(evals)
+except ImportError as e:
+    logger.debug(f"Failed to load datahub evals command: {e}")
+    datahub.add_command(
+        make_shim_command("evals", "run `pip install acryl-datahub-cloud`")
+    )
+
+try:
     from datahub.cli.iceberg_cli import iceberg
 
     datahub.add_command(iceberg)

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -60,7 +60,7 @@ MAX_CONTENT_WIDTH = 120
 
 def _evals_import_suggestion(error: ImportError) -> str:
     if getattr(error, "name", None) == "acryl_datahub_cloud":
-        return "run `pip install 'acryl-datahub-cloud[datahub-evals]'`"
+        return "run `pip install 'acryl-datahub[datahub-evals]'`"
     logger.debug("acryl-datahub-cloud is installed but failed to load: %s", error)
     return f"fix the acryl-datahub-cloud installation ({error})"
 

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -60,7 +60,7 @@ MAX_CONTENT_WIDTH = 120
 
 def _evals_import_suggestion(error: ImportError) -> str:
     if getattr(error, "name", None) == "acryl_datahub_cloud":
-        return "run `pip install 'acryl-datahub[datahub-evals]'`"
+        return "run `pip install 'acryl-datahub-cloud[datahub-evals]'`"
     logger.debug("acryl-datahub-cloud is installed but failed to load: %s", error)
     return f"fix the acryl-datahub-cloud installation ({error})"
 

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -604,6 +604,8 @@ try:
 
     datahub.add_command(evals)
 except ImportError as e:
+    if "acryl_datahub_cloud" not in str(e):
+        raise
     logger.debug(f"Failed to load datahub evals command: {e}")
     datahub.add_command(
         make_shim_command("evals", "run `pip install acryl-datahub-cloud`")

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -60,7 +60,7 @@ MAX_CONTENT_WIDTH = 120
 
 def _evals_import_suggestion(error: ImportError) -> str:
     if getattr(error, "name", None) == "acryl_datahub_cloud":
-        return "run `pip install acryl-datahub-cloud`"
+        return "run `pip install 'acryl-datahub[datahub-evals]'`"
     logger.debug("acryl-datahub-cloud is installed but failed to load: %s", error)
     return f"fix the acryl-datahub-cloud installation ({error})"
 

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -59,9 +59,9 @@ MAX_CONTENT_WIDTH = 120
 
 
 def _evals_import_suggestion(error: ImportError) -> str:
-    if "acryl_datahub_cloud" in str(error):
+    if getattr(error, "name", None) == "acryl_datahub_cloud":
         return "run `pip install acryl-datahub-cloud`"
-    logger.warning(f"acryl-datahub-cloud is installed but failed to load: {error}")
+    logger.debug("acryl-datahub-cloud is installed but failed to load: %s", error)
     return f"fix the acryl-datahub-cloud installation ({error})"
 
 

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -16,6 +16,25 @@ def test_agent_shim_command_behavior():
     assert "run `pip install datahub-agent-context`" in result.output
 
 
+@pytest.mark.parametrize(
+    "error,expected",
+    [
+        (
+            ImportError("No module named acryl_datahub_cloud"),
+            "pip install acryl-datahub-cloud",
+        ),
+        (
+            ImportError("No module named graphql"),
+            "fix the acryl-datahub-cloud installation",
+        ),
+    ],
+)
+def test_evals_import_suggestion(error, expected):
+    from datahub.entrypoints import _evals_import_suggestion
+
+    assert expected in _evals_import_suggestion(error)
+
+
 def test_agent_command_exists():
     """Test that agent command is registered in the CLI."""
     import datahub.entrypoints

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -42,7 +42,7 @@ def test_agent_command_shows_error_or_help():
 
 @pytest.mark.parametrize(
     "command_name",
-    ["agent", "actions", "lite"],
+    ["agent", "actions", "evals", "lite"],
 )
 def test_optional_commands_exist(command_name):
     """Test that optional commands (agent, actions, lite) are always registered."""
@@ -57,6 +57,7 @@ def test_optional_commands_exist(command_name):
     [
         ("agent", "pip install datahub-agent-context"),
         ("actions", "pip install acryl-datahub-actions"),
+        ("evals", "pip install acryl-datahub-cloud"),
         ("lite", "pip install 'acryl-datahub[datahub-lite]'"),
     ],
 )

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -45,7 +45,7 @@ def test_agent_command_shows_error_or_help():
     ["agent", "actions", "evals", "lite"],
 )
 def test_optional_commands_exist(command_name):
-    """Test that optional commands (agent, actions, lite) are always registered."""
+    """Test that optional commands are always registered."""
     import datahub.entrypoints
 
     # Verify the command exists in the CLI

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -25,7 +25,7 @@ def test_agent_shim_command_behavior():
             ModuleNotFoundError(
                 "No module named 'acryl_datahub_cloud'", name="acryl_datahub_cloud"
             ),
-            "pip install 'acryl-datahub-cloud[datahub-evals]'",
+            "pip install 'acryl-datahub[datahub-evals]'",
         ),
         (
             ModuleNotFoundError("No module named 'graphql'", name="graphql"),
@@ -72,7 +72,7 @@ def _assert_optional_command_shows_error_or_help(
 def test_registered_evals_command_shows_helpful_error_or_help():
     """Test that the registered evals command is usable or explains its dependency."""
     _assert_optional_command_shows_error_or_help(
-        "evals", "pip install 'acryl-datahub-cloud[datahub-evals]'", []
+        "evals", "pip install 'acryl-datahub[datahub-evals]'", []
     )
 
 
@@ -108,7 +108,7 @@ def test_optional_commands_exist(command_name):
     [
         ("agent", "pip install datahub-agent-context"),
         ("actions", "pip install acryl-datahub-actions"),
-        ("evals", "pip install 'acryl-datahub-cloud[datahub-evals]'"),
+        ("evals", "pip install 'acryl-datahub[datahub-evals]'"),
         ("lite", "pip install 'acryl-datahub[datahub-lite]'"),
     ],
 )

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from click.testing import CliRunner
 
@@ -20,19 +22,48 @@ def test_agent_shim_command_behavior():
     "error,expected",
     [
         (
-            ImportError("No module named acryl_datahub_cloud"),
+            ModuleNotFoundError(
+                "No module named 'acryl_datahub_cloud'", name="acryl_datahub_cloud"
+            ),
             "pip install acryl-datahub-cloud",
         ),
         (
-            ImportError("No module named graphql"),
+            ModuleNotFoundError("No module named 'graphql'", name="graphql"),
+            "fix the acryl-datahub-cloud installation",
+        ),
+        (
+            ModuleNotFoundError(
+                "No module named 'acryl_datahub_cloud.cli'",
+                name="acryl_datahub_cloud.cli",
+            ),
+            "fix the acryl-datahub-cloud installation",
+        ),
+        (
+            ImportError(
+                "cannot import name 'evals' from 'acryl_datahub_cloud.cli.evals'"
+            ),
             "fix the acryl-datahub-cloud installation",
         ),
     ],
 )
-def test_evals_import_suggestion(error, expected):
+def test_evals_import_suggestion(error, expected, caplog):
     from datahub.entrypoints import _evals_import_suggestion
 
     assert expected in _evals_import_suggestion(error)
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+def test_registered_evals_command_shows_helpful_error_or_help():
+    """Test that the registered evals command is usable or explains its dependency."""
+    import datahub.entrypoints
+
+    result = CliRunner().invoke(datahub.entrypoints.datahub, ["evals", "--help"])
+
+    if result.exit_code == 1:
+        assert "missing dependencies" in result.output
+        assert "pip install acryl-datahub-cloud" in result.output
+    else:
+        assert result.exit_code == 0
 
 
 def test_agent_command_exists():

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -3,11 +3,17 @@ import logging
 import pytest
 from click.testing import CliRunner
 
+import datahub.entrypoints
+from datahub.cli.cli_utils import make_shim_command
+from datahub.entrypoints import _evals_import_suggestion
+
+# Shim commands all share make_shim_command's docstring, so a probe shim tells us
+# whether a registered command is the real plugin or the fallback.
+_SHIM_HELP = make_shim_command("probe", "run `pip install probe`").help
+
 
 def test_agent_shim_command_behavior():
     """Test that the agent shim command displays the correct error message."""
-    from datahub.cli.cli_utils import make_shim_command
-
     shim_command = make_shim_command("agent", "run `pip install datahub-agent-context`")
 
     runner = CliRunner()
@@ -47,39 +53,40 @@ def test_agent_shim_command_behavior():
     ],
 )
 def test_evals_import_suggestion(error, expected, caplog):
-    from datahub.entrypoints import _evals_import_suggestion
-
     assert expected in _evals_import_suggestion(error)
     assert not any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
-def _assert_optional_command_shows_error_or_help(
-    command_name, install_message, command_args
-):
-    import datahub.entrypoints
+def _assert_optional_command_shows_error_or_help(command_name, install_message):
+    """Assert the registered command either runs or explains its missing plugin.
 
-    result = CliRunner().invoke(
-        datahub.entrypoints.datahub, [command_name, *command_args]
-    )
+    The shim only prints its message from the command body, so it has to be
+    invoked without --help, which click resolves before the callback runs. The
+    real command may require arguments, so that one is probed with --help.
+    """
+    command = datahub.entrypoints.datahub.commands[command_name]
 
-    if result.exit_code == 1:
+    if command.help == _SHIM_HELP:
+        result = CliRunner().invoke(datahub.entrypoints.datahub, [command_name])
+        assert result.exit_code == 1
         assert "missing dependencies" in result.output
         assert install_message in result.output
     else:
+        result = CliRunner().invoke(
+            datahub.entrypoints.datahub, [command_name, "--help"]
+        )
         assert result.exit_code == 0
 
 
 def test_registered_evals_command_shows_helpful_error_or_help():
     """Test that the registered evals command is usable or explains its dependency."""
     _assert_optional_command_shows_error_or_help(
-        "evals", "pip install 'acryl-datahub[datahub-evals]'", []
+        "evals", "pip install 'acryl-datahub[datahub-evals]'"
     )
 
 
 def test_agent_command_exists():
     """Test that agent command is registered in the CLI."""
-    import datahub.entrypoints
-
     # Verify agent command was added (either real or shim)
     assert "agent" in datahub.entrypoints.datahub.commands
 
@@ -87,7 +94,7 @@ def test_agent_command_exists():
 def test_agent_command_shows_error_or_help():
     """Test that agent command either works or shows helpful error."""
     _assert_optional_command_shows_error_or_help(
-        "agent", "pip install datahub-agent-context", ["--help"]
+        "agent", "pip install datahub-agent-context"
     )
 
 
@@ -97,8 +104,6 @@ def test_agent_command_shows_error_or_help():
 )
 def test_optional_commands_exist(command_name):
     """Test that optional commands are always registered."""
-    import datahub.entrypoints
-
     # Verify the command exists in the CLI
     assert command_name in datahub.entrypoints.datahub.commands
 
@@ -114,8 +119,6 @@ def test_optional_commands_exist(command_name):
 )
 def test_shim_commands_show_helpful_error(command_name, install_message):
     """Test that shim commands created by make_shim_command show helpful error messages."""
-    from datahub.cli.cli_utils import make_shim_command
-
     shim_command = make_shim_command(command_name, f"run `{install_message}`")
 
     runner = CliRunner()

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -25,7 +25,7 @@ def test_agent_shim_command_behavior():
             ModuleNotFoundError(
                 "No module named 'acryl_datahub_cloud'", name="acryl_datahub_cloud"
             ),
-            "pip install acryl-datahub-cloud",
+            "pip install 'acryl-datahub[datahub-evals]'",
         ),
         (
             ModuleNotFoundError("No module named 'graphql'", name="graphql"),
@@ -72,7 +72,7 @@ def _assert_optional_command_shows_error_or_help(
 def test_registered_evals_command_shows_helpful_error_or_help():
     """Test that the registered evals command is usable or explains its dependency."""
     _assert_optional_command_shows_error_or_help(
-        "evals", "pip install acryl-datahub-cloud", []
+        "evals", "pip install 'acryl-datahub[datahub-evals]'", []
     )
 
 
@@ -108,7 +108,7 @@ def test_optional_commands_exist(command_name):
     [
         ("agent", "pip install datahub-agent-context"),
         ("actions", "pip install acryl-datahub-actions"),
-        ("evals", "pip install acryl-datahub-cloud"),
+        ("evals", "pip install 'acryl-datahub[datahub-evals]'"),
         ("lite", "pip install 'acryl-datahub[datahub-lite]'"),
     ],
 )

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -25,7 +25,7 @@ def test_agent_shim_command_behavior():
             ModuleNotFoundError(
                 "No module named 'acryl_datahub_cloud'", name="acryl_datahub_cloud"
             ),
-            "pip install 'acryl-datahub[datahub-evals]'",
+            "pip install 'acryl-datahub-cloud[datahub-evals]'",
         ),
         (
             ModuleNotFoundError("No module named 'graphql'", name="graphql"),
@@ -72,7 +72,7 @@ def _assert_optional_command_shows_error_or_help(
 def test_registered_evals_command_shows_helpful_error_or_help():
     """Test that the registered evals command is usable or explains its dependency."""
     _assert_optional_command_shows_error_or_help(
-        "evals", "pip install 'acryl-datahub[datahub-evals]'", []
+        "evals", "pip install 'acryl-datahub-cloud[datahub-evals]'", []
     )
 
 
@@ -108,7 +108,7 @@ def test_optional_commands_exist(command_name):
     [
         ("agent", "pip install datahub-agent-context"),
         ("actions", "pip install acryl-datahub-actions"),
-        ("evals", "pip install 'acryl-datahub[datahub-evals]'"),
+        ("evals", "pip install 'acryl-datahub-cloud[datahub-evals]'"),
         ("lite", "pip install 'acryl-datahub[datahub-lite]'"),
     ],
 )

--- a/metadata-ingestion/tests/unit/test_entrypoints.py
+++ b/metadata-ingestion/tests/unit/test_entrypoints.py
@@ -53,17 +53,27 @@ def test_evals_import_suggestion(error, expected, caplog):
     assert not any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
-def test_registered_evals_command_shows_helpful_error_or_help():
-    """Test that the registered evals command is usable or explains its dependency."""
+def _assert_optional_command_shows_error_or_help(
+    command_name, install_message, command_args
+):
     import datahub.entrypoints
 
-    result = CliRunner().invoke(datahub.entrypoints.datahub, ["evals", "--help"])
+    result = CliRunner().invoke(
+        datahub.entrypoints.datahub, [command_name, *command_args]
+    )
 
     if result.exit_code == 1:
         assert "missing dependencies" in result.output
-        assert "pip install acryl-datahub-cloud" in result.output
+        assert install_message in result.output
     else:
         assert result.exit_code == 0
+
+
+def test_registered_evals_command_shows_helpful_error_or_help():
+    """Test that the registered evals command is usable or explains its dependency."""
+    _assert_optional_command_shows_error_or_help(
+        "evals", "pip install acryl-datahub-cloud", []
+    )
 
 
 def test_agent_command_exists():
@@ -76,18 +86,9 @@ def test_agent_command_exists():
 
 def test_agent_command_shows_error_or_help():
     """Test that agent command either works or shows helpful error."""
-    import datahub.entrypoints
-
-    runner = CliRunner()
-    result = runner.invoke(datahub.entrypoints.datahub, ["agent", "--help"])
-
-    # Either the command works (exit code 0) or it's a shim (exit code 1 with helpful message)
-    if result.exit_code == 1:
-        assert "missing dependencies" in result.output
-        assert "pip install datahub-agent-context" in result.output
-    else:
-        # Real command should show help
-        assert result.exit_code == 0
+    _assert_optional_command_shows_error_or_help(
+        "agent", "pip install datahub-agent-context", ["--help"]
+    )
 
 
 @pytest.mark.parametrize(

--- a/metadata-ingestion/tests/unit/test_setup_py_requirements.py
+++ b/metadata-ingestion/tests/unit/test_setup_py_requirements.py
@@ -94,10 +94,11 @@ def test_all_extras_require_are_valid_pep508() -> None:
 def test_datahub_evals_extra_forwards_to_the_cloud_extra() -> None:
     """The datahub-evals extra has to request the cloud package's own extra.
 
-    Requiring a bare acryl-datahub-cloud installs the package without the evals
-    dependencies, so `datahub evals` stays a shim after an install that reported
-    success. A version bound belongs here too, once the cloud release shipping
-    the extra is published.
+    Requiring a bare acryl-datahub-cloud installs the package without
+    graphql-core, so `datahub evals` stays a shim after an install that
+    reported success. A version bound would guard the same failure mode for
+    older cloud releases, but cannot be added while those releases pin
+    acryl-datahub exactly — see the comment in setup.py.
     """
     deps = _extract_extras_require()["datahub-evals"]
     assert len(deps) == 1

--- a/metadata-ingestion/tests/unit/test_setup_py_requirements.py
+++ b/metadata-ingestion/tests/unit/test_setup_py_requirements.py
@@ -8,23 +8,21 @@ extras_require entries, catching issues like:
 - Invalid package names
 """
 
+import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Dict, List
 
 import pytest
 from packaging.requirements import InvalidRequirement, Requirement
 
 
-def test_all_extras_require_are_valid_pep508() -> None:
-    """
-    Validate all extras_require entries using the official PEP 508 parser.
+def _extract_extras_require() -> Dict[str, List[str]]:
+    """Capture setup.py's extras_require by running it with setuptools.setup() mocked.
 
-    Runs setup.py with a mocked setuptools.setup() to capture extras_require,
-    then validates each requirement string with packaging.requirements.Requirement.
-
-    Uses a simulated release version to ensure version-pinned dependencies
-    are validated (in dev mode, _self_pin is empty and bugs may not manifest).
+    Uses a simulated release version so version-pinned dependencies are visible
+    (in dev mode, _self_pin is empty and bugs may not manifest).
     """
     script = """\
 import sys
@@ -64,19 +62,24 @@ for extra, deps in captured.get('extras_require', {}).items():
     if result.returncode != 0:
         pytest.fail(f"Failed to extract dependencies from setup.py:\n{result.stderr}")
 
-    # Validate each requirement with the official PEP 508 parser
-    import json
-
-    invalid = []
+    extras: Dict[str, List[str]] = {}
     for line in result.stdout.strip().split("\n"):
         if not line:
             continue
         data = json.loads(line)
-        extra, dep = data["extra"], data["dep"]
-        try:
-            Requirement(dep)
-        except InvalidRequirement as e:
-            invalid.append(f"  [{extra}] {dep}\n    → {e}")
+        extras.setdefault(data["extra"], []).append(data["dep"])
+    return extras
+
+
+def test_all_extras_require_are_valid_pep508() -> None:
+    """Validate all extras_require entries using the official PEP 508 parser."""
+    invalid = []
+    for extra, deps in _extract_extras_require().items():
+        for dep in deps:
+            try:
+                Requirement(dep)
+            except InvalidRequirement as e:
+                invalid.append(f"  [{extra}] {dep}\n    → {e}")
 
     if invalid:
         pytest.fail(
@@ -86,3 +89,19 @@ for extra, deps in captured.get('extras_require', {}).items():
             + "  Wrong: package==1.0[extra]\n"
             + "  Right: package[extra]==1.0"
         )
+
+
+def test_datahub_evals_extra_forwards_to_the_cloud_extra() -> None:
+    """The datahub-evals extra has to request the cloud package's own extra.
+
+    Requiring a bare acryl-datahub-cloud installs the package without the evals
+    dependencies, so `datahub evals` stays a shim after an install that reported
+    success. A version bound belongs here too, once the cloud release shipping
+    the extra is published.
+    """
+    deps = _extract_extras_require()["datahub-evals"]
+    assert len(deps) == 1
+
+    requirement = Requirement(deps[0])
+    assert requirement.name == "acryl-datahub-cloud"
+    assert requirement.extras == {"datahub-evals"}

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -388,6 +388,9 @@ datahub-documents = [
     { name = "unstructured", extra = ["md"] },
     { name = "unstructured-ingest" },
 ]
+datahub-evals = [
+    { name = "acryl-datahub-cloud" },
+]
 datahub-kafka = [
     { name = "confluent-kafka", extra = ["avro", "schemaregistry"] },
     { name = "fastavro" },
@@ -1590,6 +1593,7 @@ vertica = [
 [package.metadata]
 requires-dist = [
     { name = "acryl-datahub-cloud", marker = "extra == 'cloud'" },
+    { name = "acryl-datahub-cloud", extras = ["datahub-evals"], marker = "extra == 'datahub-evals'" },
     { name = "acryl-pyhive", extras = ["hive-pure-sasl"], marker = "extra == 'all'", specifier = "==0.6.18" },
     { name = "acryl-pyhive", extras = ["hive-pure-sasl"], marker = "extra == 'dev'", specifier = "==0.6.18" },
     { name = "acryl-pyhive", extras = ["hive-pure-sasl"], marker = "extra == 'docs'", specifier = "==0.6.18" },
@@ -2873,7 +2877,7 @@ requires-dist = [
     { name = "zstd", marker = "extra == 'docs'", specifier = "<1.5.6.8" },
     { name = "zstd", marker = "extra == 'integration-tests'", specifier = "<1.5.6.8" },
 ]
-provides-extras = ["base", "abs", "abs-slim", "aerospike", "airbyte", "athena", "aws-secret-manager", "azure-ad", "azure-auth", "azure-data-factory", "bigid", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "cube", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-gc", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-pg-queue", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "dlt", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-data-factory", "fabric-onelake", "feast", "fivetran", "flink", "gcp-secret-manager", "gcs", "gcs-slim", "github-documents", "glue", "grafana", "hana", "hex", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "informatica", "json-schema", "kafka", "kafka-connect", "kinesis", "ldap", "looker", "lookml", "mariadb", "matillion-dpc", "metabase", "microstrategy", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "odcs", "okta", "omni", "oracle", "pinecone", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "quicksight", "rdf", "redash", "redshift", "redshift-slim", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sap-datasphere", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "starrocks", "superset", "sync-file-emitter", "tableau", "teradata", "thoughtspot", "tidb", "timescaledb", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
+provides-extras = ["base", "abs", "abs-slim", "aerospike", "airbyte", "athena", "aws-secret-manager", "azure-ad", "azure-auth", "azure-data-factory", "bigid", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "cube", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-gc", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-pg-queue", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "dlt", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-data-factory", "fabric-onelake", "feast", "fivetran", "flink", "gcp-secret-manager", "gcs", "gcs-slim", "github-documents", "glue", "grafana", "hana", "hex", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "informatica", "json-schema", "kafka", "kafka-connect", "kinesis", "ldap", "looker", "lookml", "mariadb", "matillion-dpc", "metabase", "microstrategy", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "odcs", "okta", "omni", "oracle", "pinecone", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "quicksight", "rdf", "redash", "redshift", "redshift-slim", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sap-datasphere", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "starrocks", "superset", "sync-file-emitter", "tableau", "teradata", "thoughtspot", "tidb", "timescaledb", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "datahub-evals", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
 
 [[package]]
 name = "acryl-datahub-cloud"


### PR DESCRIPTION
## Summary

- Load the optional cloud evals command into the OSS `datahub` CLI.
- Add the `datahub-evals` optional plugin extra. Install it with `pip install 'acryl-datahub[datahub-evals]'`; it forwards to `acryl-datahub-cloud[datahub-evals]`, which provides the `datahub-evals` console script and the integrated `datahub evals` command.
- Keep the evals command available as a shim when the plugin or one of its dependencies cannot load, with an install or repair message appropriate to the failure.
- Keep the generated `pyproject.toml` dependency sections and `uv.lock` synchronized with `setup.py`.

## Testing

- `./gradlew :metadata-ingestion:lintFix`
- `venv/bin/python -m pytest tests/unit/test_entrypoints.py -q` — 16 passed.
- `venv/bin/python scripts/verify_pyproject_equivalence.py` — 153/153 checks passed.
- `uv lock --check` passed.