### PR TITLE
perf(gms): Fix Entity graph cache for domains

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
@@ -313,20 +313,54 @@ public class EntityGraphSnapshotBuilder {
       return new PartialScrollResult(Set.of(), false);
     }
 
-    AspectRetriever aspectRetriever = opContext.getRetrieverContext().getAspectRetriever();
-    EntityRegistry entityRegistry = aspectRetriever.getEntityRegistry();
     opContext
         .getMetricUtils()
         .ifPresent(m -> m.incrementMicrometer("entity.graph.build.primary_aspect", 1));
 
+    return accumulateEdgesFromAspects(
+        opContext, definition, frontierUrns, definition.getResolvedEdges(), accumulator);
+  }
+
+  /**
+   * Resolves destination URNs by reading the aspects the edges are declared on, rather than relying
+   * on denormalized fields in the search index. Returns the discovered destination URNs, flagging
+   * an incomplete result when the aspect batch read fails.
+   */
+  @Nonnull
+  private PartialScrollResult accumulateEdgesFromAspects(
+      @Nonnull OperationContext opContext,
+      @Nonnull EntityGraphDefinition definition,
+      @Nonnull Collection<String> sourceUrns,
+      @Nonnull Collection<ResolvedGraphEdge> candidateEdges,
+      @Nonnull EdgeAccumulator accumulator) {
+
+    Map<String, List<ResolvedGraphEdge>> edgesBySourceType = new HashMap<>();
+    for (ResolvedGraphEdge edge : candidateEdges) {
+      if (edge.getAspectName() == null || edge.getAspectName().isBlank()) {
+        continue;
+      }
+      edgesBySourceType
+          .computeIfAbsent(
+              edge.getTriplet().getSourceEntityType().toLowerCase(Locale.ROOT),
+              k -> new ArrayList<>())
+          .add(edge);
+    }
+
+    if (sourceUrns.isEmpty() || edgesBySourceType.isEmpty()) {
+      return new PartialScrollResult(Set.of(), false);
+    }
+
+    AspectRetriever aspectRetriever = opContext.getRetrieverContext().getAspectRetriever();
+    EntityRegistry entityRegistry = aspectRetriever.getEntityRegistry();
+
     Set<Urn> urns =
-        frontierUrns.stream()
+        sourceUrns.stream()
             .map(UrnUtils::getUrn)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     Set<String> aspectNames =
-        definition.getResolvedEdges().stream()
+        edgesBySourceType.values().stream()
+            .flatMap(List::stream)
             .map(ResolvedGraphEdge::getAspectName)
-            .filter(name -> name != null && !name.isBlank())
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
     Map<Urn, Map<String, Aspect>> aspectBatch;
@@ -338,13 +372,17 @@ public class EntityGraphSnapshotBuilder {
     }
 
     Set<String> neighbors = new LinkedHashSet<>();
-    for (String frontierUrn : frontierUrns) {
+    for (Urn urn : urns) {
       if (accumulator.isBypassed()) {
         break;
       }
-      Urn urn = UrnUtils.getUrn(frontierUrn);
       Map<String, Aspect> aspectsForUrn = aspectBatch.getOrDefault(urn, Map.of());
-      for (ResolvedGraphEdge resolved : definition.getResolvedEdges()) {
+      if (aspectsForUrn.isEmpty()) {
+        continue;
+      }
+      List<ResolvedGraphEdge> applicable =
+          edgesBySourceType.getOrDefault(urn.getEntityType().toLowerCase(Locale.ROOT), List.of());
+      for (ResolvedGraphEdge resolved : applicable) {
         if (accumulator.isBypassed()) {
           break;
         }
@@ -371,7 +409,7 @@ public class EntityGraphSnapshotBuilder {
               continue;
             }
             accumulator.addEdge(
-                frontierUrn,
+                urn.toString(),
                 destUrn,
                 resolved.getTriplet().getRelationshipType(),
                 definition.getBounds().getMaxVertices(),
@@ -615,21 +653,18 @@ public class EntityGraphSnapshotBuilder {
       @Nullable Collection<String> seeds,
       @Nonnull EdgeAccumulator accumulator) {
 
-    Set<String> sourceTypes =
+    List<ResolvedGraphEdge> searchableEdges =
         definition.getResolvedEdges().stream()
+            .filter(ResolvedGraphEdge::isSearchable)
+            .collect(Collectors.toList());
+
+    Set<String> sourceTypes =
+        searchableEdges.stream()
             .map(e -> e.getTriplet().getSourceEntityType().toLowerCase(Locale.ROOT))
             .collect(Collectors.toCollection(LinkedHashSet::new));
 
-    Map<String, List<ResolvedGraphEdge>> edgesBySourceType = new HashMap<>();
-    for (ResolvedGraphEdge edge : definition.getResolvedEdges()) {
-      if (!edge.isSearchable()) {
-        continue;
-      }
-      edgesBySourceType
-          .computeIfAbsent(
-              edge.getTriplet().getSourceEntityType().toLowerCase(Locale.ROOT),
-              k -> new ArrayList<>())
-          .add(edge);
+    if (sourceTypes.isEmpty()) {
+      return false;
     }
 
     SearchFlags flags =
@@ -655,25 +690,19 @@ public class EntityGraphSnapshotBuilder {
           break;
         }
 
-        for (SearchEntity entity : scrollResult.getEntities()) {
-          if (accumulator.isBypassed()) {
-            return false;
-          }
-          String sourceUrn = entity.getEntity().toString();
-          List<ResolvedGraphEdge> applicable =
-              edgesBySourceType.getOrDefault(
-                  UrnUtils.getUrn(sourceUrn).getEntityType().toLowerCase(Locale.ROOT), List.of());
-          for (ResolvedGraphEdge resolved : applicable) {
-            String destUrn = extractRelatedUrn(entity, resolved.getSearchField());
-            if (destUrn != null && !destUrn.isBlank()) {
-              accumulator.addEdge(
-                  sourceUrn,
-                  destUrn,
-                  resolved.getTriplet().getRelationshipType(),
-                  definition.getBounds().getMaxVertices(),
-                  definition.getBounds().getMaxEdges().orElse(Integer.MAX_VALUE));
-            }
-          }
+        // Search only supplies the URN listing; destinations come from the underlying aspects so
+        // that edges do not depend on denormalized fields being present in the search document.
+        Set<String> pageUrns =
+            scrollResult.getEntities().stream()
+                .map(SearchEntity::getEntity)
+                .map(Urn::toString)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        PartialScrollResult aspectResult =
+            accumulateEdgesFromAspects(
+                opContext, definition, pageUrns, searchableEdges, accumulator);
+        if (aspectResult.isScrollIncomplete()) {
+          accumulator.markScrollIncomplete();
         }
 
         scrollId = scrollResult.getScrollId();


### PR DESCRIPTION
This aims to fix entity graph cache construction for domains and other entities that rely on `buildSource=search`. Instead of relying on denormalized  destination URN info being present in the search result's `extraFields`, look for the destination URN via a batched aspect fetch instead. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes entity graph cache for domains and other search-built entities by resolving destination URNs from aspects instead of denormalized search extraFields. Previously edges depended on search documents; now we batch-fetch aspects to build edges, preventing missing edges when extraFields are absent.

- Search now only enumerates source URNs; edge destinations come from a batched aspect read via a new accumulate-from-aspects path.
- Batches aspects for page URNs and required aspect names, filters edges by source entity type, and skips edges lacking aspect names.
- Marks the scroll as incomplete when the aspect batch read fails; continues to enforce existing vertex/edge bounds.
- Expected impact: more correct edges for domains; minor increase in aspect read load; no migration required.

<sup>Written for commit 88d83d2d2d9ecbb24ada32b50f25237fac3663b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

