### PR TITLE
fix(ingest/redshift): stop the user-info join gating provisioned lineage rows

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -586,14 +586,16 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                     query_txt AS (
                         SELECT
                             query,
-                            userid,
                             RTRIM(LISTAGG(RTRIM(text) || CASE WHEN LEN(RTRIM(text)) < {_PROVISIONED_SEGMENT_SIZE} THEN ' ' ELSE '' END, '')
                                 WITHIN GROUP (ORDER BY sequence)) AS querytxt
                         FROM STL_QUERYTEXT
                         WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
                         -- Scope by query id: the query-text tables carry no timestamp.
                         AND query IN (SELECT query FROM target_tables)
-                        GROUP BY query, userid
+                        -- One row per query. Grouping by userid as well would emit a
+                        -- second row, and so duplicate every source row for that query,
+                        -- if STL_QUERYTEXT ever held two userids for one query id.
+                        GROUP BY query
                     )
                         select
                             distinct cluster,
@@ -630,10 +632,17 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                                 sti.table_id = ss.tbl
                             left join query_txt sq on
                                 ss.query = sq.query
+                            -- LEFT (enrichment only): svl_user_info supplies the
+                            -- username but must not gate the row. rdsdb is excluded by
+                            -- its system userid because a name comparison drops every
+                            -- user the view cannot resolve, via NULL propagation.
+                            -- ss.userid rather than sq.userid: query_txt is LEFT joined
+                            -- and so nullable, and a nullable column cannot carry this
+                            -- predicate without gating on it in turn.
                             left join svl_user_info sui on
-                                sq.userid = sui.usesysid
+                                ss.userid = sui.usesysid
                             where
-                                sui.usename <> 'rdsdb')
+                                ss.userid <> 1)
                         ) as source_tables
                                 using (query)
                         where
@@ -738,6 +747,9 @@ select
     ANY_VALUE(sq.pid) as session_id
 from
     target_queries si
+-- LEFT (enrichment only): svl_user_info supplies the username but must not gate the
+-- row. rdsdb is excluded by its system userid because a name comparison drops every
+-- user the view cannot resolve, via NULL propagation.
 left join svl_user_info sui on
     si.userid = sui.usesysid
 left join query_txt sq on
@@ -745,7 +757,7 @@ left join query_txt sq on
 left join stl_load_commits slc on
     slc.query = si.query
 where
-        sui.usename <> 'rdsdb'
+        si.userid <> 1
         and slc.query IS NULL
 group by
     target_table_id,

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -668,12 +668,15 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
     ) -> str:
         return """\
 with target_queries as (
-    select distinct query
+    select distinct si.query
     from
-        stl_insert
+        stl_insert si
+    join SVV_TABLE_INFO sti on
+        sti.table_id = si.tbl
     where
-        starttime >= '{start_time}'
-        and starttime < '{end_time}'
+        si.starttime >= '{start_time}'
+        and si.starttime < '{end_time}'
+        and sti.database = '{db_name}'
 ),
 query_txt as (
     select
@@ -691,9 +694,9 @@ query_txt as (
             STL_QUERYTEXT
         where
             sequence < {_QUERY_SEQUENCE_LIMIT}
-            -- Scope to the window, or this LISTAGG aggregates the cluster's entire
-            -- retained query history: STL_QUERYTEXT has no timestamp column, so the
-            -- stl_insert window predicate below cannot be pushed down into it.
+            -- Scope to the window and database, or this LISTAGG aggregates the
+            -- cluster's entire retained query history: STL_QUERYTEXT has no timestamp
+            -- column, so the stl_insert predicates below cannot be pushed down into it.
             and query in (select query from target_queries)
         order by
             sequence

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -885,7 +885,7 @@ where
         # values never enter the SQL string. Order: start_time, end_time, database.
         return """
             -- The in-window statements are a CTE so the STL_QUERYTEXT scan below can be
-            -- scoped to them while the bound parameters stay at three, in caller order.
+            -- scoped to them without repeating the three bound parameters.
             WITH in_window_queries AS (
                 SELECT sq.query, sq.pid, sq.userid, sq.starttime
                 FROM stl_query sq

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -544,27 +544,9 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
         db_name: str, start_time: datetime, end_time: datetime
     ) -> str:
         return """
-                    WITH query_txt AS (
-                        SELECT
-                            query,
-                            userid,
-                            RTRIM(LISTAGG(RTRIM(text) || CASE WHEN LEN(RTRIM(text)) < {_PROVISIONED_SEGMENT_SIZE} THEN ' ' ELSE '' END, '')
-                                WITHIN GROUP (ORDER BY sequence)) AS querytxt
-                        FROM STL_QUERYTEXT
-                        WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
-                        GROUP BY query, userid
-                    )
-                        select
-                            distinct cluster,
-                            target_schema,
-                            target_table,
-                            username as username,
-                            source_schema,
-                            source_table,
-                            querytxt as ddl,
-                            starttime as timestamp
-                        from
-                                (
+                    -- The in-window insert rows are a CTE so the two scans below can be
+                    -- scoped to the query ids that can survive the join on `query`.
+                    WITH target_tables AS (
                             select
                                 distinct tbl as target_table_id,
                                 sti.schema as target_schema,
@@ -579,7 +561,33 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                             where starttime >= '{start_time}'
                             and starttime < '{end_time}'
                             and cluster = '{db_name}'
-                                ) as target_tables
+                    ),
+                    query_txt AS (
+                        SELECT
+                            query,
+                            userid,
+                            RTRIM(LISTAGG(RTRIM(text) || CASE WHEN LEN(RTRIM(text)) < {_PROVISIONED_SEGMENT_SIZE} THEN ' ' ELSE '' END, '')
+                                WITHIN GROUP (ORDER BY sequence)) AS querytxt
+                        FROM STL_QUERYTEXT
+                        WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
+                        -- STL_QUERYTEXT has no timestamp column and the window predicate
+                        -- sits on stl_insert, so there is nothing for the optimizer to
+                        -- push down here. Unscoped, this LISTAGG aggregates the whole of
+                        -- the cluster's retained query history regardless of start_time.
+                        AND query IN (SELECT query FROM target_tables)
+                        GROUP BY query, userid
+                    )
+                        select
+                            distinct cluster,
+                            target_schema,
+                            target_table,
+                            username as username,
+                            source_schema,
+                            source_table,
+                            querytxt as ddl,
+                            starttime as timestamp
+                        from
+                                target_tables
                         join ( (
                             select
                                 sui.usename as username,
@@ -598,6 +606,7 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                                     type as scan_type
                                 from
                                     stl_scan
+                                where query IN (SELECT query FROM target_tables)
                             ) ss
                             join SVV_TABLE_INFO sti on
                                 sti.table_id = ss.tbl
@@ -658,7 +667,15 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
         db_name: str, start_time: datetime, end_time: datetime
     ) -> str:
         return """\
