### PR TITLE
fix(smoke-test): harden search pagination total under ES lag

### DIFF
--- a/smoke-test/tests/cli/search_cmd/test_search_cmd.py
+++ b/smoke-test/tests/cli/search_cmd/test_search_cmd.py
@@ -20,12 +20,14 @@ CorpUser filter tests rely on built-in DataHub system users (always present).
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 
 import pytest
 
 from tests.utils import (
     delete_urns_from_file,
+    get_sleep_info,
     ingest_file_via_rest,
     materialize_with_unique_name,
     run_datahub_cmd,
@@ -383,16 +385,48 @@ class TestSearchPagination:
     def test_total_is_consistent_across_pages(
         self, auth_session, search_data: SearchTestData
     ):
-        # Unique namespace keeps total stable under concurrent ingest elsewhere.
-        # Do not assert exact fixture size against ES ``total`` — that races lag.
-        _, p1, _ = _run_search(
-            auth_session, [search_data.ns, "--limit", "3", "--offset", "0"]
-        )
-        _, p2, _ = _run_search(
-            auth_session, [search_data.ns, "--limit", "3", "--offset", "3"]
-        )
+        # Query with the unique hex suffix only. Free-text on the full
+        # ``search_smoke_test-<suffix>`` ns tokenizes into common terms
+        # (search/smoke/test) and picks up unrelated concurrent ingest, so
+        # ES ``total`` drifts between the two page fetches on slow ARM/CDC.
+        # Do not assert exact fixture size — that still races indexing lag.
+        #
+        # Fast path (typical x64): first pair matches → no sleep.
+        # Slow path: re-sample only after a mismatch, using the env-driven
+        # DATAHUB_TEST_SLEEP_* budget (same as with_test_retry).
+        query = search_data.ns.rsplit("-", 1)[-1]
+        sleep_sec, sleep_times = get_sleep_info()
+        last_totals: tuple[int, int] | None = None
 
-        assert json.loads(p1)["total"] == json.loads(p2)["total"]
+        for attempt in range(max(sleep_times, 1)):
+            if attempt:
+                time.sleep(sleep_sec)
+
+            _, p1, _ = _run_search(
+                auth_session, [query, "--limit", "3", "--offset", "0"]
+            )
+            _, p2, _ = _run_search(
+                auth_session, [query, "--limit", "3", "--offset", "3"]
+            )
+            total1 = json.loads(p1)["total"]
+            total2 = json.loads(p2)["total"]
+            if total1 == total2:
+                return
+
+            last_totals = (total1, total2)
+            logger.info(
+                "Search total drifted across pages (attempt %s/%s): %s -> %s",
+                attempt + 1,
+                sleep_times,
+                total1,
+                total2,
+            )
+
+        assert last_totals is not None
+        assert last_totals[0] == last_totals[1], (
+            f"Search total not consistent across pages after {sleep_times} "
+            f"attempt(s): {last_totals[0]} != {last_totals[1]}"
+        )
 
 
 class TestSearchDryRun:


### PR DESCRIPTION
## Passing Nightly Workflow First Pass

https://github.com/datahub-project/datahub/actions/runs/31839136434

## Summary
- Fixes flaky nightly failure in `TestSearchPagination.test_total_is_consistent_across_pages` (seen on `quickstart-postgres-cdc` ARM), where ES `total` drifted between page fetches (`16 == 18`).
- Query the unique hex suffix instead of the full `search_smoke_test-<suffix>` namespace so free-text analysis does not match unrelated concurrent ingest.
- Re-sample only after a mismatch using the existing `DATAHUB_TEST_SLEEP_*` budget — happy path (x64) stays zero-sleep.

## Test plan
- [ ] CI smoke / lint on this PR
- [ ] Confirm x64 search smoke path does not add sleeps when totals already match
- [ ] Monitor next Nightly Docker Test ARM postgres-cdc cell for this assertion


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the search pagination smoke test under Elasticsearch lag by querying the unique hex suffix and only re-sampling totals after a mismatch. Previously, querying the full `search_smoke_test-<suffix>` let unrelated ingest affect `total`, causing flaky failures on ARM/CDC.

**Reviewer notes**
- Query only the hex suffix to avoid free-text analyzer matching common terms from the namespace.
- On mismatch, sleep and retry using the `DATAHUB_TEST_SLEEP_*` budget; fast path remains zero-sleep when totals already match.
- Assert only that `total` is consistent across pages; do not assert exact fixture size.

<sup>Written for commit aef5ee94782a105050c1049c0990e668b5b295c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

