### PR TITLE
ci(ingestion): report failed pytest results to PostHog

### DIFF
--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -253,6 +253,38 @@ jobs:
           test-results-paths: "metadata-ingestion/test-results/**"
           junit-file-globs: "metadata-ingestion/test-results/*.xml"
           retention-days: 14
+      - name: Send failed test metrics to PostHog
+        if: failure()
+        continue-on-error: true
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          if [ -z "$POSTHOG_API_KEY" ]; then
+            echo "⚠️ POSTHOG_API_KEY not configured, skipping test failure metrics"
+            exit 0
+          fi
+
+          TEMP_DIR=$(mktemp -d)
+          mkdir -p "$TEMP_DIR/test-results"
+          find . -name "junit.*.xml" -exec cp {} "$TEMP_DIR/test-results/" \; 2>/dev/null || true
+
+          python3 .github/scripts/send_failed_tests_to_posthog.py \
+            --input-dir "$TEMP_DIR/test-results" \
+            --posthog-api-key "$POSTHOG_API_KEY" \
+            --posthog-host "${POSTHOG_HOST:-https://app.posthog.com}" \
+            --repository "${{ github.repository }}" \
+            --workflow-name "${{ github.workflow }}" \
+            --branch "${GH_HEAD_REF}" \
+            --run-id "${{ github.run_id }}" \
+            --run-attempt "${{ github.run_attempt }}" \
+            --batch "${{ strategy.job-index }}" \
+            --batch-count "${{ strategy.job-total }}" \
+            --test-strategy "ingestion-pytest" \
+            --command "${{ matrix.command || matrix.connector || 'metadata-ingestion' }}"
+
+          rm -rf "$TEMP_DIR"
       - name: Upload coverage to Codecov with ingestion flag
         if: ${{ always() && matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4


### PR DESCRIPTION
## Summary
- Add a PostHog failure-reporting step to `.github/workflows/metadata-ingestion.yml`, matching the pytest pattern used in `docker-unified.yml`
- On CI failure, collect `junit.*.xml` results and send them via `.github/scripts/send_failed_tests_to_posthog.py` (non-blocking; skipped if secrets are unset)
- Tag events with matrix command/connector plus batch metadata so Quick, integration, and selective connector jobs are distinguishable

## Test plan
- [ ] Confirm workflow YAML lint / pre-commit checks pass on this PR
- [ ] After merge (or with secrets available), verify a failing metadata-ingestion job emits PostHog events when `POSTHOG_API_KEY` is configured
- [ ] Confirm the step no-ops cleanly when the API key secret is missing (`continue-on-error: true`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports failed metadata-ingestion pytest results to PostHog so CI failures are visible. Previously failures were not tracked; now failed runs emit tagged events without changing job outcomes.

- Runs only on failure with continue-on-error; does not affect pass/fail.
- Skips when `POSTHOG_API_KEY` is unset; `POSTHOG_HOST` optional (defaults to https://app.posthog.com).
- Collects `junit.*.xml` and sends via `.github/scripts/send_failed_tests_to_posthog.py`.
- Tags events with repository, workflow, branch, run id/attempt, batch index/total, test strategy `ingestion-pytest`, and matrix command/connector (fallback `metadata-ingestion`).

<sup>Written for commit d44905bce038def5aeb9254256dfab29539af098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

