### PR TITLE
fix(gms): fetch indexed search fields for entity graph cache

### DIFF
--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -767,6 +767,8 @@ Per-graph refresh timing (`population.intervalSeconds`) and graph bounds (`bound
 }
 ```
 
+The same overlay can disable a bundled graph (`{"graphs":{"domain":{"enabled":false}}}`) or switch FULL known graphs to `buildSource: graph`. See [Known graphs and bindings](./gms-entity-graph-cache.md#known-graphs-and-bindings).
+
 When a FULL build exceeds `maxVertices`, the cache key enters **`OVER_LIMIT`** (no automatic rebuild). Recovery: delete domains to reduce vertex count, or raise bounds and manually drop the graph in Hazelcast. See [Invalidation (sync writes)](./gms-entity-graph-cache.md#invalidation-sync-writes).
 
 `ENTITY_GRAPH_CACHE_ENABLED=true` on **GMS** requires a reachable Hazelcast cluster (`searchService.cache.hazelcast.serviceName`, default `hazelcast-service`). Set `ENTITY_GRAPH_CACHE_ENABLED=false` when Hazelcast is unavailable, or on MAE/MCE/upgrade pods where the graph cache is not loaded (see [GMS Entity Graph Cache](./gms-entity-graph-cache.md)).

--- a/docs/deploy/gms-entity-graph-cache.md
+++ b/docs/deploy/gms-entity-graph-cache.md
@@ -248,6 +248,24 @@ Optional overlay merged **after** the config file — typical for raising domain
 
 Set `ENTITY_GRAPH_CACHE_CONFIG_FILE_ENABLED=false` to supply graphs JSON-only. Invalid JSON fails startup when cache is enabled.
 
+Disable a bundled graph (call sites use live aspect / graph-scroll fallback) or switch its `buildSource`. Changing `buildSource` changes the Hazelcast cache key (`domain@search` → `domain@graph`); the previous key is unused after restart.
+
+```json
+{
+  "graphs": {
+    "domain": { "enabled": false }
+  }
+}
+```
+
+```json
+{
+  "graphs": {
+    "domain": { "buildSource": "graph" }
+  }
+}
+```
+
 Example overlay to raise glossary depth or component bounds:
 
 ```json
@@ -263,20 +281,20 @@ Example overlay to raise glossary depth or component bounds:
 
 ### Graph fields
 
-| Field                              | Required                     | Notes                                                                                                                                                                |
-| ---------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`                          | Yes                          | Disabled graphs are ignored                                                                                                                                          |
-| `buildSource`                      | **Yes**                      | `primary`, `graph`, or `search` — sole build path (see [Terminology — buildSource](#buildsource-required-on-every-graph))                                            |
-| `edges[]` or `lineage`             | One mode                     | Mutually exclusive triplet vs lineage edge discovery                                                                                                                 |
-| `scope.mode`                       | Yes                          | `FULL` or `PARTIAL`                                                                                                                                                  |
-| `scope.maxDepth`                   | **Required > 0 for PARTIAL** | Per-direction BFS cap during **PARTIAL build** and in-memory read traversal (explicit in config only — **no default**). **Invalid for FULL** — use `bounds` instead. |
-| `population.strategy`              | **Yes**                      | `LAZY` or `SCHEDULED`                                                                                                                                                |
-| `population.rebuildExecution`      | No                           | `SYNC` (default), `BACKGROUND` (LAZY + FULL only — async rebuild, expand fail-closed until fresh)                                                                    |
-| `population.intervalSeconds`       | No                           | Staleness / COOLDOWN retry / SCHEDULED interval (default 300; bundled `domain` uses 600; bundled `glossary` uses 1200)                                               |
-| `bounds.maxVertices` / `maxEdges`  | No                           | Build caps (defaults 10000 / 15000; bundled `domain` uses 500 / 750; bundled `glossary` uses 30000 / 45000)                                                          |
-| `bindings.*`                       | No                           | Custom call-site wiring — see [Known graphs and bindings](#known-graphs-and-bindings)                                                                                |
-| `scroll.batchSize`                 | No                           | Build scroll page size (default 500)                                                                                                                                 |
-| `entityTypes` + `relationshipType` | No                           | Triplet shorthand — mutually exclusive with `lineage`                                                                                                                |
+| Field                              | Required                     | Notes                                                                                                                                                                  |
+| ---------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                          | Yes                          | Disabled graphs are omitted from the registry (no snapshot, no scheduler). Built-in graphs may be disabled via overlay without failing startup. Live fallbacks remain. |
+| `buildSource`                      | **Yes**                      | `primary`, `graph`, or `search` — sole build path (see [Terminology — buildSource](#buildsource-required-on-every-graph))                                              |
+| `edges[]` or `lineage`             | One mode                     | Mutually exclusive triplet vs lineage edge discovery                                                                                                                   |
+| `scope.mode`                       | Yes                          | `FULL` or `PARTIAL`                                                                                                                                                    |
+| `scope.maxDepth`                   | **Required > 0 for PARTIAL** | Per-direction BFS cap during **PARTIAL build** and in-memory read traversal (explicit in config only — **no default**). **Invalid for FULL** — use `bounds` instead.   |
+| `population.strategy`              | **Yes**                      | `LAZY` or `SCHEDULED`                                                                                                                                                  |
+| `population.rebuildExecution`      | No                           | `SYNC` (default), `BACKGROUND` (LAZY + FULL only — async rebuild, expand fail-closed until fresh)                                                                      |
+| `population.intervalSeconds`       | No                           | Staleness / COOLDOWN retry / SCHEDULED interval (default 300; bundled `domain` uses 600; bundled `glossary` uses 1200)                                                 |
+| `bounds.maxVertices` / `maxEdges`  | No                           | Build caps (defaults 10000 / 15000; bundled `domain` uses 500 / 750; bundled `glossary` uses 30000 / 45000)                                                            |
+| `bindings.*`                       | No                           | Custom call-site wiring — see [Known graphs and bindings](#known-graphs-and-bindings)                                                                                  |
+| `scroll.batchSize`                 | No                           | Build scroll page size (default 500)                                                                                                                                   |
+| `entityTypes` + `relationshipType` | No                           | Triplet shorthand — mutually exclusive with `lineage`                                                                                                                  |
 
 #### Lineage graph examples
 
@@ -498,13 +516,16 @@ Bundled `domain` uses `SCHEDULED` with `intervalSeconds: 600` (proactive rebuild
 
 ### Known graphs and bindings
 
-| Enum / binding               | Config / API            | Notes                                                             |
-| ---------------------------- | ----------------------- | ----------------------------------------------------------------- |
-| `KnownEntityGraph.DOMAIN`    | `graphs.domain`         | Required when cache enabled; `search` + FULL                      |
-| `KnownEntityGraph.GLOSSARY`  | `graphs.glossary`       | Required when cache enabled; `graph` + PARTIAL                    |
-| `KnownEntityGraph.CONTAINER` | `graphs.container`      | Required when cache enabled; `graph` + PARTIAL                    |
-| `bindings.filterFields`      | `bindingForFilterField` | Requires `search` + FULL                                          |
-| `bindings.policyFieldTypes`  | `bindingForPolicyField` | `primary`, or `search` with `scope.mode: FULL` (bundled `domain`) |
+| Enum / binding                | Config / API            | Default when enabled                                                      |
+| ----------------------------- | ----------------------- | ------------------------------------------------------------------------- |
+| `KnownEntityGraph.DOMAIN`     | `graphs.domain`         | `search` + FULL; overlay may set `buildSource: graph` or `enabled: false` |
+| `KnownEntityGraph.GLOSSARY`   | `graphs.glossary`       | `graph` + PARTIAL; overlay may set `enabled: false`                       |
+| `KnownEntityGraph.CONTAINER`  | `graphs.container`      | `graph` + PARTIAL; overlay may set `enabled: false`                       |
+| `KnownEntityGraph.MEMBERSHIP` | `graphs.membership`     | `graph` + FULL; overlay may set `enabled: false`                          |
+| `bindings.filterFields`       | `bindingForFilterField` | Requires `search` or `graph` with `scope.mode: FULL`                      |
+| `bindings.policyFieldTypes`   | `bindingForPolicyField` | `primary`, or `search`/`graph` with `scope.mode: FULL`                    |
+
+Known graphs are **not required** when the cache is enabled. `enabled: false` (or omitting the graph) skips snapshot build and scheduled rebuild; GraphQL / VBAC / filter rewriters use live aspect walks or `GraphRetriever` scroll. `scope.mode` cannot be changed for an enabled known graph (FULL vs PARTIAL). Overlaying `buildSource` for FULL known graphs is limited to `graph` or `search` (not `primary`).
 
 Bundled domain, glossary, and container graphs use `KnownEntityGraph` in Java; container and glossary call sites resolve specs via `HierarchyBindings` (not YAML `bindings.*`).
 

--- a/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/KnownEntityGraph.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/KnownEntityGraph.java
@@ -1,14 +1,16 @@
 package com.linkedin.metadata.graph.cache;
 
+import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 
 /**
  * First-party entity graph definitions that GMS call sites reference directly. Each constant maps
- * to a {@code graphs.<configKey>} entry in {@code entity-graph-cache.yaml}. When the entity graph
- * cache is enabled, {@link com.linkedin.metadata.graph.cache.config.EntityGraphRegistry} requires
- * every value here to exist, be enabled, and match the expected {@link GraphSnapshotSource} and
- * scope mode.
+ * to a {@code graphs.<configKey>} entry in {@code entity-graph-cache.yaml}. Source and scope here
+ * are defaults: operators may disable a known graph or overlay {@code buildSource} within {@link
+ * #allowsBuildSource(GraphSnapshotSource)}. Enabled known graphs must still match {@link
+ * #expectedScope}.
  */
 @Getter
 public enum KnownEntityGraph {
@@ -28,6 +30,44 @@ public enum KnownEntityGraph {
     this.configKey = configKey;
     this.expectedBuildSource = expectedBuildSource;
     this.expectedScope = expectedScope;
+  }
+
+  @Nullable
+  public static KnownEntityGraph fromConfigKey(@Nullable String configKey) {
+    if (configKey == null || configKey.isBlank()) {
+      return null;
+    }
+    for (KnownEntityGraph known : values()) {
+      if (known.configKey.equals(configKey)) {
+        return known;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Overlay-compatible {@code buildSource} values for this graph's required {@link #expectedScope}.
+   * FULL known graphs accept graph or search; PARTIAL known graphs accept graph only (primary and
+   * search PARTIAL are FORWARD-only).
+   */
+  public boolean allowsBuildSource(@Nonnull GraphSnapshotSource source) {
+    return switch (expectedScope) {
+      case FULL -> source == GraphSnapshotSource.GRAPH || source == GraphSnapshotSource.SEARCH;
+      case PARTIAL -> source == GraphSnapshotSource.GRAPH;
+    };
+  }
+
+  @Nonnull
+  public String allowedBuildSourcesDescription() {
+    return switch (expectedScope) {
+      case FULL -> "graph or search";
+      case PARTIAL -> "graph";
+    };
+  }
+
+  @Nonnull
+  public String expectedBuildSourceYaml() {
+    return expectedBuildSource.name().toLowerCase(Locale.ROOT);
   }
 
   /** Expected {@code scope.mode} for this graph (validated at registry build time). */

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccess.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccess.java
@@ -39,7 +39,7 @@ public final class BoundHierarchyAccess {
     if (roots.isEmpty()) {
       return Collections.emptySet();
     }
-    if (shouldUseCache(includeSoftDelete)) {
+    if (shouldUseCache(opContext, spec, includeSoftDelete)) {
       Set<String> rootStrings =
           roots.stream().map(Urn::toString).collect(Collectors.toCollection(LinkedHashSet::new));
       GraphReadResult result =
@@ -80,7 +80,7 @@ public final class BoundHierarchyAccess {
     if (maxDepth <= 0) {
       return Collections.emptyList();
     }
-    if (shouldUseCache(includeSoftDelete)) {
+    if (shouldUseCache(opContext, spec, includeSoftDelete)) {
       AncestorWalkResult walkResult =
           EntityGraphCacheClients.walkOrderedForwardAncestors(
               opContext,
@@ -113,7 +113,7 @@ public final class BoundHierarchyAccess {
       @Nonnull Urn rootUrn,
       int maxDepth,
       boolean includeSoftDelete) {
-    if (!shouldUseCache(includeSoftDelete)) {
+    if (!shouldUseCache(opContext, spec, includeSoftDelete)) {
       return GraphScrollFallback.allDescendants(opContext, spec, rootUrn);
     }
     int cacheMaxDepth =
@@ -169,7 +169,7 @@ public final class BoundHierarchyAccess {
       @Nonnull HierarchyReadSpec spec,
       @Nonnull Urn parentUrn,
       boolean includeSoftDelete) {
-    if (!shouldUseCache(includeSoftDelete)) {
+    if (!shouldUseCache(opContext, spec, includeSoftDelete)) {
       return GraphScrollFallback.directChildren(opContext, spec, parentUrn);
     }
     GraphReadResult result =
@@ -211,7 +211,7 @@ public final class BoundHierarchyAccess {
     if (candidateUrn.equals(ancestorUrn)) {
       return false;
     }
-    if (shouldUseCache(includeSoftDelete)) {
+    if (shouldUseCache(opContext, spec, includeSoftDelete)) {
       GraphReadResult result =
           EntityGraphCacheClients.expand(
               GraphExpandRequest.builder()
@@ -229,7 +229,12 @@ public final class BoundHierarchyAccess {
     return AspectParentWalker.isAncestorOf(opContext, spec, candidateUrn, ancestorUrn);
   }
 
-  private static boolean shouldUseCache(boolean includeSoftDelete) {
-    return !includeSoftDelete;
+  private static boolean shouldUseCache(
+      @Nonnull OperationContext opContext,
+      @Nonnull HierarchyReadSpec spec,
+      boolean includeSoftDelete) {
+    return !includeSoftDelete
+        && EntityGraphCacheClients.isBoundKnownGraph(
+            opContext.getEntityGraphCache(), spec.getBinding());
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccess.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccess.java
@@ -46,7 +46,7 @@ public final class BoundMembershipAccess {
     if (relationshipTypes.isEmpty() || count <= 0) {
       return MembershipNeighborResult.fromNeighbors(List.of(), 0);
     }
-    if (shouldUseCache(includeSoftDelete)) {
+    if (shouldUseCache(opContext, spec, includeSoftDelete)) {
       MembershipNeighborResult cached =
           EntityGraphCacheClients.listRelated(
               opContext,
@@ -138,7 +138,7 @@ public final class BoundMembershipAccess {
     for (Urn groupUrn : groupsForUser(opContext, spec, userUrn, includeSoftDelete)) {
       roles.addAll(rolesForGroup(opContext, spec, groupUrn, includeSoftDelete));
     }
-    if (!roles.isEmpty() || !shouldUseCache(includeSoftDelete)) {
+    if (!roles.isEmpty() || includeSoftDelete) {
       return roles;
     }
     ServicesRegistryContext services = opContext.getServicesRegistryContext();
@@ -258,7 +258,12 @@ public final class BoundMembershipAccess {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
-  private static boolean shouldUseCache(boolean includeSoftDelete) {
-    return !includeSoftDelete;
+  private static boolean shouldUseCache(
+      @Nonnull OperationContext opContext,
+      @Nonnull MembershipReadSpec spec,
+      boolean includeSoftDelete) {
+    return !includeSoftDelete
+        && EntityGraphCacheClients.isBoundKnownGraph(
+            opContext.getEntityGraphCache(), spec.getBinding());
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/EntityGraphCacheClients.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/EntityGraphCacheClients.java
@@ -5,12 +5,14 @@ import com.linkedin.metadata.graph.cache.EntityGraphBinding;
 import com.linkedin.metadata.graph.cache.EntityGraphCache;
 import com.linkedin.metadata.graph.cache.GraphReadResult;
 import com.linkedin.metadata.graph.cache.GraphSnapshotSource;
+import com.linkedin.metadata.graph.cache.KnownEntityGraph;
 import com.linkedin.metadata.graph.cache.MembershipNeighborResult;
 import com.linkedin.metadata.graph.cache.ReadMode;
 import com.linkedin.metadata.graph.cache.TraversalDirection;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 /** Call-site helpers for {@link EntityGraphCache} including skip-cache read behavior. */
@@ -90,5 +92,19 @@ public final class EntityGraphCacheClients {
   private static boolean shouldSkipCache(@Nonnull OperationContext opContext) {
     return opContext.getSearchContext().getSearchFlags().isSkipCache() != null
         && opContext.getSearchContext().getSearchFlags().isSkipCache();
+  }
+
+  /**
+   * True when {@code binding} is a custom graph id, or an enabled known graph. False when a known
+   * graph is disabled or omitted — call sites should skip expand.
+   */
+  public static boolean isBoundKnownGraph(
+      @Nonnull EntityGraphCache cache, @Nonnull EntityGraphBinding binding) {
+    KnownEntityGraph known = KnownEntityGraph.fromConfigKey(binding.getGraphId());
+    if (known == null) {
+      return true;
+    }
+    Optional<EntityGraphBinding> bound = cache.bindingForKnownGraph(known);
+    return bound != null && bound.isPresent();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/config/EntityGraphEdgeResolver.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/config/EntityGraphEdgeResolver.java
@@ -63,7 +63,7 @@ public class EntityGraphEdgeResolver {
       if (coLocated.isPresent()
           && coLocated.get().getSearchableAnnotation().getFieldType()
               == SearchableAnnotation.FieldType.URN) {
-        searchField = relationshipField.getPath().toString();
+        searchField = coLocated.get().getSearchableAnnotation().getFieldName();
         searchable = true;
       }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistry.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistry.java
@@ -161,9 +161,6 @@ public class EntityGraphRegistry {
     }
 
     if (properties.isEnabled()) {
-      if (byId.isEmpty()) {
-        errors.add("entity graph cache has no enabled graphs with resolvable edges");
-      }
       validateKnownGraphs(byId, errors);
       if (!errors.isEmpty()) {
         throw new IllegalStateException(
@@ -193,27 +190,33 @@ public class EntityGraphRegistry {
 
   private static void validateKnownGraphs(
       @Nonnull Map<String, EntityGraphDefinition> byId, @Nonnull List<String> errors) {
+    List<String> disabled = new ArrayList<>();
     for (KnownEntityGraph known : KnownEntityGraph.values()) {
       EntityGraphDefinition definition = byId.get(known.getConfigKey());
       if (definition == null) {
-        errors.add(
-            "required graph "
-                + known.getConfigKey()
-                + " ("
-                + known.name()
-                + ") is missing or disabled");
+        disabled.add(known.getConfigKey());
         continue;
       }
-      if (definition.getBuildSource() != known.getExpectedBuildSource()) {
+      GraphSnapshotSource actualSource = definition.getBuildSource();
+      if (!known.allowsBuildSource(actualSource)) {
         errors.add(
             "graph "
                 + known.getConfigKey()
                 + " ("
                 + known.name()
-                + ") requires buildSource "
-                + known.getExpectedBuildSource().name().toLowerCase(Locale.ROOT)
-                + " but was "
-                + definition.getBuildSource().name().toLowerCase(Locale.ROOT));
+                + ") does not allow buildSource "
+                + actualSource.name().toLowerCase(Locale.ROOT)
+                + " with scope.mode "
+                + known.getExpectedScope().name()
+                + " (allowed: "
+                + known.allowedBuildSourcesDescription()
+                + ")");
+      } else if (actualSource != known.getExpectedBuildSource()) {
+        log.warn(
+            "Known entity graph {} using buildSource {} (default {})",
+            known.getConfigKey(),
+            actualSource.name().toLowerCase(Locale.ROOT),
+            known.expectedBuildSourceYaml());
       }
       ScopeMode actualScope = definition.getScope().getMode();
       if (!matchesScopeRequirement(actualScope, known.getExpectedScope())) {
@@ -227,6 +230,9 @@ public class EntityGraphRegistry {
                 + " but was "
                 + actualScope.name());
       }
+    }
+    if (!disabled.isEmpty()) {
+      log.info("Known entity graphs disabled or omitted: {}", String.join(", ", disabled));
     }
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
@@ -4,6 +4,7 @@ import com.datahub.util.RecordUtils;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.entity.Aspect;
 import com.linkedin.metadata.aspect.AspectRetriever;
@@ -507,14 +508,7 @@ public class EntityGraphSnapshotBuilder {
                 com.linkedin.metadata.query.filter.Condition.EQUAL,
                 new ArrayList<>(frontierUrns)));
 
-    SearchFlags flags =
-        new SearchFlags()
-            .setFulltext(false)
-            .setSkipCache(true)
-            .setSkipAggregates(true)
-            .setSkipHighlighting(true)
-            .setIncludeSoftDeleted(false)
-            .setIncludeRestricted(true);
+    SearchFlags flags = searchBuildFlags(definition.getResolvedEdges());
 
     SearchRetriever searchRetriever = opContext.getRetrieverContext().getSearchRetriever();
     Set<String> neighbors = new LinkedHashSet<>();
@@ -632,14 +626,7 @@ public class EntityGraphSnapshotBuilder {
           .add(edge);
     }
 
-    SearchFlags flags =
-        new SearchFlags()
-            .setFulltext(false)
-            .setSkipCache(true)
-            .setSkipAggregates(true)
-            .setSkipHighlighting(true)
-            .setIncludeSoftDeleted(false)
-            .setIncludeRestricted(true);
+    SearchFlags flags = searchBuildFlags(definition.getResolvedEdges());
 
     SearchRetriever searchRetriever = opContext.getRetrieverContext().getSearchRetriever();
     String scrollId = null;
@@ -780,6 +767,30 @@ public class EntityGraphSnapshotBuilder {
             m ->
                 m.incrementMicrometer(
                     metric, 1, "graphId", definition.getGraphId(), "reason", reason));
+  }
+
+  @Nonnull
+  private static SearchFlags searchBuildFlags(
+      @Nonnull Collection<ResolvedGraphEdge> resolvedEdges) {
+    SearchFlags flags =
+        new SearchFlags()
+            .setFulltext(false)
+            .setSkipCache(true)
+            .setSkipAggregates(true)
+            .setSkipHighlighting(true)
+            .setIncludeSoftDeleted(false)
+            .setIncludeRestricted(true);
+    List<String> extraFields =
+        resolvedEdges.stream()
+            .filter(ResolvedGraphEdge::isSearchable)
+            .map(ResolvedGraphEdge::getSearchField)
+            .filter(field -> field != null && !field.isBlank())
+            .distinct()
+            .collect(Collectors.toList());
+    if (!extraFields.isEmpty()) {
+      flags.setFetchExtraFields(new StringArray(extraFields));
+    }
+    return flags;
   }
 
   @Nullable

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -32,11 +32,13 @@ import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.metadata.search.SearchSuggestion;
 import com.linkedin.metadata.search.SearchSuggestionArray;
+import com.linkedin.metadata.search.api.SearchDocFieldFetchConfig;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.search.features.Features;
 import com.linkedin.metadata.search.utils.ESAccessControlUtil;
 import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.search.utils.InvalidSearchHitException;
+import com.linkedin.metadata.search.utils.SearchResultUtils;
 import com.linkedin.metadata.search.utils.UrnExtractionUtils;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
@@ -253,7 +255,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
 
     searchSourceBuilder.from(from);
     searchSourceBuilder.size(ConfigUtils.applyLimit(searchServiceConfig, size));
-    searchSourceBuilder.fetchSource("urn", null);
+    applyFetchSource(searchSourceBuilder, searchFlags);
 
     BoolQueryBuilder filterQuery = getFilterQuery(opContext, filter);
     searchSourceBuilder.query(
@@ -315,7 +317,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
     ESUtils.setSliceOptions(searchSourceBuilder, searchFlags.getSliceOptions());
 
     searchSourceBuilder.size(ConfigUtils.applyLimit(searchServiceConfig, size));
-    searchSourceBuilder.fetchSource("urn", null);
+    applyFetchSource(searchSourceBuilder, searchFlags);
 
     BoolQueryBuilder filterQuery = getFilterQuery(opContext, filter);
     searchSourceBuilder.query(
@@ -402,6 +404,15 @@ public class SearchRequestHandler extends BaseRequestHandler {
   public QueryBuilder getQuery(
       @Nonnull OperationContext opContext, @Nonnull String query, boolean fulltext) {
     return searchQueryBuilder.buildQuery(opContext, entitySpecs, query, fulltext);
+  }
+
+  private static void applyFetchSource(
+      @Nonnull SearchSourceBuilder searchSourceBuilder, @Nullable SearchFlags searchFlags) {
+    String[] includes =
+        SearchDocFieldFetchConfig.resolve(
+                SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SCROLL, searchFlags)
+            .toArray(String[]::new);
+    searchSourceBuilder.fetchSource(includes, null);
   }
 
   @Override
@@ -612,12 +623,20 @@ public class SearchRequestHandler extends BaseRequestHandler {
         Features.Name.SEARCH_BACKEND_SCORE.toString(), (double) searchHit.getScore());
   }
 
-  private SearchEntity getResult(@Nonnull SearchHit hit) {
-    return new SearchEntity()
-        .setEntity(getUrnFromSearchHit(hit))
-        .setMatchedFields(new MatchedFieldArray(extractMatchedFields(hit)))
-        .setScore(hit.getScore())
-        .setFeatures(new DoubleMap(extractFeatures(hit)));
+  private SearchEntity getResult(@Nonnull OperationContext opContext, @Nonnull SearchHit hit) {
+    SearchEntity entity =
+        new SearchEntity()
+            .setEntity(getUrnFromSearchHit(hit))
+            .setMatchedFields(new MatchedFieldArray(extractMatchedFields(hit)))
+            .setScore(hit.getScore())
+            .setFeatures(new DoubleMap(extractFeatures(hit)));
+    SearchFlags flags = opContext.getSearchContext().getSearchFlags();
+    if (flags != null && CollectionUtils.isNotEmpty(flags.getFetchExtraFields())) {
+      entity.setExtraFields(
+          SearchResultUtils.toExtraFields(
+              opContext.getObjectMapper(), hit.getSourceAsMap(), flags.getFetchExtraFields()));
+    }
+    return entity;
   }
 
   /**
@@ -632,7 +651,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
   private Optional<SearchEntity> getResultSafely(
       @Nonnull OperationContext opContext, @Nonnull SearchHit hit) {
     try {
-      return Optional.of(getResult(hit));
+      return Optional.of(getResult(opContext, hit));
     } catch (InvalidSearchHitException e) {
       log.warn(
           "Skipping search hit with invalid or missing URN. Index: {}, ID: {}",

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchService.java
@@ -25,7 +25,6 @@ import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -267,7 +266,9 @@ public class SemanticEntitySearchService implements SemanticEntitySearch {
 
     // 7) Build field set using same logic as keyword search
     Set<String> fieldsToFetch =
-        new HashSet<>(SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SEARCH);
+        SearchDocFieldFetchConfig.resolve(
+            SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SEARCH,
+            opContext.getSearchContext().getSearchFlags());
 
     // 8) Execute kNN query via the engine-specific SearchClientShim path
     List<SearchEntity> hits =

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchResultUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/SearchResultUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.data.template.DoubleMap;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.metadata.search.features.Features;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -59,16 +60,33 @@ public final class SearchResultUtils {
   @Nonnull
   public static StringMap toExtraFields(
       @Nonnull ObjectMapper objectMapper, @Nullable Map<String, Object> sourceAsMap) {
-    StringMap stringMap = new StringMap();
     if (sourceAsMap == null) {
+      return new StringMap();
+    }
+    return toExtraFields(objectMapper, sourceAsMap, sourceAsMap.keySet());
+  }
+
+  /**
+   * JSON-stringify only the requested {@code keys} from {@code sourceAsMap}. Missing keys are
+   * skipped. Empty or null {@code keys} yields an empty map.
+   */
+  @Nonnull
+  public static StringMap toExtraFields(
+      @Nonnull ObjectMapper objectMapper,
+      @Nullable Map<String, Object> sourceAsMap,
+      @Nullable Collection<String> keys) {
+    StringMap stringMap = new StringMap();
+    if (sourceAsMap == null || keys == null || keys.isEmpty()) {
       return stringMap;
     }
-    for (Map.Entry<String, Object> entry : sourceAsMap.entrySet()) {
+    for (String key : keys) {
+      if (key == null || key.isBlank() || !sourceAsMap.containsKey(key)) {
+        continue;
+      }
       try {
-        stringMap.put(entry.getKey(), objectMapper.writeValueAsString(entry.getValue()));
+        stringMap.put(key, objectMapper.writeValueAsString(sourceAsMap.get(key)));
       } catch (IOException e) {
-        // Log and skip fields that fail to serialize to maintain parity and aid debugging.
-        log.warn("Failed to serialize extra field {}", entry.getKey(), e);
+        log.warn("Failed to serialize extra field {}", key, e);
       }
     }
     return stringMap;

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccessDomainTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccessDomainTest.java
@@ -180,6 +180,26 @@ public class BoundHierarchyAccessDomainTest {
   }
 
   @Test
+  public void orderedParentsSkipsCacheWhenKnownGraphUnbound() {
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.DOMAIN))
+        .thenReturn(Optional.empty());
+    when(entityGraphCache.bindingForPolicyField("DOMAIN")).thenReturn(Optional.empty());
+
+    Map<Urn, Urn> parentByDomain = new LinkedHashMap<>();
+    parentByDomain.put(GRANDCHILD, CHILD);
+    parentByDomain.put(CHILD, ROOT);
+    parentByDomain.put(ROOT, null);
+    mockDomainProperties(parentByDomain);
+
+    List<Urn> parents =
+        BoundHierarchyAccess.orderedParents(opContext, domainSpec(opContext), GRANDCHILD, 10);
+    assertEquals(parents, List.of(CHILD, ROOT));
+    verify(entityGraphCache, never())
+        .walkOrderedForwardAncestors(any(), any(), any(), anyInt(), any());
+    verify(entityGraphCache, never()).expand(any(), any(), any(), any(), anyInt(), anyInt(), any());
+  }
+
+  @Test
   public void resolveDirectChildDomainUrnsUsesMaxDepthOneReverseExpand() {
     when(entityGraphCache.expand(
             eq("domain"),

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccessTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccessTest.java
@@ -29,6 +29,7 @@ import com.linkedin.metadata.entity.SearchRetriever;
 import com.linkedin.metadata.graph.cache.EntityGraphBinding;
 import com.linkedin.metadata.graph.cache.EntityGraphCache;
 import com.linkedin.metadata.graph.cache.GraphSnapshotSource;
+import com.linkedin.metadata.graph.cache.KnownEntityGraph;
 import com.linkedin.metadata.graph.cache.MembershipNeighborResult;
 import com.linkedin.metadata.graph.cache.ReadMissReason;
 import com.linkedin.metadata.graph.cache.ReadMode;
@@ -41,6 +42,7 @@ import io.datahubproject.metadata.context.ServicesRegistryContext;
 import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -62,6 +64,8 @@ public class BoundMembershipAccessTest {
   public void setUp() {
     spec = MembershipReadSpecs.membership(MEMBERSHIP_BINDING);
     entityGraphCache = mock(EntityGraphCache.class);
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
+        .thenReturn(Optional.of(MEMBERSHIP_BINDING));
   }
 
   @Test
@@ -326,6 +330,31 @@ public class BoundMembershipAccessTest {
         0,
         10,
         true);
+
+    verify(entityGraphCache, never())
+        .listRelated(any(), any(), any(), any(), any(), anyInt(), anyInt(), anyInt(), any());
+  }
+
+  @Test
+  public void listRelatedSkipsCacheWhenKnownGraphUnbound() {
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
+        .thenReturn(Optional.empty());
+
+    GraphRetriever graphRetriever = mock(GraphRetriever.class);
+    when(graphRetriever.scrollRelatedEntities(
+            any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
+        .thenReturn(new RelatedEntitiesScrollResult(0, 0, null, List.of()));
+
+    OperationContext opContext = contextWithCache(entityGraphCache, graphRetriever);
+
+    BoundMembershipAccess.listRelated(
+        opContext,
+        spec,
+        USER,
+        TraversalDirection.FORWARD,
+        Set.of(IS_MEMBER_OF_GROUP_RELATIONSHIP_NAME),
+        0,
+        10);
 
     verify(entityGraphCache, never())
         .listRelated(any(), any(), any(), any(), any(), anyInt(), anyInt(), anyInt(), any());

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistryTest.java
@@ -80,9 +80,64 @@ public class EntityGraphRegistryTest {
   }
 
   @Test
-  public void testMissingKnownGraphFailsWhenEnabled() {
+  public void testMissingKnownGraphAllowedWhenEnabled() {
     EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
     properties.getGraphs().remove("domain");
+
+    EntityGraphRegistry registry =
+        EntityGraphRegistry.build(
+            properties, new TestEntityRegistry(), new LineageRegistry(new TestEntityRegistry()));
+
+    assertEquals(registry.resolveKnownGraph(KnownEntityGraph.DOMAIN), null);
+    assertNotNull(registry.resolveKnownGraph(KnownEntityGraph.GLOSSARY));
+    assertFalse(registry.getGraphIdsForEntityType("domain").contains("domain"));
+  }
+
+  @Test
+  public void testDisabledKnownGraphAllowedWhenEnabled() {
+    EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
+    properties.getGraphs().get("domain").setEnabled(false);
+
+    EntityGraphRegistry registry =
+        EntityGraphRegistry.build(
+            properties, new TestEntityRegistry(), new LineageRegistry(new TestEntityRegistry()));
+
+    assertEquals(registry.getDefinition("domain"), null);
+    assertEquals(registry.resolveKnownGraph(KnownEntityGraph.DOMAIN), null);
+    assertNotNull(registry.resolveKnownGraph(KnownEntityGraph.GLOSSARY));
+  }
+
+  @Test
+  public void testEmptyEnabledGraphsAllowedWhenEnabled() {
+    EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
+    properties.getGraphs().values().forEach(graph -> graph.setEnabled(false));
+
+    EntityGraphRegistry registry =
+        EntityGraphRegistry.build(
+            properties, new TestEntityRegistry(), new LineageRegistry(new TestEntityRegistry()));
+
+    assertEquals(registry.getGraphsById().size(), 0);
+    assertFalse(registry.hasFullScopeGraphs());
+    assertEquals(registry.getScheduledFullGraphs().size(), 0);
+  }
+
+  @Test
+  public void testKnownDomainGraphAllowsGraphBuildSource() {
+    EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
+    properties.getGraphs().get("domain").setBuildSource("graph");
+
+    EntityGraphRegistry registry =
+        EntityGraphRegistry.build(
+            properties, new TestEntityRegistry(), new LineageRegistry(new TestEntityRegistry()));
+
+    assertEquals(
+        registry.resolveKnownGraph(KnownEntityGraph.DOMAIN).getSource(), GraphSnapshotSource.GRAPH);
+  }
+
+  @Test
+  public void testKnownDomainGraphRejectsPrimaryBuildSource() {
+    EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
+    properties.getGraphs().get("domain").setBuildSource("primary");
 
     IllegalStateException ex =
         expectThrows(
@@ -93,13 +148,13 @@ public class EntityGraphRegistryTest {
                     new TestEntityRegistry(),
                     new LineageRegistry(new TestEntityRegistry())));
     assertTrue(ex.getMessage().contains("domain"));
-    assertTrue(ex.getMessage().contains("DOMAIN"));
+    assertTrue(ex.getMessage().contains("FULL scope requires buildSource graph or search"));
   }
 
   @Test
-  public void testWrongBuildSourceForKnownGraphFailsWhenEnabled() {
+  public void testKnownGlossaryGraphRejectsSearchBuildSource() {
     EntityGraphCacheProperties properties = enabledPropertiesWithKnownGraphs();
-    properties.getGraphs().get("domain").setBuildSource("graph");
+    properties.getGraphs().get("glossary").setBuildSource("search");
 
     IllegalStateException ex =
         expectThrows(
@@ -109,8 +164,8 @@ public class EntityGraphRegistryTest {
                     properties,
                     new TestEntityRegistry(),
                     new LineageRegistry(new TestEntityRegistry())));
-    assertTrue(ex.getMessage().contains("DOMAIN"));
-    assertTrue(ex.getMessage().contains("buildSource search"));
+    assertTrue(ex.getMessage().toLowerCase().contains("glossary"));
+    assertTrue(ex.getMessage().contains("search"));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/config/EntityGraphRegistryTest.java
@@ -33,6 +33,10 @@ public class EntityGraphRegistryTest {
     assertNotNull(domain);
     assertEquals(domain.getGraphId(), "domain");
     assertEquals(domain.getSource(), GraphSnapshotSource.SEARCH);
+    assertEquals(
+        registry.getDefinition("domain").getResolvedEdges().get(0).getSearchField(),
+        "parentDomain");
+    assertTrue(registry.getDefinition("domain").getResolvedEdges().get(0).isSearchable());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
@@ -343,8 +343,7 @@ public class EntityGraphSnapshotBuilderGraphTest {
     ArgumentCaptor<SearchFlags> flagsCaptor = ArgumentCaptor.forClass(SearchFlags.class);
     verify(searchRetriever)
         .scroll(any(), any(), nullable(String.class), anyInt(), any(), flagsCaptor.capture());
-    assertNotNull(flagsCaptor.getValue().getFetchExtraFields());
-    assertTrue(flagsCaptor.getValue().getFetchExtraFields().contains("parentDomain"));
+    assertEquals(flagsCaptor.getValue().getFetchExtraFields(), List.of("parentDomain"));
 
     assertEquals(result.getStatus(), CacheStatus.ACTIVE);
     assertNotNull(result.getSnapshot());

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -30,6 +31,7 @@ import com.linkedin.metadata.graph.cache.config.EntityGraphModel.ResolvedGraphEd
 import com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshotBuilder.BuildResult;
 import com.linkedin.metadata.graph.cache.store.EntityGraphCacheKeys;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchEntity;
@@ -40,6 +42,7 @@ import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -336,6 +339,12 @@ public class EntityGraphSnapshotBuilderGraphTest {
 
     BuildResult result =
         builder.build(searchContext, searchableDefinition, GraphSnapshotSource.SEARCH, null);
+
+    ArgumentCaptor<SearchFlags> flagsCaptor = ArgumentCaptor.forClass(SearchFlags.class);
+    verify(searchRetriever)
+        .scroll(any(), any(), nullable(String.class), anyInt(), any(), flagsCaptor.capture());
+    assertNotNull(flagsCaptor.getValue().getFetchExtraFields());
+    assertTrue(flagsCaptor.getValue().getFetchExtraFields().contains("parentDomain"));
 
     assertEquals(result.getStatus(), CacheStatus.ACTIVE);
     assertNotNull(result.getSnapshot());

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -81,6 +81,7 @@ import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.fetch.subphase.FetchSourceContext;
 import org.opensearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -1633,6 +1634,107 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
     assertEquals(
         result.getEntities().get(0).getEntity().toString(),
         "urn:li:dataset:(urn:li:dataPlatform:hdfs,nullHighlights,PROD)");
+  }
+
+  @Test
+  public void testFetchSourceDefaultsToUrnOnly() {
+    SearchRequestHandler requestHandler =
+        SearchRequestHandler.getBuilder(
+            operationContext,
+            TestEntitySpecBuilder.getSpec(),
+            testQueryConfig,
+            null,
+            QueryFilterRewriteChain.EMPTY,
+            TEST_SEARCH_SERVICE_CONFIG);
+    SearchRequest searchRequest =
+        requestHandler.getSearchRequest(
+            operationContext.withSearchFlags(flags -> flags.setFulltext(false)),
+            "testQuery",
+            null,
+            null,
+            0,
+            10,
+            List.of());
+    FetchSourceContext fetchSource = searchRequest.source().fetchSource();
+    assertNotNull(fetchSource);
+    assertEquals(Set.of(fetchSource.includes()), Set.of("urn"));
+  }
+
+  @Test
+  public void testFetchSourceIncludesRequestedExtraFields() {
+    SearchRequestHandler requestHandler =
+        SearchRequestHandler.getBuilder(
+            operationContext,
+            TestEntitySpecBuilder.getSpec(),
+            testQueryConfig,
+            null,
+            QueryFilterRewriteChain.EMPTY,
+            TEST_SEARCH_SERVICE_CONFIG);
+    SearchRequest searchRequest =
+        requestHandler.getSearchRequest(
+            operationContext.withSearchFlags(
+                flags ->
+                    flags
+                        .setFulltext(false)
+                        .setFetchExtraFields(new StringArray(List.of("parentDomain")))),
+            "testQuery",
+            null,
+            null,
+            0,
+            10,
+            List.of());
+    FetchSourceContext fetchSource = searchRequest.source().fetchSource();
+    assertNotNull(fetchSource);
+    assertEquals(Set.of(fetchSource.includes()), Set.of("urn", "parentDomain"));
+  }
+
+  @Test
+  public void testExtractResultCopiesOnlyRequestedExtraFields() {
+    SearchRequestHandler handler =
+        SearchRequestHandler.getBuilder(
+            operationContext,
+            TestEntitySpecBuilder.getSpec(),
+            testQueryConfig,
+            null,
+            QueryFilterRewriteChain.EMPTY,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    SearchHits mockHits = mock(SearchHits.class);
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(new TotalHits(1L, TotalHits.Relation.EQUAL_TO));
+    when(mockResponse.getAggregations()).thenReturn(null);
+    when(mockResponse.getSuggest()).thenReturn(null);
+    SearchHit hit = mock(SearchHit.class);
+    when(hit.getSourceAsMap())
+        .thenReturn(
+            ImmutableMap.of(
+                "urn",
+                "urn:li:dataset:(urn:li:dataPlatform:hdfs,withParent,PROD)",
+                "parentDomain",
+                "urn:li:domain:root",
+                "name",
+                "should-not-appear"));
+    when(hit.getScore()).thenReturn(1.0f);
+    when(hit.getHighlightFields()).thenReturn(ImmutableMap.of());
+    when(hit.getMatchedQueries()).thenReturn(new String[0]);
+    when(mockHits.getHits()).thenReturn(new SearchHit[] {hit});
+
+    SearchResult withoutFlag = handler.extractResult(operationContext, mockResponse, null, 0, 10);
+    assertNull(withoutFlag.getEntities().get(0).getExtraFields());
+
+    SearchResult withFlag =
+        handler.extractResult(
+            operationContext.withSearchFlags(
+                flags -> flags.setFetchExtraFields(new StringArray(List.of("parentDomain")))),
+            mockResponse,
+            null,
+            0,
+            10);
+    assertEquals(withFlag.getEntities().get(0).getExtraFields().keySet(), Set.of("parentDomain"));
+    assertEquals(
+        withFlag.getEntities().get(0).getExtraFields().get("parentDomain"),
+        "\"urn:li:domain:root\"");
   }
 
   private SearchHit mockHitWithUrn(String urn) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/semantic/SemanticEntitySearchServiceTest.java
@@ -361,6 +361,7 @@ public class SemanticEntitySearchServiceTest {
     extraFields.add("name");
     extraFields.add("platform");
     extraFields.add("qualifiedName");
+    when(mockSearchFlags.getFetchExtraFields()).thenReturn(extraFields);
 
     SearchResult result =
         service.search(
@@ -371,10 +372,15 @@ public class SemanticEntitySearchServiceTest {
 
     SearchEntity entity = result.getEntities().get(0);
     assertNotNull(entity.getExtraFields());
-    assertTrue(entity.getExtraFields().size() > 0);
     assertTrue(entity.getExtraFields().containsKey("name"));
     assertTrue(entity.getExtraFields().containsKey("platform"));
     assertTrue(entity.getExtraFields().containsKey("qualifiedName"));
+
+    ArgumentCaptor<KnnSearchRequest> requestCaptor =
+        ArgumentCaptor.forClass(KnnSearchRequest.class);
+    verify(searchClientShim).searchKnn(any(OperationContext.class), requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().fieldsToFetch().containsAll(extraFields));
+    assertTrue(requestCaptor.getValue().fieldsToFetch().contains("urn"));
   }
 
   @Test

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -63,6 +63,13 @@ record SearchFlags {
    customHighlightingFields:optional array[string]
 
   /**
+   * Elasticsearch _source field names to include on each SearchEntity as extraFields.
+   * Names are passed through as-is (nested paths and wildcards allowed). Empty or absent
+   * fetches no extra document fields — only the default urn include.
+   */
+   fetchExtraFields:optional array[string]
+
+  /**
    * invoke query rewrite chain for filters based on configured rewriters
    */
    rewriteQuery: optional boolean = true

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -63,9 +63,10 @@ record SearchFlags {
    customHighlightingFields:optional array[string]
 
   /**
-   * Elasticsearch _source field names to include on each SearchEntity as extraFields.
-   * Names are passed through as-is (nested paths and wildcards allowed). Empty or absent
-   * fetches no extra document fields — only the default urn include.
+   * Elasticsearch _source include names copied onto SearchEntity.extraFields (Java / Rest.li
+   * only — not a GraphQL SearchFlags input). Nested paths and wildcards are passed through to
+   * fetch_source; extraFields copies exact top-level _source keys. Empty or absent fetches no
+   * extra document fields — only the default urn include.
    */
    fetchExtraFields:optional array[string]
 

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/fieldresolverprovider/DomainFieldResolverProviderTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/fieldresolverprovider/DomainFieldResolverProviderTest.java
@@ -215,6 +215,9 @@ public class DomainFieldResolverProviderTest
             .source(com.linkedin.metadata.graph.cache.GraphSnapshotSource.SEARCH)
             .build();
     when(entityGraphCache.bindingForPolicyField("DOMAIN")).thenReturn(Optional.of(binding));
+    when(entityGraphCache.bindingForKnownGraph(
+            com.linkedin.metadata.graph.cache.KnownEntityGraph.DOMAIN))
+        .thenReturn(Optional.of(binding));
     when(entityGraphCache.expand(
             eq("domain"),
             eq(com.linkedin.metadata.graph.cache.GraphSnapshotSource.SEARCH),

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoader.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoader.java
@@ -377,28 +377,24 @@ public class EntityGraphCacheConfigLoader {
     boolean hasFilterFields = !CollectionUtils.isEmpty(graph.getBindings().getFilterFields());
     boolean hasPolicyFields = !CollectionUtils.isEmpty(graph.getBindings().getPolicyFieldTypes());
 
-    if (hasFilterFields) {
-      if (!"SEARCH".equals(normalizedBuildSource)) {
-        errors.add(
-            "graph " + graphId + ": filterFields requires buildSource search and scope.mode FULL");
-      } else if (graph.getScope() == null || graph.getScope().getMode() != ScopeMode.FULL) {
-        errors.add("graph " + graphId + ": filterFields requires scope.mode FULL");
-      }
+    boolean fullSearchOrGraph =
+        ("SEARCH".equals(normalizedBuildSource) || "GRAPH".equals(normalizedBuildSource))
+            && graph.getScope() != null
+            && graph.getScope().getMode() == ScopeMode.FULL;
+
+    if (hasFilterFields && !fullSearchOrGraph) {
+      errors.add(
+          "graph "
+              + graphId
+              + ": filterFields requires buildSource search or graph and scope.mode FULL");
     }
 
-    if (hasPolicyFields) {
-      if ("PRIMARY".equals(normalizedBuildSource)) {
-        // ok
-      } else if ("SEARCH".equals(normalizedBuildSource)
-          && graph.getScope() != null
-          && graph.getScope().getMode() == ScopeMode.FULL) {
-        // Bundled domain@search — policy expansion uses the same FULL search snapshot.
-      } else {
-        errors.add(
-            "graph "
-                + graphId
-                + ": policyFieldTypes requires buildSource primary, or search with scope.mode FULL");
-      }
+    if (hasPolicyFields && !"PRIMARY".equals(normalizedBuildSource) && !fullSearchOrGraph) {
+      errors.add(
+          "graph "
+              + graphId
+              + ": policyFieldTypes requires buildSource primary, or search/graph with"
+              + " scope.mode FULL");
     }
 
     if ("PRIMARY".equals(normalizedBuildSource) && hasFilterFields) {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoader.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoader.java
@@ -377,10 +377,13 @@ public class EntityGraphCacheConfigLoader {
     boolean hasFilterFields = !CollectionUtils.isEmpty(graph.getBindings().getFilterFields());
     boolean hasPolicyFields = !CollectionUtils.isEmpty(graph.getBindings().getPolicyFieldTypes());
 
+    ScopeMode scopeMode =
+        graph.getScope() != null && graph.getScope().getMode() != null
+            ? graph.getScope().getMode()
+            : ScopeMode.FULL;
     boolean fullSearchOrGraph =
         ("SEARCH".equals(normalizedBuildSource) || "GRAPH".equals(normalizedBuildSource))
-            && graph.getScope() != null
-            && graph.getScope().getMode() == ScopeMode.FULL;
+            && scopeMode == ScopeMode.FULL;
 
     if (hasFilterFields && !fullSearchOrGraph) {
       errors.add(

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheProperties.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheProperties.java
@@ -239,14 +239,14 @@ public class EntityGraphCacheProperties {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class GraphEviction {
-    private LocalEviction local;
+    @JsonMerge private LocalEviction local;
 
     /**
      * Optional per-graph near cache for {@code scope.mode: PARTIAL} (each graph has its own {@code
      * entityGraphSnapshots.<graphId>} map). Ignored for {@code scope.mode: FULL} — use {@link
      * Eviction#getNearCache()}{@code .full} instead.
      */
-    private NearCache nearCache;
+    @JsonMerge private NearCache nearCache;
   }
 
   public enum ScopeMode {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheProperties.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheProperties.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.config.entitygraph;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonMerge;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -43,7 +44,8 @@ public class EntityGraphCacheProperties {
    */
   private String configJson;
 
-  private Map<String, GraphDefinition> graphs;
+  /** Overlay graph keys are merged into this map; existing {@link GraphDefinition}s are patched. */
+  @JsonMerge private Map<String, GraphDefinition> graphs;
 
   @Data
   @Builder
@@ -128,6 +130,11 @@ public class EntityGraphCacheProperties {
     private NearCache partial;
   }
 
+  /**
+   * Per-graph definition. Nested objects are {@code @JsonMerge} so {@code
+   * ENTITY_GRAPH_CACHE_CONFIG_JSON} patches fields (e.g. {@code buildSource}) without replacing the
+   * whole graph.
+   */
   @Data
   @Builder
   @NoArgsConstructor
@@ -148,12 +155,12 @@ public class EntityGraphCacheProperties {
     private List<String> entityTypes;
 
     private String relationshipType;
-    private ScopeConfig scope;
-    private GraphPopulation population;
-    private GraphBounds bounds;
+    @JsonMerge private ScopeConfig scope;
+    @JsonMerge private GraphPopulation population;
+    @JsonMerge private GraphBounds bounds;
     private ScrollConfig scroll;
-    private GraphBindings bindings;
-    private GraphEviction eviction;
+    @JsonMerge private GraphBindings bindings;
+    @JsonMerge private GraphEviction eviction;
   }
 
   @Data

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoaderTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoaderTest.java
@@ -198,6 +198,45 @@ public class EntityGraphCacheConfigLoaderTest {
   }
 
   @Test
+  public void testJsonOverlayDomainBuildSourceGraphKeepsBindings() {
+    EntityGraphCacheProperties effective = loader.loadEffective(springLikeBase());
+    loader.applyJsonOverlay(
+        "{\"graphs\":{\"domain\":{\"buildSource\":\"graph\"}}}",
+        effective,
+        EntityGraphCacheConfigLoader.ENTITY_GRAPH_CACHE_CONFIG_JSON_ENV);
+
+    loader.validate(effective);
+    assertEquals(effective.getGraphs().get("domain").getBuildSource(), "graph");
+    assertEquals(effective.getGraphs().get("domain").isEnabled(), true);
+    assertEquals(
+        effective.getGraphs().get("domain").getBindings().getPolicyFieldTypes(), List.of("DOMAIN"));
+    assertEquals(
+        effective.getGraphs().get("domain").getBindings().getFilterFields(),
+        List.of("domains.keyword"));
+  }
+
+  @Test
+  public void testJsonOverlayDomainBuildSourcePrimaryRejected() {
+    EntityGraphCacheProperties effective = loader.loadEffective(springLikeBase());
+    loader.applyJsonOverlay(
+        "{\"graphs\":{\"domain\":{\"buildSource\":\"primary\"}}}", effective, "test");
+
+    IllegalStateException ex =
+        org.testng.Assert.expectThrows(
+            IllegalStateException.class, () -> loader.validate(effective));
+    assertTrue(ex.getMessage().contains("FULL scope requires buildSource graph or search"));
+  }
+
+  @Test
+  public void testJsonOverlayDomainDisabledValidates() {
+    EntityGraphCacheProperties effective = loader.loadEffective(springLikeBase());
+    loader.applyJsonOverlay("{\"graphs\":{\"domain\":{\"enabled\":false}}}", effective, "test");
+
+    loader.validate(effective);
+    assertEquals(effective.getGraphs().get("domain").isEnabled(), false);
+  }
+
+  @Test
   public void testValidationSkippedWhenCacheDisabled() {
     EntityGraphCacheProperties config = new EntityGraphCacheProperties();
     config.setEnabled(false);

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoaderTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/entitygraph/EntityGraphCacheConfigLoaderTest.java
@@ -237,6 +237,71 @@ public class EntityGraphCacheConfigLoaderTest {
   }
 
   @Test
+  public void testJsonOverlayGraphEvictionLocalPreservesLimits() {
+    EntityGraphCacheProperties effective = loader.loadEffective(springLikeBase());
+    effective
+        .getGraphs()
+        .get("glossary")
+        .setEviction(
+            EntityGraphCacheProperties.GraphEviction.builder()
+                .local(
+                    LocalEviction.builder()
+                        .enabled(true)
+                        .maxViews(16)
+                        .maxEstimatedBytes(268435456L)
+                        .build())
+                .build());
+    loader.applyJsonOverlay(
+        "{\"graphs\":{\"glossary\":{\"eviction\":{\"local\":{\"enabled\":false}}}}}",
+        effective,
+        "test");
+
+    LocalEviction local = effective.getGraphs().get("glossary").getEviction().getLocal();
+    assertEquals(local.isEnabled(), false);
+    assertEquals(local.getMaxViews(), 16);
+    assertEquals(local.getMaxEstimatedBytes(), 268435456L);
+  }
+
+  @Test
+  public void testFilterFieldsOnGraphFullAccepted() {
+    EntityGraphCacheProperties config =
+        enabledConfigWithGraph("custom", graphWithFilterField("domains.keyword"));
+    config.getGraphs().get("custom").setBuildSource("graph");
+    loader.validate(config);
+  }
+
+  @Test
+  public void testPolicyFieldsOnGraphFullAccepted() {
+    EntityGraphCacheProperties config =
+        enabledConfigWithGraph("custom", graphWithPolicyField("DOMAIN"));
+    GraphDefinition graph = config.getGraphs().get("custom");
+    graph.setBuildSource("graph");
+    loader.validate(config);
+  }
+
+  @Test
+  public void testFilterFieldsOnGraphPartialRejected() {
+    EntityGraphCacheProperties config =
+        enabledConfigWithGraph("custom", graphWithFilterField("domains.keyword"));
+    GraphDefinition graph = config.getGraphs().get("custom");
+    graph.setBuildSource("graph");
+    graph.getScope().setMode(ScopeMode.PARTIAL);
+    graph.getScope().setMaxDepth(15);
+
+    IllegalStateException ex =
+        org.testng.Assert.expectThrows(IllegalStateException.class, () -> loader.validate(config));
+    assertTrue(ex.getMessage().contains("filterFields requires buildSource search or graph"));
+  }
+
+  @Test
+  public void testFilterFieldsOnSearchNullScopeDefaultsFull() {
+    EntityGraphCacheProperties config =
+        enabledConfigWithGraph("custom", graphWithFilterField("domains.keyword"));
+    config.getGraphs().get("custom").setScope(null);
+    loader.validate(config);
+  }
+
+  @Test
   public void testValidationSkippedWhenCacheDisabled() {
     EntityGraphCacheProperties config = new EntityGraphCacheProperties();
     config.setEnabled(false);
@@ -497,6 +562,7 @@ public class EntityGraphCacheConfigLoaderTest {
     GraphDefinition graph = validPartialGraph();
     graph.setBuildSource("search");
     graph.getScope().setMode(ScopeMode.FULL);
+    graph.getScope().setMaxDepth(0);
     if (graph.getBindings().getPolicyFieldTypes() == null) {
       graph.getBindings().setPolicyFieldTypes(new ArrayList<>());
     }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -6399,6 +6399,14 @@
       "doc" : "Include mentioned fields inside elastic highlighting query",
       "optional" : true
     }, {
+      "name" : "fetchExtraFields",
+      "type" : {
+        "type" : "array",
+        "items" : "string"
+      },
+      "doc" : "Elasticsearch _source field names to include on each SearchEntity as extraFields.\nNames are passed through as-is (nested paths and wildcards allowed). Empty or absent\nfetches no extra document fields — only the default urn include.",
+      "optional" : true
+    }, {
       "name" : "rewriteQuery",
       "type" : "boolean",
       "doc" : "invoke query rewrite chain for filters based on configured rewriters",

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/api/SearchDocFieldFetchConfig.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/api/SearchDocFieldFetchConfig.java
@@ -1,6 +1,10 @@
 package com.linkedin.metadata.search.api;
 
+import com.linkedin.metadata.query.SearchFlags;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,4 +21,22 @@ public class SearchDocFieldFetchConfig {
       Set.of("urn", "usageCountLast30Days");
 
   private Set<String> fieldsToFetch = DEFAULT_FIELDS_TO_FETCH_ON_SCROLL;
+
+  /**
+   * Union {@code defaults} with {@code searchFlags.fetchExtraFields}, preserving insertion order
+   * and dropping blank names.
+   */
+  @Nonnull
+  public static Set<String> resolve(
+      @Nonnull Set<String> defaults, @Nullable SearchFlags searchFlags) {
+    LinkedHashSet<String> fields = new LinkedHashSet<>(defaults);
+    if (searchFlags != null && searchFlags.getFetchExtraFields() != null) {
+      for (String field : searchFlags.getFetchExtraFields()) {
+        if (field != null && !field.isBlank()) {
+          fields.add(field);
+        }
+      }
+    }
+    return fields;
+  }
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/search/api/SearchDocFieldFetchConfigTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/search/api/SearchDocFieldFetchConfigTest.java
@@ -1,0 +1,41 @@
+package com.linkedin.metadata.search.api;
+
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.SearchFlags;
+import java.util.List;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+public class SearchDocFieldFetchConfigTest {
+
+  @Test
+  public void resolveReturnsDefaultsWhenFlagsAbsent() {
+    assertEquals(
+        SearchDocFieldFetchConfig.resolve(
+            SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SCROLL, null),
+        Set.of("urn"));
+  }
+
+  @Test
+  public void resolveUnionsRequestedFieldsPreservingOrder() {
+    SearchFlags flags =
+        new SearchFlags()
+            .setFetchExtraFields(new StringArray(List.of("parentDomain", "urn", "name")));
+    assertEquals(
+        List.copyOf(
+            SearchDocFieldFetchConfig.resolve(
+                SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SCROLL, flags)),
+        List.of("urn", "parentDomain", "name"));
+  }
+
+  @Test
+  public void resolveIgnoresBlankRequestedFields() {
+    SearchFlags flags = new SearchFlags().setFetchExtraFields(new StringArray(List.of(" ", "")));
+    assertEquals(
+        SearchDocFieldFetchConfig.resolve(
+            SearchDocFieldFetchConfig.DEFAULT_FIELDS_TO_FETCH_ON_SCROLL, flags),
+        Set.of("urn"));
+  }
+}


### PR DESCRIPTION
## Summary
- Keyword search now honors `SearchFlags.fetchExtraFields` so Elasticsearch `_source` includes those fields and they are copied onto `SearchEntity.extraFields`. Default fetch remains urn-only.
- Entity graph search snapshots request the indexed URN field names (e.g. `parentDomain`) so FULL graphs such as `domain@search` can resolve destinations without a second aspect fetch.
- Edge resolver uses the searchable annotation `fieldName` (`parentDomain`) rather than the PathSpec (`/parentDomain`).

## Test plan
- [x] `SearchRequestHandlerTest`: default `_source` is urn-only; requested extra fields are included; extract copies only requested keys
- [x] `SearchDocFieldFetchConfigTest`: union/dedupe of defaults and `fetchExtraFields`
- [x] `EntityGraphRegistryTest`: domain `IsPartOf` resolves `searchField=parentDomain`
- [x] `EntityGraphSnapshotBuilderGraphTest`: search build flags include `parentDomain`
- [x] `SemanticEntitySearchServiceTest`: kNN `fieldsToFetch` unions extra fields
- [ ] Confirm domain `parentDomains` / entity graph cache no longer fails with `empty_snapshot` when built from search


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches requested indexed relationship fields from Elasticsearch into `SearchEntity.extraFields` and uses them to resolve destination URNs when building FULL entity-graph snapshots from search. Known graphs can be disabled or have `buildSource` overlaid without failing startup; when a known graph is unbound, reads skip the cache and fall back to live walks/scrolls.

- Search behavior: `_source` includes the union of defaults with `SearchFlags.fetchExtraFields` via `SearchDocFieldFetchConfig.resolve`; `SearchResultUtils` copies only those keys into `extraFields` (applies to keyword and kNN). Default remains urn-only; set `SearchFlags.fetchExtraFields` to return extra fields.
- Graph snapshot build: `EntityGraphSnapshotBuilder` derives `fetchExtraFields` from searchable edges (uses searchable `fieldName`), requests them during search builds, and extracts related URNs from `extraFields` to avoid aspect fetches.
- Cache reads: `BoundHierarchyAccess`/`BoundMembershipAccess` skip cache when `includeSoftDelete` is true or when the known-graph binding is absent/disabled (`bindingForKnownGraph`), using aspect walkers or `GraphRetriever` scroll fallback.
- Known graphs/config: Enabled known graphs must match scope; FULL graphs allow `buildSource: graph` or `search`, PARTIAL requires `graph`. Disabled or missing known graphs are logged and omitted (not required for startup). `scope.mode` for a known graph cannot be changed. Changing `buildSource` changes the Hazelcast cache key.
- Bindings/overlays: `bindings.filterFields` require `buildSource` `search` or `graph` with `scope.mode: FULL`; `bindings.policyFieldTypes` require `primary` or `search`/`graph` with FULL. JSON overlays use `@JsonMerge`, so patches (e.g., `buildSource`, `enabled`, eviction limits) don’t replace bindings.
- API: adds `SearchFlags.fetchExtraFields` (Java/Rest.li; not a GraphQL input) and updates the Rest.li snapshot.

<sup>Written for commit d78874de59761fa11d191437c296652c2c725c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

