### PR TITLE
feat(ui): Add type filter dropdown to ingestion source page

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
@@ -12,6 +12,7 @@ import com.linkedin.datahub.graphql.generated.ListIngestionSourcesInput;
 import com.linkedin.datahub.graphql.generated.ListIngestionSourcesResult;
 import com.linkedin.datahub.graphql.resolvers.ingest.IngestionAuthUtils;
 import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
+import com.linkedin.datahub.graphql.util.SelectionSetUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.SortCriterion;
@@ -36,6 +37,7 @@ public class ListIngestionSourcesResolver
   private static final Integer DEFAULT_START = 0;
   private static final Integer DEFAULT_COUNT = 20;
   private static final String DEFAULT_QUERY = "";
+  private static final String FACETS_FIELD_NAME = "facets";
   private static final List<String> FACET_FIELDS = List.of("type");
 
   private final EntityClient _entityClient;
@@ -65,6 +67,13 @@ public class ListIngestionSourcesResolver
     // construct sort criteria, defaulting to systemCreated
     List<SortCriterion> sortCriteria = buildSortCriteria(input.getSort());
 
+    // Only compute the facet aggregation when the caller actually selects it, to avoid an
+    // unnecessary terms aggregation on every list/count call (e.g. getNoOfIngestionSources).
+    final List<String> facetFields =
+        SelectionSetUtils.selectedSubFieldNames(environment).contains(FACETS_FIELD_NAME)
+            ? FACET_FIELDS
+            : Collections.emptyList();
+
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           try {
@@ -78,7 +87,7 @@ public class ListIngestionSourcesResolver
                     start,
                     count,
                     sortCriteria,
-                    FACET_FIELDS);
+                    facetFields);
 
             // Now that we have entities we can bind this to a result.
             final ListIngestionSourcesResult result = new ListIngestionSourcesResult();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
@@ -86,7 +86,8 @@ public class ListIngestionSourcesResolver
             result.setCount(gmsResult.getPageSize());
             result.setTotal(gmsResult.getNumEntities());
             result.setIngestionSources(mapUnresolvedIngestionSources(gmsResult.getEntities()));
