### PR TITLE
docs(proposals): document propose-create for Domains and Data Products

### DIFF
--- a/docs/actions/events/entity-change-event.md
+++ b/docs/actions/events/entity-change-event.md
@@ -530,6 +530,55 @@ This event is emitted when a new glossary term creation is proposed on DataHub.
 }
 ```
 
+### Create Domain Request Event
+
+This event is emitted when a new Domain creation is proposed on DataHub.
+
+#### Sample Event
+
+```json
+{
+  "entityType": "actionRequest",
+  "entityUrn": "urn:li:actionRequest:create-domain-101",
+  "category": "LIFECYCLE",
+  "operation": "CREATE",
+  "auditStamp": {
+    "actor": "urn:li:corpuser:jdoe",
+    "time": 1234567890
+  },
+  "version": 0,
+  "parameters": {
+    "actionRequestType": "CREATE_DOMAIN",
+    "resourceType": "domain"
+  }
+}
+```
+
+### Create Data Product Request Event
+
+This event is emitted when a new Data Product creation is proposed on DataHub.
+
+#### Sample Event
+
+```json
+{
+  "entityType": "actionRequest",
+  "entityUrn": "urn:li:actionRequest:create-data-product-101",
+  "category": "LIFECYCLE",
+  "operation": "CREATE",
+  "auditStamp": {
+    "actor": "urn:li:corpuser:jdoe",
+    "time": 1234567890
+  },
+  "version": 0,
+  "parameters": {
+    "actionRequestType": "CREATE_DATA_PRODUCT",
+    "resourceType": "domain",
+    "resourceUrn": "urn:li:domain:marketing"
+  }
+}
+```
+
 ### Term Association Request Event
 
 This event is emitted when a glossary term association is proposed for an entity on DataHub.

--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -578,6 +578,8 @@ These privileges are to view & modify any entity within DataHub.
 | Propose Dataset Column Structured Properties[^1]  | Allow actor to propose a structured property to a dataset schema column (field).                |
 | Propose Create Glossary Term[^1]                  | Allow actor to propose creation of a new glossary term.                                         |
 | Propose Create Glossary Node[^1]                  | Allow actor to propose creation of a new glossary node.                                         |
+| Propose Create Domain[^1]                         | Allow actor to propose creation of a new Domain.                                                |
+| Propose Create Data Product[^1]                   | Allow actor to propose creation of a new Data Product.                                          |
 | Manage Tag Proposals[^1]                          | Allow actor to manage a proposal to add a tag to an asset.                                      |
 | Manage Glossary Term Proposals[^1]                | Allow actor to manage a proposal to add a glossary term to an asset.                            |
 | Manage Domain Proposals[^1]                       | Allow actor to manage a proposal to add a domain to an asset.                                   |

--- a/docs/authorization/roles.md
+++ b/docs/authorization/roles.md
@@ -162,13 +162,15 @@ These privileges are only relevant to DataHub Cloud.
 
 ##### Platform Privileges
 
-| Privilege                       | Admin              | Editor             | Reader | Description                                                                                         |
-| ------------------------------- | ------------------ | ------------------ | ------ | --------------------------------------------------------------------------------------------------- |
-| Manage Tests                    | :heavy_check_mark: | :heavy_check_mark: | :x:    | Create and remove Asset Tests.                                                                      |
-| View Metadata Proposals         | :heavy_check_mark: | :heavy_check_mark: | :x:    | View the requests tab for viewing metadata proposals.                                               |
-| Create metadata constraints[^1] | :heavy_check_mark: | :heavy_check_mark: | :x:    | Create metadata constraints.                                                                        |
-| Manage Platform Settings        | :heavy_check_mark: | :x:                | :x:    | View and change platform-level settings, like integrations & notifications.                         |
-| Manage Monitors                 | :heavy_check_mark: | :x:                | :x:    | Create, update, and delete any data asset monitors, including Custom SQL monitors. Grant with care. |
+| Privilege                       | Admin              | Editor             | Reader             | Description                                                                                           |
+| ------------------------------- | ------------------ | ------------------ | ------------------ | ----------------------------------------------------------------------------------------------------- |
+| Manage Tests                    | :heavy_check_mark: | :heavy_check_mark: | :x:                | Create and remove Asset Tests.                                                                        |
+| View Metadata Proposals         | :heavy_check_mark: | :heavy_check_mark: | :x:                | View the requests tab for viewing metadata proposals.                                                 |
+| Propose Create Domain           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Propose creation of a new Domain. Reviewers need **Manage Domains**.                                  |
+| Propose Create Data Product     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Propose creation of a new Data Product. Reviewers need **Manage Data Products** on the parent Domain. |
+| Create metadata constraints[^1] | :heavy_check_mark: | :heavy_check_mark: | :x:                | Create metadata constraints.                                                                          |
+| Manage Platform Settings        | :heavy_check_mark: | :x:                | :x:                | View and change platform-level settings, like integrations & notifications.                           |
+| Manage Monitors                 | :heavy_check_mark: | :x:                | :x:                | Create, update, and delete any data asset monitors, including Custom SQL monitors. Grant with care.   |
 
 [^1]: Deprecated feature
 

--- a/docs/managed-datahub/change-proposals.md
+++ b/docs/managed-datahub/change-proposals.md
@@ -1,5 +1,5 @@
 ---
-description: "Use DataHub Cloud Change Proposals to crowdsource Tags, Terms, Owners, and other metadata edits with reviewer approval workflows."
+description: "Use DataHub Cloud Change Proposals to crowdsource Tags, Terms, Owners, Domains, Data Products, and other metadata edits with reviewer approval."
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
@@ -10,7 +10,7 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 ## Overview
 
-Keeping your data organized can be hard work when you have a limited number of data owners. With DataHub Cloud, you can crowdsource metadata completion using change proposals. Change Proposals enable data users to suggest Tags, Terms, Domains, Owners, Descriptions, and even Structured Properties to be added to data assets. Once a change proposal is raised, data owners and stewards can review change proposals, approving or denying these suggestion.
+Keeping your data organized can be hard work when you have a limited number of data owners. With DataHub Cloud, you can crowdsource metadata completion using change proposals. Change Proposals enable data users to suggest Tags, Terms, Domains, Owners, Descriptions, and even Structured Properties to be added to data assets, and to propose creation of new Glossary Terms, Glossary Nodes, Domains, and Data Products. Once a change proposal is raised, data owners and stewards can review change proposals, approving or denying these suggestion.
 
 ## Permissions
 
@@ -29,10 +29,12 @@ To create proposals on assets, users need to have the following resource privile
 - `Propose Dataset Column Structured Properties`
 - `Propose Dataset Column Descriptions`
 
-To create proposals to change the Business Glossary, users need to have the following platform privileges:
+To create proposals to change the Business Glossary, Domains, or Data Products, users need to have the following platform privileges:
 
 - `Propose Create Glossary Term`
 - `Propose Create Glossary Node`
+- `Propose Create Domain`
+- `Propose Create Data Product`
 
 Which are granted by default using the **Reader**, **Editor**, and **Admin** roles by default.
 
@@ -50,6 +52,14 @@ To review proposals for an asset, users need to have the following resource priv
 To review proposals to change the Business Glossary, users need to have the following platform privileges:
 
 - `Manage Glossaries`
+
+To review proposals to create a new Domain, users need:
+
+- `Manage Domains`
+
+To review proposals to create a new Data Product, users need:
+
+- `Manage Data Products` on the parent Domain of the proposed Data Product
 
 Which are granted by default **Editor** and **Admin** roles.
 
@@ -173,6 +183,22 @@ Which are granted by default **Editor** and **Admin** roles.
 
 4. From there, they can choose to either accept or reject the proposal. A full log of all accepted or rejected proposals is kept for each user.
 
+### Proposing a new Domain
+
+1. Navigate to **Govern > Domains**, or open a parent Domain if you want to nest the new Domain.
+2. Click the plus button to create a new Domain.
+3. Fill in the Domain name (required) and optionally a description, parent Domain, and custom id.
+4. Click **Propose** instead of **Save**. If you also have permission to create Domains, you can still create immediately; otherwise only **Propose** is available.
+5. This proposal is sent to reviewers who hold `Manage Domains`. From the Task Center they can accept or reject it. Accepting creates the Domain.
+
+### Proposing a new Data Product
+
+1. Open the Domain that should own the Data Product and go to the **Data Products** tab.
+2. Click the plus button to create a new Data Product.
+3. Fill in the Data Product name (required) and optionally a description. The parent Domain is taken from the Domain you launched from.
+4. Click **Propose** instead of **Create**. If you also have `Manage Data Products` on that Domain, you can still create immediately; otherwise only **Propose** is available.
+5. This proposal is sent to reviewers who hold `Manage Data Products` on that Domain. From the Task Center they can accept or reject it. Accepting creates the Data Product in the parent Domain.
+
 ### Reviewing Proposals
 
 Proposals will be visible inside your **Task Center**, which is accessible via the navigation sidebar. From the task center, you can choose to accept or deny proposals sourced for assets you are responsible for.
@@ -233,7 +259,7 @@ These identifiers can be copied from the url of the corresponding entity pages.
 
 Once we've constructed an Entity URN, any relevant sub-resource identifiers, we're ready to propose! To do so, we'll use the DataHub GraphQL API.
 
-In particular, we'll be using the proposeTags, proposeTerms, proposeDomain, proposeOwners, proposeStructuredProperties, proposeCreateGlossaryTerm, proposeCreateGlossaryNode, proposeDataContract, and proposeUpdateDescription Mutations, which have the following interface:
+In particular, we'll be using the proposeTags, proposeTerms, proposeDomain, proposeOwners, proposeStructuredProperties, proposeCreateGlossaryTerm, proposeCreateGlossaryNode, proposeCreateDomain, proposeCreateDataProduct, proposeDataContract, and proposeUpdateDescription Mutations, which have the following interface:
 
 ```
 type Mutation {
@@ -337,6 +363,33 @@ input CreateGlossaryEntityInput {
   name: String! # Required. e.g. "Marketing"
   description: String # Optional
   parentNode: String # Optional. e.g. "urn:li:glossaryNode:(...)"
+  proposalNote: String # Optional. Context for the proposal
+}
+```
+
+```
+type Mutation {
+  proposeCreateDomain(input: CreateDomainProposalInput!): Boolean
+}
+
+input CreateDomainProposalInput {
+  name: String! # Required. e.g. "Marketing"
+  description: String # Optional
+  parentDomain: String # Optional. e.g. "urn:li:domain:(...)"
+  id: String # Optional. Otherwise uuid is generated when the steward accepts
+  proposalNote: String # Optional. Context for the proposal
+}
+```
+
+```
+type Mutation {
+  proposeCreateDataProduct(input: CreateDataProductProposalInput!): Boolean
+}
+
+input CreateDataProductProposalInput {
+  name: String! # Required. e.g. "Customer 360"
+  domain: String! # Required. Parent Domain URN, e.g. "urn:li:domain:(...)"
+  description: String # Optional
   proposalNote: String # Optional. Context for the proposal
 }
 ```

--- a/docs/managed-datahub/change-proposals.md
+++ b/docs/managed-datahub/change-proposals.md
@@ -185,19 +185,19 @@ Which are granted by default **Editor** and **Admin** roles.
 
 ### Proposing a new Domain
 
-1. Navigate to **Govern > Domains**, or open a parent Domain if you want to nest the new Domain.
-2. Click the plus button to create a new Domain.
-3. Fill in the Domain name (required) and optionally a description, parent Domain, and custom id.
-4. Click **Propose** instead of **Save**. If you also have permission to create Domains, you can still create immediately; otherwise only **Propose** is available.
-5. This proposal is sent to reviewers who hold `Manage Domains`. From the Task Center they can accept or reject it. Accepting creates the Domain.
+1. Navigate to **Govern > Domains**. The plus button on the Domains page and in the Domains sidebar is available if you have `Create Domains` or `Propose Create Domain`. Users who can only propose see a **Propose new Domain** tooltip on that button.
+2. Click plus to open **Create New Domain**. To nest the Domain, pick a parent Domain (or open plus from an existing parent Domain).
+3. Fill in the Domain name (required). Optionally add a description and a custom id.
+4. Click **Propose**. **Save** creates the Domain immediately and requires `Create Domains`. **Propose** requires `Propose Create Domain`. You can add an optional note for reviewers.
+5. The proposal appears in the **Task Center** for users with `Manage Domains`. Accepting creates the Domain (nested under the parent Domain when one was set). Rejecting leaves no Domain behind.
 
 ### Proposing a new Data Product
 
 1. Open the Domain that should own the Data Product and go to the **Data Products** tab.
-2. Click the plus button to create a new Data Product.
-3. Fill in the Data Product name (required) and optionally a description. The parent Domain is taken from the Domain you launched from.
-4. Click **Propose** instead of **Create**. If you also have `Manage Data Products` on that Domain, you can still create immediately; otherwise only **Propose** is available.
-5. This proposal is sent to reviewers who hold `Manage Data Products` on that Domain. From the Task Center they can accept or reject it. Accepting creates the Data Product in the parent Domain.
+2. Click plus to open the create Data Product modal. The parent Domain is the Domain you launched from.
+3. Fill in the Data Product name (required) and optionally a description.
+4. Click **Propose**. **Create** writes the Data Product immediately and requires `Manage Data Products` on that Domain. **Propose** requires `Propose Create Data Product`. You can add an optional note for reviewers.
+5. The proposal appears in the **Task Center** for users with `Manage Data Products` on that Domain. Accepting creates the Data Product in the parent Domain. Rejecting leaves no Data Product behind.
 
 ### Reviewing Proposals
 

--- a/docs/managed-datahub/datahub-api/entity-events-api.md
+++ b/docs/managed-datahub/datahub-api/entity-events-api.md
@@ -727,10 +727,12 @@ These are the common parameters for all Action Request create events.
 | Name              | Type   | Description                                                                                                                                                                                | Optional |
 | ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
 | actionRequestType | String | The type of Action Request. One of `TAG_ASSOCIATION`, `TERM_ASSOCIATION`, `CREATE_GLOSSARY_NODE`, `CREATE_GLOSSARY_TERM`, `CREATE_DOMAIN`, `CREATE_DATA_PRODUCT`, or `UPDATE_DESCRIPTION.` | False    |
-| resourceType      | String | The type of entity this Action Request is applied on, such as `dataset`.                                                                                                                   | True     |
-| resourceUrn       | String | The entity this Action Request is applied on.                                                                                                                                              | True     |
+| resourceType      | String | The type of entity this Action Request is applied on, such as `dataset`.                                                                                                                   | True\*   |
+| resourceUrn       | String | The entity this Action Request is applied on.                                                                                                                                              | True\*   |
 | subResourceType   | String | Filled if this Action Request is applied on a sub-resource, such as a `schemaField`.                                                                                                       | True     |
 | subResource       | String | Identifier of the sub-resource if this proposal is applied on one.                                                                                                                         | True     |
+
+\* `resourceType` and `resourceUrn` are optional in general, but some proposal types require them — see the per-type tables below (for example, `CREATE_DOMAIN` requires `resourceType`, and `CREATE_DATA_PRODUCT` requires both).
 
 Parameters specific to different proposal types are listed below.
 

--- a/docs/managed-datahub/datahub-api/entity-events-api.md
+++ b/docs/managed-datahub/datahub-api/entity-events-api.md
@@ -724,13 +724,13 @@ This event is emitted when a new Action Request (Metadata Proposal) has been cre
 
 These are the common parameters for all Action Request create events.
 
-| Name              | Type   | Description                                                                                                                                        | Optional |
-| ----------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| actionRequestType | String | The type of Action Request. One of `TAG_ASSOCIATION`, `TERM_ASSOCIATION`, `CREATE_GLOSSARY_NODE`, `CREATE_GLOSSARY_TERM`, or `UPDATE_DESCRIPTION.` | False    |
-| resourceType      | String | The type of entity this Action Request is applied on, such as `dataset`.                                                                           | True     |
-| resourceUrn       | String | The entity this Action Request is applied on.                                                                                                      | True     |
-| subResourceType   | String | Filled if this Action Request is applied on a sub-resource, such as a `schemaField`.                                                               | True     |
-| subResource       | String | Identifier of the sub-resource if this proposal is applied on one.                                                                                 | True     |
+| Name              | Type   | Description                                                                                                                                                                                | Optional |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| actionRequestType | String | The type of Action Request. One of `TAG_ASSOCIATION`, `TERM_ASSOCIATION`, `CREATE_GLOSSARY_NODE`, `CREATE_GLOSSARY_TERM`, `CREATE_DOMAIN`, `CREATE_DATA_PRODUCT`, or `UPDATE_DESCRIPTION.` | False    |
+| resourceType      | String | The type of entity this Action Request is applied on, such as `dataset`.                                                                                                                   | True     |
+| resourceUrn       | String | The entity this Action Request is applied on.                                                                                                                                              | True     |
+| subResourceType   | String | Filled if this Action Request is applied on a sub-resource, such as a `schemaField`.                                                                                                       | True     |
+| subResource       | String | Identifier of the sub-resource if this proposal is applied on one.                                                                                                                         | True     |
 
 Parameters specific to different proposal types are listed below.
 
@@ -804,6 +804,54 @@ Parameters specific to different proposal types are listed below.
     "glossaryEntityName": "PII",
     "parentNodeUrn": "urn:li:glossaryNode:Classification",
     "description": "Personally Identifiable Information"
+  },
+  "auditStamp": {
+    "actor": "urn:li:corpuser:jdoe",
+    "time": 1649953100653
+  }
+}
+```
+
+#### Create Domain Proposal Specific Parameters and Sample Event
+
+| Name         | Type   | Description                              | Optional |
+| ------------ | ------ | ---------------------------------------- | -------- |
+| resourceType | String | The entity type being created. `domain`. | False    |
+
+```
+{
+  "entityUrn": "urn:li:actionRequest:abc",
+  "entityType": "actionRequest",
+  "category": "LIFECYCLE",
+  "operation": "CREATED",
+  "parameters": {
+    "actionRequestType": "CREATE_DOMAIN",
+    "resourceType": "domain"
+  },
+  "auditStamp": {
+    "actor": "urn:li:corpuser:jdoe",
+    "time": 1649953100653
+  }
+}
+```
+
+#### Create Data Product Proposal Specific Parameters and Sample Event
+
+| Name         | Type   | Description                                                  | Optional |
+| ------------ | ------ | ------------------------------------------------------------ | -------- |
+| resourceType | String | The parent Domain's entity type. `domain`.                   | False    |
+| resourceUrn  | String | The parent Domain the proposed Data Product would belong to. | False    |
+
+```
+{
+  "entityUrn": "urn:li:actionRequest:abc",
+  "entityType": "actionRequest",
+  "category": "LIFECYCLE",
+  "operation": "CREATED",
+  "parameters": {
+    "actionRequestType": "CREATE_DATA_PRODUCT",
+    "resourceType": "domain",
+    "resourceUrn": "urn:li:domain:marketing"
   },
   "auditStamp": {
     "actor": "urn:li:corpuser:jdoe",


### PR DESCRIPTION
## Summary

- Document proposing creation of new Domains and Data Products in the Cloud Change Proposals guide (permissions, UI, GraphQL).
- Add `Propose Create Domain` and `Propose Create Data Product` to the policies and Cloud roles tables.
- Include `CREATE_DOMAIN` and `CREATE_DATA_PRODUCT` on Action Request / Entity Change Event docs.

## Checklist

- [x] PR conforms to the Contributing Guideline (especially PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub

## Test plan

- [x] `./gradlew :datahub-web-react:mdPrettierWrite` (and pre-commit Docusaurus markdown lint)
- [ ] Spot-check rendered docs for Change Proposals, Policies, Roles, and Entity Events

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents propose-create for Domains and Data Products and treats the Domain propose-create UI as shipped. Also clarifies Action Request event parameter optionality so `resourceType`/`resourceUrn` requirements are consistent across common and per-type tables.

- Change Proposals guide: adds UI flows for proposing a Domain (Domains page/sidebar plus button, create modal, Propose vs Save, Task Center review) and proposing a Data Product from a Domain; lists required proposer and reviewer permissions.
- GraphQL: documents `proposeCreateDomain` and `proposeCreateDataProduct` with input fields, including optional `proposalNote` and Domain `id`.
- Policies: adds platform privileges “Propose Create Domain” and “Propose Create Data Product”.
- Roles: grants both propose-create privileges to Reader, Editor, and Admin; reviewers need Manage Domains or Manage Data Products on the parent Domain.
- Entity Events docs and API: adds action types `CREATE_DOMAIN` and `CREATE_DATA_PRODUCT`, per-type parameter tables and sample events; adds a footnote in the common parameters table clarifying when `resourceType`/`resourceUrn` are required.

No product behavior change or migration required.

<sup>Written for commit f22049ccf5dfe54989e1ce4d436319b5845703e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

