### PR TITLE
fix(auth): restrict GMS /auth helpers to system client

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -73,6 +73,8 @@ Requirements:
 
 ### Other Notable Changes
 
+- **(GMS / Auth helpers)** `POST /auth/signUp`, `/auth/resetNativeUserCredentials`, `/auth/verifyNativeUserCredentials`, and `/auth/getSsoSettings` now require the GMS **system client** credentials, matching `/auth/generateSessionTokenForUser`. Frontend login, signup, password reset, and SSO continue to work (they already call these helpers with the system client). A user session token calling GMS `/auth/*` directly receives **401**. **Action:** none for standard deployments; if you called these GMS helpers with a user token, switch to the frontend routes or system client credentials.
+
 - **(GMS / Authorization)** New platform privilege `VIEW_SYSTEM_STATUS` grants read access to non-sensitive system status: messaging consumer lag, messaging transport, and registered consumers. It does **not** include system information (`/openapi/v1/system-info` and related endpoints), full system configuration, raw index access, throttle/rate-limit controls, or other operational mutations. `MANAGE_SYSTEM_OPERATIONS` remains a superset. The privilege is **not** on the default Admin or root boot policies; grant it explicitly (for example to a smoke/release-test PAT).
 
 - **(Security / Dependencies)** Logback (`logback-classic` / `logback-core`) bumped from 1.5.32 to **1.5.38** for CVE-2026-9828 (`HardenedObjectInputStream` overly broad `java.lang`/`java.util` deserialization allowlist; fixed in 1.5.33+) and CVE-2026-10532 (Proxy class deserialization; fixed in 1.5.38). **Action:** none for operators; rebuild/redeploy picks up the new JARs. DataHub does not expose Logback `SimpleSocketServer` / `SimpleSSLSocketServer` by default.

--- a/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
+++ b/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
@@ -61,7 +61,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
 @RestController
