### PR TITLE
fix(load-indices): do not default lePitEpochMs to now

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/loadindices/LoadIndicesStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/loadindices/LoadIndicesStep.java
@@ -557,8 +557,7 @@ public class LoadIndicesStep implements UpgradeStep {
     }
     restoreArgs.urnLike = args.urnLike;
     restoreArgs.gePitEpochMs = args.gePitEpochMs != null ? args.gePitEpochMs : 0L;
-    restoreArgs.lePitEpochMs =
-        args.lePitEpochMs != null ? args.lePitEpochMs : System.currentTimeMillis();
+    restoreArgs.lePitEpochMs = args.lePitEpochMs != null ? args.lePitEpochMs : 0L;
     restoreArgs.limit = limit;
 
     // Enable URN-based pagination if lastUrn is provided

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/loadindices/LoadIndicesStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/loadindices/LoadIndicesStepTest.java
@@ -27,6 +27,7 @@ import io.ebean.Database;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -117,7 +118,7 @@ public class LoadIndicesStepTest {
     aspectV2.setAspect(aspect);
     aspectV2.setVersion(version);
     aspectV2.setMetadata("{}"); // Required field
-    aspectV2.setCreatedOn(Timestamp.from(createdTime));
+    aspectV2.setCreatedOn(Timestamp.from(createdTime.truncatedTo(ChronoUnit.MILLIS)));
     aspectV2.setCreatedBy(createdBy);
     database.save(aspectV2);
   }
@@ -130,7 +131,7 @@ public class LoadIndicesStepTest {
     aspectV2.setVersion(version);
     // Provide valid container aspect JSON data
     aspectV2.setMetadata("{\"container\":{\"urn\":\"" + urn + "\"}}");
-    aspectV2.setCreatedOn(Timestamp.from(createdTime));
+    aspectV2.setCreatedOn(Timestamp.from(createdTime.truncatedTo(ChronoUnit.MILLIS)));
     aspectV2.setCreatedBy(createdBy);
     database.save(aspectV2);
   }
@@ -531,7 +532,7 @@ public class LoadIndicesStepTest {
     assertTrue(result.aspectNames == null || result.aspectNames.isEmpty());
     assertTrue(result.urnLike == null);
     assertEquals(result.gePitEpochMs, Long.valueOf(0L));
-    assertTrue(result.lePitEpochMs > 0); // Should be current time
+    assertEquals(result.lePitEpochMs, Long.valueOf(0L));
     assertEquals(result.limit, 1000);
     assertFalse(result.urnBasedPagination);
     assertTrue(result.lastUrn == null || result.lastUrn.isEmpty());


### PR DESCRIPTION
## Summary

- After #18860, `lePitEpochMs` applies independently. LoadIndices still defaulted an unset upper bound to `System.currentTimeMillis()`, which dropped same-millisecond rows whose `createdOn` had sub-ms nanos.
- Default unset `lePitEpochMs` to `0` (unbounded), matching RestoreIndices and the docs.
- Truncate test insert timestamps to milliseconds so explicit `le=now` filters stay stable.

## Test plan

- [x] `./gradlew :datahub-upgrade:test --tests com.linkedin.datahub.upgrade.loadindices.LoadIndicesStepTest`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `lePitEpochMs` to 0 (unbounded) in LoadIndices. Previously it defaulted to current time, creating an implicit upper bound and dropping same‑millisecond rows with sub‑ms nanos. This now matches `RestoreIndices` and the docs.

- **Review notes**
  - In `LoadIndicesStep.convertToRestoreIndicesArgs`, set `lePitEpochMs` to 0 when null; `gePitEpochMs` remains 0 when null.
  - Tests truncate inserted timestamps to millisecond precision and assert `lePitEpochMs == 0`.

- **Migration**
  - If you need an upper time bound, pass `lePitEpochMs` explicitly; the implicit “now” bound no longer applies.

<sup>Written for commit 41dfc33225fe84436486dc080cf38f6a1540c97d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

