### PR TITLE
docs(feature-guides): fix invalid SDK expression example on metrics g…

### DIFF
--- a/docs/features/feature-guides/metrics-and-semantic-models.md
+++ b/docs/features/feature-guides/metrics-and-semantic-models.md
@@ -130,7 +130,12 @@ Snowflake Semantic Views are a native Snowflake capability. If you also use the 
 Emit metrics and semantic models programmatically from any script or connector using the high-level SDK builders (`datahub.sdk.SemanticModel`, `.Metric`, and `.SemanticModelDataset`):
 
 ```python
-from datahub.sdk import DataHubClient, SemanticModel, Metric
+from datahub.sdk import (
+    DataHubClient,
+    DialectExpressionInput,
+    Metric,
+    SemanticModel,
+)
 
 client = DataHubClient(server="...", token="...")
 
@@ -151,7 +156,10 @@ metric = Metric(
     name="Total Revenue",
     description="Sum of order amounts.",
     semantic_model=model.urn,
-    expression={"SNOWFLAKE": "SUM(orders.amount)"},
+    expression=DialectExpressionInput(
+        dialect="SNOWFLAKE",
+        expression="SUM(orders.amount)",
+    ),
 )
 
 for mcp in [*model.as_mcps(), *metric.as_mcps()]:


### PR DESCRIPTION
…uide

The Python SDK snippet passed a dict (`{"SNOWFLAKE": "SUM(...)"}`) to `Metric(expression=...)`, but `build_metric_expression` only accepts a `str`, a `DialectExpressionInput`, a list of those, or a `MetricExpressionClass` — a dict raises `TypeError("Unsupported expression input type")`. Swap the dict for a `DialectExpressionInput`, which is publicly re-exported from `datahub.sdk`, so the snippet actually runs.

Flagged by cubic-dev-ai on #19221.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python SDK example in the metrics guide to use `DialectExpressionInput` for `Metric(expression=...)`. The old example passed a dict and raised a `TypeError`; the new example uses a supported input and runs.

- Docs-only change in `docs/features/feature-guides/metrics-and-semantic-models.md`. Verify `DialectExpressionInput` is imported from `datahub.sdk` and the snippet executes.
- Migration: If you copied the old snippet, replace `{"SNOWFLAKE": "SUM(...)"}` with `DialectExpressionInput(dialect="SNOWFLAKE", expression="SUM(...)")`.

<sup>Written for commit 0a0e6141e937960e2d17f9b5872f4a168e2e3339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

