### PR TITLE
fix(ci): do not treat pytest collection-error XML as all-passed

### DIFF
--- a/.github/scripts/parse_failed_pytest_tests.py
+++ b/.github/scripts/parse_failed_pytest_tests.py
@@ -19,6 +19,52 @@ from pathlib import Path
 from typing import Optional, Set
 
 
+class UnmappedFailuresError(Exception):
+    """JUnit reports errors/failures that could not be mapped to test modules."""
+
+
+def _module_path_from_nodeid(name: str) -> Optional[str]:
+    """Map a pytest nodeid (testcase name) to a .py path, or None if unusable."""
+    if not name:
+        return None
+    nodeid = name.split("::", 1)[0].strip().lstrip("./")
+    if nodeid.endswith(".py"):
+        return nodeid
+    return None
+
+
+def _module_path_from_testcase(testcase: ET.Element) -> Optional[str]:
+    classname = testcase.get("classname") or ""
+    name = testcase.get("name") or ""
+
+    if classname:
+        parts = classname.split(".")
+        if parts and parts[-1] and parts[-1][0].isupper():
+            parts = parts[:-1]
+        if parts:
+            return "/".join(parts) + ".py"
+
+    # Collection errors: classname is empty; name is the nodeid (file path).
+    return _module_path_from_nodeid(name)
+
+
+def _int_attr(element: ET.Element, attr: str) -> int:
+    try:
+        return int(element.get(attr) or 0)
+    except ValueError:
+        return 0
+
+
+def _suite_reported_problems(root: ET.Element) -> bool:
+    suites = root.findall(".//testsuite")
+    if root.tag == "testsuite":
+        suites = [root] + suites
+    for suite in suites:
+        if _int_attr(suite, "errors") > 0 or _int_attr(suite, "failures") > 0:
+            return True
+    return False
+
+
 def parse_failed_modules(input_dir: Path) -> Optional[Set[str]]:
     """
     Extract failed test module paths from pytest JUnit XML files.
@@ -28,8 +74,12 @@ def parse_failed_modules(input_dir: Path) -> Optional[Set[str]]:
 
     Returns:
         Set of relative test file paths (e.g., 'tests/structured_properties/test_structured_properties.py')
-        None if no XML files found
+        None if no XML files found or none parsed
         Empty set if all tests passed
+
+    Raises:
+        UnmappedFailuresError: Suite reported errors/failures but no module paths
+            could be extracted. Callers must not treat this as all-passed.
     """
     failed_modules: Set[str] = set()
     xml_files = list(input_dir.rglob("junit*.xml"))
@@ -37,35 +87,13 @@ def parse_failed_modules(input_dir: Path) -> Optional[Set[str]]:
     if not xml_files:
         return None
 
+    parsed_any = False
+    unmapped_failures = False
+
     for xml_file in xml_files:
         try:
             tree = ET.parse(xml_file)
             root = tree.getroot()
-
-            # Find all testcase elements with failures or errors
-            for testcase in root.findall('.//testcase'):
-                # Check if this testcase has a failure or error
-                has_failure = testcase.find('failure') is not None
-                has_error = testcase.find('error') is not None
-
-                if has_failure or has_error:
-                    classname = testcase.get('classname', '')
-                    if not classname:
-                        continue
-
-                    # Convert classname from dotted format to file path.
-                    # For class-based tests, pytest includes the class name in classname:
-                    #   tests.my_module.MyTestClass -> tests/my_module.py
-                    # For function-based tests, classname is just the module:
-                    #   tests.my_module -> tests/my_module.py
-                    # Python class names are PascalCase (start uppercase); module names are
-                    # snake_case (lowercase), so strip the trailing component if it's a class.
-                    parts = classname.split('.')
-                    if parts and parts[-1][0].isupper():
-                        parts = parts[:-1]
-                    module_path = '/'.join(parts) + '.py'
-                    failed_modules.add(module_path)
-
         except ET.ParseError as e:
             print(f"Warning: Failed to parse {xml_file}: {e}", file=sys.stderr)
             continue
@@ -73,13 +101,41 @@ def parse_failed_modules(input_dir: Path) -> Optional[Set[str]]:
             print(f"Warning: Error processing {xml_file}: {e}", file=sys.stderr)
             continue
 
