### PR TITLE
ci(deps): auto-select a fast APT mirror, gated by CI_USE_FAST_API_MIRROR

### DIFF
--- a/.github/actions/configure-fast-apt-mirror/action.yml
+++ b/.github/actions/configure-fast-apt-mirror/action.yml
@@ -1,12 +1,12 @@
 name: Configure fast APT mirror
 description: >
-  Select a fast Ubuntu APT mirror when vars.CI_USE_FAST_API_MIRROR is 'true'.
-  No-op otherwise. Change the underlying action here to swap implementations
-  everywhere.
+  Select a fast Ubuntu APT mirror. Callers must gate this action with
+  `if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}` (composite actions
+  cannot read `vars`). Change the underlying action here to swap
+  implementations everywhere.
 
 runs:
   using: composite
   steps:
     - name: Configure fast APT mirror
-      if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
       uses: vegardit/fast-apt-mirror.sh@806c59276adfff2df420124ad5e4587f018c358a # v1.4.5

--- a/.github/actions/configure-fast-apt-mirror/action.yml
+++ b/.github/actions/configure-fast-apt-mirror/action.yml
@@ -1,8 +1,8 @@
 name: Configure fast APT mirror
 description: >
   Select a fast Ubuntu APT mirror. Callers must gate this action with
-  `if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}` (composite actions
-  cannot read `vars`). Change the underlying action here to swap
+  if: vars.CI_USE_FAST_API_MIRROR == 'true' (composite actions cannot
+  read the vars context). Change the underlying action here to swap
   implementations everywhere.
 
 runs:

--- a/.github/actions/configure-fast-apt-mirror/action.yml
+++ b/.github/actions/configure-fast-apt-mirror/action.yml
@@ -1,0 +1,12 @@
+name: Configure fast APT mirror
+description: >
+  Select a fast Ubuntu APT mirror when vars.CI_USE_FAST_API_MIRROR is 'true'.
+  No-op otherwise. Change the underlying action here to swap implementations
+  everywhere.
+
+runs:
+  using: composite
+  steps:
+    - name: Configure fast APT mirror
+      if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
+      uses: vegardit/fast-apt-mirror.sh@806c59276adfff2df420124ad5e4587f018c358a # v1.4.5

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -107,6 +107,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install airflow package and test (extras ${{ matrix.extra_pip_requirements }})

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -297,6 +298,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -514,6 +516,7 @@ jobs:
             exit 1
           fi
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -601,6 +604,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -732,6 +736,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ on:
       - "!.github/**"
       - ".github/workflows/build-and-test.yml"
       - ".github/actions/ensure-codegen-updated"
+      - ".github/actions/configure-fast-apt-mirror"
       - ".github/scripts/send_failed_tests_to_posthog.py"
   pull_request:
     branches:
@@ -23,6 +24,7 @@ on:
       - "!.github/**"
       - ".github/workflows/build-and-test.yml"
       - ".github/actions/ensure-codegen-updated"
+      - ".github/actions/configure-fast-apt-mirror"
       - ".github/scripts/send_failed_tests_to_posthog.py"
   workflow_dispatch:
   schedule:
@@ -125,6 +127,8 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('metadata-ingestion/setup.py', 'metadata-ingestion/pyproject.toml', 'metadata-ingestion/uv.lock', 'metadata-ingestion/constraints.txt', 'metadata-ingestion/build-constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Set up JDK 25
@@ -292,6 +296,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('datahub-web-react/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Set up JDK 25
@@ -507,6 +513,8 @@ jobs:
             echo "::error::Only $count backend test modules discovered (<20) — globs/excludes likely broken; refusing near-empty sharded run."
             exit 1
           fi
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Set up JDK 25
@@ -592,6 +600,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Set up JDK 25
@@ -721,6 +731,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -45,6 +45,8 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('metadata-ingestion/setup.py', 'metadata-ingestion/pyproject.toml', 'metadata-ingestion/uv.lock', 'metadata-ingestion/constraints.txt', 'metadata-ingestion/build-constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Set up JDK 25

--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -46,6 +46,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Configure fast APT mirror
-        if: steps.uv-cache.outputs.cache-hit != 'true'
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' && steps.uv-cache.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         if: steps.uv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -65,6 +65,9 @@ jobs:
         if: steps.uv-cache.outputs.cache-hit != 'true'
         with:
           python-version: "3.11"
+      - name: Configure fast APT mirror
+        if: steps.uv-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         if: steps.uv-cache.outputs.cache-hit != 'true'
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/dagster-plugin.yml
+++ b/.github/workflows/dagster-plugin.yml
@@ -83,6 +83,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/dagster-plugin.yml
+++ b/.github/workflows/dagster-plugin.yml
@@ -82,6 +82,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install dagster package and test  (extras ${{ matrix.extraPythonRequirement }})

--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -400,6 +400,7 @@ jobs:
           }'
 
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -399,6 +399,8 @@ jobs:
             }
           }'
 
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/resusable-playwright-tests.yml"
       - ".github/actions/ci-optimization"
       - ".github/actions/restore-dependency-caches"
