### PR TITLE
test(smoke): tag every smoke-test module with its owning domain

### DIFF
--- a/smoke-test/test_authentication_e2e.py
+++ b/smoke-test/test_authentication_e2e.py
@@ -34,6 +34,7 @@ import requests
 
 from tests.privileges.utils import create_user, remove_user
 from tests.tokens.token_utils import assert_graphql_mutation_succeeded
+from tests.utilities.domains import Domain
 from tests.utils import (
     TestSessionWrapper,
     get_admin_credentials,
@@ -45,7 +46,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 
 # Test constants

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 
 from datahub.ingestion.run.pipeline import Pipeline
+from tests.utilities.domains import Domain
 from tests.utilities.messaging_transport import (
     build_pgqueue_sink_config,
     is_pgqueue_transport,
@@ -32,7 +33,10 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM, Domain.CATALOG),
+]
 
 bootstrap_sample_data = "../metadata-ingestion/examples/mce_files/bootstrap_mce.json"
 usage_sample_data = "./test_resources/bigquery_usages_golden.json"

--- a/smoke-test/test_rapid.py
+++ b/smoke-test/test_rapid.py
@@ -1,6 +1,11 @@
 from typing import Any, Dict
 
+import pytest
+
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, ingest_file_via_rest, with_test_retry
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 bootstrap_small = "test_resources/bootstrap_single.json"
 bootstrap_small_2 = "test_resources/bootstrap_single2.json"

--- a/smoke-test/test_system_info.py
+++ b/smoke-test/test_system_info.py
@@ -5,11 +5,12 @@ import requests
 
 from tests.privileges.utils import create_user, remove_user
 from tests.tokens.token_utils import assert_graphql_mutation_succeeded
+from tests.utilities.domains import Domain
 from tests.utils import get_admin_credentials, get_frontend_url, get_gms_url, login_as
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 
 # ==============================================

--- a/smoke-test/tests/actions/doc_propagation/test_propagation.py
+++ b/smoke-test/tests/actions/doc_propagation/test_propagation.py
@@ -22,6 +22,7 @@ from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
 from datahub.ingestion.sink.file import FileSink, FileSinkConfig
 from datahub.utilities.urns.urn import Urn
 from tests.utilities import env_vars
