### PR TITLE
chore(docker): default local Elasticsearch image to 8.19.2

### DIFF
--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -320,7 +320,7 @@ services:
   elasticsearch:
     profiles: *elasticsearch-profiles
     hostname: search
-    image: ${DATAHUB_SEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch}:${DATAHUB_SEARCH_TAG:-8.18.0}
+    image: ${DATAHUB_SEARCH_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch}:${DATAHUB_SEARCH_TAG:-8.19.2}
     ports:
       - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     env_file: elasticsearch/env/docker.env


### PR DESCRIPTION
The local quickstart profiles pin Elasticsearch `8.18.0`. Since 8.19 is the final 8.x minor line and carries bug and security fixes over 8.18, local development and CI runs benefit from tracking it.

This changes only the default image tag in `docker/profiles/docker-compose.prerequisites.yml`. The minimum supported Elasticsearch version is unchanged, and the tag stays overridable through `DATAHUB_SEARCH_TAG` for anyone who prefers to stay on 8.18.0:

```bash
DATAHUB_SEARCH_TAG=8.18.0 ./gradlew quickstartDebug
```

Verified that compose resolves the new tag and that the profiles still parse:

```
$ docker compose --profile debug-elasticsearch config | grep 'image:.*elasticsearch'
image: docker.elastic.co/elasticsearch/elasticsearch:8.19.2
```

`8.18.0` was the only Elasticsearch pin in the repository, and the pre-commit check for generated quickstart compose files reports no regeneration needed.

One upgrade note for reviewers: the local `elasticsearch` container is recreated on the next start after this change. Existing volume data is preserved because 8.18 to 8.19 is a minor upgrade.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults the local Elasticsearch Docker image from 8.18.0 to 8.19.2 in the quickstart profile. Previously the default was 8.18.0; now it is 8.19.2 to pick up final 8.x bug and security fixes, with no change to the minimum supported version.

**Review and rollout**
- One-line change in `docker/profiles/docker-compose.prerequisites.yml`; no other Elasticsearch pins are affected.
- The `elasticsearch` container will be recreated on the next start; existing volume data is preserved.
- To stay on 8.18.0, set `DATAHUB_SEARCH_TAG=8.18.0`.

<sup>Written for commit 5ca4e6d2f3d3cdd10342b7700b1d3956082d7ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

