### PR TITLE
fix(components): Update card and pill component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Card/Card.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Card/Card.stories.tsx
@@ -99,6 +99,34 @@ const meta = {
                 type: 'boolean',
             },
         },
+        size: {
+            description: 'Compact (`sm`) or default (`md`) card sizing',
+            table: {
+                defaultValue: { summary: `${cardDefaults.size}` },
+            },
+            control: {
+                type: 'select',
+            },
+            options: ['sm', 'md'],
+        },
+        collapsible: {
+            description: 'Whether the card body can expand and collapse',
+            table: {
+                defaultValue: { summary: `${cardDefaults.collapsible}` },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        defaultExpanded: {
+            description: 'Initial expanded state when uncontrolled',
+            table: {
+                defaultValue: { summary: `${cardDefaults.defaultExpanded}` },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
     },
 
     // Define default args
@@ -107,6 +135,9 @@ const meta = {
         subTitle: 'Subtitle',
         iconAlignment: 'horizontal',
         isEmpty: false,
+        size: 'md',
+        collapsible: false,
+        defaultExpanded: true,
     },
 } satisfies Meta<typeof Card>;
 
@@ -152,6 +183,47 @@ export const withButton = () => (
 );
 
 export const withPercentPill = () => <Card title="Title" subTitle="Subtitle" percent={2} />;
+
+export const small = () => (
+    <Card
+        size="sm"
+        title="Judges Reasoning"
+        pillLabel="Judge check — LLM-based"
+        subTitle="The agent's query adds an unwarranted filter that restricts the count to machine-translation events only."
+        width="480px"
+    />
+);
+
+export const sizes = () => (
+    <GridList>
+        <Card size="sm" title="Small" subTitle="Compact card with smaller title and padding" pillLabel="Label" />
+        <Card size="md" title="Medium" subTitle="Default card sizing" pillLabel="Label" />
+    </GridList>
+);
+
+export const collapsible = () => (
+    <GridList>
+        <Card
+            collapsible
+            defaultExpanded
+            title="Judges Reasoning"
+            pillLabel="Judge check — LLM-based"
+            subTitle="The agent's query adds an unwarranted filter that restricts the count to machine-translation events only."
+            width="480px"
+        />
+        <Card
+            collapsible
+            defaultExpanded={false}
+            size="sm"
+            title="Collapsed by default"
+            pillLabel="Details"
+            subTitle="Expand to read the full reasoning."
+            width="480px"
+        >
+            <div style={{ backgroundColor: colors.gray[1000], padding: '8px 16px' }}>Additional details</div>
+        </Card>
+    </GridList>
+);
 
 export const withAllTheElements = () => (
     <Card

--- a/datahub-web-react/src/alchemy-components/components/Card/Card.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Card/Card.tsx
@@ -152,19 +152,6 @@ export const Card = ({
                             $size={size}
                             $collapsible={collapsible}
                             onClick={handleHeaderClick}
-                            role={collapsible ? 'button' : undefined}
-                            tabIndex={collapsible ? 0 : undefined}
-                            aria-expanded={collapsible ? isExpanded : undefined}
-                            onKeyDown={
-                                collapsible
-                                    ? (e) => {
-                                          if (e.key === 'Enter' || e.key === ' ') {
-                                              e.preventDefault();
-                                              handleExpandToggle();
-                                          }
-                                      }
-                                    : undefined
-                            }
                         >
                             {icon && <div style={iconStyles}>{icon}</div>}
 

--- a/datahub-web-react/src/alchemy-components/components/Card/Card.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Card/Card.tsx
@@ -1,4 +1,6 @@
-import { Tooltip } from '@components';
+import { Icon, Tooltip } from '@components';
+import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import { TrendDown } from '@phosphor-icons/react/dist/csr/TrendDown';
 import { TrendUp } from '@phosphor-icons/react/dist/csr/TrendUp';
 import React, { useEffect, useRef, useState } from 'react';
@@ -6,6 +8,8 @@ import { useTranslation } from 'react-i18next';
 
 import {
     CardContainer,
+    CollapsibleBody,
+    ExpandButton,
     Header,
     SubTitle,
     SubTitleContainer,
@@ -19,6 +23,9 @@ export const cardDefaults: CardProps = {
     iconAlignment: 'horizontal',
     isEmpty: false,
     isCardClickable: true,
+    size: 'md',
+    collapsible: false,
+    defaultExpanded: true,
 };
 
 export const Card = ({
@@ -41,10 +48,21 @@ export const Card = ({
     iconStyles,
     pillLabel,
     pill,
+    size = cardDefaults.size,
+    collapsible = cardDefaults.collapsible,
+    defaultExpanded = cardDefaults.defaultExpanded,
+    expanded,
+    onExpandChange,
 }: CardProps) => {
     const { t } = useTranslation('alchemy');
+    const { t: tc } = useTranslation('common.actions');
     const subtitleRef = useRef<HTMLDivElement>(null);
     const [showSubtitleTooltip, setShowSubtitleTooltip] = useState(false);
+    const [internalExpanded, setInternalExpanded] = useState(defaultExpanded ?? true);
+
+    const isControlled = expanded !== undefined;
+    const isExpanded = isControlled ? expanded : internalExpanded;
+    const showBody = !collapsible || isExpanded;
 
     useEffect(() => {
         const element = subtitleRef.current;
@@ -54,67 +72,129 @@ export const Card = ({
             const isOverflowing = element.scrollHeight > element.clientHeight;
             setShowSubtitleTooltip(isOverflowing);
         });
-    }, []);
+    }, [showBody, subTitle]);
+
+    const handleExpandToggle = (e?: React.MouseEvent) => {
+        e?.stopPropagation();
+        const next = !isExpanded;
+        if (!isControlled) {
+            setInternalExpanded(next);
+        }
+        onExpandChange?.(next);
+    };
+
+    const handleHeaderClick = (e: React.MouseEvent) => {
+        if (!collapsible) return;
+        handleExpandToggle(e);
+    };
 
     const subtitleElement = (
-        <SubTitle ref={subtitleRef} $noOfSubtitleLines={noOfSubtitleLines}>
+        <SubTitle ref={subtitleRef} $noOfSubtitleLines={noOfSubtitleLines} $size={size}>
             {subTitle}
         </SubTitle>
+    );
+
+    const subtitleBlock = subTitle ? (
+        <SubTitleContainer>
+            {showSubtitleTooltip ? <Tooltip title={subTitle}>{subtitleElement}</Tooltip> : subtitleElement}
+        </SubTitleContainer>
+    ) : null;
+
+    const titleRow = (
+        <Title data-testid="title" $size={size}>
+            {title}
+            {!!percent && (
+                <Pill
+                    label={`${Math.abs(percent)}%`}
+                    size="sm"
+                    color={percent < 0 ? 'red' : 'green'}
+                    leftIcon={percent < 0 ? TrendDown : TrendUp}
+                    clickable={false}
+                />
+            )}
+            {!!pillLabel && <Pill label={pillLabel} size="sm" color="primary" clickable={false} />}
+            {pill !== null && pill !== undefined && pill}
+        </Title>
+    );
+
+    const bodyContent = (
+        <>
+            {collapsible && subtitleBlock}
+            {children}
+        </>
     );
 
     return (
         <>
             {isEmpty ? (
-                <CardContainer maxWidth={maxWidth} height={height} width={width} data-testid={dataTestId}>
+                <CardContainer maxWidth={maxWidth} height={height} width={width} $size={size} data-testid={dataTestId}>
                     <TitleContainer data-testid="no-data">
-                        <Title $isEmpty={isEmpty}>{t('noData')}</Title>
-                        <SubTitle>{subTitle}</SubTitle>
+                        <Title $isEmpty={isEmpty} $size={size}>
+                            {t('noData')}
+                        </Title>
+                        <SubTitle $size={size}>{subTitle}</SubTitle>
                     </TitleContainer>
                 </CardContainer>
             ) : (
                 <CardContainer
-                    isClickable={(!!button || onClick) && isCardClickable}
-                    onClick={onClick}
+                    isClickable={(!!button || onClick) && isCardClickable && !collapsible}
+                    onClick={collapsible ? undefined : onClick}
                     maxWidth={maxWidth}
                     height={height}
                     width={width}
+                    $size={size}
                     style={style}
                     data-testid={dataTestId}
                 >
                     {title && (
-                        <Header iconAlignment={iconAlignment}>
-                            <div style={iconStyles}>{icon}</div>
+                        <Header
+                            iconAlignment={iconAlignment}
+                            $size={size}
+                            $collapsible={collapsible}
+                            onClick={handleHeaderClick}
+                            role={collapsible ? 'button' : undefined}
+                            tabIndex={collapsible ? 0 : undefined}
+                            aria-expanded={collapsible ? isExpanded : undefined}
+                            onKeyDown={
+                                collapsible
+                                    ? (e) => {
+                                          if (e.key === 'Enter' || e.key === ' ') {
+                                              e.preventDefault();
+                                              handleExpandToggle();
+                                          }
+                                      }
+                                    : undefined
+                            }
+                        >
+                            {icon && <div style={iconStyles}>{icon}</div>}
 
                             <TitleContainer>
-                                <Title data-testid="title">
-                                    {title}
-                                    {!!percent && (
-                                        <Pill
-                                            label={`${Math.abs(percent)}%`}
-                                            size="sm"
-                                            color={percent < 0 ? 'red' : 'green'}
-                                            leftIcon={percent < 0 ? TrendDown : TrendUp}
-                                            clickable={false}
-                                        />
-                                    )}
-                                    {!!pillLabel && (
-                                        <Pill label={pillLabel} size="sm" color="primary" clickable={false} />
-                                    )}
-                                    {pill !== null && pill !== undefined && pill}
-                                </Title>
-                                <SubTitleContainer>
-                                    {showSubtitleTooltip ? (
-                                        <Tooltip title={subTitle}>{subtitleElement}</Tooltip>
-                                    ) : (
-                                        subtitleElement
-                                    )}
-                                </SubTitleContainer>
+                                {titleRow}
+                                {!collapsible && subtitleBlock}
                             </TitleContainer>
 
                             {button}
+                            {collapsible && (
+                                <ExpandButton
+                                    type="button"
+                                    aria-label={isExpanded ? tc('collapse') : tc('expand')}
+                                    aria-expanded={isExpanded}
+                                    onClick={handleExpandToggle}
+                                    data-testid="card-expand-button"
+                                >
+                                    <Icon icon={isExpanded ? CaretDown : CaretRight} size="md" color="inherit" />
+                                </ExpandButton>
+                            )}
                         </Header>
                     )}
-                    {children}
+                    {showBody &&
+                        (collapsible ? (
+                            <CollapsibleBody $size={size} data-testid="card-collapsible-body">
+                                {bodyContent}
+                            </CollapsibleBody>
+                        ) : (
+                            children
+                        ))}
                 </CardContainer>
             )}
         </>

--- a/datahub-web-react/src/alchemy-components/components/Card/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Card/components.ts
@@ -1,39 +1,71 @@
 import styled from 'styled-components';
 
+import { CardSize } from '@components/components/Card/types';
+
 import { radius, spacing, typography } from '@src/alchemy-components/theme';
 import { IconAlignmentOptions } from '@src/alchemy-components/theme/config';
 
-export const CardContainer = styled.div<{ isClickable?: boolean; width?: string; maxWidth?: string; height?: string }>(
-    ({ isClickable, width, maxWidth, height, theme }) => ({
-        border: `1px solid ${theme.colors.border}`,
-        borderRadius: radius.lg,
-        padding: spacing.md,
-        display: 'flex',
-        flex: `1 1 ${maxWidth}`,
-        minWidth: '150px',
-        boxShadow: theme.colors.shadowXs,
-        backgroundColor: theme.colors.bg,
-        flexDirection: 'column',
-        gap: spacing.md,
-        maxWidth,
-        width,
-        height,
+const SIZE_PADDING: Record<CardSize, string> = {
+    sm: spacing.sm,
+    md: spacing.md,
+};
 
-        '&:hover': isClickable
-            ? {
-                  border: `1px solid ${theme.colors.borderBrand}`,
-                  cursor: 'pointer',
-              }
-            : {},
-    }),
-);
+const SIZE_GAP: Record<CardSize, string> = {
+    sm: spacing.xsm,
+    md: spacing.md,
+};
 
-export const Header = styled.div<{ iconAlignment?: IconAlignmentOptions }>(({ iconAlignment }) => ({
+const TITLE_FONT_SIZE: Record<CardSize, string> = {
+    sm: typography.fontSizes.sm,
+    md: typography.fontSizes.lg,
+};
+
+export const CardContainer = styled.div<{
+    isClickable?: boolean;
+    width?: string;
+    maxWidth?: string;
+    height?: string;
+    $size?: CardSize;
+}>(({ isClickable, width, maxWidth, height, $size = 'md', theme }) => ({
+    border: `1px solid ${theme.colors.border}`,
+    borderRadius: radius.lg,
+    padding: SIZE_PADDING[$size],
+    display: 'flex',
+    flex: `1 1 ${maxWidth}`,
+    minWidth: '150px',
+    boxShadow: theme.colors.shadowXs,
+    backgroundColor: theme.colors.bg,
+    flexDirection: 'column',
+    gap: SIZE_GAP[$size],
+    maxWidth,
+    width,
+    height,
+    overflow: 'hidden',
+
+    '&:hover': isClickable
+        ? {
+              border: `1px solid ${theme.colors.borderBrand}`,
+              cursor: 'pointer',
+          }
+        : {},
+}));
+
+export const Header = styled.div<{
+    iconAlignment?: IconAlignmentOptions;
+    $size?: CardSize;
+    $collapsible?: boolean;
+}>(({ iconAlignment, $size = 'md', $collapsible }) => ({
     display: 'flex',
     flexDirection: iconAlignment === 'horizontal' ? 'row' : 'column',
     alignItems: iconAlignment === 'horizontal' ? 'center' : 'start',
-    gap: spacing.sm,
+    gap: $size === 'sm' ? spacing.xsm : spacing.sm,
     width: '100%',
+    ...($collapsible
+        ? {
+              cursor: 'pointer',
+              userSelect: 'none' as const,
+          }
+        : {}),
 }));
 
 export const TitleContainer = styled.div({
@@ -41,10 +73,11 @@ export const TitleContainer = styled.div({
     flexDirection: 'column',
     gap: 2,
     width: '100%',
+    minWidth: 0,
 });
 
-export const Title = styled.div<{ $isEmpty?: boolean }>(({ $isEmpty, theme }) => ({
-    fontSize: typography.fontSizes.lg,
+export const Title = styled.div<{ $isEmpty?: boolean; $size?: CardSize }>(({ $isEmpty, $size = 'md', theme }) => ({
+    fontSize: TITLE_FONT_SIZE[$size],
     fontWeight: typography.fontWeights.bold,
     color: $isEmpty ? theme.colors.textTertiary : theme.colors.text,
     display: 'flex',
@@ -59,19 +92,43 @@ export const SubTitleContainer = styled.div({
     alignItems: 'center',
 });
 
-export const SubTitle = styled.div<{ $noOfSubtitleLines?: number }>(({ $noOfSubtitleLines, theme }) => ({
-    fontSize: typography.fontSizes.md,
-    fontWeight: typography.fontWeights.normal,
-    color: theme.colors.textSecondary,
-    lineHeight: 'normal',
+export const SubTitle = styled.div<{ $noOfSubtitleLines?: number; $size?: CardSize }>(
+    ({ $noOfSubtitleLines, theme }) => ({
+        fontSize: typography.fontSizes.md,
+        fontWeight: typography.fontWeights.normal,
+        color: theme.colors.textSecondary,
+        lineHeight: 'normal',
+        wordWrap: 'break-word',
 
-    ...($noOfSubtitleLines
-        ? {
-              display: '-webkit-box',
-              WebkitLineClamp: $noOfSubtitleLines,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-          }
-        : {}),
+        ...($noOfSubtitleLines
+            ? {
+                  display: '-webkit-box',
+                  WebkitLineClamp: $noOfSubtitleLines,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+              }
+            : {}),
+    }),
+);
+
+export const ExpandButton = styled.button(({ theme }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    padding: 0,
+    margin: 0,
+    border: 'none',
+    background: 'transparent',
+    color: theme.colors.textSecondary,
+    cursor: 'pointer',
+    lineHeight: 0,
+}));
+
+export const CollapsibleBody = styled.div<{ $size?: CardSize }>(({ $size = 'md' }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: SIZE_GAP[$size],
+    width: '100%',
 }));

--- a/datahub-web-react/src/alchemy-components/components/Card/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Card/index.ts
@@ -1,2 +1,2 @@
 export { Card, cardDefaults } from './Card';
-export type { CardProps } from './types';
+export type { CardProps, CardSize } from './types';

--- a/datahub-web-react/src/alchemy-components/components/Card/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Card/types.ts
@@ -1,5 +1,7 @@
 import { IconAlignmentOptions } from '@src/alchemy-components/theme/config';
 
+export type CardSize = 'sm' | 'md';
+
 export interface CardProps {
     title?: string | React.ReactNode;
     subTitle?: string | React.ReactNode;
@@ -20,4 +22,14 @@ export interface CardProps {
     iconStyles?: React.CSSProperties;
     pillLabel?: string;
     pill?: React.ReactNode;
+    /** Compact (`sm`) or default (`md`) card sizing */
+    size?: CardSize;
+    /** Enables accordion expand/collapse for the card body */
+    collapsible?: boolean;
+    /** Initial expanded state when uncontrolled. Defaults to `true`. */
+    defaultExpanded?: boolean;
+    /** Controlled expanded state */
+    expanded?: boolean;
+    /** Called when the expanded state changes */
+    onExpandChange?: (expanded: boolean) => void;
 }

--- a/datahub-web-react/src/alchemy-components/components/Pills/Pill.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Pills/Pill.stories.tsx
@@ -1,4 +1,6 @@
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Globe } from '@phosphor-icons/react/dist/csr/Globe';
+import { Info } from '@phosphor-icons/react/dist/csr/Info';
 import { Star } from '@phosphor-icons/react/dist/csr/Star';
 import { X } from '@phosphor-icons/react/dist/csr/X';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -8,6 +10,12 @@ import { GridList } from '@components/.docs/mdx-components';
 import { Pill, SUPPORTED_CONFIGURATIONS } from '@components/components/Pills/Pill';
 import { PillProps } from '@components/components/Pills/types';
 import { ColorValues, PillVariantValues, SizeValues, getSizeName } from '@components/theme/config';
+
+const ICON_OPTIONS = {
+    Info,
+    Star,
+    Globe,
+} as const;
 
 const defaults: PillProps = {
     label: 'Label',
@@ -42,16 +50,16 @@ const meta: Meta = {
         },
         leftIcon: {
             description: 'The icon to display in the Pill icon.',
-            type: 'string',
-            options: ['Info', 'Star', 'Globe'],
+            options: Object.keys(ICON_OPTIONS),
+            mapping: ICON_OPTIONS,
             control: {
                 type: 'select',
             },
         },
         rightIcon: {
             description: 'The icon to display in the Pill icon.',
-            type: 'string',
-            options: ['Info', 'Star', 'Globe'],
+            options: Object.keys(ICON_OPTIONS),
+            mapping: ICON_OPTIONS,
             control: {
                 type: 'select',
             },
@@ -78,7 +86,7 @@ const meta: Meta = {
         },
         color: {
             description: 'The color of the Pill.',
-            options: Object.values(ColorValues),
+            options: Object.values(ColorValues).filter((color) => color !== ColorValues.black),
             table: {
                 defaultValue: { summary: defaults.color },
             },
@@ -100,8 +108,6 @@ const meta: Meta = {
     // Define defaults
     args: {
         label: defaults.label,
-        leftIcon: defaults.leftIcon,
-        rightIcon: defaults.rightIcon,
         size: defaults.size,
         variant: defaults.variant,
         showLabel: true,
@@ -140,6 +146,24 @@ export const outline = () => (
         <Pill label="Default" variant="outline" clickable />
         {SUPPORTED_CONFIGURATIONS[PillVariantValues.outline].map((color) => (
             <Pill key={color} label={color} color={color} variant="outline" clickable />
+        ))}
+    </GridList>
+);
+
+export const squareFilled = () => (
+    <GridList>
+        <Pill label="Default" variant="squareFilled" clickable />
+        {SUPPORTED_CONFIGURATIONS[PillVariantValues.squareFilled].map((color) => (
+            <Pill key={color} label={color} color={color} variant="squareFilled" clickable />
+        ))}
+    </GridList>
+);
+
+export const squareOutline = () => (
+    <GridList>
+        <Pill label="Default" variant="squareOutline" clickable />
+        {SUPPORTED_CONFIGURATIONS[PillVariantValues.squareOutline].map((color) => (
+            <Pill key={color} label={color} color={color} variant="squareOutline" clickable />
         ))}
     </GridList>
 );

--- a/datahub-web-react/src/alchemy-components/components/Pills/Pill.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Pills/Pill.tsx
@@ -89,7 +89,7 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
         }
 
         const renderIcon = (
-            icon: React.ComponentType<any>,
+            icon: NonNullable<PillProps['leftIcon']>,
             onClick?: (e: React.MouseEvent<HTMLElement>) => void,
             ariaLabel?: string,
             testId?: string,

--- a/datahub-web-react/src/alchemy-components/components/Pills/Pill.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Pills/Pill.tsx
@@ -1,7 +1,7 @@
-import { Button, Icon } from '@components';
+import { Icon } from '@components';
 import React from 'react';
 
-import { PillContainer, PillText } from '@components/components/Pills/components';
+import { PillContainer, PillIconButton, PillIconSlot, PillText } from '@components/components/Pills/components';
 import { PillProps, PillPropsDefaults } from '@components/components/Pills/types';
 import { ColorOptions, ColorValues, PillVariantOptions, PillVariantValues, SizeValues } from '@components/theme/config';
 
@@ -16,6 +16,24 @@ export const SUPPORTED_CONFIGURATIONS: Record<PillVariantOptions, ColorOptions[]
         ColorValues.gray,
     ],
     [PillVariantValues.outline]: [
+        ColorValues.primary,
+        ColorValues.violet,
+        ColorValues.blue,
+        ColorValues.green,
+        ColorValues.red,
+        ColorValues.yellow,
+        ColorValues.gray,
+    ],
+    [PillVariantValues.squareFilled]: [
+        ColorValues.primary,
+        ColorValues.violet,
+        ColorValues.blue,
+        ColorValues.green,
+        ColorValues.red,
+        ColorValues.yellow,
+        ColorValues.gray,
+    ],
+    [PillVariantValues.squareOutline]: [
         ColorValues.primary,
         ColorValues.violet,
         ColorValues.blue,
@@ -70,6 +88,40 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
             console.debug(`Unsupported configuration for Pill: variant=${variant}, color=${color}`);
         }
 
+        const renderIcon = (
+            icon: React.ComponentType<any>,
+            onClick?: (e: React.MouseEvent<HTMLElement>) => void,
+            ariaLabel?: string,
+            testId?: string,
+            key?: string,
+        ) => {
+            const iconNode = <Icon icon={icon} size={size} color="inherit" />;
+
+            if (onClick) {
+                return (
+                    <PillIconButton
+                        key={key}
+                        type="button"
+                        $size={size}
+                        onClick={onClick}
+                        aria-label={ariaLabel}
+                        data-testid={testId}
+                    >
+                        {iconNode}
+                    </PillIconButton>
+                );
+            }
+
+            return (
+                <PillIconSlot key={key} $size={size}>
+                    {iconNode}
+                </PillIconSlot>
+            );
+        };
+
+        const hasLeftIcon = Boolean(customIconRenderer || leftIcon);
+        const hasRightIcon = Boolean((rightIcons && rightIcons.length > 0) || rightIcon);
+
         return (
             <PillContainer
                 ref={ref}
@@ -77,6 +129,8 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
                 color={color}
                 size={size}
                 clickable={clickable}
+                $hasLeftIcon={hasLeftIcon}
+                $hasRightIcon={hasRightIcon}
                 id={id}
                 data-testid={dataTestId ?? 'pill-container'}
                 onClick={onPillClick}
@@ -92,30 +146,19 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
                 title={showLabel ? label : undefined}
                 className={className}
             >
-                {customIconRenderer
-                    ? customIconRenderer()
-                    : leftIcon && <Icon icon={leftIcon} size={size} onClick={onClickLeftIcon} />}
+                {customIconRenderer ? customIconRenderer() : leftIcon && renderIcon(leftIcon, onClickLeftIcon)}
                 <PillText style={customStyle}>{label}</PillText>
                 {rightIcons && rightIcons.length > 0
-                    ? rightIcons.map((r, idx) => (
-                          <Button
-                              // eslint-disable-next-line react/no-array-index-key
-                              key={idx}
-                              style={{ padding: 0 }}
-                              variant="text"
-                              color={color}
-                              onClick={r.onClick}
-                              aria-label={r.ariaLabel}
-                              data-testid={r.testId}
-                          >
-                              <Icon icon={r.icon} size={size} />
-                          </Button>
-                      ))
-                    : rightIcon && (
-                          <Button style={{ padding: 0 }} variant="text" color={color} onClick={onClickRightIcon}>
-                              <Icon icon={rightIcon} size={size} />
-                          </Button>
-                      )}
+                    ? rightIcons.map((r) =>
+                          renderIcon(
+                              r.icon,
+                              r.onClick,
+                              r.ariaLabel,
+                              r.testId,
+                              r.testId ?? r.ariaLabel ?? r.icon.displayName ?? r.icon.name,
+                          ),
+                      )
+                    : rightIcon && renderIcon(rightIcon, onClickRightIcon)}
             </PillContainer>
         );
     },

--- a/datahub-web-react/src/alchemy-components/components/Pills/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Pills/components.ts
@@ -3,25 +3,52 @@ import styled from 'styled-components';
 import { PillStyleProps } from '@components/components/Pills/types';
 import { getPillStyle } from '@components/components/Pills/utils';
 import { spacing } from '@components/theme';
+import { SizeOptions } from '@components/theme/config';
 
-export const PillContainer = styled.div(
-    {
+const ICON_HIT_AREA: Record<SizeOptions, string> = {
+    xs: '16px',
+    sm: '22px',
+    md: '24px',
+    lg: '30px',
+    xl: '34px',
+    inherit: '1em',
+};
+
+const PILL_PADDING_X = 8;
+const PILL_PADDING_X_WITH_ICON = 4;
+
+type PillContainerProps = PillStyleProps & {
+    $hasLeftIcon?: boolean;
+    $hasRightIcon?: boolean;
+};
+
+export const PillContainer = styled.div<PillContainerProps>(
+    ({ $hasLeftIcon, $hasRightIcon }) => ({
         // Base root styles
         display: 'inline-flex',
         alignItems: 'center',
         gap: spacing.xxsm,
         cursor: 'pointer',
-        padding: '0px 8px',
+        // Tighten end padding when an icon sits on that side so the pill doesn't feel stretched
+        padding: `0 ${$hasRightIcon ? PILL_PADDING_X_WITH_ICON : PILL_PADDING_X}px 0 ${
+            $hasLeftIcon ? PILL_PADDING_X_WITH_ICON : PILL_PADDING_X
+        }px`,
         borderRadius: '200px',
         maxWidth: '100%',
+
+        // Keep icons matched to the pill text color and vertically centered
+        '& svg': {
+            color: 'currentColor',
+            display: 'block',
+        },
 
         // Base Disabled styles
         '&:disabled': {
             cursor: 'not-allowed',
         },
-    },
+    }),
     // Dynamic styles
-    (props: PillStyleProps) => ({ ...getPillStyle(props) }),
+    (props) => ({ ...getPillStyle(props) }),
 );
 
 export const PillText = styled.span({
@@ -30,4 +57,35 @@ export const PillText = styled.span({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    lineHeight: 'inherit',
 });
+
+const iconHitAreaStyles = ($size: SizeOptions) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: ICON_HIT_AREA[$size],
+    height: ICON_HIT_AREA[$size],
+    padding: 0,
+    margin: 0,
+    border: 'none',
+    background: 'transparent',
+    color: 'inherit',
+    lineHeight: 0,
+});
+
+/** Non-interactive icon slot — same footprint as the clickable hit area */
+export const PillIconSlot = styled.span<{ $size: SizeOptions }>(({ $size }) => ({
+    ...iconHitAreaStyles($size),
+}));
+
+/** Clickable icon hit area — sized to the pill line-height for an easy tap target */
+export const PillIconButton = styled.button<{ $size: SizeOptions }>(({ $size }) => ({
+    ...iconHitAreaStyles($size),
+    cursor: 'pointer',
+
+    '&:disabled': {
+        cursor: 'not-allowed',
+    },
+}));

--- a/datahub-web-react/src/alchemy-components/components/Pills/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Pills/types.ts
@@ -1,3 +1,4 @@
+import type { IconWeight, Icon as PhosphorIcon } from '@phosphor-icons/react';
 import React, { HTMLAttributes } from 'react';
 
 import { ColorOptions, PillVariantOptions, SizeOptions } from '@src/alchemy-components/theme/config';
@@ -11,12 +12,24 @@ export interface PillPropsDefaults {
     theme?: Theme;
 }
 
+/** Props forwarded to a Pill icon (matches what Alchemy `Icon` passes through). */
+export type PillIconProps = {
+    style?: React.CSSProperties;
+    weight?: IconWeight;
+    className?: string;
+    color?: string;
+    size?: number | string;
+};
+
+/** Phosphor icons plus any component that accepts the props we actually pass. */
+export type PillIcon = PhosphorIcon | React.ComponentType<PillIconProps>;
+
 /**
  * A trailing icon inside a Pill. Prefer this shape over `rightIcon`/`onClickRightIcon`
  * when you need MORE THAN ONE trailing icon (e.g. edit + remove).
  */
 export interface PillRightIcon {
-    icon: React.ComponentType<any>;
+    icon: PillIcon;
     onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
     ariaLabel?: string;
     testId?: string;
@@ -25,13 +38,13 @@ export interface PillRightIcon {
 export interface PillProps extends Partial<PillPropsDefaults>, Omit<HTMLAttributes<HTMLElement>, 'color'> {
     label: string;
     color?: ColorOptions;
-    rightIcon?: React.ComponentType<any>;
+    rightIcon?: PillIcon;
     /**
      * Optional array of trailing icons — use instead of `rightIcon` when you need more
      * than one (e.g. edit + remove on the same pill). Ignored if empty.
      */
     rightIcons?: PillRightIcon[];
-    leftIcon?: React.ComponentType<any>;
+    leftIcon?: PillIcon;
     customStyle?: React.CSSProperties;
     showLabel?: boolean;
     customIconRenderer?: () => React.ReactNode;

--- a/datahub-web-react/src/alchemy-components/components/Pills/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Pills/utils.ts
@@ -4,7 +4,7 @@ import { PillStyleProps } from '@components/components/Pills/types';
 import { ColorOptions, PillVariantOptions, SizeOptions } from '@components/theme/config';
 
 import { Theme } from '@conf/theme/types';
-import { typography } from '@src/alchemy-components/theme';
+import { radius, typography } from '@src/alchemy-components/theme';
 import { getColor, getFontSize } from '@src/alchemy-components/theme/utils';
 
 interface ColorStyles {
@@ -93,28 +93,40 @@ function getPillColorStyles(variant: PillVariantOptions, color: ColorOptions, th
     };
 }
 
+const getFilledStyles = (colorStyles: ColorStyles): CSSObject => ({
+    backgroundColor: colorStyles.bgColor,
+    border: `1px solid transparent`,
+    color: colorStyles.primaryColor,
+    '&:hover': {
+        backgroundColor: colorStyles.hoverColor,
+    },
+});
+
+const getOutlineStyles = (colorStyles: ColorStyles): CSSObject => ({
+    backgroundColor: 'transparent',
+    border: `1px solid ${colorStyles.bgColor}`,
+    color: colorStyles.primaryColor,
+    '&:hover': {
+        backgroundColor: colorStyles.hoverColor,
+        border: `1px solid transparent`,
+    },
+    '&:disabled': {
+        border: `1px solid transparent`,
+    },
+});
+
 // Generate variant styles for pill
 const getPillVariantStyles = (variant: PillVariantOptions, colorStyles: ColorStyles): CSSObject =>
     ({
-        filled: {
-            backgroundColor: colorStyles.bgColor,
-            border: `1px solid transparent`,
-            color: colorStyles.primaryColor,
-            '&:hover': {
-                backgroundColor: colorStyles.hoverColor,
-            },
+        filled: getFilledStyles(colorStyles),
+        outline: getOutlineStyles(colorStyles),
+        squareFilled: {
+            ...getFilledStyles(colorStyles),
+            borderRadius: radius.sm,
         },
-        outline: {
-            backgroundColor: 'transparent',
-            border: `1px solid ${colorStyles.bgColor}`,
-            color: colorStyles.primaryColor,
-            '&:hover': {
-                backgroundColor: colorStyles.hoverColor,
-                border: `1px solid transparent`,
-            },
-            '&:disabled': {
-                border: `1px solid transparent`,
-            },
+        squareOutline: {
+            ...getOutlineStyles(colorStyles),
+            borderRadius: radius.sm,
         },
         text: {
             color: colorStyles.primaryColor,
@@ -126,7 +138,7 @@ const getPillVariantStyles = (variant: PillVariantOptions, colorStyles: ColorSty
             '&:hover': {
                 backgroundColor: colorStyles.hoverColor,
             },
-            borderRadius: '4px',
+            borderRadius: radius.sm,
         },
     })[variant];
 
@@ -160,8 +172,10 @@ const getPillFontStyles = (variant: PillVariantOptions, size: SizeOptions): CSSO
     };
 };
 
+const ACTIVE_BORDER_VARIANTS: PillVariantOptions[] = ['filled', 'outline', 'squareFilled', 'squareOutline'];
+
 const getPillActiveStyles = (variant: PillVariantOptions, colorStyles: ColorStyles): CSSObject => ({
-    borderColor: variant === 'filled' || variant === 'outline' ? colorStyles.primaryColor : '',
+    borderColor: ACTIVE_BORDER_VARIANTS.includes(variant) ? colorStyles.primaryColor : '',
 });
 
 export function getPillStyle(props: PillStyleProps): CSSObject {

--- a/datahub-web-react/src/alchemy-components/theme/config/types.ts
+++ b/datahub-web-react/src/alchemy-components/theme/config/types.ts
@@ -96,6 +96,8 @@ export type RotationOptions = '0' | '90' | '180' | '270';
 export enum PillVariantValues {
     filled = 'filled',
     outline = 'outline',
+    squareFilled = 'squareFilled',
+    squareOutline = 'squareOutline',
     version = 'version',
 }
 

--- a/datahub-web-react/src/alchemy-components/theme/utils.ts
+++ b/datahub-web-react/src/alchemy-components/theme/utils.ts
@@ -23,7 +23,8 @@ export const getColor = (
     }
 
     if (!color) return finalColors.black;
-    if (color === 'inherit' || color === 'transparent' || color === 'current') return finalColors;
+    if (color === 'inherit' || color === 'transparent') return color;
+    if (color === 'current') return 'currentColor';
     if (color === 'white') return finalColors.white;
     if (color === 'black') return finalColors.black;
     const colorValue = finalColors[color];


### PR DESCRIPTION

<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 10 17 AM" src="https://github.com/user-attachments/assets/9dba5e61-10f9-4c88-896f-186006c841cf" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 32 AM" src="https://github.com/user-attachments/assets/0cdb4c63-e134-441e-aab3-0b0abf97803d" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 30 AM" src="https://github.com/user-attachments/assets/4f6334ca-d1aa-4890-80ed-092735c6cb60" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 28 AM" src="https://github.com/user-attachments/assets/ea6c40b3-4f9f-4603-95c7-3b89c15e3986" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 21 AM" src="https://github.com/user-attachments/assets/e6cbba2b-0bda-46c6-8404-7fcfd954d26e" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 03 AM" src="https://github.com/user-attachments/assets/3d95061e-6d7f-44c9-a5e9-3bf276132a9b" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 11 01 AM" src="https://github.com/user-attachments/assets/9657a2ce-398e-46aa-bf5a-d88f7a19cda4" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 10 59 AM" src="https://github.com/user-attachments/assets/4d9ce9a0-48ca-4d16-8011-e267592a3863" />
<img width="1840" height="1196" alt="Screenshot 2026-08-17 at 11 10 57 AM" src="https://github.com/user-attachments/assets/b1188081-49c9-40e0-8978-c3049561cd1d" />
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compact sizing and accessible expand/collapse to Card, and adds square variants plus consistent icon hit areas to Pill to match updated designs. Default behavior is unchanged; when collapsible is enabled, the header toggles the body and the card’s onClick is suppressed.

- Card
  - New props: size `('sm' | 'md')`, `collapsible`, `defaultExpanded`, controlled `expanded`, and `onExpandChange`.
  - Header toggle with caret and an `ExpandButton` that exposes `aria-expanded`; clicking the header or button toggles the body when `collapsible` is true.
  - Size-aware spacing/typography with `CollapsibleBody`; title/subtitle styling adapts to `size`. Tooltip still appears for truncated subtitles.
  - Card-level `onClick` is disabled when `collapsible` is true to avoid conflicts.

- Pill
  - New variants: `squareFilled` and `squareOutline` (small-radius corners).
  - Icons render in consistent tap targets via `PillIconSlot`/`PillIconButton`; container padding tightens when icons are present, and icons use `currentColor`.
  - `leftIcon`/`rightIcon` now accept Phosphor icons or components matching `PillIconProps`; `rightIcons` mapping improved in stories.

- Theme utils
  - `getColor('current')` now returns `'currentColor'`; `'inherit'` and `'transparent'` pass through. Icons and pills using these inherit text color. No migration required.

- Migration
  - Cards using `collapsible` cannot use card-level `onClick`; attach interactions to the header, `ExpandButton`, or body content.

<sup>Written for commit 50543407aa3c680ac1b11bbde9a5b9cdf3c402e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

