### PR TITLE
feat(ingest/rdf): source RDF from a Git repository

### DIFF
--- a/metadata-ingestion/docs/sources/rdf/rdf_pre.md
+++ b/metadata-ingestion/docs/sources/rdf/rdf_pre.md
@@ -32,6 +32,7 @@ The `source` parameter accepts multiple input types:
 - **URL**: `source: https://example.com/ontology.ttl`
 - **Comma-separated files**: `source: file1.ttl, file2.ttl, file3.ttl`
 - **Glob pattern**: `source: path/to/**/*.ttl`
+- **Git repository**: `git_info: {repo: https://github.com/acme/onto}` — shallow-clones the repo (SSH deploy key auth); `source` is then a path relative to the checkout, or omit to scan the repo root
 
 #### RDF Dialects
 
@@ -76,3 +77,22 @@ source:
 ```
 
 Available entity types: `glossary` (or `glossary_terms`), `relationship` (or `relationships`).
+
+#### Git repository
+
+Set `git_info` to shallow-clone a Git repository (authenticated with an SSH deploy key) and scan
+it for RDF files. The `source` parameter is then resolved relative to the repository checkout —
+for example `source: glossary/` processes only the `glossary/` subdirectory. Omit `source`
+entirely to scan the entire repository root.
+
+```yaml
+source:
+  type: rdf
+  config:
+    git_info:
+      repo: https://github.com/acme/ontologies
+      branch: main
+      deploy_key_file: ~/.ssh/datahub_rdf_deploy_key
+    source: glossary/ # optional — defaults to repo root
+    format: turtle
+```

--- a/metadata-ingestion/docs/sources/rdf/rdf_recipe.yml
+++ b/metadata-ingestion/docs/sources/rdf/rdf_recipe.yml
@@ -3,6 +3,12 @@ source:
   config:
     # Required: RDF source (file, folder, URL, or comma-separated files)
     source: path/to/glossary.ttl
+
+    # Or clone a Git repository and scan it (source is resolved relative to checkout):
+    # git_info:
+    #   repo: https://github.com/acme/ontologies
+    #   branch: main
+    #   deploy_key_file: ~/.ssh/datahub_rdf_deploy_key
     
     # Optional: DataHub environment
     environment: PROD

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -869,6 +869,7 @@ quicksight = [
 ]
 
 rdf = [
+    "GitPython>=3.1.58,<4.0.0",
     "rdflib==6.3.2",
     "requests==2.32.5",
     "requests_file==3.0.1",
@@ -1708,6 +1709,7 @@ integration-tests = [
     "deltalake>=0.6.3, != 0.6.4, <1.0.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
     "feast>=0.34.0,<1",
     "flask-openid>=1.3.0,<2.0.0",
+    "GitPython>=3.1.58,<4.0.0",
     "google-cloud-aiplatform>=1.80.0,<2.0.0",
     "greenlet<4.0.0",
     "hdbcli>=2.11.20,<3.0.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -772,7 +772,12 @@ plugins: Dict[str, Set[str]] = {
     },
     "pulsar": {"requests<3.0.0"},
     "redash": {"redash-toolbelt<0.2.0"} | sqlglot_lib,
-    "rdf": {"rdflib==6.3.2", "requests==2.32.5", "requests_file==3.0.1"},
+    "rdf": {
+        "rdflib==6.3.2",
+        "requests==2.32.5",
+        "requests_file==3.0.1",
+        "GitPython>=3.1.58,<4.0.0",
+    },
     "redshift": sql_common
     | redshift_common
     | usage_common

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/ingestion/rdf_source.py
@@ -17,7 +17,10 @@ Example recipe:
           - lineage
 """
 
+import contextlib
 import logging
+import pathlib
+import tempfile
 from dataclasses import dataclass, field
 from typing import Any, Iterable, List, Optional
 
@@ -78,6 +81,7 @@ class RDFSourceReport(StaleEntityRemovalSourceReport):
 
     # File-level tracking
     files_processed: List[str] = field(default_factory=list)
+    git_checkout: Optional[str] = None
 
     def report_triples_processed(self, count: int) -> None:
         """Add to triples counter."""
@@ -217,6 +221,19 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
         """
         from pathlib import Path
 
+        if config.git_info is not None:
+            return CapabilityReport(
+                capable=True,
+                failure_reason=None,
+                mitigation_message=(
+                    "Git repository reachability and deploy-key auth are validated "
+                    "during ingestion, not during the connection test."
+                ),
+            )
+
+        if config.source is None:
+            return CapabilityReport(capable=True, failure_reason=None)
+
         try:
             source_path = config.source
 
@@ -283,6 +300,13 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
         Returns:
             CapabilityReport indicating if RDF parsing succeeded
         """
+        if config.git_info is not None or config.source is None:
+            return CapabilityReport(
+                capable=True,
+                failure_reason=None,
+                mitigation_message="RDF parsing validated during ingestion for git sources",
+            )
+
         try:
             from datahub.ingestion.source.rdf.core.rdf_loader import load_rdf_graph
 
@@ -359,6 +383,14 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
             AutoStaleEntityRemovalProcessor,
         ]
 
+    def _resolve_git_source(self, checkout_dir: pathlib.Path) -> str:
+        # Split comma-separated parts and prefix each with the checkout directory.
+        # Absolute-path and '..' rejection already happened at config-parse time.
+        if not self.config.source:
+            return str(checkout_dir)
+        parts = [p.strip() for p in self.config.source.split(",") if p.strip()]
+        return ",".join(str(checkout_dir / part) for part in parts)
+
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         """
         Generate work units from RDF data.
@@ -370,19 +402,42 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
         """
         logger.info("Starting RDF ingestion")
 
-        rdf_graph = self._load_rdf_graph()
-        if rdf_graph is None:
-            return
+        with contextlib.ExitStack() as stack:
+            if self.config.git_info is not None:
+                tmp_dir = stack.enter_context(tempfile.TemporaryDirectory("rdf_git"))
+                try:
+                    checkout_dir = self.config.git_info.clone(tmp_path=tmp_dir)
+                except RuntimeError as e:
+                    self._handle_load_error(
+                        e,
+                        "Failed to clone git repository",
+                        f"Repository: {self.config.git_info.repo_ssh_locator}",
+                    )
+                    return
+                self.report.git_checkout = str(checkout_dir)
+                resolved_source: str = self._resolve_git_source(checkout_dir)
+                # Confine loading to the checkout so a symlink inside the repo
+                # can't cause files outside it to be read.
+                base_dir: Optional[str] = str(checkout_dir)
+            else:
+                # The model validator guarantees source is set when git_info is None.
+                assert self.config.source is not None
+                resolved_source = self.config.source
+                base_dir = None
 
-        datahub_ast = self.ast_converter.convert_safe(rdf_graph)
-        if datahub_ast is None:
-            return
+            rdf_graph = self._load_rdf_graph(resolved_source, base_dir=base_dir)
+            if rdf_graph is None:
+                return
 
-        workunits = self.workunit_generator.generate_safe(datahub_ast)
-        if workunits is None:
-            return
+            datahub_ast = self.ast_converter.convert_safe(rdf_graph)
+            if datahub_ast is None:
+                return
 
-        yield from self.workunit_generator.yield_with_error_handling(workunits)
+            workunits = self.workunit_generator.generate_safe(datahub_ast)
+            if workunits is None:
+                return
+
+            yield from self.workunit_generator.yield_with_error_handling(workunits)
 
     def _handle_load_error(
         self, error: Exception, error_type: str, error_context: str
@@ -432,9 +487,14 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
         self.report.report_triples_processed(filtered_count)
         return filtered_graph
 
-    def _load_rdf_graph(self) -> Optional[Graph]:
+    def _load_rdf_graph(
+        self, source: str, base_dir: Optional[str] = None
+    ) -> Optional[Graph]:
         """
         Load RDF graph from configured source.
+
+        base_dir, when set, restricts loading to that directory (files resolving
+        outside it are rejected) — used to confine git checkouts.
 
         Returns:
             Loaded RDF graph, or None if loading failed
@@ -442,10 +502,11 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
         try:
             logger.info("Loading RDF graph from source")
             rdf_graph = load_rdf_graph(
-                source=self.config.source,
+                source=source,
                 format=self.config.format,
                 recursive=self.config.recursive,
                 file_extensions=self.config.extensions,
+                base_dir=base_dir,
             )
             triple_count = len(rdf_graph)
             logger.info(f"Loaded {triple_count} triples from source")
@@ -472,7 +533,7 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
             return rdf_graph
         except FileNotFoundError as e:
             error_context = (
-                f"Source: {self.config.source}. "
+                f"Source: {source}. "
                 f"Please verify the file or directory exists and is accessible. "
                 f"If using a URL, ensure it's reachable. "
                 f"Supported file extensions: {', '.join(self.config.extensions)}"
@@ -481,7 +542,7 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
             return None
         except ValueError as e:
             error_context = (
-                f"Source: {self.config.source}, Error: {str(e)}. "
+                f"Source: {source}, Error: {str(e)}. "
                 f"Please verify the file is valid RDF in a supported format "
                 f"(turtle, xml, json-ld, n3, nt). "
                 f"If format is not auto-detected, specify it explicitly using the 'format' config option."
@@ -490,7 +551,7 @@ class RDFSource(StatefulIngestionSourceBase, TestableSource):
             return None
         except (OSError, RuntimeError) as e:
             error_context = (
-                f"Source: {self.config.source}. "
+                f"Source: {source}. "
                 f"Unexpected error while loading RDF. "
                 f"Please verify the file is accessible, properly formatted, and in a supported RDF format. "
                 f"Check the logs for more details."

--- a/metadata-ingestion/src/datahub/ingestion/source/rdf/rdf_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/rdf/rdf_config.py
@@ -5,10 +5,12 @@ This module contains the configuration class for the RDF ingestion source,
 following DataHub conventions for separating configuration from source implementation.
 """
 
+import os
 from typing import List, Optional
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
+from datahub.configuration.git import GitInfo
 from datahub.configuration.source_common import (
     EnvConfigMixin,
     PlatformInstanceConfigMixin,
@@ -117,14 +119,21 @@ class RDFSourceConfig(
     """
 
     # Source Options
-    source: str = Field(
+    source: Optional[str] = Field(
+        default=None,
         description=(
-            "Primary: Web URL to .ttl or .zip file (e.g. https://example.org/glossary.ttl, "
-            "https://example.org/data.zip). Also supports web folder URLs. "
-            "Local file/folder paths work only when running via CLI. "
-            "Examples: 'https://example.org/glossary.ttl', 'https://example.org/data.zip', "
-            "'https://example.org/folder/', '/path/to/file.ttl' (CLI-only)"
-        )
+            "Location of RDF data: a file, folder, URL, zip, comma-separated list, or glob "
+            "pattern; or — when `git_info` is set — a path relative to the repository checkout "
+            "(optional, defaults to the repo root)."
+        ),
+    )
+    git_info: Optional[GitInfo] = Field(
+        default=None,
+        description=(
+            "Git repository to shallow-clone (SSH deploy key auth); when set, `source` is "
+            "resolved relative to the repository checkout (e.g. a file or folder within the "
+            "repo), and may be omitted to scan the repo root."
+        ),
     )
     format: Optional[str] = Field(
         default=None,
@@ -240,12 +249,41 @@ class RDFSourceConfig(
     @classmethod
     def validate_source(cls, v):
         """Validate source parameter is not empty."""
-        if not v or not v.strip():
+        if v is None:
+            return None
+        if not v.strip():
             raise ValueError(
                 "Source parameter cannot be empty. Please provide a web URL (.ttl or .zip), "
                 "or a local path when running via CLI."
             )
         return v.strip()
+
+    @model_validator(mode="after")
+    def source_or_git_required(self) -> "RDFSourceConfig":
+        if not self.source and self.git_info is None:
+            raise ValueError("source is required unless git_info is set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_git_source_paths(self) -> "RDFSourceConfig":
+        # When git_info is set and source is provided, each comma-separated part
+        # must be a relative path so it can't escape the checkout directory.
+        if self.git_info is not None and self.source:
+            parts = [p.strip() for p in self.source.split(",")]
+            for part in parts:
+                if not part:
+                    continue
+                if os.path.isabs(part) or part.startswith("\\"):
+                    raise ValueError(
+                        f"source path '{part}' must be relative when git_info is set; "
+                        "absolute paths are not allowed"
+                    )
+                components = part.replace("\\", "/").split("/")
+                if ".." in components:
+                    raise ValueError(
+                        f"source path '{part}' must not contain '..' components when git_info is set"
+                    )
+        return self
 
     @field_validator("sparql_filter")
     @classmethod

--- a/metadata-ingestion/tests/integration/rdf/test_rdf_git.py
+++ b/metadata-ingestion/tests/integration/rdf/test_rdf_git.py
@@ -1,0 +1,152 @@
+import os
+import pathlib
+from unittest.mock import patch
+
+import git
+import pytest
+
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.ingestion.run.pipeline import Pipeline
+from datahub.ingestion.source.rdf.ingestion.rdf_source import RDFSourceReport
+
+_SKOS_TTL = """\
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/glossary/> .
+
+ex:ConceptA a skos:Concept ;
+    skos:prefLabel "Concept A" ;
+    skos:definition "First concept." .
+
+ex:ConceptB a skos:Concept ;
+    skos:prefLabel "Concept B" ;
+    skos:definition "Second concept." .
+"""
+
+
+@pytest.mark.integration
+def test_git_clone_and_walk(
+    tmp_path: pathlib.Path, mock_datahub_graph_instance: DataHubGraph
+) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = git.Repo.init(repo_dir)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "email", "test@example.com")
+        cw.set_value("user", "name", "Test")
+    glossary_dir = repo_dir / "glossary"
+    glossary_dir.mkdir()
+    (glossary_dir / "concepts.ttl").write_text(_SKOS_TTL, encoding="utf-8")
+    repo.index.add(["glossary/concepts.ttl"])
+    repo.index.commit("add glossary")
+
+    output_path = tmp_path / "output.json"
+    pipeline = Pipeline.create(
+        {
+            "run_id": "test-rdf-git",
+            "source": {
+                "type": "rdf",
+                "config": {
+                    "source": "glossary",
+                    "format": "turtle",
+                    "git_info": {
+                        "repo": "https://github.com/acme/onto",
+                        "repo_ssh_locator": f"file://{repo_dir}",
+                    },
+                },
+            },
+            "sink": {"type": "file", "config": {"filename": str(output_path)}},
+        }
+    )
+    pipeline.ctx.graph = mock_datahub_graph_instance
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = pipeline.source.get_report()
+    assert isinstance(report, RDFSourceReport)
+    assert report.git_checkout is not None
+    assert report.num_workunits_produced > 0
+    assert report.num_glossary_terms == 2
+
+
+@pytest.mark.integration
+def test_clone_failure_reports_gracefully(
+    tmp_path: pathlib.Path, mock_datahub_graph_instance: DataHubGraph
+) -> None:
+    output_path = tmp_path / "output.json"
+    with patch(
+        "datahub.configuration.git.GitInfo.clone",
+        side_effect=RuntimeError("boom"),
+    ):
+        pipeline = Pipeline.create(
+            {
+                "run_id": "test-rdf-git-fail",
+                "source": {
+                    "type": "rdf",
+                    "config": {
+                        "git_info": {
+                            "repo": "https://github.com/acme/onto",
+                            "repo_ssh_locator": "git@github.com:acme/onto.git",
+                        },
+                    },
+                },
+                "sink": {"type": "file", "config": {"filename": str(output_path)}},
+            }
+        )
+        pipeline.ctx.graph = mock_datahub_graph_instance
+        pipeline.run()
+
+    report = pipeline.source.get_report()
+    assert isinstance(report, RDFSourceReport)
+    assert report.failures
+    assert report.num_workunits_produced == 0
+
+
+@pytest.mark.integration
+def test_symlink_escaping_checkout_is_not_loaded(
+    tmp_path: pathlib.Path, mock_datahub_graph_instance: DataHubGraph
+) -> None:
+    # A file outside the repo that must never be ingested via the checkout.
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "secret.ttl").write_text(_SKOS_TTL, encoding="utf-8")
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = git.Repo.init(repo_dir)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "email", "test@example.com")
+        cw.set_value("user", "name", "Test")
+    # A symlink whose textual path is a clean relative name but resolves outside.
+    os.symlink(outside_dir / "secret.ttl", repo_dir / "escape.ttl")
+    repo.index.add(["escape.ttl"])
+    repo.index.commit("add escaping symlink")
+
+    output_path = tmp_path / "output.json"
+    pipeline = Pipeline.create(
+        {
+            "run_id": "test-rdf-git-symlink",
+            "source": {
+                "type": "rdf",
+                "config": {
+                    "source": "escape.ttl",
+                    "format": "turtle",
+                    "git_info": {
+                        "repo": "https://github.com/acme/onto",
+                        "repo_ssh_locator": f"file://{repo_dir}",
+                    },
+                },
+            },
+            "sink": {"type": "file", "config": {"filename": str(output_path)}},
+        }
+    )
+    pipeline.ctx.graph = mock_datahub_graph_instance
+    pipeline.run()
+
+    report = pipeline.source.get_report()
+    assert isinstance(report, RDFSourceReport)
+    assert report.git_checkout is not None
+    # Containment is enforced against the checkout, so the outside file is
+    # rejected and nothing is emitted.
+    assert report.failures
+    assert report.num_glossary_terms == 0
+    assert report.num_workunits_produced == 0

--- a/metadata-ingestion/tests/unit/rdf/test_rdf_config.py
+++ b/metadata-ingestion/tests/unit/rdf/test_rdf_config.py
@@ -11,6 +11,7 @@ Tests verify:
 """
 
 import pytest
+from pydantic import ValidationError
 
 from datahub.ingestion.source.rdf.ingestion.rdf_source import RDFSourceConfig
 
@@ -26,6 +27,29 @@ class TestRDFConfig:
             RDFSourceConfig.model_validate(config_dict)
 
         assert "source" in str(exc_info.value).lower()
+
+    def test_git_info_accepted(self):
+        """Test that git_info is accepted and parsed."""
+        config_dict = {
+            "source": "glossary.ttl",
+            "git_info": {"repo": "https://github.com/acme/onto"},
+        }
+        config = RDFSourceConfig.model_validate(config_dict)
+        assert config.git_info is not None
+        assert config.git_info.repo == "https://github.com/acme/onto"
+
+    def test_source_optional_when_git_info_set(self):
+        """Test that source may be omitted when git_info is set."""
+        config_dict = {"git_info": {"repo": "https://github.com/acme/onto"}}
+        config = RDFSourceConfig.model_validate(config_dict)
+        assert config.source is None
+        assert config.git_info is not None
+
+    def test_neither_source_nor_git_info_raises(self):
+        """Test that omitting both source and git_info is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            RDFSourceConfig.model_validate({})
+        assert "source is required unless git_info is set" in str(exc_info.value)
 
     def test_source_must_be_string(self):
         """Test that source must be a string."""
@@ -243,3 +267,36 @@ class TestRDFConfig:
 
         error_str = str(exc_info.value).lower()
         assert "construct" in error_str or "select" in error_str
+
+    def test_git_source_absolute_path_rejected(self):
+        """Absolute source paths are forbidden when git_info is set."""
+        with pytest.raises(ValidationError) as exc_info:
+            RDFSourceConfig.model_validate(
+                {
+                    "source": "/etc/passwd",
+                    "git_info": {"repo": "https://github.com/acme/onto"},
+                }
+            )
+        assert "absolute" in str(exc_info.value).lower()
+
+    def test_git_source_dotdot_rejected(self):
+        """Source paths with '..' are forbidden when git_info is set."""
+        with pytest.raises(ValidationError) as exc_info:
+            RDFSourceConfig.model_validate(
+                {
+                    "source": "../secrets",
+                    "git_info": {"repo": "https://github.com/acme/onto"},
+                }
+            )
+        assert ".." in str(exc_info.value)
+
+    def test_git_source_relative_path_accepted(self):
+        """Relative source paths are accepted when git_info is set."""
+        config = RDFSourceConfig.model_validate(
+            {
+                "source": "glossary/",
+                "git_info": {"repo": "https://github.com/acme/onto"},
+            }
+        )
+        assert config.source == "glossary/"
+        assert config.git_info is not None

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -1060,6 +1060,7 @@ integration-tests = [
     { name = "deltalake" },
     { name = "feast" },
     { name = "flask-openid" },
+    { name = "gitpython" },
     { name = "google-cloud-aiplatform" },
     { name = "greenlet" },
     { name = "hdbcli", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
@@ -1337,6 +1338,7 @@ quicksight = [
     { name = "sqlglot", extra = ["c"] },
 ]
 rdf = [
+    { name = "gitpython" },
     { name = "rdflib" },
     { name = "requests" },
     { name = "requests-file" },
@@ -1960,9 +1962,11 @@ requires-dist = [
     { name = "gitpython", marker = "extra == 'all'", specifier = ">=3.1.58,<4.0.0" },
     { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.58,<4.0.0" },
     { name = "gitpython", marker = "extra == 'docs'", specifier = ">=3.1.58,<4.0.0" },
+    { name = "gitpython", marker = "extra == 'integration-tests'", specifier = ">=3.1.58,<4.0.0" },
     { name = "gitpython", marker = "extra == 'looker'", specifier = ">=3.1.58,<4.0.0" },
     { name = "gitpython", marker = "extra == 'lookml'", specifier = ">=3.1.58,<4.0.0" },
     { name = "gitpython", marker = "extra == 'odcs'", specifier = ">=3.1.58,<4.0.0" },
+    { name = "gitpython", marker = "extra == 'rdf'", specifier = ">=3.1.58,<4.0.0" },
     { name = "google-auth", marker = "extra == 'all'", specifier = ">=2.0.0,<3.0.0" },
     { name = "google-auth", marker = "extra == 'confluence'", specifier = ">=2.0.0,<3.0.0" },
     { name = "google-auth", marker = "extra == 'datahub-documents'", specifier = ">=2.0.0,<3.0.0" },


### PR DESCRIPTION
## Summary

Adds Git-repository support to the `rdf` ingestion source. Previously the
source could only read from web URLs, zip files, and (CLI-only) local paths.
You can now point it at a Git repo, which is shallow-cloned with an SSH deploy
key and scanned for RDF files — following the same `GitInfo` pattern the LookML
and ODCS sources already use.

```yaml
source:
  type: rdf
  config:
    git_info:
      repo: https://github.com/acme/ontologies
      deploy_key_file: ~/.ssh/datahub_rdf_deploy_key
    source: glossary/   # path within the repo; omit to scan the whole checkout
    format: turtle
