### PR TITLE
test(smoke): add p0 and domain markers with --domain selection

### DIFF
--- a/.agent-skills/test-review/standards/smoke-and-integration.md
+++ b/.agent-skills/test-review/standards/smoke-and-integration.md
@@ -225,19 +225,22 @@ Ingestion via REST uses `ingest_file_via_rest(auth_session, filename)` which cre
 
 ### 1.7 Marker Conventions
 
-**Source:** `smoke-test/pyproject.toml:84-88`
+**Source:** `smoke-test/pyproject.toml` (`[tool.pytest.ini_options] markers`)
 
-| Marker              | Purpose                       | When to Use                                  |
-| ------------------- | ----------------------------- | -------------------------------------------- |
-| `read_only`         | Tests that don't mutate data  | Service health, search, analytics            |
-| `no_cypress_suite1` | Module-level batch separation | Large test modules                           |
-| `dependency()`      | Test ordering                 | When test B depends on test A's side effects |
+| Marker              | Purpose                            | When to Use                                  |
+| ------------------- | ---------------------------------- | -------------------------------------------- |
+| `read_only`         | Tests that don't mutate data       | Service health, search, analytics            |
+| `no_cypress_suite1` | Module-level batch separation      | Large test modules                           |
+| `p0`                | Critical enough to run on every PR | High-signal regression guards                |
+| `domain(*names)`    | Product domain(s) owning the test  | Every test; select with `--domain`           |
+| `dependency()`      | Test ordering                      | When test B depends on test A's side effects |
 
 **Rules:**
 
 - WARNING: `read_only` tests must not create, modify, or delete any entities
 - WARNING: `@pytest.mark.dependency()` chains should be kept short (ideally <=3 levels)
 - SUGGESTION: New test modules should specify batch markers for CI parallelism
+- `domain(...)` takes values from the `Domain` enum in `tests/utilities/domains.py`; a test spanning areas declares each one and is selected by any of them
 
 ### 1.8 Environment Variable Discipline
 