-with query_txt as (
+with target_queries as (
+    select distinct query
+    from
+        stl_insert
+    where
+        starttime >= '{start_time}'
+        and starttime < '{end_time}'
+),
+query_txt as (
     select
         query,
         pid,
@@ -674,6 +691,10 @@ with query_txt as (
             STL_QUERYTEXT
         where
             sequence < {_QUERY_SEQUENCE_LIMIT}
+            -- Scope to the window, or this LISTAGG aggregates the cluster's entire
+            -- retained query history: STL_QUERYTEXT has no timestamp column, so the
+            -- stl_insert window predicate below cannot be pushed down into it.
+            and query in (select query from target_queries)
         order by
             sequence
     )
@@ -860,7 +881,17 @@ where
         # RedshiftDataDictionary.get_query_result, so config/catalog-derived
         # values never enter the SQL string. Order: start_time, end_time, database.
         return """
-            WITH query_txt AS (
+            -- The in-window statements are a CTE so the STL_QUERYTEXT scan below can be
+            -- scoped to them while the bound parameters stay at three, in caller order.
+            WITH in_window_queries AS (
+                SELECT sq.query, sq.pid, sq.userid, sq.starttime
+                FROM stl_query sq
+                WHERE sq.starttime >= %s
+                AND sq.starttime < %s
+                AND sq.database = %s
+                AND sq.aborted = 0
+            ),
+            query_txt AS (
                 SELECT
                     query,
                     pid,
@@ -870,6 +901,10 @@ where
                     SELECT query, pid, text, sequence
                     FROM STL_QUERYTEXT
                     WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
+                    -- Scope to the window, or this LISTAGG aggregates the cluster's
+                    -- entire retained query history: STL_QUERYTEXT has no timestamp
+                    -- column, so the stl_query window predicate cannot reach it.
+                    AND query IN (SELECT query FROM in_window_queries)
                     ORDER BY sequence
                 )
                 GROUP BY query, pid
@@ -880,14 +915,10 @@ where
                 sui.usename AS username,
                 q.starttime AS starttime,
                 q.pid AS session_id
-            FROM stl_query q
+            FROM in_window_queries q
               JOIN query_txt qt ON q.query = qt.query AND q.pid = qt.pid
               LEFT JOIN svl_user_info sui ON q.userid = sui.usesysid
-            WHERE q.starttime >= %s
-            AND q.starttime < %s
-            AND q.aborted = 0
-            AND q.database = %s
-            AND (sui.usename IS NULL OR sui.usename <> 'rdsdb')
+            WHERE (sui.usename IS NULL OR sui.usename <> 'rdsdb')
             ORDER BY q.starttime
         """.format(
             _PROVISIONED_SEGMENT_SIZE=_PROVISIONED_SEGMENT_SIZE,
@@ -1042,6 +1073,11 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                         PARTITION BY query_id, sequence
                         ) as rn
                     FROM SYS_QUERY_TEXT
+                    -- The join to the time-filtered `queries` CTE cannot bound this
+                    -- ROW_NUMBER() window, so scope it to the same query ids -- exactly
+                    -- those that survive that join -- rather than de-duplicating all of
+                    -- SYS_QUERY_TEXT.
+                    WHERE query_id IN (SELECT query_id FROM queries)
                     )
                 WHERE rn = 1
             ),

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -21,13 +21,19 @@ _SERVERLESS_SEGMENT_SIZE = 4000  # SYS_QUERY_TEXT
 # only reach them through query ids borrowed from a table that has one -- stl_insert,
 # stl_query or SYS_QUERY_DETAIL.
 #
-# Whether a given use needs that scoping written out depends on what sits between the
-# base table and the time predicate. An aggregate (the LISTAGG that stitches segments)
-# or a window function (the ROW_NUMBER that de-duplicates SYS_QUERY_TEXT) has to
-# materialize over the whole table before an outer join can filter anything, so those
-# uses must restrict their own scan or they reassemble the cluster's entire retained
-# query history on every run, however small start_time makes the window. A plain join
-# in the same WHERE has no such barrier and needs nothing extra.
+# Whether a given use needs that scoping written out depends on whether the window can
+# apply before the segments are stitched. Most uses reassemble text with a LISTAGG, so
+# the presence of an aggregate says nothing on its own: what matters is where the time
+# predicate sits relative to it. In the same query block, WHERE runs before GROUP BY,
+# and an inner select feeding the aggregate has already bounded the scan -- both are
+# fine as written.
+#
+# Scoping has to be spelled out when nothing time-bound is in reach of the aggregate:
+# text reassembled in its own CTE that joins no windowed table, or a ROW_NUMBER window
+# de-duplicating the whole table. There the aggregate materializes over everything and
+# only an outer join can filter, which is too late -- so the query reassembles the
+# cluster's entire retained history on every run, however small start_time makes the
+# window.
 
 # TODO: Boundary detection uses LEN(RTRIM(text)) < segment_size to decide whether to
 # add a space when stitching segments. This approach can't distinguish between padding
@@ -919,8 +925,10 @@ where
             )
             -- No DISTINCT: in_window_queries is one row per stl_query row, query_txt is
             -- grouped by (query, pid) so the join matches at most once, and
-            -- svl_user_info is keyed on usesysid. It would only cost a sort over the
-            -- largest result set in this feed.
+            -- svl_user_info is keyed on usesysid, so it would only cost a sort over the
+            -- largest result set here. Should any of those three stop holding, the
+            -- duplicate reaches the aggregator as a second ObservedQuery and inflates
+            -- usage rather than raising, and this feed is the sole producer of usage.
             SELECT
                 q.query AS query_id,
                 qt.query_text AS query_text,
@@ -1210,8 +1218,6 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     SYS_QUERY_DETAIL qd
                     JOIN SVV_TABLE_INFO sti ON sti.table_id = qd.table_id
                     LEFT JOIN SVV_USER_INFO sui ON sui.user_id = qd.user_id
