### PR TITLE
feat(semantic-search): add a minScore relevance floor on the semantic kNN path

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
@@ -75,6 +75,9 @@ public class SearchFlagsInputMapper
     if (searchFlags.getIncludeHiddenLifecycleStages() != null) {
       result.setIncludeHiddenLifecycleStages(searchFlags.getIncludeHiddenLifecycleStages());
     }
+    if (searchFlags.getMinScore() != null) {
+      result.setMinScore(searchFlags.getMinScore());
+    }
     return result;
   }
 }

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -198,6 +198,17 @@ input SearchFlags {
   Determines whether to filter out any non-latest entity version if entity is part of a Version Set, default true
   """
   filterNonLatestVersions: Boolean
+
+  """
+  Minimum relevance score (inclusive) for the semantic (kNN) search path. Hits scoring below this
+  floor are dropped, letting an agent abstain instead of returning weak matches. Currently honored
+  only by the semantic search path.
+
+  The value is compared against the engine's raw kNN relevance score (cosine-derived), which is not
+  a normalized 0..1 value; its scale depends on the embedding model and search engine, so a suitable
+  floor must be calibrated per deployment rather than assumed.
+  """
+  minScore: Float
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapperTest.java
@@ -1,0 +1,25 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+import com.linkedin.datahub.graphql.generated.SearchFlags;
+import org.testng.annotations.Test;
+
+public class SearchFlagsInputMapperTest {
+
+  @Test
+  public void testMinScoreMappedThrough() {
+    SearchFlags input = new SearchFlags();
+    input.setMinScore(0.75f);
+    com.linkedin.metadata.query.SearchFlags result = SearchFlagsInputMapper.map(null, input);
+    assertEquals(result.getMinScore(), 0.75f);
+  }
+
+  @Test
+  public void testMinScoreOmittedWhenNull() {
+    com.linkedin.metadata.query.SearchFlags result =
+        SearchFlagsInputMapper.map(null, new SearchFlags());
+    assertFalse(result.hasMinScore());
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchService.java
@@ -280,6 +280,19 @@ public class SemanticEntitySearchService implements SemanticEntitySearch {
             finalFilterMap,
             fieldsToFetch);
 
+    // Apply relevance floor: drop hits scoring below minScore so a caller (e.g. an agent) can
+    // abstain rather than surface weak matches. Post-kNN filtering keeps this engine-agnostic
+    // across the ES8 and OpenSearch shims.
+    final com.linkedin.metadata.query.SearchFlags searchFlags =
+        opContext.getSearchContext().getSearchFlags();
+    final Float minScore = searchFlags != null ? searchFlags.getMinScore() : null;
+    if (minScore != null) {
+      hits =
+          hits.stream()
+              .filter(h -> h.getScore() != null && h.getScore() >= minScore)
+              .collect(Collectors.toList());
+    }
+
     // 9) Slice [from, from+pageSize)
     if (from >= hits.size()) {
       return emptyResult(from, normalizedPageSize);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchServiceTest.java
@@ -225,6 +225,27 @@ public class SemanticEntitySearchServiceTest {
   }
 
   @Test
+  public void testSearchAppliesMinScoreFloor() throws IOException {
+    setupMockKnnResponse(
+        Arrays.asList(
+            "urn:li:dataset:(urn:li:dataPlatform:test,table1,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:test,table2,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:test,table3,PROD)"),
+        Arrays.asList(0.95, 0.80, 0.50));
+    when(mockSearchFlags.getMinScore()).thenReturn(0.75f);
+
+    SearchResult result =
+        service.search(
+            mockOpContext, Arrays.asList(TEST_ENTITY_NAME), TEST_QUERY, null, null, 0, 10);
+
+    assertNotNull(result);
+    // the 0.50 hit is below the 0.75 floor and is dropped; 0.95 and 0.80 remain
+    assertEquals(result.getNumEntities().intValue(), 2);
+    assertEquals(result.getEntities().size(), 2);
+    assertTrue(result.getEntities().stream().allMatch(e -> e.getScore() >= 0.75));
+  }
+
+  @Test
   public void testSearchPaginationBeyondResults() throws IOException {
     // Setup mock response with 1 hit
     setupMockKnnResponse(

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -93,4 +93,15 @@ record SearchFlags {
     id: int
     max: int
   }
+
+  /**
+   * Minimum relevance score (inclusive) for results on the semantic (kNN) search path. Hits scoring
+   * below this floor are dropped, letting an agent abstain instead of returning weak matches. When
+   * null/unset, no floor is applied. Currently honored only by the semantic search path.
+   *
+   * The value is compared against the engine's raw kNN relevance score (cosine-derived), which is
+   * not a normalized 0..1 value; its scale depends on the embedding model and search engine, so a
+   * suitable floor must be calibrated per deployment rather than assumed.
+   */
+  minScore: optional float
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -6436,6 +6436,11 @@
       },
       "doc" : "Sets slice parameter for elasticsearch query,\nto allow multiple clients to scroll the same query at once.\nOnly supported by the ElasticSearchService",
       "optional" : true
+    }, {
+      "name" : "minScore",
+      "type" : "float",
+      "doc" : "Minimum relevance score (inclusive) for results on the semantic (kNN) search path. Hits scoring\nbelow this floor are dropped, letting an agent abstain instead of returning weak matches. When\nnull/unset, no floor is applied. Currently honored only by the semantic search path.\n\nThe value is compared against the engine's raw kNN relevance score (cosine-derived), which is\nnot a normalized 0..1 value; its scale depends on the embedding model and search engine, so a\nsuitable floor must be calibrated per deployment rather than assumed.",
+      "optional" : true
     } ]
   }, "com.linkedin.metadata.query.SliceOptions", {
     "type" : "enum",


### PR DESCRIPTION
Adds an optional `minScore` to `SearchFlags` and honors it on the semantic (kNN) search path. Hits scoring below the floor are dropped after the kNN returns, so a caller such as an agent can abstain ("nothing is relevant enough") instead of surfacing weak matches. An off-topic query that currently returns every result at a low score can now be given a floor so it returns nothing.

Post-kNN filtering keeps this engine-agnostic across the ES8 and OpenSearch shims. Wired end to end: model `SearchFlags.pdl`, the GraphQL `SearchFlags` input, and `SearchFlagsInputMapper`. When unset, no floor is applied and behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional minScore relevance floor on the semantic (kNN) search path to drop low-scoring hits. Previously the semantic path returned weak, off-topic hits; now callers can set a floor so results below it are removed and empty results are possible. When unset, behavior is unchanged.

**Details**
- Adds `minScore` to GraphQL `SearchFlags` and Pegasus `SearchFlags`; maps through `SearchFlagsInputMapper`.
- Filters kNN hits with score < `minScore` in `SemanticEntitySearchService` before pagination; engine-agnostic across ES8 and OpenSearch.
- Optional and limited to the semantic path; exact/keyword paths unchanged. Clients may set `searchFlags: { minScore: <float> }`. Tests cover mapping and filtering.

<sup>Written for commit 2e41db622e0662835c0ab1764e9d3370c627eeec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

