### PR TITLE
fix(policy): fix for default view self policy

### DIFF
--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -78,6 +78,8 @@ public class DataHubAuthorizerTest {
 
   private static final Urn USER_WITH_ADMIN_ROLE =
       UrnUtils.getUrn("urn:li:corpuser:user-with-admin");
+  // A user with no configured policies, exercising only the default self policies.
+  private static final Urn SELF_USER = UrnUtils.getUrn("urn:li:corpuser:selfUser");
   private static final Urn USER_WITH_DOMAIN_ACCESS =
       UrnUtils.getUrn("urn:li:corpuser:domainAccessUser");
   private static final Urn USER_WITH_CONTAINER_ACCESS =
@@ -609,6 +611,43 @@ public class DataHubAuthorizerTest {
             Collections.emptyList());
 
     assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
+  }
+
+  @Test
+  public void testDefaultSelfPolicyAllowsReadOnSelf() throws Exception {
+
+    // No configured policy grants these; they come from the "View Self" default policy.
+    for (String privilege : ImmutableList.of("VIEW_ENTITY_PAGE", "GET_ENTITY_PRIVILEGE")) {
+      AuthorizationRequest request =
+          new AuthorizationRequest(
+              SELF_USER.toString(),
+              privilege,
+              Optional.of(selfEntitySpec()),
+              Collections.emptyList());
+
+      assertEquals(
+          _dataHubAuthorizer.authorize(request).getType(),
+          AuthorizationResult.Type.ALLOW,
+          String.format("Expected the View Self default policy to grant %s on self", privilege));
+    }
+  }
+
+  @Test
+  public void testDefaultSelfPolicyDeniesWriteOnSelf() throws Exception {
+
+    for (String privilege : ImmutableList.of("EDIT_ENTITY", "DELETE_ENTITY")) {
+      AuthorizationRequest request =
+          new AuthorizationRequest(
+              SELF_USER.toString(),
+              privilege,
+              Optional.of(selfEntitySpec()),
+              Collections.emptyList());
+
+      assertEquals(
+          _dataHubAuthorizer.authorize(request).getType(),
+          AuthorizationResult.Type.DENY,
+          String.format("Expected no default policy to grant %s on self", privilege));
+    }
   }
 
   @Test
