### PR TITLE
ci: separate lint from Gradle build and test

### DIFF
--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -60,3 +60,6 @@ docs-website:
   - "docs-website/package.json"
   - "docs-website/yarn.lock"
   - "docs-website/build.gradle"
+spotless:
+  - added|modified: "**/*.java"
+  - "build.gradle"

--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -62,4 +62,5 @@ docs-website:
   - "docs-website/build.gradle"
 spotless:
   - added|modified: "**/*.java"
-  - "build.gradle"
+  - "**/*.gradle"
+  - "**/*.gradle.kts"

--- a/.github/path-filters/lint-jobs-filters.yml
+++ b/.github/path-filters/lint-jobs-filters.yml
@@ -53,3 +53,10 @@ prefect-plugin:
   - added|modified: "metadata-ingestion-modules/prefect-plugin/**"
 playwright-e2e:
   - added|modified: "e2e-test/ui/playwright/**"
+docs-website:
+  - added|modified: "docs-website/generateDocsDir.ts"
+  - added|modified: "docs-website/sidebars.js"
+  - added|modified: "docs-website/src/pages/index.js"
+  - "docs-website/package.json"
+  - "docs-website/yarn.lock"
+  - "docs-website/build.gradle"

--- a/.github/scripts/pre-commit/generate_pre_commit.py
+++ b/.github/scripts/pre-commit/generate_pre_commit.py
@@ -350,6 +350,12 @@ def main():
             taskName="githubActionsPrettierWriteChanged",
             filePattern="^\\.github/.*\\.(yml|yaml)$"
         ),
+        Project(
+            path="datahub-web-react",
+            type=ProjectType.PRETTIER,
+            taskName="graphqlPrettierWriteChanged",
+            filePattern="^datahub-graphql-core/src/main/resources/.*\\.graphql$",
+        ),
     ]
     projects = [*prettier_projects, *finder.find_all_projects()]
 

--- a/.github/scripts/pre-commit/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit/pre-commit-override.yaml
@@ -70,6 +70,15 @@ repos:
         # lintFix + prettierWrite are self-correcting formatters (slow, module-wide
         # Gradle invocation). Run them at pre-push instead of pre-commit; see PFP-5002.
         stages: [pre-push]
+      - id: docs-website-prettier
+        name: docs-website Prettier
+        entry: ./gradlew :docs-website:yarnLintFix -x generateGitPropertiesGlobal
+        language: system
+        files: ^docs-website/(generateDocsDir\.ts|sidebars\.js|src/pages/index\.js)$
+        pass_filenames: false
+        # yarnLintFix is a self-correcting formatter. Run at pre-push instead of
+        # pre-commit so commits stay fast; see PFP-5002.
+        stages: [pre-push]
       - id: bump-schema-versions
         name: Bump PDL schema versions
         entry: python .github/scripts/bump_schema_versions.py

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -534,7 +534,7 @@ jobs:
         with:
           path: ~/.gradle/caches/build-cache-1
           key: gradle-backend-build-cache-${{ github.run_id }}
-      - name: Build + non-test checks once (assemble, spotless, etc.)
+      - name: Build + non-test checks once (assemble, compile, etc.)
         # Compile main + test + non-test checks (no tests) to warm the shard cache.
         # Keep yarnGenerate / generateLazyIconStubs (codegen + graphqlUsageRegistryCheck need them);
         # drop yarnBuild via -x :datahub-frontend:testClasses / :datahub-web-react:jar (frontend-build

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -209,3 +209,40 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: playwright-${{ runner.os }}-yarn-${{ hashFiles('./e2e-test/ui/playwright/package.json', './e2e-test/ui/playwright/yarn.lock') }}
+
+  # Separate job so the docs-website entry stays small instead of duplicating the
+  # ~1.2GB web-react cache under a second key. Prefix matches lint-jobs.yml
+  # docs-website-lint; this is the family's GitHub-hosted master-scoped writer.
+  warm-docs-website-yarn-cache:
+    name: Warm docs-website yarn cache
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      # Key must stay byte-identical with the yarn restore key in lint-jobs.yml
+      # docs-website-lint and the save key at the bottom of this job.
+      - name: Check for existing cache entry
+        id: yarn-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: docs-website-${{ runner.os }}-yarn-${{ hashFiles('docs-website/yarn.lock') }}
+          lookup-only: true
+      - name: Set up JDK 25
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "temurin"
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - name: Populate yarn cache
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: ./gradlew :docs-website:yarnInstall
+      - name: Save yarn cache
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: docs-website-${{ runner.os }}-yarn-${{ hashFiles('docs-website/yarn.lock') }}

