### PR TITLE
fix(ingest/looker): preserve cross-project view project assignment in explore lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -223,8 +223,13 @@ class LookerViewId:
         for pattern in str_to_remove:
             new_file_path = re.sub(pattern, "", new_file_path)
 
+        # Use the project embedded in the file path itself when it is a cross-project import so
+        # that the prefix strip succeeds even if self.project_name is the explore's project.
+        project_in_path = (
+            extract_project_from_imported_file_path(new_file_path) or self.project_name
+        )
         str_to_replace: Dict[str, str] = {
-            f"^imported_projects/{re.escape(self.project_name)}/": "",  # escape any special regex character present in project-name
+            f"^imported_projects/{re.escape(project_in_path)}/": "",  # escape any special regex character present in project-name
             "/": ".",  # / is not urn friendly
         }
 
@@ -494,6 +499,20 @@ class ExploreUpstreamViewField:
         )
 
 
+def extract_project_from_imported_file_path(file_path: str) -> Optional[str]:
+    """
+    Returns the project name embedded in an imported_projects/ file path, or None.
+
+    Example: "imported_projects/project-a/views/foo.view.lkml" -> "project-a"
+    """
+    prefix = f"{IMPORTED_PROJECTS}/"
+    if file_path.startswith(prefix):
+        tokens = file_path.split("/")
+        if len(tokens) >= 2:
+            return tokens[1]
+    return None
+
+
 def create_view_project_map(
     view_fields: List[ViewField],
     explore_primary_view: Optional[str] = None,
@@ -511,19 +530,11 @@ def create_view_project_map(
     view_project_map: Dict[str, str] = {}
     for view_field in view_fields:
         if view_field.view_name is not None and view_field.project_name is not None:
-            # Override field-level project assignment for the primary view when different
-            if (
-                view_field.view_name == explore_primary_view
-                and explore_project_name is not None
-                and explore_project_name != view_field.project_name
-            ):
-                logger.debug(
-                    f"Overriding project assignment for primary view '{view_field.view_name}': "
-                    f"field-level project '{view_field.project_name}' → explore-level project '{explore_project_name}'"
-                )
-                view_project_map[view_field.view_name] = explore_project_name
-            else:
-                view_project_map[view_field.view_name] = view_field.project_name
+            # project_name is only non-None when set by extract_project_name_from_source_file(),
+            # which only returns a value for imported_projects/ paths (cross-project imports).
+            # Same-project views have project_name=None, so they never enter this map and fall
+            # back to explore_project_name via the BASE_PROJECT_NAME sentinel in _form_field_name().
+            view_project_map[view_field.view_name] = view_field.project_name
 
     return view_project_map
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -513,19 +513,13 @@ def extract_project_from_imported_file_path(file_path: str) -> Optional[str]:
     return None
 
 
-def create_view_project_map(
-    view_fields: List[ViewField],
-    explore_primary_view: Optional[str] = None,
-    explore_project_name: Optional[str] = None,
-) -> Dict[str, str]:
+def create_view_project_map(view_fields: List[ViewField]) -> Dict[str, str]:
     """
     Each view in a model has unique name.
     Use this function in scope of a model.
 
     Args:
         view_fields: List of ViewField objects
-        explore_primary_view: The primary view name of the explore (explore.view_name)
-        explore_project_name: The project name of the explore (explore.project_name)
     """
     view_project_map: Dict[str, str] = {}
     for view_field in view_fields:
@@ -1277,11 +1271,7 @@ class LookerExplore:
                                 )
                             )
 
-            view_project_map: Dict[str, str] = create_view_project_map(
-                view_fields,
-                explore_primary_view=explore.view_name,
-                explore_project_name=explore.project_name,
-            )
+            view_project_map: Dict[str, str] = create_view_project_map(view_fields)
             if view_project_map:
                 logger.debug(f"views and their projects: {view_project_map}")
 

--- a/metadata-ingestion/tests/integration/looker/golden_test_external_project_view_mces.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_external_project_view_mces.json
@@ -625,7 +625,7 @@
                         "time": 1586847600000,
                         "actor": "urn:li:corpuser:datahub"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,looker_hub.view.faa_flights,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,datahub-demo.view.faa_flights,PROD)",
                     "type": "VIEW"
                 }
             ]

--- a/metadata-ingestion/tests/integration/looker/golden_test_file_path_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_file_path_ingest.json
@@ -699,7 +699,7 @@
                         "time": 1586847600000,
                         "actor": "urn:li:corpuser:datahub"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,looker_hub.imported_projects.datahub-demo.views.datahub-demo.datasets.faa_flights.view.faa_flights,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:looker,datahub-demo.views.datahub-demo.datasets.faa_flights.view.faa_flights,PROD)",
                     "type": "VIEW"
                 }
             ]

--- a/metadata-ingestion/tests/unit/looker/test_looker_common.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_common.py
@@ -12,6 +12,10 @@ from datahub.ingestion.source.looker.looker_common import (
     ExploreUpstreamViewField,
     LookerExplore,
     LookerExploreJoin,
+    ViewField,
+    ViewFieldType,
+    create_view_project_map,
+    extract_project_from_imported_file_path,
 )
 from datahub.ingestion.source.looker.looker_config import LookerCommonConfig
 