@@ -181,10 +180,12 @@ public class AuthServiceController {
     if (maybeAuth.isEmpty()) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
+    final Authentication authentication = maybeAuth.get();
+    if (!isSystemClient(authentication.getActor().getId())) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     recordUsageSession(
         httpEntity.getHeaders(), "generateSessionTokenForUser", UsageOperation.OTHER_WRITE);
-    final Authentication authentication = maybeAuth.get();
-    final String actorId = authentication.getActor().getId();
     final String actorUrn = authentication.getActor().toUrnStr();
     final OperationContext opContext =
         OperationContext.asSession(
@@ -200,81 +201,71 @@ public class AuthServiceController {
             true);
     return CompletableFuture.supplyAsync(
         () -> {
-          // 1. Verify that only those authorized to generate a token (datahub system) are able to.
-          if (isAuthorizedToGenerateSessionToken(actorId)) {
-            try {
-              final boolean verboseAuthFailureLogging =
-                  _configProvider.getAuthentication().isVerboseAuthFailureLogging();
-              final boolean enforceExistence =
-                  _configProvider.getAuthentication().isEnforceExistenceEnabled();
-              final String loginSource =
-                  resolveLoginSource(httpEntity.getHeaders(), LOGIN_SOURCE_UNKNOWN);
-              final Optional<LoginDenialReason> eligibilityDenial =
-                  _userSessionEligibilityChecker.checkEligibility(
-                      opContext, userId.asText(), enforceExistence);
-              if (eligibilityDenial.isPresent()) {
-                final LoginDenialReason denialReason = eligibilityDenial.get();
-                recordFailedLoginUsageEvent(
-                    httpEntity,
-                    new CorpuserUrn(userId.asText()).toString(),
-                    denialReason,
-                    "failedLoginSessionEligibility",
-                    loginSource);
-                emitLoginDenialLog(
-                    verboseAuthFailureLogging,
-                    userId.asText(),
-                    denialReason,
-                    "generateSessionTokenForUser");
-                return new ResponseEntity<>(
-                    buildLoginDenialJsonBody(denialReason), HttpStatus.FORBIDDEN);
-              }
-
-              // 2. Generate a new DataHub JWT
-              final long sessionTokenDurationMs =
-                  _configProvider.getAuthentication().getSessionTokenDurationMs();
-              final String token =
-                  _statelessTokenService.generateAccessToken(
-                      TokenType.SESSION,
-                      new Actor(ActorType.USER, userId.asText()),
-                      sessionTokenDurationMs);
-              log.info(
-                  "Successfully generated session token for userRef: {}, duration: {} ms",
-                  LoginIdentityMask.mask(userId.asText()),
-                  sessionTokenDurationMs);
-              return opContext.withSpan(
-                  "loginSuccess",
-                  () -> {
-                    AttributesBuilder loginEventAttributes = Attributes.builder();
-                    loginEventAttributes.put(
-                        USER_ID_ATTR, new CorpuserUrn(userId.asText()).toString());
-                    loginEventAttributes.put(
-                        EVENT_TYPE_ATTR, DataHubUsageEventType.LOG_IN_EVENT.getType());
-                    if (!LOGIN_SOURCE_UNKNOWN.equals(loginSource)) {
-                      loginEventAttributes.put(LOGIN_SOURCE_ATTR, loginSource);
-                    }
-                    List<String> sourceIP = httpEntity.getHeaders().getOrEmpty(X_FORWARDED_FOR);
-                    if (!sourceIP.isEmpty()) {
-                      loginEventAttributes.put(SOURCE_IP, sourceIP.get(0));
-                    }
-                    Span.current().addEvent(LOGIN_EVENT, loginEventAttributes.build());
-                    incrementLoginMetric(
-                        LOGIN_OUTCOME_SUCCESS, loginSource, LOGIN_DENIAL_REASON_NONE);
-                    return new ResponseEntity<>(buildTokenResponse(token), HttpStatus.OK);
-                  });
-            } catch (Exception e) {
-              log.error(
-                  "Failed to generate session token for userRef: {}",
-                  LoginIdentityMask.mask(userId.asText()),
-                  e);
-              return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+          try {
+            final boolean verboseAuthFailureLogging =
+                _configProvider.getAuthentication().isVerboseAuthFailureLogging();
+            final boolean enforceExistence =
+                _configProvider.getAuthentication().isEnforceExistenceEnabled();
+            final String loginSource =
+                resolveLoginSource(httpEntity.getHeaders(), LOGIN_SOURCE_UNKNOWN);
+            final Optional<LoginDenialReason> eligibilityDenial =
+                _userSessionEligibilityChecker.checkEligibility(
+                    opContext, userId.asText(), enforceExistence);
+            if (eligibilityDenial.isPresent()) {
+              final LoginDenialReason denialReason = eligibilityDenial.get();
+              recordFailedLoginUsageEvent(
+                  httpEntity,
+                  new CorpuserUrn(userId.asText()).toString(),
+                  denialReason,
+                  "failedLoginSessionEligibility",
+                  loginSource);
+              emitLoginDenialLog(
+                  verboseAuthFailureLogging,
+                  userId.asText(),
+                  denialReason,
+                  "generateSessionTokenForUser");
+              return new ResponseEntity<>(
+                  buildLoginDenialJsonBody(denialReason), HttpStatus.FORBIDDEN);
             }
+
+            final long sessionTokenDurationMs =
+                _configProvider.getAuthentication().getSessionTokenDurationMs();
+            final String token =
+                _statelessTokenService.generateAccessToken(
+                    TokenType.SESSION,
+                    new Actor(ActorType.USER, userId.asText()),
+                    sessionTokenDurationMs);
+            log.info(
+                "Successfully generated session token for userRef: {}, duration: {} ms",
+                LoginIdentityMask.mask(userId.asText()),
+                sessionTokenDurationMs);
+            return opContext.withSpan(
+                "loginSuccess",
+                () -> {
+                  AttributesBuilder loginEventAttributes = Attributes.builder();
+                  loginEventAttributes.put(
+                      USER_ID_ATTR, new CorpuserUrn(userId.asText()).toString());
+                  loginEventAttributes.put(
+                      EVENT_TYPE_ATTR, DataHubUsageEventType.LOG_IN_EVENT.getType());
+                  if (!LOGIN_SOURCE_UNKNOWN.equals(loginSource)) {
+                    loginEventAttributes.put(LOGIN_SOURCE_ATTR, loginSource);
+                  }
+                  List<String> sourceIP = httpEntity.getHeaders().getOrEmpty(X_FORWARDED_FOR);
+                  if (!sourceIP.isEmpty()) {
+                    loginEventAttributes.put(SOURCE_IP, sourceIP.get(0));
+                  }
+                  Span.current().addEvent(LOGIN_EVENT, loginEventAttributes.build());
+                  incrementLoginMetric(
+                      LOGIN_OUTCOME_SUCCESS, loginSource, LOGIN_DENIAL_REASON_NONE);
+                  return new ResponseEntity<>(buildTokenResponse(token), HttpStatus.OK);
+                });
+          } catch (Exception e) {
+            log.error(
+                "Failed to generate session token for userRef: {}",
+                LoginIdentityMask.mask(userId.asText()),
+                e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
           }
-          throw HttpClientErrorException.create(
-              HttpStatus.UNAUTHORIZED,
-              actorUrn + " unauthorized to perform this action.",
-              new HttpHeaders(),
-              null,
-              null);
         });
   }
 
@@ -330,8 +321,11 @@ public class AuthServiceController {
     if (maybeAuth.isEmpty()) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
-    recordUsageSession(httpEntity.getHeaders(), "signUp", UsageOperation.OTHER_WRITE);
     final Authentication auth = maybeAuth.get();
+    if (!isSystemClient(auth.getActor().getId())) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
+    recordUsageSession(httpEntity.getHeaders(), "signUp", UsageOperation.OTHER_WRITE);
 
     String userUrnString = userUrn.asText();
     String systemClientUser =
@@ -422,9 +416,12 @@ public class AuthServiceController {
     if (maybeAuth.isEmpty()) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
+    final Authentication auth = maybeAuth.get();
+    if (!isSystemClient(auth.getActor().getId())) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     recordUsageSession(
         httpEntity.getHeaders(), "resetNativeUserCredentials", UsageOperation.OTHER_WRITE);
-    final Authentication auth = maybeAuth.get();
     log.info("Attempting to reset credentials for native user {}", userUrnString);
     final OperationContext opContext =
         OperationContext.asSession(
@@ -493,9 +490,12 @@ public class AuthServiceController {
     if (maybeAuth.isEmpty()) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
+    final Authentication auth = maybeAuth.get();
+    if (!isSystemClient(auth.getActor().getId())) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     recordUsageSession(
         httpEntity.getHeaders(), "verifyNativeUserCredentials", UsageOperation.OTHER_READ);
-    final Authentication auth = maybeAuth.get();
     log.info(
         "Attempting to verify credentials for native userRef={}",
         LoginIdentityMask.mask(userUrnString));
@@ -644,11 +644,14 @@ public class AuthServiceController {
     if (maybeAuth.isEmpty()) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
+    final Authentication auth = maybeAuth.get();
+    if (!isSystemClient(auth.getActor().getId())) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     recordUsageSession(
         httpEntity != null ? httpEntity.getHeaders() : null,
         "getSsoSettings",
         UsageOperation.OTHER_READ);
-    final Authentication auth = maybeAuth.get();
     final OperationContext opContext =
         OperationContext.asSession(
             systemOperationContext,
@@ -678,7 +681,6 @@ public class AuthServiceController {
         });
   }
 
-  // Currently, only internal system is authorized to generate a token on behalf of a user!
   private void recordUsageSession(
       HttpHeaders headers, String operation, UsageOperation usageOperation) {
     final Optional<Authentication> maybeAuth = AuthenticationContext.maybeAuthentication();
@@ -695,10 +697,8 @@ public class AuthServiceController {
         true);
   }
 
-  private boolean isAuthorizedToGenerateSessionToken(final String actorId) {
-    // Verify that the actor is an internal system caller.
-    final String systemClientId = _systemAuthentication.getActor().getId();
-    return systemClientId.equals(actorId);
+  private boolean isSystemClient(final String actorId) {
+    return _systemAuthentication.getActor().getId().equals(actorId);
   }
 
   private String buildTokenResponse(final String token) {

--- a/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
+++ b/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
@@ -113,8 +113,6 @@ public class AuthServiceController {
 
   @Autowired private StatelessTokenService _statelessTokenService;
 
-  @Autowired private Authentication _systemAuthentication;
-
   @Autowired
   @Qualifier("configurationProvider")
   private ConfigurationProvider _configProvider;
@@ -181,7 +179,7 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication authentication = maybeAuth.get();
-    if (!isSystemClient(authentication.getActor().getId())) {
+    if (!isSystemClient(authentication)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(
@@ -322,7 +320,7 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth.getActor().getId())) {
+    if (!isSystemClient(auth)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(httpEntity.getHeaders(), "signUp", UsageOperation.OTHER_WRITE);
@@ -417,7 +415,7 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth.getActor().getId())) {
+    if (!isSystemClient(auth)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(
@@ -491,7 +489,7 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth.getActor().getId())) {
+    if (!isSystemClient(auth)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(
@@ -645,7 +643,7 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth.getActor().getId())) {
+    if (!isSystemClient(auth)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(
@@ -697,8 +695,15 @@ public class AuthServiceController {
         true);
   }
 
-  private boolean isSystemClient(final String actorId) {
-    return _systemAuthentication.getActor().getId().equals(actorId);
+  /**
+   * Frontend and other internal callers authenticate with HTTP Basic. User sessions are Bearer
+   * JWTs, even when the actor id happens to match a system client id, so scheme is the trust signal
+   * — do not re-validate secrets or pin a single actor id.
+   */
+  private boolean isSystemClient(@Nonnull Authentication authentication) {
+    final String credentials = authentication.getCredentials();
+    return credentials != null
+        && (credentials.startsWith("Basic ") || credentials.startsWith("basic "));
   }
 
   private String buildTokenResponse(final String token) {

--- a/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
+++ b/metadata-service/auth-servlet-impl/src/main/java/com/datahub/auth/authentication/AuthServiceController.java
@@ -17,6 +17,7 @@ import com.datahub.authentication.LoginDenialReason;
 import com.datahub.authentication.invite.InviteTokenService;
 import com.datahub.authentication.session.UserSessionEligibilityChecker;
 import com.datahub.authentication.token.StatelessTokenService;
+import com.datahub.authentication.token.TokenClaims;
 import com.datahub.authentication.token.TokenType;
 import com.datahub.authentication.user.NativeUserService;
 import com.datahub.authorization.AuthorizerChain;
@@ -27,7 +28,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.metadata.auth.LoginIdentityMask;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventType;
 import com.linkedin.metadata.datahubusage.event.LoginSource;
@@ -36,6 +39,7 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.settings.global.GlobalSettingsInfo;
 import com.linkedin.settings.global.OidcSettings;
 import com.linkedin.settings.global.SsoSettings;
+import io.datahubproject.metadata.context.ActorContext;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.context.usage.UsageOperation;
@@ -45,6 +49,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -113,6 +118,8 @@ public class AuthServiceController {
 
   @Autowired private StatelessTokenService _statelessTokenService;
 
+  @Autowired private Authentication _systemAuthentication;
+
   @Autowired
   @Qualifier("configurationProvider")
   private ConfigurationProvider _configProvider;
@@ -179,9 +186,6 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication authentication = maybeAuth.get();
-    if (!isSystemClient(authentication)) {
-      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
-    }
     recordUsageSession(
         httpEntity.getHeaders(), "generateSessionTokenForUser", UsageOperation.OTHER_WRITE);
     final String actorUrn = authentication.getActor().toUrnStr();
@@ -197,6 +201,9 @@ public class AuthServiceController {
             Authorizer.SYSTEM,
             authentication,
             true);
+    if (!isTrustedAuthHelperCaller(opContext)) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     return CompletableFuture.supplyAsync(
         () -> {
           try {
@@ -320,7 +327,15 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth)) {
+    final OperationContext opContext =
+        OperationContext.asSession(
+            systemOperationContext,
+            RequestContext.builder()
+                .buildOpenapi(auth.getActor().toUrnStr(), request, "signUp", List.of()),
+            Authorizer.SYSTEM,
+            auth,
+            true);
+    if (!isTrustedAuthHelperCaller(opContext)) {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     recordUsageSession(httpEntity.getHeaders(), "signUp", UsageOperation.OTHER_WRITE);
@@ -339,14 +354,6 @@ public class AuthServiceController {
     String passwordString = password.asText();
     String inviteTokenString = inviteToken.asText();
     log.info("Attempting to create native user {}", userUrnString);
-    final OperationContext opContext =
-        OperationContext.asSession(
-            systemOperationContext,
-            RequestContext.builder()
-                .buildOpenapi(auth.getActor().toUrnStr(), request, "signUp", List.of()),
-            Authorizer.SYSTEM,
-            auth,
-            true);
     return CompletableFuture.supplyAsync(
         () -> {
           try {
@@ -415,9 +422,6 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth)) {
-      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
-    }
     recordUsageSession(
         httpEntity.getHeaders(), "resetNativeUserCredentials", UsageOperation.OTHER_WRITE);
     log.info("Attempting to reset credentials for native user {}", userUrnString);
@@ -430,6 +434,9 @@ public class AuthServiceController {
             Authorizer.SYSTEM,
             auth,
             true);
+    if (!isTrustedAuthHelperCaller(opContext)) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     return CompletableFuture.supplyAsync(
         () -> {
           try {
@@ -489,9 +496,6 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth)) {
-      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
-    }
     recordUsageSession(
         httpEntity.getHeaders(), "verifyNativeUserCredentials", UsageOperation.OTHER_READ);
     log.info(
@@ -506,6 +510,9 @@ public class AuthServiceController {
             Authorizer.SYSTEM,
             auth,
             true);
+    if (!isTrustedAuthHelperCaller(opContext)) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     return CompletableFuture.supplyAsync(
         () -> {
           try {
@@ -643,9 +650,6 @@ public class AuthServiceController {
       return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
     }
     final Authentication auth = maybeAuth.get();
-    if (!isSystemClient(auth)) {
-      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
-    }
     recordUsageSession(
         httpEntity != null ? httpEntity.getHeaders() : null,
         "getSsoSettings",
@@ -658,6 +662,9 @@ public class AuthServiceController {
             Authorizer.SYSTEM,
             auth,
             true);
+    if (!isTrustedAuthHelperCaller(opContext)) {
+      return CompletableFuture.completedFuture(new ResponseEntity<>(HttpStatus.UNAUTHORIZED));
+    }
     return CompletableFuture.supplyAsync(
         () -> {
           try {
@@ -696,14 +703,49 @@ public class AuthServiceController {
   }
 
   /**
-   * Frontend and other internal callers authenticate with HTTP Basic. User sessions are Bearer
-   * JWTs, even when the actor id happens to match a system client id, so scheme is the trust signal
-   * — do not re-validate secrets or pin a single actor id.
+   * UI session JWTs are never allowed. Otherwise allow the GMS system principal or a corp user with
+   * {@code CorpUserInfo.system} (same identity check as SecretService).
    */
-  private boolean isSystemClient(@Nonnull Authentication authentication) {
-    final String credentials = authentication.getCredentials();
-    return credentials != null
-        && (credentials.startsWith("Basic ") || credentials.startsWith("basic "));
+  private boolean isTrustedAuthHelperCaller(@Nonnull OperationContext opContext) {
+    Authentication session = opContext.getSessionAuthentication();
+    if (isUiSessionToken(session)) {
+      return false;
+    }
+    if (ActorContext.isSystemSession(session, _systemAuthentication)) {
+      return true;
+    }
+    Urn actorUrn = opContext.getSessionActorContext().getActorUrn();
+    if (SYSTEM_ACTOR.equals(actorUrn.toString())) {
+      return true;
+    }
+    return isSystemCorpUser(actorUrn);
+  }
+
+  private boolean isUiSessionToken(@Nonnull Authentication authentication) {
+    Map<String, Object> claims = authentication.getClaims();
+    if (claims == null) {
+      return false;
+    }
+    Object tokenType = claims.get(TokenClaims.TOKEN_TYPE_CLAIM_NAME);
+    return TokenType.SESSION.name().equals(String.valueOf(tokenType));
+  }
+
+  private boolean isSystemCorpUser(@Nonnull Urn actorUrn) {
+    if (!CORP_USER_ENTITY_NAME.equals(actorUrn.getEntityType())) {
+      return false;
+    }
+    try {
+      RecordTemplate aspect =
+          _entityService.getLatestAspect(
+              systemOperationContext, actorUrn, CORP_USER_INFO_ASPECT_NAME);
+      if (!(aspect instanceof CorpUserInfo info)) {
+        return false;
+      }
+      return info.isSystem();
+    } catch (Exception e) {
+      log.debug("Failed to load CorpUserInfo for {} — deny auth helper", actorUrn, e);
+      return false;
+    }
   }
 
   private String buildTokenResponse(final String token) {

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
@@ -1,6 +1,7 @@
 package com.datahub.auth.authentication;
 
 import static com.datahub.auth.authentication.AuthServiceTestConfiguration.SYSTEM_CLIENT_ID;
+import static com.linkedin.metadata.Constants.CORP_USER_INFO_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.DATAHUB_LOGIN_SOURCE_HEADER_NAME;
 import static com.linkedin.metadata.Constants.GLOBAL_SETTINGS_INFO_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.GLOBAL_SETTINGS_URN;
@@ -22,6 +23,7 @@ import com.datahub.authentication.LoginDenialReason;
 import com.datahub.authentication.invite.InviteTokenService;
 import com.datahub.authentication.session.UserSessionEligibilityChecker;
 import com.datahub.authentication.token.StatelessTokenService;
+import com.datahub.authentication.token.TokenClaims;
 import com.datahub.authentication.token.TokenType;
 import com.datahub.authentication.user.NativeUserService;
 import com.datahub.telemetry.TrackingService;
@@ -29,8 +31,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.metadata.datahubusage.event.LoginSource;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
@@ -42,6 +46,7 @@ import io.datahubproject.metadata.services.SecretService;
 import io.opentelemetry.api.trace.SpanContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,6 +82,7 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     reset(mockUserSessionEligibilityChecker);
     reset(mockMetricUtils);
     reset(mockTokenService);
+    reset(mockEntityService);
     when(mockUserSessionEligibilityChecker.checkEligibility(
             any(OperationContext.class), anyString(), anyBoolean()))
         .thenReturn(Optional.empty());
@@ -309,6 +315,11 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     AuthenticationContext.setAuthentication(
         new Authentication(
             new Actor(ActorType.USER, "other-system"), "Basic other-system:shared-secret"));
+    when(mockEntityService.getLatestAspect(
+            any(OperationContext.class),
+            eq(UrnUtils.getUrn("urn:li:corpuser:other-system")),
+            eq(CORP_USER_INFO_ASPECT_NAME)))
+        .thenReturn(new CorpUserInfo().setSystem(true));
     when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
         .thenReturn("test-token-123");
     when(mockConfigProvider.getAuthentication()).thenReturn(new AuthenticationConfiguration());
@@ -320,6 +331,26 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
         authServiceController.generateSessionTokenForUser(request, httpEntity).join();
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
+  }
+
+  @Test
+  public void testGenerateSessionTokenRejectsSessionEvenWhenCorpUserIsSystem() throws Exception {
+    setBearerAuthentication("other-system");
+    when(mockEntityService.getLatestAspect(
+            any(OperationContext.class),
+            eq(UrnUtils.getUrn("urn:li:corpuser:other-system")),
+            eq(CORP_USER_INFO_ASPECT_NAME)))
+        .thenReturn(new CorpUserInfo().setSystem(true));
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", "testUser");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockTokenService, never())
+        .generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong());
   }
 
   @Test
@@ -1006,7 +1037,10 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   private void setBearerAuthentication(String actorId) {
     reset(mockTokenService, mockNativeUserService, mockInviteTokenService, mockEntityService);
     AuthenticationContext.setAuthentication(
-        new Authentication(new Actor(ActorType.USER, actorId), "Bearer user-token"));
+        new Authentication(
+            new Actor(ActorType.USER, actorId),
+            "Bearer user-token",
+            Map.of(TokenClaims.TOKEN_TYPE_CLAIM_NAME, TokenType.SESSION.name())));
   }
 
   private void verifyLoginMetric(String outcome, String loginSource, String denialReason) {

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
@@ -43,7 +43,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.CompletionException;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -267,22 +266,19 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     verifyLoginMetric("success", "unknown", "none");
   }
 
-  @Test(expectedExceptions = CompletionException.class)
+  @Test
   public void testGenerateSessionTokenForUserUnauthorized() throws Exception {
-    // Setup with non-system user
-    Authentication nonSystemAuth = mock(Authentication.class);
-    Actor regularActor = new Actor(ActorType.USER, "regularActor");
-    when(nonSystemAuth.getActor()).thenReturn(regularActor);
-    AuthenticationContext.setAuthentication(nonSystemAuth);
-
-    // Create request body
+    setNonSystemAuthentication();
     ObjectNode requestBody = objectMapper.createObjectNode();
     requestBody.put("userId", "testUser");
     HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
 
-    // Execute
     ResponseEntity<String> response =
         authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockTokenService, never())
+        .generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong());
   }
 
   @Test
@@ -871,6 +867,74 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     ResponseEntity<String> response = authServiceController.getSsoSettings(request, null).join();
 
     assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+  }
+
+  @Test
+  public void testSignUpNonSystemClientReturnsUnauthorized() throws Exception {
+    setNonSystemAuthentication();
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userUrn", "urn:li:corpuser:testUser");
+    requestBody.put("fullName", "Test User");
+    requestBody.put("email", "test@example.com");
+    requestBody.put("title", "Engineer");
+    requestBody.put("password", "password");
+    requestBody.put("inviteToken", "token");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response = authServiceController.signUp(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockNativeUserService, never())
+        .createNativeUser(any(), anyString(), anyString(), anyString(), any(), anyString());
+    verify(mockInviteTokenService, never()).isInviteTokenValid(any(), any());
+  }
+
+  @Test
+  public void testResetNativeUserCredentialsNonSystemClientReturnsUnauthorized() throws Exception {
+    setNonSystemAuthentication();
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userUrn", "urn:li:corpuser:testUser");
+    requestBody.put("password", "password");
+    requestBody.put("resetToken", "token");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response =
+        authServiceController.resetNativeUserCredentials(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockNativeUserService, never())
+        .resetCorpUserCredentials(any(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  public void testVerifyNativeUserCredentialsNonSystemClientReturnsUnauthorized() throws Exception {
+    setNonSystemAuthentication();
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userUrn", "urn:li:corpuser:testUser");
+    requestBody.put("password", "password");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response =
+        authServiceController.verifyNativeUserCredentials(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockNativeUserService, never()).doesPasswordMatch(any(), anyString(), anyString());
+  }
+
+  @Test
+  public void testGetSsoSettingsNonSystemClientReturnsUnauthorized() {
+    setNonSystemAuthentication();
+
+    ResponseEntity<String> response = authServiceController.getSsoSettings(request, null).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockEntityService, never()).getLatestAspect(any(), any(), anyString());
+  }
+
+  private void setNonSystemAuthentication() {
+    reset(mockTokenService, mockNativeUserService, mockInviteTokenService, mockEntityService);
+    AuthenticationContext.setAuthentication(
+        new Authentication(new Actor(ActorType.USER, "regularActor"), "Bearer user-token"));
   }
 
   private void verifyLoginMetric(String outcome, String loginSource, String denialReason) {

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
@@ -76,6 +76,7 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   public void stubSessionEligibility() {
     reset(mockUserSessionEligibilityChecker);
     reset(mockMetricUtils);
+    reset(mockTokenService);
     when(mockUserSessionEligibilityChecker.checkEligibility(
             any(OperationContext.class), anyString(), anyBoolean()))
         .thenReturn(Optional.empty());
@@ -178,6 +179,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     // Mock token service
@@ -218,6 +221,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
@@ -246,6 +251,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
@@ -282,11 +289,47 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   }
 
   @Test
+  public void testGenerateSessionTokenRejectsBearerWhenActorIdMatchesSystemClient()
+      throws Exception {
+    setBearerAuthentication(SYSTEM_CLIENT_ID);
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", "testUser");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockTokenService, never())
+        .generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong());
+  }
+
+  @Test
+  public void testGenerateSessionTokenAcceptsBasicForOtherSystemActor() throws Exception {
+    AuthenticationContext.setAuthentication(
+        new Authentication(
+            new Actor(ActorType.USER, "other-system"), "Basic other-system:shared-secret"));
+    when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
+        .thenReturn("test-token-123");
+    when(mockConfigProvider.getAuthentication()).thenReturn(new AuthenticationConfiguration());
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", "testUser");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+  }
+
+  @Test
   public void testGenerateSessionTokenForUserBadRequest() throws Exception {
     // Setup
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     // Create invalid request body (missing userId)
@@ -307,6 +350,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     when(mockUserSessionEligibilityChecker.checkEligibility(
@@ -375,6 +420,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     when(mockUserSessionEligibilityChecker.checkEligibility(
@@ -404,6 +451,8 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
     Authentication systemAuth = mock(Authentication.class);
     Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
     when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
     AuthenticationContext.setAuthentication(systemAuth);
 
     when(mockUserSessionEligibilityChecker.checkEligibility(
@@ -890,6 +939,25 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   }
 
   @Test
+  public void testSignUpRejectsBearerWhenActorIdMatchesSystemClient() throws Exception {
+    setBearerAuthentication(SYSTEM_CLIENT_ID);
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userUrn", "urn:li:corpuser:spawned");
+    requestBody.put("fullName", "Spawned User");
+    requestBody.put("email", "spawned@example.com");
+    requestBody.put("title", "Engineer");
+    requestBody.put("password", "password");
+    requestBody.put("inviteToken", "token");
+    HttpEntity<String> httpEntity = new HttpEntity<>(objectMapper.writeValueAsString(requestBody));
+
+    ResponseEntity<String> response = authServiceController.signUp(request, httpEntity).join();
+
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    verify(mockNativeUserService, never())
+        .createNativeUser(any(), anyString(), anyString(), anyString(), any(), anyString());
+  }
+
+  @Test
   public void testResetNativeUserCredentialsNonSystemClientReturnsUnauthorized() throws Exception {
     setNonSystemAuthentication();
     ObjectNode requestBody = objectMapper.createObjectNode();
@@ -932,9 +1000,13 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   }
 
   private void setNonSystemAuthentication() {
+    setBearerAuthentication("regularActor");
+  }
+
+  private void setBearerAuthentication(String actorId) {
     reset(mockTokenService, mockNativeUserService, mockInviteTokenService, mockEntityService);
     AuthenticationContext.setAuthentication(
-        new Authentication(new Actor(ActorType.USER, "regularActor"), "Bearer user-token"));
+        new Authentication(new Actor(ActorType.USER, actorId), "Bearer user-token"));
   }
 
   private void verifyLoginMetric(String outcome, String loginSource, String denialReason) {


### PR DESCRIPTION
## Summary
- Require the GMS system client on `POST /auth/signUp`, `/auth/resetNativeUserCredentials`, `/auth/verifyNativeUserCredentials`, and `/auth/getSsoSettings`, matching `/auth/generateSessionTokenForUser`.
- A user session can no longer create extra native accounts, reset/verify arbitrary passwords, or read SSO client secrets via these internal helpers.
- Frontend login/signup/reset/SSO is unchanged (it already uses system Basic credentials).

## Test plan
- [x] `./gradlew :metadata-service:auth-servlet-impl:test --tests com.datahub.auth.authentication.AuthServiceControllerTest`
- [ ] Confirm frontend native signup, password login, password reset, and SSO still succeed against a running stack
- [ ] Confirm a user Bearer token against GMS `POST /auth/signUp` (and the other helpers) returns 401


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts GMS /auth helpers to system principals and rejects UI session tokens, closing a privilege gap. Old: a user Bearer token could call sign-up/reset/verify/SSO and mint session tokens if its actor id matched the system client; new: only the GMS system principal or a corp user marked system can call, and any session JWT receives 401. Frontend login/signup/reset/SSO remain unchanged.

- Affects POST /auth/signUp, /auth/resetNativeUserCredentials, /auth/verifyNativeUserCredentials, /auth/getSsoSettings, and /auth/generateSessionTokenForUser.
- Gates via a system-identity check: denies TokenType.SESSION; allows `ActorContext.isSystemSession(...)`, the system actor, or a corp user with `CorpUserInfo.system=true`. Removes the actor-id equality check; acceptance is no longer tied to the `Basic` prefix.
- Migration: if you called these GMS helpers with a user token, use frontend routes or call as the system principal (system client or a corp user with `CorpUserInfo.system=true`).
- Tests cover 401 for non-system callers and Bearer even when the actor id matches the system client, and acceptance for system principals; docs updated under “Other Notable Changes.”

<sup>Written for commit 37f3acecd4a09cf2929792e1a5893b20b07e6715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

