### PR TITLE
fix(actions): handle signals correctly to shutdown datahub-actions pipelines gracefully

### DIFF
--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -193,7 +193,8 @@ def version() -> None:
 def handle_shutdown(signum: int, frame: Any) -> None:
     logger.info("Stopping all running Action Pipelines...")
     pipeline_manager.stop_all()
-    sys.exit(1)
+    sys.exit(0)
 
 
 signal.signal(signal.SIGINT, handle_shutdown)
+signal.signal(signal.SIGTERM, handle_shutdown)

--- a/docker/datahub-actions/start.sh
+++ b/docker/datahub-actions/start.sh
@@ -97,7 +97,7 @@ else
 fi
 
 if [ "$MONITORING_ENABLED" = true ]; then
-    datahub-actions --enable-monitoring --monitoring-port "$MONITORING_PORT" actions $config_files
+    exec datahub-actions --enable-monitoring --monitoring-port "$MONITORING_PORT" actions $config_files
 else
-    datahub-actions actions $config_files
+    exec datahub-actions actions $config_files
 fi


### PR DESCRIPTION
This PR fixes the signal handling in the DataHub Actions container, to shutdown action pipelines gracefully, e.g. when Kubernetes is stopping the pod. If action pipelines are not shutdown gracefully, e.g. the offsets of the DataHub Cloud Event Source are never committed to DataHub Cloud.

1. Kubernetes is using a SIGTERM instead of SIGINT for interrupting a container by default, therefore also this signal must be handled by the handle_shutdown function.
2. The process id 1 in the container must be the datahub-actions process, otherwise the signals are only sent to the start.sh script, but not the datahub-actions process - this is done by using exec.

There is also a ticket on the DataHub Customer Support Portal for this issue resp. the ticket describes this issue and another issue with the DataHub Cloud Event Source: https://support.datahub.com/hc/en-us/requests/8639

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully shuts down DataHub Actions pipelines on container termination so event-source offsets are committed. Previously only SIGINT was handled and the shell owned PID 1, so Kubernetes SIGTERM did not stop pipelines and the process exited with code 1.

- In `datahub_actions/cli/actions.py`, handle SIGTERM and exit with 0 after stopping pipelines.
- In `docker/datahub-actions/start.sh`, use `exec` so `datahub-actions` runs as PID 1 and receives signals directly (with and without monitoring).

**Rollout**
- No config changes. Build and deploy the updated image and restart pods to apply the fix.

<sup>Written for commit d2b46102a55a127d13292d03c6bd0c333d211d7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