@@ -170,3 +174,73 @@ class TestLookerExploreJoinReconstruction:
         view_logic = explore._build_explore_view_logic()
         assert view_logic is not None
         assert r'label: "My \"Q3\" Explore"' in view_logic
+
+
+class TestExtractProjectFromImportedFilePath:
+    @pytest.mark.parametrize(
+        "file_path,expected",
+        [
+            (
+                "imported_projects/project-a/views/foo.view.lkml",
+                "project-a",
+            ),
+            (
+                "imported_projects/my-project/path/to/file.view.lkml",
+                "my-project",
+            ),
+            (
+                "views/foo.view.lkml",  # same-project path, no imported_projects/ prefix
+                None,
+            ),
+            (
+                "imported_projects",  # malformed: no slash after the prefix
+                None,
+            ),
+        ],
+    )
+    def test_extract(self, file_path: str, expected: "str | None") -> None:
+        assert extract_project_from_imported_file_path(file_path) == expected
+
+
+class TestCreateViewProjectMap:
+    def _make_view_field(self, view_name: str, project_name: "str | None") -> ViewField:
+        return ViewField(
+            name=f"{view_name}.some_field",
+            label=None,
+            type="string",
+            description="",
+            field_type=ViewFieldType.DIMENSION,
+            project_name=project_name,
+            view_name=view_name,
+        )
+
+    def test_cross_project_primary_view_not_overridden(self) -> None:
+        # Regression test: the primary view's project must NOT be replaced with the explore's
+        # project when the view is a cross-project import (project_name already set correctly).
+        view_field = self._make_view_field("my_view", project_name="project-a")
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert result["my_view"] == "project-a"
+
+    def test_cross_project_non_primary_view(self) -> None:
+        view_field = self._make_view_field("other_view", project_name="project-a")
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert result["other_view"] == "project-a"
+
+    def test_same_project_view_not_in_map(self) -> None:
+        # Same-project views have project_name=None; they should not appear in the map
+        # and fall back to explore_project_name via the BASE_PROJECT_NAME sentinel.
+        view_field = self._make_view_field("my_view", project_name=None)
+        result = create_view_project_map(
+            view_fields=[view_field],
+            explore_primary_view="my_view",
+            explore_project_name="project-b",
+        )
+        assert "my_view" not in result

--- a/metadata-ingestion/tests/unit/looker/test_looker_common.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_common.py
@@ -214,33 +214,21 @@ class TestCreateViewProjectMap:
             view_name=view_name,
         )
 
-    def test_cross_project_primary_view_not_overridden(self) -> None:
-        # Regression test: the primary view's project must NOT be replaced with the explore's
-        # project when the view is a cross-project import (project_name already set correctly).
-        view_field = self._make_view_field("my_view", project_name="project-a")
+    def test_cross_project_views_keep_their_own_project(self) -> None:
+        # Regression test: a cross-project imported view must keep the project taken from its
+        # source_file, even when it is the explore's primary view and the explore belongs to a
+        # different project. Overriding it produced upstream URNs that matched no view entity.
         result = create_view_project_map(
-            view_fields=[view_field],
-            explore_primary_view="my_view",
-            explore_project_name="project-b",
+            view_fields=[
+                self._make_view_field("my_view", project_name="project-a"),
+                self._make_view_field("other_view", project_name="project-b"),
+            ]
         )
-        assert result["my_view"] == "project-a"
-
-    def test_cross_project_non_primary_view(self) -> None:
-        view_field = self._make_view_field("other_view", project_name="project-a")
-        result = create_view_project_map(
-            view_fields=[view_field],
-            explore_primary_view="my_view",
-            explore_project_name="project-b",
-        )
-        assert result["other_view"] == "project-a"
+        assert result == {"my_view": "project-a", "other_view": "project-b"}
 
     def test_same_project_view_not_in_map(self) -> None:
         # Same-project views have project_name=None; they should not appear in the map
-        # and fall back to explore_project_name via the BASE_PROJECT_NAME sentinel.
+        # and fall back to the explore's project via the BASE_PROJECT_NAME sentinel.
         view_field = self._make_view_field("my_view", project_name=None)
-        result = create_view_project_map(
-            view_fields=[view_field],
-            explore_primary_view="my_view",
-            explore_project_name="project-b",
-        )
+        result = create_view_project_map(view_fields=[view_field])
         assert "my_view" not in result


### PR DESCRIPTION
## Description

Cross-project imported views lose their correct project assignment when they are an explore's primary view, producing an `upstreamLineage` reference to a view URN that no entity ever gets created for. The dangling reference severs downstream lineage from the view to the explore and everything below it.

Supersedes #17815 — same fix, rebased onto current master (that branch had conflicts in `test_looker_common.py`), plus a signature cleanup described below.

## Root cause