--- a/smoke-test/README.md
+++ b/smoke-test/README.md
@@ -57,6 +57,26 @@ pytest test_system_info.py::test_system_info_main_endpoint -vv
 pytest test_e2e.py::test_healthchecks test_e2e.py::test_gms_usage_fetch -v
 ```
 
+#### Selecting tests by domain
+
+Tests can declare the product domain that owns them with
+`@pytest.mark.domain(...)`, using the `Domain` enum in
+`tests/utilities/domains.py` (`platform`, `observe`, `ingestion`, `ai`,
+`catalog`). The `--domain` option then runs only the tests those domains own:
+
+```bash
+# One domain
+pytest --domain catalog -vv
+
+# Several — a test owned by any of them runs
+pytest --domain catalog --domain ingestion -vv
+```
+
+A test that spans domains declares all of them, e.g.
+`@pytest.mark.domain(Domain.CATALOG, Domain.INGESTION)`, and is selected by
+either. Tests marked `p0` are the ones critical enough to run on every pull
+request; combine the two with `pytest -m p0 --domain catalog`.
+
 ## Test Categories
 
 ### System Info Tests (`test_system_info.py`)

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -18,6 +18,12 @@ from datahub.ingestion.graph.client import (
 )
 from tests.test_result_msg import send_message
 from tests.utilities import env_vars
+from tests.utilities.domains import (
+    ALL_DOMAINS,
+    domains_of,
+    is_selected,
+    parse_requested_domains,
+)
 from tests.utils import (
     TestSessionWrapper,
     assert_admin_corpuser_info_preserved,
@@ -203,6 +209,54 @@ def _ingest_cleanup_unique_dataset_impl(
     delete_urns_from_file(graph_client, unique_file)
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--domain",
+        action="append",
+        default=[],
+        metavar="DOMAIN",
+        help=(
+            "Only run tests owned by this product domain. Repeatable, e.g. "
+            "--domain catalog --domain ingestion. Valid values: "
+            f"{', '.join(sorted(ALL_DOMAINS))}."
+        ),
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Validate here rather than during collection: a bad value raised from
+    # pytest_collection_modifyitems surfaces as an INTERNALERROR instead of a
+    # readable usage error.
+    try:
+        parse_requested_domains(config.getoption("--domain"))
+    except ValueError as exc:
+        raise pytest.UsageError(str(exc)) from exc
+
+
+def _apply_domain_filter(config: pytest.Config, items: List[Item]) -> None:
+    """Deselect tests outside the domains requested with --domain."""
+    requested = parse_requested_domains(config.getoption("--domain"))
+    if not requested:
+        return
+
+    selected: List[Item] = []
+    deselected: List[Item] = []
+    for item in items:
+        declared = domains_of(item.get_closest_marker("domain"))
+        target = selected if is_selected(declared, requested) else deselected
+        target.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+    logger.info(
+        "--domain %s: selected %s of %s test(s)",
+        ",".join(sorted(requested)),
+        len(selected),
+        len(items),
+    )
+    items[:] = selected
+
+
 def pytest_sessionfinish(session, exitstatus):
     """whole test run finishes."""
     send_message(exitstatus)
@@ -386,6 +440,10 @@ def _apply_smoke_policy_phase_filter(items: List[Item]) -> None:
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: List[Item]
 ) -> None:
+    # Runs before every early return below, and before the weight-based batching,
+    # so batches are packed from the selected tests only.
+    _apply_domain_filter(config, items)
+
     # Check if FILTERED_TESTS is set (for retry logic)
     filtered_tests_file = env_vars.get_filtered_tests_file()
     if filtered_tests_file:

--- a/smoke-test/pyproject.toml
+++ b/smoke-test/pyproject.toml
@@ -87,6 +87,8 @@ markers = [
     "no_cypress_suite1: main smoke tests, suite 1",
     "integration: marks tests as integration tests requiring a running DataHub stack",
     "global_policy_mutator: module mutates shared platform policy state (disables All Users defaults and/or heavy policy-cache tests); smoke.sh runs these serially in a second pytest invocation after non-mutators",
+    "p0: critical smoke test; runs on every pull request",
+    "domain(*names): product domain(s) owning this test, from the Domain enum in tests/utilities/domains.py; select with --domain",
 ]
 filterwarnings = [
     # Ignore some warnings that come from dependencies.

--- a/smoke-test/tests/utilities/domains.py
+++ b/smoke-test/tests/utilities/domains.py
@@ -1,0 +1,67 @@
+"""
+Product-domain taxonomy for the smoke-test suite.
+
+Every smoke test declares the domain that owns it, so CI can select a subset of
+the suite per pull request and route a failure to the owning team:
+
+    @pytest.mark.domain(Domain.CATALOG)
+    @pytest.mark.domain(Domain.CATALOG, Domain.INGESTION)   # spans two domains
+
+The helpers here back the `--domain` command-line option wired up in conftest.py.
+"""
+
+from enum import Enum
+from typing import Optional, Sequence, Set
+
+from _pytest.mark.structures import Mark
+
+
+class Domain(str, Enum):
+    """Product domains that own smoke tests."""
+
+    PLATFORM = "platform"
+    OBSERVE = "observe"
+    INGESTION = "ingestion"
+    AI = "ai"
+    CATALOG = "catalog"
+
+
+ALL_DOMAINS: Set[str] = {domain.value for domain in Domain}
+
+
+def parse_requested_domains(values: Sequence[str]) -> Set[str]:
+    """Normalise `--domain` values, rejecting anything outside the enum.
+
+    Unknown values are rejected rather than silently matching nothing, which
+    would otherwise produce a green run over zero tests.
+    """
+    requested = {value.strip().lower() for value in values if value.strip()}
+    unknown = sorted(requested - ALL_DOMAINS)
+    if unknown:
+        raise ValueError(
+            f"Unknown --domain value(s): {', '.join(unknown)}. "
+            f"Valid domains: {', '.join(sorted(ALL_DOMAINS))}"
+        )
+    return requested
+
+
+def domains_of(marker: Optional[Mark]) -> Set[str]:
+    """The domain values a test declares via its `domain(...)` marker."""
+    if marker is None:
+        return set()
+    return {
+        arg.value if isinstance(arg, Domain) else str(arg).lower()
+        for arg in marker.args
+    }
+
+
+def is_selected(declared: Set[str], requested: Set[str]) -> bool:
+    """Whether a test declaring `declared` runs when `requested` was asked for.
+
+    An empty request selects everything. Otherwise a test runs when it declares
+    at least one requested domain, so a test spanning domains is picked up by
+    any of them, and an untagged test is not picked up at all.
+    """
+    if not requested:
+        return True
+    return bool(declared & requested)


### PR DESCRIPTION
Groundwork for running a smaller, faster subset of the smoke suite on pull requests while the full suite keeps running post-commit.

This PR adds the two markers and the option to select by them. Nothing is tagged yet, so CI behaves exactly as it did before.

## Changes

- `smoke-test/pyproject.toml` — registers two markers alongside the existing ones:
  - `p0` — a test critical enough to run on every pull request.
  - `domain(...)` — which product domain owns a test.
- `smoke-test/tests/utilities/domains.py` — a `Domain` enum listing the five product domains (platform, observe, ingestion, ai, catalog), plus the helpers backing the option below.
- `smoke-test/conftest.py` — a repeatable `--domain` option that runs only the tests owned by the given domains.
- `smoke-test/README.md` — documents `--domain` under Running Tests.
- `.agent-skills/test-review/standards/smoke-and-integration.md` — adds both markers to the marker table (and drops a stale line-number reference to `pyproject.toml`).

The two markers are independent: a test can carry either, both, or neither.

## Using `--domain`

```bash
pytest --domain catalog                      # one domain
pytest --domain catalog --domain ingestion   # several
pytest -m p0 --domain catalog                # combined with the criticality marker
```

A test spanning domains declares `@pytest.mark.domain(Domain.CATALOG, Domain.INGESTION)` and is picked up by either. An unknown value is rejected up front rather than quietly selecting nothing:

```
$ pytest --domain catalogue
ERROR: Unknown --domain value(s): catalogue. Valid domains: ai, catalog, ingestion, observe, platform
```

The filter runs at the top of `pytest_collection_modifyitems`, ahead of the weight-based batching, so batches are packed from the selected tests only.

## Testing

- `pytest --markers` lists both new markers.
- Collection is unchanged — 1144 tests before and after.
- An unknown value exits 4 with the usage error above.
- `./gradlew :smoke-test:lint` passes.

Later PRs tag the suite by domain, curate the `p0` set, and wire up the CI tiers.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) — not applicable, no behaviour change until the suite is tagged
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — not applicable
