### PR TITLE
fix(ingestion/kafka-connect): restore sink column lineage with bulk resolvers

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -46,6 +46,7 @@ from datahub.utilities.urns.dataset_urn import DatasetUrn
 from datahub.utilities.urns.field_paths import get_simple_field_path_from_v2_field_path
 
 if TYPE_CHECKING:
+    from datahub.ingestion.graph.client import DataHubGraph
     from datahub.sql_parsing.schema_resolver import SchemaResolver
 
 logger = logging.getLogger(__name__)
@@ -787,6 +788,7 @@ class BaseConnector:
     all_cluster_topics: Optional[List[str]] = (
         None  # All topics from Kafka cluster (Confluent Cloud only, for validation)
     )
+    graph: Optional["DataHubGraph"] = None
 
     def extract_lineages(self) -> List[KafkaConnectLineage]:
         """Extract lineage mappings for this connector. Override in subclasses."""
@@ -1192,8 +1194,11 @@ class BaseConnector:
             self.config.use_schema_resolver
             and self.config.schema_resolver_finegrained_lineage
             and self.schema_resolver
-            and self.schema_resolver.graph
         ):
+            return None
+
+        graph = self.schema_resolver.graph or self.graph
+        if not graph:
             return None
 
         try:
@@ -1207,9 +1212,7 @@ class BaseConnector:
                 platform_instance=kafka_platform_instance,
             )
 
-            kafka_schema_aspect = self.schema_resolver.graph.get_aspect(
-                str(source_urn), SchemaMetadataClass
-            )
+            kafka_schema_aspect = graph.get_aspect(str(source_urn), SchemaMetadataClass)
             if not kafka_schema_aspect:
                 logger.debug(
                     f"No schema found in DataHub for Kafka topic '{source_topic}'. "

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
@@ -150,6 +150,8 @@ class ConnectorRegistry:
             )
             if schema_resolver:
                 connector.schema_resolver = schema_resolver
+                if manifest.type == SINK and schema_resolver_provider is not None:
+                    connector.graph = schema_resolver_provider.graph
         else:
             logger.debug(
                 f"No handler found for connector '{manifest.name}' with class '{connector_class_value}'"

--- a/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/schema_resolver_provider.py
@@ -58,6 +58,10 @@ class SchemaResolverProvider:
         self._batch_size = batch_size
         self._report = report
 
+    @property
+    def graph(self) -> "DataHubGraph":
+        return self._graph
+
     @functools.lru_cache
     def get(
         self,

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
@@ -600,6 +600,29 @@ class TestConnectorRegistrySchemaResolver:
             env="PROD",
         )
 
+    def test_sink_connector_receives_provider_graph(self) -> None:
+        """Sink connectors use the provider graph to resolve Kafka schemas."""
+        manifest = create_manifest(SINK, CONFLUENT_JDBC_SINK_CONNECTOR_CLASS)
+        config = create_mock_config()
+        config.use_schema_resolver = True
+        report = create_mock_report()
+
+        graph = Mock()
+        mock_schema_resolver = Mock()
+        mock_schema_resolver.graph = None
+        mock_provider = Mock(spec=SchemaResolverProvider)
+        mock_provider.graph = graph
+        mock_provider.get.return_value = mock_schema_resolver
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report, schema_resolver_provider=mock_provider
+        )
+
+        assert connector is not None
+        assert connector.graph is graph
+        assert connector.schema_resolver is mock_schema_resolver
+        assert connector.schema_resolver.graph is None
+
     def test_schema_resolver_with_platform_instance(self) -> None:
         """Test schema resolver created with platform instance."""
         manifest = create_manifest(

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -1289,9 +1289,13 @@ class TestSinkFineGrainedLineage:
         )
 
         assert result is not None
-        assert sorted(
-            (lineage.upstreams[0], lineage.downstreams[0]) for lineage in result
-        ) == sorted(
+        lineage_pairs = []
+        for lineage in result:
+            assert lineage.upstreams is not None
+            assert lineage.downstreams is not None
+            lineage_pairs.append((lineage.upstreams[0], lineage.downstreams[0]))
+
+        assert sorted(lineage_pairs) == sorted(
             [
                 (
                     f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},id)",

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -1289,8 +1289,22 @@ class TestSinkFineGrainedLineage:
         )
 
         assert result is not None
+        assert result is not None
         assert len(result) == 2
-
+        upstreams = sorted(l.upstreams[0] for l in result)
+        downstreams = sorted(l.downstreams[0] for l in result)
+        assert upstreams == sorted(
+            [
+                f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},id)",
+                f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},amount)",
+            ]
+        )
+        assert downstreams == sorted(
+            [
+                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),id)",
+                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),amount)",
+            ]
+        )
     def test_returns_none_when_kafka_schema_missing(self) -> None:
         """Returns None gracefully when the Kafka topic has no schema in DataHub."""
         manifest = ConnectorManifest(

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -1289,22 +1289,21 @@ class TestSinkFineGrainedLineage:
         )
 
         assert result is not None