--- a/.github/workflows/dagster-plugin.yml
+++ b/.github/workflows/dagster-plugin.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install dagster package and test  (extras ${{ matrix.extraPythonRequirement }})
-        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extraPythonRequirement }}' :metadata-ingestion-modules:dagster-plugin:lint :metadata-ingestion-modules:dagster-plugin:testFull
+        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extraPythonRequirement }}' :metadata-ingestion-modules:dagster-plugin:testFull
       - name: pip freeze show list installed
         if: always()
         run: source metadata-ingestion-modules/dagster-plugin/venv/bin/activate && uv pip freeze

--- a/.github/workflows/gx-plugin.yml
+++ b/.github/workflows/gx-plugin.yml
@@ -64,11 +64,11 @@ jobs:
         include:
           - python-version: "3.10"
             extraPythonRequirement: "great-expectations~=0.18.0"
-            gradleTasks: ":metadata-ingestion-modules:gx-plugin:lint :metadata-ingestion-modules:gx-plugin:testFull"
+            gradleTasks: ":metadata-ingestion-modules:gx-plugin:testFull"
             venvName: "venv"
           - python-version: "3.11"
             extraPythonRequirement: "great-expectations~=0.18.0"
-            gradleTasks: ":metadata-ingestion-modules:gx-plugin:lint :metadata-ingestion-modules:gx-plugin:testFull"
+            gradleTasks: ":metadata-ingestion-modules:gx-plugin:testFull"
             venvName: "venv"
           # GX Core 1.x exercises datahub_gx_plugin.action_v1 in its own venv.
           - python-version: "3.11"

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -36,6 +36,7 @@ jobs:
       python-lint: ${{ steps.filter.outputs.metadata-ingestion == 'true' || steps.filter.outputs.datahub-actions == 'true' || steps.filter.outputs.datahub-agent-context == 'true' || steps.filter.outputs.airflow-plugin == 'true' || steps.filter.outputs.gx-plugin == 'true' || steps.filter.outputs.dagster-plugin == 'true' || steps.filter.outputs.prefect-plugin == 'true' || steps.filter.outputs.lint-job == 'true' }}
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      docs-website: ${{ steps.filter.outputs.docs-website == 'true' || steps.filter.outputs.lint-job == 'true' }}
       default-runner: ${{ steps.runners.outputs.default-runner }}
       default-gh-runner: ${{ steps.runners.outputs.default-gh-runner }}
     steps:
@@ -111,6 +112,32 @@ jobs:
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
+
+  docs-website-lint:
+    name: docs-website-lint
+    runs-on: ${{ needs.setup.outputs.default-gh-runner }}
+    needs: setup
+    if: needs.setup.outputs.docs-website == 'true'
+    steps:
+      - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "temurin"
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      # Restore-only: this workflow is pull_request-only, so a save here would be
+      # ref-scoped to the PR and never shared. Prefix keeps this small entry out of
+      # the '<os>-yarn-' family used by datahub-web-react.
+      - name: Restore yarn cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ~/.cache/yarn
+          key: docs-website-${{ runner.os }}-yarn-${{ hashFiles('docs-website/yarn.lock') }}
+          restore-keys: |
+            docs-website-${{ runner.os }}-yarn-
+            ${{ runner.os }}-yarn-
+      - name: Run docs-website prettier check
+        run: ./gradlew :docs-website:yarnLint
 
   validate-post-workflow-list:
     name: validate_post_workflow_list
@@ -373,6 +400,9 @@ jobs:
       - name: Run lint
         run: |
           ./gradlew :datahub-web-react:yarnLint
+      - name: Check GraphQL prettier
+        run: |
+          ./gradlew :datahub-web-react:graphqlPrettierCheck
       - name: Check i18n locale parity
         run: |
           ./gradlew :datahub-web-react:yarnI18nParityCheck

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -37,6 +37,7 @@ jobs:
       smoke-test-python: ${{ steps.filter.outputs.smoke-test-python == 'true' || steps.filter.outputs.lint-job == 'true' }}
       playwright-e2e: ${{ steps.filter.outputs.playwright-e2e == 'true' || steps.filter.outputs.lint-job == 'true' }}
       docs-website: ${{ steps.filter.outputs.docs-website == 'true' || steps.filter.outputs.lint-job == 'true' }}
