### PR TITLE
fix(ci): keep the -slim suffix inside the actions image tag variable

### DIFF
--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -6,7 +6,7 @@ x-search-datastore-elasticsearch-env: &search-datastore-env
 
 x-datahub-actions-service: &datahub-actions-service
   hostname: actions
-  image: ${DATAHUB_ACTIONS_IMAGE:-${DATAHUB_REPO:-acryldata}/datahub-actions}:${DATAHUB_ACTIONS_VERSION:-${DATAHUB_VERSION:-quickstart}}-slim
+  image: ${DATAHUB_ACTIONS_IMAGE:-${DATAHUB_REPO:-acryldata}/datahub-actions}:${DATAHUB_ACTIONS_VERSION:-${DATAHUB_VERSION:-quickstart}-slim}
   env_file:
     - datahub-actions/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}

--- a/smoke-test/run-quickstart.sh
+++ b/smoke-test/run-quickstart.sh
@@ -58,6 +58,22 @@ echo "Resolved service images:"
 resolved_images=$(quickstart_compose config --images)
 echo "$resolved_images"
 
+# A digest-pinned reference has to end at the digest. Trailing text means a
+# compose template appended a variant suffix *outside* its ${VAR:-...}
+# substitution, which the daemon rejects as "invalid reference format" only at
+# `up` time -- minutes later, with no mention of which template is at fault.
+# Fail here, where the offending reference can be named.
+while read -r image; do
+  [[ -n "${image}" ]] || continue
+  if [[ "${image}" == *"@sha256:"* ]] && [[ ! "${image}" =~ @sha256:[0-9a-f]{64}$ ]]; then
+    echo "ERROR: malformed digest reference: ${image}" >&2
+    echo "       A digest must be the last element of the reference. Text after it" >&2
+    echo "       usually means a compose template appends a suffix outside the" >&2
+    echo "       \${VAR:-...} substitution that carries the pinned digest." >&2
+    exit 1
+  fi
+done <<<"${resolved_images}"
+
 # EXPECT_PR_TAGGED_IMAGES lists the docker repos CI built for this run. Each one
 # has to come up on DATAHUB_VERSION; if it resolved to the reused tag instead,
 # the tests would run against binaries that predate the change and still pass,


### PR DESCRIPTION
## Summary

Follow-up to #18983. Digest pinning made the reused actions image render as an **invalid reference**, so every PR in the reuse-everything bucket (docs-only, smoke-test-only, e2e-only) fails `Run quickstart` on all seven batches.

Seen on #19235 ([job](https://github.com/datahub-project/datahub/actions/runs/31906261424/job/95064903723)):

```
unable to get image 'acryldata/datahub-actions:quickstart-slim@sha256:161bec…ca1b-slim':
Error response from daemon: invalid reference format
```

The actions template appended `-slim` **after** the `${DATAHUB_ACTIONS_VERSION:-…}` substitution. That was correct while the variable held a bare tag (`quickstart` → `quickstart-slim`), but #18983 now puts a complete `quickstart-slim@sha256:…` reference in it, so the suffix landed after the digest. **actions is the only one of the six service templates that appends text after the substitution** — the other five end at `}`, which is why nothing else broke.

## The fix

Move the suffix inside the variable's default, so the variable always holds a complete tag reference:

```diff
-${DATAHUB_ACTIONS_VERSION:-${DATAHUB_VERSION:-quickstart}}-slim
+${DATAHUB_ACTIONS_VERSION:-${DATAHUB_VERSION:-quickstart}-slim}
```

Verified against the real `quickstart-consumers` profile with the exact digest from the failing job:

| path | variable | renders |
| --- | --- | --- |
| build (unchanged) | unset | `…:pr19235-bed76de-slim` |
| reuse (fixed) | `quickstart-slim@sha256:161bec…` | `…:quickstart-slim@sha256:161bec…` |
| local default | unset, no `DATAHUB_VERSION` | `…:quickstart-slim` |

`:docker:generateQuickstartComposeConfig` produces no diff, so `verify-quickstart-compose` is unaffected.

## Regression guard

A unit test can't catch this — the resolver's output is valid in isolation; only the template interaction breaks it. So `run-quickstart.sh` now asserts, next to the existing stale-image check, that a digest is the **last** element of every resolved reference. A future template making the same mistake fails immediately and names the image, instead of surfacing as an opaque daemon error minutes into the pulls.

## Test plan

- [x] Both render paths verified against the real compose profile
- [x] Guard rejects the exact failing reference, accepts the valid one
- [x] `test_resolve_image_builds.sh` 42/42; shellcheck clean; generated compose unchanged
- [ ] CI: this PR only touches `docker/profiles/` + `smoke-test/`, so it lands in the reuse-everything bucket itself — a green `Run quickstart` here **is** the end-to-end proof

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid Docker image references for the actions service by keeping the `-slim` suffix inside the tag variable. Previously the template appended `-slim` after `${DATAHUB_ACTIONS_VERSION:-...}`, which now holds a digest-pinned value; this produced `<…>@sha256:<digest>-slim` and failed at `docker compose up`. The suffix now lives in the default so the digest remains the last element, restoring quickstart reuse jobs.

**Reviewer notes**
- `docker/profiles/docker-compose.actions.yml`: move `-slim` into the default — `${DATAHUB_ACTIONS_VERSION:-${DATAHUB_VERSION:-quickstart}-slim}`; other service templates already end at `}` and are unaffected.
- `smoke-test/run-quickstart.sh`: add a guard that fails if any resolved image with `@sha256:` has trailing text; prints the offending image for fast triage.
- Generated quickstart compose remains unchanged; `verify-quickstart-compose` unaffected. No migrations required; a green `Run quickstart` on this PR is the end-to-end proof.

<sup>Written for commit e2e7cc65ed6ac192ee9b1595c236175473875acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

