### PR TITLE
fix(embed): add embedded profile for DataFlow and MLModelGroup

### DIFF
--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -25,6 +25,7 @@ import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/pro
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import StatusSection from '@app/entityV2/shared/containers/profile/sidebar/shared/StatusSection';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
+import EmbeddedProfile from '@app/entityV2/shared/embed/EmbeddedProfile';
 import SidebarNotesSection from '@app/entityV2/shared/sidebarSection/SidebarNotesSection';
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
@@ -281,4 +282,13 @@ export class DataFlowEntity implements Entity<DataFlow> {
             EntityCapabilityType.FORMS,
         ]);
     };
+
+    renderEmbeddedProfile = (urn: string) => (
+        <EmbeddedProfile
+            urn={urn}
+            entityType={EntityType.DataFlow}
+            useEntityQuery={useGetDataFlowQuery}
+            getOverrideProperties={this.getOverridePropertiesFromEntity}
+        />
+    );
 }

--- a/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
@@ -21,6 +21,7 @@ import { SidebarGlossaryTermsSection } from '@app/entityV2/shared/containers/pro
 import { SidebarTagsSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarTagsSection';
 import StatusSection from '@app/entityV2/shared/containers/profile/sidebar/shared/StatusSection';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
+import EmbeddedProfile from '@app/entityV2/shared/embed/EmbeddedProfile';
 import SidebarNotesSection from '@app/entityV2/shared/sidebarSection/SidebarNotesSection';
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
@@ -232,4 +233,13 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
             EntityCapabilityType.FORMS,
         ]);
     };
+
+    renderEmbeddedProfile = (urn: string) => (
+        <EmbeddedProfile
+            urn={urn}
+            entityType={EntityType.MlmodelGroup}
+            useEntityQuery={useGetMlModelGroupQuery}
+            getOverrideProperties={this.getOverridePropertiesFromEntity}
+        />
+    );
 }


### PR DESCRIPTION
## Summary

Adds `renderEmbeddedProfile` overrides for `DataFlowEntity` and `MLModelGroupEntity` so both entity types render an embedded profile view, consistent with the existing implementations for Dataset, Dashboard, Chart, Container, and Document. Without this override, DataFlow and MLModelGroup entities fall back to the default (non-embedded) profile when accessed via an embedded URL context.

The fix mirrors the established pattern in `DatasetEntity.tsx` (lines 536-543): construct the `EmbeddedProfile` component with the appropriate `urn`, `entityType`, `useEntityQuery`, and `getOverrideProperties` props.

This PR is scoped to the two entity types reported in #19208; other entity types without `renderEmbeddedProfile` remain on the `renderProfile` fallback for now.

Closes #19208

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (Commit Message Format)
- [x] Links to related issues (Closes #19208)
- [ ] Tests for the changes have been added/updated - N/A, matches existing precedent (no dedicated tests for any of the existing `renderEmbeddedProfile` implementations)
- [ ] Docs related to the changes have been added/updated - N/A, no user-facing doc change
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub - N/A, purely additive

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render embedded profiles for DataFlow and MLModelGroup when loaded via embedded URLs. Previously they showed the full profile; now they render the compact embedded layout without changing non-embedded routes.

- Confirm embedded routes show the compact profile for both entities; standard routes remain unchanged.
- Verify wiring via new renderEmbeddedProfile overrides: `EntityType.DataFlow` with `useGetDataFlowQuery` and `EntityType.MlmodelGroup` with `useGetMlModelGroupQuery`, each passing `getOverridePropertiesFromEntity`. No migrations or config/doc changes.

<sup>Written for commit 5317def4097499b4d340d0f9ef4a6b672dad6953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

