### PR TITLE
fix(docs): clarify permissions for SF dynamic table extraction

### DIFF
--- a/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
@@ -30,7 +30,7 @@ grant references on all views in database "<your-database>" to role datahub_role
 grant references on future views in database "<your-database>" to role datahub_role;
 -- Note: Semantic views are covered by the above view grants
 
--- Grant monitor privileges for dynamic tables
+// Required if you have Dynamic Tables and want DataHub to extract them and their lineage.
 grant monitor on all dynamic tables in database "<your-database>" to role datahub_role;
 grant monitor on future dynamic tables in database "<your-database>" to role datahub_role;
 
@@ -100,6 +100,7 @@ grant usage on schema "<your-database>"."<your-schema>" to role datahub_role;
 - `usage` on `stages` is required to list stages via `SHOW STAGES`. Only needed if `include_stages: true` or `include_pipes: true`.
 - `monitor` on `tasks` is required to list tasks via `SHOW TASKS`. Only needed if `include_tasks: true`.
 - `monitor` on `pipes` is required to list pipes via `SHOW PIPES`. Only needed if `include_pipes: true`.
+- `monitor` on `dynamic tables` is required for DataHub to extract their lineage, both table-level and column-level.
 
 This represents the bare minimum privileges required to extract databases, schemas, views, and tables from Snowflake.
 


### PR DESCRIPTION
Need to clarify what permissions are needed to get lineage for dynamic SF tables

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Snowflake docs: DataHub requires MONITOR on Dynamic Tables to extract those tables and their table- and column-level lineage. Previously, the docs did not state this requirement.

- Operator action: Grant MONITOR on all and future dynamic tables in each relevant database to the DataHub role to capture Dynamic Table lineage.

<sup>Written for commit a2d15f6a681b64fd0a195ddcf9f59b76a0190131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