@@ -1552,6 +1591,10 @@ public class DataHubAuthorizerTest {
         .aspectRetriever(aspectRetriever)
         .entityGraphCache(EntityGraphCache.NO_OP)
         .build();
+  }
+
+  private EntitySpec selfEntitySpec() {
+    return new EntitySpec(CORP_USER_ENTITY_NAME, SELF_USER.toString());
   }
 
   private AuthorizerContext createAuthorizerContext(

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -1,7 +1,5 @@
 package com.linkedin.metadata.authorization;
 
-import static com.linkedin.metadata.authorization.ApiGroup.ENTITY;
-import static com.linkedin.metadata.authorization.ApiOperation.READ;
 import static com.linkedin.metadata.authorization.Disjunctive.DENY_ACCESS;
 
 import com.google.common.collect.ImmutableList;
@@ -1429,8 +1427,7 @@ public class PoliciesConfig {
                 .setDescription("View self entity page.")
                 .setActors(new DataHubActorFilter().setUsers(new UrnArray(actorUrn)))
                 .setPrivileges(
-                    PoliciesConfig.API_PRIVILEGE_MAP.get(ENTITY).get(READ).stream()
-                        .flatMap(Collection::stream)
+                    Stream.of(VIEW_ENTITY_PAGE_PRIVILEGE, GET_ENTITY_PRIVILEGE)
                         .map(PoliciesConfig.Privilege::getType)
                         .collect(Collectors.toCollection(StringArray::new)))
                 .setType(PoliciesConfig.METADATA_POLICY_TYPE)

--- a/metadata-utils/src/test/java/com/linkedin/metadata/authorization/PoliciesConfigDefaultPoliciesTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/authorization/PoliciesConfigDefaultPoliciesTest.java
@@ -1,0 +1,75 @@
+package com.linkedin.metadata.authorization;
+
+import static com.linkedin.metadata.authorization.ApiGroup.ENTITY;
+import static com.linkedin.metadata.authorization.PoliciesConfig.GET_ENTITY_PRIVILEGE;
+import static com.linkedin.metadata.authorization.PoliciesConfig.VIEW_ENTITY_PAGE_PRIVILEGE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.policy.DataHubPolicyInfo;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+/**
+ * The default policies are granted to every actor on their own entity without an administrator
+ * opting in, so any privilege they carry beyond read access is a self-service escalation: edit
+ * access on your own corpuser entity is enough to grant yourself the Admin role.
+ */
+public class PoliciesConfigDefaultPoliciesTest {
+
+  private static final Urn ACTOR_URN = UrnUtils.getUrn("urn:li:corpuser:test");
+
+  @Test
+  public void testDefaultPoliciesGrantOnlyEntityReadPrivileges() {
+    assertEquals(
+        grantedPrivilegeTypes(),
+        Set.of(VIEW_ENTITY_PAGE_PRIVILEGE.getType(), GET_ENTITY_PRIVILEGE.getType()),
+        "Default self policies must remain read-only");
+  }
+
+  @Test
+  public void testDefaultPoliciesDoNotSatisfyMutatingEntityOperations() {
+    final Set<String> granted = grantedPrivilegeTypes();
+
+    assertTrue(
+        satisfies(granted, ApiOperation.READ),
+        "Default self policies must still allow read on self");
+
+    for (ApiOperation operation :
+        List.of(
+            ApiOperation.CREATE, ApiOperation.UPDATE, ApiOperation.DELETE, ApiOperation.EXECUTE)) {
+      assertFalse(
+          satisfies(granted, operation),
+          String.format("Default self policies must not authorize ENTITY %s on self", operation));
+    }
+  }
+
+  private static Set<String> grantedPrivilegeTypes() {
+    return PoliciesConfig.getDefaultPolicies(ACTOR_URN).stream()
+        .map(DataHubPolicyInfo::getPrivileges)
+        .flatMap(List::stream)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Mirrors {@code AuthUtil.isAPIAuthorized}: an operation is authorized once the actor holds every
+   * privilege of at least one of the disjoint conjunctives required for it.
+   */
+  private static boolean satisfies(Set<String> granted, ApiOperation operation) {
+    final Disjunctive<Conjunctive<PoliciesConfig.Privilege>> required =
+        PoliciesConfig.API_PRIVILEGE_MAP.get(ENTITY).get(operation);
+    return required.stream()
+        .anyMatch(
+            conjunctive ->
+                !conjunctive.isEmpty()
+                    && granted.containsAll(
+                        conjunctive.stream()
+                            .map(PoliciesConfig.Privilege::getType)
+                            .collect(Collectors.toSet())));
+  }
+}

--- a/smoke-test/tests/authorization/test_self_entity_auth.py
+++ b/smoke-test/tests/authorization/test_self_entity_auth.py
@@ -1,0 +1,160 @@
+"""
+E2E authorization smoke tests for a non-admin acting on their own corpuser entity.
+
+Self-service profile editing is allowed by an explicit self short-circuit in ``CorpUserType``,
+not by any policy. The generic write APIs have no such short-circuit and must keep denying
+writes to your own user entity - otherwise any user could patch their own roleMembership and
+grant themselves the Admin role.
+"""
+
+import logging
+import uuid
+
+import pytest
+
+from datahub.metadata.schema_classes import RoleMembershipClass
+from tests.consistency_utils import wait_for_writes_to_sync
+from tests.privileges.utils import create_user, is_graphql_auth_denied, remove_user
+from tests.utilities.domains import Domain
+from tests.utils import (
+    get_frontend_session,
+    get_frontend_url,
+    login_as,
+    with_test_retry,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM),
+]
+
+_UNIQUE = uuid.uuid4().hex[:8]
+TEST_USER_EMAIL = f"self.auth.test.{_UNIQUE}@smoke.datahub.test"
+TEST_USER_URN = f"urn:li:corpuser:{TEST_USER_EMAIL}"
+OTHER_USER_EMAIL = f"self.auth.other.{_UNIQUE}@smoke.datahub.test"
+OTHER_USER_URN = f"urn:li:corpuser:{OTHER_USER_EMAIL}"
+TEST_USER_PASSWORD = "user"
+
+ADMIN_ROLE_URN = "urn:li:dataHubRole:Admin"
+
+UPDATE_CORP_USER_PROPERTIES_MUTATION = """
+mutation updateCorpUserProperties($urn: String!, $input: CorpUserUpdateInput!) {
+  updateCorpUserProperties(urn: $urn, input: $input) {
+    urn
+    editableProperties {
+      aboutMe
+      title
+    }
+  }
+}
+"""
+
+PATCH_ENTITY_MUTATION = """
+mutation patchEntity($input: PatchEntityInput!) {
+  patchEntity(input: $input) {
+    urn
+    success
+    error
+  }
+}
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def self_auth_setup(auth_session):
+    admin_session = get_frontend_session()
+    admin_session = create_user(admin_session, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    admin_session = create_user(admin_session, OTHER_USER_EMAIL, TEST_USER_PASSWORD)
+
+    yield
+
+    remove_user(admin_session, TEST_USER_URN)
+    remove_user(admin_session, OTHER_USER_URN)
+
+
+@with_test_retry(max_attempts=10)
+def _post_graphql_as_user(email: str, password: str, payload: dict) -> dict:
+    user_session = login_as(email, password)
+    response = user_session.post(f"{get_frontend_url()}/api/v2/graphql", json=payload)
+    response.raise_for_status()
+    return response.json()
+
+
+def _update_profile_payload(target_urn: str, about_me: str) -> dict:
+    return {
+        "query": UPDATE_CORP_USER_PROPERTIES_MUTATION,
+        "variables": {
+            "urn": target_urn,
+            "input": {"aboutMe": about_me, "title": "Analyst"},
+        },
+    }
+
+
+def test_user_can_edit_own_profile():
+    """A user with no granted privileges can still edit their own profile."""
+    about_me = f"Self edit {_UNIQUE}"
+    res = _post_graphql_as_user(
+        TEST_USER_EMAIL,
+        TEST_USER_PASSWORD,
+        _update_profile_payload(TEST_USER_URN, about_me),
+    )
+
+    assert not is_graphql_auth_denied(res), res
+    editable = (
+        (res.get("data") or {}).get("updateCorpUserProperties") or {}
+    ).get("editableProperties") or {}
+    assert editable.get("aboutMe") == about_me, res
+    assert editable.get("title") == "Analyst", res
+
+
+def test_user_cannot_edit_another_users_profile():
+    """The self short-circuit must not extend to other users' profiles."""
+    res = _post_graphql_as_user(
+        TEST_USER_EMAIL,
+        TEST_USER_PASSWORD,
+        _update_profile_payload(OTHER_USER_URN, f"Cross edit {_UNIQUE}"),
+    )
+
+    assert is_graphql_auth_denied(res), res
+
+
+def test_user_cannot_patch_own_role_membership(graph_client):
+    """A user must not be able to grant themselves the Admin role on their own entity.
+
+    patchEntity is gated on EDIT_ENTITY, which the default self policy must never grant.
+    """
+    payload = {
+        "query": PATCH_ENTITY_MUTATION,
+        "variables": {
+            "input": {
+                "urn": TEST_USER_URN,
+                "entityType": "corpuser",
+                "aspectName": "roleMembership",
+                "patch": [
+                    {
+                        "op": "ADD",
+                        "path": f"/roles/{ADMIN_ROLE_URN}",
+                        "value": ADMIN_ROLE_URN,
+                    }
+                ],
+                "arrayPrimaryKeys": [{"arrayField": "roles", "keys": []}],
+                "forceGenericPatch": True,
+            }
+        },
+    }
+    res = _post_graphql_as_user(TEST_USER_EMAIL, TEST_USER_PASSWORD, payload)
+
+    # PatchEntityResolver reports authorization failures in the payload rather than as a
+    # GraphQL error, so check the reason too - success=False alone would also be satisfied
+    # by an unrelated failure.
+    result = (res.get("data") or {}).get("patchEntity") or {}
+    assert result.get("success") is False, res
+    assert "unauthorized" in (result.get("error") or "").lower(), res
+
+    wait_for_writes_to_sync(mcp_only=True)
+    role_membership = graph_client.get_aspect(TEST_USER_URN, RoleMembershipClass)
+    assert role_membership is None or ADMIN_ROLE_URN not in role_membership.roles, (
+        f"Test user was granted {ADMIN_ROLE_URN}: {role_membership}"
+    )

--- a/smoke-test/tests/authorization/test_self_entity_auth.py
+++ b/smoke-test/tests/authorization/test_self_entity_auth.py
@@ -102,9 +102,9 @@ def test_user_can_edit_own_profile():
     )
 
     assert not is_graphql_auth_denied(res), res
-    editable = (
-        (res.get("data") or {}).get("updateCorpUserProperties") or {}
-    ).get("editableProperties") or {}
+    editable = ((res.get("data") or {}).get("updateCorpUserProperties") or {}).get(
+        "editableProperties"
+    ) or {}
     assert editable.get("aboutMe") == about_me, res
     assert editable.get("title") == "Analyst", res
 


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the default “View Self” policy to read-only on a user’s own corpuser to prevent self‑escalation (SEC-1538). Previously it inherited the full ENTITY READ API set; now it grants only VIEW_ENTITY_PAGE and GET_ENTITY, so generic write APIs on self are denied while profile edits via the existing self short‑circuit still work.

- In `PoliciesConfig.getDefaultPolicies`, replace API privilege map expansion with explicit `VIEW_ENTITY_PAGE_PRIVILEGE` and `GET_ENTITY_PRIVILEGE`.
- Tests: unit test for default self privileges and mutating ops denial; authorizer tests that allow read and deny write on self; E2E smoke tests that own profile edits succeed, other users’ profiles are denied, and self `roleMembership` patch is blocked.
- Rollout: no migration. If you relied on the default self policy to edit/delete your own corpuser via generic APIs, switch to an admin-granted policy.

<sup>Written for commit 350df676234f6d25bf4c20d7ecc3b5987d4122d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

