### PR TITLE
fix(gms): skip null entity-graph-cache relationship endpoints

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccess.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundHierarchyAccess.java
@@ -1,11 +1,11 @@
 package com.linkedin.metadata.graph.cache.client;
 
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.graph.cache.AncestorWalkResult;
 import com.linkedin.metadata.graph.cache.EntityGraphCache;
 import com.linkedin.metadata.graph.cache.GraphReadResult;
 import com.linkedin.metadata.graph.cache.TraversalDirection;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpoints;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,9 +53,7 @@ public final class BoundHierarchyAccess {
                   .limit(Integer.MAX_VALUE)
                   .build());
       if (result.isHit()) {
-        return result.verticesOrEmpty().stream()
-            .map(UrnUtils::getUrn)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+        return EntityGraphEndpoints.toUrnSet(result.verticesOrEmpty());
       }
     }
     return AspectParentWalker.expandAncestors(opContext, spec, new LinkedHashSet<>(roots));
@@ -89,9 +87,7 @@ public final class BoundHierarchyAccess {
               seedUrn.toString(),
               maxDepth);
       if (walkResult.isHit()) {
-        return walkResult.ancestorsOrEmpty().stream()
-            .map(UrnUtils::getUrn)
-            .collect(Collectors.toList());
+        return EntityGraphEndpoints.toUrnList(walkResult.ancestorsOrEmpty());
       }
     }
     return AspectParentWalker.orderedParents(opContext, spec, seedUrn, maxDepth);
@@ -130,10 +126,10 @@ public final class BoundHierarchyAccess {
                 .maxDepth(cacheMaxDepth)
                 .build());
     if (result.isHit()) {
-      return result.verticesOrEmpty().stream()
-          .filter(urn -> !urn.equals(rootUrn.toString()))
-          .map(UrnUtils::getUrn)
-          .collect(Collectors.toCollection(LinkedHashSet::new));
+      return EntityGraphEndpoints.toUrnSet(
+          result.verticesOrEmpty().stream()
+              .filter(urn -> !urn.equals(rootUrn.toString()))
+              .collect(Collectors.toCollection(LinkedHashSet::new)));
     }
     return GraphScrollFallback.allDescendants(opContext, spec, rootUrn);
   }
@@ -185,10 +181,10 @@ public final class BoundHierarchyAccess {
                 .build());
     if (result.isHit()) {
       Set<Urn> children =
-          result.verticesOrEmpty().stream()
-              .filter(urn -> !urn.equals(parentUrn.toString()))
-              .map(UrnUtils::getUrn)
-              .collect(Collectors.toCollection(LinkedHashSet::new));
+          EntityGraphEndpoints.toUrnSet(
+              result.verticesOrEmpty().stream()
+                  .filter(urn -> !urn.equals(parentUrn.toString()))
+                  .collect(Collectors.toCollection(LinkedHashSet::new)));
       return new DirectChildrenResult(children, false);
     }
     return GraphScrollFallback.directChildren(opContext, spec, parentUrn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccess.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccess.java
@@ -2,9 +2,9 @@ package com.linkedin.metadata.graph.cache.client;
 
 import com.datahub.authorization.SessionActorIdentity;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.graph.cache.MembershipNeighborResult;
 import com.linkedin.metadata.graph.cache.TraversalDirection;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpoints;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
 import java.util.ArrayList;
@@ -252,10 +252,10 @@ public final class BoundMembershipAccess {
 
   @Nonnull
   private static Set<Urn> toNeighborUrns(@Nonnull MembershipNeighborResult result) {
-    return result.neighborsOrEmpty().stream()
-        .map(MembershipNeighborResult.Neighbor::neighborUrn)
-        .map(UrnUtils::getUrn)
-        .collect(Collectors.toCollection(LinkedHashSet::new));
+    return EntityGraphEndpoints.toUrnSet(
+        result.neighborsOrEmpty().stream()
+            .map(MembershipNeighborResult.Neighbor::neighborUrn)
+            .collect(Collectors.toCollection(LinkedHashSet::new)));
   }
 
   private static boolean shouldUseCache(

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
@@ -1,10 +1,10 @@
 package com.linkedin.metadata.graph.cache.client;
 
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.aspect.GraphRetriever;
 import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpoints;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -67,9 +67,12 @@ public final class GraphScrollFallback {
                 null,
                 null);
         if (result.getEntities() != null) {
-          result.getEntities().stream()
-              .map(related -> UrnUtils.getUrn(related.getSourceUrn()))
-              .forEach(children::add);
+          for (var related : result.getEntities()) {
+            Urn child = EntityGraphEndpoints.toUrn(related.getSourceUrn());
+            if (child != null) {
+              children.add(child);
+            }
+          }
         }
       }
       return new DirectChildrenResult(children, false);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
@@ -91,11 +91,12 @@ public final class MembershipGraphScrollFallback {
                 direction == TraversalDirection.FORWARD
                     ? related.getDestinationUrn()
                     : related.getSourceUrn();
-            if (EntityGraphEndpoints.parse(neighborUrn) == null) {
+            String canonical = EntityGraphEndpoints.parse(neighborUrn);
+            if (canonical == null) {
               continue;
             }
             neighbors.add(
-                new MembershipNeighborResult.Neighbor(neighborUrn, related.getRelationshipType()));
+                new MembershipNeighborResult.Neighbor(canonical, related.getRelationshipType()));
           }
         }
       }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
