### PR TITLE
fix(playwright): remove wait for networkidle state on homepage in search tests

### DIFF
--- a/e2e-test/ui/playwright/pages/search.page.ts
+++ b/e2e-test/ui/playwright/pages/search.page.ts
@@ -44,7 +44,6 @@ export class SearchPage extends BasePage {
       localStorage.setItem('skipOnboardingTour', 'true');
     });
     await this.navigate('/');
-    await this.page.waitForLoadState('networkidle');
     await this.searchInput.waitFor({ state: 'visible', timeout: 10000 });
     // Dismiss any remaining dialog (e.g. "Narrow your search" welcome modal).
     await this.dismissOnboardingOverlays();


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/PRD-2384/fix-playwright-tests-in-searchsearch-within-operatorspects

**Description:**

Tests have been failing where wait for network idle is used on homepage after some changes made recently.
This removes that wait call from search page tests.

Brings this commit from SaaS merge PR to OSS: https://github.com/acryldata/datahub-fork/pull/11686/changes/e5e85572c2139a7c93f0352ab918f8c8ae25e657

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `networkidle` wait on homepage navigation in search Playwright tests to prevent timeouts caused by persistent background requests. Previously tests waited for `networkidle` after navigating to the homepage; now they proceed once the search input is visible and then dismiss onboarding overlays.

- Scope: `e2e-test/ui/playwright/pages/search.page.ts` only; no product behavior change.
- Rationale: homepage changes keep requests open, so `networkidle` rarely occurs, causing flakiness (Linear PRD-2384).
- Expected effect: more stable and slightly faster CI; no migration required.
- Aligns OSS tests with SaaS behavior.

<sup>Written for commit f0d8add75ed4e409f681d2acbd0183663104caba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

