### PR TITLE
perf(entity): cache DefaultAspectsUtil dataPlatform lookups

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2Step.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2Step.java
@@ -195,8 +195,7 @@ public class BackfillBrowsePathsV2Step implements UpgradeStep {
 
   private void ingestBrowsePathsV2(
       @Nonnull OperationContext opContext, Urn urn, AuditStamp auditStamp) throws Exception {
-    BrowsePathsV2 browsePathsV2 =
-        DefaultAspectsUtil.buildDefaultBrowsePathV2(opContext, urn, true, entityService);
+    BrowsePathsV2 browsePathsV2 = DefaultAspectsUtil.buildDefaultBrowsePathV2(opContext, urn, true);
     log.debug(String.format("Adding browse path v2 for urn %s with value %s", urn, browsePathsV2));
     MetadataChangeProposal proposal = new MetadataChangeProposal();
     proposal.setEntityUrn(urn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtil.java
@@ -7,7 +7,6 @@ import static com.linkedin.metadata.search.utils.BrowsePathUtils.buildDataPlatfo
 import static com.linkedin.metadata.search.utils.BrowsePathUtils.getDefaultBrowsePath;
 import static com.linkedin.metadata.search.utils.BrowsePathV2Utils.getDefaultBrowsePathV2;
 
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.BrowsePaths;
 import com.linkedin.common.BrowsePathsV2;
 import com.linkedin.common.urn.Urn;
@@ -16,7 +15,7 @@ import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.dataplatform.DataPlatformInfo;
-import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.Aspect;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.batch.AspectsBatch;
@@ -232,12 +231,11 @@ public class DefaultAspectsUtil {
                   case BROWSE_PATHS_ASPECT_NAME:
                     return Pair.of(
                         BROWSE_PATHS_ASPECT_NAME,
-                        (RecordTemplate) buildDefaultBrowsePath(opContext, urn, entityService));
+                        (RecordTemplate) buildDefaultBrowsePath(opContext, urn));
                   case BROWSE_PATHS_V2_ASPECT_NAME:
                     return Pair.of(
                         BROWSE_PATHS_V2_ASPECT_NAME,
-                        (RecordTemplate)
-                            buildDefaultBrowsePathV2(opContext, urn, false, entityService));
+                        (RecordTemplate) buildDefaultBrowsePathV2(opContext, urn, false));
                   case DATA_PLATFORM_INSTANCE_ASPECT_NAME:
                     return DataPlatformInstanceUtils.buildDataPlatformInstance(
                             urn.getEntityType(), entityKeyAspect)
@@ -265,8 +263,8 @@ public class DefaultAspectsUtil {
    */
   @Nonnull
   public static BrowsePaths buildDefaultBrowsePath(
-      @Nonnull OperationContext opContext, final @Nonnull Urn urn, EntityService<?> entityService) {
-    Character dataPlatformDelimiter = getDataPlatformDelimiter(opContext, urn, entityService);
+      @Nonnull OperationContext opContext, final @Nonnull Urn urn) {
+    Character dataPlatformDelimiter = getDataPlatformDelimiter(opContext, urn);
     String defaultBrowsePath =
         getDefaultBrowsePath(urn, opContext.getEntityRegistry(), dataPlatformDelimiter);
     StringArray browsePaths = new StringArray();
@@ -284,29 +282,19 @@ public class DefaultAspectsUtil {
    */
   @Nonnull
   public static BrowsePathsV2 buildDefaultBrowsePathV2(
-      @Nonnull OperationContext opContext,
-      final @Nonnull Urn urn,
-      boolean useContainerPaths,
-      EntityService<?> entityService) {
-    Character dataPlatformDelimiter = getDataPlatformDelimiter(opContext, urn, entityService);
+      @Nonnull OperationContext opContext, final @Nonnull Urn urn, boolean useContainerPaths) {
+    Character dataPlatformDelimiter = getDataPlatformDelimiter(opContext, urn);
     return getDefaultBrowsePathV2(
-        opContext,
-        urn,
-        opContext.getEntityRegistry(),
-        dataPlatformDelimiter,
-        entityService,
-        useContainerPaths);
+        opContext, urn, opContext.getEntityRegistry(), dataPlatformDelimiter, useContainerPaths);
   }
 
   /** Returns a delimiter on which the name of an asset may be split. */
-  private static Character getDataPlatformDelimiter(
-      @Nonnull OperationContext opContext, Urn urn, EntityService<?> entityService) {
+  private static Character getDataPlatformDelimiter(@Nonnull OperationContext opContext, Urn urn) {
     // Attempt to construct the appropriate Data Platform URN
     Urn dataPlatformUrn = buildDataPlatformUrn(urn, opContext.getEntityRegistry());
     if (dataPlatformUrn != null) {
       // Attempt to resolve the delimiter from Data Platform Info
-      DataPlatformInfo dataPlatformInfo =
-          getDataPlatformInfo(opContext, dataPlatformUrn, entityService);
+      DataPlatformInfo dataPlatformInfo = getDataPlatformInfo(opContext, dataPlatformUrn);
       if (dataPlatformInfo != null && dataPlatformInfo.hasDatasetNameDelimiter()) {
         return dataPlatformInfo.getDatasetNameDelimiter().charAt(0);
       }
@@ -317,23 +305,15 @@ public class DefaultAspectsUtil {
 
   @Nullable
   private static DataPlatformInfo getDataPlatformInfo(
-      @Nonnull OperationContext opContext, Urn urn, EntityService<?> entityService) {
+      @Nonnull OperationContext opContext, Urn urn) {
     try {
-      final EntityResponse entityResponse =
-          entityService.getEntityV2(
-              opContext,
-              Constants.DATA_PLATFORM_ENTITY_NAME,
-              urn,
-              ImmutableSet.of(Constants.DATA_PLATFORM_INFO_ASPECT_NAME));
-      if (entityResponse != null
-          && entityResponse.hasAspects()
-          && entityResponse.getAspects().containsKey(Constants.DATA_PLATFORM_INFO_ASPECT_NAME)) {
-        return new DataPlatformInfo(
-            entityResponse
-                .getAspects()
-                .get(Constants.DATA_PLATFORM_INFO_ASPECT_NAME)
-                .getValue()
-                .data());
+      final Aspect aspect =
+          opContext
+              .getRetrieverContext()
+              .getCachingAspectRetriever()
+              .getLatestAspectObject(opContext, urn, Constants.DATA_PLATFORM_INFO_ASPECT_NAME);
+      if (aspect != null) {
+        return new DataPlatformInfo(aspect.data());
       }
     } catch (Exception e) {
       log.warn(String.format("Failed to find Data Platform Info for urn %s", urn));

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search.utils;
 
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME;
 
 import com.linkedin.common.BrowsePathEntry;
 import com.linkedin.common.BrowsePathEntryArray;
@@ -8,10 +9,9 @@ import com.linkedin.common.BrowsePathsV2;
 import com.linkedin.common.urn.DataPlatformInstanceUrn;
 import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.data.DataMap;
-import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.Aspect;
 import com.linkedin.metadata.Constants;
-import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.key.DataJobKey;
 import com.linkedin.metadata.key.DatasetKey;
 import com.linkedin.metadata.models.AspectSpec;
@@ -21,7 +21,6 @@ import com.linkedin.metadata.utils.EntityKeyUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -49,7 +48,6 @@ public class BrowsePathV2Utils {
       @Nonnull Urn urn,
       @Nonnull EntityRegistry entityRegistry,
       @Nonnull Character dataPlatformDelimiter,
-      @Nonnull EntityService<?> entityService,
       boolean useContainerPaths) {
 
     BrowsePathsV2 result = new BrowsePathsV2();
@@ -62,7 +60,7 @@ public class BrowsePathV2Utils {
                 EntityKeyUtils.convertUrnToEntityKey(
                     urn, getKeyAspectSpec(urn.getEntityType(), entityRegistry));
         BrowsePathEntryArray datasetContainerPathEntries =
-            useContainerPaths ? getContainerPathEntries(opContext, urn, entityService) : null;
+            useContainerPaths ? getContainerPathEntries(opContext, urn) : null;
         if (useContainerPaths && datasetContainerPathEntries.size() > 0) {
           browsePathEntries.addAll(datasetContainerPathEntries);
         } else {
@@ -70,7 +68,7 @@ public class BrowsePathV2Utils {
               getDefaultDatasetPathEntries(dsKey.getName(), dataPlatformDelimiter);
           if (defaultDatasetPathEntries.size() > 0) {
             tryResolvePlatformInstanceEntry(
-                opContext, defaultDatasetPathEntries, dsKey.getPlatform(), entityService);
+                opContext, defaultDatasetPathEntries, dsKey.getPlatform());
             browsePathEntries.addAll(defaultDatasetPathEntries);
           } else {
             browsePathEntries.add(createBrowsePathEntry(DEFAULT_FOLDER_NAME, null));
@@ -82,7 +80,7 @@ public class BrowsePathV2Utils {
       case Constants.CHART_ENTITY_NAME:
       case Constants.DASHBOARD_ENTITY_NAME:
         BrowsePathEntryArray containerPathEntries =
-            useContainerPaths ? getContainerPathEntries(opContext, urn, entityService) : null;
+            useContainerPaths ? getContainerPathEntries(opContext, urn) : null;
         if (useContainerPaths && containerPathEntries.size() > 0) {
           browsePathEntries.addAll(containerPathEntries);
         } else {
@@ -133,8 +131,7 @@ public class BrowsePathV2Utils {
   private static void tryResolvePlatformInstanceEntry(
       @Nonnull OperationContext opContext,
       @Nonnull BrowsePathEntryArray entries,
-      @Nonnull Urn platformUrn,
-      @Nonnull EntityService<?> entityService) {
+      @Nonnull Urn platformUrn) {
     if (entries.isEmpty()) {
       return;
     }
@@ -142,7 +139,10 @@ public class BrowsePathV2Utils {
       String firstSegment = entries.get(0).getId();
       DataPlatformInstanceUrn platformInstanceUrn =
           new DataPlatformInstanceUrn(DataPlatformUrn.createFromUrn(platformUrn), firstSegment);
-      if (entityService.exists(opContext, platformInstanceUrn, true)) {
+      if (cachingAspectRetriever(opContext)
+              .getLatestAspectObject(
+                  opContext, platformInstanceUrn, DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME)
+          != null) {
         entries.set(0, createBrowsePathEntry(platformInstanceUrn.toString(), platformInstanceUrn));
       }
     } catch (Exception e) {
@@ -155,26 +155,19 @@ public class BrowsePathV2Utils {
   }
 
   private static void aggregateParentContainers(
-      @Nonnull OperationContext opContext,
-      List<Urn> containerUrns,
-      Urn entityUrn,
-      EntityService entityService) {
+      @Nonnull OperationContext opContext, List<Urn> containerUrns, Urn entityUrn) {
     try {
-      EntityResponse entityResponse =
-          entityService.getEntityV2(
-              opContext,
-              entityUrn.getEntityType(),
-              entityUrn,
-              Collections.singleton(CONTAINER_ASPECT_NAME));
+      Aspect containerAspect =
+          cachingAspectRetriever(opContext)
+              .getLatestAspectObject(opContext, entityUrn, CONTAINER_ASPECT_NAME);
 
-      if (entityResponse != null
-          && entityResponse.getAspects().containsKey(CONTAINER_ASPECT_NAME)) {
-        DataMap dataMap = entityResponse.getAspects().get(CONTAINER_ASPECT_NAME).getValue().data();
-        com.linkedin.container.Container container = new com.linkedin.container.Container(dataMap);
+      if (containerAspect != null) {
+        com.linkedin.container.Container container =
+            new com.linkedin.container.Container(containerAspect.data());
         Urn containerUrn = container.getContainer();
         // add to beginning of the array, we want the highest level container first
         containerUrns.add(0, containerUrn);
-        aggregateParentContainers(opContext, containerUrns, containerUrn, entityService);
+        aggregateParentContainers(opContext, containerUrns, containerUrn);
       }
     } catch (Exception e) {
       log.error(
@@ -190,17 +183,21 @@ public class BrowsePathV2Utils {
    * call aggregateParentContainers to get the full container path to be included in this path.
    */
   private static BrowsePathEntryArray getContainerPathEntries(
-      @Nonnull OperationContext opContext,
-      @Nonnull final Urn entityUrn,
-      @Nonnull final EntityService entityService) {
+      @Nonnull OperationContext opContext, @Nonnull final Urn entityUrn) {
     BrowsePathEntryArray browsePathEntries = new BrowsePathEntryArray();
     final List<Urn> containerUrns = new ArrayList<>();
-    aggregateParentContainers(opContext, containerUrns, entityUrn, entityService);
+    aggregateParentContainers(opContext, containerUrns, entityUrn);
     containerUrns.forEach(
         urn -> {
           browsePathEntries.add(createBrowsePathEntry(urn.toString(), urn));
         });
     return browsePathEntries;
+  }
+
+  @Nonnull
+  private static CachingAspectRetriever cachingAspectRetriever(
+      @Nonnull OperationContext opContext) {
+    return opContext.getRetrieverContext().getCachingAspectRetriever();
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtilTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtilTest.java
@@ -1,18 +1,29 @@
 package com.linkedin.metadata.aspect.utils;
 
+import static com.linkedin.metadata.Constants.DATA_PLATFORM_INFO_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.linkedin.common.BrowsePaths;
 import com.linkedin.common.FabricType;
 import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.DatasetUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.dataplatform.DataPlatformInfo;
+import com.linkedin.dataplatform.PlatformType;
+import com.linkedin.entity.Aspect;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.EbeanTestUtils;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.patch.builder.DatasetPropertiesPatchBuilder;
 import com.linkedin.metadata.config.EbeanConfiguration;
 import com.linkedin.metadata.config.EntityServiceConfiguration;
 import com.linkedin.metadata.config.PreProcessHooks;
 import com.linkedin.metadata.entity.EntityServiceImpl;
+import com.linkedin.metadata.entity.TestEntityRegistry;
 import com.linkedin.metadata.entity.ebean.EbeanAspectDao;
 import com.linkedin.metadata.entity.ebean.PassThroughScopedTransactionFactory;
 import com.linkedin.metadata.entity.ebean.PlainAspectTableResolver;
@@ -23,6 +34,7 @@ import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.ebean.Database;
 import java.util.List;
@@ -33,9 +45,71 @@ import org.testng.annotations.Test;
 
 public class DefaultAspectsUtilTest {
 
+  private static final Urn HDFS_PLATFORM_URN = UrnUtils.getUrn("urn:li:dataPlatform:hdfs");
+  private static final Urn HDFS_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hdfs,a/b/c,PROD)");
+
   private Database server;
 
   public DefaultAspectsUtilTest() {}
+
+  @Test
+  public void testGetDataPlatformInfoUsesCachingAspectRetrieverDelimiter() {
+    DataPlatformInfo platformInfo =
+        new DataPlatformInfo()
+            .setName("hdfs")
+            .setType(PlatformType.FILE_SYSTEM)
+            .setDatasetNameDelimiter("/");
+    CachingAspectRetriever retriever = mock(CachingAspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(), eq(HDFS_PLATFORM_URN), eq(DATA_PLATFORM_INFO_ASPECT_NAME)))
+        .thenReturn(new Aspect(platformInfo.data()));
+
+    BrowsePaths browsePaths =
+        DefaultAspectsUtil.buildDefaultBrowsePath(mockOpContext(retriever), HDFS_DATASET_URN);
+
+    Assert.assertEquals(browsePaths.getPaths().get(0), "/prod/hdfs/a/b");
+    verify(retriever)
+        .getLatestAspectObject(any(), eq(HDFS_PLATFORM_URN), eq(DATA_PLATFORM_INFO_ASPECT_NAME));
+  }
+
+  @Test
+  public void testGetDataPlatformInfoMissingFallsBackToDefaultDelimiter() {
+    CachingAspectRetriever retriever = mock(CachingAspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(), eq(HDFS_PLATFORM_URN), eq(DATA_PLATFORM_INFO_ASPECT_NAME)))
+        .thenReturn(null);
+
+    BrowsePaths browsePaths =
+        DefaultAspectsUtil.buildDefaultBrowsePath(mockOpContext(retriever), HDFS_DATASET_URN);
+
+    // Name has no '.', so default delimiter yields no dataset name path segments.
+    Assert.assertEquals(browsePaths.getPaths().get(0), "/prod/hdfs");
+    verify(retriever)
+        .getLatestAspectObject(any(), eq(HDFS_PLATFORM_URN), eq(DATA_PLATFORM_INFO_ASPECT_NAME));
+  }
+
+  @Test
+  public void testGetDataPlatformInfoExceptionFallsBackToDefaultDelimiter() {
+    CachingAspectRetriever retriever = mock(CachingAspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(), eq(HDFS_PLATFORM_URN), eq(DATA_PLATFORM_INFO_ASPECT_NAME)))
+        .thenThrow(new RuntimeException("cache miss failure"));
+
+    BrowsePaths browsePaths =
+        DefaultAspectsUtil.buildDefaultBrowsePath(mockOpContext(retriever), HDFS_DATASET_URN);
+
+    Assert.assertEquals(browsePaths.getPaths().get(0), "/prod/hdfs");
+  }
+
+  private OperationContext mockOpContext(CachingAspectRetriever retriever) {
+    OperationContext opContext = mock(OperationContext.class);
+    RetrieverContext retrieverContext = mock(RetrieverContext.class);
+    when(opContext.getEntityRegistry()).thenReturn(new TestEntityRegistry());
+    when(opContext.getRetrieverContext()).thenReturn(retrieverContext);
+    when(retrieverContext.getCachingAspectRetriever()).thenReturn(retriever);
+    return opContext;
+  }
 
   @Test
   public void testAdditionalChanges() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -47,8 +47,8 @@ public class EbeanEntityServiceOptimizationTest {
   // Default Aspect Generation Step
   // 1. *Key,
   // 2. browsePathsV2 & dataPlatformInstance
-  // 3. dataPlatformInfo
-  private static final int defaultAspectsGeneration = 3;
+  // dataPlatformInfo is read via cachingAspectRetriever, not EntityService/DAO
+  private static final int defaultAspectsGeneration = 2;
   // Next Version Calculation
   // 1. *Key
   // 2. browsePathsV2 & dataPlatformInstance

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/BrowsePathV2UtilsTest.java
@@ -1,8 +1,8 @@
 package com.linkedin.metadata.search.utils;
 
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -17,19 +17,15 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.container.Container;
 import com.linkedin.entity.Aspect;
-import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.entity.EnvelopedAspectMap;
-import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.entity.TestEntityRegistry;
 import com.linkedin.metadata.key.DataJobKey;
 import com.linkedin.metadata.key.DatasetKey;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RetrieverContext;
 import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -51,12 +47,11 @@ public class BrowsePathV2UtilsTest {
     Urn datasetUrn = UrnUtils.getUrn(DATASET_URN);
     final Urn containerUrn1 = UrnUtils.getUrn(CONTAINER_URN1);
     final Urn containerUrn2 = UrnUtils.getUrn(CONTAINER_URN2);
-    EntityService mockService =
-        initMockServiceWithContainerParents(datasetUrn, containerUrn1, containerUrn2);
+    OperationContext opContext =
+        mockOpContextWithContainerParents(datasetUrn, containerUrn1, containerUrn2);
 
     BrowsePathsV2 browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, datasetUrn, this.registry, '.', true);
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     BrowsePathEntry entry1 =
         new BrowsePathEntry().setId(containerUrn1.toString()).setUrn(containerUrn1);
@@ -70,14 +65,10 @@ public class BrowsePathV2UtilsTest {
   @Test
   public void testGetDefaultDatasetBrowsePathV2WithContainersFlagOff() throws URISyntaxException {
     Urn datasetUrn = UrnUtils.getUrn(DATASET_URN);
-    final Urn containerUrn1 = UrnUtils.getUrn(CONTAINER_URN1);
-    final Urn containerUrn2 = UrnUtils.getUrn(CONTAINER_URN2);
-    EntityService mockService =
-        initMockServiceWithContainerParents(datasetUrn, containerUrn1, containerUrn2);
 
     BrowsePathsV2 browsePathsV2 =
         BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+            mockOpContext(), datasetUrn, this.registry, '.', false);
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     BrowsePathEntry entry1 = new BrowsePathEntry().setId("test");
     BrowsePathEntry entry2 = new BrowsePathEntry().setId("a");
@@ -91,12 +82,11 @@ public class BrowsePathV2UtilsTest {
     Urn chartUrn = UrnUtils.getUrn(CHART_URN);
     final Urn containerUrn1 = UrnUtils.getUrn(CONTAINER_URN1);
     final Urn containerUrn2 = UrnUtils.getUrn(CONTAINER_URN2);
-    EntityService mockService =
-        initMockServiceWithContainerParents(chartUrn, containerUrn1, containerUrn2);
+    OperationContext opContext =
+        mockOpContextWithContainerParents(chartUrn, containerUrn1, containerUrn2);
 
     BrowsePathsV2 browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), chartUrn, this.registry, '.', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, chartUrn, this.registry, '.', true);
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     BrowsePathEntry entry1 =
         new BrowsePathEntry().setId(containerUrn1.toString()).setUrn(containerUrn1);
@@ -112,12 +102,11 @@ public class BrowsePathV2UtilsTest {
     Urn dashboardUrn = UrnUtils.getUrn(DASHBOARD_URN);
     final Urn containerUrn1 = UrnUtils.getUrn(CONTAINER_URN1);
     final Urn containerUrn2 = UrnUtils.getUrn(CONTAINER_URN2);
-    EntityService mockService =
-        initMockServiceWithContainerParents(dashboardUrn, containerUrn1, containerUrn2);
+    OperationContext opContext =
+        mockOpContextWithContainerParents(dashboardUrn, containerUrn1, containerUrn2);
 
     BrowsePathsV2 browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), dashboardUrn, this.registry, '.', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, dashboardUrn, this.registry, '.', true);
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     BrowsePathEntry entry1 =
         new BrowsePathEntry().setId(containerUrn1.toString()).setUrn(containerUrn1);
@@ -130,7 +119,7 @@ public class BrowsePathV2UtilsTest {
 
   @Test
   public void testGetDefaultBrowsePathV2WithoutContainers() throws URISyntaxException {
-    EntityService mockService = mock(EntityService.class);
+    OperationContext opContext = mockOpContext();
 
     // Datasets
     DatasetKey datasetKey =
@@ -139,15 +128,8 @@ public class BrowsePathV2UtilsTest {
             .setOrigin(FabricType.PROD)
             .setPlatform(Urn.createFromString("urn:li:dataPlatform:kafka"));
     Urn datasetUrn = EntityKeyUtils.convertEntityKeyToUrn(datasetKey, "dataset");
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(datasetUrn.getEntityType()),
-            eq(datasetUrn),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(new EntityResponse().setAspects(new EnvelopedAspectMap()));
     BrowsePathsV2 browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, datasetUrn, this.registry, '.', true);
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     BrowsePathEntry entry1 = new BrowsePathEntry().setId("Test");
     BrowsePathEntry entry2 = new BrowsePathEntry().setId("A");
@@ -157,15 +139,8 @@ public class BrowsePathV2UtilsTest {
 
     // Charts
     Urn chartUrn = UrnUtils.getUrn(CHART_URN);
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(chartUrn.getEntityType()),
-            eq(chartUrn),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(new EntityResponse().setAspects(new EnvelopedAspectMap()));
     browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), chartUrn, this.registry, '/', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, chartUrn, this.registry, '/', true);
     expectedPath = new BrowsePathEntryArray();
     entry1 = new BrowsePathEntry().setId("Default");
     expectedPath.add(entry1);
@@ -173,15 +148,8 @@ public class BrowsePathV2UtilsTest {
 
     // Dashboards
     Urn dashboardUrn = UrnUtils.getUrn(DASHBOARD_URN);
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(dashboardUrn.getEntityType()),
-            eq(dashboardUrn),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(new EntityResponse().setAspects(new EnvelopedAspectMap()));
     browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), dashboardUrn, this.registry, '/', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, dashboardUrn, this.registry, '/', true);
     expectedPath = new BrowsePathEntryArray();
     entry1 = new BrowsePathEntry().setId("Default");
     expectedPath.add(entry1);
@@ -189,15 +157,8 @@ public class BrowsePathV2UtilsTest {
 
     // Data Flows
     Urn dataFlowUrn = UrnUtils.getUrn(DATA_FLOW_URN);
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(dataFlowUrn.getEntityType()),
-            eq(dataFlowUrn),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(new EntityResponse().setAspects(new EnvelopedAspectMap()));
     browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), dataFlowUrn, this.registry, '/', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, dataFlowUrn, this.registry, '/', true);
     expectedPath = new BrowsePathEntryArray();
     entry1 = new BrowsePathEntry().setId("Default");
     expectedPath.add(entry1);
@@ -207,8 +168,7 @@ public class BrowsePathV2UtilsTest {
     DataJobKey dataJobKey = new DataJobKey().setFlow(dataFlowUrn).setJobId("Job/A/B");
     Urn dataJobUrn = EntityKeyUtils.convertEntityKeyToUrn(dataJobKey, "dataJob");
     browsePathsV2 =
-        BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), dataJobUrn, this.registry, '/', mockService, true);
+        BrowsePathV2Utils.getDefaultBrowsePathV2(opContext, dataJobUrn, this.registry, '/', true);
     expectedPath = new BrowsePathEntryArray();
     entry1 = new BrowsePathEntry().setId(dataFlowUrn.toString()).setUrn(dataFlowUrn);
     expectedPath.add(entry1);
@@ -224,22 +184,21 @@ public class BrowsePathV2UtilsTest {
     String snowflakeDatasetUrn =
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,myinstance.DB.SCHEMA.TABLE,PROD)";
     Urn datasetUrn = UrnUtils.getUrn(snowflakeDatasetUrn);
-    EntityService mockService = mock(EntityService.class);
-
     DataPlatformInstanceUrn platformInstanceUrn =
         new DataPlatformInstanceUrn(new DataPlatformUrn("snowflake"), "myinstance");
-    when(mockService.exists(any(OperationContext.class), eq(platformInstanceUrn), anyBoolean()))
-        .thenReturn(true);
+
+    CachingAspectRetriever retriever = mock(CachingAspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(), eq(platformInstanceUrn), eq(DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME)))
+        .thenReturn(new Aspect());
 
     BrowsePathsV2 browsePathsV2 =
         BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+            mockOpContext(retriever), datasetUrn, this.registry, '.', false);
 
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
-    // First entry: URN-form platform instance (corrected by tryResolvePlatformInstanceEntry)
     expectedPath.add(
         new BrowsePathEntry().setId(platformInstanceUrn.toString()).setUrn(platformInstanceUrn));
-    // Remaining entries: plain-name database and schema segments
     expectedPath.add(new BrowsePathEntry().setId("DB"));
     expectedPath.add(new BrowsePathEntry().setId("SCHEMA"));
     Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
@@ -254,12 +213,10 @@ public class BrowsePathV2UtilsTest {
     String snowflakeDatasetUrn =
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,myinstance.DB.SCHEMA.TABLE,PROD)";
     Urn datasetUrn = UrnUtils.getUrn(snowflakeDatasetUrn);
-    // No stubbing → exists() returns empty Set → tryResolvePlatformInstanceEntry is a no-op
-    EntityService mockService = mock(EntityService.class);
 
     BrowsePathsV2 browsePathsV2 =
         BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+            mockOpContext(), datasetUrn, this.registry, '.', false);
 
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     expectedPath.add(new BrowsePathEntry().setId("myinstance"));
@@ -268,20 +225,15 @@ public class BrowsePathV2UtilsTest {
     Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
   }
 
-  /**
-   * BigQuery datasets without a platform instance: exists() returns false, entries are unchanged.
-   */
+  /** BigQuery datasets without a platform instance: missing key aspect, entries are unchanged. */
   @Test
   public void testGetDefaultDatasetBrowsePathV2BigQueryNoPlatformInstance()
       throws URISyntaxException {
-    // DATASET_URN = urn:li:dataset:(urn:li:dataPlatform:bigquery,test.a.b,DEV)
     Urn datasetUrn = UrnUtils.getUrn(DATASET_URN);
-    // No stubbing → exists() returns empty Set → no change
-    EntityService mockService = mock(EntityService.class);
 
     BrowsePathsV2 browsePathsV2 =
         BrowsePathV2Utils.getDefaultBrowsePathV2(
-            mock(OperationContext.class), datasetUrn, this.registry, '.', mockService, false);
+            mockOpContext(), datasetUrn, this.registry, '.', false);
 
     BrowsePathEntryArray expectedPath = new BrowsePathEntryArray();
     expectedPath.add(new BrowsePathEntry().setId("test"));
@@ -289,43 +241,26 @@ public class BrowsePathV2UtilsTest {
     Assert.assertEquals(browsePathsV2.getPath(), expectedPath);
   }
 
-  private EntityService initMockServiceWithContainerParents(
-      Urn entityUrn, Urn containerUrn1, Urn containerUrn2) throws URISyntaxException {
-    EntityService mockService = mock(EntityService.class);
+  private OperationContext mockOpContext() {
+    return mockOpContext(mock(CachingAspectRetriever.class));
+  }
 
-    final Container container1 = new Container().setContainer(containerUrn1);
-    final Map<String, EnvelopedAspect> aspectMap1 = new HashMap<>();
-    aspectMap1.put(
-        CONTAINER_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(container1.data())));
-    final EntityResponse entityResponse1 =
-        new EntityResponse().setAspects(new EnvelopedAspectMap(aspectMap1));
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(entityUrn.getEntityType()),
-            eq(entityUrn),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(entityResponse1);
+  private OperationContext mockOpContext(CachingAspectRetriever retriever) {
+    when(retriever.getLatestAspectObjects(any(), any(), any())).thenReturn(Map.of());
+    OperationContext opContext = mock(OperationContext.class);
+    RetrieverContext retrieverContext = mock(RetrieverContext.class);
+    when(opContext.getRetrieverContext()).thenReturn(retrieverContext);
+    when(retrieverContext.getCachingAspectRetriever()).thenReturn(retriever);
+    return opContext;
+  }
 
-    final Container container2 = new Container().setContainer(containerUrn2);
-    final Map<String, EnvelopedAspect> aspectMap2 = new HashMap<>();
-    aspectMap2.put(
-        CONTAINER_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(container2.data())));
-    final EntityResponse entityResponse2 =
-        new EntityResponse().setAspects(new EnvelopedAspectMap(aspectMap2));
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(containerUrn1.getEntityType()),
-            eq(containerUrn1),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(entityResponse2);
-
-    when(mockService.getEntityV2(
-            any(OperationContext.class),
-            eq(containerUrn2.getEntityType()),
-            eq(containerUrn2),
-            eq(Collections.singleton(CONTAINER_ASPECT_NAME))))
-        .thenReturn(new EntityResponse().setAspects(new EnvelopedAspectMap()));
-
-    return mockService;
+  private OperationContext mockOpContextWithContainerParents(
+      Urn entityUrn, Urn containerUrn1, Urn containerUrn2) {
+    CachingAspectRetriever retriever = mock(CachingAspectRetriever.class);
+    when(retriever.getLatestAspectObject(any(), eq(entityUrn), eq(CONTAINER_ASPECT_NAME)))
+        .thenReturn(new Aspect(new Container().setContainer(containerUrn1).data()));
+    when(retriever.getLatestAspectObject(any(), eq(containerUrn1), eq(CONTAINER_ASPECT_NAME)))
+        .thenReturn(new Aspect(new Container().setContainer(containerUrn2).data()));
+    return mockOpContext(retriever);
   }
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1777,6 +1777,10 @@ cache:
           telemetryClientId: 86400 # 1 day
         dataHubRetention:
           dataHubRetentionConfig: 21600 # 6hrs
+        dataPlatform:
+          dataPlatformInfo: 86400 # 1 day
+        dataPlatformInstance:
+          dataPlatformInstanceKey: 300 # 5 min
 
 graphQL:
   graphiql:


### PR DESCRIPTION
Route delimiter and browse-path reference reads through OperationContext's cachingAspectRetriever so new-entity ingest does not hit the DB for the same dataPlatformInfo on every URN.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches Data Platform delimiter, container ancestry, and platform instance lookups via `OperationContext`’s `cachingAspectRetriever`, replacing `EntityService` reads to cut repeated DB queries during new-entity ingest without changing browse-path behavior.

- Replaces `EntityService` calls in `DefaultAspectsUtil` and `BrowsePathV2Utils` with cached aspect reads (`DataPlatformInfo`, `Container`, and `dataPlatformInstanceKey` checks).
- Updates `BackfillBrowsePathsV2Step` to use the new `buildDefaultBrowsePathV2(opContext, urn, useContainerPaths)` signature.
- Adds cache TTLs in `application.yaml`: `dataPlatformInfo` 1 day, `dataPlatformInstanceKey` 5 minutes.
- Tests now mock `CachingAspectRetriever`, reduce DAO interactions, and add coverage for cached `DataPlatformInfo` delimiter resolution and fallback behavior.

**Migration**
- Drop the `EntityService` argument from `buildDefaultBrowsePath`, `buildDefaultBrowsePathV2`, and `getDefaultBrowsePathV2`. Pass `OperationContext`, `Urn`, and `useContainerPaths` where applicable.

<sup>Written for commit 64ad7f3073ed7885df8bf46c9af0deb320c39822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