-            if (gmsResult.getMetadata() != null && gmsResult.getMetadata().getAggregations() != null) {
+            if (gmsResult.getMetadata() != null
+                && gmsResult.getMetadata().getAggregations() != null) {
               result.setFacets(
                   gmsResult.getMetadata().getAggregations().stream()
                       .map(facet -> MapperUtils.mapFacet(context, facet))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
@@ -11,6 +11,7 @@ import com.linkedin.datahub.graphql.generated.IngestionSource;
 import com.linkedin.datahub.graphql.generated.ListIngestionSourcesInput;
 import com.linkedin.datahub.graphql.generated.ListIngestionSourcesResult;
 import com.linkedin.datahub.graphql.resolvers.ingest.IngestionAuthUtils;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.SortCriterion;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 /** Lists all ingestion sources stored within DataHub. Requires the MANAGE_INGESTION privilege. */
@@ -34,6 +36,7 @@ public class ListIngestionSourcesResolver
   private static final Integer DEFAULT_START = 0;
   private static final Integer DEFAULT_COUNT = 20;
   private static final String DEFAULT_QUERY = "";
+  private static final List<String> FACET_FIELDS = List.of("type");
 
   private final EntityClient _entityClient;
 
@@ -67,14 +70,15 @@ public class ListIngestionSourcesResolver
           try {
             // First, get all ingestion sources Urns.
             final SearchResult gmsResult =
-                _entityClient.search(
+                _entityClient.searchAcrossEntities(
                     context.getOperationContext().withSearchFlags(flags -> flags.setFulltext(true)),
-                    Constants.INGESTION_SOURCE_ENTITY_NAME,
+                    List.of(Constants.INGESTION_SOURCE_ENTITY_NAME),
                     query,
                     buildFilter(filters, Collections.emptyList()),
-                    sortCriteria,
                     start,
-                    count);
+                    count,
+                    sortCriteria,
+                    FACET_FIELDS);
 
             // Now that we have entities we can bind this to a result.
             final ListIngestionSourcesResult result = new ListIngestionSourcesResult();
@@ -82,6 +86,14 @@ public class ListIngestionSourcesResolver
             result.setCount(gmsResult.getPageSize());
             result.setTotal(gmsResult.getNumEntities());
             result.setIngestionSources(mapUnresolvedIngestionSources(gmsResult.getEntities()));
+            if (gmsResult.getMetadata() != null && gmsResult.getMetadata().getAggregations() != null) {
+              result.setFacets(
+                  gmsResult.getMetadata().getAggregations().stream()
+                      .map(facet -> MapperUtils.mapFacet(context, facet))
+                      .collect(Collectors.toList()));
+            } else {
+              result.setFacets(Collections.emptyList());
+            }
             return result;
           } catch (Exception e) {
             throw new RuntimeException("Failed to list ingestion sources", e);

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -568,6 +568,11 @@ type ListIngestionSourcesResult {
   The Ingestion Sources themselves
   """
   ingestionSources: [IngestionSource!]!
+
+  """
+  Candidate facets for search filters, including the source type facet
+  """
+  facets: [FacetMetadata!]
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourceResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourceResolverTest.java
@@ -11,9 +11,14 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.FilterValueArray;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -31,14 +36,15 @@ public class ListIngestionSourceResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(
-            mockClient.search(
+            mockClient.searchAcrossEntities(
                 any(),
-                Mockito.eq(Constants.INGESTION_SOURCE_ENTITY_NAME),
+                Mockito.eq(List.of(Constants.INGESTION_SOURCE_ENTITY_NAME)),
                 Mockito.eq(""),
                 Mockito.any(),
-                Mockito.any(),
                 Mockito.eq(0),
-                Mockito.eq(20)))
+                Mockito.eq(20),
+                Mockito.any(),
+                Mockito.eq(List.of("type"))))
         .thenReturn(
             new SearchResult()
                 .setFrom(0)
@@ -46,7 +52,18 @@ public class ListIngestionSourceResolverTest {
                 .setNumEntities(1)
                 .setEntities(
                     new SearchEntityArray(
-                        ImmutableSet.of(new SearchEntity().setEntity(TEST_INGESTION_SOURCE_URN)))));
+                        ImmutableSet.of(new SearchEntity().setEntity(TEST_INGESTION_SOURCE_URN))))
+                .setMetadata(
+                    new SearchResultMetadata()
+                        .setAggregations(
+                            new AggregationMetadataArray(
+                                new AggregationMetadata()
+                                    .setName("type")
+                                    .setFilterValues(
+                                        new FilterValueArray(
+                                            new FilterValue()
+                                                .setValue("snowflake")
+                                                .setFacetCount(1)))))));
 
     ListIngestionSourcesResolver resolver = new ListIngestionSourcesResolver(mockClient);
 
@@ -66,6 +83,13 @@ public class ListIngestionSourceResolverTest {
 
     assertEquals(
         result.getIngestionSources().get(0).getUrn(), TEST_INGESTION_SOURCE_URN.toString());
+
+    // Facet assertions
+    assertEquals(result.getFacets().size(), 1);
+    assertEquals(result.getFacets().get(0).getField(), "type");
+    assertEquals(result.getFacets().get(0).getAggregations().size(), 1);
+    assertEquals(result.getFacets().get(0).getAggregations().get(0).getValue(), "snowflake");
+    assertEquals(result.getFacets().get(0).getAggregations().get(0).getCount(), Long.valueOf(1));
   }
 
   @Test
@@ -84,13 +108,15 @@ public class ListIngestionSourceResolverTest {
     Mockito.verify(mockClient, Mockito.times(0))
         .batchGetV2(any(), Mockito.any(), Mockito.anySet(), Mockito.anySet());
     Mockito.verify(mockClient, Mockito.times(0))
-        .search(
+        .searchAcrossEntities(
             any(),
             Mockito.any(),
             Mockito.eq(""),
-            Mockito.anyMap(),
+            Mockito.any(),
             Mockito.anyInt(),
-            Mockito.anyInt());
+            Mockito.anyInt(),
+            Mockito.any(),
+            Mockito.any());
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourceResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourceResolverTest.java
@@ -20,6 +20,9 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.MergedField;
+import graphql.language.Field;
+import graphql.language.SelectionSet;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import org.mockito.Mockito;
@@ -73,6 +76,10 @@ public class ListIngestionSourceResolverTest {
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getMergedField())
+        .thenReturn(
+            mergedListIngestionSourcesField(
+                "start", "count", "total", "ingestionSources", "facets"));
     var result = resolver.get(mockEnv).get();
 
     // Data Assertions
@@ -90,6 +97,48 @@ public class ListIngestionSourceResolverTest {
     assertEquals(result.getFacets().get(0).getAggregations().size(), 1);
     assertEquals(result.getFacets().get(0).getAggregations().get(0).getValue(), "snowflake");
     assertEquals(result.getFacets().get(0).getAggregations().get(0).getCount(), Long.valueOf(1));
+  }
+
+  @Test
+  public void testGetSuccessSkipsFacetsWhenNotSelected() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                Mockito.eq(List.of(Constants.INGESTION_SOURCE_ENTITY_NAME)),
+                Mockito.eq(""),
+                Mockito.any(),
+                Mockito.eq(0),
+                Mockito.eq(20),
+                Mockito.any(),
+                Mockito.eq(List.of())))
+        .thenReturn(
+            new SearchResult()
+                .setFrom(0)
+                .setPageSize(1)
+                .setNumEntities(1)
+                .setEntities(
+                    new SearchEntityArray(
+                        ImmutableSet.of(new SearchEntity().setEntity(TEST_INGESTION_SOURCE_URN))))
+                .setMetadata(
+                    new SearchResultMetadata().setAggregations(new AggregationMetadataArray())));
+
+    ListIngestionSourcesResolver resolver = new ListIngestionSourcesResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getMergedField())
+        .thenReturn(mergedListIngestionSourcesField("start", "count", "total"));
+    var result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getIngestionSources().size(), 1);
+    assertEquals(result.getFacets().size(), 0);
   }
 
   @Test
@@ -133,8 +182,24 @@ public class ListIngestionSourceResolverTest {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getMergedField())
+        .thenReturn(mergedListIngestionSourcesField("start", "count", "total"));
 
     assertThrows(RuntimeException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  /**
+   * Builds a real query AST for {@code listIngestionSources { <selectedFields> }} so the resolver
+   * reads the selection the same way it does at runtime.
+   */
+  private static MergedField mergedListIngestionSourcesField(final String... selectedFields) {
+    final SelectionSet.Builder selectionSet = SelectionSet.newSelectionSet();
+    for (String name : selectedFields) {
+      selectionSet.selection(Field.newField(name).build());
+    }
+    return MergedField.newMergedField(
+            Field.newField("listIngestionSources").selectionSet(selectionSet.build()).build())
+        .build();
   }
 
   @Test

--- a/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
+++ b/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
@@ -1,6 +1,6 @@
 import { Button, PageTitle, Tabs, Tooltip } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router';
 import styled from 'styled-components';
@@ -97,11 +97,22 @@ export const ManageIngestionPage = () => {
     const { value: hideSystemSources, setValue: setHideSystemSources } = useUrlQueryParam('hideSystem', 'true');
     const { value: sourceFilter, setValue: setSourceFilter } = useUrlQueryParam('sourceFilter');
     const { value: searchQuery, setValue: setSearchQuery } = useUrlQueryParam('query');
+    const { value: sourceTypesParam, setValue: setSourceTypesParam } = useUrlQueryParam('sourceTypes');
+
+    const sourceTypes = useMemo(
+        () => (sourceTypesParam ? sourceTypesParam.split(',').filter(Boolean) : []),
+        [sourceTypesParam],
+    );
 
     // Stable callbacks to prevent infinite re-render loops in child components
     const handleSetSourceFilter = useCallback(
         (value: number | undefined) => setSourceFilter(value?.toString() || ''),
         [setSourceFilter],
+    );
+
+    const handleSetSourceTypes = useCallback(
+        (values: string[]) => setSourceTypesParam(values.join(',')),
+        [setSourceTypesParam],
     );
 
     const handleSetHideSystemSources = useCallback(
@@ -162,6 +173,8 @@ export const ManageIngestionPage = () => {
                     setSourceFilter={handleSetSourceFilter}
                     searchQuery={searchQuery}
                     setSearchQuery={setSearchQuery}
+                    sourceTypes={sourceTypes}
+                    setSourceTypes={handleSetSourceTypes}
                 />
             ),
             key: TabType.Sources as string,

--- a/datahub-web-react/src/app/ingestV2/shared/components/filters/SourceTypeFilter.tsx
+++ b/datahub-web-react/src/app/ingestV2/shared/components/filters/SourceTypeFilter.tsx
@@ -1,4 +1,4 @@
-import { Select } from '@components';
+import { Select, Text } from '@components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +17,7 @@ interface Props {
 
 export default function SourceTypeFilter({ values, onUpdate, hideSystemSources }: Props) {
     const { t } = useTranslation('ingestion');
+    const { t: tf } = useTranslation('common.feedback');
     const { ingestionSources } = useIngestionSources();
 
     const displayNameByType = useMemo(
@@ -35,6 +36,7 @@ export default function SourceTypeFilter({ values, onUpdate, hideSystemSources }
         fetchPolicy: 'cache-and-network',
     });
 
+    const isInitialLoading = loading && !data;
     const typeFacet = data?.listIngestionSources?.facets?.find((facet) => facet.field === 'type');
 
     const options = useMemo(
@@ -57,7 +59,7 @@ export default function SourceTypeFilter({ values, onUpdate, hideSystemSources }
             onUpdate={onUpdate}
             options={options}
             isMultiSelect
-            isLoading={loading && !data}
+            emptyState={isInitialLoading ? <Text color="gray">{tf('loading')}</Text> : undefined}
             selectLabelProps={{ variant: 'labeled', label: t('filters.sourceType') }}
             renderCustomOptionText={(option) => <NameColumn type={option.value} record={{ name: option.label }} />}
             showSearch

--- a/datahub-web-react/src/app/ingestV2/shared/components/filters/SourceTypeFilter.tsx
+++ b/datahub-web-react/src/app/ingestV2/shared/components/filters/SourceTypeFilter.tsx
@@ -1,0 +1,69 @@
+import { Select } from '@components';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { NameColumn } from '@app/ingestV2/source/IngestionSourceTableColumns';
+import { useIngestionSources } from '@app/ingestV2/source/builder/useIngestionSources';
+import { getIngestionSourceSystemFilter } from '@app/ingestV2/source/utils';
+import { capitalizeFirstLetter } from '@app/shared/textUtil';
+
+import { useListIngestionSourceTypeFacetsQuery } from '@graphql/ingestion.generated';
+
+interface Props {
+    values: string[];
+    onUpdate: (selectedValues: string[]) => void;
+    hideSystemSources: boolean;
+}
+
+export default function SourceTypeFilter({ values, onUpdate, hideSystemSources }: Props) {
+    const { t } = useTranslation('ingestion');
+    const { ingestionSources } = useIngestionSources();
+
+    const displayNameByType = useMemo(
+        () => new Map(ingestionSources.map((source) => [source.name, source.displayName])),
+        [ingestionSources],
+    );
+
+    const { data, loading } = useListIngestionSourceTypeFacetsQuery({
+        variables: {
+            input: {
+                start: 0,
+                count: 0,
+                filters: [getIngestionSourceSystemFilter(hideSystemSources)],
+            },
+        },
+        fetchPolicy: 'cache-and-network',
+    });
+
+    const typeFacet = data?.listIngestionSources?.facets?.find((facet) => facet.field === 'type');
+
+    const options = useMemo(
+        () =>
+            (typeFacet?.aggregations ?? [])
+                .filter((aggregation) => !!aggregation.value)
+                .map((aggregation) => ({
+                    label:
+                        displayNameByType.get(aggregation.value) ??
+                        capitalizeFirstLetter(aggregation.value) ??
+                        aggregation.value,
+                    value: aggregation.value,
+                })),
+        [typeFacet, displayNameByType],
+    );
+
+    return (
+        <Select
+            values={values}
+            onUpdate={onUpdate}
+            options={options}
+            isMultiSelect
+            isLoading={loading && !data}
+            selectLabelProps={{ variant: 'labeled', label: t('filters.sourceType') }}
+            renderCustomOptionText={(option) => <NameColumn type={option.value} record={{ name: option.label }} />}
+            showSearch
+            size="sm"
+            width="fit-content"
+            data-testid="ingestion-source-type-filter"
+        />
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -17,6 +17,7 @@ import { ExecutionCancelInfo } from '@app/ingestV2/executions/types';
 import { isExecutionRequestActive } from '@app/ingestV2/executions/utils';
 import { useIngestionOnboardingRedesignV1 } from '@app/ingestV2/hooks/useIngestionOnboardingRedesignV1';
 import RefreshButton from '@app/ingestV2/shared/components/RefreshButton';
+import SourceTypeFilter from '@app/ingestV2/shared/components/filters/SourceTypeFilter';
 import useCommandS from '@app/ingestV2/shared/hooks/useCommandS';
 import IngestionSourceRefetcher from '@app/ingestV2/source/IngestionSourceRefetcher';
 import IngestionSourceTable from '@app/ingestV2/source/IngestionSourceTable';
@@ -131,6 +132,8 @@ interface Props {
     setSourceFilter: (sourceFilter: number | undefined) => void;
     searchQuery?: string;
     setSearchQuery: (query: string) => void;
+    sourceTypes?: string[];
+    setSourceTypes: (sourceTypes: string[]) => void;
 }
 
 export const IngestionSourceList = ({
@@ -145,6 +148,8 @@ export const IngestionSourceList = ({
     setSourceFilter: setSourceFilterFromUrl,
     searchQuery: searchQueryFromUrl,
     setSearchQuery: setSearchQueryFromUrl,
+    sourceTypes: sourceTypesFromUrl,
+    setSourceTypes: setSourceTypesFromUrl,
 }: Props) => {
     const { t } = useTranslation('ingestion');
     const { t: tc } = useTranslation('common.actions');
@@ -211,6 +216,9 @@ export const IngestionSourceList = ({
     const sourceFilter = useMemo(() => sourceFilterFromUrl ?? IngestionSourceType.ALL, [sourceFilterFromUrl]);
     const prevSourceFilter = usePrevious(sourceFilter);
 
+    const sourceTypes = useMemo(() => sourceTypesFromUrl ?? [], [sourceTypesFromUrl]);
+    const prevSourceTypes = usePrevious(sourceTypes);
+
     // Debounce the search query
     useDebounce(
         () => {
@@ -231,6 +239,13 @@ export const IngestionSourceList = ({
         }
     }, [sourceFilter, setPage, prevSourceFilter]);
 
+    // When source type filter changes, reset page to 1
+    useEffect(() => {
+        if (prevSourceTypes !== undefined && prevSourceTypes !== sourceTypes) {
+            setPage(1);
+        }
+    }, [sourceTypes, setPage, prevSourceTypes]);
+
     /**
      * Show or hide system ingestion sources using a hidden command S command.
      */
@@ -246,8 +261,11 @@ export const IngestionSourceList = ({
                 negated: sourceFilter !== IngestionSourceType.CLI,
             });
         }
+        if (sourceTypes.length) {
+            draftFilters.push({ field: 'type', values: sourceTypes });
+        }
         return draftFilters;
-    }, [sourceFilter, hideSystemSources]);
+    }, [sourceFilter, hideSystemSources, sourceTypes]);
 
     const queryInputs = useMemo(
         () => ({
@@ -669,6 +687,11 @@ export const IngestionSourceList = ({
                                 width="fit-content"
                                 size="lg"
                                 data-testid="ingestions-type-filter"
+                            />
+                            <SourceTypeFilter
+                                values={sourceTypes}
+                                onUpdate={setSourceTypesFromUrl}
+                                hideSystemSources={hideSystemSources}
                             />
                         </SearchContainer>
                         <FilterButtonsContainer>

--- a/datahub-web-react/src/graphql/ingestion.graphql
+++ b/datahub-web-react/src/graphql/ingestion.graphql
@@ -26,6 +26,18 @@ query getNoOfIngestionSources($input: ListIngestionSourcesInput!) {
     }
 }
 
+query listIngestionSourceTypeFacets($input: ListIngestionSourcesInput!) {
+    listIngestionSources(input: $input) {
+        facets {
+            field
+            aggregations {
+                value
+                count
+            }
+        }
+    }
+}
+
 query getIngestionSource($urn: String!, $runStart: Int, $runCount: Int) {
     ingestionSource(urn: $urn) {
         ...ingestionSourceFields

--- a/datahub-web-react/src/i18n/locales/en/ingestion.json
+++ b/datahub-web-react/src/i18n/locales/en/ingestion.json
@@ -58,6 +58,7 @@
     "filters.allStatuses": "All Statuses",
     "filters.cli": "CLI",
     "filters.resultStatus": "Result Status",
+    "filters.sourceType": "Source Type",
     "filters.ui": "UI",
     "page.noPermissionTooltip": "You don't have permission to perform this action. Please contact your DataHub admin for more info.",
     "page.subtitle": "Configure and schedule syncs to import data from your data sources",


### PR DESCRIPTION
Adds support for a new filter for ingestion source type on the ingestion sources page. I needed to pass back facets so we can show all of the types we have in the filter hence the backend change. 

<img width="1724" height="901" alt="Screenshot 2026-08-17 at 3 38 28 PM" src="https://github.com/user-attachments/assets/17b7a20c-377c-470a-a770-2111bcbf1e9c" />

<img width="879" height="635" alt="Screenshot 2026-08-17 at 3 38 42 PM" src="https://github.com/user-attachments/assets/c168fbfd-361e-4aee-ab4f-4eb44e5b8187" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a type filter dropdown to the Ingestion Sources page so users can filter by connector type. Previously unavailable, the new multi-select persists to the `sourceTypes` URL param and resets pagination when it changes.

- Backend (`datahub-graphql-core`): `ListIngestionSourcesResolver` now calls `searchAcrossEntities` and computes the `type` facet only when the GraphQL selection requests `facets`; maps aggregations into `ListIngestionSourcesResult.facets` (schema adds `facets: [FacetMetadata!]`). Tests cover facet mapping, skipping facet aggregation when not selected, and auth paths.
- Frontend (`datahub-web-react`): Adds `SourceTypeFilter` using `listIngestionSourceTypeFacets`, respects the “hide system sources” filter when fetching facet options, applies selected types to the search filter, persists in `sourceTypes`, and resets page to 1 on updates. Adds i18n label `filters.sourceType`.

<sup>Written for commit 01a9bb0f763b3df3b4302a8a7a55c7637b3d54e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