+      - ".github/actions/configure-fast-apt-mirror"
       - ".github/scripts/check_python_package.py"
       - ".github/scripts/parse_failed_pytest_tests.py"
       - ".github/scripts/docker_logs.sh"
@@ -50,6 +51,7 @@ on:
       - ".github/workflows/resusable-playwright-tests.yml"
       - ".github/actions/ci-optimization"
       - ".github/actions/restore-dependency-caches"
+      - ".github/actions/configure-fast-apt-mirror"
       - ".github/scripts/check_python_package.py"
       - ".github/scripts/parse_failed_pytest_tests.py"
       - ".github/scripts/docker_logs.sh"
@@ -430,7 +432,7 @@ jobs:
             build_modules_flag=("-PbuildModules=$IMAGE_BUILD_MODULES")
           fi
           echo "Using build task: $BUILD_TASK"
-          ./gradlew --max-workers="$(nproc)" $BUILD_TASK "${build_modules_flag[@]}" -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
+          ./gradlew --max-workers="$(nproc)" "$BUILD_TASK" "${build_modules_flag[@]}" -Ptag=${{ needs.setup.outputs.tag }} -PpythonDockerVersion=${{ needs.setup.outputs.python_release_version }} -PdockerRegistry=${{ env.DOCKER_REGISTRY }} -Pdatahub.dependencies.python.uvDockerProfile=${{ steps.uv-creds.outputs.uv_profile }}
       - name: Build all Images (Publish)
         if: ${{ needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' }}
         # Push immutable tags (sha-*, pr*, release v*) to the registry during the coordinated depot bake.
@@ -696,6 +698,8 @@ jobs:
             }
           }'
 
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
 
@@ -907,6 +911,9 @@ jobs:
             }
           }'
 
+      - name: Configure fast APT mirror
+        if: steps.retry-check.outputs.parse_result != 'all_passed'
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         if: steps.retry-check.outputs.parse_result != 'all_passed'
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -699,6 +699,7 @@ jobs:
           }'
 
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -912,7 +913,7 @@ jobs:
           }'
 
       - name: Configure fast APT mirror
-        if: steps.retry-check.outputs.parse_result != 'all_passed'
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' && steps.retry-check.outputs.parse_result != 'all_passed' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         if: steps.retry-check.outputs.parse_result != 'all_passed'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -58,6 +58,8 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('metadata-ingestion/setup.py', 'metadata-ingestion/pyproject.toml', 'metadata-ingestion/uv.lock', 'metadata-ingestion/constraints.txt', 'metadata-ingestion/build-constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install Python dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Run tests

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,6 +59,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install Python dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/gx-plugin.yml
+++ b/.github/workflows/gx-plugin.yml
@@ -88,6 +88,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install GX package and test  (extras ${{ matrix.extraPythonRequirement }})

