### PR TITLE
chore(tests): remove outdated TODO for UpdateIndicesHook

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
-// TODO: Backfill tests for this class in UpdateIndicesHookTest.java
+
 @Slf4j
 @Component
 @Import({


### PR DESCRIPTION

This PR removes a stale TODO comment from `UpdateIndicesHook.java`. The `UpdateIndicesHookTest.java` file already has comprehensive unit tests covering all of the hook's logic, including `invoke`, `invokeBatch`, and the `shouldProcessEvent` UI filter behavior.

Fixes #19231


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a stale TODO comment from `UpdateIndicesHook.java` now that `UpdateIndicesHookTest.java` covers `invoke`, `invokeBatch`, and the `shouldProcessEvent` filter. No runtime or test behavior changes.

<sup>Written for commit f445fcace1441cf2272c223efc6e91964830acb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

