### PR TITLE
feat(bootstrap): skip datahub-documents ingestion when semantic search is off

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStep.java
@@ -76,9 +76,27 @@ public class BootstrapMCPStep implements UpgradeStep {
     return mcpTemplate.isOptional();
   }
 
+  /**
+   * Resolve an environment variable. Extracted so tests can override env-var resolution without
+   * manipulating the JVM's process environment (which is effectively immutable from inside the
+   * JVM). Production code reads straight from {@link System#getenv(String)}.
+   */
+  protected String resolveEnvValue(String name) {
+    return System.getenv(name);
+  }
+
   /** Returns whether the upgrade should be skipped. */
   @Override
   public boolean skip(UpgradeContext context) {
+    // Per-template kill switch: when the template names an enabledEnvVar and
+    // that env var is set to "false", skip the step entirely (no DB write).
+    if (mcpTemplate.getEnabledEnvVar() != null && !mcpTemplate.getEnabledEnvVar().isEmpty()) {
+      String envValue = resolveEnvValue(mcpTemplate.getEnabledEnvVar());
+      if (envValue != null && envValue.equalsIgnoreCase("false")) {
+        log.info("{} skipped — {} resolves to 'false'.", id(), mcpTemplate.getEnabledEnvVar());
+        return true;
+      }
+    }
     if (!mcpTemplate.isForce()) {
       boolean previouslyRun =
           entityService.exists(

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStep.java
@@ -15,6 +15,8 @@ import com.linkedin.upgrade.DataHubUpgradeState;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -77,6 +79,15 @@ public class BootstrapMCPStep implements UpgradeStep {
   }
 
   /**
+   * Values that count as "off" for {@code enabledEnvVar}, matching Spring's {@code
+   * StringToBooleanConverter}. The variables named by {@code enabledEnvVar} are typically the same
+   * ones bound to boolean properties elsewhere in the app (for example {@code
+   * ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED} in {@code application.yaml}), so the two readings must
+   * agree — otherwise {@code =0} would disable the feature but leave its bootstrap enabled.
+   */
+  private static final Set<String> FALSEY_VALUES = Set.of("false", "off", "no", "0");
+
+  /**
    * Resolve an environment variable. Extracted so tests can override env-var resolution without
    * manipulating the JVM's process environment (which is effectively immutable from inside the
    * JVM). Production code reads straight from {@link System#getenv(String)}.
@@ -85,15 +96,30 @@ public class BootstrapMCPStep implements UpgradeStep {
     return System.getenv(name);
   }
 
-  /** Returns whether the upgrade should be skipped. */
+  /**
+   * An unset variable is deliberately not falsey: templates that do not opt into a kill switch
+   * never set one, and treating absent as "off" would disable the whole bootstrap.
+   */
+  private static boolean isFalsey(String envValue) {
+    return envValue != null && FALSEY_VALUES.contains(envValue.trim().toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Returns whether the upgrade should be skipped.
+   *
+   * <p>The {@code enabledEnvVar} kill switch is evaluated before the forced-run branch, so a
+   * template that is switched off stays off even when it declares {@code force: true}. {@code
+   * force} means "re-run even if already run", not "ignore the kill switch".
+   */
   @Override
   public boolean skip(UpgradeContext context) {
     // Per-template kill switch: when the template names an enabledEnvVar and
-    // that env var is set to "false", skip the step entirely (no DB write).
+    // that env var is off, skip the step entirely (no DB write).
     if (mcpTemplate.getEnabledEnvVar() != null && !mcpTemplate.getEnabledEnvVar().isEmpty()) {
       String envValue = resolveEnvValue(mcpTemplate.getEnabledEnvVar());
-      if (envValue != null && envValue.equalsIgnoreCase("false")) {
-        log.info("{} skipped — {} resolves to 'false'.", id(), mcpTemplate.getEnabledEnvVar());
+      if (isFalsey(envValue)) {
+        log.info(
+            "{} skipped — {} resolves to '{}'.", id(), mcpTemplate.getEnabledEnvVar(), envValue);
         return true;
       }
     }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/model/BootstrapMCPConfigFile.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/model/BootstrapMCPConfigFile.java
@@ -44,8 +44,10 @@ public class BootstrapMCPConfigFile {
 
     /**
      * Name of an environment variable acting as a per-template kill switch. When the variable
-     * resolves to {@code "false"}, the template is skipped and nothing is written. An unset
-     * variable leaves the template enabled, so templates that do not opt in are unaffected.
+     * resolves to a falsey value ({@code false}, {@code off}, {@code no} or {@code 0}, trimmed and
+     * case-insensitive, matching Spring's boolean binding), the template is skipped and nothing is
+     * written. An unset variable leaves the template enabled, so templates that do not opt in are
+     * unaffected. The switch takes precedence over {@link #force}.
      */
     @Nullable private String enabledEnvVar;
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/model/BootstrapMCPConfigFile.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/model/BootstrapMCPConfigFile.java
@@ -42,6 +42,13 @@ public class BootstrapMCPConfigFile {
     @Nullable private String values_env;
     @Nullable private String revision_env;
 
+    /**
+     * Name of an environment variable acting as a per-template kill switch. When the variable
+     * resolves to {@code "false"}, the template is skipped and nothing is written. An unset
+     * variable leaves the template enabled, so templates that do not opt in are unaffected.
+     */
+    @Nullable private String enabledEnvVar;
+
     public MCPTemplate withOverride(ObjectMapper objectMapper) {
       if (revision_env != null) {
         String overrideJson = System.getenv().getOrDefault(revision_env, "{}");

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
@@ -1,0 +1,100 @@
+package com.linkedin.datahub.upgrade.system.bootstrapmcps;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.datahub.upgrade.UpgradeContext;
+import com.linkedin.datahub.upgrade.system.bootstrapmcps.model.BootstrapMCPConfigFile;
+import com.linkedin.metadata.entity.EntityService;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.io.IOException;
+import org.testng.annotations.Test;
+
+public class BootstrapMCPStepTest {
+  private static final OperationContext OP_CONTEXT =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+
+  /** Index of the template in test.yaml carrying {@code enabledEnvVar: "MY_FEATURE_ENABLED"}. */
+  private static final int GATED_TEMPLATE_INDEX = 1;
+
+  private static BootstrapMCPConfigFile.MCPTemplate template(int index) throws IOException {
+    return BootstrapMCPUtil.resolveYamlConf(
+            OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class)
+        .getBootstrap()
+        .getTemplates()
+        .get(index);
+  }
+
+  private static BootstrapMCPStep stepWithEnv(
+      BootstrapMCPConfigFile.MCPTemplate template,
+      EntityService<?> entityService,
+      String envValue) {
+    return new BootstrapMCPStep(OP_CONTEXT, entityService, template) {
+      @Override
+      protected String resolveEnvValue(String name) {
+        return envValue;
+      }
+    };
+  }
+
+  @Test
+  public void testEnabledEnvVarSkipsWhenFalse() throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+
+    BootstrapMCPConfigFile.MCPTemplate template = template(GATED_TEMPLATE_INDEX);
+
+    assertTrue(stepWithEnv(template, mockEntityService, "false").skip(mockUpgradeContext));
+    assertTrue(stepWithEnv(template, mockEntityService, "FALSE").skip(mockUpgradeContext));
+  }
+
+  @Test
+  public void testEnabledEnvVarDoesNotSkipWhenTrue() throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+    when(mockEntityService.exists(any(OperationContext.class), any(), any(), eq(true)))
+        .thenReturn(false);
+
+    assertFalse(
+        stepWithEnv(template(GATED_TEMPLATE_INDEX), mockEntityService, "true")
+            .skip(mockUpgradeContext));
+  }
+
+  /**
+   * An unset variable must leave the template enabled — templates that never opt in have no env var
+   * set either, and skipping them would disable the whole bootstrap.
+   */
+  @Test
+  public void testEnabledEnvVarDoesNotSkipWhenUnset() throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+    when(mockEntityService.exists(any(OperationContext.class), any(), any(), eq(true)))
+        .thenReturn(false);
+
+    assertFalse(
+        stepWithEnv(template(GATED_TEMPLATE_INDEX), mockEntityService, null)
+            .skip(mockUpgradeContext));
+  }
+
+  @Test
+  public void testTemplateWithoutEnabledEnvVarFallsThroughToPreviouslyRunCheck()
+      throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+    when(mockEntityService.exists(any(OperationContext.class), any(), any(), eq(true)))
+        .thenReturn(true);
+
+    BootstrapMCPStep step = new BootstrapMCPStep(OP_CONTEXT, mockEntityService, template(0));
+
+    assertTrue(step.skip(mockUpgradeContext));
+  }
+}

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
@@ -22,6 +22,9 @@ public class BootstrapMCPStepTest {
   /** Index of the template in test.yaml carrying {@code enabledEnvVar: "MY_FEATURE_ENABLED"}. */
   private static final int GATED_TEMPLATE_INDEX = 1;
 
+  /** Same kill switch, but with {@code force: true} as well. */
+  private static final int GATED_FORCED_TEMPLATE_INDEX = 2;
+
   private static BootstrapMCPConfigFile.MCPTemplate template(int index) throws IOException {
     return BootstrapMCPUtil.resolveYamlConf(
             OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class)
@@ -52,6 +55,46 @@ public class BootstrapMCPStepTest {
 
     assertTrue(stepWithEnv(template, mockEntityService, "false").skip(mockUpgradeContext));
     assertTrue(stepWithEnv(template, mockEntityService, "FALSE").skip(mockUpgradeContext));
+  }
+
+  /**
+   * These variables are usually the same ones Spring binds to boolean properties, so the kill
+   * switch has to read them the way Spring does. Otherwise {@code =0} disables the feature while
+   * leaving its bootstrap enabled.
+   */
+  @Test
+  public void testEnabledEnvVarAcceptsSpringFalseyForms() throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+
+    BootstrapMCPConfigFile.MCPTemplate template = template(GATED_TEMPLATE_INDEX);
+
+    for (String value : new String[] {"off", "no", "0", " false ", "\tFALSE\n"}) {
+      assertTrue(
+          stepWithEnv(template, mockEntityService, value).skip(mockUpgradeContext),
+          "expected '" + value + "' to be treated as off");
+    }
+  }
+
+  /**
+   * The kill switch has to win over {@code force: true}, otherwise a forced template could not be
+   * switched off at all.
+   */
+  @Test
+  public void testEnabledEnvVarBeatsForce() throws IOException {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    UpgradeContext mockUpgradeContext = mock(UpgradeContext.class);
+    when(mockUpgradeContext.opContext()).thenReturn(OP_CONTEXT);
+
+    BootstrapMCPConfigFile.MCPTemplate template = template(GATED_FORCED_TEMPLATE_INDEX);
+    assertTrue(template.isForce());
+
+    assertTrue(stepWithEnv(template, mockEntityService, "false").skip(mockUpgradeContext));
+    // Switched on, force still means "run even if previously run".
+    when(mockEntityService.exists(any(OperationContext.class), any(), any(), eq(true)))
+        .thenReturn(true);
+    assertFalse(stepWithEnv(template, mockEntityService, "true").skip(mockUpgradeContext));
   }
 
   @Test

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPStepTest.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.upgrade.system.bootstrapmcps;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -55,6 +56,11 @@ public class BootstrapMCPStepTest {
 
     assertTrue(stepWithEnv(template, mockEntityService, "false").skip(mockUpgradeContext));
     assertTrue(stepWithEnv(template, mockEntityService, "FALSE").skip(mockUpgradeContext));
+
+    // Nothing is read or written while switched off. This is what makes the switch
+    // reversible: no DataHubUpgradeResult is recorded, so the step is not considered
+    // "already run" and will execute normally once the variable flips to true.
+    verifyNoInteractions(mockEntityService);
   }
 
   /**

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPUtilTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPUtilTest.java
@@ -47,7 +47,7 @@ public class BootstrapMCPUtilTest {
     BootstrapMCPConfigFile initConfig =
         BootstrapMCPUtil.resolveYamlConf(
             OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class);
-    assertEquals(initConfig.getBootstrap().getTemplates().size(), 2);
+    assertEquals(initConfig.getBootstrap().getTemplates().size(), 3);
 
     BootstrapMCPConfigFile.MCPTemplate template = initConfig.getBootstrap().getTemplates().get(0);
     assertEquals(template.getName(), "datahub-test");
@@ -67,7 +67,7 @@ public class BootstrapMCPUtilTest {
     BootstrapMCPConfigFile initConfig =
         BootstrapMCPUtil.resolveYamlConf(
             OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class);
-    assertEquals(initConfig.getBootstrap().getTemplates().size(), 2);
+    assertEquals(initConfig.getBootstrap().getTemplates().size(), 3);
 
     BootstrapMCPConfigFile.MCPTemplate template =
         initConfig.getBootstrap().getTemplates().get(0).withOverride(new ObjectMapper());

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPUtilTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/bootstrapmcps/BootstrapMCPUtilTest.java
@@ -47,7 +47,7 @@ public class BootstrapMCPUtilTest {
     BootstrapMCPConfigFile initConfig =
         BootstrapMCPUtil.resolveYamlConf(
             OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class);
-    assertEquals(initConfig.getBootstrap().getTemplates().size(), 1);
+    assertEquals(initConfig.getBootstrap().getTemplates().size(), 2);
 
     BootstrapMCPConfigFile.MCPTemplate template = initConfig.getBootstrap().getTemplates().get(0);
     assertEquals(template.getName(), "datahub-test");
@@ -67,7 +67,7 @@ public class BootstrapMCPUtilTest {
     BootstrapMCPConfigFile initConfig =
         BootstrapMCPUtil.resolveYamlConf(
             OP_CONTEXT, "bootstrapmcp/test.yaml", BootstrapMCPConfigFile.class);
-    assertEquals(initConfig.getBootstrap().getTemplates().size(), 1);
+    assertEquals(initConfig.getBootstrap().getTemplates().size(), 2);
 
     BootstrapMCPConfigFile.MCPTemplate template =
         initConfig.getBootstrap().getTemplates().get(0).withOverride(new ObjectMapper());

--- a/datahub-upgrade/src/test/resources/bootstrapmcp/test.yaml
+++ b/datahub-upgrade/src/test/resources/bootstrapmcp/test.yaml
@@ -8,3 +8,8 @@ bootstrap:
       mcps_location: "bootstrapmcp/datahub-test-mcp.yaml"
       values_env: "DATAHUB_TEST_VALUES_ENV"
       revision_env: "DATAHUB_TEST_REVISION_ENV"
+    - name: datahub-test-gated
+      version: v1
+      optional: true
+      mcps_location: "bootstrapmcp/datahub-test-mcp.yaml"
+      enabledEnvVar: "MY_FEATURE_ENABLED"

--- a/datahub-upgrade/src/test/resources/bootstrapmcp/test.yaml
+++ b/datahub-upgrade/src/test/resources/bootstrapmcp/test.yaml
@@ -13,3 +13,8 @@ bootstrap:
       optional: true
       mcps_location: "bootstrapmcp/datahub-test-mcp.yaml"
       enabledEnvVar: "MY_FEATURE_ENABLED"
+    - name: datahub-test-gated-force
+      version: v1
+      force: true
+      mcps_location: "bootstrapmcp/datahub-test-mcp.yaml"
+      enabledEnvVar: "MY_FEATURE_ENABLED"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -68,7 +68,5 @@ bootstrap:
       mcps_location: "bootstrap_mcps/ingestion-datahub-documents.yaml"
       values_env: "DATAHUB_DOCUMENTS_BOOTSTRAP_VALUES"
       revision_env: "DATAHUB_DOCUMENTS_REVISION"
-      # This source only produces embeddings for semantic search. Without it the
-      # scheduled runs scroll, chunk, and emit nothing, so skip creating the
-      # source when semantic search is off.
+      # Only produces embeddings for semantic search, so don't create it when off.
       enabledEnvVar: "ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -68,3 +68,7 @@ bootstrap:
       mcps_location: "bootstrap_mcps/ingestion-datahub-documents.yaml"
       values_env: "DATAHUB_DOCUMENTS_BOOTSTRAP_VALUES"
       revision_env: "DATAHUB_DOCUMENTS_REVISION"
+      # This source only produces embeddings for semantic search. Without it the
+      # scheduled runs scroll, chunk, and emit nothing, so skip creating the
+      # source when semantic search is off.
+      enabledEnvVar: "ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED"


### PR DESCRIPTION
## Summary

The `datahub-documents` bootstrap creates a system ingestion source scheduled every 15 minutes on **every** instance. Its only output is embeddings for semantic search, so on an instance with semantic search disabled every run scrolls documents, runs the `unstructured` chunking pass, and emits nothing.

Observed on a real instance with semantic search off:

```
INFO {datahub.ingestion.source.unstructured.chunking_source:1020} -
  Semantic search is disabled on the DataHub server — skipping embedding generation.
Pipeline finished with at least 1 warnings; produced 0 events in 0.41 seconds.
'events_produced': 0
```

At the default `*/15` schedule that is 96 empty executions a day, each preceded by a full plugin venv build, and 96 empty rows in the ingestion execution history. On the executor inspected it accounted for 32 of 48 plugin venv builds in the log window — four times the next most frequent system source.

Everything else in the semantic-search stack is already gated (`BridgeDocumentHook`, `SemanticSearchServiceFactory`, the MCP document tools). The thing that *schedules* the work is not.

## What this changes

Adds an optional `enabledEnvVar` kill switch to bootstrap MCP templates, and points the `datahub-documents` template at `ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED`.

A template that names an `enabledEnvVar` is skipped when that variable resolves to `"false"`. An **unset** variable leaves the template enabled, so every template that does not opt in is completely unaffected — important because most deployments set no such variable at all.

`resolveEnvValue` is a `protected` seam purely so tests can vary the env var without mutating the JVM's process environment.

## Caveat

This gates **creation only**. Instances that already bootstrapped the source keep it and it keeps running on its schedule; it has to be removed or disabled from the Ingestion tab. Turning semantic search on later restores the source on the next upgrade.

## Testing

`./gradlew :datahub-upgrade:test --tests "...bootstrapmcps.*"` — 9 passing.

New `BootstrapMCPStepTest` covers the contract: `"false"` (and `"FALSE"`) skips; `"true"` does not; unset does not; and a template without `enabledEnvVar` still falls through to the normal previously-run check.

For the flag to actually be present and `"false"` on a disabled deployment, the Helm chart has to emit it rather than omit it — acryldata/datahub-helm#724.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip bootstrapping the `datahub-documents` system ingestion source when semantic search is disabled, avoiding no-op runs and venv builds. Previously the source was always created; now it is skipped when `ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED` is falsey; this applies even if the template is forced.

- Adds an optional `enabledEnvVar` kill switch to MCP templates; when the env var trims to `false`, `off`, `no`, or `0` (case-insensitive, matching Spring’s boolean binding), the template is not created; when unset, behavior is unchanged.
- Gates the `datahub-documents` template in `bootstrap_mcps.yaml`.
- Evaluates the kill switch before `force`; a switched-off template stays off even with `force: true`.
- Skips before any DB read/write and leaves no upgrade record while off, so turning the env var on later will create the source (tests added).
- Gates creation only; existing `datahub-documents` sources continue to run until manually removed or disabled.

**Rollout**
- Set `ELASTICSEARCH_SEMANTIC_SEARCH_ENABLED` to a falsey value (`false`, `off`, `no`, or `0`) to skip creation; omitting the variable will not skip creation.
- Existing deployments that already bootstrapped `datahub-documents` must remove or disable the source manually.

<sup>Written for commit 6f42573481f0a49b9231150297a95c0fb80a5186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