--- a/.github/workflows/gx-plugin.yml
+++ b/.github/workflows/gx-plugin.yml
@@ -89,6 +89,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -282,6 +282,7 @@ jobs:
           restore-keys: |
             uv-python-lint-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -281,6 +281,8 @@ jobs:
           key: uv-python-lint-${{ hashFiles('./metadata-ingestion/setup.py', './metadata-ingestion/pyproject.toml', './metadata-ingestion/uv.lock', './metadata-ingestion/constraints.txt', './metadata-ingestion/build-constraints.txt', './datahub-actions/setup.py', './datahub-actions/pyproject.toml', './datahub-agent-context/setup.py', './datahub-agent-context/pyproject.toml', './metadata-ingestion-modules/airflow-plugin/setup.py', './metadata-ingestion-modules/airflow-plugin/pyproject.toml', './metadata-ingestion-modules/gx-plugin/setup.py', './metadata-ingestion-modules/gx-plugin/pyproject.toml', './metadata-ingestion-modules/dagster-plugin/setup.py', './metadata-ingestion-modules/dagster-plugin/pyproject.toml', './metadata-ingestion-modules/prefect-plugin/setup.py', './metadata-ingestion-modules/prefect-plugin/pyproject.toml') }}
           restore-keys: |
             uv-python-lint-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       # Per-module lint steps. Each runs independently (if: always()) so a failure in one

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -152,6 +152,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
@@ -385,7 +386,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Configure fast APT mirror
-        if: steps.check-changes.outputs.should_run == 'true'
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' && steps.check-changes.outputs.should_run == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         if: steps.check-changes.outputs.should_run == 'true'

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -151,6 +151,8 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('metadata-ingestion/setup.py', 'metadata-ingestion/pyproject.toml', 'metadata-ingestion/uv.lock', 'metadata-ingestion/constraints.txt', 'metadata-ingestion/build-constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install ODBC driver for mssql tests
@@ -382,6 +384,9 @@ jobs:
         if: steps.check-changes.outputs.should_run == 'true'
         with:
           python-version: "3.11"
+      - name: Configure fast APT mirror
+        if: steps.check-changes.outputs.should_run == 'true'
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install system dependencies
         if: steps.check-changes.outputs.should_run == 'true'
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Run model generation

--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -51,6 +51,7 @@ jobs:
           python-version: "3.10"
           cache: "pip"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/prefect-plugin.yml
+++ b/.github/workflows/prefect-plugin.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install prefect package

--- a/.github/workflows/prefect-plugin.yml
+++ b/.github/workflows/prefect-plugin.yml
@@ -66,6 +66,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -200,6 +200,7 @@ jobs:
             }'
 
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install Playwright dependencies
         working-directory: e2e-test/ui/playwright

--- a/.github/workflows/resusable-playwright-tests.yml
+++ b/.github/workflows/resusable-playwright-tests.yml
@@ -199,6 +199,8 @@ jobs:
               }
             }'
 
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install Playwright dependencies
         working-directory: e2e-test/ui/playwright
         run: |

--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -54,6 +54,7 @@ jobs:
           python-version: "3.10"
           cache: "pip"
       - name: Configure fast APT mirror
+        if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh

--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+      - name: Configure fast APT mirror
+        uses: ./.github/actions/configure-fast-apt-mirror
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Disk Check


### PR DESCRIPTION
## Summary
- Add a composite action that picks a fast Ubuntu APT mirror before `apt-get`.
- Gate it with repo variable `CI_USE_FAST_API_MIRROR`: set to `true` to enable, set to `false` (or unset) to skip the step in every workflow.
- Wire it into every `install_deps.sh` caller (build-and-test, docker-unified, lint, ingestion, plugins, docs, nightly, cache warmup) and Playwright `--with-deps`.

## Test plan
- [ ] Set `CI_USE_FAST_API_MIRROR=true` and confirm the Configure fast APT mirror step runs
- [ ] Set it to `false` (or unset) and confirm the step is skipped
- [ ] Confirm `install_deps.sh` and `npx playwright install --with-deps` still succeed either way


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects a fast Ubuntu APT mirror in CI to speed up package installs. Previously jobs used the default mirror; now, when `CI_USE_FAST_API_MIRROR` is `true`, workflows run `vegardit/fast-apt-mirror.sh` before installing system dependencies. Also fixes the composite action description to avoid `${{ }}` interpolation that could fail action loading.

- Enable by setting repo variable `CI_USE_FAST_API_MIRROR=true`. The gate is evaluated at each call site with `if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}` because composite actions cannot read `vars`.
- Adds a composite action at `./.github/actions/configure-fast-apt-mirror` and wires it into all workflows that install system packages (including Playwright `--with-deps` and docker-unified retry paths).
- Pins `vegardit/fast-apt-mirror.sh` to v1.4.5 (commit SHA); update the composite action to change implementations globally.
- Quotes `$BUILD_TASK` in `docker-unified.yml` to prevent word-splitting during Gradle invocation.

<sup>Written for commit 87aacdfa835f61b37a4bbe0e02d7e232013be091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

