### PR TITLE
docs: Clarify anomaly detection 14-day history requirement

### DIFF
--- a/docs/managed-datahub/observe/anomaly-detection.md
+++ b/docs/managed-datahub/observe/anomaly-detection.md
@@ -34,6 +34,14 @@ Anomaly Detection can be enabled on the following assertion types:
 - **Column Value** assertions — checks like "value matches regex" or "value in set" are deterministic and do not have a statistical notion of "normal".
 - **Schema** assertions — schema changes are discrete events, not anomalies. Use [Monitoring Rules](./data-health-dashboard.md#monitoring-rules) to apply Schema assertions at scale across many datasets.
 
+## How much history does Anomaly Detection need?
+
+A new Anomaly Detection assertion collects **14 days of history** before it starts alerting. During that period the assertion evaluates on its normal schedule and records results, but does not raise failures. This gives the model enough data to learn daily and weekly patterns, and avoids noisy false alarms from a thinly-trained model.
+
+Once an assertion is past that point, its predictions are preserved through temporary shortages of retraining data, so a gap in evaluations does not send it back to a cold start.
+
+To skip the wait entirely, enable [Backfill Assertion History](./assertion-backfill.md) at creation time — it populates the assertion's metrics history from your warehouse so predictions are available from day one.
+
 ## Does Anomaly Detection require a warehouse connection?
 
 No — Anomaly Detection is **not** limited to Snowflake, Redshift, BigQuery, or Databricks. For Freshness, Volume, and Column Metric, the ML model trains on whichever signal the underlying assertion is configured to use:
@@ -71,7 +79,7 @@ Bucketing requires an active warehouse query, so it is only available on Snowfla
 Backfill is currently in **Private Beta** — contact your DataHub Cloud representative to request access.
 :::
 
-When you enable Anomaly Detection with time-series bucketing, you can optionally **backfill historical data** so the AI model has enough context to make accurate predictions from day one. Without backfill, the model needs to accumulate data over days or weeks of scheduled evaluations before it can reliably detect anomalies.
+When you enable Anomaly Detection with time-series bucketing, you can optionally **backfill historical data** so the AI model has enough context to make accurate predictions from day one. Without backfill, the assertion must accumulate 14 days of history through scheduled evaluations before it starts alerting.
 
 With backfill enabled, the system queries your warehouse for historical data and populates the assertion's metrics history immediately. This means you get meaningful anomaly detection thresholds right away, with full awareness of seasonality patterns.
 

--- a/docs/managed-datahub/observe/anomaly-detection.md
+++ b/docs/managed-datahub/observe/anomaly-detection.md
@@ -38,8 +38,6 @@ Anomaly Detection can be enabled on the following assertion types:
 
 A new Anomaly Detection assertion collects **14 days of history** before it starts alerting. During that period the assertion evaluates on its normal schedule and records results, but does not raise failures. This gives the model enough data to learn daily and weekly patterns, and avoids noisy false alarms from a thinly-trained model.
 
-Once an assertion is past that point, its predictions are preserved through temporary shortages of retraining data, so a gap in evaluations does not send it back to a cold start.
-
 To skip the wait entirely, enable [Backfill Assertion History](./assertion-backfill.md) at creation time — it populates the assertion's metrics history from your warehouse so predictions are available from day one.
 
 ## Does Anomaly Detection require a warehouse connection?

--- a/docs/managed-datahub/observe/assertion-backfill.md
+++ b/docs/managed-datahub/observe/assertion-backfill.md
@@ -12,7 +12,7 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 ## Introduction
 
-When you enable [Anomaly Detection](./anomaly-detection.md) on a new assertion, the underlying ML model needs historical data to learn what "normal" looks like before it can make accurate predictions. Without historical context, the model has nothing to train on, meaning it takes days or weeks of real-time evaluations before it can reliably detect anomalies.
+When you enable [Anomaly Detection](./anomaly-detection.md) on a new assertion, the underlying ML model needs historical data to learn what "normal" looks like before it can make accurate predictions. Without historical context, the model has nothing to train on: the assertion must collect 14 days of history through real-time evaluations before it starts alerting.
 
 **Backfill Assertion History** solves this by running the assertion against historical data at the time of creation. Instead of waiting for the model to accumulate enough data points through scheduled evaluations, the system queries your warehouse for past data and populates the assertion's metrics history in one go. This means you get accurate anomaly detection thresholds from day one, with full awareness of daily, weekly, or monthly seasonality in your data.
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -38,6 +38,12 @@ This release rolls up hotfixes on top of v2.1.1.
 - **RFC 8693 token-exchange client registration** — authenticated OAuth client registration accepts the canonical token-exchange grant (anonymous DCR still rejects it).
 - **Document chunking / nltk** — `nltk` 3.10.1 is excluded so document chunking no longer fails silently ([datahub-project/datahub#18847](https://github.com/datahub-project/datahub/pull/18847)).
 
+#### Observe
+
+- **New anomaly detection assertions must now collect 14 days of history** before alerting; existing predictions are preserved during temporary retraining-data shortages. This gives the assertion more time to detect daily and weekly patterns and avoid noisy false alarms.
+- Improved volume assertion anomaly detection accuracy and reliability — predictions now better align with sub-daily seasonality, remain more stable over time, and use more practical sensitivity bounds.
+- Fixed issue where assertion backfill jobs would get stuck forever.
+
 #### Platform
 
 - **Prometheus on consumers** — Micrometer Prometheus actuator is exposed on MCE/MAE consumers for shared monitoring scrapes.
@@ -60,7 +66,6 @@ This release rolls up hotfixes on top of v2.1.1.
 - Fixed the structured-property "Show in Search Filters" toggle silently disabling filters on Update after reopening the edit drawer.
 - Fixed duplicate tags, terms, and owners rendering when the same attribution was applied both manually and via propagation.
 - Fixed column-level lineage highlighting on data-product lineage graphs where the same entity appears under multiple data products.
-- Fixed smart volume assertions producing noisy alerts on cumulative/sub-daily schedules, and restored reliable bootstrap for new volume assertions (14 days of history before predictions).
 - Fixed bridge documents for semantic search inflating platform analytics counts.
 - Fixed Ask DataHub `draft_sql_for_tables` (and related tools) failing under Sonnet 5 when list arguments were serialized as schema-shaped XML.
 - Fixed compliance forms not refreshing correctly after submit/verify, and group usernames appearing as URNs in forms analytics.


### PR DESCRIPTION
## Description

Updates documentation to clarify the 14-day history requirement for new anomaly detection assertions before they start alerting. This aligns the docs with the actual behavior implemented in v2.1.0.

## Changes

- **anomaly-detection.md**: Added new section "How much history does Anomaly Detection need?" explaining the 14-day collection period, prediction preservation during data gaps, and the backfill option to skip the wait
- **assertion-backfill.md**: Updated introduction to explicitly state the 14-day history requirement instead of vague "days or weeks"
- **v_2_1_0.md**: 
  - Added release notes under Observe section documenting the 14-day history requirement and related improvements
  - Removed duplicate entry about volume assertions from the fixes section (consolidated into the new Observe section)

## Motivation

The documentation previously used vague language like "days or weeks" for the history accumulation period. The actual implementation requires exactly 14 days of history before alerting begins. This change makes the requirement explicit and helps users understand the expected behavior and how backfill can eliminate this wait.

## Test Plan

N/A - Documentation only changes

https://claude.ai/code/session_01XxWsDQTgu73VzQsTS7udia

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Documentation now states that **new Anomaly Detection assertions need 14 days of history** before they alert, matching v2.1.0 Observe behavior instead of vague “days or weeks” wording.
> 
> **`anomaly-detection.md`** adds **How much history does Anomaly Detection need?**, covering the 14-day warmup (evaluations still run but failures are not raised), why that window exists, and using **Backfill Assertion History** for day-one predictions. The backfill section is tightened to the same **14 days without backfill** language.
> 
> **`assertion-backfill.md`** updates the intro to the explicit 14-day requirement when backfill is not used.
> 
> **`v_2_1_0.md`** adds an **Observe** subsection under v2.1.2 (14-day history, prediction preservation during retraining gaps, volume anomaly improvements, stuck backfill fix) and removes a duplicate smart-volume fix bullet from Bug Fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59337ea8080088c620dcf9d251b29f6a99d4f6ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that new anomaly detection assertions wait 14 days before alerting and how to bypass the wait. This replaces vague timing, documents prediction preservation during short data gaps, and explains using Backfill for day-one predictions.

- Adds “How much history” to the Anomaly Detection guide: 14-day warmup, no alerts during warmup, and Backfill to skip it.
- Updates `assertion-backfill.md` intro to state the 14-day requirement when Backfill is not enabled.
- Expands v2.1.0 release notes with an Observe section: 14-day requirement, improved volume assertion predictions, and a fix for stuck backfill jobs; removes a redundant volume-assertion fix bullet.

<sup>Written for commit 59337ea8080088c620dcf9d251b29f6a99d4f6ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