+        parsed_any = True
+        mapped_from_this_file = False
+
+        for testcase in root.findall(".//testcase"):
+            has_failure = testcase.find("failure") is not None
+            has_error = testcase.find("error") is not None
+            if not (has_failure or has_error):
+                continue
+
+            module_path = _module_path_from_testcase(testcase)
+            if module_path:
+                failed_modules.add(module_path)
+                mapped_from_this_file = True
+            else:
+                unmapped_failures = True
+
+        if _suite_reported_problems(root) and not mapped_from_this_file:
+            unmapped_failures = True
+
+    if not parsed_any:
+        return None
+
+    if not failed_modules and unmapped_failures:
+        raise UnmappedFailuresError(
+            "JUnit XML reported errors or failures that could not be mapped "
+            "to test modules; refusing to treat results as all-passed"
+        )
+
     return failed_modules
 
 
 def main() -> None:
     """Main entry point for the script."""
     parser = argparse.ArgumentParser(
-        description='Parse failed pytest modules from JUnit XML',
+        description="Parse failed pytest modules from JUnit XML",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exit codes:
@@ -87,19 +143,19 @@ Exit codes:
   1 - Error during processing
   2 - No failures found (all tests passed)
   3 - No test results found (missing artifacts)
-        """
+        """,
     )
     parser.add_argument(
-        '--input-dir',
+        "--input-dir",
         required=True,
         type=Path,
-        help='Directory containing junit*.xml files'
+        help="Directory containing junit*.xml files",
     )
     parser.add_argument(
-        '--output',
+        "--output",
         required=True,
         type=Path,
-        help='Output file path for failed module list'
+        help="Output file path for failed module list",
     )
     args = parser.parse_args()
 
@@ -116,16 +172,19 @@ Exit codes:
             sys.exit(2)
 
         # Write failed modules (one per line)
-        args.output.write_text('\n'.join(sorted(failed_modules)) + '\n')
+        args.output.write_text("\n".join(sorted(failed_modules)) + "\n")
         print(f"Found {len(failed_modules)} failed module(s):")
         for module in sorted(failed_modules):
             print(f"  - {module}")
         sys.exit(0)
 
