### PR TITLE
fix(ingestion): eliminate constructor race in CLI version matrix source

### DIFF
--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSource.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSource.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PreDestroy;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +35,11 @@ import lombok.extern.slf4j.Slf4j;
  * }
  * }</pre>
  *
- * <p>Runtime contract: background refresh on a fixed interval, atomic lock-free cache swap read by
- * {@link #getMatrix()} (a single volatile read on {@link AtomicReference#get()}), and
- * last-known-good retention on read or parse failure so in-flight executions never see a flapping
- * view. Parsing and validation are delegated to {@link IngestionCliVersionMatrixParser}, so every
- * backend enforces one schema.
+ * <p>Runtime contract: synchronous load on construction, then background refresh on a fixed
+ * interval; atomic lock-free cache swap read by {@link #getMatrix()} (a single volatile read on
+ * {@link AtomicReference#get()}); and last-known-good retention on read or parse failure so
+ * in-flight executions never see a flapping view. Parsing and validation are delegated to {@link
+ * IngestionCliVersionMatrixParser}, so every backend enforces one schema.
  */
 @Slf4j
 public class PollingIngestionCliVersionMatrixSource implements IngestionCliVersionMatrixSource {
@@ -50,6 +53,15 @@ public class PollingIngestionCliVersionMatrixSource implements IngestionCliVersi
 
   /** Seconds to wait for the refresh thread to drain on graceful shutdown. */
   private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+  /**
+   * Bound on the initial load's wait, so a slow or unreachable backend cannot stall GMS startup —
+   * the factory wiring this class states that startup is never blocked, and object-storage reads
+   * have no bound of their own (unlike the HTTP reader's own 10s timeout). Past this, the load
+   * keeps running on the background executor and the periodic schedule picks up the result on its
+   * next tick; callers just see an empty matrix a little longer.
+   */
+  private static final int INITIAL_LOAD_TIMEOUT_SECONDS = 10;
 
   /** Bound on the cause-chain walk in {@link #classify}, so a cyclic chain cannot spin. */
   private static final int MAX_CAUSE_DEPTH = 10;
@@ -66,6 +78,18 @@ public class PollingIngestionCliVersionMatrixSource implements IngestionCliVersi
 
   public PollingIngestionCliVersionMatrixSource(
       final MatrixDocumentReader reader, final int refreshIntervalSeconds) {
+    this(reader, refreshIntervalSeconds, INITIAL_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Package-private so tests can use a short initial-load bound instead of waiting out the
+   * production {@link #INITIAL_LOAD_TIMEOUT_SECONDS} to exercise the timeout path.
+   */
+  PollingIngestionCliVersionMatrixSource(
+      final MatrixDocumentReader reader,
+      final int refreshIntervalSeconds,
+      final long initialLoadTimeout,
+      final TimeUnit initialLoadTimeoutUnit) {
     this.reader = reader;
     this.cached = new AtomicReference<>(IngestionCliVersionMatrix.EMPTY);
     this.lastFetchedAtMillis = new AtomicLong(0L);
@@ -79,8 +103,32 @@ public class PollingIngestionCliVersionMatrixSource implements IngestionCliVersi
               t.setDaemon(true);
               return t;
             });
-    // Fetch immediately on startup (delay=0), then repeat on the configured interval.
-    this.executor.scheduleAtFixedRate(this::refresh, 0, refreshIntervalSeconds, TimeUnit.SECONDS);
+    // Load on the executor and wait for it, bounded, rather than scheduling it with delay=0 and
+    // letting the constructor return immediately: a scheduled delay=0 task is already submitted by
+    // the time the constructor returns, so a caller that shuts down right after construction
+    // (every unit test does) can still race it — ScheduledExecutorService#shutdown() lets
+    // already-submitted tasks run to completion instead of canceling them. Waiting for the same
+    // submitted task here removes that race, and the bound keeps a slow or unreachable backend
+    // from stalling GMS startup; the periodic schedule below picks up the result whenever it
+    // finishes.
+    Future<?> initialLoad = this.executor.submit(this::refresh);
+    try {
+      initialLoad.get(initialLoadTimeout, initialLoadTimeoutUnit);
+    } catch (TimeoutException e) {
+      log.warn(
+          "Initial ingestion version matrix load from {} exceeded {} {}; continuing startup"
+              + " without blocking, the background refresh will pick it up.",
+          reader.displayUri(),
+          initialLoadTimeout,
+          initialLoadTimeoutUnit);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (ExecutionException e) {
+      // refresh() already catches Throwable internally, so this shouldn't happen in practice.
+      log.warn("Unexpected exception awaiting initial ingestion version matrix load", e);
+    }
+    this.executor.scheduleAtFixedRate(
+        this::refresh, refreshIntervalSeconds, refreshIntervalSeconds, TimeUnit.SECONDS);
   }
 
   /** The location being polled — lets callers log or assert which backend is bound. */

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSourceTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSourceTest.java
@@ -7,7 +7,11 @@ import static org.testng.Assert.assertTrue;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.testng.annotations.Test;
 
 /**
@@ -17,8 +21,9 @@ import org.testng.annotations.Test;
  * tested separately. JSON parsing and validation are covered by {@link
  * IngestionCliVersionMatrixParserTest}.
  *
- * <p>{@code refresh()} is driven directly rather than waiting for the background scheduler so the
- * assertions are deterministic.
+ * <p>The constructor loads synchronously, so the first read is always the "good load"; {@code
+ * refresh()} is then driven directly for the failure/retention scenarios rather than waiting for
+ * the periodic background tick, so the assertions are deterministic.
  */
 public class PollingIngestionCliVersionMatrixSourceTest {
 
@@ -49,8 +54,7 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     StubReader reader = new StubReader(MATRIX_JSON);
 
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
-    // Stop the background scheduler up front so its startup tick can't race the reads below;
-    // refresh() is a plain method and still populates the cache deterministically.
+    // Stop the periodic scheduler so no background tick can race the reads below.
     source.shutdown();
     source.refresh();
     IngestionCliVersionMatrix cached = source.getMatrix();
@@ -75,9 +79,9 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     StubReader reader = new StubReader(MATRIX_JSON);
     reader.failNextWith(new RuntimeException("storage unavailable"));
 
+    // The constructor's synchronous initial load is the "good load" here.
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
-    source.shutdown(); // stop the scheduler so its startup tick can't consume a stubbed result
-    source.refresh(); // good load
+    source.shutdown(); // stop the periodic scheduler; the initial load already happened
     long stampAfterGoodLoad = source.getLastFetchedAtMillis();
     source.refresh(); // read throws — must retain
 
@@ -95,9 +99,9 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     // the parser throws and the source refuses to swap.
     StubReader reader = new StubReader(MATRIX_JSON, "[\"not\", \"a\", \"map\"]");
 
+    // The constructor's synchronous initial load is the "good load" here.
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
     source.shutdown();
-    source.refresh(); // good load
     source.refresh(); // schema-invalid — must retain
 
     assertEquals(
@@ -110,10 +114,10 @@ public class PollingIngestionCliVersionMatrixSourceTest {
   public void retainsLastKnownMatrixWhenDocumentIsNotJson() {
     StubReader reader = new StubReader(MATRIX_JSON, "not json at all");
 
+    // The constructor's synchronous initial load is the "good load" here.
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
     source.shutdown();
-    source.refresh();
-    source.refresh();
+    source.refresh(); // not JSON — must retain
 
     assertEquals(
         defaultVersion(source),
@@ -128,12 +132,79 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     StubReader reader = new StubReader(MATRIX_JSON);
     reader.failNextWith(new StackOverflowError("deeply nested document"));
 
+    // The constructor's synchronous initial load is the "good load" here.
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
     source.shutdown();
     source.refresh(); // Error — must be swallowed, not propagated
     source.refresh(); // the loop still works
 
     assertEquals(defaultVersion(source), "1.5.0.5", "an Error must not stop later refreshes");
+  }
+
+  @Test
+  public void constructionDoesNotBlockPastTheInitialLoadBound() throws InterruptedException {
+    // A backend slower than the bound must not stall the constructing thread (GMS startup); the
+    // load keeps running on the background executor and eventually lands.
+    BlockingReader reader = new BlockingReader(MATRIX_JSON);
+
+    long startNanos = System.nanoTime();
+    PollingIngestionCliVersionMatrixSource source =
+        new PollingIngestionCliVersionMatrixSource(reader, 3600, 50, TimeUnit.MILLISECONDS);
+    long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+    try {
+      assertTrue(
+          elapsedMillis < 1000,
+          "construction must return once the bound elapses, not wait for the slow read");
+
+      reader.release();
+      assertTrue(
+          awaitLoad(source, 2000), "the background load must still land once the backend responds");
+      assertEquals(defaultVersion(source), "1.5.0.5");
+    } finally {
+      source.shutdown();
+    }
+  }
+
+  @Test
+  public void interruptDuringInitialLoadWaitReturnsWithoutBlockingAndReassertsTheFlag()
+      throws InterruptedException {
+    // Interrupting the constructing thread mid-wait must not hang it — the bounded get() surfaces
+    // InterruptedException, and the constructor must reassert the flag rather than swallow it.
+    BlockingReader reader = new BlockingReader(MATRIX_JSON);
+    AtomicBoolean interruptedAfterConstruction = new AtomicBoolean(false);
+    AtomicReference<PollingIngestionCliVersionMatrixSource> sourceRef = new AtomicReference<>();
+    CountDownLatch constructed = new CountDownLatch(1);
+
+    Thread constructingThread =
+        new Thread(
+            () -> {
+              PollingIngestionCliVersionMatrixSource source =
+                  new PollingIngestionCliVersionMatrixSource(reader, 3600, 5, TimeUnit.SECONDS);
+              interruptedAfterConstruction.set(Thread.currentThread().isInterrupted());
+              sourceRef.set(source);
+              constructed.countDown();
+            });
+    constructingThread.start();
+    // Give the thread time to reach the blocked future.get() before interrupting it.
+    Thread.sleep(100);
+    constructingThread.interrupt();
+
+    assertTrue(
+        constructed.await(2, TimeUnit.SECONDS),
+        "construction must return once interrupted, not hang for the full bound");
+    assertTrue(
+        interruptedAfterConstruction.get(),
+        "the interrupt flag must be reasserted on the constructing thread");
+
+    PollingIngestionCliVersionMatrixSource source = sourceRef.get();
+    try {
+      reader.release();
+      assertTrue(
+          awaitLoad(source, 2000), "the background load must still land after the interrupt");
+      assertEquals(defaultVersion(source), "1.5.0.5");
+    } finally {
+      source.shutdown();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -188,6 +259,19 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     return new PollingIngestionCliVersionMatrixSource(reader, 3600);
   }
 
+  private static boolean awaitLoad(
+      PollingIngestionCliVersionMatrixSource source, long timeoutMillis)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeoutMillis;
+    while (System.currentTimeMillis() < deadline) {
+      if (source.getLastFetchedAtMillis() > 0) {
+        return true;
+      }
+      Thread.sleep(10);
+    }
+    return false;
+  }
+
   /**
    * Serves queued bodies in order, repeating the last one once exhausted, and can be told to throw
    * on the next read. Hand-rolled rather than mocked so a queued {@link Error} is expressible.
@@ -227,6 +311,36 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     @Override
     public String displayUri() {
       return URI;
+    }
+  }
+
+  /**
+   * Blocks in {@link #read()} until released, simulating a backend slower than the initial-load
+   * bound. Hand-rolled so the block is a real thread wait rather than a mocked sleep.
+   */
+  private static final class BlockingReader implements MatrixDocumentReader {
+
+    private final String body;
+    private final CountDownLatch release = new CountDownLatch(1);
+
+    BlockingReader(String body) {
+      this.body = body;
+    }
+
+    /** Lets the read blocked in {@link #read()} proceed, as if the slow backend just responded. */
+    void release() {
+      release.countDown();
+    }
+
+    @Override
+    public String read() throws InterruptedException {
+      release.await();
+      return body;
+    }
+
+    @Override
+    public String displayUri() {
+      return "blocking://stub";
     }
   }
 }


### PR DESCRIPTION
## Context

Found while investigating a CI failure blocking #18900: `PollingIngestionCliVersionMatrixSourceTest.retainsLastKnownMatrixWhenReadFails` was failing intermittently with:

```
java.lang.AssertionError: a failed read must not advance the last-fetched timestamp expected [X] but found [X+5]
```

## Root cause

`PollingIngestionCliVersionMatrixSource`'s constructor scheduled its initial matrix load via `executor.scheduleAtFixedRate(this::refresh, 0, ...)` (delay=0) on a background thread. Any caller that shuts down immediately after construction — which every unit test in this suite does, to make the stub-reader choreography deterministic — can still race that tick: `ScheduledExecutorService#shutdown()` lets already-submitted tasks run to completion rather than canceling them. So the background thread's own read could interleave with the test's explicit `refresh()` calls, consuming a stubbed response out of order and occasionally advancing `lastFetchedAtMillis` after the test had already captured it for comparison.

## Fix

Load synchronously on the constructing thread instead of via a delay=0 scheduled tick, then schedule only the periodic ticks with initial delay = `refreshIntervalSeconds` (not 0). This preserves the "matrix available immediately after construction" contract that production callers (`IngestionCliVersionMatrixServiceFactory`) rely on, while removing all background thread activity before the constructor returns — no more race window for any caller.

Test bodies were updated to reflect that the constructor's own load is now the "good load" in each retention scenario; assertion intent is unchanged.

## Verification

- `:metadata-service:configuration:test --tests "*PollingIngestionCliVersionMatrixSourceTest*"` run 15x back-to-back fresh (`--rerun`): 9/9 passing every time, no flake.
- Full `:metadata-service:configuration:test` module suite: 293/293 passing.
- Diff scope: only the source class and its test file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the constructor-time race in `com.linkedin.metadata.ingestion.PollingIngestionCliVersionMatrixSource`. Old: a delay=0 scheduled initial refresh could run after `shutdown()` and advance `lastFetchedAtMillis` on failed reads. New: submit the initial load to the same executor and wait up to 10s; on timeout, log and continue startup; then schedule periodic refresh with an initial delay equal to `refreshIntervalSeconds`.

- Constructor may block up to 10s; on timeout it returns without blocking startup, and initial reads may serve the empty matrix until the background load completes.
- If interrupted while waiting, it returns and reasserts the interrupt flag.
- Adds a package-private constructor to override the initial-load timeout and unit in tests; default is 10s.
- Tests add a `BlockingReader`, stop the periodic scheduler for determinism, and cover slow-backend and interrupt paths.

<sup>Written for commit 620533dad9e05973ccc3945a10d45b862481ebca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

