### PR TITLE
test(smoke): mark the p0 critical smoke tests per domain

### DIFF
--- a/smoke-test/test_authentication_e2e.py
+++ b/smoke-test/test_authentication_e2e.py
@@ -172,6 +172,7 @@ def test_excluded_paths_no_auth(endpoint: str) -> None:
 # ===========================================
 
 
+@pytest.mark.p0
 def test_graphql_endpoint_no_auth() -> None:
     """GraphQL endpoint should return 401 without authentication."""
     query = {"query": "{ me { corpUser { username } } }"}
@@ -220,6 +221,7 @@ def test_graphql_endpoint_via_frontend_uses_gzip(auth_session):
     logger.info("✅ GraphQL via frontend uses gzip compression")
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "endpoint,method",
     [
@@ -261,6 +263,7 @@ def test_protected_endpoints_no_auth(endpoint: str, method: str) -> None:
     logger.info(f"✅ {method} {endpoint} without auth: {response.status_code}")
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "endpoint,method",
     [

--- a/smoke-test/test_system_info.py
+++ b/smoke-test/test_system_info.py
@@ -31,6 +31,7 @@ pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)
 # ==============================================
 
 
+@pytest.mark.p0
 def test_system_info_main_endpoint(auth_session):
     """Test that main system info endpoint returns expected structure with authentication."""
     response = auth_session.get(f"{auth_session.gms_url()}/openapi/v1/system-info")

--- a/smoke-test/tests/assertions/assertions_test.py
+++ b/smoke-test/tests/assertions/assertions_test.py
@@ -315,12 +315,14 @@ def _gms_get_latest_assertions_results_by_partition(auth_session):
     assert all(row[assertee_urn_index] == urn for row in rows)
 
 
+@pytest.mark.p0
 def test_gms_get_latest_assertions_results_by_partition(
     auth_session, test_run_ingestion
 ):
     _gms_get_latest_assertions_results_by_partition(auth_session)
 
 
+@pytest.mark.p0
 def test_gms_get_assertions_on_dataset(auth_session, test_run_ingestion):
     """lists all assertion urns including those which may not have executed"""
     urn = make_dataset_urn("postgres", "foo")

--- a/smoke-test/tests/cli/search_cmd/test_search_cmd.py
+++ b/smoke-test/tests/cli/search_cmd/test_search_cmd.py
@@ -186,6 +186,7 @@ class TestSearchFiltersByEntityType:
         for result in data["searchResults"]:
             assert result["entity"]["type"] == "DATASET"
 
+    @pytest.mark.p0
     def test_filter_chart_returns_only_charts(self, auth_session):
         exit_code, stdout, _ = _run_search(
             auth_session, ["*", "--filter", "entity_type=chart", "--limit", "20"]
@@ -235,6 +236,7 @@ class TestSearchFiltersByEntityType:
 class TestSearchFiltersByPlatform:
     """Prove --filter platform=X returns only entities from that platform."""
 
+    @pytest.mark.p0
     def test_filter_snowflake_returns_snowflake_datasets(
         self, auth_session, search_data: SearchTestData
     ):
@@ -335,6 +337,7 @@ class TestSearchFilterCombinations:
         ):
             assert urn in or_urns, f"Expected URN missing from OR results: {urn}"
 
+    @pytest.mark.p0
     def test_complex_filters_json_and(self, auth_session, search_data: SearchTestData):
         """--filters JSON AND logic returns correct entity type."""
         exit_code, stdout, _ = _run_search(

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -85,6 +85,7 @@ def get_group_membership(graph_client: DataHubGraph, user_urn: str) -> List[str]
     return [entity.urn for entity in entities]
 
 
+@pytest.mark.p0
 def test_group_upsert(auth_session: Any, graph_client: DataHubGraph) -> None:
     num_groups: int = 10
     for i, datahub_group in enumerate(gen_datahub_groups(num_groups)):

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -17,6 +17,7 @@ def ingest_cleanup_data(auth_session, graph_client):
     )
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_get_full_container(auth_session, ingest_cleanup_data):
     container_urn = "urn:li:container:SCHEMA"
@@ -142,6 +143,7 @@ def test_get_parent_container(auth_session):
     assert dataset["container"]["properties"]["name"] == "datahub_schema"
 
 
+@pytest.mark.p0
 @pytest.mark.dependency(depends=["test_get_full_container"])
 def test_update_container(auth_session):
     container_urn = "urn:li:container:SCHEMA"

--- a/smoke-test/tests/domains/domain_entities_batching_test.py
+++ b/smoke-test/tests/domains/domain_entities_batching_test.py
@@ -162,6 +162,7 @@ query domainEntityCounts($a: String!, $b: String!, $c: String!) {{
 """
 
 
+@pytest.mark.p0
 def test_domain_entities_counts_are_batched_and_correct(auth_session):
     variables: Dict[str, Any] = {
         "a": _DOMAIN_A,

--- a/smoke-test/tests/glossary/glossary_children_count_test.py
+++ b/smoke-test/tests/glossary/glossary_children_count_test.py
@@ -122,6 +122,7 @@ def _fetch_counts(auth_session, parent_urn: str) -> Dict[str, Dict[str, int]]:
     return counts
 
 
+@pytest.mark.p0
 def test_children_count_is_correct_for_a_batch_of_sibling_nodes(
     auth_session, glossary_tree
 ):

--- a/smoke-test/tests/graph/test_graph_client.py
+++ b/smoke-test/tests/graph/test_graph_client.py
@@ -27,6 +27,7 @@ def ingest_cleanup_data(auth_session, graph_client):
     )
 
 
+@pytest.mark.p0
 def test_get_aspect_v2(graph_client, ingest_cleanup_data):
     urn = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-rollback,PROD)"
     schema_metadata: Optional[SchemaMetadataClass] = graph_client.get_aspect_v2(
@@ -43,6 +44,7 @@ def test_get_aspect_v2(graph_client, ingest_cleanup_data):
     )
 
 
+@pytest.mark.p0
 def test_get_entities_v3(graph_client, ingest_cleanup_data):
     ownership_aspect_name = "ownership"
     dataset_properties_aspect_name = "datasetProperties"

--- a/smoke-test/tests/incidents/health_batch_test.py
+++ b/smoke-test/tests/incidents/health_batch_test.py
@@ -137,6 +137,7 @@ def test_incident_health_survives_soft_deleted_asset(auth_session):
         _set_soft_deleted(auth_session, urn, False)
 
 
+@pytest.mark.p0
 def test_batched_incident_health(auth_session):
     wait_for_writes_to_sync()
     query, variables = _build_query()

--- a/smoke-test/tests/incidents/incidents_test.py
+++ b/smoke-test/tests/incidents/incidents_test.py
@@ -23,6 +23,7 @@ TEST_DATASET_URN = (
 TEST_INCIDENT_URN = "urn:li:incident:test"
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_list_dataset_incidents(auth_session):
     # Sleep for eventual consistency (not ideal)

--- a/smoke-test/tests/knowledge/document_search_filter_test.py
+++ b/smoke-test/tests/knowledge/document_search_filter_test.py
@@ -351,6 +351,7 @@ def test_search_across_entities_filters_documents(auth_session):
         _delete_document(auth_session, published_context_urn)
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_related_documents_shows_context_only_documents(auth_session):
     """

--- a/smoke-test/tests/knowledge/test_document_crud.py
+++ b/smoke-test/tests/knowledge/test_document_crud.py
@@ -43,6 +43,7 @@ class TestDocumentCrudAndMutations:
         del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
         assert del_res["data"]["deleteDocument"] is True
 
+    @pytest.mark.p0
     def test_get_document(self, auth_session):
         document_id = unique_id("smoke-doc-get")
 

--- a/smoke-test/tests/lineage/test_lineage_sdk.py
+++ b/smoke-test/tests/lineage/test_lineage_sdk.py
@@ -100,6 +100,7 @@ def validate_lineage_results(
         assert len(lineage_result.paths) == paths_len
 
 
+@pytest.mark.p0
 def test_table_level_lineage(
     test_client: DataHubClient, test_datasets: Dict[str, Dataset]
 ):
@@ -142,6 +143,7 @@ def test_table_level_lineage(
     )
 
 
+@pytest.mark.p0
 def test_column_level_lineage(
     test_client: DataHubClient, test_datasets: Dict[str, Dataset]
 ):

--- a/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
+++ b/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
@@ -163,6 +163,7 @@ def test_timeseries_scroll_returns_scrollid(auth_session, setup_timeseries_data)
     )
 
 
+@pytest.mark.p0
 def test_timeseries_scroll_pagination_no_duplicates(
     auth_session, setup_timeseries_data
 ):

--- a/smoke-test/tests/openapi/v3/test_scroll_lineage.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_lineage.py
@@ -115,6 +115,7 @@ def _assert_lineage_edges(
     )
 
 
+@pytest.mark.p0
 def test_scroll_lineage_all_edges_around_urn(graph_client: DataHubGraph) -> None:
     """With no direction, every lineage edge touching ALPHA is returned. ALPHA is the upstream
     endpoint of all three (the graph is queried undirected, so both sides are matched)."""
@@ -164,6 +165,7 @@ def test_scroll_lineage_produces_source_is_upstream(graph_client: DataHubGraph) 
     logger.info("scroll_lineage GAMMA: 1 upstream (Produces), 0 downstream")
 
 
+@pytest.mark.p0
 def test_scroll_lineage_datajob_directions(graph_client: DataHubGraph) -> None:
     """JOB_1 is the source of both its edges (both stored as OUTGOING), yet one is its upstream
     (Consumes ALPHA) and the other its downstream (Produces GAMMA). Edge direction alone cannot

--- a/smoke-test/tests/patch/test_dataset_patches.py
+++ b/smoke-test/tests/patch/test_dataset_patches.py
@@ -68,6 +68,7 @@ def test_dataset_terms_patch(patch_dataset):
     helper_test_entity_terms_patch(graph_client, dataset_urn, DatasetPatchBuilder)
 
 
+@pytest.mark.p0
 def test_dataset_upstream_lineage_patch(patch_dataset):
     graph_client, dataset_urn = patch_dataset
 
@@ -396,6 +397,7 @@ def get_custom_properties(
     return dataset_properties.customProperties
 
 
+@pytest.mark.p0
 def test_custom_properties_patch(patch_dataset):
     graph_client, dataset_urn = patch_dataset
     orig_dataset_properties = DatasetPropertiesClass(

--- a/smoke-test/tests/restli/restli_test.py
+++ b/smoke-test/tests/restli/restli_test.py
@@ -103,6 +103,7 @@ def test_gms_ignore_unknown_dashboard_info(graph_client):
     assert dashboard_info.description == invalid_dashboard_info["description"]
 
 
+@pytest.mark.p0
 def test_gms_delete_mcp(graph_client):
     dashboard_urn = make_dashboard_urn(platform="looker", name="test-delete-mcp")
     generated_urns.extend([dashboard_urn])

--- a/smoke-test/tests/restli/test_restli_batch_ingestion.py
+++ b/smoke-test/tests/restli/test_restli_batch_ingestion.py
@@ -116,6 +116,7 @@ def _create_invalid_dataset_mcps() -> List[MetadataChangeProposalWrapper]:
     return bad_mcps
 
 
+@pytest.mark.p0
 def test_restli_batch_ingestion_sync(graph_client):
     # Positive Test (all valid MetadataChangeProposal)
     mcps = _create_valid_dashboard_mcps()

--- a/smoke-test/tests/semantic/test_current_offset_api.py
+++ b/smoke-test/tests/semantic/test_current_offset_api.py
@@ -75,6 +75,7 @@ def test_get_current_offset_no_params(auth_session: TestSessionWrapper):
     assert len(offset_id) > 0, "Offset ID should not be empty"
 
 
+@pytest.mark.p0
 def test_poll_with_retrieved_offset(auth_session: TestSessionWrapper):
     """
     Test that we can use the retrieved offset to poll for new events.

--- a/smoke-test/tests/test_kafka_default_sink.py
+++ b/smoke-test/tests/test_kafka_default_sink.py
@@ -85,6 +85,7 @@ def _create_default_sink_pipeline(auth_session, monkeypatch, default_sink, data_
     )
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "default_sink,expected_sink_type",
     [("rest", "datahub-rest"), ("kafka", "datahub-kafka")],

--- a/smoke-test/tests/test_stateful_ingestion.py
+++ b/smoke-test/tests/test_stateful_ingestion.py
@@ -15,6 +15,7 @@ from tests.utils import get_db_password, get_db_type, get_db_url, get_db_usernam
 pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
+@pytest.mark.p0
 def test_stateful_ingestion(auth_session):
     def create_db_engine(sql_source_config_dict: Dict[str, Any]) -> Any:
         sql_config: Union[MySQLConfig, PostgresConfig]


### PR DESCRIPTION
Stacked on #19202. Marks the critical subset of the smoke suite with `p0`, the marker registered in #19200. Still no behaviour change — nothing selects on `p0` until CI passes `-m p0`.

## What is marked

32 test functions across 22 modules, which collect as **42 tests / 231s** of recorded runtime (a marked function covers all of its parametrisations).

| domain | tests | weight |
| --- | --- | --- |
| platform | 20 | 32s |
| ingestion | 10 | 73s |
| catalog | 9 | 83s |
| observe | 4 | 30s |
| ai | 3 | 35s |

Per-domain columns overlap slightly: four tests are dual-owned (`tests/cli/search_cmd/`, `tests/cli/user_groups_cmd/`) and are marked once.

## How the set was chosen

Selection was driven by observed CI behaviour rather than intuition. Per-test outcome history was mined from junit artifacts across **53 "Docker Build, Scan, Test" runs on many unrelated branches (~60k test executions)**, joined against `pytest_test_weights.json`.

Priority was blast radius first, then breadth-per-second, then non-redundancy, then cost. Anything matching one of these was excluded outright:

- ever failed in the CI window (the RFC's no-flake bar),
- skipped in ≥80% of CI appearances, so it yields no signal — **59 tests suite-wide are in this state**,
- marked `global_policy_mutator` (runs serially in a separate second pytest phase),
- marked `read_only` (a different execution mode).

## Verification

- Every node id resolves against live collection; re-derived weight matches independently.
- `-m p0` selects 42 of 1144; total collection unchanged at 1144.
- No selected test violates any exclusion rule above (re-checked from the raw data, not from the selection process).
- No `p0` test has a `pytest-dependency` prerequisite outside the set, so a `p0`-only run cannot silently skip one. `tests/containers/containers_test.py` needs both halves of its chain and has them.
- `./gradlew :smoke-test:lintFix` clean.

## Coverage this set does not reach

Worth reading before Phase 2 flips the default, since these are the things a `p0`-only PR run would miss:

1. **Policy-based authorization is entirely uncovered.** Every test under `tests/authorization/`, `tests/privileges/` and `tests/policies/` carries `global_policy_mutator` and is therefore excluded, so a policy engine that fails open would reach main. Closing this needs a new test shaped to be cheap and order-independent — create a scoped policy, assert allow and deny on a throwaway entity, tear it down in one test. Nothing in the suite has that shape today.
2. **No test asserts "ingest a dataset named X, free-text search for X, get X back"** — arguably the most common user action in the product. The existing free-text assertions check only that totals agree across pages, which passes when the total is zero.
3. **`browseV2` has no smoke coverage at any tier.** No smoke-test module references `browseV2`/`browsePathsV2`; the one browse test exercises the legacy `browse` resolver the current UI no longer calls.
4. **Observe write paths** (`raiseIncident`, `updateIncidentStatus`, assertion create/report) are post-commit only — the cheapest candidates are 29.6s and 35.4s.
5. Pre-existing CI blind spots the exercise surfaced rather than caused: `tests/semantic/` (19 of 22 env-gated off, so semantic search and embedding have no CI signal at all), `tests/oauth/` (9 tests, skipped in every run), `tests/pgqueue/` (7), `entity_versioning` link/unlink (5).

## Budget

Recorded weight is 231s. Realistic serial time is nearer 260s, because `weight_s` is the junit per-test total and a module's fixture cost lands on whichever test is collected first — two entries here inherit setup they do not currently carry. At `xdist -n 2` with `--dist=loadscope` over 22 modules, wall clock should land around 150–180s, against ~92 minutes of pytest for the full suite.

Suggested answer to the RFC's open budget question: **300s enforced p0 pytest wall-clock**, with the 420s summed-weight figure kept as the separate admission ceiling for individual nominations. The unspent half of that ceiling is better reserved for the two tests that need writing (items 1 and 2 above) than spent promoting marginal existing tests.

## One thing to fix before Phase 2

`smoke.sh`'s `_pytest_ok()` treats exit code **5** — "no tests collected" — as success. That is harmless today, but once CI runs `-m p0`, a marker expression that matches nothing yields a green smoke job that ran zero tests. Worth a guard asserting the selection is non-empty before the default flips.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) — not applicable, markers only
- [ ] Docs related to the changes have been added/updated (if applicable) — markers documented in #19200
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — not applicable


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks a critical subset of smoke tests with the `p0` marker to enable a fast CI path. Old behavior: full smoke suite by default. New behavior: unchanged unless CI runs pytest with `-m p0`, which selects only these tests.

- Adds `@pytest.mark.p0` to 32 functions across 22 modules (42 tests; ~231s recorded). No test logic changed.
- Selection driven by CI history and test weights; excludes flaky, mostly-skipped, `global_policy_mutator`, and `read_only` tests.
- Verified: `-m p0` selects 42/1144 tests; all node ids resolve; no `pytest-dependency` outside the set.
- Rollout: CI must pass `-m p0` to opt in. Before making `p0` the default, update `smoke.sh` to fail if the selection is empty (exit code 5 is currently treated as success). No other actions required.

<sup>Written for commit 1b285c0433a3c425416b4c54fb40078bde69f3b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