-                    -- No id scoping needed: this is a plain join in the same WHERE as
-                    -- the qd.start_time window, with no aggregate or window between.
                     LEFT JOIN SYS_QUERY_TEXT qt ON qt.query_id = qd.query_id
                     LEFT JOIN SYS_LOAD_DETAIL ld ON ld.query_id = qd.query_id
                 WHERE
@@ -1376,8 +1382,6 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                         WITHIN GROUP (ORDER BY qt.sequence)) AS query_text
                 FROM
                     SYS_QUERY_HISTORY qh
-                    -- No id scoping needed: this is a plain join in the same WHERE as
-                    -- the qh.start_time window, with no aggregate or window between.
                     LEFT JOIN SYS_QUERY_TEXT qt ON qt.query_id = qh.query_id
                     LEFT JOIN SVV_USER_INFO sui ON sui.user_id = qh.user_id
                 WHERE

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -14,6 +14,21 @@ _MAX_COPY_ENTRIES_PER_TABLE = 20
 _PROVISIONED_SEGMENT_SIZE = 200  # STL_QUERYTEXT, SVL_STATEMENTTEXT
 _SERVERLESS_SEGMENT_SIZE = 4000  # SYS_QUERY_TEXT
 
+# Scoping the query-text tables by query id
+#
+# STL_QUERYTEXT (userid/xid/pid/query/sequence/text) and SYS_QUERY_TEXT
+# (query_id/sequence/text) carry no timestamp of their own, so the ingestion window can
+# only reach them through query ids borrowed from a table that has one -- stl_insert,
+# stl_query or SYS_QUERY_DETAIL.
+#
+# Whether a given use needs that scoping written out depends on what sits between the
+# base table and the time predicate. An aggregate (the LISTAGG that stitches segments)
+# or a window function (the ROW_NUMBER that de-duplicates SYS_QUERY_TEXT) has to
+# materialize over the whole table before an outer join can filter anything, so those
+# uses must restrict their own scan or they reassemble the cluster's entire retained
+# query history on every run, however small start_time makes the window. A plain join
+# in the same WHERE has no such barrier and needs nothing extra.
+
 # TODO: Boundary detection uses LEN(RTRIM(text)) < segment_size to decide whether to
 # add a space when stitching segments. This approach can't distinguish between padding
 # and tokens that exactly fill a segment. Edge case: a 199-char token followed by a
@@ -547,20 +562,20 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                     -- The in-window insert rows are a CTE so the two scans below can be
                     -- scoped to the query ids that can survive the join on `query`.
                     WITH target_tables AS (
-                            select
-                                distinct tbl as target_table_id,
-                                sti.schema as target_schema,
-                                sti.table as target_table,
-                                sti.database as cluster,
-                                query,
-                                starttime
-                            from
-                                stl_insert
-                            join SVV_TABLE_INFO sti on
-                                sti.table_id = tbl
-                            where starttime >= '{start_time}'
-                            and starttime < '{end_time}'
-                            and cluster = '{db_name}'
+                        select
+                            distinct tbl as target_table_id,
+                            sti.schema as target_schema,
+                            sti.table as target_table,
+                            sti.database as cluster,
+                            query,
+                            starttime
+                        from
+                            stl_insert
+                        join SVV_TABLE_INFO sti on
+                            sti.table_id = tbl
+                        where starttime >= '{start_time}'
+                        and starttime < '{end_time}'
+                        and cluster = '{db_name}'
                     ),
                     query_txt AS (
                         SELECT
@@ -570,10 +585,7 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                                 WITHIN GROUP (ORDER BY sequence)) AS querytxt
                         FROM STL_QUERYTEXT
                         WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
-                        -- STL_QUERYTEXT has no timestamp column and the window predicate
-                        -- sits on stl_insert, so there is nothing for the optimizer to
-                        -- push down here. Unscoped, this LISTAGG aggregates the whole of
-                        -- the cluster's retained query history regardless of start_time.
+                        -- Scope by query id: the query-text tables carry no timestamp.
                         AND query IN (SELECT query FROM target_tables)
                         GROUP BY query, userid
                     )
@@ -587,7 +599,7 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                             querytxt as ddl,
                             starttime as timestamp
                         from
