### PR TITLE
docs: decode the labels on the integrations page

### DIFF
--- a/docs-website/src/pages/docs/_components/FilterCard/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterCard/index.jsx
@@ -4,6 +4,7 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 import Link from "@docusaurus/Link";
 import styles from "./quicklinkcard.module.scss";
 import { Tag } from "antd";
+import { getSupportStatusTooltip } from "../supportStatus";
 
 const FilterCard = ({
   image,
@@ -135,17 +136,6 @@ const FilterCard = ({
     return "";
   }
 
-  function getSupportStatusTooltip() {
-    const status = supportStatus.trim().toLowerCase();
-    if (status === "certified")
-      return "Certified: well-tested and widely adopted; expected to be stable.";
-    if (status === "incubating")
-      return "Incubating: ready for adoption, but not yet tested across a wide variety of edge cases.";
-    if (status === "testing")
-      return "Testing: available for experimentation; may change without notice.";
-    return "";
-  }
-
   return (
     <div className={clsx("col col--4", styles.featureCol)}>
       <Link
@@ -156,7 +146,7 @@ const FilterCard = ({
         {supportStatus && (
           <div
             className={clsx(styles.supportBadge, getSupportBadgeClass())}
-            title={getSupportStatusTooltip()}
+            title={getSupportStatusTooltip(supportStatus)}
           >
             {supportStatus.trim() === "Certified" && "✓ "}
             {supportStatus.trim()}

--- a/docs-website/src/pages/docs/_components/FilterCard/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterCard/index.jsx
@@ -135,6 +135,17 @@ const FilterCard = ({
     return "";
   }
 
+  function getSupportStatusTooltip() {
+    const status = supportStatus.trim().toLowerCase();
+    if (status === "certified")
+      return "Certified: well-tested and widely adopted; expected to be stable.";
+    if (status === "incubating")
+      return "Incubating: ready for adoption, but not yet tested across a wide variety of edge cases.";
+    if (status === "testing")
+      return "Testing: available for experimentation; may change without notice.";
+    return "";
+  }
+
   return (
     <div className={clsx("col col--4", styles.featureCol)}>
       <Link
@@ -143,7 +154,10 @@ const FilterCard = ({
         onClick={handleCardClick}
       >
         {supportStatus && (
-          <div className={clsx(styles.supportBadge, getSupportBadgeClass())}>
+          <div
+            className={clsx(styles.supportBadge, getSupportBadgeClass())}
+            title={getSupportStatusTooltip()}
+          >
             {supportStatus.trim() === "Certified" && "✓ "}
             {supportStatus.trim()}
           </div>
@@ -159,6 +173,7 @@ const FilterCard = ({
             {isApiConnector && (
               <Tag
                 color="blue"
+                title="No ready-made connector exists. DataHub can model this platform, but you emit the metadata yourself using the SDK or APIs."
                 style={{
                   marginLeft: "0.5rem",
                   fontSize: "0.7rem",

--- a/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
@@ -39,9 +39,12 @@
   text-transform: uppercase;
 }
 
+// Mirrored by the legend samples in FilterPage/legend.module.scss; change both
+// together. Foregrounds clear WCAG AA's 4.5:1 for normal text, which applies
+// because the badge is well under the 18pt large-text threshold.
 .badgeCertified {
   background: #e6f4ea;
-  color: #1a7f37;
+  color: #136c2e;
 }
 
 .badgeIncubating {
@@ -51,7 +54,7 @@
 
 .badgeTesting {
   background: #f0f0f5;
-  color: #6b7280;
+  color: #585d66;
 }
 
 .featureImage {

--- a/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
@@ -25,12 +25,18 @@
   }
 }
 
-// Infima pads .card__header with --ifm-card-vertical-spacing (1rem), which is
-// generous for a logo-plus-title header and makes the grid taller than it
-// needs to be. Scoped to these cards via a descendant selector so the value
-// wins on specificity rather than on stylesheet order.
-.feature :global(.card__header) {
-  padding: 0.5rem;
+// Infima pads all three card sections with --ifm-card-vertical-spacing (1rem),
+// which is generous for a logo, a title and a sentence, and is paid on every
+// one of 148 cards. Set the padding directly rather than overriding the
+// variable, so this does not depend on Infima's internal custom property
+// names. Scoped to these cards via a descendant selector so the value wins on
+// specificity rather than on stylesheet order.
+.feature {
+  :global(.card__header),
+  :global(.card__body),
+  :global(.card__footer) {
+    padding: 0.5rem;
+  }
 }
 
 // Support Status Badge

--- a/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterCard/quicklinkcard.module.scss
@@ -25,6 +25,14 @@
   }
 }
 
+// Infima pads .card__header with --ifm-card-vertical-spacing (1rem), which is
+// generous for a logo-plus-title header and makes the grid taller than it
+// needs to be. Scoped to these cards via a descendant selector so the value
+// wins on specificity rather than on stylesheet order.
+.feature :global(.card__header) {
+  padding: 0.5rem;
+}
+
 // Support Status Badge
 .supportBadge {
   position: absolute;

--- a/docs-website/src/pages/docs/_components/FilterCards/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterCards/index.jsx
@@ -5,14 +5,21 @@ import Link from "@docusaurus/Link";
 import styles from "./quicklinkcards.module.scss";
 import FilterCard from "../FilterCard";
 
-const FilterCards = ({ content, filterBar }) =>
+// `aside` is optional supplementary content shown in a sticky rail to the right
+// of the cards. It deliberately sits alongside the grid rather than above it:
+// anything placed between the filter bar and the cards pushes the results
+// themselves below the fold.
+const FilterCards = ({ content, filterBar, aside }) =>
   content?.length > 0 ? (
     <div style={{ padding: "2vh 0" }}>
       <div className="container">
-        <div className="row">
-          {content.map((props, idx) => (
-            <FilterCard key={idx} {...props} />
-          ))}
+        <div className={clsx(aside && styles.withAside)}>
+          <div className="row">
+            {content.map((props, idx) => (
+              <FilterCard key={idx} {...props} />
+            ))}
+          </div>
+          {aside}
         </div>
       </div>
     </div>

--- a/docs-website/src/pages/docs/_components/FilterCards/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterCards/index.jsx
@@ -6,23 +6,43 @@ import styles from "./quicklinkcards.module.scss";
 import FilterCard from "../FilterCard";
 
 // `aside` is optional supplementary content shown in a sticky rail to the right
-// of the cards. It deliberately sits alongside the grid rather than above it:
-// anything placed between the filter bar and the cards pushes the results
-// themselves below the fold.
-const FilterCards = ({ content, filterBar, aside }) =>
-  content?.length > 0 ? (
+// of the cards at wide widths.
+//
+// It is deliberately rendered BEFORE the cards in the DOM. The two-column grid
+// reorders it back to the right-hand column via `order` (see
+// quicklinkcards.module.scss), so the visual result is unchanged above 1200px.
+// Below that the grid collapses to one column and DOM order takes over, which
+// puts the aside above the cards instead of stranding it below all ~148 of
+// them - where a badge legend is functionally absent.
+//
+// The aside also survives an empty result set. It explains the badges rather
+// than describing any particular card, so it stays useful when a filter matches
+// nothing, and an empty state is shown in place of the grid.
+const FilterCards = ({ content, filterBar, aside }) => {
+  const hasContent = content?.length > 0;
+
+  if (!hasContent && !aside) return null;
+
+  return (
     <div style={{ padding: "2vh 0" }}>
       <div className="container">
         <div className={clsx(aside && styles.withAside)}>
-          <div className="row">
-            {content.map((props, idx) => (
-              <FilterCard key={idx} {...props} />
-            ))}
-          </div>
           {aside}
+          {hasContent ? (
+            <div className="row">
+              {content.map((props, idx) => (
+                <FilterCard key={idx} {...props} />
+              ))}
+            </div>
+          ) : (
+            <p className={styles.noResults}>
+              No connectors match the current filters.
+            </p>
+          )}
         </div>
       </div>
     </div>
-  ) : null;
+  );
+};
 
 export default FilterCards;

--- a/docs-website/src/pages/docs/_components/FilterCards/quicklinkcards.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterCards/quicklinkcards.module.scss
@@ -27,17 +27,42 @@
 // Cards plus an optional sticky rail. `align-items: start` is load-bearing:
 // the default `stretch` would give the rail full column height and its
 // `position: sticky` would then have nothing to travel within.
+//
+// The rail comes first in the DOM (see index.jsx) so that it lands above the
+// cards once this grid collapses to a single column. Grid places items in
+// order-modified document order, so `order` puts the cards back in the left
+// column and the rail in the right one at wide widths. There are always
+// exactly two children here: the aside, then the card grid or the empty state.
 .withAside {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 17rem;
   gap: 1.5rem;
   align-items: start;
+
+  > :first-child {
+    order: 2;
+  }
+
+  > :last-child {
+    order: 1;
+  }
 }
 
-// Below this width the rail would squeeze the card grid past two across, so
-// it returns to normal flow underneath the cards.
+// Below this width the rail would squeeze the card grid past two across, so it
+// returns to normal flow - above the cards, per the DOM order, rather than
+// below every card. Dropping the `order` overrides is what restores that.
 @media (max-width: 1200px) {
   .withAside {
     grid-template-columns: minmax(0, 1fr);
+
+    > :first-child,
+    > :last-child {
+      order: 0;
+    }
   }
+}
+
+.noResults {
+  margin: 0.5rem;
+  color: var(--ifm-color-emphasis-700);
 }

--- a/docs-website/src/pages/docs/_components/FilterCards/quicklinkcards.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterCards/quicklinkcards.module.scss
@@ -23,3 +23,21 @@
     border-color: var(--ifm-color-primary);
   }
 }
+
+// Cards plus an optional sticky rail. `align-items: start` is load-bearing:
+// the default `stretch` would give the rail full column height and its
+// `position: sticky` would then have nothing to travel within.
+.withAside {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 17rem;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+// Below this width the rail would squeeze the card grid past two across, so
+// it returns to normal flow underneath the cards.
+@media (max-width: 1200px) {
+  .withAside {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import FilterBar from "../FilterBar";
 import FilterCards from "../FilterCards";
 import styles from "./legend.module.scss";
+import { SUPPORT_STATUS_DESCRIPTIONS } from "../supportStatus";
 
 // Decodes the two independent labels shown on each card. Support status
 // describes how mature an existing connector is; connection type describes how
@@ -28,7 +29,7 @@ function CardLegend() {
               >
                 Certified
               </span>
-              Well-tested and widely adopted; expected to be stable.
+              {SUPPORT_STATUS_DESCRIPTIONS.certified}
             </li>
             <li>
               <span
@@ -36,14 +37,13 @@ function CardLegend() {
               >
                 Incubating
               </span>
-              Ready for adoption, but not yet tested across a wide variety of
-              edge cases.
+              {SUPPORT_STATUS_DESCRIPTIONS.incubating}
             </li>
             <li>
               <span className={clsx(styles.legendSample, styles.sampleTesting)}>
                 Testing
               </span>
-              Available for experimentation; may change without notice.
+              {SUPPORT_STATUS_DESCRIPTIONS.testing}
             </li>
             <li>
               <b>No badge</b> - the connector does not declare a support status.
@@ -86,12 +86,14 @@ export function FilterPage(
   metadata,
   title,
   subtitle,
-  allowExclusivity = false,
-  useTags = false,
-  useFilters = false,
-  seoTitle = siteConfig.tagline,
-  seoDescription = "DataHub is a data discovery application built on an extensible metadata platform that helps you tame the complexity of diverse data ecosystems.",
-  showLegend = false
+  {
+    allowExclusivity = false,
+    useTags = false,
+    useFilters = false,
+    showLegend = false,
+    seoTitle = siteConfig.tagline,
+    seoDescription = "DataHub is a data discovery application built on an extensible metadata platform that helps you tame the complexity of diverse data ecosystems.",
+  } = {}
 ) {
   const [textState, setTextState] = React.useState("");
   const [filterState, setFilterState] = React.useState([]);

--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -221,7 +221,7 @@ export function FilterPage(
       </Head>
       <header className={"hero"}>
         <div className="container">
-          <div className="hero__content">
+          <div className={clsx("hero__content", styles.heroContent)}>
             <div>
               <h1 className="hero__title">{title}</h1>
               <p className="hero__subtitle">{subtitle}</p>

--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -1,8 +1,85 @@
 import React from "react";
 import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
+import clsx from "clsx";
 import FilterBar from "../FilterBar";
 import FilterCards from "../FilterCards";
+import styles from "./legend.module.scss";
+
+// Decodes the two independent labels shown on each card. Support status
+// describes how mature an existing connector is; connection type describes how
+// metadata reaches DataHub, and its "API" value means no connector exists at
+// all. Readers have mistaken "API" for a support level, so both axes are
+// spelled out here rather than left to inference.
+function CardLegend() {
+  return (
+    <details className={styles.legend} open>
+      <summary>
+        Labels on these cards describe two separate things: how mature a
+        connector is, and how metadata reaches DataHub.
+      </summary>
+      <div className={styles.legendGrid}>
+        <div>
+          <h4>Support status (badge in the corner of each card)</h4>
+          <ul>
+            <li>
+              <span
+                className={clsx(styles.legendSample, styles.sampleCertified)}
+              >
+                Certified
+              </span>
+              Well-tested and widely adopted; expected to be stable.
+            </li>
+            <li>
+              <span
+                className={clsx(styles.legendSample, styles.sampleIncubating)}
+              >
+                Incubating
+              </span>
+              Ready for adoption, but not yet tested across a wide variety of
+              edge cases.
+            </li>
+            <li>
+              <span className={clsx(styles.legendSample, styles.sampleTesting)}>
+                Testing
+              </span>
+              Available for experimentation; may change without notice.
+            </li>
+            <li>
+              <b>No badge</b> - the connector does not declare a support status.
+            </li>
+          </ul>
+          <a href="docs/metadata-ingestion/source_overview#metadata-ingestion-source-status">
+            More on support status
+          </a>
+        </div>
+        <div>
+          <h4>Connection type (how metadata reaches DataHub)</h4>
+          <ul>
+            <li>
+              <b>Pull</b> - DataHub connects to the platform and reads metadata
+              on a schedule.
+            </li>
+            <li>
+              <b>Push</b> - the platform sends metadata to DataHub.
+            </li>
+            <li>
+              <span className={clsx(styles.legendSample, styles.sampleApi)}>
+                API
+              </span>
+              <b>No ready-made connector exists.</b> DataHub can model this
+              platform, but you emit the metadata yourself using the SDK or
+              APIs.
+            </li>
+          </ul>
+          <a href="docs/metadata-ingestion/datahub-skills">
+            Build your own integration
+          </a>
+        </div>
+      </div>
+    </details>
+  );
+}
 
 export function FilterPage(
   siteConfig,
@@ -13,7 +90,8 @@ export function FilterPage(
   useTags = false,
   useFilters = false,
   seoTitle = siteConfig.tagline,
-  seoDescription = "DataHub is a data discovery application built on an extensible metadata platform that helps you tame the complexity of diverse data ecosystems."
+  seoDescription = "DataHub is a data discovery application built on an extensible metadata platform that helps you tame the complexity of diverse data ecosystems.",
+  showLegend = false
 ) {
   const [textState, setTextState] = React.useState("");
   const [filterState, setFilterState] = React.useState([]);
@@ -160,6 +238,8 @@ export function FilterPage(
                 setIsExclusive={setIsExclusive}
                 categoryCounts={categoryCounts}
               />
+
+              {showLegend && <CardLegend />}
             </div>
           </div>
         </div>

--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -14,14 +14,10 @@ import { SUPPORT_STATUS_DESCRIPTIONS } from "../supportStatus";
 // spelled out here rather than left to inference.
 function CardLegend() {
   return (
-    <details className={styles.legend} open>
-      <summary>
-        Labels on these cards describe two separate things: how mature a
-        connector is, and how metadata reaches DataHub.
-      </summary>
+    <aside className={styles.legend} aria-label="Card legend">
       <div className={styles.legendGrid}>
         <div>
-          <h4>Support status (badge in the corner of each card)</h4>
+          <h4>Support status</h4>
           <ul>
             <li>
               <span
@@ -54,7 +50,7 @@ function CardLegend() {
           </a>
         </div>
         <div>
-          <h4>Connection type (how metadata reaches DataHub)</h4>
+          <h4>Connection type</h4>
           <ul>
             <li>
               <b>Pull</b> - DataHub connects to the platform and reads metadata
@@ -68,8 +64,8 @@ function CardLegend() {
                 API
               </span>
               <b>No ready-made connector exists.</b> DataHub can model this
-              platform, but you emit the metadata yourself using the SDK or
-              APIs.
+              platform, but you emit the metadata yourself using the DataHub SDK
+              or APIs.
             </li>
           </ul>
           <a href="docs/metadata-ingestion/datahub-skills">
@@ -77,7 +73,7 @@ function CardLegend() {
           </a>
         </div>
       </div>
-    </details>
+    </aside>
   );
 }
 
@@ -226,20 +222,22 @@ export function FilterPage(
       <header className={"hero"}>
         <div className="container">
           <div className="hero__content">
-            <div>
-              <h1 className="hero__title">{title}</h1>
-              <p className="hero__subtitle">{subtitle}</p>
+            <div className={clsx(showLegend && styles.heroLayout)}>
+              <div className={clsx(showLegend && styles.heroMain)}>
+                <h1 className="hero__title">{title}</h1>
+                <p className="hero__subtitle">{subtitle}</p>
 
-              <FilterBar
-                textState={textState}
-                setTextState={setTextState}
-                filterState={filterState}
-                setFilterState={setFilterState}
-                filterOptions={filterOptions}
-                allowExclusivity={allowExclusivity}
-                setIsExclusive={setIsExclusive}
-                categoryCounts={categoryCounts}
-              />
+                <FilterBar
+                  textState={textState}
+                  setTextState={setTextState}
+                  filterState={filterState}
+                  setFilterState={setFilterState}
+                  filterOptions={filterOptions}
+                  allowExclusivity={allowExclusivity}
+                  setIsExclusive={setIsExclusive}
+                  categoryCounts={categoryCounts}
+                />
+              </div>
 
               {showLegend && <CardLegend />}
             </div>

--- a/docs-website/src/pages/docs/_components/FilterPage/index.jsx
+++ b/docs-website/src/pages/docs/_components/FilterPage/index.jsx
@@ -222,24 +222,20 @@ export function FilterPage(
       <header className={"hero"}>
         <div className="container">
           <div className="hero__content">
-            <div className={clsx(showLegend && styles.heroLayout)}>
-              <div className={clsx(showLegend && styles.heroMain)}>
-                <h1 className="hero__title">{title}</h1>
-                <p className="hero__subtitle">{subtitle}</p>
+            <div>
+              <h1 className="hero__title">{title}</h1>
+              <p className="hero__subtitle">{subtitle}</p>
 
-                <FilterBar
-                  textState={textState}
-                  setTextState={setTextState}
-                  filterState={filterState}
-                  setFilterState={setFilterState}
-                  filterOptions={filterOptions}
-                  allowExclusivity={allowExclusivity}
-                  setIsExclusive={setIsExclusive}
-                  categoryCounts={categoryCounts}
-                />
-              </div>
-
-              {showLegend && <CardLegend />}
+              <FilterBar
+                textState={textState}
+                setTextState={setTextState}
+                filterState={filterState}
+                setFilterState={setFilterState}
+                filterOptions={filterOptions}
+                allowExclusivity={allowExclusivity}
+                setIsExclusive={setIsExclusive}
+                categoryCounts={categoryCounts}
+              />
             </div>
           </div>
         </div>
@@ -248,6 +244,7 @@ export function FilterPage(
       <FilterCards
         content={filteredIngestionSourceContent}
         filterBar={<FilterBar />}
+        aside={showLegend ? <CardLegend /> : null}
       />
 
       <div

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -1,23 +1,9 @@
-// Three columns keep the hero's title, subtitle and filter bar centred on the
-// page: the empty first column always mirrors the legend in the third, so the
-// middle column stays dead-centre whatever width the legend takes. Below the
-// breakpoint the grid collapses and the legend sits under the filter bar.
-.heroLayout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 44rem) minmax(0, 1fr);
-  gap: 1.5rem;
-  align-items: start;
-}
-
-.heroMain {
-  grid-column: 2;
-  min-width: 0;
-}
-
+// Sticks below the fixed navbar so the legend stays on screen while the cards
+// scroll past it. Sticky only engages while the rail is shorter than its grid
+// column, which is why the card grid sets `align-items: start`.
 .legend {
-  grid-column: 3;
-  justify-self: start;
-  max-width: 17rem;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
   padding: 0.75rem 1rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 8px;
@@ -26,20 +12,12 @@
   text-align: left;
 }
 
-@media (max-width: 996px) {
-  .heroLayout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .heroMain {
-    grid-column: 1;
-  }
-
+// Once the rail drops back into normal flow under the cards, sticky would pin
+// it to the viewport for the rest of the page with nothing beside it.
+@media (max-width: 1200px) {
   .legend {
-    grid-column: 1;
-    justify-self: stretch;
-    max-width: none;
-    margin-top: 1rem;
+    position: static;
+    margin-top: 1.5rem;
   }
 }
 

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -1,3 +1,16 @@
+// global.scss gives .hero 5vh of vertical padding and then .hero__content
+// another 2rem inside it, so the header carries both before a single card is
+// reached. Drop the inner one.
+//
+// Scoped here rather than fixed in global.scss because the Learn list page
+// uses .hero__content too and is not ours to restyle. The class is doubled to
+// out-specify global.scss's `.hero .hero__content` without resorting to
+// !important or depending on stylesheet order.
+:global(.hero) .heroContent.heroContent {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 // Sticks below the fixed navbar so the legend stays on screen while the cards
 // scroll past it. Sticky only engages while the rail is shorter than its grid
 // column, which is why the card grid sets `align-items: start`.

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -1,29 +1,52 @@
+// Three columns keep the hero's title, subtitle and filter bar centred on the
+// page: the empty first column always mirrors the legend in the third, so the
+// middle column stays dead-centre whatever width the legend takes. Below the
+// breakpoint the grid collapses and the legend sits under the filter bar.
+.heroLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 44rem) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.heroMain {
+  grid-column: 2;
+  min-width: 0;
+}
+
 .legend {
-  margin-top: 1rem;
+  grid-column: 3;
+  justify-self: start;
+  max-width: 17rem;
   padding: 0.75rem 1rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 8px;
   background: var(--ifm-background-surface-color);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-align: left;
+}
 
-  summary {
-    cursor: pointer;
-    font-weight: 500;
-    color: var(--ifm-color-emphasis-800);
-    list-style-position: outside;
+@media (max-width: 996px) {
+  .heroLayout {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  summary:hover {
-    color: var(--ifm-color-primary);
+  .heroMain {
+    grid-column: 1;
+  }
+
+  .legend {
+    grid-column: 1;
+    justify-self: stretch;
+    max-width: none;
+    margin-top: 1rem;
   }
 }
 
 .legendGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
-  gap: 1.25rem;
-  margin-top: 0.75rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
 
   h4 {
     margin-bottom: 0.35rem;

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -14,9 +14,23 @@
 // Sticks below the fixed navbar so the legend stays on screen while the cards
 // scroll past it. Sticky only engages while the rail is shorter than its grid
 // column, which is why the card grid sets `align-items: start`.
+//
+// The offset has to clear BOTH bars. global.scss pins .navbar at
+// `top: var(--docusaurus-announcement-bar-height)` with `height:
+// var(--ifm-navbar-height)`, so the navbar occupies 45-105px of the viewport.
+// `position: sticky` resolves `top` against the scrollport, not the
+// padding-shifted body, so an offset of navbar-height alone pins the legend
+// 29px inside the navbar and hides its own heading. The announcement bar is
+// declared `isCloseable: false`, so it is always present.
+//
+// Note global.scss switches to a 65px bar under 768px without redefining the
+// variable; that does not matter here because the 1200px rule below drops
+// sticky positioning entirely well before that width is reached.
 .legend {
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + 1rem);
+  top: calc(
+    var(--docusaurus-announcement-bar-height) + var(--ifm-navbar-height) + 1rem
+  );
   padding: 0.75rem 1rem;
   border: 1px solid var(--ifm-color-emphasis-300);
   border-radius: 8px;

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -54,9 +54,14 @@
   vertical-align: middle;
 }
 
+// These must stay in step with the real badges in
+// FilterCard/quicklinkcard.module.scss - the legend is only useful if it
+// reproduces what the cards show. Foregrounds are darkened to clear WCAG AA's
+// 4.5:1 for normal text, which applies here because the samples are well under
+// the 18pt large-text threshold.
 .sampleCertified {
   background: #e6f4ea;
-  color: #1a7f37;
+  color: #136c2e;
 }
 
 .sampleIncubating {
@@ -66,10 +71,13 @@
 
 .sampleTesting {
   background: #f0f0f5;
-  color: #6b7280;
+  color: #585d66;
 }
 
+// The cards render this one as an antd Tag with color="blue", so the sample
+// takes antd v5's blue preset rather than an approximation of it.
 .sampleApi {
-  background: #e6f0fb;
-  color: #1d4ed8;
+  background: #e6f4ff;
+  border: 1px solid #91caff;
+  color: #0958d9;
 }

--- a/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
+++ b/docs-website/src/pages/docs/_components/FilterPage/legend.module.scss
@@ -1,0 +1,75 @@
+.legend {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  font-size: 0.85rem;
+  text-align: left;
+
+  summary {
+    cursor: pointer;
+    font-weight: 500;
+    color: var(--ifm-color-emphasis-800);
+    list-style-position: outside;
+  }
+
+  summary:hover {
+    color: var(--ifm-color-primary);
+  }
+}
+
+.legendGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.25rem;
+  margin-top: 0.75rem;
+
+  h4 {
+    margin-bottom: 0.35rem;
+    font-size: 0.85rem;
+    color: var(--ifm-color-emphasis-800);
+  }
+
+  ul {
+    margin: 0 0 0.35rem;
+    padding-left: 1.1rem;
+  }
+
+  li {
+    margin-bottom: 0.2rem;
+    color: var(--ifm-color-emphasis-700);
+  }
+}
+
+.legendSample {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-right: 0.35rem;
+  vertical-align: middle;
+}
+
+.sampleCertified {
+  background: #e6f4ea;
+  color: #1a7f37;
+}
+
+.sampleIncubating {
+  background: #fff3e0;
+  color: #b45309;
+}
+
+.sampleTesting {
+  background: #f0f0f5;
+  color: #6b7280;
+}
+
+.sampleApi {
+  background: #e6f0fb;
+  color: #1d4ed8;
+}

--- a/docs-website/src/pages/docs/_components/supportStatus.js
+++ b/docs-website/src/pages/docs/_components/supportStatus.js
@@ -1,0 +1,21 @@
+// Single source for the support-status glossary. The integrations page shows
+// these in a legend, and each card repeats the matching one as a hover tooltip;
+// keeping one copy stops the two drifting apart.
+export const SUPPORT_STATUS_DESCRIPTIONS = {
+  certified: "Well-tested and widely adopted; expected to be stable.",
+  incubating:
+    "Ready for adoption, but not yet tested across a wide variety of edge cases.",
+  testing: "Available for experimentation; may change without notice.",
+};
+
+export function getSupportStatusDescription(supportStatus) {
+  return SUPPORT_STATUS_DESCRIPTIONS[supportStatus.trim().toLowerCase()] || "";
+}
+
+// Cards prefix the label, e.g. "Certified: well-tested and widely adopted...".
+export function getSupportStatusTooltip(supportStatus) {
+  const description = getSupportStatusDescription(supportStatus);
+  if (!description) return "";
+  const label = supportStatus.trim();
+  return `${label}: ${description[0].toLowerCase()}${description.slice(1)}`;
+}

--- a/docs-website/src/pages/integrations.jsx
+++ b/docs-website/src/pages/integrations.jsx
@@ -16,12 +16,12 @@ function DataProviderComponent() {
     metadata,
     "DataHub Integrations",
     `Connect to ${connectorCount}+ data and AI systems`,
-    false, // allowExclusivity
-    true, // useTags
-    false, // useFilters
-    `DataHub Connector Directory: ${connectorCount}+ Integrations`, // seoTitle
-    `Find every system DataHub integrates with. Browse ${connectorCount}+ DataHub connectors across databases, BI tools, ETL, AI/ML systems, and more.`, // seoDescription
-    true // showLegend
+    {
+      useTags: true,
+      showLegend: true,
+      seoTitle: `DataHub Connector Directory: ${connectorCount}+ Integrations`,
+      seoDescription: `Find every system DataHub integrates with. Browse ${connectorCount}+ DataHub connectors across databases, BI tools, ETL, AI/ML systems, and more.`,
+    }
   );
 }
 

--- a/docs-website/src/pages/integrations.jsx
+++ b/docs-website/src/pages/integrations.jsx
@@ -16,11 +16,12 @@ function DataProviderComponent() {
     metadata,
     "DataHub Integrations",
     `Connect to ${connectorCount}+ data and AI systems`,
-    false,
-    true,
-    false,
-    `DataHub Connector Directory: ${connectorCount}+ Integrations`,
-    `Find every system DataHub integrates with. Browse ${connectorCount}+ DataHub connectors across databases, BI tools, ETL, AI/ML systems, and more.`
+    false, // allowExclusivity
+    true, // useTags
+    false, // useFilters
+    `DataHub Connector Directory: ${connectorCount}+ Integrations`, // seoTitle
+    `Find every system DataHub integrates with. Browse ${connectorCount}+ DataHub connectors across databases, BI tools, ETL, AI/ML systems, and more.`, // seoDescription
+    true // showLegend
   );
 }
 

--- a/metadata-ingestion/scripts/docgen.py
+++ b/metadata-ingestion/scripts/docgen.py
@@ -32,6 +32,11 @@ DENY_LIST = {
     "datahub-mock-data",
 }
 
+# Fallback target for the "Request Native Connector" link on API-only cards.
+# Relative so it resolves under a non-root DOCUSAURUS_CONFIG_BASE_URL, matching
+# the other in-page links on the integrations page.
+DEFAULT_REQUEST_CONNECTOR_URL = "docs/metadata-ingestion/request-connector"
+
 
 def get_snippet(long_string: str, max_length: int = 100) -> str:
     snippet = ""
@@ -607,8 +612,12 @@ def generate_filter_tag_indexes(
 
         if is_api:
             entry["isApiConnector"] = True
-            if meta.get("requestNativeUrl"):
-                entry["requestNativeUrl"] = meta["requestNativeUrl"]
+            # Every API-only card offers a way to ask for a real connector.
+            # Without a default here the card renders the "API" tag and nothing
+            # else, which reads as "supported" to anyone scanning the page.
+            entry["requestNativeUrl"] = meta.get(
+                "requestNativeUrl", DEFAULT_REQUEST_CONNECTOR_URL
+            )
 
         entries.append(entry)
 

--- a/metadata-ingestion/scripts/docgen.py
+++ b/metadata-ingestion/scripts/docgen.py
@@ -615,8 +615,11 @@ def generate_filter_tag_indexes(
             # Every API-only card offers a way to ask for a real connector.
             # Without a default here the card renders the "API" tag and nothing
             # else, which reads as "supported" to anyone scanning the page.
-            entry["requestNativeUrl"] = meta.get(
-                "requestNativeUrl", DEFAULT_REQUEST_CONNECTOR_URL
+            # `or` rather than a get() default: an entry carrying an empty
+            # requestNativeUrl would otherwise pass the falsy value straight
+            # through and reinstate the dead-end card.
+            entry["requestNativeUrl"] = (
+                meta.get("requestNativeUrl") or DEFAULT_REQUEST_CONNECTOR_URL
             )
 
         entries.append(entry)

--- a/metadata-ingestion/tests/unit/test_docgen.py
+++ b/metadata-ingestion/tests/unit/test_docgen.py
@@ -1,0 +1,65 @@
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import docgen
+
+
+def _generate(tmp_path: Path, catalog: Dict[str, Any]) -> Dict[str, Any]:
+    """Run the generator over a catalog with no registry platforms."""
+    catalog_path = tmp_path / "integrations_catalog.json"
+    catalog_path.write_text(json.dumps(catalog), encoding="utf-8")
+    output_path = tmp_path / "integrations.json"
+
+    docgen.generate_filter_tag_indexes(
+        platforms={},
+        catalog_path=str(catalog_path),
+        output_path=str(output_path),
+    )
+
+    return json.loads(output_path.read_text(encoding="utf-8"))
+
+
+def _entry(tmp_path: Path, meta: Dict[str, Any]) -> Dict[str, Any]:
+    result = _generate(tmp_path, {"my-platform": {"title": "My Platform", **meta}})
+    entries = result["ingestionSources"]
+    assert len(entries) == 1
+    return entries[0]
+
+
+def test_api_entry_gets_the_default_request_url(tmp_path: Path) -> None:
+    entry = _entry(tmp_path, {"api_connector": True})
+
+    assert entry["isApiConnector"] is True
+    assert entry["requestNativeUrl"] == docgen.DEFAULT_REQUEST_CONNECTOR_URL
+    assert entry["tags"]["Connection Type"] == "API"
+
+
+def test_explicit_request_url_overrides_the_default(tmp_path: Path) -> None:
+    entry = _entry(
+        tmp_path, {"api_connector": True, "requestNativeUrl": "docs/custom-request"}
+    )
+
+    assert entry["requestNativeUrl"] == "docs/custom-request"
+
+
+@pytest.mark.parametrize("value", ["", None])
+def test_empty_request_url_falls_back_to_the_default(
+    tmp_path: Path, value: Optional[str]
+) -> None:
+    """An empty value must not leave the card without a link to request one."""
+    entry = _entry(tmp_path, {"api_connector": True, "requestNativeUrl": value})
+
+    assert entry["requestNativeUrl"] == docgen.DEFAULT_REQUEST_CONNECTOR_URL
+
+
+def test_non_api_entry_has_no_request_url(tmp_path: Path) -> None:
+    entry = _entry(tmp_path, {"external": True})
+
+    assert "requestNativeUrl" not in entry
+    assert "isApiConnector" not in entry


### PR DESCRIPTION
## Problem

The integrations page shows two independent labels on every card and explains neither of them.

**Support status** (`Certified`, `Incubating`, `Testing`) rates how mature an existing connector is. **Connection type** (`Pull`, `Push`, `API`) describes how metadata reaches DataHub. They come from different places in `docgen.py` and mean different things, but they render as similar-looking chips on the same card with no key.

The `API` value is the one that misleads. On a page that reads as a catalogue of integrations, an `API` tag looks like a capability tier alongside Certified and Incubating. It means the opposite: no connector exists, and the tile links to the generic API docs rather than a source page. 27 of the 148 entries are in this state, including Azure Cosmos DB, Azure Kusto, Alteryx, Domo and Microsoft Fabric.

This is not hypothetical. Someone picking connectors for a bundled executor image read the Azure Cosmos DB tile as a shipped integration and asked which plugin name to install, and the same misreading has come up before. The page currently generates questions rather than answering them.

## Changes

**A legend under the filter bar**, covering both axes with colour samples that match the real badges, including the case where a card carries no badge at all. It links out to the definitions that already exist in `source_overview.md` rather than restating them, and that page already links here, so this closes the loop.

It renders expanded. A collapsed explanation does not reach the reader who does not yet know they have misunderstood something, which is exactly the reader this is for. It remains a `<details>` so repeat visitors can fold it away.

The legend is gated behind a new `showLegend` parameter defaulting to `false`, passed as `true` from `integrations.jsx`. `FilterPage` has only one caller today, but an unconditional legend would be a surprise for any future one. I also added inline comments to the positional arguments at the call site, since the signature is now eight parameters deep.

**Tooltips** on the support badge and the API tag, for readers who hover rather than read the legend.

**`requestNativeUrl` now defaults for every API-only card.** `FilterCard` already renders a "Request Native Connector" link when this field is set, but no catalog entry has ever set it, so the affordance has never rendered for any of the 27 affected platforms. Defaulting it in the generator rather than in the catalog means new API entries inherit it without a data change. This turns each of those cards from a dead end into a request funnel.

## Verification

Ran the generator against the real catalog: 148 entries, 27 API cards, `requestNativeUrl` now populated on 27 of 27 (previously 0). Confirmed the Azure Cosmos DB entry emits it alongside `"Connection Type": "API"`.

`ruff check`, `ruff format --check` and `mypy` pass on `docgen.py` with the pinned ruff 0.15.22, and the three JSX files parse cleanly. I did not run a full `docs-website` build locally, so the rendered layout is unverified beyond the CSS being scoped to a new module; a preview build is the real check on the visual result.

## Follow-ups, not included here

Some `api_connector` entries look stale rather than accurate. `microsoft-fabric`, `azuresql` and `azure-synapse` are all marked API-only despite `fabric-onelake`, `fabric-data-factory` and `mssql` shipping today. The guard at `docgen.py` that raises when a catalog entry is marked `api_connector` while present in the source registry only compares exact platform ids, so it cannot catch these. Happy to open a separate issue or PR if that reading is right.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies support status and connection type labels on Integrations cards and makes API-only cards actionable. Previously chips were unlabeled and “API” looked like a support tier; now a sticky legend and tooltips explain both, and API-only cards link to request a native connector.

- Adds a sticky right-side legend in `FilterCards` with samples matching the badge styles (including `antd` blue for “API”); the sticky offset clears both the announcement bar and navbar; the legend renders before the grid and is reordered via CSS, appears above the cards below 1200px, and remains visible when filters match nothing (with an empty-state message).
- Adds hover tooltips: support badge text comes from a single glossary in `supportStatus.js`; the “API” tag explains no ready-made connector exists.
- Improves readability: darkens badge foregrounds to meet WCAG AA; legend samples mirror the card styles.
- Defaults `requestNativeUrl` for API-only entries in `docgen.py`; explicit values override and falsy values fall back. Adds unit tests.
- Replaces `FilterPage`’s trailing booleans with an options object and adds `showLegend` (enabled on `integrations.jsx`). Migration: update other `FilterPage` callers to pass an options object.
- Tightens spacing: sets 0.5rem padding on card header/body/footer and removes doubled `.hero__content` padding to surface the grid sooner.

<sup>Written for commit 32233591e5f4da9e797d513dcf4c538b5a9c466f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