@@ -12,6 +12,7 @@ import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.graph.cache.MembershipNeighborResult;
 import com.linkedin.metadata.graph.cache.ReadMissReason;
 import com.linkedin.metadata.graph.cache.TraversalDirection;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpoints;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -90,6 +91,9 @@ public final class MembershipGraphScrollFallback {
                 direction == TraversalDirection.FORWARD
                     ? related.getDestinationUrn()
                     : related.getSourceUrn();
+            if (EntityGraphEndpoints.parse(neighborUrn) == null) {
+              continue;
+            }
             neighbors.add(
                 new MembershipNeighborResult.Neighbor(neighborUrn, related.getRelationshipType()));
           }
@@ -148,7 +152,10 @@ public final class MembershipGraphScrollFallback {
         listRelated(opContext, spec, seedUrn, direction, relationshipTypes, 0, Integer.MAX_VALUE);
     LinkedHashSet<Urn> urns = new LinkedHashSet<>();
     for (MembershipNeighborResult.Neighbor neighbor : result.neighborsOrEmpty()) {
-      urns.add(UrnUtils.getUrn(neighbor.neighborUrn()));
+      Urn urn = EntityGraphEndpoints.toUrn(neighbor.neighborUrn());
+      if (urn != null) {
+        urns.add(urn);
+      }
     }
     return urns;
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphEndpoints.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphEndpoints.java
@@ -1,0 +1,96 @@
+package com.linkedin.metadata.graph.cache.snapshot;
+
+import com.linkedin.common.urn.Urn;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Parses optional relationship endpoints for entity graph snapshots. Missing, JSON-null, blank, or
+ * unparsable values are absence — not vertices.
+ */
+@Slf4j
+public final class EntityGraphEndpoints {
+
+  private EntityGraphEndpoints() {}
+
+  /**
+   * Returns a canonical URN string when {@code raw} parses as a URN; {@code null} when the value is
+   * missing, JSON-null, blank, or unparsable.
+   */
+  @Nullable
+  public static String parse(@Nullable String raw) {
+    Urn urn = toUrn(raw);
+    return urn == null ? null : urn.toString();
+  }
+
+  /**
+   * Returns a {@link Urn} when {@code raw} parses; {@code null} when the value is missing,
+   * JSON-null, blank, or unparsable. Does not throw.
+   */
+  @Nullable
+  public static Urn toUrn(@Nullable String raw) {
+    if (raw == null || raw.isBlank()) {
+      return null;
+    }
+    String stripped = stripQuotes(raw.trim());
+    if (stripped.isEmpty() || "null".equalsIgnoreCase(stripped)) {
+      return null;
+    }
+    try {
+      return Urn.createFromString(stripped);
+    } catch (URISyntaxException e) {
+      log.debug("Skipping unparsable entity graph endpoint {}", stripped, e);
+      return null;
+    }
+  }
+
+  public static boolean isValidEdge(@Nullable String source, @Nullable String dest) {
+    return parse(source) != null && parse(dest) != null;
+  }
+
+  @Nonnull
+  public static List<Urn> toUrnList(@Nullable Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return List.of();
+    }
+    List<Urn> urns = new ArrayList<>();
+    for (String value : values) {
+      Urn urn = toUrn(value);
+      if (urn != null) {
+        urns.add(urn);
+      }
+    }
+    return urns;
+  }
+
+  @Nonnull
+  public static Set<Urn> toUrnSet(@Nullable Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return Collections.emptySet();
+    }
+    LinkedHashSet<Urn> urns = new LinkedHashSet<>();
+    for (String value : values) {
+      Urn urn = toUrn(value);
+      if (urn != null) {
+        urns.add(urn);
+      }
+    }
+    return urns;
+  }
+
+  static String stripQuotes(@Nonnull String value) {
+    String trimmed = value.trim();
+    if (trimmed.startsWith("\"") && trimmed.endsWith("\"") && trimmed.length() >= 2) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
@@ -842,17 +842,22 @@ public class EntityGraphSnapshotBuilder {
       @Nonnull String relType,
       @Nonnull EntityGraphDefinition definition,
       @Nullable Set<String> neighbors) {
-    if (!EntityGraphEndpoints.isValidEdge(related.getSourceUrn(), related.getDestinationUrn())) {
+    String source = EntityGraphEndpoints.parse(related.getSourceUrn());
+    String dest = EntityGraphEndpoints.parse(related.getDestinationUrn());
+    if (source == null || dest == null) {
       return false;
     }
-    accumulator.addEdge(
-        related.getSourceUrn(),
-        related.getDestinationUrn(),
+    accumulator.addCanonicalEdge(
+        source,
+        dest,
         relType,
         definition.getBounds().getMaxVertices(),
         definition.getBounds().getMaxEdges().orElse(Integer.MAX_VALUE));
     if (neighbors != null) {
-      neighbors.add(related.asRelatedEntity().getUrn());
+      String neighbor = EntityGraphEndpoints.parse(related.asRelatedEntity().getUrn());
+      if (neighbor != null) {
+        neighbors.add(neighbor);
+      }
     }
     return true;
   }
@@ -907,12 +912,17 @@ public class EntityGraphSnapshotBuilder {
     }
 
     void addEdge(String sourceUrn, String destUrn, String relType, int maxVertices, int maxEdges) {
-      if (bypassed) {
-        return;
-      }
-      String source = EntityGraphEndpoints.parse(sourceUrn);
-      String dest = EntityGraphEndpoints.parse(destUrn);
-      if (source == null || dest == null) {
+      addCanonicalEdge(
+          EntityGraphEndpoints.parse(sourceUrn),
+          EntityGraphEndpoints.parse(destUrn),
+          relType,
+          maxVertices,
+          maxEdges);
+    }
+
+    void addCanonicalEdge(
+        String source, String dest, String relType, int maxVertices, int maxEdges) {
+      if (bypassed || source == null || dest == null) {
         return;
       }
       vertices.add(source);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilder.java
@@ -442,13 +442,7 @@ public class EntityGraphSnapshotBuilder {
           if (accumulator.isBypassed()) {
             break;
           }
-          accumulator.addEdge(
-              related.getSourceUrn(),
-              related.getDestinationUrn(),
-              relType,
-              definition.getBounds().getMaxVertices(),
-              definition.getBounds().getMaxEdges().orElse(Integer.MAX_VALUE));
-          neighbors.add(related.asRelatedEntity().getUrn());
+          addRelatedEdge(accumulator, related, relType, definition, neighbors);
         }
 
         if (result.getScrollId() != null && accumulator.isBypassed()) {
@@ -727,12 +721,7 @@ public class EntityGraphSnapshotBuilder {
                   if (accumulator.isBypassed()) {
                     return;
                   }
-                  accumulator.addEdge(
-                      related.getSourceUrn(),
-                      related.getDestinationUrn(),
-                      relType,
-                      definition.getBounds().getMaxVertices(),
-                      definition.getBounds().getMaxEdges().orElse(Integer.MAX_VALUE));
+                  addRelatedEdge(accumulator, related, relType, definition, null);
                 });
       } while (result != null && result.getScrollId() != null && !accumulator.isBypassed());
 
@@ -799,19 +788,19 @@ public class EntityGraphSnapshotBuilder {
       return null;
     }
     StringMap extra = entity.getExtraFields();
-    String direct = extra.get(searchField);
-    if (direct != null && !direct.isBlank()) {
-      return stripQuotes(direct);
+    String parsed = EntityGraphEndpoints.parse(extra.get(searchField));
+    if (parsed != null) {
+      return parsed;
     }
     String leaf = leafFieldName(searchField);
     if (leaf != null) {
-      String leafVal = extra.get(leaf);
-      if (leafVal != null && !leafVal.isBlank()) {
-        return stripQuotes(leafVal);
+      parsed = EntityGraphEndpoints.parse(extra.get(leaf));
+      if (parsed != null) {
+        return parsed;
       }
-      String keyword = extra.get(leaf + ".keyword");
-      if (keyword != null && !keyword.isBlank()) {
-        return stripQuotes(keyword);
+      parsed = EntityGraphEndpoints.parse(extra.get(leaf + ".keyword"));
+      if (parsed != null) {
+        return parsed;
       }
     }
     return null;
@@ -820,14 +809,6 @@ public class EntityGraphSnapshotBuilder {
   private static String leafFieldName(@Nonnull String searchField) {
     int idx = searchField.lastIndexOf('.');
     return idx >= 0 ? searchField.substring(idx + 1) : searchField;
-  }
-
-  private static String stripQuotes(@Nonnull String value) {
-    String trimmed = value.trim();
-    if (trimmed.startsWith("\"") && trimmed.endsWith("\"") && trimmed.length() >= 2) {
-      return trimmed.substring(1, trimmed.length() - 1);
-    }
-    return trimmed;
   }
 
   @Nonnull
@@ -852,7 +833,28 @@ public class EntityGraphSnapshotBuilder {
     if (value instanceof Urn urn) {
       return urn.toString();
     }
-    return value.toString();
+    return EntityGraphEndpoints.parse(value.toString());
+  }
+
+  private static boolean addRelatedEdge(
+      @Nonnull EdgeAccumulator accumulator,
+      @Nonnull RelatedEntities related,
+      @Nonnull String relType,
+      @Nonnull EntityGraphDefinition definition,
+      @Nullable Set<String> neighbors) {
+    if (!EntityGraphEndpoints.isValidEdge(related.getSourceUrn(), related.getDestinationUrn())) {
+      return false;
+    }
+    accumulator.addEdge(
+        related.getSourceUrn(),
+        related.getDestinationUrn(),
+        relType,
+        definition.getBounds().getMaxVertices(),
+        definition.getBounds().getMaxEdges().orElse(Integer.MAX_VALUE));
+    if (neighbors != null) {
+      neighbors.add(related.asRelatedEntity().getUrn());
+    }
+    return true;
   }
 
   @Nonnull
@@ -908,16 +910,21 @@ public class EntityGraphSnapshotBuilder {
       if (bypassed) {
         return;
       }
-      vertices.add(sourceUrn);
-      vertices.add(destUrn);
+      String source = EntityGraphEndpoints.parse(sourceUrn);
+      String dest = EntityGraphEndpoints.parse(destUrn);
+      if (source == null || dest == null) {
+        return;
+      }
+      vertices.add(source);
+      vertices.add(dest);
       if (vertices.size() > maxVertices) {
         bypass("vertex_limit");
         return;
       }
       DirectedEdge edge =
           DirectedEdge.builder()
-              .sourceUrn(sourceUrn)
-              .destinationUrn(destUrn)
+              .sourceUrn(source)
+              .destinationUrn(dest)
               .relationshipType(relType)
               .build();
       edgesByLine.putIfAbsent(edge.canonicalLine(), edge);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphView.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphView.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.graph.AsSubgraph;
@@ -308,6 +309,23 @@ public class EntityGraphView {
     return direction == TraversalDirection.FORWARD ? edge.getDestinationUrn() : edge.getSourceUrn();
   }
 
+  @Nullable
+  private static DirectedEdge canonicalize(@Nonnull DirectedEdge edge) {
+    String source = EntityGraphEndpoints.parse(edge.getSourceUrn());
+    String dest = EntityGraphEndpoints.parse(edge.getDestinationUrn());
+    if (source == null || dest == null) {
+      return null;
+    }
+    if (source.equals(edge.getSourceUrn()) && dest.equals(edge.getDestinationUrn())) {
+      return edge;
+    }
+    return DirectedEdge.builder()
+        .sourceUrn(source)
+        .destinationUrn(dest)
+        .relationshipType(edge.getRelationshipType())
+        .build();
+  }
+
   @Nonnull
   private DirectedMultigraph<String, DirectedEdge> forwardGraph() {
     DirectedMultigraph<String, DirectedEdge> graph = forwardGraph;
@@ -357,13 +375,14 @@ public class EntityGraphView {
   private DirectedMultigraph<String, DirectedEdge> buildForwardGraph() {
     DirectedMultigraph<String, DirectedEdge> graph = new DirectedMultigraph<>(DirectedEdge.class);
     for (DirectedEdge edge : edges) {
-      if (!EntityGraphEndpoints.isValidEdge(edge.getSourceUrn(), edge.getDestinationUrn())) {
+      DirectedEdge canonical = canonicalize(edge);
+      if (canonical == null) {
         continue;
       }
-      graph.addVertex(edge.getSourceUrn());
-      graph.addVertex(edge.getDestinationUrn());
-      if (!graph.containsEdge(edge)) {
-        graph.addEdge(edge.getSourceUrn(), edge.getDestinationUrn(), edge);
+      graph.addVertex(canonical.getSourceUrn());
+      graph.addVertex(canonical.getDestinationUrn());
+      if (!graph.containsEdge(canonical)) {
+        graph.addEdge(canonical.getSourceUrn(), canonical.getDestinationUrn(), canonical);
       }
     }
     return graph;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphView.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphView.java
@@ -357,6 +357,9 @@ public class EntityGraphView {
   private DirectedMultigraph<String, DirectedEdge> buildForwardGraph() {
     DirectedMultigraph<String, DirectedEdge> graph = new DirectedMultigraph<>(DirectedEdge.class);
     for (DirectedEdge edge : edges) {
+      if (!EntityGraphEndpoints.isValidEdge(edge.getSourceUrn(), edge.getDestinationUrn())) {
+        continue;
+      }
       graph.addVertex(edge.getSourceUrn());
       graph.addVertex(edge.getDestinationUrn());
       if (!graph.containsEdge(edge)) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallbackTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallbackTest.java
@@ -151,6 +151,66 @@ public class MembershipGraphScrollFallbackTest {
   }
 
   @Test
+  public void listRelatedCanonicalizesQuotedNeighborsAndSkipsNull() {
+    GraphRetriever graphRetriever = mock(GraphRetriever.class);
+    when(graphRetriever.scrollRelatedEntities(
+            eq(Set.of(CORP_USER_ENTITY_NAME)),
+            any(),
+            eq(Set.of(CORP_GROUP_ENTITY_NAME)),
+            isNull(),
+            eq(spec.getGroupRelationshipTypes()),
+            any(),
+            eq(Edge.EDGE_SORT_CRITERION),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                3,
+                3,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        IS_MEMBER_OF_GROUP_RELATIONSHIP_NAME,
+                        USER.toString(),
+                        "  " + GROUP.toString() + "  ",
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        IS_MEMBER_OF_GROUP_RELATIONSHIP_NAME,
+                        USER.toString(),
+                        "null",
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        IS_MEMBER_OF_GROUP_RELATIONSHIP_NAME,
+                        USER.toString(),
+                        "\"urn:li:corpGroup:other\"",
+                        RelationshipDirection.OUTGOING,
+                        null))));
+
+    opContext = contextWithGraphRetriever(graphRetriever);
+
+    MembershipNeighborResult result =
+        MembershipGraphScrollFallback.listRelated(
+            opContext,
+            spec,
+            USER.toString(),
+            TraversalDirection.FORWARD,
+            spec.getGroupRelationshipTypes(),
+            0,
+            10);
+
+    assertTrue(result.isHit());
+    assertEquals(
+        result.neighborsOrEmpty().stream()
+            .map(MembershipNeighborResult.Neighbor::neighborUrn)
+            .toList(),
+        List.of(GROUP.toString(), "urn:li:corpGroup:other"));
+  }
+
+  @Test
   public void listRelatedScrollsGroupReverseToMembers() {
     GraphRetriever graphRetriever = mock(GraphRetriever.class);
     when(graphRetriever.scrollRelatedEntities(

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphEndpointsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphEndpointsTest.java
@@ -1,0 +1,63 @@
+package com.linkedin.metadata.graph.cache.snapshot;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class EntityGraphEndpointsTest {
+
+  private static final String CHILD = "urn:li:foo:a";
+  private static final String PARENT = "urn:li:foo:b";
+
+  @Test
+  public void parseTreatsMissingAndJsonNullAsAbsent() {
+    assertNull(EntityGraphEndpoints.parse(null));
+    assertNull(EntityGraphEndpoints.parse(""));
+    assertNull(EntityGraphEndpoints.parse("   "));
+    assertNull(EntityGraphEndpoints.parse("null"));
+    assertNull(EntityGraphEndpoints.parse("NULL"));
+    assertNull(EntityGraphEndpoints.parse("\"null\""));
+  }
+
+  @Test
+  public void parseAcceptsQuotedAndRawUrns() {
+    assertEquals(EntityGraphEndpoints.parse(CHILD), CHILD);
+    assertEquals(EntityGraphEndpoints.parse("\"" + PARENT + "\""), PARENT);
+    assertEquals(EntityGraphEndpoints.parse("  " + CHILD + "  "), CHILD);
+  }
+
+  @Test
+  public void parseSkipsUnparsableTokensWithoutThrowing() {
+    assertNull(EntityGraphEndpoints.parse("not-a-urn"));
+    assertNull(EntityGraphEndpoints.parse("urn:garbage"));
+    assertNull(EntityGraphEndpoints.toUrn("not-a-urn"));
+  }
+
+  @Test
+  public void isValidEdgeRequiresBothEndpoints() {
+    assertTrue(EntityGraphEndpoints.isValidEdge(CHILD, PARENT));
+    assertFalse(EntityGraphEndpoints.isValidEdge(CHILD, "null"));
+    assertFalse(EntityGraphEndpoints.isValidEdge(null, PARENT));
+    assertFalse(EntityGraphEndpoints.isValidEdge(CHILD, "not-a-urn"));
+  }
+
+  @Test
+  public void toUrnListAndSetDropInvalidAndKeepOrder() {
+    Urn child = UrnUtils.getUrn(CHILD);
+    Urn parent = UrnUtils.getUrn(PARENT);
+
+    assertEquals(EntityGraphEndpoints.toUrnList(List.of("null")), List.of());
+    assertEquals(
+        EntityGraphEndpoints.toUrnList(List.of(CHILD, "null", PARENT, "not-a-urn")),
+        List.of(child, parent));
+    assertEquals(
+        EntityGraphEndpoints.toUrnSet(List.of("null", CHILD, "null", PARENT)),
+        java.util.Set.of(child, parent));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderGraphTest.java
@@ -140,6 +140,49 @@ public class EntityGraphSnapshotBuilderGraphTest {
   }
 
   @Test
+  public void fullGraphBuildSkipsUnparsableEndpoints() {
+    when(graphRetriever.scrollRelatedEntities(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                2,
+                2,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        "IsPartOf",
+                        "urn:li:foo:child",
+                        "urn:li:foo:parent",
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        "IsPartOf",
+                        "urn:li:foo:other",
+                        "null",
+                        RelationshipDirection.OUTGOING,
+                        null))));
+
+    BuildResult result =
+        builder.build(opContext, fullGraphDefinition, GraphSnapshotSource.GRAPH, null);
+
+    assertEquals(result.getStatus(), CacheStatus.ACTIVE);
+    assertNotNull(result.getSnapshot());
+    assertEquals(result.getSnapshot().getEdges().size(), 1);
+    assertEquals(result.getSnapshot().getEdges().get(0).getSourceUrn(), "urn:li:foo:child");
+    assertEquals(result.getSnapshot().getEdges().get(0).getDestinationUrn(), "urn:li:foo:parent");
+  }
+
+  @Test
   public void fullGraphBuildSucceedsFromGraphScroll() {
     when(graphRetriever.scrollRelatedEntities(
             any(),

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderPartialTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderPartialTest.java
@@ -45,6 +45,7 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.test.metadata.aspect.TestEntityRegistry;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -187,6 +188,85 @@ public class EntityGraphSnapshotBuilderPartialTest {
     assertEquals(result.getStatus(), CacheStatus.ACTIVE);
     assertTrue(result.getSnapshot().getTraversalCoverage().canSatisfy(TraversalDirection.FORWARD));
     assertEquals(result.getSnapshot().getEdges().size(), 2);
+  }
+
+  @Test
+  public void searchBuildSkipsJsonNullRelatedField() {
+    String grandchild = "urn:li:foo:grandchild";
+    String child = "urn:li:foo:child";
+    GraphEdgeTriplet triplet =
+        GraphEdgeTriplet.builder()
+            .sourceEntityType("foo")
+            .destinationEntityType("foo")
+            .relationshipType("Related")
+            .build();
+    EntityGraphDefinition definition =
+        partialDefinition(
+            GraphSnapshotSource.SEARCH,
+            List.of(
+                ResolvedGraphEdge.builder()
+                    .triplet(triplet)
+                    .searchField("related")
+                    .searchable(true)
+                    .graphDirection(RelationshipDirection.OUTGOING)
+                    .build()),
+            100);
+
+    SearchRetriever searchRetriever = mock(SearchRetriever.class);
+    when(searchRetriever.scroll(any(), any(), nullable(String.class), anyInt(), any(), any()))
+        .thenReturn(searchScrollResult("related", grandchild, child))
+        .thenReturn(searchScrollResult("related", child, "null"));
+
+    BuildResult result =
+        builder.buildPartial(
+            opContextWithSearch(searchRetriever),
+            definition,
+            GraphSnapshotSource.SEARCH,
+            Set.of(grandchild),
+            TraversalDirection.FORWARD,
+            null,
+            null,
+            null);
+
+    assertEquals(result.getStatus(), CacheStatus.ACTIVE);
+    assertEquals(result.getSnapshot().getEdges().size(), 1);
+    assertEquals(result.getSnapshot().getEdges().get(0).getSourceUrn(), grandchild);
+    assertEquals(result.getSnapshot().getEdges().get(0).getDestinationUrn(), child);
+  }
+
+  @Test
+  public void primaryBuildSkipsUnsetRelatedEndpoint() {
+    when(aspectRetriever.getLatestAspectObjects(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Set<Urn> urns = invocation.getArgument(1);
+              HashMap<Urn, Map<String, Aspect>> batch = new HashMap<>();
+              if (urns.contains(UrnUtils.getUrn(CHILD))) {
+                batch.putAll(aspectBatch(CHILD, ROOT));
+              }
+              if (urns.contains(UrnUtils.getUrn(ROOT))) {
+                batch.put(
+                    UrnUtils.getUrn(ROOT),
+                    Map.of("domainProperties", new Aspect(new DomainProperties().data())));
+              }
+              return batch;
+            });
+
+    BuildResult result =
+        builder.buildPartial(
+            opContext,
+            primaryDefinition,
+            GraphSnapshotSource.PRIMARY,
+            Set.of(CHILD),
+            TraversalDirection.FORWARD,
+            null,
+            null,
+            null);
+
+    assertEquals(result.getStatus(), CacheStatus.ACTIVE);
+    assertEquals(result.getSnapshot().getEdges().size(), 1);
+    assertEquals(result.getSnapshot().getEdges().get(0).getSourceUrn(), CHILD);
+    assertEquals(result.getSnapshot().getEdges().get(0).getDestinationUrn(), ROOT);
   }
 
   @Test
@@ -494,10 +574,14 @@ public class EntityGraphSnapshotBuilderPartialTest {
   }
 
   private static ScrollResult searchScrollResult(String sourceUrn, String destUrn) {
+    return searchScrollResult("parentDomain", sourceUrn, destUrn);
+  }
+
+  private static ScrollResult searchScrollResult(String field, String sourceUrn, String destUrn) {
     SearchEntity entity =
         new SearchEntity()
             .setEntity(UrnUtils.getUrn(sourceUrn))
-            .setExtraFields(new StringMap(Map.of("parentDomain", destUrn)));
+            .setExtraFields(new StringMap(Map.of(field, destUrn)));
     return new ScrollResult().setEntities(new SearchEntityArray(entity));
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderPartialTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderPartialTest.java
@@ -37,6 +37,7 @@ import com.linkedin.metadata.graph.cache.config.EntityGraphModel.LocalEvictionLi
 import com.linkedin.metadata.graph.cache.config.EntityGraphModel.ResolvedGraphEdge;
 import com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshotBuilder.BuildResult;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
 import com.linkedin.metadata.search.ScrollResult;
@@ -267,6 +268,79 @@ public class EntityGraphSnapshotBuilderPartialTest {
     assertEquals(result.getSnapshot().getEdges().size(), 1);
     assertEquals(result.getSnapshot().getEdges().get(0).getSourceUrn(), CHILD);
     assertEquals(result.getSnapshot().getEdges().get(0).getDestinationUrn(), ROOT);
+  }
+
+  @Test
+  public void graphPartialBuildCanonicalizesQuotedNeighborFrontier() {
+    EntityGraphDefinition graphDefinition =
+        partialDefinition(GraphSnapshotSource.GRAPH, resolvedEdges, 100);
+
+    when(graphRetriever.scrollRelatedEntities(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            argThat(
+                (RelationshipFilter filter) ->
+                    filter.getDirection() == RelationshipDirection.OUTGOING),
+            any(),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenAnswer(
+            invocation -> {
+              Filter sourceFilter = invocation.getArgument(1);
+              if (filterHasExactUrn(sourceFilter, GRANDCHILD)) {
+                return new RelatedEntitiesScrollResult(
+                    1,
+                    1,
+                    null,
+                    List.of(
+                        new RelatedEntities(
+                            "IsPartOf",
+                            GRANDCHILD,
+                            "\"" + CHILD + "\"",
+                            RelationshipDirection.OUTGOING,
+                            null)));
+              }
+              if (filterHasExactUrn(sourceFilter, CHILD)) {
+                return new RelatedEntitiesScrollResult(
+                    1,
+                    1,
+                    null,
+                    List.of(
+                        new RelatedEntities(
+                            "IsPartOf", CHILD, ROOT, RelationshipDirection.OUTGOING, null)));
+              }
+              return new RelatedEntitiesScrollResult(0, 0, null, List.of());
+            });
+
+    BuildResult result =
+        builder.buildPartial(
+            opContext,
+            graphDefinition,
+            GraphSnapshotSource.GRAPH,
+            Set.of(GRANDCHILD),
+            TraversalDirection.FORWARD,
+            null,
+            null,
+            null);
+
+    assertEquals(result.getStatus(), CacheStatus.ACTIVE);
+    assertEquals(result.getSnapshot().getEdges().size(), 2);
+    assertTrue(
+        result.getSnapshot().getEdges().stream()
+            .anyMatch(
+                edge ->
+                    CHILD.equals(edge.getSourceUrn()) && ROOT.equals(edge.getDestinationUrn())));
+    assertTrue(
+        result.getSnapshot().getEdges().stream()
+            .anyMatch(
+                edge ->
+                    GRANDCHILD.equals(edge.getSourceUrn())
+                        && CHILD.equals(edge.getDestinationUrn())));
   }
 
   @Test
@@ -551,6 +625,17 @@ public class EntityGraphSnapshotBuilderPartialTest {
         .scrollBatchSize(100)
         .enabled(true)
         .build();
+  }
+
+  private static boolean filterHasExactUrn(Filter filter, String urn) {
+    if (filter == null || filter.getOr() == null) {
+      return false;
+    }
+    return filter.getOr().stream()
+        .filter(or -> or.getAnd() != null)
+        .flatMap(or -> or.getAnd().stream())
+        .anyMatch(
+            criterion -> criterion.getValues() != null && criterion.getValues().contains(urn));
   }
 
   private OperationContext opContextWithSearch(SearchRetriever searchRetriever) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderUtilitiesTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphSnapshotBuilderUtilitiesTest.java
@@ -53,6 +53,30 @@ public class EntityGraphSnapshotBuilderUtilitiesTest {
   }
 
   @Test
+  public void extractRelatedUrnTreatsJsonNullAndGarbageAsAbsent() {
+    SearchEntity entity =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:foo:a"))
+            .setExtraFields(
+                new StringMap(
+                    java.util.Map.of(
+                        "related", "null", "related.keyword", "\"null\"", "other", "not-a-urn")));
+
+    assertNull(EntityGraphSnapshotBuilder.extractRelatedUrn(entity, "related"));
+    assertNull(EntityGraphSnapshotBuilder.extractRelatedUrn(entity, "other"));
+  }
+
+  @Test
+  public void extractRelatedUrnReadsGenericRelatedField() {
+    SearchEntity entity =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:foo:a"))
+            .setExtraFields(new StringMap(java.util.Map.of("related", "urn:li:foo:b")));
+
+    assertEquals(EntityGraphSnapshotBuilder.extractRelatedUrn(entity, "related"), "urn:li:foo:b");
+  }
+
+  @Test
   public void topologyFingerprintIsStableAndOrderIndependent() {
     List<EntityGraphSnapshot.DirectedEdge> edgesA =
         List.of(

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphViewTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphViewTest.java
@@ -117,6 +117,26 @@ public class EntityGraphViewTest {
   }
 
   @Test
+  public void expandCanonicalizesQuotedAndPaddedEndpoints() {
+    String child = "urn:li:foo:a";
+    String parent = "urn:li:foo:b";
+    EntityGraphView view =
+        new EntityGraphView(
+            List.of(
+                DirectedEdge.builder()
+                    .sourceUrn("  " + child + "  ")
+                    .destinationUrn("\"" + parent + "\"")
+                    .relationshipType("Related")
+                    .build()));
+
+    assertEquals(
+        view.expand(TraversalDirection.FORWARD, Set.of(child), 100, 2), Set.of(child, parent));
+    assertTrue(view.containsVertex(child));
+    assertTrue(view.containsVertex(parent));
+    assertEquals(view.orderedForwardAncestors(child, 10), List.of(parent));
+  }
+
+  @Test
   public void orderedForwardAncestorsReturnsParentChain() {
     EntityGraphView view = linearView();
     assertEquals(view.orderedForwardAncestors(GRANDCHILD, 10), List.of(CHILD, ROOT));

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphViewTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/snapshot/EntityGraphViewTest.java
@@ -93,6 +93,30 @@ public class EntityGraphViewTest {
   }
 
   @Test
+  public void expandAndAncestorsSkipUnparsableEndpoints() {
+    String child = "urn:li:foo:a";
+    String parent = "urn:li:foo:b";
+    EntityGraphView view =
+        new EntityGraphView(
+            List.of(
+                DirectedEdge.builder()
+                    .sourceUrn(child)
+                    .destinationUrn(parent)
+                    .relationshipType("Related")
+                    .build(),
+                DirectedEdge.builder()
+                    .sourceUrn(child)
+                    .destinationUrn("null")
+                    .relationshipType("Related")
+                    .build()));
+
+    assertEquals(
+        view.expand(TraversalDirection.FORWARD, Set.of(child), 100, 2), Set.of(child, parent));
+    assertEquals(view.orderedForwardAncestors(child, 10), List.of(parent));
+    assertFalse(view.containsVertex("null"));
+  }
+
+  @Test
   public void orderedForwardAncestorsReturnsParentChain() {
     EntityGraphView view = linearView();
     assertEquals(view.orderedForwardAncestors(GRANDCHILD, 10), List.of(CHILD, ROOT));

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/store/EntityGraphDistributedStorePublishTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/store/EntityGraphDistributedStorePublishTest.java
@@ -108,7 +108,7 @@ public class EntityGraphDistributedStorePublishTest {
   }
 
   @Test
-  public void staleBuildingLeaseCanBeReclaimedExclusively() throws InterruptedException {
+  public void staleBuildingLeaseCanBeReclaimedExclusively() {
     String cacheKey = EntityGraphCacheKeys.fullCacheKey("domain", GraphSnapshotSource.SEARCH);
     long leaseBlockMillis = 60_000L;
     long staleAfterMillis = 50L;
@@ -116,10 +116,17 @@ public class EntityGraphDistributedStorePublishTest {
     assertTrue(store.tryClaimRebuild(cacheKey, leaseBlockMillis));
     assertFalse(store.tryClaimRebuild(cacheKey, leaseBlockMillis));
 
-    Thread.sleep(staleAfterMillis + 20);
+    // Backdate the BUILDING lease so staleness does not depend on Thread.sleep under CI load.
+    hazelcast
+        .getMap(EntityGraphCacheProperties.STATUS_MAP)
+        .put(
+            cacheKey,
+            EntityGraphOperationalStatus.of(
+                CacheStatus.BUILDING, System.currentTimeMillis() - staleAfterMillis - 1));
 
     assertTrue(store.tryClaimRebuild(cacheKey, staleAfterMillis));
-    assertFalse(store.tryClaimRebuild(cacheKey, staleAfterMillis));
+    // Exclusive check uses a long TTL so a GC pause cannot make the new lease look stale.
+    assertFalse(store.tryClaimRebuild(cacheKey, leaseBlockMillis));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinatorAlignmentTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/flush/AdaptiveFlushCoordinatorAlignmentTest.java
@@ -135,15 +135,19 @@ public class AdaptiveFlushCoordinatorAlignmentTest {
   }
 
   @Test
-  public void testAlignmentOffPreservesExistingScheduledBehavior() throws Exception {
+  public void testAlignmentOffPreservesExistingScheduledBehavior() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-07-10T10:50:00Z"));
     RecordingUsageFlushSink sink = new RecordingUsageFlushSink();
     InMemoryUsageAggregationStore store = store(sink, 300);
-    try (AdaptiveFlushCoordinator coordinator =
+    AdaptiveFlushCoordinator coordinator =
         new AdaptiveFlushCoordinator(
-            TestOperationContexts.systemContextNoSearchAuthorization(), store, 1)) {
-      Thread.sleep(1500);
+            TestOperationContexts.systemContextNoSearchAuthorization(), store, 1, clock, false);
+    try {
+      coordinator.tick();
       Assert.assertTrue(
           sink.batches().stream().anyMatch(batch -> batch.trigger() == FlushTrigger.SCHEDULED));
+    } finally {
+      coordinator.shutdown();
     }
   }
 


### PR DESCRIPTION
## Summary
- JSON-null and unset related fields were being stored as the string `"null"`, and cache hits then threw in `UrnUtils.getUrn`.
- Treat missing, blank, JSON-null, or unparsable relationship endpoints as no edge when building search, graph, and SQL snapshots, and when reading cached vertex/ancestor lists.
- Centralize that parsing in `EntityGraphEndpoints` and cover the skip paths in snapshot/view unit tests.

## Test plan
- [x] `./gradlew :metadata-io:spotlessApply` (no formatting changes)
- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpointsTest" --tests "com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshotBuilderGraphTest" --tests "com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshotBuilderPartialTest" --tests "com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshotBuilderUtilitiesTest" --tests "com.linkedin.metadata.graph.cache.snapshot.EntityGraphViewTest" --tests "com.linkedin.metadata.graph.cache.client.*"` (132 passing)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip and canonicalize invalid relationship endpoints across entity-graph cache builds and reads to prevent URN parsing errors, “null” vertices, and missed hops. Old behavior parsed raw strings (including "null", quoted, or padded) and could throw or add bad vertices; new behavior drops invalid endpoints and stores the canonical URN.

- Centralizes endpoint parsing/canonicalization in `EntityGraphEndpoints`; replaces direct URN parsing in cache clients, snapshot builders (search/graph/primary/SQL), membership and graph scroll fallbacks, and view construction.
- Writes canonical URNs to snapshots and view graphs; quoted or padded endpoints no longer break connectivity or traversal.
- Filters invalid endpoints when constructing graphs (`EntityGraphView`) and when reading cached vertex/ancestor lists and membership neighbors.
- Adds unit tests for parsing, snapshot building (full and partial), membership scroll, and view traversal with invalid endpoints.
- Deflakes lease reclaim and usage flush alignment tests by removing sleep-based timing and using backdated leases and deterministic ticks.
- No schema or config changes. No migrations required; existing caches with "null" entries are ignored on read.

<sup>Written for commit 845749f4458f486ae3e284907e5833feddc107a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

