### PR TITLE
chore(entity): de-duplicate scoped-retry failed results to prevent duplicate dead-letter events

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1353,6 +1353,17 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                                 final Set<Pair<Urn, String>> committedKeys = new HashSet<>();
                                 committedKeys.addAll(committedKeysOf(attempt.batchWriteResult));
 
+                                // (urn, aspect) pairs already recorded as failed. A terminally
+                                // validation-failing aspect on a URN that also has a conflicting
+                                // sibling is re-included in every scoped-retry sub-batch (scoped by
+                                // URN) and re-fails validation on each pass; without this guard the
+                                // same failure is appended — and, on the consumer path,
+                                // dead-letter-emitted — once per pass. Seed from the first pass so
+                                // a
+                                // pass-0 failure is not re-counted on a later pass.
+                                final Set<Pair<Urn, String>> seenFailedKeys =
+                                    new HashSet<>(failedKeysOf(failedUpsertResults));
+
                                 int scopedAttempt = 0;
                                 while (batchWriteResult.hasConflicts()
                                     && scopedAttempt < SCOPED_RETRY_MAX_ATTEMPTS) {
@@ -1407,7 +1418,10 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                                   // only
                                   // the newly resolved results are spliced in.
                                   upsertResults.addAll(retry.upsertResults);
-                                  failedUpsertResults.addAll(retry.failedUpsertResults);
+                                  appendNewFailedResults(
+                                      failedUpsertResults,
+                                      retry.failedUpsertResults,
+                                      seenFailedKeys);
                                   updatedLatestAspects =
                                       AspectsBatch.merge(
                                           updatedLatestAspects, retry.updatedLatestAspects);
@@ -3990,6 +4004,47 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
   static boolean isAlreadyCommitted(
       @Nonnull Set<Pair<Urn, String>> committedKeys, @Nonnull ChangeMCP writeItem) {
     return committedKeys.contains(Pair.of(writeItem.getUrn(), writeItem.getAspectName()));
+  }
+
+  /**
+   * (urn, aspect) keys of the given failed results, for cross-pass dedup of {@code
+   * failedUpsertResults} on the scoped-retry path. Package-private for unit testing.
+   */
+  @Nonnull
+  static Set<Pair<Urn, String>> failedKeysOf(
+      @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> failedResults) {
+    return failedResults.stream()
+        .map(failed -> Pair.of(failed.getFirst().getUrn(), failed.getFirst().getAspectName()))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Append only the failed results whose (urn, aspect) has not been recorded yet, updating {@code
+   * seenFailedKeys} in place. A scoped-retry sub-batch is scoped by URN, so an aspect that
+   * terminally fails validation is re-validated (and re-fails) on every pass while its conflicting
+   * sibling is retried; deduping by (urn, aspect) records that failure exactly once instead of once
+   * per pass (which on the consumer path would emit duplicate dead-letter events). Package-private
+   * for unit testing.
+   */
+  static void appendNewFailedResults(
+      @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> accumulator,
+      @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> incoming,
+      @Nonnull Set<Pair<Urn, String>> seenFailedKeys) {
+    // Suppress only keys recorded in EARLIER passes. Snapshot seenFailedKeys before this pass so
+    // that two distinct items sharing a (urn, aspect) WITHIN this pass are both kept — matching the
+    // un-deduped first-pass behavior — while a key that already failed in a prior pass is dropped.
+    // Dedup is keyed on (urn, aspect), not item identity, because the retry stamps a fresh traceId
+    // each pass so a ChangeMCP's content/hashCode is not stable across passes; (urn, aspect) is the
+    // only stable cross-pass key for the same logical failure.
+    final Set<Pair<Urn, String>> priorPassKeys = new HashSet<>(seenFailedKeys);
+    for (Pair<ChangeMCP, Set<AspectValidationException>> failed : incoming) {
+      final Pair<Urn, String> key =
+          Pair.of(failed.getFirst().getUrn(), failed.getFirst().getAspectName());
+      if (!priorPassKeys.contains(key)) {
+        accumulator.add(failed);
+      }
+      seenFailedKeys.add(key);
+    }
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1353,14 +1353,15 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                                 final Set<Pair<Urn, String>> committedKeys = new HashSet<>();
                                 committedKeys.addAll(committedKeysOf(attempt.batchWriteResult));
 
-                                // (urn, aspect) pairs already recorded as failed. A terminally
-                                // validation-failing aspect on a URN that also has a conflicting
-                                // sibling is re-included in every scoped-retry sub-batch (scoped by
-                                // URN) and re-fails validation on each pass; without this guard the
-                                // same failure is appended — and, on the consumer path,
-                                // dead-letter-emitted — once per pass. Seed from the first pass so
-                                // a
-                                // pass-0 failure is not re-counted on a later pass.
+                                // (urn, aspect) pairs already recorded as failed. Dedups failures
+                                // across scoped-retry passes: a terminally validation-failing
+                                // aspect
+                                // on a URN whose sibling also conflicts is re-included in every
+                                // URN-scoped retry sub-batch and re-fails each pass, so without
+                                // this
+                                // guard it would be dead-lettered once per pass on the consumer
+                                // path.
+                                // Seeded from the first pass's failures.
                                 final Set<Pair<Urn, String>> seenFailedKeys =
                                     new HashSet<>(failedKeysOf(failedUpsertResults));
 
@@ -4015,21 +4016,23 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> failedResults) {
     return failedResults.stream()
         .map(failed -> Pair.of(failed.getFirst().getUrn(), failed.getFirst().getAspectName()))
-        .collect(Collectors.toSet());
+        .collect(Collectors.toUnmodifiableSet());
   }
 
   /**
-   * Append only the failed results whose (urn, aspect) has not been recorded yet, updating {@code
-   * seenFailedKeys} in place. A scoped-retry sub-batch is scoped by URN, so an aspect that
-   * terminally fails validation is re-validated (and re-fails) on every pass while its conflicting
-   * sibling is retried; deduping by (urn, aspect) records that failure exactly once instead of once
-   * per pass (which on the consumer path would emit duplicate dead-letter events). Package-private
-   * for unit testing.
+   * Append only the failed results whose (urn, aspect) has not been recorded yet. A scoped-retry
+   * sub-batch is scoped by URN, so an aspect that terminally fails validation is re-validated (and
+   * re-fails) on every pass while its conflicting sibling is retried; deduping by (urn, aspect)
+   * records that failure exactly once instead of once per pass (which on the consumer path would
+   * emit duplicate dead-letter events). Package-private for unit testing.
+   *
+   * <p>Mutates both {@code accumulator} (appends the new failures) and {@code seenFailedKeys}
+   * (records every incoming key).
    */
   static void appendNewFailedResults(
-      @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> accumulator,
+      @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> accumulator, // mutated
       @Nonnull List<Pair<ChangeMCP, Set<AspectValidationException>>> incoming,
-      @Nonnull Set<Pair<Urn, String>> seenFailedKeys) {
+      @Nonnull Set<Pair<Urn, String>> seenFailedKeys) { // mutated
     // Suppress only keys recorded in EARLIER passes. Snapshot seenFailedKeys before this pass so
     // that two distinct items sharing a (urn, aspect) WITHIN this pass are both kept — matching the
     // un-deduped first-pass behavior — while a key that already failed in a prior pass is dropped.
@@ -4043,6 +4046,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       if (!priorPassKeys.contains(key)) {
         accumulator.add(failed);
       }
+      // Record unconditionally (no-op if already present) so a later pass sees this key as
+      // prior-seen and suppresses a repeat of it.
       seenFailedKeys.add(key);
     }
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplScopedRetryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceImplScopedRetryTest.java
@@ -9,7 +9,10 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.aspect.batch.BatchItem;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
 import com.linkedin.util.Pair;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -98,6 +101,71 @@ public class EntityServiceImplScopedRetryTest {
     assertTrue(
         !EntityServiceImpl.isAlreadyCommitted(committedKeys, changeFor(URN_A, ASPECT_STATUS)),
         "conflicted sibling on the same URN must still be retried");
+  }
+
+  private static Pair<ChangeMCP, Set<AspectValidationException>> failureFor(
+      Urn urn, String aspect) {
+    return Pair.of(changeFor(urn, aspect), Set.<AspectValidationException>of());
+  }
+
+  @Test
+  public void failedKeysOfExtractsUrnAspectPairs() {
+    List<Pair<ChangeMCP, Set<AspectValidationException>>> failures =
+        List.of(failureFor(URN_A, ASPECT_STATUS), failureFor(URN_B, ASPECT_KEY));
+
+    assertEquals(
+        EntityServiceImpl.failedKeysOf(failures),
+        Set.of(Pair.of(URN_A, ASPECT_STATUS), Pair.of(URN_B, ASPECT_KEY)));
+  }
+
+  @Test
+  public void appendNewFailedResultsRecordsEachUrnAspectOnceAcrossPasses() {
+    // A terminally validation-failing aspect (URN_A/status) is re-included in every URN-scoped
+    // scoped-retry sub-batch and re-fails validation on each pass. It must be recorded exactly once
+    // — not once per pass — while a genuinely new failure on a later pass is still appended.
+    List<Pair<ChangeMCP, Set<AspectValidationException>>> accumulator = new ArrayList<>();
+    accumulator.add(failureFor(URN_A, ASPECT_STATUS)); // pass-0 failure
+    Set<Pair<Urn, String>> seenFailedKeys =
+        new HashSet<>(EntityServiceImpl.failedKeysOf(accumulator));
+
+    // Retry pass re-reports the same (URN_A, status) failure plus a new (URN_B, status) one.
+    EntityServiceImpl.appendNewFailedResults(
+        accumulator,
+        List.of(failureFor(URN_A, ASPECT_STATUS), failureFor(URN_B, ASPECT_STATUS)),
+        seenFailedKeys);
+
+    assertEquals(accumulator.size(), 2, "repeated (urn, aspect) recorded once; new one appended");
+    assertEquals(
+        EntityServiceImpl.failedKeysOf(accumulator),
+        Set.of(Pair.of(URN_A, ASPECT_STATUS), Pair.of(URN_B, ASPECT_STATUS)));
+
+    // A third pass that only re-reports already-seen failures adds nothing.
+    EntityServiceImpl.appendNewFailedResults(
+        accumulator,
+        List.of(failureFor(URN_A, ASPECT_STATUS), failureFor(URN_B, ASPECT_STATUS)),
+        seenFailedKeys);
+    assertEquals(accumulator.size(), 2, "no new keys on a repeat pass → no growth");
+  }
+
+  @Test
+  public void appendNewFailedResultsKeepsDistinctSameKeyFailuresWithinAPassButNotAcrossPasses() {
+    // Two DISTINCT items sharing (URN_A, status) that both fail in the SAME pass must both be kept
+    // — the dedup only removes a (urn, aspect) that already failed in an EARLIER pass, so it never
+    // collapses two distinct failures reported together (preserving the un-deduped pass-0
+    // behavior).
+    List<Pair<ChangeMCP, Set<AspectValidationException>>> accumulator = new ArrayList<>();
+    Set<Pair<Urn, String>> seenFailedKeys = new HashSet<>();
+
+    EntityServiceImpl.appendNewFailedResults(
+        accumulator,
+        List.of(failureFor(URN_A, ASPECT_STATUS), failureFor(URN_A, ASPECT_STATUS)),
+        seenFailedKeys);
+    assertEquals(accumulator.size(), 2, "distinct same-key failures within one pass are both kept");
+
+    // A later pass restating (URN_A, status) adds nothing — it already failed in an earlier pass.
+    EntityServiceImpl.appendNewFailedResults(
+        accumulator, List.of(failureFor(URN_A, ASPECT_STATUS)), seenFailedKeys);
+    assertEquals(accumulator.size(), 2, "cross-pass repeat of an earlier-failed key is suppressed");
   }
 
   @Test


### PR DESCRIPTION
On the optimistic-locking scoped-retry path, a validation-failing aspect on a URN
that also has a CAS-conflicting sibling was appended to `failedUpsertResults` once
per retry pass. Because `filterItemsForRecompute` scopes the retry sub-batch by URN,
the terminally-failing sibling is re-validated (and re-fails) on every pass, so on the
Kafka consumer path the same failure was dead-lettered up to `SCOPED_RETRY_MAX_ATTEMPTS`
times. Request path and OL-off path are unaffected.

## Changes
- Add `failedKeysOf` / `appendNewFailedResults` helpers and a per-transaction
  `seenFailedKeys` guard (mirrors the existing `committedKeys` double-commit guard).
- Dedup is keyed on `(urn, aspect)` — the only stable cross-pass key, since the retry
  stamps a fresh traceId each pass so item content/hashCode isn't stable.
- Snapshot prior-pass keys so two *distinct* failures sharing a `(urn, aspect)` within
  one pass are both kept (matches first-pass behavior); only cross-pass repeats are
  suppressed.
- Unit tests for key extraction, cross-pass dedup, and within-pass preservation.

## Effect
A given aspect's terminal validation failure is dead-lettered exactly once per ingest,
not once per scoped-retry pass. No behavior change when optimistic locking is off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes duplicate **failed MCP / dead-letter** emissions on the Kafka ingest path when **optimistic locking + scoped retry** are enabled.
> 
> Scoped retry sub-batches are filtered by **URN**, so an aspect that **always fails validation** is re-run on every CAS retry pass alongside a conflicting sibling. Previously each pass appended the same failure to `failedUpsertResults`, which could dead-letter the same logical error up to **`SCOPED_RETRY_MAX_ATTEMPTS`** times.
> 
> The scoped-retry loop now keeps a per-transaction **`seenFailedKeys`** set (seeded from the first pass), mirroring the existing **`committedKeys`** guard for successful writes. Retry passes call **`appendNewFailedResults`** instead of `addAll`, deduping on **`(urn, aspect)`** because retries stamp a new traceId and item identity is not stable across passes. Within a single pass, two distinct failures for the same key are still preserved.
> 
> Adds **`failedKeysOf`** / **`appendNewFailedResults`** helpers and unit tests in `EntityServiceImplScopedRetryTest`. Request path and OL-off behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22872a73370223998ee50e72b5402d0d3188a10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates scoped-retry failed results keyed by (urn, aspect) to prevent duplicate dead-letter events on the Kafka consumer path. Previously, a terminal validation failure on a URN with a CAS-conflicting sibling was re-added each retry pass and dead-lettered up to the retry limit; now it is emitted once per ingest. Request path and optimistic-locking off remain unchanged.

**Review notes**
- Adds `failedKeysOf`, `appendNewFailedResults`, and a per-transaction `seenFailedKeys` guard, seeded from the first pass to suppress only cross-pass repeats.
- Dedups by (urn, aspect) because the retry stamps a new traceId each pass; preserves distinct same-key failures within a single pass.
- Replaces direct `failedUpsertResults.addAll(...)` with `appendNewFailedResults(...)` in the scoped-retry loop.
- Includes unit tests for key extraction, cross-pass dedup, and within-pass preservation.

<sup>Written for commit d22872a73370223998ee50e72b5402d0d3188a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

