### PR TITLE
fix(entity): route EntityClient default methods through cached batchGetV2

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/client/EntityClientGetLatestAspectsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/EntityClientGetLatestAspectsTest.java
@@ -1,0 +1,102 @@
+package com.linkedin.metadata.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.client.EntityClient;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that {@link EntityClient#getLatestAspects} routes through the 4-arg {@code batchGetV2}
+ * (cacheable) rather than the 5-arg overload, and that {@code alwaysIncludeKeyAspect=true}
+ * synthesizes the key aspect client-side without polluting the cache key.
+ */
+public class EntityClientGetLatestAspectsTest {
+
+  private static final Urn DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)");
+
+  private EntityClient entityClient;
+  private OperationContext opContext;
+
+  @BeforeMethod
+  public void setup() {
+    entityClient =
+        mock(EntityClient.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    opContext = TestOperationContexts.systemContextNoSearchAuthorization();
+  }
+
+  @Test
+  public void testGetLatestAspectsRoutesThroughCachedOverload() throws Exception {
+    when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(Map.of());
+
+    entityClient.getLatestAspects(opContext, Set.of(DATASET_URN), Set.of("ownership"), false);
+
+    // Must call the 4-arg (cached) overload with unmodified aspectNames
+    verify(entityClient)
+        .batchGetV2(eq(opContext), eq("dataset"), eq(Set.of(DATASET_URN)), eq(Set.of("ownership")));
+  }
+
+  @Test
+  public void testGetLatestAspectsWithKeyAspectSynthesizesWithoutCachePollution() throws Exception {
+    when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(Map.of());
+
+    Map<Urn, Map<String, Aspect>> result =
+        entityClient.getLatestAspects(opContext, Set.of(DATASET_URN), Set.of("ownership"), true);
+
+    // batchGetV2 called with original aspectNames — key aspect NOT added to the cache key
+    verify(entityClient)
+        .batchGetV2(eq(opContext), eq("dataset"), eq(Set.of(DATASET_URN)), eq(Set.of("ownership")));
+
+    // Key aspect synthesized in the result
+    Map<String, Aspect> aspects = result.get(DATASET_URN);
+    assertNotNull(aspects);
+    Aspect keyAspect = aspects.get("datasetKey");
+    assertNotNull(keyAspect, "Key aspect should be synthesized when alwaysIncludeKeyAspect=true");
+    assertEquals(aspects.size(), 1, "Only the synthesized key aspect should be present");
+  }
+
+  @Test
+  public void testGetLatestSystemAspectRoutesThroughCachedOverload() throws Exception {
+    when(entityClient.batchGetV2(any(), any(), any(), any())).thenReturn(Map.of());
+
+    entityClient.getLatestSystemAspect(
+        opContext, Set.of(DATASET_URN), Set.of("schemaMetadata"), false);
+
+    verify(entityClient)
+        .batchGetV2(
+            eq(opContext), eq("dataset"), eq(Set.of(DATASET_URN)), eq(Set.of("schemaMetadata")));
+  }
+
+  @Test
+  public void testGetLatestSystemAspectWithKeyAspectCallsUncachedOverload() throws Exception {
+    when(entityClient.batchGetV2(any(), any(), any(), any(), any())).thenReturn(Map.of());
+
+    entityClient.getLatestSystemAspect(
+        opContext, Set.of(DATASET_URN), Set.of("schemaMetadata"), true);
+
+    // Must call the 5-arg (uncached) overload since SystemAspect needs DB metadata
+    verify(entityClient)
+        .batchGetV2(
+            eq(opContext),
+            eq("dataset"),
+            eq(Set.of(DATASET_URN)),
+            eq(Set.of("schemaMetadata")),
+            eq(true));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/client/EntityClientGetLatestAspectsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/EntityClientGetLatestAspectsTest.java
@@ -9,10 +9,12 @@ import static org.mockito.Mockito.withSettings;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.key.DatasetKey;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Map;
@@ -69,6 +71,12 @@ public class EntityClientGetLatestAspectsTest {
     Aspect keyAspect = aspects.get("datasetKey");
     assertNotNull(keyAspect, "Key aspect should be synthesized when alwaysIncludeKeyAspect=true");
     assertEquals(aspects.size(), 1, "Only the synthesized key aspect should be present");
+
+    DatasetUrn datasetUrn = DatasetUrn.createFromUrn(DATASET_URN);
+    DatasetKey datasetKey = new DatasetKey(keyAspect.data());
+    assertEquals(datasetKey.getPlatform(), datasetUrn.getPlatformEntity());
+    assertEquals(datasetKey.getName(), datasetUrn.getDatasetNameEntity());
+    assertEquals(datasetKey.getOrigin(), datasetUrn.getOriginEntity());
   }
 
   @Test

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;
 import com.linkedin.metadata.graph.LineageDirection;
+import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.AutoCompleteResult;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.query.ListUrnsResult;
@@ -27,6 +28,7 @@ import com.linkedin.metadata.search.LineageScrollResult;
 import com.linkedin.metadata.search.LineageSearchResult;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.EntityApiUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.PlatformEvent;
 import com.linkedin.mxe.SystemMetadata;
@@ -34,6 +36,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -684,6 +687,10 @@ public interface EntityClient {
         .get(aspectName);
   }
 
+  // Routes through the 4-arg batchGetV2 so SystemEntityClient implementations can intercept
+  // it with a cache. The 5-arg overload bypasses that cache. When alwaysIncludeKeyAspect is
+  // requested, the key aspect is synthesized from the URN after the cached fetch — zero DB
+  // cost, no cache-key pollution, and no contract change on other batchGetV2 callers.
   @Nonnull
   default Map<Urn, Map<String, Aspect>> getLatestAspects(
       @Nonnull OperationContext opContext,
@@ -692,10 +699,26 @@ public interface EntityClient {
       @Nullable Boolean alwaysIncludeKeyAspect)
       throws RemoteInvocationException, URISyntaxException {
     String entityName = urns.stream().findFirst().map(Urn::getEntityType).get();
-    return entityResponseToAspectMap(
-        batchGetV2(opContext, entityName, urns, aspectNames, alwaysIncludeKeyAspect));
+    Map<Urn, Map<String, Aspect>> result =
+        entityResponseToAspectMap(batchGetV2(opContext, entityName, urns, aspectNames));
+    if (alwaysIncludeKeyAspect != null && alwaysIncludeKeyAspect) {
+      EntityRegistry registry = opContext.getEntityRegistry();
+      for (Urn urn : urns) {
+        Map<String, Aspect> aspects = result.computeIfAbsent(urn, k -> new HashMap<>());
+        String keyName = opContext.getKeyAspectName(urn);
+        if (!aspects.containsKey(keyName)) {
+          RecordTemplate key = EntityApiUtils.buildKeyAspect(registry, urn);
+          aspects.put(keyName, new Aspect(key.data()));
+        }
+      }
+    }
+    return result;
   }
 
+  // Same cache-routing rationale as getLatestAspects above. When alwaysIncludeKeyAspect is
+  // requested, the call falls through to the uncached 5-arg batchGetV2 because SystemAspect
+  // carries DB metadata (version, createdOn, systemMetadata) that cannot be synthesized from
+  // the URN alone.
   @Nonnull
   default Map<Urn, Map<String, SystemAspect>> getLatestSystemAspect(
       @Nonnull OperationContext opContext,
@@ -704,8 +727,12 @@ public interface EntityClient {
       @Nullable Boolean alwaysIncludeKeyAspect)
       throws RemoteInvocationException, URISyntaxException {
     String entityName = urns.stream().findFirst().map(Urn::getEntityType).get();
+    if (alwaysIncludeKeyAspect != null && alwaysIncludeKeyAspect) {
+      return entityResponseToSystemAspectMap(
+          batchGetV2(opContext, entityName, urns, aspectNames, true),
+          opContext.getEntityRegistry());
+    }
     return entityResponseToSystemAspectMap(
-        batchGetV2(opContext, entityName, urns, aspectNames, alwaysIncludeKeyAspect),
-        opContext.getEntityRegistry());
+        batchGetV2(opContext, entityName, urns, aspectNames), opContext.getEntityRegistry());
   }
 }


### PR DESCRIPTION
Problem:
EntityClient.getLatestAspects and getLatestSystemAspect default methods always called the 5-arg batchGetV2(..., alwaysIncludeKeyAspect). On SystemJavaEntityClient that overload skips the entity response cache, so hot paths that only need latest aspects paid a full DB/remote fetch even when the 4-arg cached path would have hit.

Fix:
- alwaysIncludeKeyAspect=false (or null): call the 4-arg batchGetV2 so SystemEntityClient implementations can serve from cache.
- getLatestAspects with alwaysIncludeKeyAspect=true: still use the cached 4-arg fetch, then synthesize the key aspect from the URN via EntityApiUtils.buildKeyAspect (no extra DB round-trip, cache key stays the requested aspect set).
- getLatestSystemAspect with alwaysIncludeKeyAspect=true: fall through to the uncached 5-arg batchGetV2, because SystemAspect needs DB metadata (version, createdOn, systemMetadata) that cannot be synthesized.

No current in-repo caller passes alwaysIncludeKeyAspect=true through EntityClient; the true branches are kept for API completeness.

Adds EntityClientGetLatestAspectsTest covering cache routing and key aspect synthesis behavior.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `EntityClient.getLatestAspects` and `getLatestSystemAspect` through the cached 4-arg `batchGetV2` when `alwaysIncludeKeyAspect` is false or null, avoiding the uncached 5-arg path and cutting unnecessary DB/remote fetches on latest-only reads.

- `getLatestAspects`: with `alwaysIncludeKeyAspect=false/null`, call the cached 4-arg fetch. With `true`, still use the cached 4-arg fetch and synthesize the key aspect from the URN via `EntityApiUtils.buildKeyAspect` (using the `EntityRegistry` and `opContext.getKeyAspectName`), so no DB hit and no cache-key change.
- `getLatestSystemAspect`: with `alwaysIncludeKeyAspect=false/null`, call the cached 4-arg fetch; with `true`, use the uncached 5-arg fetch because `SystemAspect` requires DB metadata.
- No in-repo callers use `alwaysIncludeKeyAspect=true`; no migration required.
- Adds `EntityClientGetLatestAspectsTest` to verify cache routing and that the synthesized `datasetKey` matches the URN’s platform, name, and origin.

<sup>Written for commit 8166289bef08fde0d31e1442fb652f8d70445745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