+    except UnmappedFailuresError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.github/scripts/test/test_parse_failed_pytest_tests.py
+++ b/.github/scripts/test/test_parse_failed_pytest_tests.py
@@ -1,0 +1,203 @@
+"""Unit tests for parse_failed_pytest_tests (run by test-github-scripts.yml)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import parse_failed_pytest_tests as parser  # noqa: E402
+
+SCRIPT = Path(__file__).resolve().parent.parent / "parse_failed_pytest_tests.py"
+
+COLLECTION_ERROR_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1" time="0.1">
+    <testcase classname="" name="tests/foo/test_bar.py" time="0">
+      <error message="collection failure">ImportError: cannot import name X</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+COLLECTION_ERROR_WITH_NODEID_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1" time="0.1">
+    <testcase classname="" name="tests/foo/test_bar.py::test_something" time="0">
+      <error message="collection failure">ImportError: cannot import name X</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+MIXED_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="2" time="0.2">
+    <testcase classname="tests.ok_module" name="test_ok" time="0.01"/>
+    <testcase classname="" name="tests/foo/test_broken.py" time="0">
+      <error message="collection failure">ImportError: boom</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+CLASS_BASED_FAILURE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="0" failures="1" skipped="0" tests="1" time="0.2">
+    <testcase classname="tests.my_module.MyTest" name="test_it" time="0.1">
+      <failure message="assert False">assert False</failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+ALL_PASS_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="2" time="0.2">
+    <testcase classname="tests.ok_module" name="test_ok" time="0.01"/>
+    <testcase classname="tests.ok_module" name="test_skip" time="0.0">
+      <skipped message="skip"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+UNMAPPED_SUITE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="0" time="0.1">
+  </testsuite>
+</testsuites>
+"""
+
+UNMAPPED_EMPTY_NAME_XML = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="1" failures="0" skipped="0" tests="1" time="0.1">
+    <testcase classname="" name="" time="0">
+      <error message="collection failure">ImportError: boom</error>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+
+def _write_junit(directory: Path, contents: str, name: str = "junit.smoke.xml") -> Path:
+    path = directory / name
+    path.write_text(contents)
+    return path
+
+
+class ParseFailedModulesTests(unittest.TestCase):
+    def test_collection_error_maps_file_from_name(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), COLLECTION_ERROR_XML)
+            self.assertEqual(
+                parser.parse_failed_modules(Path(d)),
+                {"tests/foo/test_bar.py"},
+            )
+
+    def test_collection_error_strips_nodeid_suffix(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), COLLECTION_ERROR_WITH_NODEID_XML)
+            self.assertEqual(
+                parser.parse_failed_modules(Path(d)),
+                {"tests/foo/test_bar.py"},
+            )
+
+    def test_mixed_pass_and_collection_error(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), MIXED_XML)
+            self.assertEqual(
+                parser.parse_failed_modules(Path(d)),
+                {"tests/foo/test_broken.py"},
+            )
+
+    def test_class_based_failure_strips_class_name(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), CLASS_BASED_FAILURE_XML)
+            self.assertEqual(
+                parser.parse_failed_modules(Path(d)),
+                {"tests/my_module.py"},
+            )
+
+    def test_all_pass_returns_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), ALL_PASS_XML)
+            self.assertEqual(parser.parse_failed_modules(Path(d)), set())
+
+    def test_unmapped_suite_errors_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), UNMAPPED_SUITE_XML)
+            with self.assertRaises(parser.UnmappedFailuresError):
+                parser.parse_failed_modules(Path(d))
+
+    def test_unmapped_empty_classname_and_name_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), UNMAPPED_EMPTY_NAME_XML)
+            with self.assertRaises(parser.UnmappedFailuresError):
+                parser.parse_failed_modules(Path(d))
+
+    def test_no_xml_files_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(parser.parse_failed_modules(Path(d)))
+
+    def test_unparsed_xml_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "junit.broken.xml").write_text("not xml <<<")
+            self.assertIsNone(parser.parse_failed_modules(Path(d)))
+
+
+class MainExitCodeTests(unittest.TestCase):
+    def _run(self, input_dir: Path) -> subprocess.CompletedProcess[str]:
+        output = input_dir / "failed.txt"
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--input-dir",
+                str(input_dir),
+                "--output",
+                str(output),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_collection_error_exits_has_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), COLLECTION_ERROR_XML)
+            result = self._run(Path(d))
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(
+                (Path(d) / "failed.txt").read_text(),
+                "tests/foo/test_bar.py\n",
+            )
+
+    def test_all_pass_exits_all_passed(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), ALL_PASS_XML)
+            result = self._run(Path(d))
+            self.assertEqual(result.returncode, 2)
+
+    def test_unmapped_suite_exits_error_not_all_passed(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _write_junit(Path(d), UNMAPPED_SUITE_XML)
+            result = self._run(Path(d))
+            self.assertEqual(result.returncode, 1)
+
+    def test_no_xml_exits_no_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            result = self._run(Path(d))
+            self.assertEqual(result.returncode, 3)
+
+    def test_unparsed_xml_exits_no_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            (Path(d) / "junit.broken.xml").write_text("not xml <<<")
+            result = self._run(Path(d))
+            self.assertEqual(result.returncode, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pytest collection/import failures write JUnit testcases with an empty `classname` and the file path in `name`. The smoke-test retry parser skipped those cases, returned exit 2 (`all_passed`), and `docker-unified.yml` skipped pytest on the next attempt — masking the original failure.

This change:

- Maps empty-classname errors from the pytest nodeid (`name`)
- Refuses to treat unmapped suite `errors`/`failures` as a pass (exit 1 → full-batch retry)
- Treats unparseable XML as missing results (exit 3), not all-passed

## Tests

- [x] Unit tests in `.github/scripts/test/test_parse_failed_pytest_tests.py` (collection-error, mixed pass + collection error, class-based failure, all-pass, unmapped suite, no XML)

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated (if applicable)
- [ ] Docs added/updated (if applicable)
- [ ] Breaking changes documented in `docs/how/updating-datahub.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be2a0ad3-d45b-4434-8caa-5db8cb215652?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be2a0ad3-d45b-4434-8caa-5db8cb215652&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI retry behavior by correctly parsing pytest collection/import errors in JUnit XML. Previously, empty-classname testcases were ignored, the parser returned “all passed” (exit 2), and the next attempt skipped pytest, masking real failures; now these errors are detected and trigger a retry.

- Maps empty-classname testcases to module paths using the pytest nodeid in `name`.
- If a suite reports errors/failures but no modules can be mapped, exits 1 to force a full-batch retry (not treated as pass).
- Treats unparseable or missing XML as missing results (exit 3), not all-passed.
- Adds unit tests covering collection errors, mixed results, class-based failures, unmapped suites, and missing/invalid XML.

<sup>Written for commit 4d20c13a3e91e33a0e3656c6ee2969e0e6e7fd43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