-        assert result is not None
-        assert len(result) == 2
-        upstreams = sorted(l.upstreams[0] for l in result)
-        downstreams = sorted(l.downstreams[0] for l in result)
-        assert upstreams == sorted(
+        assert sorted(
+            (lineage.upstreams[0], lineage.downstreams[0]) for lineage in result
+        ) == sorted(
             [
-                f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},id)",
-                f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},amount)",
+                (
+                    f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},id)",
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),id)",
+                ),
+                (
+                    f"urn:li:schemaField:({self._KAFKA_ORDERS_URN},amount)",
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),amount)",
+                ),
             ]
         )
-        assert downstreams == sorted(
-            [
-                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),id)",
-                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.orders,PROD),amount)",
-            ]
-        )
+
     def test_returns_none_when_kafka_schema_missing(self) -> None:
         """Returns None gracefully when the Kafka topic has no schema in DataHub."""
         manifest = ConnectorManifest(

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -1260,6 +1260,37 @@ class TestSinkFineGrainedLineage:
 
         assert result is None
 
+    def test_uses_connector_graph_with_bulk_schema_resolver(self) -> None:
+        """Bulk resolvers stay graphless while sink lineage reads Kafka schemas."""
+        manifest = ConnectorManifest(
+            name="jdbc-sink",
+            type="sink",
+            config={
+                "connection.url": "jdbc:postgresql://localhost/testdb",
+                "topics": "orders",
+            },
+            tasks=[],
+        )
+        connector = JdbcSinkConnector(
+            manifest, self._config(), KafkaConnectSourceReport(), platform="postgres"
+        )
+        resolver = self._resolver(
+            platform="postgres",
+            db_schemas={"testdb.public.orders": {"id": "INTEGER", "amount": "NUMERIC"}},
+            kafka_schemas={self._KAFKA_ORDERS_URN: ["id", "amount"]},
+        )
+        graph = resolver.graph
+        resolver.graph = None  # type: ignore[assignment]
+        connector.schema_resolver = resolver  # type: ignore[assignment]
+        connector.graph = graph
+
+        result = connector._extract_sink_fine_grained_lineage(
+            "orders", "testdb.public.orders", "postgres"
+        )
+
+        assert result is not None
+        assert len(result) == 2
+
     def test_returns_none_when_kafka_schema_missing(self) -> None:
         """Returns None gracefully when the Kafka topic has no schema in DataHub."""
         manifest = ConnectorManifest(


### PR DESCRIPTION
Restores Kafka Connect sink column lineage when schemas are supplied by bulk-initialized resolvers.

<details>
<summary>AI generated description! 👇</summary>

## Context

`SchemaResolverProvider` intentionally bulk-loads schemas into resolvers without retaining a graph reference. Sink lineage also needs graph access to fetch Kafka topic schema metadata, so its guard returned early and silently emitted only dataset-level lineage.

## What changed

- Expose the provider's existing graph as a read-only property.
- Attach that graph to successfully initialized sink connectors while keeping bulk resolvers graphless.
- Prefer an existing resolver graph and use the connector graph only as a fallback.
- Add regression coverage for provider wiring and graphless bulk-resolver extraction.

## Testing

- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/kafka_connect/test_kafka_connect_connector_registry.py`
- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py`
- Pre-commit Ruff, secret detection, and applicable formatting checks passed.

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Kafka Connect sink column-level lineage when schemas come from bulk-initialized resolvers. Previously sinks required a resolver graph and fell back to dataset-only lineage; sinks now use the provider graph, or the connector graph if the resolver is graphless, to preserve fine-grained lineage.

- Exposes a read-only `graph` on `SchemaResolverProvider` and sets it on sink connectors in `ConnectorRegistry`; bulk resolvers remain graphless.
- Adds `graph` to `BaseConnector`; sink lineage now uses `schema_resolver.graph` or falls back to `connector.graph`, returning None only if both are missing.
- Uses the selected graph for Kafka schema lookups instead of hard-requiring `schema_resolver.graph`.
- Tests cover provider wiring, connector-graph fallback for bulk resolvers, and missing Kafka schema; tighten assertions to pin Kafka fields to target columns and make optional handling type-safe.

<sup>Written for commit 097033c87c1dc6bf5a43eb6cd3167ebaff0c23ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

