### PR TITLE
fix(actions): Bump actions executor dependencies

### DIFF
--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -79,7 +79,7 @@ plugins: Dict[str, Set[str]] = {
         "confluent-kafka[schemaregistry]<2.13.0",
     },
     # Action Plugins
-    "executor": {"acryl-executor>=0.3.11,<1"},
+    "executor": {"acryl-executor>=0.3.19,<1"},
     "slack": {
         "slack-bolt>=1.15.5",
     },


### PR DESCRIPTION
0.3.19 contains vital fixes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `acryl-executor` >= 0.3.19 for the `executor` extra in `datahub-actions` to pick up critical fixes. Previously we allowed >= 0.3.11, which could resolve to affected versions.

- Affects only installations using the executor extra; no runtime code changes.
- If you use lockfiles or pinned constraints, re-resolve to pull `acryl-executor` >= 0.3.19.
- Verify CI images and dev environments install the updated version.

<sup>Written for commit 29c61d61ec8888f498f183c806fe42b2358691a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

