### PR TITLE
fix(graphql): fix clearing description writing empty string

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -38,6 +38,7 @@ import com.linkedin.schema.EditableSchemaMetadata;
 import com.linkedin.tag.TagProperties;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Map;
+import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +49,15 @@ public class DescriptionUtils {
           ImmutableList.of(PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()));
 
   private DescriptionUtils() {}
+
+  private static void setOrRemoveDescription(
+      String newDescription, Runnable removeFn, Consumer<String> setFn) {
+    if (newDescription == null || newDescription.trim().isEmpty()) {
+      removeFn.run();
+    } else {
+      setFn.accept(newDescription);
+    }
+  }
 
   public static void updateDatasetDescription(
       @Nonnull OperationContext opContext,
@@ -65,7 +75,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableDatasetProperties());
 
-    editableDatasetProperties.setDescription(newDescription);
+    setOrRemoveDescription(newDescription, editableDatasetProperties::removeDescription, editableDatasetProperties::setDescription);
 
     persistAspect(
         opContext,
@@ -94,7 +104,7 @@ public class DescriptionUtils {
     EditableSchemaFieldInfo editableFieldInfo =
         getFieldInfoFromSchema(editableSchemaMetadata, fieldPath);
 
-    editableFieldInfo.setDescription(newDescription);
+    setOrRemoveDescription(newDescription, editableFieldInfo::removeDescription, editableFieldInfo::setDescription);
 
     persistAspect(
         opContext,
@@ -119,7 +129,7 @@ public class DescriptionUtils {
                 Constants.CONTAINER_EDITABLE_PROPERTIES_ASPECT_NAME,
                 entityService,
                 new EditableContainerProperties());
-    containerProperties.setDescription(newDescription);
+    setOrRemoveDescription(newDescription, containerProperties::removeDescription, containerProperties::setDescription);
     persistAspect(
         opContext,
         resourceUrn,
@@ -148,7 +158,7 @@ public class DescriptionUtils {
       // properties model also requires a name.
       throw new IllegalArgumentException("Properties for this Domain do not yet exist!");
     }
-    domainProperties.setDescription(newDescription);
+    setOrRemoveDescription(newDescription, domainProperties::removeDescription, domainProperties::setDescription);
     persistAspect(
         opContext,
         resourceUrn,
@@ -173,10 +183,12 @@ public class DescriptionUtils {
                 entityService,
                 null);
     if (tagProperties == null) {
-      tagProperties =
-          new TagProperties().setName(resourceUrn.getId()).setDescription(newDescription);
+      tagProperties = new TagProperties().setName(resourceUrn.getId());
+      if (newDescription != null && !newDescription.trim().isEmpty()) {
+        tagProperties.setDescription(newDescription);
+      }
     } else {
-      tagProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, tagProperties::removeDescription, tagProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -202,7 +214,7 @@ public class DescriptionUtils {
                 entityService,
                 new CorpGroupEditableInfo());
     if (corpGroupEditableInfo != null) {
-      corpGroupEditableInfo.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, corpGroupEditableInfo::removeDescription, corpGroupEditableInfo::setDescription);
     }
     persistAspect(
         opContext,
@@ -232,8 +244,7 @@ public class DescriptionUtils {
       // model also requires a name.
       throw new IllegalArgumentException("Properties for this Glossary Term do not yet exist!");
     }
-    glossaryTermInfo.setDefinition(
-        newDescription); // We call description 'definition' for glossary terms. Not great, we know.
+    setOrRemoveDescription(newDescription, glossaryTermInfo::removeDefinition, glossaryTermInfo::setDefinition); // We call description 'definition' for glossary terms. Not great, we know.
     // :(
     persistAspect(
         opContext,
@@ -261,7 +272,7 @@ public class DescriptionUtils {
     if (glossaryNodeInfo == null) {
       throw new IllegalArgumentException("Glossary Node does not exist");
     }
-    glossaryNodeInfo.setDefinition(newDescription);
+    setOrRemoveDescription(newDescription, glossaryNodeInfo::removeDefinition, glossaryNodeInfo::setDefinition);
     persistAspect(
         opContext,
         resourceUrn,
@@ -286,7 +297,7 @@ public class DescriptionUtils {
                 entityService,
                 null);
     if (notebookProperties != null) {
-      notebookProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, notebookProperties::removeDescription, notebookProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -427,7 +438,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableMLModelProperties());
     if (editableProperties != null) {
-      editableProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, editableProperties::removeDescription, editableProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -453,7 +464,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableMLModelGroupProperties());
     if (editableProperties != null) {
-      editableProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, editableProperties::removeDescription, editableProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -479,7 +490,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableMLFeatureProperties());
     if (editableProperties != null) {
-      editableProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, editableProperties::removeDescription, editableProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -505,7 +516,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableMLFeatureTableProperties());
     if (editableProperties != null) {
-      editableProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, editableProperties::removeDescription, editableProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -531,7 +542,7 @@ public class DescriptionUtils {
                 entityService,
                 new EditableMLPrimaryKeyProperties());
     if (editableProperties != null) {
-      editableProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, editableProperties::removeDescription, editableProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -557,7 +568,7 @@ public class DescriptionUtils {
                 entityService,
                 new DataProductProperties());
     if (properties != null) {
-      properties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, properties::removeDescription, properties::setDescription);
     }
     persistAspect(
         opContext,
@@ -583,7 +594,7 @@ public class DescriptionUtils {
                 entityService,
                 new ApplicationProperties());
     if (applicationProperties != null) {
-      applicationProperties.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, applicationProperties::removeDescription, applicationProperties::setDescription);
     }
     persistAspect(
         opContext,
@@ -609,7 +620,7 @@ public class DescriptionUtils {
                 entityService,
                 new BusinessAttributeInfo());
     if (businessAttributeInfo != null) {
-      businessAttributeInfo.setDescription(newDescription);
+      setOrRemoveDescription(newDescription, businessAttributeInfo::removeDescription, businessAttributeInfo::setDescription);
     }
     persistAspect(
         opContext,
@@ -699,7 +710,9 @@ public class DescriptionUtils {
             : new DocumentationAssociationArray();
 
     // Add the new UI-authored documentation
-    associations.add(newDocAssociation);
+    if (newDescription != null && !newDescription.trim().isEmpty()) {
+      associations.add(newDocAssociation);
+    }
     documentation.setDocumentations(associations);
 
     persistAspect(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtilsTest.java
@@ -9,6 +9,11 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.entity.EntityService;
 import io.datahubproject.metadata.context.OperationContext;
 import org.mockito.Mockito;
+
+import org.mockito.ArgumentCaptor;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.dataset.EditableDatasetProperties;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -29,14 +34,38 @@ public class DescriptionUtilsTest {
   }
 
   @Test
-  public void testUpdateDatasetDescriptionCallsIngestProposal() throws Exception {
+  public void testUpdateDatasetDescriptionWithValidString() throws Exception {
     Urn datasetUrn = Urn.createFromString(TEST_DATASET_URN);
     Urn actorUrn = Urn.createFromString(TEST_ACTOR_URN);
 
     DescriptionUtils.updateDatasetDescription(
         mockOpContext, TEST_DESCRIPTION, datasetUrn, actorUrn, mockEntityService);
 
-    verify(mockEntityService).ingestProposal(eq(mockOpContext), any(), any(), eq(false));
+    ArgumentCaptor<MetadataChangeProposal> captor = ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockEntityService).ingestProposal(eq(mockOpContext), captor.capture(), any(), eq(false));
+
+    MetadataChangeProposal proposal = captor.getValue();
+    EditableDatasetProperties props = new EditableDatasetProperties(proposal.getAspect().data());
+    
+    assertTrue(props.hasDescription());
+    assertEquals(props.getDescription(), TEST_DESCRIPTION);
+  }
+
+  @Test
+  public void testUpdateDatasetDescriptionWithEmptyString() throws Exception {
+    Urn datasetUrn = Urn.createFromString(TEST_DATASET_URN);
+    Urn actorUrn = Urn.createFromString(TEST_ACTOR_URN);
+
+    DescriptionUtils.updateDatasetDescription(
+        mockOpContext, "   ", datasetUrn, actorUrn, mockEntityService);
+
+    ArgumentCaptor<MetadataChangeProposal> captor = ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    verify(mockEntityService).ingestProposal(eq(mockOpContext), captor.capture(), any(), eq(false));
+
+    MetadataChangeProposal proposal = captor.getValue();
+    EditableDatasetProperties props = new EditableDatasetProperties(proposal.getAspect().data());
+    
+    assertFalse(props.hasDescription(), "Description should be removed when empty string is provided");
   }
 
   @Test


### PR DESCRIPTION
## Description
Resolves #19229.

Currently, when a user clears a manually-edited description in the UI, the frontend passes an empty string `""` to the `updateDescription` GraphQL mutation. The `DescriptionUtils.java` backend handler blindly accepts this and sets the description on the editable aspect (e.g., `EditableSchemaMetadata` or `EditableDatasetProperties`) to `""` instead of removing it.

Because an empty string is treated as a valid user-edited override, the UI displays a blank space instead of properly falling back to the ingested source documentation.

This PR fixes the issue by updating `DescriptionUtils.java` to check if the incoming description string is null or entirely whitespace. If it is, the field is properly removed from the aspect via `.removeDescription()` (or omitted entirely from lists, as with `DocumentationAssociation`), allowing the fallback logic to naturally take over. 

### Changes Made
- Updated all `update*Description` methods in `DescriptionUtils.java` across all 16 supported entity types (Datasets, Schema Fields, Glossaries, Tags, etc.) to check `if (newDescription == null || newDescription.trim().isEmpty())`.
- For standard editable properties, called `.removeDescription()`/`.removeDefinition()` when cleared.
- For `updateDocumentDescription`, skipped appending a new `DocumentationAssociation` if the new description is cleared.

### Testing
- Verified that clearing the description removes the field and successfully un-shadows the ingested source documentation.

---

<!--
Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:
-->

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clearing a description now removes the editable override instead of saving an empty string, so the UI falls back to ingested docs. Previously, clearing saved "", which blanked the UI and blocked fallback.

- Adds a helper to remove on null/whitespace and set otherwise, applied across all `DescriptionUtils` GraphQL update paths (datasets, schema fields, containers, domains, tags, corp groups, notebooks, glossary terms/nodes, ML entities, data products, applications, business attributes).
- For tags, initializes `TagProperties` when missing and only sets `description` when non-empty; glossary term/node uses the same logic for `definition`.
- Skips appending a `DocumentationAssociation` when input is cleared.
- Updates tests to capture the emitted MCP and assert non-empty strings set `description` and whitespace removes it.
- No schema or client changes.

<sup>Written for commit 3bc5432365bf0005b79f88e0b8453828e30a511c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