+      spotless: ${{ steps.filter.outputs.spotless == 'true' || steps.filter.outputs.lint-job == 'true' }}
       default-runner: ${{ steps.runners.outputs.default-runner }}
       default-gh-runner: ${{ steps.runners.outputs.default-gh-runner }}
     steps:
@@ -138,6 +139,21 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Run docs-website prettier check
         run: ./gradlew :docs-website:yarnLint
+
+  spotless-check:
+    name: spotless-check
+    runs-on: ${{ needs.setup.outputs.default-gh-runner }}
+    needs: setup
+    if: needs.setup.outputs.spotless == 'true'
+    steps:
+      - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: "temurin"
+          java-version: 25
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - name: Run Spotless check
+        run: ./gradlew spotlessCheck
 
   validate-post-workflow-list:
     name: validate_post_workflow_list

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -127,8 +127,9 @@ jobs:
           java-version: 25
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       # Restore-only: this workflow is pull_request-only, so a save here would be
-      # ref-scoped to the PR and never shared. Prefix keeps this small entry out of
-      # the '<os>-yarn-' family used by datahub-web-react.
+      # ref-scoped to the PR and never shared. The master-scoped entry is written
+      # by ci-cache-warmup.yml warm-docs-website-yarn-cache. Prefix keeps this
+      # small entry out of the '<os>-yarn-' family used by datahub-web-react.
       - name: Restore yarn cache
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:

--- a/.github/workflows/prefect-plugin.yml
+++ b/.github/workflows/prefect-plugin.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install prefect package
-        run: ./gradlew :metadata-ingestion-modules:prefect-plugin:lint :metadata-ingestion-modules:prefect-plugin:testFull
+        run: ./gradlew :metadata-ingestion-modules:prefect-plugin:testFull
       - name: pip freeze show list installed
         if: always()
         run: source metadata-ingestion-modules/prefect-plugin/venv/bin/activate && uv pip freeze

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,15 @@ repos:
         stages:
           - pre-push
 
+      - id: datahub-web-react-graphqlPrettierWriteChanged
+        name: graphqlPrettierWriteChanged
+        entry: ./gradlew :datahub-web-react:graphqlPrettierWriteChanged -x generateGitPropertiesGlobal
+        language: system
+        files: ^datahub-graphql-core/src/main/resources/.*\.graphql$
+        pass_filenames: false
+        stages:
+          - pre-push
+
       - id: contrib-metadata-model-extensions-datahub-demo-dataset-governance-validator-spotless
         name: contrib/metadata-model-extensions/datahub-demo-dataset-governance-validator
           Spotless Apply
@@ -681,6 +690,15 @@ repos:
           -x generateGitPropertiesGlobal
         language: system
         files: ^e2e-test/ui/playwright/.*\.ts$
+        pass_filenames: false
+        stages:
+          - pre-push
+
+      - id: docs-website-prettier
+        name: docs-website Prettier
+        entry: ./gradlew :docs-website:yarnLintFix -x generateGitPropertiesGlobal
+        language: system
+        files: ^docs-website/(generateDocsDir\.ts|sidebars\.js|src/pages/index\.js)$
         pass_filenames: false
         stages:
           - pre-push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ See [docs/lsp-setup.md](docs/lsp-setup.md) for installation and configuration.
 
 ```bash
 ./gradlew build           # Build entire project
-./gradlew check           # Run all tests and linting
+./gradlew check           # Run all tests (Python/JS lint lives in lint-jobs.yml / :module:lint)
+./gradlew lintCheck       # Run all lint checks (Python, JS, GraphQL, markdown, Java)
+./gradlew lintFix         # Auto-fix all lint issues
 ./gradlew format          # Format all code (Java, Markdown, GraphQL, YAML)
 
 # Note that each directory typically has a build.gradle file, but the available tasks follow similar conventions.
@@ -56,6 +58,8 @@ See [docs/lsp-setup.md](docs/lsp-setup.md) for installation and configuration.
 **Format everything:**
 
 ```bash
+./gradlew lintCheck           # Run all lint checks (Python, JS, GraphQL, markdown, Java)
+./gradlew lintFix             # Auto-fix all lint issues
 ./gradlew format              # Format all code (Java, Markdown, GraphQL, YAML)
 ./gradlew formatChanged       # Format only changed files (faster)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ If you see CI failures like:
 
 - `markdown_format / markdown_format_check (pull_request)` - Use `./gradlew :datahub-web-react:mdPrettierWrite`
 - `graphql_prettier_check` - Use `./gradlew :datahub-web-react:graphqlPrettierWrite`
