### PR TITLE
fix(smoke-test): wait for searchable ingest and UPSERT missing migrate lineage

### DIFF
--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -362,25 +362,27 @@ def merge_additive_aspects(
     if "upstreamLineage" in src_aspects:
         aspect = src_aspects["upstreamLineage"]
         assert isinstance(aspect, UpstreamLineageClass)
+        has_lineage = bool(aspect.upstreams) or bool(aspect.fineGrainedLineages)
         # JSON PATCH against a missing aspect is a no-op in GMS (it logs
         # "Did not find ... aspect: upstreamLineage version: 0" and never
         # writes). UPSERT creates the aspect; PATCH is only for unioning
-        # into lineage that already exists.
-        existing_lineage = graph.get_aspect(dst_urn, UpstreamLineageClass)
-        if existing_lineage is None:
-            if not dry_run:
-                graph.emit_mcp(
-                    MetadataChangeProposalWrapper(
-                        entityUrn=dst_urn,
-                        aspect=aspect,
+        # into lineage that already exists. Empty source lineage is a no-op.
+        if has_lineage:
+            existing_lineage = graph.get_aspect(dst_urn, UpstreamLineageClass)
+            if existing_lineage is None:
+                if not dry_run:
+                    graph.emit_mcp(
+                        MetadataChangeProposalWrapper(
+                            entityUrn=dst_urn,
+                            aspect=aspect,
+                        )
                     )
-                )
-            lineage_upserts = 1
-        else:
-            for upstream in aspect.upstreams or []:
-                patch_builder.add_upstream_lineage(upstream)
-            for fine_grained in aspect.fineGrainedLineages or []:
-                patch_builder.add_fine_grained_lineage(fine_grained)
+                lineage_upserts = 1
+            else:
+                for upstream in aspect.upstreams or []:
+                    patch_builder.add_upstream_lineage(upstream)
+                for fine_grained in aspect.fineGrainedLineages or []:
+                    patch_builder.add_fine_grained_lineage(fine_grained)
 
     mcps = patch_builder.build()
     for mcp in mcps:

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -325,7 +325,8 @@ def merge_additive_aspects(
 ) -> int:
     """Merge additive aspects from source into existing target via Patch API.
 
-    Returns the number of patch MCPs emitted.
+    Returns the number of MCPs emitted (JSON patches, plus a lineage UPSERT
+    when the target has no ``upstreamLineage`` aspect yet).
 
     **Known limitation (multi-downstream FGL):** the Patch API keys
     fine-grained lineage entries on ``(transformOp, downstream, query)`` and
@@ -338,6 +339,7 @@ def merge_additive_aspects(
     multi-downstream FGL entries.
     """
     patch_builder = DatasetPatchBuilder(dst_urn)
+    lineage_upserts = 0
 
     if "ownership" in src_aspects:
         aspect = src_aspects["ownership"]
@@ -360,16 +362,31 @@ def merge_additive_aspects(
     if "upstreamLineage" in src_aspects:
         aspect = src_aspects["upstreamLineage"]
         assert isinstance(aspect, UpstreamLineageClass)
-        for upstream in aspect.upstreams or []:
-            patch_builder.add_upstream_lineage(upstream)
-        for fine_grained in aspect.fineGrainedLineages or []:
-            patch_builder.add_fine_grained_lineage(fine_grained)
+        # JSON PATCH against a missing aspect is a no-op in GMS (it logs
+        # "Did not find ... aspect: upstreamLineage version: 0" and never
+        # writes). UPSERT creates the aspect; PATCH is only for unioning
+        # into lineage that already exists.
+        existing_lineage = graph.get_aspect(dst_urn, UpstreamLineageClass)
+        if existing_lineage is None:
+            if not dry_run:
+                graph.emit_mcp(
+                    MetadataChangeProposalWrapper(
+                        entityUrn=dst_urn,
+                        aspect=aspect,
+                    )
+                )
+            lineage_upserts = 1
+        else:
+            for upstream in aspect.upstreams or []:
+                patch_builder.add_upstream_lineage(upstream)
+            for fine_grained in aspect.fineGrainedLineages or []:
+                patch_builder.add_fine_grained_lineage(fine_grained)
 
     mcps = patch_builder.build()
     for mcp in mcps:
         if not dry_run:
             graph.emit(mcp)
-    return len(mcps)
+    return len(mcps) + lineage_upserts
 
 
 def should_overwrite_scalar(

--- a/metadata-ingestion/src/datahub/cli/migration_utils.py
+++ b/metadata-ingestion/src/datahub/cli/migration_utils.py
@@ -363,10 +363,12 @@ def merge_additive_aspects(
         aspect = src_aspects["upstreamLineage"]
         assert isinstance(aspect, UpstreamLineageClass)
         has_lineage = bool(aspect.upstreams) or bool(aspect.fineGrainedLineages)
-        # JSON PATCH against a missing aspect is a no-op in GMS (it logs
-        # "Did not find ... aspect: upstreamLineage version: 0" and never
-        # writes). UPSERT creates the aspect; PATCH is only for unioning
-        # into lineage that already exists. Empty source lineage is a no-op.
+        # DatasetPatchBuilder lineage PATCH is a GMS no-op when the target has
+        # no upstreamLineage: it is a plain JSON Patch (no GenericJsonPatch /
+        # arrayPrimaryKeys), and GMS never writes. Ownership, globalTags, and
+        # glossaryTerms PATCH through GenericJsonPatch + aspect templates, which
+        # create the aspect from a default. UPSERT is lineage-only. Empty source
+        # lineage is a no-op; PATCH is only for unioning into existing lineage.
         if has_lineage:
             existing_lineage = graph.get_aspect(dst_urn, UpstreamLineageClass)
             if existing_lineage is None:

--- a/metadata-ingestion/tests/unit/cli/test_migration_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_utils.py
@@ -211,14 +211,56 @@ class TestMergeAdditiveAspects:
             "upstreamLineage": UpstreamLineageClass(upstreams=[upstream])
         }
         graph = MagicMock()
+        graph.get_aspect.return_value = UpstreamLineageClass(upstreams=[])
 
         result = merge_additive_aspects(src_aspects, self.DST_URN, graph, False)
 
         assert result > 0
+        graph.emit_mcp.assert_not_called()
         assert any(
             name == "upstreamLineage" and "src.table" in value
             for name, value in _emitted_patch_values(graph)
         )
+
+    def test_upserts_lineage_when_target_has_none(self):
+        """Missing target lineage is created with UPSERT, not a no-op PATCH."""
+        upstream = UpstreamClass(
+            dataset="urn:li:dataset:(urn:li:dataPlatform:snowflake,src.table,PROD)",
+            type="TRANSFORMED",
+        )
+        src_aspects: Dict[str, DictWrapper] = {
+            "upstreamLineage": UpstreamLineageClass(upstreams=[upstream])
+        }
+        graph = MagicMock()
+        graph.get_aspect.return_value = None
+
+        result = merge_additive_aspects(src_aspects, self.DST_URN, graph, False)
+
+        assert result == 1
+        graph.emit.assert_not_called()
+        graph.emit_mcp.assert_called_once()
+        mcp = graph.emit_mcp.call_args.args[0]
+        assert mcp.entityUrn == self.DST_URN
+        assert isinstance(mcp.aspect, UpstreamLineageClass)
+        assert mcp.aspect.upstreams[0].dataset == upstream.dataset
+
+    def test_upserts_lineage_dry_run_does_not_emit(self):
+        """Dry-run still counts a lineage UPSERT but does not emit it."""
+        upstream = UpstreamClass(
+            dataset="urn:li:dataset:(urn:li:dataPlatform:snowflake,src.table,PROD)",
+            type="TRANSFORMED",
+        )
+        src_aspects: Dict[str, DictWrapper] = {
+            "upstreamLineage": UpstreamLineageClass(upstreams=[upstream])
+        }
+        graph = MagicMock()
+        graph.get_aspect.return_value = None
+
+        result = merge_additive_aspects(src_aspects, self.DST_URN, graph, True)
+
+        assert result == 1
+        graph.emit.assert_not_called()
+        graph.emit_mcp.assert_not_called()
 
     def test_empty_aspects_no_patches(self):
         """No patches should be emitted when there are no additive aspects."""

--- a/metadata-ingestion/tests/unit/cli/test_migration_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_utils.py
@@ -244,6 +244,20 @@ class TestMergeAdditiveAspects:
         assert isinstance(mcp.aspect, UpstreamLineageClass)
         assert mcp.aspect.upstreams[0].dataset == upstream.dataset
 
+    def test_skips_empty_lineage_upsert(self):
+        src_aspects: Dict[str, DictWrapper] = {
+            "upstreamLineage": UpstreamLineageClass(upstreams=[])
+        }
+        graph = MagicMock()
+        graph.get_aspect.return_value = None
+
+        result = merge_additive_aspects(src_aspects, self.DST_URN, graph, False)
+
+        assert result == 0
+        graph.get_aspect.assert_not_called()
+        graph.emit.assert_not_called()
+        graph.emit_mcp.assert_not_called()
+
     def test_upserts_lineage_dry_run_does_not_emit(self):
         """Dry-run still counts a lineage UPSERT but does not emit it."""
         upstream = UpstreamClass(

--- a/smoke-test/tests/browse/browse_test.py
+++ b/smoke-test/tests/browse/browse_test.py
@@ -4,7 +4,11 @@ from typing import Any, Dict
 import pytest
 
 from conftest import _ingest_cleanup_data_impl
-from tests.utils import execute_graphql
+from tests.utils import (
+    execute_graphql,
+    wait_for_browse_path_entities,
+    wait_for_browse_path_entity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,19 @@ def test_get_browse_paths(auth_session, ingest_cleanup_data):
     # /prod -- There should be one entity
     # These are all read-only browse queries with no writes in between, so the
     # first two skip the sync wait -- only the final query's response needs one.
+    wait_for_browse_path_entity(
+        auth_session,
+        path=["prod"],
+        expected_urn=TEST_DATASET_3_URN,
+        entity_type="DATASET",
+    )
+    wait_for_browse_path_entities(
+        auth_session,
+        path=["prod", "kafka1"],
+        expected_urns=[TEST_DATASET_1_URN, TEST_DATASET_2_URN, TEST_DATASET_3_URN],
+        entity_type="DATASET",
+    )
+
     variables: Dict[str, Any] = {
         "input": {"type": "DATASET", "path": ["prod"], "start": 0, "count": 100}
     }

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import time
 from random import randint
 
+from datahub.cli.migration_utils import get_incoming_relationships
 from datahub.emitter.mce_builder import (
     make_dashboard_urn,
     make_data_platform_urn,
@@ -47,7 +49,7 @@ from datahub.metadata.schema_classes import (
     UpstreamLineageClass,
 )
 from tests.consistency_utils import wait_for_writes_to_sync
-from tests.utils import delete_urns, run_datahub_cmd
+from tests.utils import delete_urns, get_sleep_info, run_datahub_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -380,6 +382,29 @@ def _seed_urns_mapping_scenario(graph_client: DataHubGraph) -> None:
     wait_for_writes_to_sync()
 
 
+def _wait_for_incoming_asserts(
+    graph: DataHubGraph, dataset_urn: str, assertion_urns: list[str]
+) -> None:
+    """Poll until assertion URNs are incoming Asserts edges on the dataset."""
+    expected = set(assertion_urns)
+    sleep_sec, sleep_times = get_sleep_info()
+    found: set[str] = set()
+    for attempt in range(sleep_times):
+        found = {
+            rel.urn
+            for rel in get_incoming_relationships(dataset_urn, graph=graph)
+            if rel.relationship_type == "Asserts"
+        }
+        if expected <= found:
+            return
+        if attempt < sleep_times - 1:
+            time.sleep(sleep_sec)
+    raise AssertionError(
+        f"Incoming Asserts on {dataset_urn} did not include {sorted(expected)}; "
+        f"found {sorted(found)}"
+    )
+
+
 def test_urns_mapping_full_scenario(graph_client: DataHubGraph, tmp_path) -> None:
     """A multi-entity urns-mapping migration (dataset + dashboard) carries every
     user aspect, rewrites the dataset's own column-level lineage, and repoints the
@@ -397,6 +422,7 @@ def test_urns_mapping_full_scenario(graph_client: DataHubGraph, tmp_path) -> Non
     delete_urns(graph_client, all_urns)
     wait_for_writes_to_sync()
     _seed_urns_mapping_scenario(graph_client)
+    _wait_for_incoming_asserts(graph_client, um_ds_src, [um_assert1, um_assert2])
 
     # Migrate the referenced entity (dataset) before the referrer (dashboard):
     # the dataset's incoming-reference pass repoints the dashboard in the primary
@@ -490,6 +516,7 @@ def test_assertion_reference_is_rewritten(graph_client: DataHubGraph) -> None:
     ]:
         graph_client.emit_mcp(mcp)
     wait_for_writes_to_sync()
+    _wait_for_incoming_asserts(graph_client, asrt_src, [assertion_urn])
 
     try:
         result = run_datahub_cmd(

--- a/smoke-test/tests/unit/test_ingest_search_wait.py
+++ b/smoke-test/tests/unit/test_ingest_search_wait.py
@@ -149,6 +149,41 @@ def test_wait_for_ingested_urns_searchable_retries_when_graphql_errors(
     assert responses == []
 
 
+def test_wait_for_ingested_urns_searchable_retries_when_graphql_raises(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": MCP_URN}]))
+
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    responses = [
+        ConnectionError("network down"),
+        {
+            "data": {
+                "searchAcrossEntities": {
+                    "searchResults": [{"entity": {"urn": MCP_URN}}]
+                }
+            }
+        },
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        next_response = responses.pop(0)
+        if isinstance(next_response, Exception):
+            raise next_response
+        return next_response
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+    assert sleeps == [1]
+    assert responses == []
+
+
 def test_wait_for_ingested_urns_searchable_times_out_when_graphql_errors(
     tmp_path, monkeypatch
 ):
@@ -257,6 +292,35 @@ def test_wait_for_browse_path_entities_retries_on_graphql_errors(monkeypatch):
     def fake_graphql(*args, **kwargs):
         assert kwargs.get("expect_errors") is True
         return responses.pop(0)
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_browse_path_entities(
+        MagicMock(),
+        path=["prod"],
+        expected_urns=[SNAPSHOT_URN],
+        entity_type="DATASET",
+    )
+    assert sleeps == [1]
+    assert responses == []
+
+
+def test_wait_for_browse_path_entities_retries_when_graphql_raises(monkeypatch):
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    responses = [
+        ConnectionError("network down"),
+        {"data": {"browse": {"entities": [{"urn": SNAPSHOT_URN}]}}},
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        assert kwargs.get("expect_errors") is True
+        next_response = responses.pop(0)
+        if isinstance(next_response, Exception):
+            raise next_response
+        return next_response
 
     monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
 

--- a/smoke-test/tests/unit/test_ingest_search_wait.py
+++ b/smoke-test/tests/unit/test_ingest_search_wait.py
@@ -117,7 +117,39 @@ def test_wait_for_ingested_urns_searchable_skips_non_searchable_types(
     assert search_calls == [[MCP_URN]]
 
 
-def test_wait_for_ingested_urns_searchable_skips_when_graphql_errors(
+def test_wait_for_ingested_urns_searchable_retries_when_graphql_errors(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": MCP_URN}]))
+
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    responses = [
+        {"errors": [{"message": "boom"}]},
+        {
+            "data": {
+                "searchAcrossEntities": {
+                    "searchResults": [{"entity": {"urn": MCP_URN}}]
+                }
+            }
+        },
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+    assert sleeps == [1]
+    assert responses == []
+
+
+def test_wait_for_ingested_urns_searchable_times_out_when_graphql_errors(
     tmp_path, monkeypatch
 ):
     path = tmp_path / "ingest.json"
@@ -130,7 +162,8 @@ def test_wait_for_ingested_urns_searchable_skips_when_graphql_errors(
         lambda *args, **kwargs: {"errors": [{"message": "boom"}]},
     )
 
-    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+    with pytest.raises(AssertionError, match="not searchable"):
+        wait_for_ingested_urns_searchable(MagicMock(), str(path))
 
 
 def test_wait_for_ingested_urns_searchable_times_out(tmp_path, monkeypatch):
@@ -205,6 +238,32 @@ def test_wait_for_browse_path_entities_waits_for_all_urns(monkeypatch):
         MagicMock(),
         path=["prod", "kafka1"],
         expected_urns=[SNAPSHOT_URN, other],
+        entity_type="DATASET",
+    )
+    assert sleeps == [1]
+    assert responses == []
+
+
+def test_wait_for_browse_path_entities_retries_on_graphql_errors(monkeypatch):
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    responses = [
+        {"errors": [{"message": "boom"}]},
+        {"data": {"browse": {"entities": [{"urn": SNAPSHOT_URN}]}}},
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        assert kwargs.get("expect_errors") is True
+        return responses.pop(0)
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_browse_path_entities(
+        MagicMock(),
+        path=["prod"],
+        expected_urns=[SNAPSHOT_URN],
         entity_type="DATASET",
     )
     assert sleeps == [1]

--- a/smoke-test/tests/unit/test_ingest_search_wait.py
+++ b/smoke-test/tests/unit/test_ingest_search_wait.py
@@ -1,0 +1,211 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils import (
+    entity_urns_from_ingest_file,
+    searchable_ingest_urns,
+    wait_for_browse_path_entities,
+    wait_for_browse_path_entity,
+    wait_for_ingested_urns_searchable,
+)
+
+pytestmark = pytest.mark.no_cypress_suite1
+
+SNAPSHOT_URN = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-browse-3,PROD)"
+MCP_URN = "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.table,PROD)"
+ASSERTION_URN = "urn:li:assertion:test-assertion"
+INCIDENT_URN = "urn:li:incident:test-incident"
+PLATFORM_URN = "urn:li:dataPlatform:postgres"
+ENTITY_TYPE_URN = "urn:li:entityType:dataset"
+QUERY_URN = "urn:li:query:test-query"
+POST_URN = "urn:li:post:test-post"
+STRUCTURED_PROPERTY_URN = "urn:li:structuredProperty:io.datahub.test.formsSmokeProperty"
+DPI_URN = "urn:li:dataProcessInstance:test-dpi"
+DPI_PLATFORM_URN = "urn:li:dataPlatformInstance:(urn:li:dataPlatform:airflow,prod)"
+
+
+def test_entity_urns_from_snapshot_and_mcp(tmp_path):
+    payload = [
+        {
+            "proposedSnapshot": {
+                "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                    "urn": SNAPSHOT_URN,
+                    "aspects": [],
+                }
+            }
+        },
+        {"entityUrn": MCP_URN, "aspectName": "datasetProperties"},
+        {"entityUrn": MCP_URN, "aspectName": "schemaMetadata"},
+    ]
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps(payload))
+
+    assert entity_urns_from_ingest_file(str(path)) == [SNAPSHOT_URN, MCP_URN]
+
+
+def test_wait_for_ingested_urns_searchable_retries_until_found(tmp_path, monkeypatch):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": MCP_URN}]))
+
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    search_calls: list = []
+
+    def fake_search(auth_session, urns):
+        search_calls.append(list(urns))
+        if len(search_calls) < 2:
+            return set()
+        return {MCP_URN}
+
+    monkeypatch.setattr("tests.utils._search_results_contain_urns", fake_search)
+
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+    assert search_calls == [[MCP_URN], [MCP_URN]]
+    assert sleeps == [1]
+
+
+def test_searchable_ingest_urns_skips_non_catalog_types():
+    mixed = [
+        MCP_URN,
+        ASSERTION_URN,
+        INCIDENT_URN,
+        PLATFORM_URN,
+        ENTITY_TYPE_URN,
+        QUERY_URN,
+        POST_URN,
+        STRUCTURED_PROPERTY_URN,
+        DPI_URN,
+        DPI_PLATFORM_URN,
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db.t,PROD),col)",
+    ]
+    assert searchable_ingest_urns(mixed) == [MCP_URN]
+
+
+def test_wait_for_ingested_urns_searchable_skips_non_searchable_types(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "ingest.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"entityUrn": ASSERTION_URN},
+                {"entityUrn": INCIDENT_URN},
+                {"entityUrn": PLATFORM_URN},
+                {"entityUrn": ENTITY_TYPE_URN},
+                {"entityUrn": MCP_URN},
+            ]
+        )
+    )
+
+    search_calls: list = []
+
+    def fake_search(auth_session, urns):
+        search_calls.append(list(urns))
+        return {MCP_URN}
+
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", lambda seconds: None)
+    monkeypatch.setattr("tests.utils._search_results_contain_urns", fake_search)
+
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+    assert search_calls == [[MCP_URN]]
+
+
+def test_wait_for_ingested_urns_searchable_skips_when_graphql_errors(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": MCP_URN}]))
+
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (0, 2))
+    monkeypatch.setattr("tests.utils.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        "tests.utils.execute_graphql",
+        lambda *args, **kwargs: {"errors": [{"message": "boom"}]},
+    )
+
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+
+def test_wait_for_ingested_urns_searchable_times_out(tmp_path, monkeypatch):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": MCP_URN}]))
+
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (0, 2))
+    monkeypatch.setattr("tests.utils.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        "tests.utils._search_results_contain_urns", lambda *args, **kwargs: set()
+    )
+
+    with pytest.raises(AssertionError, match="not searchable"):
+        wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+
+def test_wait_for_ingested_urns_searchable_empty_when_only_non_searchable(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "ingest.json"
+    path.write_text(json.dumps([{"entityUrn": ASSERTION_URN}]))
+
+    def fail_search(*args, **kwargs):
+        raise AssertionError("should not search non-searchable types")
+
+    monkeypatch.setattr("tests.utils._search_results_contain_urns", fail_search)
+    wait_for_ingested_urns_searchable(MagicMock(), str(path))
+
+
+def test_wait_for_browse_path_entity_retries_until_found(monkeypatch):
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    responses = [
+        {"data": {"browse": {"entities": []}}},
+        {"data": {"browse": {"entities": [{"urn": SNAPSHOT_URN}]}}},
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_browse_path_entity(
+        MagicMock(),
+        path=["prod"],
+        expected_urn=SNAPSHOT_URN,
+        entity_type="DATASET",
+    )
+    assert sleeps == [1]
+    assert responses == []
+
+
+def test_wait_for_browse_path_entities_waits_for_all_urns(monkeypatch):
+    sleeps: list = []
+    monkeypatch.setattr("tests.utils.get_sleep_info", lambda: (1, 3))
+    monkeypatch.setattr("tests.utils.time.sleep", sleeps.append)
+
+    other = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-browse-1,PROD)"
+    responses = [
+        {"data": {"browse": {"entities": [{"urn": SNAPSHOT_URN}]}}},
+        {"data": {"browse": {"entities": [{"urn": SNAPSHOT_URN}, {"urn": other}]}}},
+    ]
+
+    def fake_graphql(*args, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("tests.utils.execute_graphql", fake_graphql)
+
+    wait_for_browse_path_entities(
+        MagicMock(),
+        path=["prod", "kafka1"],
+        expected_urns=[SNAPSHOT_URN, other],
+        entity_type="DATASET",
+    )
+    assert sleeps == [1]
+    assert responses == []

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -614,19 +614,19 @@ def _search_results_contain_urns(auth_session, urns: List[str]) -> Optional[Set[
         )
     except Exception as exc:
         logger.warning(
-            "searchAcrossEntities failed during ingest wait; skipping: %s", exc
+            "searchAcrossEntities failed during ingest wait; retrying: %s", exc
         )
         return None
     if res_data.get("errors") or not res_data.get("data"):
         logger.warning(
-            "searchAcrossEntities failed during ingest wait; skipping: %s",
+            "searchAcrossEntities failed during ingest wait; retrying: %s",
             res_data.get("errors"),
         )
         return None
     search = res_data["data"].get("searchAcrossEntities")
     if not search:
         logger.warning(
-            "searchAcrossEntities returned no data during ingest wait; skipping"
+            "searchAcrossEntities returned no data during ingest wait; retrying"
         )
         return None
     results = search.get("searchResults", []) or []
@@ -648,11 +648,10 @@ def wait_for_ingested_urns_searchable(auth_session, filename: str) -> None:
     sleep_sec, sleep_times = get_sleep_info()
     for attempt in range(sleep_times):
         found = _search_results_contain_urns(auth_session, sorted(remaining))
-        if found is None:
-            return
-        remaining -= found
-        if not remaining:
-            return
+        if found is not None:
+            remaining -= found
+            if not remaining:
+                return
         if attempt < sleep_times - 1:
             time.sleep(sleep_sec)
 
@@ -674,21 +673,31 @@ def wait_for_browse_path_entities(
     sleep_sec, sleep_times = get_sleep_info()
     found: Set[str] = set()
     for attempt in range(sleep_times):
-        res_data = execute_graphql(
-            auth_session,
-            _BROWSE_ENTITIES_QUERY,
-            {
-                "input": {
-                    "type": entity_type,
-                    "path": path,
-                    "start": 0,
-                    "count": 100,
-                }
-            },
-            no_sync_wait=True,
-        )
-        entities = res_data.get("data", {}).get("browse", {}).get("entities", []) or []
-        found = {entity.get("urn") for entity in entities if entity.get("urn")}
+        try:
+            res_data = execute_graphql(
+                auth_session,
+                _BROWSE_ENTITIES_QUERY,
+                {
+                    "input": {
+                        "type": entity_type,
+                        "path": path,
+                        "start": 0,
+                        "count": 100,
+                    }
+                },
+                expect_errors=True,
+                no_sync_wait=True,
+            )
+        except Exception as exc:
+            logger.warning("browse failed during ingest wait; retrying: %s", exc)
+            res_data = {}
+        if res_data.get("errors") or not res_data.get("data"):
+            found = set()
+        else:
+            entities = (
+                res_data.get("data", {}).get("browse", {}).get("entities", []) or []
+            )
+            found = {entity.get("urn") for entity in entities if entity.get("urn")}
         if remaining <= found:
             return
         if attempt < sleep_times - 1:

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -3,10 +3,11 @@ import json
 import logging
 import os
 import socket
+import time
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import quote, urlparse, urlunparse
 
 import click
@@ -20,8 +21,10 @@ from requests.structures import CaseInsensitiveDict
 from datahub.cli import cli_utils, env_utils
 from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.entrypoints import datahub
+from datahub.ingestion.graph.client import entity_type_to_graphql
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.sql.sqlalchemy_uri import parse_host_port
+from datahub.utilities.urns.urn import guess_entity_type
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.utilities import env_vars
 
@@ -481,6 +484,234 @@ def run_datahub_cmd(
     return runner.invoke(datahub, command, input=input, env=env)
 
 
+_SEARCH_URNS_QUERY = """
+query searchIngestedUrns($input: SearchAcrossEntitiesInput!) {
+  searchAcrossEntities(input: $input) {
+    searchResults {
+      entity {
+        urn
+      }
+    }
+  }
+}
+"""
+
+_BROWSE_ENTITIES_QUERY = """
+query browse($input: BrowseInput!) {
+  browse(input: $input) {
+    entities {
+      urn
+    }
+  }
+}
+"""
+
+
+def entity_urns_from_ingest_file(filename: str) -> List[str]:
+    """Unique entity URNs from a file ingest payload (MCP or snapshot JSON)."""
+    with open(filename) as f:
+        payload = json.load(f)
+    if not isinstance(payload, list):
+        payload = [payload]
+
+    urns: List[str] = []
+    seen: Set[str] = set()
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        urn: Optional[str] = None
+        if entry.get("entityUrn"):
+            urn = entry["entityUrn"]
+        else:
+            snapshot_union = entry.get("proposedSnapshot")
+            if isinstance(snapshot_union, dict) and snapshot_union:
+                snapshot = next(iter(snapshot_union.values()))
+                if isinstance(snapshot, dict):
+                    urn = snapshot.get("urn")
+        if urn and urn not in seen:
+            seen.add(urn)
+            urns.append(urn)
+    return urns
+
+
+# Entity types ``searchAcrossEntities`` actually returns for ingest gating.
+# Matches elasticsearch.search.defaultEntityTypes minus types that never show
+# up (or should not gate ingest): schemaField, plus assertion/incident/etc.
+_SEARCH_WAIT_ENTITY_TYPES = frozenset(
+    {
+        "dataset",
+        "dashboard",
+        "chart",
+        "mlModel",
+        "mlModelGroup",
+        "mlFeatureTable",
+        "mlFeature",
+        "mlPrimaryKey",
+        "dataFlow",
+        "dataJob",
+        "glossaryTerm",
+        "glossaryNode",
+        "tag",
+        "role",
+        "corpuser",
+        "corpGroup",
+        "container",
+        "domain",
+        "dataProduct",
+        "notebook",
+        "businessAttribute",
+        "application",
+        "document",
+    }
+)
+
+
+def searchable_ingest_urns(urns: List[str]) -> List[str]:
+    """URNs whose entity types ``searchAcrossEntities`` can return."""
+    kept: List[str] = []
+    for urn in urns:
+        try:
+            entity_type = guess_entity_type(urn)
+        except AssertionError:
+            continue
+        if entity_type in _SEARCH_WAIT_ENTITY_TYPES:
+            kept.append(urn)
+    return kept
+
+
+def _search_results_contain_urns(auth_session, urns: List[str]) -> Optional[Set[str]]:
+    if not urns:
+        return set()
+    graphql_types = sorted(
+        {entity_type_to_graphql(guess_entity_type(urn)) for urn in urns}
+    )
+    try:
+        res_data = execute_graphql(
+            auth_session,
+            _SEARCH_URNS_QUERY,
+            {
+                "input": {
+                    "types": graphql_types,
+                    "query": "*",
+                    "start": 0,
+                    "count": max(len(urns), 1),
+                    "orFilters": [
+                        {
+                            "and": [
+                                {
+                                    "field": "urn",
+                                    "values": urns,
+                                    "condition": "EQUAL",
+                                }
+                            ]
+                        }
+                    ],
+                    "searchFlags": {"skipCache": True},
+                }
+            },
+            expect_errors=True,
+            no_sync_wait=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "searchAcrossEntities failed during ingest wait; skipping: %s", exc
+        )
+        return None
+    if res_data.get("errors") or not res_data.get("data"):
+        logger.warning(
+            "searchAcrossEntities failed during ingest wait; skipping: %s",
+            res_data.get("errors"),
+        )
+        return None
+    search = res_data["data"].get("searchAcrossEntities")
+    if not search:
+        logger.warning(
+            "searchAcrossEntities returned no data during ingest wait; skipping"
+        )
+        return None
+    results = search.get("searchResults", []) or []
+    return {
+        result["entity"]["urn"]
+        for result in results
+        if result.get("entity") and result["entity"].get("urn")
+    }
+
+
+def wait_for_ingested_urns_searchable(auth_session, filename: str) -> None:
+    """Poll GraphQL search until searchable ingested URNs are indexed."""
+    remaining: Set[str] = set(
+        searchable_ingest_urns(entity_urns_from_ingest_file(filename))
+    )
+    if not remaining:
+        return
+
+    sleep_sec, sleep_times = get_sleep_info()
+    for attempt in range(sleep_times):
+        found = _search_results_contain_urns(auth_session, sorted(remaining))
+        if found is None:
+            return
+        remaining -= found
+        if not remaining:
+            return
+        if attempt < sleep_times - 1:
+            time.sleep(sleep_sec)
+
+    raise AssertionError(
+        f"Entities not searchable after ingest of {filename}: {sorted(remaining)}"
+    )
+
+
+def wait_for_browse_path_entities(
+    auth_session,
+    path: List[str],
+    expected_urns: List[str],
+    entity_type: str = "DATASET",
+) -> None:
+    """Poll browse v1 until every URN in ``expected_urns`` appears at ``path``."""
+    remaining: Set[str] = set(expected_urns)
+    if not remaining:
+        return
+    sleep_sec, sleep_times = get_sleep_info()
+    found: Set[str] = set()
+    for attempt in range(sleep_times):
+        res_data = execute_graphql(
+            auth_session,
+            _BROWSE_ENTITIES_QUERY,
+            {
+                "input": {
+                    "type": entity_type,
+                    "path": path,
+                    "start": 0,
+                    "count": 100,
+                }
+            },
+            no_sync_wait=True,
+        )
+        entities = res_data.get("data", {}).get("browse", {}).get("entities", []) or []
+        found = {entity.get("urn") for entity in entities if entity.get("urn")}
+        if remaining <= found:
+            return
+        if attempt < sleep_times - 1:
+            time.sleep(sleep_sec)
+
+    raise AssertionError(
+        f"Browse path {path} did not contain {sorted(remaining)} after ingest; "
+        f"missing {sorted(remaining - found)}"
+    )
+
+
+def wait_for_browse_path_entity(
+    auth_session,
+    path: List[str],
+    expected_urn: str,
+    entity_type: str = "DATASET",
+) -> None:
+    """Poll browse v1 until ``expected_urn`` appears at ``path``."""
+    wait_for_browse_path_entities(
+        auth_session, path, [expected_urn], entity_type=entity_type
+    )
+
+
 def ingest_file_via_rest(
     auth_session, filename: str, mode: str = "ASYNC_BATCH"
 ) -> Pipeline:
@@ -503,6 +734,7 @@ def ingest_file_via_rest(
     pipeline.run()
     pipeline.raise_from_status()
     wait_for_writes_to_sync()
+    wait_for_ingested_urns_searchable(auth_session, filename)
     return pipeline
 
 


### PR DESCRIPTION
## Summary
- Smoke ingest now waits only for entity types `searchAcrossEntities` can return (assertion/incident/dataPlatform/etc. are skipped), and browse tests wait for indexed paths before `no_sync_wait` reads.
- `migrate` UPSERTs `upstreamLineage` when the target has none, because JSON PATCH on a missing aspect is a no-op; smoke migrate tests poll incoming `Asserts` edges after seed.

## Test plan
- [ ] `./gradlew :metadata-ingestion:lint :metadata-ingestion:testSingle -PtestFile=tests/unit/cli/test_migration_utils.py`
- [ ] `smoke-test/venv/bin/python -m pytest tests/unit/test_ingest_search_wait.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits only for searchable entities after ingest and retries GraphQL polling on errors and exceptions; UPSERTs missing `upstreamLineage` during migrate while skipping empty lineage. This reduces smoke-test flakiness, prevents false readiness during backend outages, and ensures lineage creation where a PATCH was previously a no-op.

- `merge_additive_aspects`: When source has non-empty `upstreamLineage` and target has none, emit a single MCP UPSERT (dry-run counts but does not emit); otherwise JSON PATCH unions lineage. Ownership/globalTags/glossaryTerms remain PATCH-only via GenericJsonPatch templates. Return value now equals JSON patch count plus 1 when a lineage UPSERT occurs.
- `ingest_file_via_rest`: Calls `wait_for_ingested_urns_searchable` after `wait_for_writes_to_sync`. Extracts URNs from the ingest file, filters to entity types `searchAcrossEntities` returns, polls until indexed, and retries on GraphQL errors or raised exceptions instead of skipping.
- Browse smoke tests: Use `wait_for_browse_path_entity`/`wait_for_browse_path_entities` to poll for indexed paths before `no_sync_wait` reads; retries on GraphQL errors or raised exceptions.
- Migration smoke tests: Poll incoming `Asserts` edges via `get_incoming_relationships` to avoid race conditions before migrating assertions.

<sup>Written for commit 0c67de8de057e38e54966df6373c2ee4a27b54cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **migrate** additive merge so **upstreamLineage** is not lost when the target dataset has no lineage aspect yet: GMS treats a plain JSON PATCH as a no-op in that case, so `merge_additive_aspects` now **UPSERTs** non-empty source lineage via `emit_mcp` and only uses patch merge when lineage already exists (empty source lineage stays a no-op; dry-run still counts the upsert).
> 
> Smoke tests get **eventual-consistency polling** in `tests/utils`: after REST file ingest, wait only for entity types that `searchAcrossEntities` can return; **browse** tests poll indexed browse paths before `no_sync_wait` reads; **migrate** scenarios poll incoming `Asserts` edges on seeded datasets. Unit tests cover lineage upsert behavior and the new wait helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c67de8de057e38e54966df6373c2ee4a27b54cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->