`create_view_project_map()` overrode the field-level project for an explore's primary view whenever it differed from the explore's project. But `ViewField.project_name` is only non-`None` when `extract_project_name_from_source_file()` pulled it out of an `imported_projects/` path — so the override fired **exclusively** for cross-project imports, precisely the case where the field-level value is the correct one.

Two symptoms followed, both visible in the generated URN:

1. `{project}` resolved to the explore's project rather than the project the view actually lives in.
2. `{file_path}` then failed to strip its prefix, because `preprocess_file_path()` looked for `imported_projects/<self.project_name>/` while the real path contained `imported_projects/<importing-project>/`. The unstripped prefix leaked into the URN.

Views that are *not* an explore's primary view were unaffected, which is why this only surfaces on hub-and-spoke style setups where explores live in one project and their base views are imported from another.


## Why #14119's override was the wrong fix

#14119 added a primary-view override that forced the explore's project onto any imported primary view, and flipped `golden_test_external_project_view_mces.json` so the upstream URN used the explore project. That was the wrong ground truth.

On the LookML side, a cross-project include emits the view entity under `include.project` (the imported project), with a file path relative to that project's own base folder — no `imported_projects/` prefix. See `lookml_source.py` and `looker_view_id_cache.py`. So the URN that actually exists is `{imported-project}.view.{view}`, not `{explore-project}.view.{view}`. The override produced a dangling upstream reference.

The mixed-field case #14119 described (a local view that inherits some imported fields) is real, but the right fix is narrower: keep the view off `view_project_map` when any field has a local `source_file`, and only map all-imported views to the imported project.

## Changes

- **Narrow, don't delete, the #14119 override.** `create_view_project_map()` maps a view to an imported project only when every field (including parameters) is imported. A local `source_file` keeps the view on the explore project so inherited imported fields cannot re-home it. Same-project views still fall back via `BASE_PROJECT_NAME`.
- **One slash-anchored extractor.** `extract_project_from_imported_file_path()` is the only `imported_projects/` parser (`IMPORTED_PROJECTS_PREFIX` in `looker_constant.py`). `preprocess_file_path()` strips the prefix using the project embedded in the path, and warns on a malformed import path.
- **Conflict reporting.** Distinct imported projects or local `source_file`s on the same view emit a `reporter.warning` instead of silently picking different fields for project vs file path.

## Testing

- New unit tests for `extract_project_from_imported_file_path()` (imported paths, same-project paths, and a malformed prefix) and for `create_view_project_map()` (cross-project views keep their own project; same-project views are excluded from the map).
- Two golden files updated. Both had encoded the incorrect behaviour:
  - `golden_test_external_project_view_mces.json` — the upstream view now uses the imported project, matching the URN the LookML source produces for that same view.
  - `golden_test_file_path_ingest.json` — the URN with the unstripped `imported_projects.` segment is replaced by the correctly stripped form.

Note that these two golden files are the meaningful behavioural assertions here: they are the regression that would catch a reintroduction of the override.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated — no user-facing surface changes
- [ ] Breaking change entry in Updating DataHub — not a breaking change to configuration or APIs

One caveat worth surfacing for review: this changes the emitted view URN for cross-project imported views, so deployments that already ingested the incorrect URNs will see lineage re-point to the correct entity on the next run. The previously-referenced URNs were never materialised as entities, so there is nothing orphaned to clean up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **broken explore upstream lineage** when an explore’s primary view is imported from another Looker project. The ingester no longer forces the explore’s project onto that view, and view URNs are built from the project embedded in `imported_projects/...` paths when stripping prefixes in `preprocess_file_path`.
> 
> `create_view_project_map` now only records cross-project views (those with a non-`None` `project_name` from `imported_projects/` paths); same-project views still fall back to the explore project via `BASE_PROJECT_NAME`. Unit tests cover path parsing and project mapping; integration golden files update expected upstream view dataset URNs.
> 
> **Note:** The next ingest may emit different view URNs for these cases; lineage should attach to entities that actually exist rather than dangling references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7e2b9f1c686d9e7d327464910f9b4f72f5b638. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken explore upstream lineage for cross-project imported views, where the primary view's project was forced to match the explore's project and produced view URNs that matched no entity, severing downstream lineage. Cross-project imported views now keep their field-level project, and re-ingesting reconnects lineage to the right entities.

- Removes the primary-view project override; same-project views still fall back to the explore's project.
- Maps a view to an imported project only when every schema field is imported; imported parameters count toward the mapping, but a missing or local parameter `source_file` is not treated as evidence the view is local.
- Consolidates `imported_projects/` extraction into a single slash-anchored helper and strips the prefix using the project embedded in the file path.
- `get_view_file_path` now prefers a local source file and reports warnings for conflicting view file paths or imported projects.
- Updates unit tests and two golden files so emitted URNs match the LookML source.

No config or API changes; the previously referenced URNs were never materialized, so no cleanup is required.

<sup>Written for commit 9cde67eebe0440a99e5eab2ed3da33f705455ef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