-- `spotlessJavaCheck` - Use `./gradlew spotlessApply`
+- `spotless-check` - Use `./gradlew spotlessApply`
 - Python linting failures - Use `./gradlew :metadata-ingestion:lintFix`
 
 **Never do this:**

--- a/build.gradle
+++ b/build.gradle
@@ -997,6 +997,46 @@ tasks.register('formatChanged') {
   dependsOn(':scripts:dev:lintFix')
 }
 
+tasks.register('lintCheck') {
+  group = 'verification'
+  description = 'Run all lint checks (Python, JS, GraphQL, markdown, Java)'
+  dependsOn(':metadata-ingestion:lint')
+  dependsOn(':datahub-actions:lint')
+  dependsOn(':datahub-agent-context:lint')
+  dependsOn(':metadata-ingestion-modules:airflow-plugin:lint')
+  dependsOn(':metadata-ingestion-modules:gx-plugin:lint')
+  dependsOn(':metadata-ingestion-modules:dagster-plugin:lint')
+  dependsOn(':metadata-ingestion-modules:prefect-plugin:lint')
+  dependsOn(':smoke-test:lint')
+  dependsOn(':scripts:dev:lint')
+  dependsOn(':datahub-web-react:lint')
+  dependsOn(':datahub-web-react:graphqlPrettierCheck')
+  dependsOn(':datahub-web-react:mdPrettierCheck')
+  dependsOn(':datahub-web-react:githubActionsPrettierCheck')
+  dependsOn(':datahub-web-react:docusaurusMarkdownLint')
+  dependsOn(':docs-website:yarnLint')
+  dependsOn('spotlessCheck')
+}
+
+tasks.register('lintFix') {
+  group = 'formatting'
+  description = 'Auto-fix all lint issues'
+  dependsOn('format')
+  dependsOn(':metadata-ingestion:lintFix')
+  dependsOn(':datahub-actions:lintFix')
+  dependsOn(':datahub-agent-context:lintFix')
+  dependsOn(':metadata-ingestion-modules:airflow-plugin:lintFix')
+  dependsOn(':metadata-ingestion-modules:gx-plugin:lintFix')
+  dependsOn(':metadata-ingestion-modules:dagster-plugin:lintFix')
+  dependsOn(':metadata-ingestion-modules:prefect-plugin:lintFix')
+  dependsOn(':datahub-web-react:lintFix')
+  dependsOn(':docs-website:yarnLintFix')
+  dependsOn(':smoke-test:lintFix')
+  dependsOn(':e2e-test:ui:playwright:lintFix')
+  dependsOn(':e2e-test:ui:playwright:prettierWrite')
+  dependsOn(':metadata-service:iceberg-catalog:lintFix')
+}
+
 // Gradle 9 forbids resolving one project's configurations from another project's task
 // (a root doLast looping over allprojects throws "attempted without an exclusive lock").
 // Register a per-project resolver instead: each runs inside its OWN project's context, which

