### PR TITLE
fix(graph): match relatedEntityTypes case-insensitively

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -42,6 +42,7 @@ import io.datahubproject.metadata.context.ActorContext;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -115,8 +116,14 @@ public class EntityRelationshipsResultResolver
     final RelationshipDirection resolvedDirection =
         RelationshipDirection.valueOf(relationshipDirection.toString());
     final boolean includeSoftDelete = input.getIncludeSoftDelete();
+    // Normalize case so callers may pass entity types in the GraphQL enum form ("DATASET") or
+    // the entity-registry form ("dataset", "dataHubPolicy"); Urn.getEntityType() is lowercase.
     final Set<String> relatedEntityTypes =
-        input.getRelatedEntityTypes() == null ? null : new HashSet<>(input.getRelatedEntityTypes());
+        input.getRelatedEntityTypes() == null
+            ? null
+            : input.getRelatedEntityTypes().stream()
+                .map(type -> type.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
 
     if (isDomainDirectChildDomainsQuery(urn, relationshipTypes, resolvedDirection)) {
       return GraphQLConcurrencyUtils.supplyAsync(
@@ -614,7 +621,8 @@ public class EntityRelationshipsResultResolver
                 rel ->
                     (existentUrns == null || existentUrns.contains(rel.getEntity()))
                         && (relatedEntityTypes == null
-                            || relatedEntityTypes.contains(rel.getEntity().getEntityType()))
+                            || relatedEntityTypes.contains(
+                                rel.getEntity().getEntityType().toLowerCase(Locale.ROOT)))
                         && (context == null
                             || canView(context.getOperationContext(), rel.getEntity())))
             .collect(Collectors.toList());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -192,6 +192,18 @@ public class EntityRelationshipsResultResolverTest {
     assertEquals(result.getRelationships().size(), 2);
   }
 
+  // Callers pass entity types in the GraphQL enum form ("CORPUSER"/"DATASET"); the URN entity type
+  // is lowercase ("corpuser"/"dataset"). The filter must match case-insensitively rather than drop
+  // every edge and return an empty, correct-looking result.
+  @Test
+  public void testFilterByRelatedEntityTypesIsCaseInsensitive()
+      throws ExecutionException, InterruptedException {
+    input.setRelatedEntityTypes(List.of("CORPUSER"));
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+    assertEquals(result.getCount().intValue(), 2);
+    assertEquals(result.getRelationships().size(), 2);
+  }
+
   /**
    * Reproduces the Settings → Roles page crash. A role's {@code policies} are its incoming {@code
    * IsAssociatedWithRole} edges, but that relationship name is shared: it is emitted toward a role


### PR DESCRIPTION
`RelationshipsInput.relatedEntityTypes` (added in #18119) filtered relationship edges by comparing the caller-supplied type strings against `Urn.getEntityType()` with a case-sensitive `Set.contains`. `Urn.getEntityType()` is always lowercase (`dataset`, `corpuser`), while callers commonly pass the GraphQL enum form (`DATASET`), so the mismatch dropped every edge and returned an empty, correct-looking result (`total: 0`) instead of the filtered set.

This normalizes both sides to lower case (`Locale.ROOT`). The entity-registry form (`dataHubPolicy`) keeps working and the enum form now works too. Adds a resolver test covering the uppercase-enum input.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes case-sensitive filtering of related entity types in the graph resolver so callers using GraphQL enum values (e.g., DATASET) no longer get empty results. Previously the filter compared uppercase inputs to lowercase URN types and dropped all edges; now both sides are normalized to lowercase, and counts and relationships are correct.

- Normalize input `relatedEntityTypes` with `Locale.ROOT` when building the filter set and lowercase the URN entity type during filtering.
- Adds a resolver test covering uppercase enum input; no API changes and no migration required.

<sup>Written for commit 84a11e0ffdeea607f313d9a46dfe77a5800e88e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