-                                target_tables
+                            target_tables
                         join ( (
                             select
                                 sui.usename as username,
@@ -606,7 +618,7 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                                     type as scan_type
                                 from
                                     stl_scan
-                                where query IN (SELECT query FROM target_tables)
+                                where query in (select query from target_tables)
                             ) ss
                             join SVV_TABLE_INFO sti on
                                 sti.table_id = ss.tbl
@@ -694,9 +706,7 @@ query_txt as (
             STL_QUERYTEXT
         where
             sequence < {_QUERY_SEQUENCE_LIMIT}
-            -- Scope to the window and database, or this LISTAGG aggregates the
-            -- cluster's entire retained query history: STL_QUERYTEXT has no timestamp
-            -- column, so the stl_insert predicates below cannot be pushed down into it.
+            -- Scope by query id: the query-text tables carry no timestamp.
             and query in (select query from target_queries)
         order by
             sequence
@@ -726,6 +736,10 @@ left join query_txt sq on
 left join stl_load_commits slc on
     slc.query = si.query
 where
+        -- These three predicates are a second copy of the ones bounding
+        -- target_queries above, and the two sets must agree: a row that falls out of
+        -- target_queries still reaches the left join to query_txt, so it comes back
+        -- with ddl and query_id NULL rather than raising anything. Edit both together.
         sui.usename <> 'rdsdb'
         and cluster = '{db_name}'
         and slc.query IS NULL
@@ -884,8 +898,6 @@ where
         # RedshiftDataDictionary.get_query_result, so config/catalog-derived
         # values never enter the SQL string. Order: start_time, end_time, database.
         return """
-            -- The in-window statements are a CTE so the STL_QUERYTEXT scan below can be
-            -- scoped to them without repeating the three bound parameters.
             WITH in_window_queries AS (
                 SELECT sq.query, sq.pid, sq.userid, sq.starttime
                 FROM stl_query sq
@@ -904,9 +916,7 @@ where
                     SELECT query, pid, text, sequence
                     FROM STL_QUERYTEXT
                     WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
-                    -- Scope to the window, or this LISTAGG aggregates the cluster's
-                    -- entire retained query history: STL_QUERYTEXT has no timestamp
-                    -- column, so the stl_query window predicate cannot reach it.
+                    -- Scope by query id: the query-text tables carry no timestamp.
                     AND query IN (SELECT query FROM in_window_queries)
                     ORDER BY sequence
                 )
@@ -1076,10 +1086,8 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                         PARTITION BY query_id, sequence
                         ) as rn
                     FROM SYS_QUERY_TEXT
-                    -- The join to the time-filtered `queries` CTE cannot bound this
-                    -- ROW_NUMBER() window, so scope it to the same query ids -- exactly
-                    -- those that survive that join -- rather than de-duplicating all of
-                    -- SYS_QUERY_TEXT.
+                    -- Scope by query id: a ROW_NUMBER() window materializes over the
+                    -- whole table before the join to `queries` can filter anything.
                     WHERE query_id IN (SELECT query_id FROM queries)
                     )
                 WHERE rn = 1
@@ -1203,6 +1211,8 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     SYS_QUERY_DETAIL qd
                     JOIN SVV_TABLE_INFO sti ON sti.table_id = qd.table_id
                     LEFT JOIN SVV_USER_INFO sui ON sui.user_id = qd.user_id
+                    -- No id scoping needed: this is a plain join in the same WHERE as
+                    -- the qd.start_time window, with no aggregate or window between.
                     LEFT JOIN SYS_QUERY_TEXT qt ON qt.query_id = qd.query_id
                     LEFT JOIN SYS_LOAD_DETAIL ld ON ld.query_id = qd.query_id
                 WHERE
@@ -1367,6 +1377,8 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                         WITHIN GROUP (ORDER BY qt.sequence)) AS query_text
                 FROM
                     SYS_QUERY_HISTORY qh
+                    -- No id scoping needed: this is a plain join in the same WHERE as
+                    -- the qh.start_time window, with no aggregate or window between.
                     LEFT JOIN SYS_QUERY_TEXT qt ON qt.query_id = qh.query_id
                     LEFT JOIN SVV_USER_INFO sui ON sui.user_id = qh.user_id
                 WHERE

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -680,7 +680,14 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
     ) -> str:
         return """\
 with target_queries as (
-    select distinct si.query
+    select
+        si.query,
+        si.tbl,
+        si.starttime,
+        si.userid,
+        sti.schema as target_schema,
+        sti.table as target_table,
+        sti.database as cluster
     from
         stl_insert si
     join SVV_TABLE_INFO sti on
@@ -708,27 +715,23 @@ query_txt as (
             sequence < {_QUERY_SEQUENCE_LIMIT}
             -- Scope by query id: the query-text tables carry no timestamp.
             and query in (select query from target_queries)
-        order by
-            sequence
     )
     group by
         query,
         pid
 )
 select
-    distinct tbl as target_table_id,
-    sti.schema as target_schema,
-    sti.table as target_table,
-    sti.database as cluster,
-    usename as username,
-    ddl,
+    distinct si.tbl as target_table_id,
+    si.target_schema,
+    si.target_table,
+    si.cluster,
+    sui.usename as username,
+    sq.ddl,
     sq.query as query_id,
     min(si.starttime) as timestamp,
-    ANY_VALUE(pid) as session_id
+    ANY_VALUE(sq.pid) as session_id
 from
-    stl_insert as si
-left join SVV_TABLE_INFO sti on
-    sti.table_id = tbl
+    target_queries si
 left join svl_user_info sui on
     si.userid = sui.usesysid
 left join query_txt sq on
@@ -736,22 +739,15 @@ left join query_txt sq on
 left join stl_load_commits slc on
     slc.query = si.query
 where
-        -- These three predicates are a second copy of the ones bounding
-        -- target_queries above, and the two sets must agree: a row that falls out of
-        -- target_queries still reaches the left join to query_txt, so it comes back
-        -- with ddl and query_id NULL rather than raising anything. Edit both together.
         sui.usename <> 'rdsdb'
-        and cluster = '{db_name}'
         and slc.query IS NULL
-        and si.starttime >= '{start_time}'
-        and si.starttime < '{end_time}'
 group by
     target_table_id,
-    target_schema,
-    target_table,
-    cluster,
+    si.target_schema,
+    si.target_table,
+    si.cluster,
     username,
-    ddl,
+    sq.ddl,
     sq.query
         """.format(
             _QUERY_SEQUENCE_LIMIT=_QUERY_SEQUENCE_LIMIT,
@@ -866,7 +862,7 @@ where
               JOIN stl_query sq ON ss.query = sq.query
               -- LEFT (enrichment only): svl_user_info supplies the username but must
               -- not gate the row. An INNER join drops any scan whose user has no row
-              -- in the view -- which includes the rdsdb system user (excluded below by
+              -- in the view, which includes the rdsdb system user (excluded below by
               -- userid) and, on Redshift editions that keep the user-info views
               -- superuser/self-only, real users a non-superuser can't resolve.
               LEFT JOIN svl_user_info sui ON sq.userid = sui.usesysid
@@ -918,11 +914,14 @@ where
                     WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
                     -- Scope by query id: the query-text tables carry no timestamp.
                     AND query IN (SELECT query FROM in_window_queries)
-                    ORDER BY sequence
                 )
                 GROUP BY query, pid
             )
-            SELECT DISTINCT
+            -- No DISTINCT: in_window_queries is one row per stl_query row, query_txt is
+            -- grouped by (query, pid) so the join matches at most once, and
+            -- svl_user_info is keyed on usesysid. It would only cost a sort over the
+            -- largest result set in this feed.
+            SELECT
                 q.query AS query_id,
                 qt.query_text AS query_text,
                 sui.usename AS username,
@@ -1219,7 +1218,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     qd.step_name = 'insert' AND
                     -- Exclude rdsdb by its system user_id (1), not by name. SVV_USER_INFO
                     -- has no rdsdb row, so a name-based rdsdb filter relied on NULL
-                    -- propagation to drop it -- which also silently dropped any real
+                    -- propagation to drop it, which also silently dropped any real
                     -- user the view can't resolve. Filtering by user_id excludes rdsdb
                     -- while the LEFT join keeps unresolved real users (username NULL).
                     qd.user_id <> 1 AND

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -575,7 +575,7 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                             sti.table_id = tbl
                         where starttime >= '{start_time}'
                         and starttime < '{end_time}'
-                        and cluster = '{db_name}'
+                        and sti.database = '{db_name}'
                     ),
                     query_txt AS (
                         SELECT
@@ -1065,7 +1065,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     LEFT JOIN
                     SVV_USER_INFO sui ON qs.user_id = sui.user_id
                 WHERE
-                    cluster = '{db_name}' AND
+                    sti.database = '{db_name}' AND
                     qs.user_id <> 1 AND -- this is user 'rdsdb'
                     qs.start_time >= '{start_time}' AND
                     qs.start_time < '{end_time}'
@@ -1222,7 +1222,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     -- user the view can't resolve. Filtering by user_id excludes rdsdb
                     -- while the LEFT join keeps unresolved real users (username NULL).
                     qd.user_id <> 1 AND
-                    cluster = '{db_name}' AND
+                    sti.database = '{db_name}' AND
                     qd.start_time >= '{start_time}' AND
                     qd.start_time < '{end_time}' AND
                     qt.sequence < 16 AND -- See https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -95,6 +95,7 @@ REDSHIFT_SYSTEM_SCHEMA: Dict[str, object] = {
         "session_id": "INT",
     },
     "svv_user_info": {"user_id": "INT", "user_name": "VARCHAR"},
+    "sys_load_detail": {"query_id": "BIGINT"},
 }
 
 
@@ -111,8 +112,44 @@ def assert_valid_redshift_sql(sql: str, expected_ctes: List[str]) -> None:
 
     assert [cte.alias for cte in parsed.find_all(exp.CTE)] == expected_ctes
 
+    # Given a table it has no entry for, qualify() infers a schema rather than failing,
+    # which turns column resolution off for that table with no signal -- a misspelled
+    # table name would take every column on it out of the check. Neither the default nor
+    # infer_schema=False raises, so require the entry instead.
+    referenced = {table.name.lower() for table in parsed.find_all(exp.Table)}
+    cte_names = {cte.alias.lower() for cte in parsed.find_all(exp.CTE)}
+    unregistered = referenced - cte_names - set(REDSHIFT_SYSTEM_SCHEMA)
+    assert not unregistered, (
+        f"{sorted(unregistered)} absent from REDSHIFT_SYSTEM_SCHEMA, so their columns "
+        "would go unchecked; add them"
+    )
+
     # qualify() rewrites in place, so resolve only after reading the CTE order.
     qualify(parsed, schema=REDSHIFT_SYSTEM_SCHEMA, dialect="redshift")
+
+
+def assert_query_text_scoped(sql: str, table: str) -> None:
+    """Assert every scan of `table` is restricted by a subquery predicate.
+
+    Counting occurrences of the predicate text cannot see which scan carries it, so a
+    query that drops the scope from the query-text table and gains a redundant one
+    elsewhere keeps the same count. Locating the scan and inspecting its own WHERE
+    binds the assertion to the scan that matters, and leaves it indifferent to `IN`
+    versus `EXISTS`, to casing and wrapping, and to the driving CTE's name.
+    """
+    parsed = sqlglot.parse_one(sql.replace("%s", "'?'"), dialect="redshift")
+
+    scans = [t for t in parsed.find_all(exp.Table) if t.name.lower() == table.lower()]
+    assert scans, f"{table} is not scanned by this query"
+
+    for scan in scans:
+        select = scan.find_ancestor(exp.Select)
+        where = select and select.args.get("where")
+        assert where is not None, f"the {table} scan has no WHERE clause"
+        assert any(
+            predicate.find(exp.Select) is not None
+            for predicate in where.find_all(exp.In, exp.Exists)
+        ), f"the {table} scan is not restricted by a subquery predicate"
 
 
 # The boundary-aware LISTAGG pattern for 200-byte segments (provisioned).
@@ -312,14 +349,15 @@ class TestQueryTextScopedToWindow:
         # and the stl_scan subquery can be scoped to it.
         assert "target_tables AS" in sql
         assert f"starttime >= '{START_TIME.strftime(redshift_datetime_format)}'" in sql
-        assert sql.lower().count("query in (select query from target_tables)") == 2
+        assert_query_text_scoped(sql, "stl_querytext")
+        assert_query_text_scoped(sql, "stl_scan")
 
     def test_provisioned_insert_create_scopes_query_text(self):
         sql = RedshiftProvisionedQuery.list_insert_create_queries_sql(
             db_name="test_db", start_time=START_TIME, end_time=END_TIME
         )
         assert "with target_queries as" in sql.lower()
-        assert "query in (select query from target_queries)" in sql.lower()
+        assert_query_text_scoped(sql, "stl_querytext")
         # stl_insert is cluster-wide, so the driving set joins SVV_TABLE_INFO to scope
         # by database too; without it the LISTAGG reassembles text for inserts into
         # every other database on the cluster, which the outer query discards.
@@ -328,7 +366,7 @@ class TestQueryTextScopedToWindow:
     def test_provisioned_list_all_queries_scopes_query_text(self):
         sql = RedshiftProvisionedQuery.list_all_queries_sql()
         assert "in_window_queries" in sql
-        assert "query IN (SELECT query FROM in_window_queries)" in sql
+        assert_query_text_scoped(sql, "stl_querytext")
         # The window and database are bound as three positional parameters in the
         # caller's order (start_time, end_time, database); reordering them would
         # silently bind the database name into a timestamp comparison.
@@ -345,7 +383,7 @@ class TestQueryTextScopedToWindow:
         )
         # SYS_QUERY_TEXT is de-duplicated with a ROW_NUMBER() window, which the outer
         # join to the time-filtered `queries` CTE cannot bound.
-        assert "query_id IN (SELECT query_id FROM queries)" in sql
+        assert_query_text_scoped(sql, "sys_query_text")
 
 
 class TestGeneratedSqlResolves:
@@ -388,6 +426,16 @@ class TestGeneratedSqlResolves:
                 "insert_queries",
             ],
         )
+
+    def test_serverless_list_insert_create_queries_sql(self):
+        sql = RedshiftServerlessQuery.list_insert_create_queries_sql(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        assert_valid_redshift_sql(sql, expected_ctes=[])
+        # Naming the column rather than the select alias it is given: Redshift resolves
+        # an alias in WHERE, and so does qualify(), so a slip back to `cluster = ...`
+        # would either empty or silently widen serverless insert lineage unnoticed.
+        assert "sti.database = 'test_db'" in sql
 
 
 def _assert_no_inner_join_on(sql: str, view: str) -> None:

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -488,6 +488,22 @@ class TestUserInfoJoinResilience:
         _assert_no_inner_join_on(sql, "svv_user_info")
         assert "qd.user_id <> 1" in sql
 
+    def test_provisioned_stl_scan_lineage_excludes_rdsdb_by_id_not_name(self):
+        sql = RedshiftProvisionedQuery.stl_scan_based_lineage_query(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        _assert_no_inner_join_on(sql, "svl_user_info")
+        assert "ss.userid <> 1" in sql
+        assert "usename <> 'rdsdb'" not in sql
+
+    def test_provisioned_insert_lineage_excludes_rdsdb_by_id_not_name(self):
+        sql = RedshiftProvisionedQuery.list_insert_create_queries_sql(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        _assert_no_inner_join_on(sql, "svl_user_info")
+        assert "si.userid <> 1" in sql
+        assert "usename <> 'rdsdb'" not in sql
+
     def test_serverless_insert_lineage_excludes_rdsdb_by_id_not_name(self):
         # rdsdb has no row in SVV_USER_INFO, so a name-based `<> 'rdsdb'` relied on NULL
         # propagation and also dropped any real user the view couldn't resolve. Excluding

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -221,6 +221,10 @@ class TestQueryTextScopedToWindow:
         )
         assert "with target_queries as" in sql.lower()
         assert "query in (select query from target_queries)" in sql.lower()
+        # stl_insert is cluster-wide, so the driving set joins SVV_TABLE_INFO to scope
+        # by database too -- otherwise the LISTAGG still reassembles text for inserts
+        # into every other database on the cluster, which the outer query discards.
+        assert "sti.database = 'test_db'" in sql
 
     def test_provisioned_list_all_queries_scopes_query_text(self):
         sql = RedshiftProvisionedQuery.list_all_queries_sql()

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -6,6 +6,11 @@ queries from fixed-width character segments (200 bytes provisioned, 4000 bytes s
 """
 
 from datetime import datetime
+from typing import Dict, List
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.optimizer.qualify import qualify
 
 from datahub.ingestion.source.redshift.query import (
     RedshiftCommonQuery,
@@ -15,6 +20,99 @@ from datahub.ingestion.source.redshift.query import (
 
 START_TIME = datetime(2024, 1, 1, 12, 0, 0)
 END_TIME = datetime(2024, 1, 10, 12, 0, 0)
+
+# Enough of the Redshift system catalog for sqlglot to resolve every column these
+# builders reference. Only the log/catalog tables the lineage queries touch.
+# Typed as sqlglot's own `schema` parameter expects (dict values are invariant).
+REDSHIFT_SYSTEM_SCHEMA: Dict[str, object] = {
+    "stl_querytext": {
+        "userid": "INT",
+        "xid": "BIGINT",
+        "pid": "INT",
+        "query": "INT",
+        "sequence": "INT",
+        "text": "VARCHAR",
+    },
+    "stl_query": {
+        "userid": "INT",
+        "query": "INT",
+        "label": "VARCHAR",
+        "xid": "BIGINT",
+        "pid": "INT",
+        "database": "VARCHAR",
+        "querytxt": "VARCHAR",
+        "starttime": "TIMESTAMP",
+        "endtime": "TIMESTAMP",
+        "aborted": "INT",
+    },
+    "stl_insert": {
+        "userid": "INT",
+        "query": "INT",
+        "slice": "INT",
+        "segment": "INT",
+        "step": "INT",
+        "starttime": "TIMESTAMP",
+        "endtime": "TIMESTAMP",
+        "tbl": "INT",
+        "rows": "BIGINT",
+    },
+    "stl_scan": {
+        "userid": "INT",
+        "query": "INT",
+        "slice": "INT",
+        "segment": "INT",
+        "step": "INT",
+        "starttime": "TIMESTAMP",
+        "endtime": "TIMESTAMP",
+        "tbl": "INT",
+        "type": "INT",
+        "rows": "BIGINT",
+    },
+    "stl_load_commits": {"userid": "INT", "query": "INT", "slice": "INT"},
+    "svv_table_info": {
+        "database": "VARCHAR",
+        "schema": "VARCHAR",
+        "table_id": "INT",
+        "table": "VARCHAR",
+        "size": "BIGINT",
+        "tbl_rows": "BIGINT",
+    },
+    "svl_user_info": {"usesysid": "INT", "usename": "VARCHAR"},
+    "sys_query_detail": {
+        "user_id": "INT",
+        "query_id": "BIGINT",
+        "table_id": "INT",
+        "step_name": "VARCHAR",
+        "source": "VARCHAR",
+        "start_time": "TIMESTAMP",
+        "end_time": "TIMESTAMP",
+    },
+    "sys_query_text": {
+        "query_id": "BIGINT",
+        "sequence": "INT",
+        "text": "VARCHAR",
+        "session_id": "INT",
+    },
+    "svv_user_info": {"user_id": "INT", "user_name": "VARCHAR"},
+}
+
+
+def assert_valid_redshift_sql(sql: str, expected_ctes: List[str]) -> None:
+    """Resolve every column reference and check CTE declaration order.
+
+    A CTE projection missing a column its outer SELECT references parses cleanly and
+    fails only on a live cluster; qualify() reports `Unknown column`. A non-recursive
+    WITH can only reference CTEs declared before it, so `expected_ctes` asserts
+    correctness rather than style.
+    """
+    # The bound parameters are placeholders, not SQL; give them a literal to parse.
+    parsed = sqlglot.parse_one(sql.replace("%s", "'?'"), dialect="redshift")
+
+    assert [cte.alias for cte in parsed.find_all(exp.CTE)] == expected_ctes
+
+    # qualify() rewrites in place, so resolve only after reading the CTE order.
+    qualify(parsed, schema=REDSHIFT_SYSTEM_SCHEMA, dialect="redshift")
+
 
 # The boundary-aware LISTAGG pattern for 200-byte segments (provisioned).
 # Appends a space when the trimmed segment is shorter than the segment size,
@@ -209,8 +307,8 @@ class TestQueryTextScopedToWindow:
         sql = RedshiftProvisionedQuery.stl_scan_based_lineage_query(
             db_name="test_db", start_time=START_TIME, end_time=END_TIME
         )
-        # The in-window insert rows move into a named CTE so both STL_QUERYTEXT and
-        # stl_scan -- neither of which was bounded before -- can be scoped to it.
+        # The in-window insert rows sit in a named CTE so both the STL_QUERYTEXT scan
+        # and the stl_scan subquery can be scoped to it.
         assert "WITH target_tables AS" in sql
         assert "starttime >= '2024-01-01 12:00:00'" in sql
         assert sql.lower().count("query in (select query from target_tables)") == 2
@@ -222,16 +320,16 @@ class TestQueryTextScopedToWindow:
         assert "with target_queries as" in sql.lower()
         assert "query in (select query from target_queries)" in sql.lower()
         # stl_insert is cluster-wide, so the driving set joins SVV_TABLE_INFO to scope
-        # by database too -- otherwise the LISTAGG still reassembles text for inserts
-        # into every other database on the cluster, which the outer query discards.
+        # by database too; without it the LISTAGG reassembles text for inserts into
+        # every other database on the cluster, which the outer query discards.
         assert "sti.database = 'test_db'" in sql
 
     def test_provisioned_list_all_queries_scopes_query_text(self):
         sql = RedshiftProvisionedQuery.list_all_queries_sql()
         assert "in_window_queries" in sql
         assert "query IN (SELECT query FROM in_window_queries)" in sql
-        # The window and database stay bound as three positional parameters in the
-        # caller's order (start_time, end_time, database) -- reordering them would
+        # The window and database are bound as three positional parameters in the
+        # caller's order (start_time, end_time, database); reordering them would
         # silently bind the database name into a timestamp comparison.
         assert sql.count("%s") == 3
         assert (
@@ -247,6 +345,48 @@ class TestQueryTextScopedToWindow:
         # SYS_QUERY_TEXT is de-duplicated with a ROW_NUMBER() window, which the outer
         # join to the time-filtered `queries` CTE cannot bound.
         assert "query_id IN (SELECT query_id FROM queries)" in sql
+
+
+class TestGeneratedSqlResolves:
+    """Each query's driving set lives in a CTE whose projection the outer SELECT
+    depends on. A projection missing a column the outer query still reads parses
+    clean and satisfies every substring assertion, failing only against a live
+    cluster, so the contract needs resolving rather than matching."""
+
+    def test_provisioned_stl_scan_based_lineage_query(self):
+        assert_valid_redshift_sql(
+            RedshiftProvisionedQuery.stl_scan_based_lineage_query(
+                db_name="test_db", start_time=START_TIME, end_time=END_TIME
+            ),
+            expected_ctes=["target_tables", "query_txt"],
+        )
+
+    def test_provisioned_list_insert_create_queries_sql(self):
+        assert_valid_redshift_sql(
+            RedshiftProvisionedQuery.list_insert_create_queries_sql(
+                db_name="test_db", start_time=START_TIME, end_time=END_TIME
+            ),
+            expected_ctes=["target_queries", "query_txt"],
+        )
+
+    def test_provisioned_list_all_queries_sql(self):
+        assert_valid_redshift_sql(
+            RedshiftProvisionedQuery.list_all_queries_sql(),
+            expected_ctes=["in_window_queries", "query_txt"],
+        )
+
+    def test_serverless_stl_scan_based_lineage_query(self):
+        assert_valid_redshift_sql(
+            RedshiftServerlessQuery.stl_scan_based_lineage_query(
+                db_name="test_db", start_time=START_TIME, end_time=END_TIME
+            ),
+            expected_ctes=[
+                "queries",
+                "unique_query_text",
+                "scan_queries",
+                "insert_queries",
+            ],
+        )
 
 
 def _assert_no_inner_join_on(sql: str, view: str) -> None:

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -103,7 +103,7 @@ class TestProvisionedQueries:
         sql = RedshiftProvisionedQuery.stl_scan_based_lineage_query(
             db_name="test_db", start_time=START_TIME, end_time=END_TIME
         )
-        assert "WITH query_txt AS" in sql
+        assert "query_txt AS" in sql
         assert "STL_QUERYTEXT" in sql
         # Should join query_txt CTE (not stl_query table) for querytxt
         assert "join query_txt sq" in sql.lower()
@@ -133,9 +133,9 @@ class TestProvisionedQueries:
         assert "stl_scan" not in sql.lower()
         # Time window and database are bound as parameters (%s), not interpolated,
         # so config/catalog values never enter the SQL string.
-        assert "q.database = %s" in sql
-        assert "q.starttime >= %s" in sql
-        assert "q.starttime < %s" in sql
+        assert "sq.database = %s" in sql
+        assert "sq.starttime >= %s" in sql
+        assert "sq.starttime < %s" in sql
         assert sql.count("%s") == 3
         # Internal Redshift user must be excluded to avoid usage noise.
         assert "rdsdb" in sql
@@ -193,6 +193,56 @@ class TestServerlessQueries:
             # Should not have bare LISTAGG without RTRIM wrapper
             assert 'LISTAGG(qt."text")' not in sql
             assert "LEN(RTRIM(querytxt)) = 0" not in sql
+
+
+class TestQueryTextScopedToWindow:
+    """The query-text sources carry no timestamp of their own (STL_QUERYTEXT has only
+    userid/xid/pid/query/sequence/text), and the window predicate sits on a different
+    table in the outer query -- stl_insert, stl_query or SYS_QUERY_DETAIL. So there is
+    nothing for the optimizer to push into the aggregating query-text CTE: it must
+    restrict its own scan to the query ids the time-filtered driving set already
+    selected. Otherwise LISTAGG aggregates the cluster's whole retained query history
+    on every run, and the query times out on busy clusters no matter how small
+    start_time makes the window."""
+
+    def test_provisioned_stl_scan_lineage_scopes_query_text_and_scan(self):
+        sql = RedshiftProvisionedQuery.stl_scan_based_lineage_query(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        # The in-window insert rows move into a named CTE so both STL_QUERYTEXT and
+        # stl_scan -- neither of which was bounded before -- can be scoped to it.
+        assert "WITH target_tables AS" in sql
+        assert "starttime >= '2024-01-01 12:00:00'" in sql
+        assert sql.lower().count("query in (select query from target_tables)") == 2
+
+    def test_provisioned_insert_create_scopes_query_text(self):
+        sql = RedshiftProvisionedQuery.list_insert_create_queries_sql(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        assert "with target_queries as" in sql.lower()
+        assert "query in (select query from target_queries)" in sql.lower()
+
+    def test_provisioned_list_all_queries_scopes_query_text(self):
+        sql = RedshiftProvisionedQuery.list_all_queries_sql()
+        assert "in_window_queries" in sql
+        assert "query IN (SELECT query FROM in_window_queries)" in sql
+        # The window and database stay bound as three positional parameters in the
+        # caller's order (start_time, end_time, database) -- reordering them would
+        # silently bind the database name into a timestamp comparison.
+        assert sql.count("%s") == 3
+        assert (
+            sql.index("sq.starttime >= %s")
+            < sql.index("sq.starttime < %s")
+            < sql.index("sq.database = %s")
+        )
+
+    def test_serverless_stl_scan_lineage_scopes_query_text(self):
+        sql = RedshiftServerlessQuery.stl_scan_based_lineage_query(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        # SYS_QUERY_TEXT is de-duplicated with a ROW_NUMBER() window, which the outer
+        # join to the time-filtered `queries` CTE cannot bound.
+        assert "query_id IN (SELECT query_id FROM queries)" in sql
 
 
 def _assert_no_inner_join_on(sql: str, view: str) -> None:

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -16,6 +16,7 @@ from datahub.ingestion.source.redshift.query import (
     RedshiftCommonQuery,
     RedshiftProvisionedQuery,
     RedshiftServerlessQuery,
+    redshift_datetime_format,
 )
 
 START_TIME = datetime(2024, 1, 1, 12, 0, 0)
@@ -309,8 +310,8 @@ class TestQueryTextScopedToWindow:
         )
         # The in-window insert rows sit in a named CTE so both the STL_QUERYTEXT scan
         # and the stl_scan subquery can be scoped to it.
-        assert "WITH target_tables AS" in sql
-        assert "starttime >= '2024-01-01 12:00:00'" in sql
+        assert "target_tables AS" in sql
+        assert f"starttime >= '{START_TIME.strftime(redshift_datetime_format)}'" in sql
         assert sql.lower().count("query in (select query from target_tables)") == 2
 
     def test_provisioned_insert_create_scopes_query_text(self):


### PR DESCRIPTION
> **Stacked on #19167.** Based on that branch because the change here edits the `where` clause that #19167 restructures. Retarget to `master` once it merges.

## Problem

`svl_user_info` is joined `LEFT` in the provisioned lineage queries because it only supplies a username — the row should survive whether or not the user resolves. But both queries then filtered on:

```sql
left join svl_user_info sui on ... = sui.usesysid
where sui.usename <> 'rdsdb'
```

`NULL <> 'rdsdb'` evaluates to `NULL`, not `true`, so any user the view cannot resolve is silently dropped. The `LEFT` join behaves as an inner one, and that row's lineage is lost — no error, no warning, nothing in the report.

On Redshift editions that keep the user-info views superuser-or-self-only, a non-superuser ingestion user cannot resolve other people, so this discards real users' lineage, not just `rdsdb`'s.

## This completes #18518

This is not a new pattern. #18518 ("make user-info join enrichment-only, exclude rdsdb by id") fixed exactly this in July, converting the joins to `LEFT` and excluding `rdsdb` by system `userid`. It covered the usage and operations paths but not the two lineage ones, which kept the name comparison and so remained gated.

Auditing every user-info join in `query.py` on `master`:

| Flavour | Method | State on master |
| --- | --- | --- |
| provisioned | `usage_query` | ✅ safe — #18518 |
| provisioned | `operation_aspect_query` | ✅ safe — #18518, both branches |
| provisioned | `list_all_queries_sql` | ✅ safe — name filter, but written `IS NULL OR …` |
| provisioned | **`stl_scan_based_lineage_query`** | ❌ **gates, drops lineage** |
| provisioned | **`list_insert_create_queries_sql`** | ❌ **gates, drops lineage** |
| serverless | all five | ✅ safe |

Every join in the file is already `LEFT`; the two stragglers re-gate themselves through the name comparison. Both `list_all_queries_sql` variants also filter by name but spell it `(sui.usename IS NULL OR sui.usename <> 'rdsdb')` — that explicit null branch is exactly what the two broken methods are missing.

The invariant is already encoded in the test suite as `_assert_no_inner_join_on`; it had simply never been applied to these two methods. `TestUserInfoJoinResilience` now covers them.

## It also makes the existing docs true

`docs/sources/redshift/redshift_post.md`, added by #18518, already tells users:

> The user-info views (`SVL_USER_INFO` / `SVV_USER_INFO`) are used only to enrich those log rows with a username — they never decide which rows are kept.
>
> If a query's user can't be resolved in the user-info views … usage, **lineage**, and operations are **still extracted**; the row is simply attributed to an `unknown` user (usage) or emitted without an actor (operations) rather than being dropped.

That is currently inaccurate for lineage. This PR makes it accurate, so no doc change is needed.

## Fix

| Query | Was | Now |
| --- | --- | --- |
| `stl_scan_based_lineage_query` | `sui.usename <> 'rdsdb'` | `ss.userid <> 1` |
| `list_insert_create_queries_sql` | `sui.usename <> 'rdsdb'` | `si.userid <> 1` |

Nothing downstream depends on the restored rows carrying a username: `LineageRow` has no `username` field, so `get_lineage_rows` never reads that column.

### Two consequences worth calling out

**The join key moves from `sq.userid` to `ss.userid`** in the scan query. `query_txt` is `LEFT` joined and therefore nullable, and a nullable column cannot carry this predicate without gating on it in turn. `stl_scan` is always present.

**That leaves `userid` unreferenced in `query_txt`, which now groups by `query` alone.** Grouping by `userid` as well would emit a second row — and so duplicate every source row for that query — if `STL_QUERYTEXT` ever held two userids for one query id.

## This changes output

Affected deployments will emit lineage that was previously dropped. That is the fix working. If a golden file moves after this lands, this is the likely reason.

## Testing

- `tests/unit/redshift/` passes, 130 tests.
- `./gradlew :metadata-ingestion:lint` clean (ruff + mypy).
- `TestUserInfoJoinResilience` extended to both provisioned methods: the join must be `LEFT`, and `rdsdb` must be excluded by id rather than by name.
- Both queries still resolve under sqlglot's `qualify()` against a schema of the Redshift system tables, with CTE order asserted.

**Not verified on a live cluster, and the available one cannot reach it.** `SVL_USER_INFO` there is not self-restricted: the ingestion user is not a superuser (`usesuper = false`) and still sees all seven rows, identical to what a superuser sees, with `rdsdb` correctly absent. So every user resolves, the broken predicate never fires, and old and new return identical rows regardless of which user connects. That is a property of the cluster's configuration rather than of the test setup — reproducing this needs an edition that keeps the user-info views superuser-or-self-only.

The reasoning is straightforward — `NULL <> 'literal'` is `NULL`, and a `WHERE` discards `NULL` — but it is reasoning rather than measurement, which is part of why this is separate from #19167.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated — the existing `redshift_post.md` text already describes the fixed behaviour; this PR makes it true
- [ ] Entry in Updating DataHub — this is a bug fix rather than a breaking change, but it does change output on affected deployments. Happy to add an entry if maintainers would like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