--- a/build.gradle
+++ b/build.gradle
@@ -902,6 +902,9 @@ subprojects {
     }
 
     spotless {
+      // Format checks run in lint-jobs.yml (spotless-check) and ./gradlew lintCheck,
+      // not as part of check/build.
+      enforceCheck false
       java {
         googleJavaFormat(googleJavaFormatVersion)
         target project.fileTree(project.projectDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -984,11 +984,14 @@ wrapper {
   distributionSha256Sum = 'a3c4ba4aca8f0075688b9c5b18939fd28e8cb4357c227da5c1d9f38343791439'
 }
 
+def spotlessApplyTasks = subprojects.collect { "${it.path}:spotlessApply" }
+def spotlessCheckTasks = subprojects.collect { "${it.path}:spotlessCheck" }
+
 tasks.register('format') {
   dependsOn(':datahub-web-react:graphqlPrettierWrite')
   dependsOn(':datahub-web-react:githubActionsPrettierWrite')
   dependsOn(':datahub-web-react:mdPrettierWrite')
-  dependsOn('spotlessApply')
+  dependsOn(spotlessApplyTasks)
   dependsOn(':scripts:dev:lintFix')
 }
 
@@ -996,7 +999,7 @@ tasks.register('formatChanged') {
   dependsOn(':datahub-web-react:graphqlPrettierWriteChanged')
   dependsOn(':datahub-web-react:githubActionsPrettierWriteChanged')
   dependsOn(':datahub-web-react:mdPrettierWriteChanged')
-  dependsOn('spotlessApply')
+  dependsOn(spotlessApplyTasks)
   dependsOn(':scripts:dev:lintFix')
 }
 
@@ -1018,7 +1021,7 @@ tasks.register('lintCheck') {
   dependsOn(':datahub-web-react:githubActionsPrettierCheck')
   dependsOn(':datahub-web-react:docusaurusMarkdownLint')
   dependsOn(':docs-website:yarnLint')
-  dependsOn('spotlessCheck')
+  dependsOn(spotlessCheckTasks)
 }
 
 tasks.register('lintFix') {

--- a/datahub-actions/build.gradle
+++ b/datahub-actions/build.gradle
@@ -167,7 +167,6 @@ docker {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testFull
 
 clean {

--- a/datahub-agent-context/build.gradle
+++ b/datahub-agent-context/build.gradle
@@ -108,7 +108,6 @@ task cleanPythonCache(type: Exec) {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testFull
 
 clean {

--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -79,5 +79,4 @@ clean {
 }
 
 compileJava.dependsOn 'graphqlCodegen'
-build.dependsOn ':datahub-web-react:graphqlPrettierCheck'
 sourceSets.main.java.srcDir "$projectDir/src/mainGeneratedGraphQL/java"

--- a/docker/snippets/uv/profiles/chainguard-ci.toml
+++ b/docker/snippets/uv/profiles/chainguard-ci.toml
@@ -24,7 +24,7 @@ index-strategy = "unsafe-best-match"
 
 # Remediations can list a version as sdist-only (or without a usable platform wheel);
 # unsafe-best-match then prefers that sdist over a wheel from Chainguard main / PyPI.
-# Force wheels for packages known to hit that path in datahub-ingestion full builds.
+# Force wheels for packages known to hit that path
 no-build-package = [
     "beautifulsoup4",
     "orjson",

--- a/docs-website/build.gradle
+++ b/docs-website/build.gradle
@@ -121,25 +121,21 @@ task fastReload(type: YarnTask) {
   args = ['run', 'generate-rsync']
 }
 
+def yarnLintInputs = [
+  file('generateDocsDir.ts'),
+  file('sidebars.js'),
+  file('src/pages/index.js'),
+  file('package.json'),
+  file('yarn.lock'),
+]
+
 task yarnLint(type: YarnTask, dependsOn: [yarnInstall]) {
-  inputs.files(
-    file('generateDocsDir.ts'),
-    file('sidebars.js'),
-    file('src/pages/index.js'),
-    file('package.json'),
-    file('yarn.lock'),
-  )
+  inputs.files(yarnLintInputs)
   args = ['run', 'lint-check']
 }
 
 task yarnLintFix(type: YarnTask, dependsOn: [yarnInstall]) {
-  inputs.files(
-    file('generateDocsDir.ts'),
-    file('sidebars.js'),
-    file('src/pages/index.js'),
-    file('package.json'),
-    file('yarn.lock'),
-  )
+  inputs.files(yarnLintInputs)
   args = ['run', 'lint-fix']
 }
 

--- a/docs-website/build.gradle
+++ b/docs-website/build.gradle
@@ -121,13 +121,25 @@ task fastReload(type: YarnTask) {
   args = ['run', 'generate-rsync']
 }
 
-task yarnLint(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
-  inputs.files(projectMdFiles)
+task yarnLint(type: YarnTask, dependsOn: [yarnInstall]) {
+  inputs.files(
+    file('generateDocsDir.ts'),
+    file('sidebars.js'),
+    file('src/pages/index.js'),
+    file('package.json'),
+    file('yarn.lock'),
+  )
   args = ['run', 'lint-check']
 }
 
 task yarnLintFix(type: YarnTask, dependsOn: [yarnInstall]) {
-  inputs.files(projectMdFiles)
+  inputs.files(
+    file('generateDocsDir.ts'),
+    file('sidebars.js'),
+    file('src/pages/index.js'),
+    file('package.json'),
+    file('yarn.lock'),
+  )
   args = ['run', 'lint-fix']
 }
 
@@ -136,7 +148,7 @@ task serve(type: YarnTask, dependsOn: [yarnInstall] ) {
 }
 
 
-task yarnBuild(type: YarnTask, dependsOn: [yarnLint, yarnGenerate]) {
+task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
   inputs.files(projectMdFiles)
   inputs.file("package.json").withPathSensitivity(PathSensitivity.RELATIVE)
   inputs.dir("src").withPathSensitivity(PathSensitivity.RELATIVE)

--- a/metadata-ingestion-modules/airflow-plugin/build.gradle
+++ b/metadata-ingestion-modules/airflow-plugin/build.gradle
@@ -114,7 +114,6 @@ task buildWheel(type: Exec, dependsOn: [environmentSetup]) {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testFull
 
 clean {

--- a/metadata-ingestion-modules/dagster-plugin/build.gradle
+++ b/metadata-ingestion-modules/dagster-plugin/build.gradle
@@ -102,7 +102,6 @@ task cleanPythonCache(type: Exec) {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testFull
 
 clean {

--- a/metadata-ingestion-modules/gx-plugin/build.gradle
+++ b/metadata-ingestion-modules/gx-plugin/build.gradle
@@ -142,7 +142,6 @@ task cleanPythonCache(type: Exec) {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testFull
 
 clean {

--- a/metadata-ingestion-modules/prefect-plugin/build.gradle
+++ b/metadata-ingestion-modules/prefect-plugin/build.gradle
@@ -115,7 +115,6 @@ task cleanPythonCache(type: Exec) {
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testQuick
 
 clean {

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -361,7 +361,6 @@ task buildWheel(type: Exec, dependsOn: [install, codegen, cleanPythonCache, chec
 }
 
 build.dependsOn install
-check.dependsOn lint
 check.dependsOn testQuick
 check.dependsOn checkLockFile
 


### PR DESCRIPTION
## Summary
- Stop running Python, GraphQL prettier, docs-website prettier, and Java Spotless as part of Gradle `check`/`build` / plugin test workflows. Those checks already have pre-commit coverage (mypy stays CI-only) and now live in `.github/workflows/lint-jobs.yml`.
- Add root `./gradlew lintCheck` / `lintFix` aggregators for local whole-repo lint.
- Move GraphQL prettier off `graphql-core:build` so the Java build no longer pulls in frontend `yarnInstall`.

## Test plan
- [ ] `python-lint` still runs ruff + mypy for changed Python modules
- [ ] gx/dagster/prefect test workflows no longer invoke `:lint`
- [ ] `datahub-web-react-lint` runs `graphqlPrettierCheck`; Java `build` does not
- [ ] `docs-website-lint` and `spotless-check` jobs run on relevant path changes
- [ ] `./gradlew lintCheck` / `lintFix` are documented in AGENTS.md


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits lint from Gradle build/test and adds dedicated `docs-website` and Spotless jobs to cut duplicate work and keep frontend tooling out of Java builds. Previously `check`/`build` ran Python, JS/GraphQL, and Spotless; now lint runs in `lint-jobs.yml` or via `./gradlew lintCheck`/`lintFix`.

- CI: adds `docs-website-lint` and `spotless-check`; restores a master-scoped docs-website yarn cache in `ci-cache-warmup.yml`; runs `graphqlPrettierCheck` under `datahub-web-react-lint`; updates path filters for `docs-website` and `spotless`; stops invoking `:lint` in GX/Dagster/Prefect plugin test workflows.
- Gradle: introduces `lintCheck`/`lintFix`; removes `check.dependsOn lint` from Python modules; sets `spotless { enforceCheck false }`; fans Spotless out to subprojects so `format`, `formatChanged`, and `lintCheck` call per-project `spotlessApply`/`spotlessCheck`; removes `build.dependsOn ':datahub-web-react:graphqlPrettierCheck'` from `datahub-graphql-core`.
- `docs-website`: moves Prettier to `yarnLint`/`yarnLintFix`; narrows their inputs; `yarnBuild` no longer runs lint.
- Pre-commit: adds pre-push hooks for GraphQL Prettier (`graphqlPrettierWriteChanged`) and docs-website Prettier.

Use `./gradlew lintCheck` or `lintFix` locally. Lint failures appear in `docs-website-lint`, `spotless-check`, `datahub-web-react-lint`, or `python-lint`.

<sup>Written for commit 18e186a1a7ae85b9b515ddd8101d358dee6d61bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

