### PR TITLE
fix(telemetry): build the Telemetry singleton on first use, not at import

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -91,7 +91,7 @@ from datahub.metadata.urns import (
     MlPrimaryKeyUrn,
     Urn,
 )
-from datahub.telemetry.telemetry import telemetry_instance
+from datahub.telemetry.telemetry import get_telemetry_instance
 from datahub.utilities.server_state_disk_cache import ServerStateDiskCache
 from datahub.utilities.urns.urn import guess_entity_type
 
@@ -238,9 +238,7 @@ class DataHubGraph(DatahubRestEmitter, OpenApiAPI, EntityVersioningAPI):
         super().test_connection()
 
         # Cache the server id for telemetry.
-        from datahub.telemetry.telemetry import telemetry_instance
-
-        if not telemetry_instance.enabled:
+        if not get_telemetry_instance().enabled:
             self.server_id = _MISSING_SERVER_ID
             return
         try:
@@ -2387,5 +2385,5 @@ def get_default_graph(
     graph_config.datahub_component = datahub_component
     graph = DataHubGraph(graph_config)
     graph.test_connection()
-    telemetry_instance.set_context(server=graph)
+    get_telemetry_instance().set_context(server=graph)
     return graph

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -60,7 +60,7 @@ from datahub.ingestion.source.source_registry import source_registry
 from datahub.ingestion.transformer.transform_registry import transform_registry
 from datahub.sdk._attribution import KnownAttribution, change_default_attribution
 from datahub.telemetry import stats
-from datahub.telemetry.telemetry import telemetry_instance
+from datahub.telemetry.telemetry import get_telemetry_instance
 from datahub.upgrade.upgrade import (
     is_server_default_cli_ahead,
     retrieve_version_stats,
@@ -415,7 +415,7 @@ class Pipeline:
                     if self.graph is not None:
                         self.graph.test_connection()
             self.ctx.graph = self.graph
-            telemetry_instance.set_context(server=self.graph)
+            get_telemetry_instance().set_context(server=self.graph)
 
             with set_graph_context(self.graph):
                 with _add_init_error_context("configure reporters"):
@@ -860,7 +860,7 @@ class Pipeline:
             self.source.get_report().get_aspects_by_subtypes_dict()
         )
 
-        telemetry_instance.ping(
+        get_telemetry_instance().ping(
             "ingest_stats",
             {
                 "source_type": self.source_type,

--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -382,14 +382,43 @@ class Telemetry:
             }
 
 
-telemetry_instance = Telemetry()
+_telemetry_instance: Optional["Telemetry"] = None
+
+
+def get_telemetry_instance() -> "Telemetry":
+    """The process-wide Telemetry singleton, constructed on first use.
+
+    Not built at module import: ``Telemetry.__init__`` calls ``sentry_sdk.init()``
+    when SENTRY_DSN is set, and sentry's init imports every auto-enabling
+    integration module. At module scope that runs third-party imports inside
+    whatever import first reached this module (usually
+    ``datahub.ingestion.graph.client``, via rest_emitter -> server_config_util),
+    so any of them importing back into ``datahub`` hits a partially initialized
+    module. Building on first use avoids that.
+    """
+    global _telemetry_instance
+    if _telemetry_instance is None:
+        _telemetry_instance = Telemetry()
+    return _telemetry_instance
+
+
+def __getattr__(name: str) -> Any:
+    # PEP 562: keeps `telemetry.telemetry_instance.ping(...)` and
+    # `from datahub.telemetry.telemetry import telemetry_instance` working
+    # unchanged for external callers, while the construction stays lazy.
+    # Note this fires only for module *attribute* access — code inside this
+    # module must call get_telemetry_instance() directly.
+    if name == "telemetry_instance":
+        return get_telemetry_instance()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def suppress_telemetry() -> None:
     """disables telemetry for this invocation, doesn't affect persistent client settings"""
-    if telemetry_instance.enabled:
+    instance = get_telemetry_instance()
+    if instance.enabled:
         logger.debug("Disabling telemetry locally due to server config")
-    telemetry_instance.enabled = False
+    instance.enabled = False
 
 
 def get_full_class_name(obj):
@@ -440,15 +469,16 @@ def with_telemetry(
 
         @wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
-            telemetry_instance.init_tracking()
-            telemetry_instance.init_capture_exception()
+            instance = get_telemetry_instance()
+            instance.init_tracking()
+            instance.init_capture_exception()
 
             call_props: Dict[str, Any] = {"function": function}
             call_props.update(_get_cli_context())
             for kwarg in kwargs_to_track:
                 call_props[f"arg_{kwarg}"] = kwargs.get(kwarg)
 
-            telemetry_instance.ping(
+            instance.ping(
                 "function-call",
                 {**call_props, "status": "start"},
             )
@@ -459,7 +489,7 @@ def with_telemetry(
                 finally:
                     call_props["duration"] = timer.elapsed_seconds()
 
-                telemetry_instance.ping(
+                instance.ping(
                     "function-call",
                     {**call_props, "status": "completed"},
                 )
@@ -470,13 +500,13 @@ def with_telemetry(
                 # Forward successful exits
                 # 0 or None imply success
                 if not e.code:
-                    telemetry_instance.ping(
+                    instance.ping(
                         "function-call",
                         {**call_props, "status": "completed"},
                     )
                 # Report failed exits
                 else:
-                    telemetry_instance.ping(
+                    instance.ping(
                         "function-call",
                         {
                             **call_props,
@@ -485,20 +515,20 @@ def with_telemetry(
                             "code": e.code,
                         },
                     )
-                telemetry_instance.capture_exception(e)
+                instance.capture_exception(e)
                 raise e
             # Catch SIGINTs
             except KeyboardInterrupt as e:
-                telemetry_instance.ping(
+                instance.ping(
                     "function-call",
                     {**call_props, "status": "cancelled"},
                 )
-                telemetry_instance.capture_exception(e)
+                instance.capture_exception(e)
                 raise e
 
             # Catch general exceptions
             except BaseException as e:
-                telemetry_instance.ping(
+                instance.ping(
                     "function-call",
                     {
                         **call_props,
@@ -506,7 +536,7 @@ def with_telemetry(
                         **_error_props(e),
                     },
                 )
-                telemetry_instance.capture_exception(e)
+                instance.capture_exception(e)
                 raise e
 
         return wrapper

--- a/metadata-ingestion/tests/unit/telemetry/test_telemetry_lazy_init.py
+++ b/metadata-ingestion/tests/unit/telemetry/test_telemetry_lazy_init.py
@@ -1,0 +1,86 @@
+# Importing the SDK must not initialize Sentry.
+#
+# `Telemetry.__init__` calls `sentry_sdk.init()` when SENTRY_DSN is set, and
+# sentry's init imports every auto-enabling integration module. Building the
+# singleton at module scope ran that inside whatever import first reached this
+# module -- `datahub.ingestion.graph.client` pulls it in via rest_emitter ->
+# server_config_util -- so a third-party integration importing back into
+# `datahub` would hit a partially initialized module. This has happened: the
+# sentry `openai_agents` integration probes with a bare `import agents`, which
+# a local package can answer to.
+#
+# Subprocesses: sentry's client is process-global and `sys.modules` must be
+# pristine for each case.
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Parses fine, routes nowhere: init() never contacts it and no event is sent.
+FAKE_SENTRY_DSN = "https://public@127.0.0.1:1/1"
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    import os
+
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "SENTRY_DSN": FAKE_SENTRY_DSN},
+        timeout=120,
+    )
+
+
+def test_importing_graph_client_does_not_init_sentry():
+    result = _run(
+        """
+import sentry_sdk
+
+calls = []
+_real_init = sentry_sdk.init
+sentry_sdk.init = lambda *a, **kw: calls.append(1)
+
+import datahub.ingestion.graph.client  # noqa: F401
+
+assert not calls, "importing graph.client called sentry_sdk.init()"
+print("NO_INIT_AT_IMPORT")
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert "NO_INIT_AT_IMPORT" in result.stdout
+
+
+def test_telemetry_singleton_is_built_on_first_use_and_reused():
+    result = _run(
+        """
+from datahub.telemetry import telemetry as t
+
+assert t._telemetry_instance is None, "singleton was built at import time"
+first = t.get_telemetry_instance()
+assert t._telemetry_instance is first
+assert t.get_telemetry_instance() is first, "expected a cached singleton"
+print("LAZY_SINGLETON")
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert "LAZY_SINGLETON" in result.stdout
+
+
+def test_module_attribute_access_still_resolves_telemetry_instance():
+    # PEP 562 compat: both spellings used across the codebase keep working.
+    result = _run(
+        """
+from datahub.telemetry import telemetry as t
+from datahub.telemetry.telemetry import telemetry_instance
+
+assert telemetry_instance is t.get_telemetry_instance()
+assert t.telemetry_instance is telemetry_instance
+print("COMPAT_OK")
+"""
+    )
+    assert result.returncode == 0, result.stderr
+    assert "COMPAT_OK" in result.stdout


### PR DESCRIPTION
## Problem

`datahub/telemetry/telemetry.py` builds its singleton at module scope:

```python
telemetry_instance = Telemetry()
```

`Telemetry.__init__` calls `sentry_sdk.init()` when `SENTRY_DSN` is set, and sentry's init imports every auto-enabling integration module to see which ones apply.

So importing the SDK runs third-party module bodies inside another module's import:

```
import datahub.ingestion.graph.client     # starts; DataHubGraph not yet defined
  -> datahub.emitter.rest_emitter
    -> datahub.utilities.server_config_util
      -> datahub.telemetry.telemetry      # module body runs
        -> Telemetry() -> sentry_sdk.init()
          -> imports every auto-enabling sentry integration
```

If one of those integrations imports back into `datahub`, it gets a partially initialized module.

That is not theoretical. The sentry `openai_agents` integration probes with a bare `import agents`, which became auto-enabling in sentry-sdk 2.45.0 ([getsentry/sentry-python#5111](https://github.com/getsentry/sentry-python/pull/5111)). `agents` is a generic enough name that an unrelated local package can answer to it, and one did — importing back into the half-built `graph.client`:

```
ImportError: cannot import name 'DataHubGraph' from partially initialized module
'datahub.ingestion.graph.client' (most likely due to a circular import)
```

Sentry notes the risk in its own source:

```python
# "agents" is too generic. If someone has an agents.py file in their project
# or another package that's importable via "agents", no ImportError would
# be thrown and the integration would enable itself even if openai-agents is
# not installed.
```

The name collision is the caller's to fix, and it is being fixed separately. But the SDK shouldn't open the window: no library should run third-party plugin discovery from a module body.

Worth noting this only reproduces with `SENTRY_DSN` set, which dev and CI usually don't have. The DSN doesn't need to be reachable — `init()` alone is enough.

## Repro

```python
# Before this change, with SENTRY_DSN set, prints True.
import sentry_sdk

calls = []
sentry_sdk.init = lambda *a, **kw: calls.append(1)

import datahub.ingestion.graph.client

print("sentry_sdk.init() called during import:", bool(calls))
```

## Change

Build the singleton on first use instead of at import.

- `get_telemetry_instance()` builds and caches on first call.
- A PEP 562 module `__getattr__` keeps both existing spellings working — `telemetry.telemetry_instance.ping(...)` and `from datahub.telemetry.telemetry import telemetry_instance` — so the ~50 call sites are untouched. No public API change.
- `graph/client.py` and `run/pipeline.py` drop their module-scope `from ... import telemetry_instance`, which resolved the singleton eagerly at their own import line, and call the accessor instead. (`graph/client.py` already had a function-local import for one use.)

Same singleton semantics, same telemetry, same sentry config — just constructed when first needed.

## Test plan

New `metadata-ingestion/tests/unit/telemetry/test_telemetry_lazy_init.py`, run in subprocesses with `SENTRY_DSN` set so the path is exercised:

- importing `datahub.ingestion.graph.client` doesn't call `sentry_sdk.init()`
- the singleton is built on first use and cached
- both existing access spellings resolve to that same instance

- [x] `metadata-ingestion/tests/unit/telemetry/` — 7 passed
- [x] `./gradlew :metadata-ingestion:lint` — ruff clean, mypy clean (2534 files)
- [x] `./gradlew :metadata-ingestion:testQuick` — 16424 passed. The 21 failures and 1 collection error are pre-existing and environmental (missing `vcrpy`/`pyzipper`, a missing `libodbc`, and a timezone-dependent date assertion); identical counts on the parent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