```

## Details

- `source` is now optional. When `git_info` is set it is resolved relative to
  the repository checkout (a file or subdirectory), or may be omitted to scan
  the repo root. A model validator requires one of `source` / `git_info`.
- The clone runs in `get_workunits_internal` inside a `contextlib.ExitStack`
  so the temporary checkout outlives the workunit generator; the effective
  path is then handed to the existing folder-loading path in the RDF loader —
  no loader changes were needed.
- `test_connection` short-circuits to `capable` for git sources (it cannot
  cheaply clone during a connection test).
- `GitPython` is added to the `rdf` extra. `uv.lock` only gains `gitpython`
  markers for the `rdf` / `integration-tests` extras, since the package was
  already locked via the looker/odcs extras.

## Testing

- Unit (`tests/unit/rdf/test_rdf_config.py`): `git_info` accepted, `source`
  optional when `git_info` is set, and neither-provided is rejected.
- Integration (`tests/integration/rdf/test_rdf_git.py`): builds a real on-disk
  git repo containing a SKOS glossary, clones it via a `file://`
  `repo_ssh_locator`, and asserts the checkout is recorded and workunits are
  produced. Mirrors the ODCS `test_git_clone_and_walk` idiom — hermetic, no
  network or Docker required.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [x] Docs updated (`rdf_pre.md`, `rdf_recipe.yml`)
- [ ] Breaking changes — none (`source` was required and stays valid; the only
  change is that it is now also optional when `git_info` is provided)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Git repository support to the RDF source. Previously it read URLs, zips, and CLI-only local paths; now it shallow-clones a repo with an SSH deploy key and scans the checkout. `source` is now optional when `git_info` is set, and is resolved relative to the checkout; absolute paths and `..` components are rejected for git sources.

- Config requires one of `source` or `git_info`; when `git_info` is set, `source` may be omitted to scan the repo root.
- Execution clones in `get_workunits_internal` into a temporary checkout and passes `base_dir` to the RDF loader so symlinks can't read files outside the repo; `RDFSourceReport` records `git_checkout`.
- Capability checks return capable for git sources or when `source` is omitted; validation happens during ingestion.
- Adds `GitPython>=3.1.58,<4.0.0` to the `rdf` and `integration-tests` extras; docs and recipe updated; unit tests cover validation and integration tests cover clone, workunit generation, and symlink-escape blocking.
- Rollout: no breaking changes; existing `source` configs continue to work, and git sources just add `git_info` plus an optional relative `source`.

<sup>Written for commit 5f6f62f9c932356a88d69bda7961bd324d9ce64a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