+from tests.utilities.domains import Domain
 from tests.utils import (
     delete_urns_from_file,
     get_gms_url,
@@ -30,6 +31,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 DELETE_AFTER_TEST = env_vars.get_delete_after_test()
 

--- a/smoke-test/tests/analytics/test_analytics.py
+++ b/smoke-test/tests/analytics/test_analytics.py
@@ -2,9 +2,11 @@ import logging
 
 import pytest
 
+from tests.utilities.domains import Domain
+
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 
 def test_analytics_charts_have_data(auth_session, analytics_events_loaded):

--- a/smoke-test/tests/analytics/test_highlights.py
+++ b/smoke-test/tests/analytics/test_highlights.py
@@ -5,11 +5,12 @@ from typing import Dict, List
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import get_highlights
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/assertions/assertions_test.py
+++ b/smoke-test/tests/assertions/assertions_test.py
@@ -33,6 +33,7 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.utilities.urns.urn import guess_entity_type
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import (
     delete_urn,
     delete_urns_from_file,
@@ -41,6 +42,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 restli_default_headers = {
     "X-RestLi-Protocol-Version": "2.0.0",

--- a/smoke-test/tests/assertions/custom_assertions_test.py
+++ b/smoke-test/tests/assertions/custom_assertions_test.py
@@ -8,7 +8,10 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import StatusClass
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import delete_urn, with_test_retry
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 TEST_DATASET_URN = make_dataset_urn(platform="postgres", name="foo_custom")
 

--- a/smoke-test/tests/audit_events/audit_events_test.py
+++ b/smoke-test/tests/audit_events/audit_events_test.py
@@ -12,6 +12,7 @@ from tests.tokens.token_utils import (
     token_name_filter,
     wait_for_no_tokens_matching,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     TestSessionWrapper,
     get_admin_credentials,
@@ -22,7 +23,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/authorization/test_aspect_write_auth.py
+++ b/smoke-test/tests/authorization/test_aspect_write_auth.py
@@ -33,6 +33,7 @@ from tests.privileges.utils import (
     set_view_entity_profile_privileges_policy_status,
     wait_until_graphql_auth_denied,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_frontend_session,
     get_frontend_url,
@@ -42,7 +43,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 TEST_USER_EMAIL = f"aspect.auth.test.{_UNIQUE}@smoke.datahub.test"

--- a/smoke-test/tests/authorization/test_container_view_auth.py
+++ b/smoke-test/tests/authorization/test_container_view_auth.py
@@ -29,6 +29,7 @@ from tests.privileges.utils import (
     set_view_dataset_sensitive_info_policy_status,
     set_view_entity_profile_privileges_policy_status,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_frontend_session,
     get_frontend_url,
@@ -38,7 +39,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 TEST_USER_EMAIL = f"container.view.auth.{_UNIQUE}@smoke.datahub.test"

--- a/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
+++ b/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
@@ -46,11 +46,16 @@ from tests.privileges.utils import (
     set_view_dataset_sensitive_info_policy_status,
     set_view_entity_profile_privileges_policy_status,
 )
+from tests.utilities.domains import Domain
 from tests.utils import get_frontend_session, get_frontend_url, get_gms_url, login_as
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 POLICY_PREFIX = "Test DomainScoped CREATE_ENTITY"

--- a/smoke-test/tests/authorization/test_query_entity_read_auth.py
+++ b/smoke-test/tests/authorization/test_query_entity_read_auth.py
@@ -34,6 +34,7 @@ from tests.privileges.utils import (
     set_view_dataset_sensitive_info_policy_status,
     set_view_entity_profile_privileges_policy_status,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_frontend_session,
     get_frontend_url,
@@ -43,7 +44,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 _UNIQUE = uuid.uuid4().hex[:8]
 TEST_USER_EMAIL = f"query.auth.test.{_UNIQUE}@smoke.datahub.test"

--- a/smoke-test/tests/browse/browse_test.py
+++ b/smoke-test/tests/browse/browse_test.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utils import (
     execute_graphql,
     wait_for_browse_path_entities,
@@ -11,6 +12,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 TEST_DATASET_1_URN = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-browse-1,PROD)"
 TEST_DATASET_2_URN = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-browse-2,PROD)"

--- a/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
+++ b/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
@@ -12,9 +12,12 @@ from datahub.api.entities.dataset.dataset import Dataset
 from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.ingestion.graph.client import DataHubGraph
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.CATALOG)
 
 # Generate random dataset IDs to avoid test interference
 start_index = randint(10, 10000)

--- a/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
+++ b/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
@@ -5,10 +5,13 @@ import tempfile
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional
 
+import pytest
+
 import datahub.emitter.mce_builder as builder
 from datahub.emitter.serialization_helper import pre_json_transform
 from datahub.metadata.schema_classes import DatasetProfileClass
 from tests.aspect_generators.timeseries.dataset_profile_gen import gen_dataset_profiles
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_strftime_from_timestamp_millis,
     run_datahub_cmd,
@@ -16,6 +19,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 test_aspect_name: str = "datasetProfile"
 test_dataset_urn: str = builder.make_dataset_urn_with_platform_instance(

--- a/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
+++ b/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
@@ -17,7 +17,10 @@ from typing import Any, Optional
 import pytest
 import requests
 
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd, wait_for_healthcheck_util
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
 
 
 class TestGraphQLCLIStandalone:

--- a/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
+++ b/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
@@ -1,10 +1,15 @@
 import json
 from typing import Dict, List, Optional
 
+import pytest
+
 import datahub.emitter.mce_builder as builder
 from datahub.emitter.serialization_helper import post_json_transform
 from datahub.metadata.schema_classes import DatasetProfileClass
+from tests.utilities.domains import Domain
 from tests.utils import ingest_file_via_rest, run_datahub_cmd, sync_elastic
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 def datahub_rollback(auth_session, run_id: str) -> None:

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
@@ -32,9 +32,12 @@ from datahub.metadata.schema_classes import (
     UpstreamLineageClass,
 )
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 PLATFORM = "snowflake"
 ENV = "PROD"

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
@@ -3,6 +3,8 @@ import logging
 import time
 from random import randint
 
+import pytest
+
 from datahub.cli.migration_utils import get_incoming_relationships
 from datahub.emitter.mce_builder import (
     make_dashboard_urn,
@@ -49,9 +51,12 @@ from datahub.metadata.schema_classes import (
     UpstreamLineageClass,
 )
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, get_sleep_info, run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 PLATFORM = "snowflake"
 ENV = "PROD"

--- a/smoke-test/tests/cli/search_cmd/test_search_cmd.py
+++ b/smoke-test/tests/cli/search_cmd/test_search_cmd.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import (
     delete_urns_from_file,
     get_sleep_info,
@@ -35,6 +36,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.CATALOG)
 
 _TEST_DATA = "tests/cli/search_cmd/search_test_data.json"
 

--- a/smoke-test/tests/cli/user_cmd/test_user_add.py
+++ b/smoke-test/tests/cli/user_cmd/test_user_add.py
@@ -6,9 +6,12 @@ import pytest
 
 from datahub.ingestion.graph.client import DataHubGraph
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd, unique_suffix
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
 
 
 def generate_test_email() -> str:

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -3,11 +3,15 @@ import sys
 import tempfile
 from typing import Any, Dict, Iterable, List
 
+import pytest
 import yaml
 
 from datahub.api.entities.corpgroup.corpgroup import CorpGroup
 from datahub.ingestion.graph.client import DataHubGraph
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd, sync_elastic
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
 
 
 def datahub_upsert_group(auth_session: Any, group: CorpGroup) -> None:

--- a/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
@@ -4,11 +4,15 @@ import tempfile
 import time
 from typing import Any, Dict, Iterable, List
 
+import pytest
 import yaml
 
 from datahub.api.entities.corpuser.corpuser import CorpUser
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
+
+pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
 
 
 def datahub_upsert_user(auth_session, user: CorpUser) -> None:

--- a/smoke-test/tests/containers/container_entities_batching_test.py
+++ b/smoke-test/tests/containers/container_entities_batching_test.py
@@ -19,9 +19,12 @@ from datahub.metadata.schema_classes import (
     ContainerPropertiesClass,
     DatasetPropertiesClass,
 )
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Unique per run so the containers are freshly seeded and their counts are deterministic
 # regardless of what else is in the instance.

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import add_tag, add_term, update_description
 from tests.utils import (
     delete_urns_from_file,
@@ -26,6 +27,9 @@ class ContainerFixtures:
     tag_urn: str
     term_urn: str
     owner_urn: str
+
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="module", autouse=False)

--- a/smoke-test/tests/data_process_instance/test_data_process_instance.py
+++ b/smoke-test/tests/data_process_instance/test_data_process_instance.py
@@ -25,9 +25,12 @@ from datahub.metadata.schema_classes import (
     SubTypesClass,
     TimeWindowSizeClass,
 )
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Generate unique DPI ID
 dpi_id = f"test-pipeline-run-{randint(1000, 9999)}"

--- a/smoke-test/tests/database/test_database.py
+++ b/smoke-test/tests/database/test_database.py
@@ -4,9 +4,12 @@ import pytest
 
 from datahub.emitter.mce_builder import make_dataset_urn
 from tests.utilities.concurrent_openapi import run_tests
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 generated_urns = [make_dataset_urn("test", f"database_test_{i}") for i in range(0, 100)]

--- a/smoke-test/tests/datapack/test_datapack_smoke.py
+++ b/smoke-test/tests/datapack/test_datapack_smoke.py
@@ -19,9 +19,12 @@ from datahub.emitter.rest_emitter import EmitMode
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import StatusClass
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, run_datahub_cmd, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 # Showcase pack definitions file sets status.removed=false then propertyDefinition.
 # After datapack unload (rollback), these entities are soft-deleted with no definition.

--- a/smoke-test/tests/dataproduct/test_dataproduct.py
+++ b/smoke-test/tests/dataproduct/test_dataproduct.py
@@ -32,9 +32,12 @@ from datahub.metadata.schema_classes import (
     MLModelPropertiesClass,
 )
 from datahub.utilities.urns.urn import Urn
+from tests.utilities.domains import Domain
 from tests.utils import wait_for_writes_to_sync, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 start_index = randint(10, 10000)

--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from datahub.cli.cli_utils import get_aspects_for_entity
 from datahub.emitter.mce_builder import make_dataset_urn, make_tag_urn
+from tests.utilities.domains import Domain
 from tests.utils import (
     delete_urns_from_file,
     ingest_file_via_rest,
@@ -14,6 +15,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/deprecation/deprecation_test.py
+++ b/smoke-test/tests/deprecation/deprecation_test.py
@@ -3,7 +3,10 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_unique_dataset_impl
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, get_root_urn
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/dev_tooling/test_dev_tooling.py
+++ b/smoke-test/tests/dev_tooling/test_dev_tooling.py
@@ -3,11 +3,12 @@ import logging
 import pytest
 import requests
 
+from tests.utilities.domains import Domain
 from tests.utils import get_gms_url
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 # ==============================================
 # DEV TOOLING API TESTS

--- a/smoke-test/tests/domains/domain_entities_batching_test.py
+++ b/smoke-test/tests/domains/domain_entities_batching_test.py
@@ -22,9 +22,12 @@ from datahub.metadata.schema_classes import (
     DomainPropertiesClass,
     DomainsClass,
 )
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Unique per run so the three domains are freshly seeded and their entity counts
 # are deterministic regardless of what else is in the instance.

--- a/smoke-test/tests/domains/domains_test.py
+++ b/smoke-test/tests/domains/domains_test.py
@@ -5,9 +5,12 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_unique_dataset_impl
+from tests.utilities.domains import Domain
 from tests.utils import delete_entity, execute_graphql, unique_suffix, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="module", autouse=False)

--- a/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
+++ b/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
@@ -52,8 +52,11 @@ from tests.entity_graph_cache.helpers import (
     wait_for_hierarchy_writes,
     wait_for_session_group_membership_labels,
 )
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 METRIC_SEARCH_SCROLL = "entity.graph.build.search_scroll"
 METRIC_GRAPH_SCROLL = "entity.graph.build.graph_scroll"

--- a/smoke-test/tests/entity_versioning/test_versioning.py
+++ b/smoke-test/tests/entity_versioning/test_versioning.py
@@ -9,6 +9,9 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import DatasetUrn, VersionSetUrn
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 VERSION_SET_URN = VersionSetUrn("12345678910", DatasetUrn.ENTITY_TYPE).urn()
 ENTITY_URN_OBJS = [DatasetUrn("snowflake", f"versioning_{i}") for i in range(3)]

--- a/smoke-test/tests/entity_versioning/test_versioning_ingest.py
+++ b/smoke-test/tests/entity_versioning/test_versioning_ingest.py
@@ -10,6 +10,9 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import DatasetUrn, VersionSetUrn
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 OLD_LATEST_URN = DatasetUrn("v", "versioning_old_latest")
 ENTITY_URN = DatasetUrn("v", "versioning_entity")

--- a/smoke-test/tests/entity_versioning/test_versioning_timeline.py
+++ b/smoke-test/tests/entity_versioning/test_versioning_timeline.py
@@ -21,8 +21,11 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import DatasetUrn, VersionSetUrn
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Stable URNs for this test — deterministic so cleanup is reliable.
 _PLATFORM = "timeline_smoke"

--- a/smoke-test/tests/forms/forms_test.py
+++ b/smoke-test/tests/forms/forms_test.py
@@ -17,9 +17,12 @@ from typing import Any, Dict, List
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utils import delete_entity, execute_graphql, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 DATASET_URNS = [
     f"urn:li:dataset:(urn:li:dataPlatform:kafka,test-forms-sample-kafka-{i},PROD)"

--- a/smoke-test/tests/glossary/glossary_children_count_test.py
+++ b/smoke-test/tests/glossary/glossary_children_count_test.py
@@ -5,9 +5,12 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import delete_entity, execute_graphql, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # One request that resolves childrenCount for the parent and for every child at the next
 # level, so the children are batched together by GlossaryNodeChildrenCountBatchLoader.

--- a/smoke-test/tests/graph/test_graph_client.py
+++ b/smoke-test/tests/graph/test_graph_client.py
@@ -11,7 +11,10 @@ from datahub.metadata.schema_classes import (
     SchemaMetadataClass,
     SystemMetadataClass,
 )
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns_from_file, ingest_file_via_rest, with_test_retry
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 graph = "test_resources/graph_data.json"
 graph_2 = "test_resources/graph_dataDiff.json"

--- a/smoke-test/tests/incidents/health_batch_test.py
+++ b/smoke-test/tests/incidents/health_batch_test.py
@@ -4,9 +4,12 @@ from typing import Any, Dict, List, Optional, Tuple
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, wait_for_writes_to_sync, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/incidents/incidents_test.py
+++ b/smoke-test/tests/incidents/incidents_test.py
@@ -4,7 +4,10 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utils import delete_entity, execute_graphql
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/institutional_memory/institutional_memory_test.py
+++ b/smoke-test/tests/institutional_memory/institutional_memory_test.py
@@ -1,7 +1,10 @@
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, get_admin_username
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/smoke-test/tests/knowledge/document_change_history_test.py
+++ b/smoke-test/tests/knowledge/document_change_history_test.py
@@ -13,8 +13,11 @@ import uuid
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def execute_graphql(

--- a/smoke-test/tests/knowledge/document_search_filter_test.py
+++ b/smoke-test/tests/knowledge/document_search_filter_test.py
@@ -18,9 +18,12 @@ import pytest
 import tenacity
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import get_sleep_info
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 # Same env-driven timing as with_test_retry(), but scoped to a single retryable
 # condition (see _fetch_related_documents) rather than any exception.

--- a/smoke-test/tests/knowledge/test_document_crud.py
+++ b/smoke-test/tests/knowledge/test_document_crud.py
@@ -5,8 +5,11 @@ import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.knowledge.document_helpers import execute_graphql, unique_id
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 class TestDocumentCrudAndMutations:

--- a/smoke-test/tests/knowledge/test_document_hierarchy_settings.py
+++ b/smoke-test/tests/knowledge/test_document_hierarchy_settings.py
@@ -5,8 +5,11 @@ import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.knowledge.document_helpers import execute_graphql, unique_id
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 class TestDocumentHierarchyAndSettings:

--- a/smoke-test/tests/knowledge/test_document_search_history.py
+++ b/smoke-test/tests/knowledge/test_document_search_history.py
@@ -5,8 +5,11 @@ import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.knowledge.document_helpers import execute_graphql, unique_id
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 class TestDocumentSearchAndHistory:

--- a/smoke-test/tests/library_examples/test_library_examples.py
+++ b/smoke-test/tests/library_examples/test_library_examples.py
@@ -19,7 +19,11 @@ from pathlib import Path
 
 import pytest
 
+from tests.utilities.domains import Domain
+
 from .example_manifest import EXAMPLE_DEPENDENCIES, EXAMPLE_MANIFEST
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 # Path to metadata-ingestion examples
 EXAMPLES_DIR = (

--- a/smoke-test/tests/lineage/test_lineage.py
+++ b/smoke-test/tests/lineage/test_lineage.py
@@ -38,9 +38,12 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 from datahub.utilities.urns.urn import Urn
+from tests.utilities.domains import Domain
 from tests.utils import ingest_file_via_rest, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 class DeleteAgent:

--- a/smoke-test/tests/lineage/test_lineage_counts.py
+++ b/smoke-test/tests/lineage/test_lineage_counts.py
@@ -13,9 +13,12 @@ from datahub.emitter.mce_builder import (
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DataHubGraph
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 COUNTS_QUERY = """
 query($input: SearchAcrossLineageCountsInput!) {

--- a/smoke-test/tests/lineage/test_lineage_sdk.py
+++ b/smoke-test/tests/lineage/test_lineage_sdk.py
@@ -8,7 +8,10 @@ from datahub.sdk.dataset import Dataset
 from datahub.sdk.lineage_client import LineageResult
 from datahub.sdk.main_client import DataHubClient
 from datahub.sdk.search_filters import FilterDsl as F
+from tests.utilities.domains import Domain
 from tests.utils import wait_for_writes_to_sync
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="module")

--- a/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
+++ b/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import pytest
 
 from tests.privileges.utils import create_user
+from tests.utilities.domains import Domain
 from tests.utils import (
     TestSessionWrapper,
     execute_graphql,
@@ -16,6 +17,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 _SMOKE_SECRET_NAMES = ["SMOKE_TEST", "SMOKE_TEST_BIGQUERY_KEY", "SMOKE_TEST_EDGE_CASES"]
 _SMOKE_INGESTION_SOURCE_PREFIX = "SMOKE_INGESTION_"

--- a/smoke-test/tests/metrics/test_metrics.py
+++ b/smoke-test/tests/metrics/test_metrics.py
@@ -26,11 +26,14 @@ from tests.metrics.usage_aggregation_metrics import (
     wait_for_metric_at_least,
     wait_for_metric_delta,
 )
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import get_prometheus_metrics
 from tests.utilities.multi_user import cleanup_step_actor_user, make_step_actor_user
 from tests.utils import get_gms_prometheus_base_url
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _require_prometheus_url() -> str:

--- a/smoke-test/tests/metrics/test_queue_ingest_usage.py
+++ b/smoke-test/tests/metrics/test_queue_ingest_usage.py
@@ -17,6 +17,7 @@ from tests.metrics.usage_aggregation_metrics import (
     REQUEST_COUNT_METRIC,
     sum_matching_metric_values,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_kafka_broker_url,
     get_kafka_schema_registry,
@@ -24,6 +25,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _fetch_messaging_ingest_total(prom_url: str) -> float:

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -47,6 +47,7 @@ from tests.metrics.usage_aggregation_metrics import (
     wait_for_metric_at_least,
     wait_for_metric_delta,
 )
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import get_prometheus_metrics
 from tests.utilities.multi_user import cleanup_step_actor_user, make_step_actor_user
 from tests.utils import (
@@ -57,6 +58,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _require_prometheus_url() -> str:

--- a/smoke-test/tests/ml_models/test_ml_models.py
+++ b/smoke-test/tests/ml_models/test_ml_models.py
@@ -16,8 +16,11 @@ from datahub.metadata.schema_classes import (
     MLModelGroupPropertiesClass,
     MLModelPropertiesClass,
 )
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Generate unique model names for testing
 start_index = randint(10, 10000)

--- a/smoke-test/tests/object_storage/test_object_storage.py
+++ b/smoke-test/tests/object_storage/test_object_storage.py
@@ -14,11 +14,12 @@ import pytest
 from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import DatasetPropertiesClass
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 _OBJECT_STORAGE_URI_KEY = "datahub.objectStorage.uri"
 

--- a/smoke-test/tests/openapi/test_openapi.py
+++ b/smoke-test/tests/openapi/test_openapi.py
@@ -10,9 +10,14 @@ list of globs (or a single glob). Example:
 import logging
 import os
 
+import pytest
+
 from tests.utilities.concurrent_openapi import run_tests
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 _ROOT_FIXTURE_GLOBS = [
     "tests/openapi/v1/*.json",

--- a/smoke-test/tests/openapi/v1/test_tracking.py
+++ b/smoke-test/tests/openapi/v1/test_tracking.py
@@ -26,10 +26,13 @@ from confluent_kafka import Consumer, KafkaError
 from dotenv import load_dotenv
 
 from tests.utilities import env_vars
+from tests.utilities.domains import Domain
 from tests.utilities.messaging_transport import is_pgqueue_transport
 from tests.utils import get_kafka_broker_url
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 # Load environment variables from .env file if it exists
 load_dotenv()

--- a/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
+++ b/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
@@ -15,8 +15,11 @@ from typing import Any, Dict, List, Optional, Set
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 # Test configuration
 TEST_ENTITY_NAME = "dataset"

--- a/smoke-test/tests/openapi/v3/test_scroll_entities.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_entities.py
@@ -9,7 +9,10 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.filters import RawSearchFilter
 from datahub.ingestion.graph.openapi import SortCriterionDict
 from datahub.metadata.schema_classes import DatasetKeyClass
+from tests.utilities.domains import Domain
 from tests.utils import with_test_retry
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 PLATFORM = "urn:li:dataPlatform:scrolltest"
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"

--- a/smoke-test/tests/openapi/v3/test_scroll_lineage.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_lineage.py
@@ -28,9 +28,12 @@ import pytest
 from conftest import _ingest_cleanup_data_impl
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.openapi import LineageDirection
+from tests.utilities.domains import Domain
 from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"
 GAMMA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,gamma,PROD)"

--- a/smoke-test/tests/openapi/v3/test_scroll_relationships.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_relationships.py
@@ -8,8 +8,11 @@ from conftest import _ingest_cleanup_data_impl
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.filters import RawSearchFilter
 from datahub.ingestion.graph.openapi import RelationshipDirection
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"
 ZETA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,zeta,PROD)"

--- a/smoke-test/tests/patch/test_datajob_patches.py
+++ b/smoke-test/tests/patch/test_datajob_patches.py
@@ -20,6 +20,9 @@ from tests.patch.common_patch_tests import (
     helper_test_ownership_patch,
     helper_test_set_fine_grained_lineages,
 )
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _make_test_datajob_urn(

--- a/smoke-test/tests/patch/test_dataset_patches.py
+++ b/smoke-test/tests/patch/test_dataset_patches.py
@@ -33,6 +33,9 @@ from tests.patch.common_patch_tests import (
     helper_test_ownership_patch,
     helper_test_set_fine_grained_lineages,
 )
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture(params=["graph_client", "openapi_graph_client"])

--- a/smoke-test/tests/patch/test_domain_patches.py
+++ b/smoke-test/tests/patch/test_domain_patches.py
@@ -15,8 +15,11 @@ from datahub.metadata.schema_classes import (
     MetadataAttributionClass,
 )
 from datahub.specific.dataset import DatasetPatchBuilder
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _make_domain_urn() -> str:

--- a/smoke-test/tests/pgqueue/test_messaging_operations.py
+++ b/smoke-test/tests/pgqueue/test_messaging_operations.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, List
 
 import pytest
 
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
+
 _MESSAGING_BASE = "/openapi/operations/messaging"
 
 

--- a/smoke-test/tests/platform_resources/test_platform_resource.py
+++ b/smoke-test/tests/platform_resources/test_platform_resource.py
@@ -11,9 +11,12 @@ from datahub.api.entities.platformresource.platform_resource import (
     PlatformResourceKey,
     PlatformResourceSearchFields,
 )
+from tests.utilities.domains import Domain
 from tests.utils import wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def generate_random_id(length=8):

--- a/smoke-test/tests/policies/test_policies.py
+++ b/smoke-test/tests/policies/test_policies.py
@@ -3,11 +3,12 @@ from typing import Any, Dict
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, get_root_urn, with_test_retry
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.global_policy_mutator
+pytestmark = [pytest.mark.global_policy_mutator, pytest.mark.domain(Domain.PLATFORM)]
 
 TEST_POLICY_NAME = "Updated Platform Policy"
 

--- a/smoke-test/tests/policies/test_policy_eval_perf.py
+++ b/smoke-test/tests/policies/test_policy_eval_perf.py
@@ -14,11 +14,12 @@ from datahub.metadata.schema_classes import (
 )
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.privileges.utils import create_user, remove_user
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns, get_admin_credentials, get_frontend_url, login_as
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.global_policy_mutator
+pytestmark = [pytest.mark.global_policy_mutator, pytest.mark.domain(Domain.PLATFORM)]
 
 PERF_NUM_QUERIES = 25
 PERF_LATENCY_RATIO_THRESHOLD = 2

--- a/smoke-test/tests/privileges/test_privileges.py
+++ b/smoke-test/tests/privileges/test_privileges.py
@@ -20,6 +20,7 @@ from tests.privileges.utils import (
     set_view_dataset_sensitive_info_policy_status,
     set_view_entity_profile_privileges_policy_status,
 )
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_admin_credentials,
     get_frontend_session,
@@ -31,7 +32,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).
 TEST_PRIVILEGES_USER_EMAIL = "privileges.user@smoke.datahub.test"

--- a/smoke-test/tests/query_projection/test_query_projection_smoke.py
+++ b/smoke-test/tests/query_projection/test_query_projection_smoke.py
@@ -5,8 +5,11 @@ import logging
 import pytest
 
 from datahub.configuration.common import GraphError
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 # --- A. Basic integration — projection doesn't break valid queries ---

--- a/smoke-test/tests/read_only/test_analytics.py
+++ b/smoke-test/tests/read_only/test_analytics.py
@@ -1,10 +1,13 @@
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import (
     get_analytics_charts,
     get_highlights,
     get_metadata_analytics_charts,
 )
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_dataproduct.py
+++ b/smoke-test/tests/read_only/test_dataproduct.py
@@ -2,9 +2,12 @@ import logging
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import get_data_product, get_search_results
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_ingestion_list.py
+++ b/smoke-test/tests/read_only/test_ingestion_list.py
@@ -1,7 +1,10 @@
 import pytest
 
 from tests.test_result_msg import add_datahub_stats
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import list_ingestion_sources
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_lineage_apis.py
+++ b/smoke-test/tests/read_only/test_lineage_apis.py
@@ -5,6 +5,7 @@ import logging
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import (
     get_search_results,
     scroll_across_lineage,
@@ -13,6 +14,8 @@ from tests.utilities.metadata_operations import (
 from tests.utils import execute_graphql
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 def _find_urn_with_lineage(auth_session) -> str:

--- a/smoke-test/tests/read_only/test_policies.py
+++ b/smoke-test/tests/read_only/test_policies.py
@@ -1,7 +1,10 @@
 import pytest
 
 from tests.test_result_msg import add_datahub_stats
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import list_policies
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -9,10 +9,13 @@ from tests.utilities.concurrent_test_runner import (
     run_concurrent_tests,
     run_concurrent_tests_with_args,
 )
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import get_search_results
 from tests.utils import get_gms_url
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 BASE_URL_V3 = f"{get_gms_url()}/openapi/v3"
 

--- a/smoke-test/tests/read_only/test_services_up.py
+++ b/smoke-test/tests/read_only/test_services_up.py
@@ -4,8 +4,11 @@ import re
 import pytest
 
 from tests.utilities import env_vars
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 # Kept separate so that it does not cause failures in PRs
 DATAHUB_VERSION = env_vars.get_test_datahub_version()

--- a/smoke-test/tests/restli/restli_test.py
+++ b/smoke-test/tests/restli/restli_test.py
@@ -19,7 +19,10 @@ from datahub.metadata.schema_classes import (
     MetadataChangeProposalClass,
 )
 from datahub.utilities.urns.urn import guess_entity_type
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 generated_urns: List[str] = []
 

--- a/smoke-test/tests/restli/test_restli_batch_ingestion.py
+++ b/smoke-test/tests/restli/test_restli_batch_ingestion.py
@@ -18,9 +18,12 @@ from datahub.metadata.schema_classes import (
 from datahub.metadata.urns import MlModelUrn
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.restli.restli_test import MetadataChangeProposalInvalidWrapper
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 generated_urns: List[str] = []
 

--- a/smoke-test/tests/schema_fields/test_schemafields.py
+++ b/smoke-test/tests/schema_fields/test_schemafields.py
@@ -14,8 +14,11 @@ from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
 from datahub.ingestion.api.sink import NoopWriteCallback
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.sink.file import FileSink, FileSinkConfig
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 start_index = randint(10, 10000)

--- a/smoke-test/tests/search/test_lineage_search_index_fields.py
+++ b/smoke-test/tests/search/test_lineage_search_index_fields.py
@@ -7,9 +7,12 @@ from typing import Any, Dict, List, Optional
 import pytest
 import tenacity
 
+from tests.utilities.domains import Domain
 from tests.utils import delete_urns_from_file, ingest_file_via_rest
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Test constants
 UPSTREAM_DATASET_URN = "urn:li:dataset:(urn:li:dataPlatform:hive,upstream_table,PROD)"

--- a/smoke-test/tests/search/test_search_projection.py
+++ b/smoke-test/tests/search/test_search_projection.py
@@ -2,10 +2,15 @@ import json
 import logging
 from typing import Any, Dict
 
+import pytest
+
 from datahub.cli.search_cli import _build_search_query
+from tests.utilities.domains import Domain
 from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 # Shared variables for all search queries
 _BASE_VARIABLES = {

--- a/smoke-test/tests/semantic/test_config_fingerprint.py
+++ b/smoke-test/tests/semantic/test_config_fingerprint.py
@@ -40,9 +40,12 @@ from tests.semantic.test_semantic_search import (
     create_documents_with_sdk,
     delete_document,
 )
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def create_ingestion_recipe(

--- a/smoke-test/tests/semantic/test_current_offset_api.py
+++ b/smoke-test/tests/semantic/test_current_offset_api.py
@@ -10,11 +10,15 @@ import json
 import logging
 from typing import Any
 
+import pytest
 import requests
 
+from tests.utilities.domains import Domain
 from tests.utils import TestSessionWrapper
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def test_get_current_offset_no_params(auth_session: TestSessionWrapper):

--- a/smoke-test/tests/semantic/test_event_driven_docs.py
+++ b/smoke-test/tests/semantic/test_event_driven_docs.py
@@ -44,9 +44,12 @@ from tests.semantic.test_semantic_search import (
     create_documents_with_sdk,
     delete_document,
 )
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 # Test gating - disabled by default (reuse same flag as semantic search tests)
 # Incremental wait times for event processing

--- a/smoke-test/tests/semantic/test_event_mode_fallback.py
+++ b/smoke-test/tests/semantic/test_event_mode_fallback.py
@@ -40,9 +40,12 @@ from tests.semantic.test_semantic_search import (
     create_documents_with_sdk,
     delete_document,
 )
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def create_event_mode_recipe(

--- a/smoke-test/tests/semantic/test_local_embedding_provider.py
+++ b/smoke-test/tests/semantic/test_local_embedding_provider.py
@@ -46,8 +46,11 @@ from tests.semantic.test_semantic_search import (
     search_documents_semantic,
     verify_semantic_content,
 )
+from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 # ---------------------------------------------------------------------------
 # Environment gates

--- a/smoke-test/tests/semantic/test_semantic_search.py
+++ b/smoke-test/tests/semantic/test_semantic_search.py
@@ -41,9 +41,12 @@ from typing import Any
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 # Test gating - disabled by default
 SEMANTIC_SEARCH_ENABLED = (

--- a/smoke-test/tests/semantic/test_source_type_filtering.py
+++ b/smoke-test/tests/semantic/test_source_type_filtering.py
@@ -40,9 +40,12 @@ from tests.semantic.test_semantic_search import (
     delete_document,
     execute_graphql,
 )
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def create_external_document(

--- a/smoke-test/tests/semantic/test_stateful_ingestion.py
+++ b/smoke-test/tests/semantic/test_stateful_ingestion.py
@@ -40,9 +40,12 @@ from tests.semantic.test_semantic_search import (
     create_documents_with_sdk,
     delete_document,
 )
+from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.AI)
 
 
 def create_ingestion_recipe(

--- a/smoke-test/tests/service_accounts/test_service_accounts.py
+++ b/smoke-test/tests/service_accounts/test_service_accounts.py
@@ -12,11 +12,15 @@ Tests the following operations:
 import logging
 from typing import Optional
 
+import pytest
 import tenacity
 
+from tests.utilities.domains import Domain
 from tests.utils import get_sleep_info
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 sleep_sec, sleep_times = get_sleep_info()
 

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -20,9 +20,12 @@ from typing import Any, Dict, List, Optional
 import pytest
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 SMOKE_TEST_STAGE_PREFIX = "smoketest"
 

--- a/smoke-test/tests/structured_properties/test_structured_properties.py
+++ b/smoke-test/tests/structured_properties/test_structured_properties.py
@@ -27,6 +27,7 @@ from datahub.specific.dataset import DatasetPatchBuilder
 from datahub.utilities.urns.structured_properties_urn import StructuredPropertyUrn
 from datahub.utilities.urns.urn import Urn
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utilities.file_emitter import FileEmitter
 from tests.utils import (
     delete_urns,
@@ -36,6 +37,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 start_index = randint(10, 10000)
 dataset_urns = [

--- a/smoke-test/tests/tags_and_terms/tags_and_terms_test.py
+++ b/smoke-test/tests/tags_and_terms/tags_and_terms_test.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_unique_dataset_impl
+from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import (
     add_tag,
     add_term,
@@ -11,6 +12,8 @@ from tests.utilities.metadata_operations import (
     update_description,
 )
 from tests.utils import execute_graphql
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/telemetry/telemetry_test.py
+++ b/smoke-test/tests/telemetry/telemetry_test.py
@@ -1,6 +1,11 @@
 import json
 
+import pytest
+
 from datahub.cli.cli_utils import get_aspects_for_entity
+from tests.utilities.domains import Domain
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def test_no_client_id(graph_client):

--- a/smoke-test/tests/test_kafka_default_sink.py
+++ b/smoke-test/tests/test_kafka_default_sink.py
@@ -5,6 +5,7 @@ import pytest
 from datahub.ingestion.graph.client import get_default_graph
 from datahub.ingestion.run.pipeline import Pipeline
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utilities.messaging_transport import (
     build_pgqueue_sink_config,
     is_pgqueue_transport,
@@ -17,6 +18,8 @@ from tests.utils import (
     get_kafka_schema_registry,
     unique_dataset_urn,
 )
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 # Template for this module's sample ingestion data. The dataset URN inside is a
 # placeholder — `sample_dataset` rewrites it to a run-unique URN so this module

--- a/smoke-test/tests/test_stateful_ingestion.py
+++ b/smoke-test/tests/test_stateful_ingestion.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Union, cast
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text
 
@@ -8,7 +9,10 @@ from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.sql.mysql import MySQLConfig
 from datahub.ingestion.source.sql.postgres import PostgresConfig
 from datahub.testing.state_helpers import get_current_checkpoint_from_pipeline
+from tests.utilities.domains import Domain
 from tests.utils import get_db_password, get_db_type, get_db_url, get_db_username
+
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 def test_stateful_ingestion(auth_session):

--- a/smoke-test/tests/timeline/timeline_change_history_auth_test.py
+++ b/smoke-test/tests/timeline/timeline_change_history_auth_test.py
@@ -28,11 +28,16 @@ from tests.privileges.utils import (
     set_view_dataset_sensitive_info_policy_status,
     set_view_entity_profile_privileges_policy_status,
 )
+from tests.utilities.domains import Domain
 from tests.utils import get_frontend_session, get_frontend_url, login_as
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.global_policy_mutator]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.global_policy_mutator,
+    pytest.mark.domain(Domain.CATALOG),
+]
 
 # ---------------------------------------------------------------------------
 # Constants — unique per test run so the test is idempotent

--- a/smoke-test/tests/timeline/timeline_change_history_test.py
+++ b/smoke-test/tests/timeline/timeline_change_history_test.py
@@ -54,11 +54,12 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import StructuredPropertyUrn
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, with_test_retry
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.CATALOG)]
 
 
 def _is_transient_sp_error(exc: BaseException) -> bool:

--- a/smoke-test/tests/timeline/timeline_test.py
+++ b/smoke-test/tests/timeline/timeline_test.py
@@ -4,9 +4,10 @@ import pytest
 
 from datahub.cli import timeline_cli
 from datahub.cli.cli_utils import guess_entity_type, post_entity
+from tests.utilities.domains import Domain
 from tests.utils import ingest_file_via_rest, wait_for_writes_to_sync
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.CATALOG)]
 
 
 def test_all(auth_session, graph_client):

--- a/smoke-test/tests/timeseries/test_dataset_profiles_graphql.py
+++ b/smoke-test/tests/timeseries/test_dataset_profiles_graphql.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import (
     execute_graphql,
     get_timestampmillis_at_start_of_day,
@@ -21,6 +22,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 _DATASET_URNS = [
     f"urn:li:dataset:(urn:li:dataPlatform:test,profilesGraphqlDataset{i},PROD)"

--- a/smoke-test/tests/timeseries/test_stats_summary_graphql.py
+++ b/smoke-test/tests/timeseries/test_stats_summary_graphql.py
@@ -30,6 +30,7 @@ import pytest
 import requests as _requests
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 from tests.utils import (
     execute_graphql,
     get_timestampmillis_at_start_of_day,
@@ -37,6 +38,8 @@ from tests.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.OBSERVE)
 
 # ---------------------------------------------------------------------------
 # Test entities

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_admin_credentials,
     get_frontend_url,
@@ -19,7 +20,7 @@ from .token_utils import (
     wait_for_user_in_list,
 )
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/tokens/session_access_token_test.py
+++ b/smoke-test/tests/tokens/session_access_token_test.py
@@ -6,6 +6,7 @@ from requests.exceptions import HTTPError
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import AuditStampClass, CorpUserStatusClass
+from tests.utilities.domains import Domain
 from tests.utils import (
     get_admin_credentials,
     get_frontend_url,
@@ -15,7 +16,7 @@ from tests.utils import (
 
 from .token_utils import getUserId, listUsers, removeUser
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/trace/test_api_trace.py
+++ b/smoke-test/tests/trace/test_api_trace.py
@@ -4,9 +4,12 @@ import time
 import pytest
 from opensearchpy import OpenSearch
 
+from tests.utilities.domains import Domain
 from tests.utils import delete_urn, delete_urns, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 es = OpenSearch(["http://localhost:9200"])
 
 

--- a/smoke-test/tests/unit/test_consistency_utils_wait.py
+++ b/smoke-test/tests/unit/test_consistency_utils_wait.py
@@ -4,8 +4,9 @@ import pytest
 import requests
 
 from tests.consistency_utils import wait_for_writes_to_sync
+from tests.utilities.domains import Domain
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 
 class _Clock:

--- a/smoke-test/tests/unit/test_ingest_search_wait.py
+++ b/smoke-test/tests/unit/test_ingest_search_wait.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import (
     entity_urns_from_ingest_file,
     searchable_ingest_urns,
@@ -11,7 +12,7 @@ from tests.utils import (
     wait_for_ingested_urns_searchable,
 )
 
-pytestmark = pytest.mark.no_cypress_suite1
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
 
 SNAPSHOT_URN = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-browse-3,PROD)"
 MCP_URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.table,PROD)"

--- a/smoke-test/tests/views/views_test.py
+++ b/smoke-test/tests/views/views_test.py
@@ -3,9 +3,12 @@ from typing import Any, Dict
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.utils import execute_graphql, with_test_retry
 
 logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @with_test_retry()

--- a/smoke-test/tests/zdu/framework/test_build_images.py
+++ b/smoke-test/tests/zdu/framework/test_build_images.py
@@ -7,9 +7,12 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.build_images import BuildImagesPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_catchup_executor.py
+++ b/smoke-test/tests/zdu/framework/test_catchup_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.catchup_executor import CatchUpScenarioExecutor
 from tests.zdu.framework.context import (
     IndexState,
@@ -13,6 +14,8 @@ from tests.zdu.framework.context import (
 )
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _scenario(

--- a/smoke-test/tests/zdu/framework/test_cleanup.py
+++ b/smoke-test/tests/zdu/framework/test_cleanup.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import PrepareOldStackResult, TestContext
 from tests.zdu.framework.phases.cleanup import CleanupPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_config.py
+++ b/smoke-test/tests/zdu/framework/test_config.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig, _resolve_gms_token
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 # Repo root resolved the same way config.py does it — keeps the test
 # decoupled from CWD so pytest can be invoked from anywhere.

--- a/smoke-test/tests/zdu/framework/test_docker_compose.py
+++ b/smoke-test/tests/zdu/framework/test_docker_compose.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.docker_compose import DockerComposeClient
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_es_client.py
+++ b/smoke-test/tests/zdu/framework/test_es_client.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.es_client import ElasticsearchClient
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _resp(json_data: object = None, status: int = 200, text: str = "") -> MagicMock:

--- a/smoke-test/tests/zdu/framework/test_failure_bundle.py
+++ b/smoke-test/tests/zdu/framework/test_failure_bundle.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import (
     IOObservation,
     IOWriteResult,
@@ -19,6 +20,8 @@ from tests.zdu.framework.context import (
 from tests.zdu.framework.failure_bundle import FailureBundleWriter
 from tests.zdu.framework.phases.base import PhaseResult
 from tests.zdu.framework.runner import ZDUReport
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _failed_report() -> ZDUReport:

--- a/smoke-test/tests/zdu/framework/test_host_mounts.py
+++ b/smoke-test/tests/zdu/framework/test_host_mounts.py
@@ -6,7 +6,10 @@ import pathlib
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.host_mounts import worktree_mount_env
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _make_worktree(root: pathlib.Path, side: str) -> pathlib.Path:

--- a/smoke-test/tests/zdu/framework/test_inject_traffic_dual.py
+++ b/smoke-test/tests/zdu/framework/test_inject_traffic_dual.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import IndexState, TestContext, UpgradeBlockingResult
 from tests.zdu.framework.mysql_client import EbeanAspectV2Row
 from tests.zdu.framework.phases.inject_traffic_dual import InjectTrafficDualPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_inject_traffic_pre.py
+++ b/smoke-test/tests/zdu/framework/test_inject_traffic_pre.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import IndexState, TestContext, UpgradeBlockingResult
 from tests.zdu.framework.mysql_client import EbeanAspectV2Row
 from tests.zdu.framework.phases.inject_traffic_pre import InjectTrafficPrePhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_live_traffic_executor.py
+++ b/smoke-test/tests/zdu/framework/test_live_traffic_executor.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import (
     DataIntegritySnapshot,
     IOObservation,
@@ -15,6 +16,8 @@ from tests.zdu.framework.context import (
 from tests.zdu.framework.live_traffic_executor import LiveTrafficExecutor
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _scenario(

--- a/smoke-test/tests/zdu/framework/test_log_monitor.py
+++ b/smoke-test/tests/zdu/framework/test_log_monitor.py
@@ -1,3 +1,6 @@
+import pytest
+
+from tests.utilities.domains import Domain
 from tests.zdu.framework.log_monitor import (
     NonBlockingState,
     Phase1State,
@@ -7,6 +10,8 @@ from tests.zdu.framework.log_monitor import (
     _parse_nonblocking_line,
     _parse_phase1_line,
 )
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def test_parse_started():

--- a/smoke-test/tests/zdu/framework/test_mysql_client.py
+++ b/smoke-test/tests/zdu/framework/test_mysql_client.py
@@ -8,7 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.mysql_client import EbeanAspectV2Row, MySQLClient
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_nuke_and_redeploy.py
+++ b/smoke-test/tests/zdu/framework/test_nuke_and_redeploy.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.nuke_and_redeploy import NukeAndRedeployPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_phase1_reindex_executor.py
+++ b/smoke-test/tests/zdu/framework/test_phase1_reindex_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import (
     TestContext,
     UpgradeBlockingReRunResult,
@@ -12,6 +13,8 @@ from tests.zdu.framework.context import (
 from tests.zdu.framework.phase1_reindex_executor import Phase1ReindexExecutor
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _scenario(

--- a/smoke-test/tests/zdu/framework/test_preflight.py
+++ b/smoke-test/tests/zdu/framework/test_preflight.py
@@ -8,9 +8,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.preflight import PreflightPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_prepare_old_stack.py
+++ b/smoke-test/tests/zdu/framework/test_prepare_old_stack.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.prepare_old_stack import PrepareOldStackPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_rolling_restart.py
+++ b/smoke-test/tests/zdu/framework/test_rolling_restart.py
@@ -7,11 +7,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.rolling_restart import (
     RollingRestartPhase,
     _compose_env_for_service,
 )
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 class TestComposeEnvForService:

--- a/smoke-test/tests/zdu/framework/test_runtime_migration.py
+++ b/smoke-test/tests/zdu/framework/test_runtime_migration.py
@@ -6,9 +6,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import SeededEntity, TestContext
 from tests.zdu.framework.datahub_client import AspectResponse
 from tests.zdu.framework.phases.runtime_migration import RuntimeMigrationPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _seeded(i: int, expected_version: int = 4) -> SeededEntity:

--- a/smoke-test/tests/zdu/framework/test_scenario_executor.py
+++ b/smoke-test/tests/zdu/framework/test_scenario_executor.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import TestContext, ValidationResult
 from tests.zdu.framework.scenario_executor import (
     ScenarioTypeExecutor,
@@ -14,6 +15,8 @@ from tests.zdu.framework.scenario_executor import (
 )
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _scenario(tc: int, stype: str) -> ZDUTestScenario:

--- a/smoke-test/tests/zdu/framework/test_scenario_loader.py
+++ b/smoke-test/tests/zdu/framework/test_scenario_loader.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import SeededEntity, TestContext
 from tests.zdu.framework.scenario_loader import (
     KNOWN_FAILURES,
@@ -17,6 +20,8 @@ from tests.zdu.framework.scenario_loader import (
 )
 from tests.zdu.framework.scenarios import SUITE_N_SCENARIOS, load_scenarios
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 class TestLoadScenarios:

--- a/smoke-test/tests/zdu/framework/test_seed.py
+++ b/smoke-test/tests/zdu/framework/test_seed.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.seed import SeedPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _build_phase() -> tuple[SeedPhase, MagicMock, MagicMock]:

--- a/smoke-test/tests/zdu/framework/test_setup_old_stack.py
+++ b/smoke-test/tests/zdu/framework/test_setup_old_stack.py
@@ -8,10 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.base import PhaseResult
 from tests.zdu.framework.phases.setup_old_stack import SetupOldStackPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _phase_result(

--- a/smoke-test/tests/zdu/framework/test_shared.py
+++ b/smoke-test/tests/zdu/framework/test_shared.py
@@ -7,8 +7,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.constants import TOKEN_SERVICE_KEYS
 from tests.zdu.framework.phases._shared import read_token_passthrough
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 class TestReadTokenPassthrough:

--- a/smoke-test/tests/zdu/framework/test_snapshot_t0.py
+++ b/smoke-test/tests/zdu/framework/test_snapshot_t0.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.snapshot_t0 import SnapshotT0Phase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_suite.py
+++ b/smoke-test/tests/zdu/framework/test_suite.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.suite import Suite, suite_for_tc
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 class TestSuiteEnum:

--- a/smoke-test/tests/zdu/framework/test_sweep_executor.py
+++ b/smoke-test/tests/zdu/framework/test_sweep_executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import (
     BatchDelayCapture,
     KillSwitchCapture,
@@ -14,6 +15,8 @@ from tests.zdu.framework.context import (
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
 from tests.zdu.framework.sweep_executor import dispatch_sweep_scenario
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _scenario(

--- a/smoke-test/tests/zdu/framework/test_upgrade_blocking.py
+++ b/smoke-test/tests/zdu/framework/test_upgrade_blocking.py
@@ -8,11 +8,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.phases.upgrade_blocking import (
     UpgradeBlockingPhase,
     parse_indices_state,
 )
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 class TestParseIndicesState:

--- a/smoke-test/tests/zdu/framework/test_upgrade_jar_freshness.py
+++ b/smoke-test/tests/zdu/framework/test_upgrade_jar_freshness.py
@@ -6,8 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework import upgrade_jar_freshness
 from tests.zdu.framework.upgrade_jar_freshness import ensure_upgrade_jar_fresh
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture(autouse=True)

--- a/smoke-test/tests/zdu/framework/test_upgrade_nonblocking.py
+++ b/smoke-test/tests/zdu/framework/test_upgrade_nonblocking.py
@@ -7,10 +7,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.config import ZDUTestConfig
 from tests.zdu.framework.context import TestContext
 from tests.zdu.framework.log_monitor import SweepEvent, SweepState
 from tests.zdu.framework.phases.upgrade_nonblocking import UpgradeNonBlockingPhase
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 @pytest.fixture

--- a/smoke-test/tests/zdu/framework/test_validation.py
+++ b/smoke-test/tests/zdu/framework/test_validation.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import MagicMock
 
+import pytest
+
+from tests.utilities.domains import Domain
 from tests.zdu.framework.context import (
     IndexState,
     RollingRestartResult,
@@ -17,6 +20,8 @@ from tests.zdu.framework.context import (
 from tests.zdu.framework.phases.validation import ValidationPhase
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 from tests.zdu.framework.suite import Suite
+
+pytestmark = pytest.mark.domain(Domain.PLATFORM)
 
 
 def _ctx_with_post_upgrade_state(

--- a/smoke-test/tests/zdu/test_zdu_upgrade.py
+++ b/smoke-test/tests/zdu/test_zdu_upgrade.py
@@ -3,6 +3,7 @@ import warnings
 
 import pytest
 
+from tests.utilities.domains import Domain
 from tests.zdu.framework.runner import ZDUReport
 from tests.zdu.framework.scenario_loader import ZDUTestScenario
 
@@ -19,14 +20,17 @@ from tests.zdu.framework.scenario_loader import ZDUTestScenario
 # behind ZDU_E2E_ENABLED so it only runs when explicitly opted in.
 # The fast, side-effect-free unit tests under tests/zdu/framework/ are
 # unaffected — they don't import this module or the zdu_report fixture.
-pytestmark = pytest.mark.skipif(
-    os.environ.get("ZDU_E2E_ENABLED") not in ("1", "true", "True", "yes"),
-    reason=(
-        "ZDU end-to-end pipeline is destructive (nukes the Compose stack). "
-        "Set ZDU_E2E_ENABLED=1 to run; the daily zdu-e2e workflow uses the "
-        "CLI entry point instead of pytest."
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("ZDU_E2E_ENABLED") not in ("1", "true", "True", "yes"),
+        reason=(
+            "ZDU end-to-end pipeline is destructive (nukes the Compose stack). "
+            "Set ZDU_E2E_ENABLED=1 to run; the daily zdu-e2e workflow uses the "
+            "CLI entry point instead of pytest."
+        ),
     ),
-)
+    pytest.mark.domain(Domain.PLATFORM),
+]
 
 # ── Infrastructure phase tests ───────────────────────────────────────────────
 


### PR DESCRIPTION
Stacked on #19200, which added the `p0` / `domain` markers and the `--domain` option. This is the one-time tagging pass: every smoke-test module now declares the domain that owns it. No behaviour change — nothing filters by domain until CI passes `--domain`.

## What changed

A module-level `pytestmark = pytest.mark.domain(Domain.<X>)` on 142 of the 143 test modules. Module level rather than a path map in `conftest.py`, so the domain is visible in the file and survives file moves.

Assignment is by directory. Two directories split across domains and are tagged per module instead:

- `tests/restli/` — `restli_test.py` → platform, `test_restli_batch_ingestion.py` → ingestion
- `tests/read_only/` — one domain per module, matching the surface each one reads

`tests/cli/**` is ingestion-owned (the `datahub` CLI ships from `metadata-ingestion`), and the modules that drive another domain's surface declare both:

| module | domains |
| --- | --- |
| `test_e2e.py` | platform, catalog |
| `tests/cli/dataset_cmd/`, `tests/cli/search_cmd/` | ingestion, catalog |
| `tests/cli/graphql_cmd/`, `tests/cli/user_cmd/`, `tests/cli/user_groups_cmd/` | ingestion, platform |

## One module is deliberately untagged

`tests/oauth/test_oauth_cli_gms.py` carries no domain marker. It is collected by this suite but always skips here — it needs a Keycloak token endpoint that only its own harness provides — and it really runs from `oauth-smoke.yml`, which mounts just its own directory into a container and invokes pytest on the single file. `tests` is not an importable package there, so the module cannot import the `Domain` enum, and marker-based selection never reaches it either way. A tag would be decorative, so it doesn't have one.

## Distribution

| domain | tests | modules |
| --- | --- | --- |
| platform | 806 | 77 |
| catalog | 223 | 35 |
| ingestion | 156 | 18 |
| ai | 45 | 13 |
| observe | 15 | 6 |

The column sums exceed the 1135 tagged tests because 110 tests belong to two domains. Platform is skewed by `tests/zdu/framework/` — 426 offline unit tests of the upgrade harness rather than tests against a running stack.

## Testing

- Collection unchanged at 1144 tests.
- Requesting all five domains selects 1135. The set difference against an unfiltered run is exactly one module, `tests/oauth/test_oauth_cli_gms.py` — so nothing else was missed.
- `./gradlew :smoke-test:lintFix` clean (ruff + mypy over 309 files).

A lint that rejects a new test module carrying no `domain(...)` marker is the natural follow-up; it needs an exemption for the module above.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) — not applicable, markers only
- [ ] Docs related to the changes have been added/updated (if applicable) — `--domain` is documented in #19200
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — not applicable
