### PR TITLE
test(smoke): fix flaky test_list_groups and container smoke tests

### DIFF
--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -752,6 +752,11 @@ def test_list_users(auth_session):
 
 
 @pytest.mark.dependency()
+# The bootstrapped groups come from bootstrap_mce.json and are only visible here
+# once Elasticsearch has indexed them. wait_for_writes_to_sync() inside
+# execute_graphql() only covers the write pipeline, not the search refresh, so
+# an unretried run can legitimately see fewer than the 2 expected groups.
+@with_test_retry()
 def test_list_groups(auth_session):
     query = """query listGroups($input: ListGroupsInput!) {
         listGroups(input: $input) {

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -1,22 +1,75 @@
+import logging
+from dataclasses import dataclass
 from typing import Any, Dict
 
 import pytest
 
-from conftest import _ingest_cleanup_data_impl
 from tests.utilities.metadata_operations import add_tag, add_term, update_description
-from tests.utils import execute_graphql
+from tests.utils import (
+    delete_urns_from_file,
+    execute_graphql,
+    ingest_file_via_rest,
+    materialize_with_unique_name,
+    with_test_retry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ContainerUrns:
+    """Run-unique URNs of the containers ingested by :func:`ingest_cleanup_data`."""
+
+    schema_urn: str
+    database_urn: str
 
 
 @pytest.fixture(scope="module", autouse=False)
-def ingest_cleanup_data(auth_session, graph_client):
-    yield from _ingest_cleanup_data_impl(
-        auth_session, graph_client, "tests/containers/data.json", "containers"
+def ingest_cleanup_data(auth_session, graph_client, tmp_path_factory):
+    """Ingest the container fixtures under run-unique container URNs.
+
+    data.json used to hardcode ``urn:li:container:SCHEMA`` and
+    ``urn:li:container:DATABASE``. Under pytest-xdist ``--dist=loadscope`` (see
+    smoke-test/smoke.sh) test modules run concurrently against the same GMS, so
+    another module's teardown could delete those containers while this module
+    was mid-query. Rewriting both keys to a run-unique value gives this module
+    sole ownership of the entities it asserts on.
+
+    ``SCHEMA`` and ``DATABASE`` are uppercase and occur in data.json only inside
+    the container URNs, which is what ``materialize_with_unique_name`` requires
+    (its substitution is a plain, case-sensitive replace over the whole file).
+    The human-readable ``datahub_schema``/``datahub_db`` names are lowercase and
+    so are deliberately left untouched.
+    """
+    tmp_dir = tmp_path_factory.mktemp("containers")
+    data_file, schema_key = materialize_with_unique_name(
+        "tests/containers/data.json", "SCHEMA", tmp_dir
     )
+    data_file, database_key = materialize_with_unique_name(
+        data_file, "DATABASE", tmp_dir
+    )
+    urns = ContainerUrns(
+        schema_urn=f"urn:li:container:{schema_key}",
+        database_urn=f"urn:li:container:{database_key}",
+    )
+
+    # No pre-ingest idempotency delete: the URNs are freshly unique per run, so
+    # nothing pre-exists to clean up.
+    logger.info(f"ingesting containers test data (schema={urns.schema_urn})")
+    ingest_file_via_rest(auth_session, data_file)
+    yield urns
+    logger.info("removing containers test data")
+    delete_urns_from_file(graph_client, data_file)
 
 
 @pytest.mark.dependency()
+# The query below reads platform, subTypes, editableProperties and related
+# entities in one shot, and each aspect is indexed independently -- a single
+# lagging aspect fails an otherwise correct run. The test is a pure read, so
+# retrying it is safe.
+@with_test_retry()
 def test_get_full_container(auth_session, ingest_cleanup_data):
-    container_urn = "urn:li:container:SCHEMA"
+    container_urn = ingest_cleanup_data.schema_urn
     container_name = "datahub_schema"
     container_description = "The DataHub schema"
     editable_container_description = "custom description"
@@ -103,6 +156,7 @@ def test_get_full_container(auth_session, ingest_cleanup_data):
     assert container["platform"]["urn"] == "urn:li:dataPlatform:mysql"
     assert container["properties"]["name"] == container_name
     assert container["properties"]["description"] == container_description
+    assert container["container"]["urn"] == ingest_cleanup_data.database_urn
     assert container["subTypes"]["typeNames"][0] == "Schema"
     assert (
         container["editableProperties"]["description"] == editable_container_description
@@ -114,7 +168,7 @@ def test_get_full_container(auth_session, ingest_cleanup_data):
 
 
 @pytest.mark.dependency(depends=["test_get_full_container"])
-def test_get_parent_container(auth_session):
+def test_get_parent_container(auth_session, ingest_cleanup_data):
     dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"
 
     # Get count of existing secrets
@@ -140,8 +194,8 @@ def test_get_parent_container(auth_session):
 
 
 @pytest.mark.dependency(depends=["test_get_full_container"])
-def test_update_container(auth_session):
-    container_urn = "urn:li:container:SCHEMA"
+def test_update_container(auth_session, ingest_cleanup_data):
+    container_urn = ingest_cleanup_data.schema_urn
 
     # add_tag/add_term/addOwner/addLink below are back-to-back writes to the same
     # container with no intermediate read -- only the combined state after the

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -17,29 +17,33 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ContainerUrns:
-    """Run-unique URNs of the containers ingested by :func:`ingest_cleanup_data`."""
+class ContainerFixtures:
+    """Run-unique URNs ingested by :func:`ingest_cleanup_data`."""
 
     schema_urn: str
     database_urn: str
+    dataset_urn: str
+    tag_urn: str
+    term_urn: str
+    owner_urn: str
 
 
 @pytest.fixture(scope="module", autouse=False)
 def ingest_cleanup_data(auth_session, graph_client, tmp_path_factory):
-    """Ingest the container fixtures under run-unique container URNs.
+    """Ingest container fixtures under run-unique URNs.
 
-    data.json used to hardcode ``urn:li:container:SCHEMA`` and
-    ``urn:li:container:DATABASE``. Under pytest-xdist ``--dist=loadscope`` (see
-    smoke-test/smoke.sh) test modules run concurrently against the same GMS, so
-    another module's teardown could delete those containers while this module
-    was mid-query. Rewriting both keys to a run-unique value gives this module
-    sole ownership of the entities it asserts on.
+    data.json used to hardcode shared URNs (``SCHEMA``/``DATABASE`` containers,
+    ``SampleHiveDataset``, ``urn:li:tag:Test``, ``urn:li:glossaryTerm:Term``,
+    ``urn:li:corpuser:jdoe``). Under pytest-xdist ``--dist=loadscope`` (see
+    smoke-test/smoke.sh) modules run concurrently against the same GMS, so
+    another module's teardown could delete those entities mid-query. Rewriting
+    every entity key this module owns to a run-unique value avoids that race.
 
     ``SCHEMA`` and ``DATABASE`` are uppercase and occur in data.json only inside
-    the container URNs, which is what ``materialize_with_unique_name`` requires
-    (its substitution is a plain, case-sensitive replace over the whole file).
-    The human-readable ``datahub_schema``/``datahub_db`` names are lowercase and
-    so are deliberately left untouched.
+    container URNs. Tag/term/user tokens are the full URN strings so a plain
+    replace cannot corrupt substrings (e.g. ``Term`` inside ``glossaryTerm``).
+    Human-readable ``datahub_schema``/``datahub_db`` names are lowercase and
+    deliberately left untouched.
     """
     tmp_dir = tmp_path_factory.mktemp("containers")
     data_file, schema_key = materialize_with_unique_name(
@@ -48,18 +52,38 @@ def ingest_cleanup_data(auth_session, graph_client, tmp_path_factory):
     data_file, database_key = materialize_with_unique_name(
         data_file, "DATABASE", tmp_dir
     )
-    urns = ContainerUrns(
+    data_file, dataset_name = materialize_with_unique_name(
+        data_file, "SampleHiveDataset", tmp_dir
+    )
+    # Full-URN tokens: avoid substring collisions (e.g. Term ⊂ glossaryTerm).
+    data_file, tag_urn = materialize_with_unique_name(
+        data_file, "urn:li:tag:Test", tmp_dir
+    )
+    data_file, term_urn = materialize_with_unique_name(
+        data_file, "urn:li:glossaryTerm:Term", tmp_dir
+    )
+    data_file, owner_urn = materialize_with_unique_name(
+        data_file, "urn:li:corpuser:jdoe", tmp_dir
+    )
+    fixtures = ContainerFixtures(
         schema_urn=f"urn:li:container:{schema_key}",
         database_urn=f"urn:li:container:{database_key}",
+        dataset_urn=(f"urn:li:dataset:(urn:li:dataPlatform:hive,{dataset_name},PROD)"),
+        tag_urn=tag_urn,
+        term_urn=term_urn,
+        owner_urn=owner_urn,
     )
 
     # No pre-ingest idempotency delete: the URNs are freshly unique per run, so
-    # nothing pre-exists to clean up.
-    logger.info(f"ingesting containers test data (schema={urns.schema_urn})")
-    ingest_file_via_rest(auth_session, data_file)
-    yield urns
-    logger.info("removing containers test data")
-    delete_urns_from_file(graph_client, data_file)
+    # nothing pre-exists to clean up. try/finally still runs cleanup if ingest
+    # fails partway so partially-written unique entities do not orphan in GMS.
+    logger.info(f"ingesting containers test data (schema={fixtures.schema_urn})")
+    try:
+        ingest_file_via_rest(auth_session, data_file)
+        yield fixtures
+    finally:
+        logger.info("removing containers test data")
+        delete_urns_from_file(graph_client, data_file)
 
 
 @pytest.mark.dependency()
@@ -169,9 +193,8 @@ def test_get_full_container(auth_session, ingest_cleanup_data):
 
 @pytest.mark.dependency(depends=["test_get_full_container"])
 def test_get_parent_container(auth_session, ingest_cleanup_data):
-    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"
+    dataset_urn = ingest_cleanup_data.dataset_urn
 
-    # Get count of existing secrets
     get_dataset_query = """query dataset($urn: String!) {
           dataset(urn: $urn) {
             urn
@@ -190,6 +213,7 @@ def test_get_parent_container(auth_session, ingest_cleanup_data):
     assert res_data["data"]["dataset"] is not None
 
     dataset = res_data["data"]["dataset"]
+    assert dataset["container"]["urn"] == ingest_cleanup_data.schema_urn
     assert dataset["container"]["properties"]["name"] == "datahub_schema"
 
 
@@ -201,13 +225,13 @@ def test_update_container(auth_session, ingest_cleanup_data):
     # container with no intermediate read -- only the combined state after the
     # whole batch (checked once via get_container_query below) matters, so all
     # but the last write skip the sync wait.
-    new_tag = "urn:li:tag:Test"
+    new_tag = ingest_cleanup_data.tag_urn
     assert add_tag(auth_session, container_urn, new_tag, no_sync_wait=True)
 
-    new_term = "urn:li:glossaryTerm:Term"
+    new_term = ingest_cleanup_data.term_urn
     assert add_term(auth_session, container_urn, new_term, no_sync_wait=True)
 
-    new_owner = "urn:li:corpuser:jdoe"
+    new_owner = ingest_cleanup_data.owner_urn
 
     add_owner_query = """mutation addOwner($input: AddOwnerInput!) {
             addOwner(input: $input)


### PR DESCRIPTION
## Summary

Fixes flaky `Pytest Smoke Tests (Batch 3/7)` failures on `master` for `test_list_groups` and `test_get_full_container` ([PFP-5627](https://linear.app/acryl-data/issue/PFP-5627/fix-flaky-pytest-smoke-tests-batch-37-failures)).

- **`test_list_groups`**: add `@with_test_retry()` for the ES search-refresh gap that `wait_for_writes_to_sync()` does not cover.
- **`containers_test.py`**: rewrite `SCHEMA`/`DATABASE` to run-unique container URNs via `materialize_with_unique_name()` (same pattern as `tests/delete/delete_test.py`); add `@with_test_retry()` on `test_get_full_container`; have dependent tests request the fixture explicitly instead of relying on run order.

Previously opened against the wrong repo: https://github.com/acryldata/datahub/pull/407

## Test plan

- [x] `./gradlew :smoke-test:lintFix` — ruff + mypy clean
- [ ] Smoke job on this PR (`Pytest Smoke Tests (Batch 3/7)`) validates end-to-end

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests updated
- [ ] Docs — n/a
- [ ] Breaking changes — none


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky smoke tests by adding safe read retries and isolating container fixtures with run‑unique URNs to prevent cross‑module teardown races (PFP‑5627). Previously, reads failed on ES refresh gaps and shared URNs; now read tests retry and fixtures do not share state. No product behavior changes.

- Add @with_test_retry() to test_list_groups (ES search refresh) and test_get_full_container (multi‑aspect indexing); both are read‑only.
- Introduce a module fixture that materializes run‑unique URNs for schema, database, dataset, tag, term, and owner; ingests via REST; always cleans up in finally; returns a frozen dataclass of URNs.
- Update container tests to request the fixture explicitly, use the run‑unique URNs for reads/updates, and assert the parent container URN; removes reliance on test order and is safe under pytest‑xdist --dist=loadscope.

<sup>Written for commit 3c5a9aa6499449196fd985b7b93c5971bd44d11a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

