### PR TITLE
style: use ASCII hyphens in pre-commit comments

### DIFF
--- a/.github/scripts/pre-commit/generate_pre_commit.py
+++ b/.github/scripts/pre-commit/generate_pre_commit.py
@@ -152,7 +152,7 @@ class HookGenerator:
         # Python module dirs that have a build.gradle (and thus a Gradle-managed
         # venv). These are the dirs the collapsed repo-wide ruff hooks cover.
         # Non-module .py (e.g. .github/scripts/, docker/, python-build/) is
-        # intentionally NOT covered — it had no ruff coverage before and would
+        # intentionally NOT covered - it had no ruff coverage before and would
         # fail under ruff's default rules.
         ruff_module_dirs: list[str] = []
 
@@ -178,7 +178,7 @@ class HookGenerator:
 
         # Collapse all per-module ruff hooks into two repo-wide hooks (one check,
         # one format) using the official ruff Docker image (pinned to the latest
-        # version pinned across modules — metadata-ingestion pins 0.15.18, the
+        # version pinned across modules - metadata-ingestion pins 0.15.18, the
         # rest 0.11.7). Using the Docker image (language: docker_image) avoids
         # needing any system/venv ruff install and gives a reproducible version
         # across all machines. ruff does per-file config discovery, so each

--- a/.github/scripts/pre-commit/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit/pre-commit-override.yaml
@@ -14,7 +14,7 @@ repos:
         # once before this guard. A >500-file push is still rejected, but only
         # after the formatters have run on the diff. Making the guard fast-fail
         # first would require changing the generator's merge order (prepend
-        # override hooks) — deferred as not worth it for now.
+        # override hooks) - deferred as not worth it for now.
         stages: [pre-push]
       - id: update-lineage-file
         name: update-lineage-file
@@ -99,7 +99,7 @@ repos:
         language: system
         pass_filenames: false
         # Scans only the staged diff. A native (non-docker) binary resolves git worktrees
-        # correctly — a docker_image hook cannot (it only mounts $PWD, not the external gitdir).
+        # correctly - a docker_image hook cannot (it only mounts $PWD, not the external gitdir).
         # Keep pass_filenames: false: betterleaks reads the staged diff itself; passing files
         # would switch it to `dir` semantics (whole-file, and broken/slow on multiple file args).
         stages: [pre-commit]


### PR DESCRIPTION
Four em dashes (U+2014) sat in comments under `.github/scripts/pre-commit/`. Non-ASCII punctuation is easy to reintroduce by copy-paste and awkward to match with a plain `grep`, so keep these files within ASCII.

```
.github/scripts/pre-commit/pre-commit-override.yaml:17
.github/scripts/pre-commit/pre-commit-override.yaml:93
.github/scripts/pre-commit/generate_pre_commit.py:155
.github/scripts/pre-commit/generate_pre_commit.py:181
```

Comments only - four characters, no wording changed. Comments do not survive YAML generation, so the generated `.pre-commit-config.yaml` is byte-identical and needs no regeneration.

Split out of #19185 deliberately: that PR is a behavioural fix to the push-size guard, and unrelated punctuation churn does not belong in its diff. `guard_push_file_count.sh` carries a fifth em dash which is left alone here, since #19185 rewrites that line anyway.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline, particularly PR Title Format
- [ ] Tests - not applicable, comments only
- [ ] Docs - not applicable
- [ ] Breaking change - none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use ASCII hyphens in pre-commit comments to keep these files ASCII-only and make grep/tooling consistent. Behavior is unchanged; the generated `.pre-commit-config.yaml` is byte-identical.

- Scope: comments only in `.github/scripts/pre-commit/generate_pre_commit.py` and `.github/scripts/pre-commit/pre-commit-override.yaml`.
- No regeneration, tests, or docs changes required.

<sup>Written for commit eb0494ac87d3f3292b17de5d5389764a652b4d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

