### PR TITLE
chore(openapi): deprecate v2 entity and relationship APIs

### DIFF
--- a/docs/api/tutorials/structured-properties.md
+++ b/docs/api/tutorials/structured-properties.md
@@ -140,7 +140,11 @@ mutation createStructuredProperty {
 
 </TabItem>
 
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 ```shell
 curl -X 'POST' -v \
@@ -572,7 +576,11 @@ Example Response:
 
 </TabItem>
 
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 Example Request:
 
@@ -734,7 +742,11 @@ If successful, you should see `Update succeeded for urn:li:dataset:...`
 
 </TabItem>
 
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 Following command will set structured properties `retentionTime` as `60.0` to a dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)`.
 Please note that the structured property and the dataset must exist before executing this command. (You can create sample datasets using the `datahub docker ingest-sample-data`)
@@ -904,7 +916,11 @@ For this example, we'll extend create a second structured property and apply bot
 After this your system should include both `io.acryl.privacy.retentionTime` and `io.acryl.privacy.retentionTime02`.
 
 <Tabs>
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 Let's start by creating the second structured property.
 
@@ -1101,7 +1117,11 @@ The expected state of our test dataset include 2 structured properties.
 We'd like to remove the first one (`io.acryl.privacy.retentionTime`) and preserve the second property. (`io.acryl.privacy.retentionTime02`).
 
 <Tabs>
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 ```shell
 curl -X 'PATCH' -v \
@@ -1241,7 +1261,11 @@ mutation updateStructuredProperty {
 ```
 
 </TabItem>
-<TabItem value="OpenAPI v2" label="OpenAPI v2">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (deprecated)">
+
+:::caution Deprecated
+Prefer [OpenAPI v3](/docs/api/openapi/openapi-usage-guide.md) (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 ```shell
 curl -X 'PATCH' -v \
@@ -1458,7 +1482,11 @@ datahub delete --urn {urn}
 ```
 
 </TabItem>
-<TabItem value="OpenAPI v2" label="OpenAPI v2 (Soft Delete)">
+<TabItem value="OpenAPI v2" label="OpenAPI v2 (Soft Delete, deprecated)">
+
+:::caution Deprecated
+Prefer OpenAPI v3 soft-delete examples below (`/openapi/v3/entity`). OpenAPI v2 entity APIs remain available but are deprecated.
+:::
 
 The following command will soft delete the test property by writing to the status aspect.
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -63,6 +63,8 @@ Requirements:
 
 ### Deprecations
 
+- **(OpenAPI)** OpenAPI v2 entity and relationship APIs (`/openapi/v2/entity`, `/openapi/v2/relationship`, including generated typed entity endpoints under `/openapi/v2/entity`) are deprecated in favor of `/openapi/v3/entity` and `/openapi/v3/relationship`. They remain available; plan removal in a future release after a deprecation notice period. Timeseries (`/openapi/v2/timeseries`), platform entity ingest (`/openapi/v2/platform/entities/v1`), and timeline (`/openapi/v2/timeline/v1`) under v2 are **not** deprecated by this change.
+
 ### Other Notable Changes
 
 - **(Security / Dependencies)** Logback (`logback-classic` / `logback-core`) bumped from 1.5.32 to **1.5.38** for CVE-2026-9828 (`HardenedObjectInputStream` overly broad `java.lang`/`java.util` deserialization allowlist; fixed in 1.5.33+) and CVE-2026-10532 (Proxy class deserialization; fixed in 1.5.38). **Action:** none for operators; rebuild/redeploy picks up the new JARs. DataHub does not expose Logback `SimpleSocketServer` / `SimpleSSLSocketServer` by default.

--- a/metadata-service/openapi-entity-servlet/src/main/resources/JavaSpring/apiController.mustache
+++ b/metadata-service/openapi-entity-servlet/src/main/resources/JavaSpring/apiController.mustache
@@ -79,8 +79,12 @@ import java.util.concurrent.Callable;
 {{^useOas2}}
 {{/useOas2}}
 {{#operations}}
+@Deprecated
 @RestController
 @RequestMapping("/openapi/v2/entity")
+@io.swagger.v3.oas.annotations.tags.Tag(
+    name = "{{classname}}",
+    description = "Deprecated: prefer /openapi/v3/entity for entity operations.")
 public class {{classname}}Controller implements {{classname}} {
 
     private static final Logger log = LoggerFactory.getLogger({{classname}}Controller.class);

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/config/SpringWebConfig.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/config/SpringWebConfig.java
@@ -66,7 +66,7 @@ public class SpringWebConfig implements WebMvcConfigurer {
   public GroupedOpenApi openApiGroupV2() {
     return GroupedOpenApi.builder()
         .group("openapi-v2")
-        .displayName("5. DataHub v2 (OpenAPI)")
+        .displayName("5. DataHub v2 (OpenAPI, deprecated)")
         .addOpenApiCustomizer(
             openApi -> openApi.specVersion(SpecVersion.V30).openapi(LEGACY_VERSION))
         .addOpenApiCustomizer(this::configureServerUrl)

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/EntityController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/EntityController.java
@@ -72,17 +72,26 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/*
+ Prefer /openapi/v3/entity instead
+*/
+@Deprecated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/openapi/v2/entity")
 @Slf4j
+@Tag(
+    name = "Generic Entities",
+    description = "Deprecated: prefer /openapi/v3/entity for entity operations.")
 public class EntityController
     extends GenericEntitiesController<
         GenericAspectV2, GenericEntityV2, GenericEntityScrollResultV2> {
 
-  @Tag(name = "Generic Entities")
   @PostMapping(value = "/batch/{entityName}", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Get a batch of entities")
+  @Operation(
+      deprecated = true,
+      summary = "Get a batch of entities",
+      description = "Deprecated: prefer /openapi/v3/entity/{entityName}/batchGet.")
   public ResponseEntity<BatchGetUrnResponseV2<GenericAspectV2, GenericEntityV2>> getEntityBatch(
       HttpServletRequest httpServletRequest,
       @PathVariable("entityName") String entityName,

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/RelationshipController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/RelationshipController.java
@@ -7,13 +7,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/*
+ Prefer /openapi/v3/relationship instead
+*/
+@Deprecated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/openapi/v2/relationship")
 @Slf4j
 @Tag(
     name = "Generic Relationships",
-    description = "APIs for ingesting and accessing entity relationships.")
+    description = "Deprecated: prefer /openapi/v3/relationship for relationship operations.")
 public class RelationshipController extends GenericRelationshipController {
   // Supports same methods as GenericRelationshipController.
 }


### PR DESCRIPTION
## Summary

- Soft-deprecate OpenAPI v2 **entity** and **relationship** APIs (typed codegen + generic controllers) in favor of `/openapi/v3/entity` and `/openapi/v3/relationship`
- Mark generated typed controllers via Mustache template; label Swagger group as deprecated
- Document the deprecation in `updating-datahub.md` and mark OpenAPI v2 tabs in the structured-properties tutorial
- **Not** deprecated: timeseries, timeline, and platform MCP ingest (no v3 parity yet)

## Test plan

- [ ] Confirm Swagger UI shows `5. DataHub v2 (OpenAPI, deprecated)` and Tag/Operation deprecation text for entity/relationship
- [ ] Smoke: existing `smoke-test/tests/openapi/v2/` fixtures still pass (endpoints remain available)
- [ ] Confirm Timeseries / Timeline / Platform controllers are unchanged (no `@Deprecated`)
- [ ] Spot-check structured-properties docs render with deprecated v2 tab labels


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates OpenAPI v2 entity and relationship APIs in favor of /openapi/v3/entity and /openapi/v3/relationship. v2 endpoints remain available but are labeled deprecated in Swagger and annotations; timeseries, timeline, and platform MCP ingest are unchanged.

**Review and rollout**
- Code: add @Deprecated to v2 `EntityController`, `RelationshipController`, and generated typed entity controllers; update Swagger group name to “5. DataHub v2 (OpenAPI, deprecated)” and add deprecation text on tags/operations. No routing or behavior changes.
- Docs: mark v2 examples as deprecated in the structured-properties tutorial and note the deprecation in updating-datahub.
- Migration: no immediate action; move clients from /openapi/v2/entity and /openapi/v2/relationship to v3 equivalents.

<sup>Written for commit 5e3b613a1a1c8fdb3c46a0f97fed32d617014d9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

