### PR TITLE
perf(docker): improve layer caching for Python ingestion images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 */build/
 */*/build/
 **/venv/
+**/.venv/
+.venv
 **/.tox/
 **/.mypy_cache/
 **/.pytest_cache/
@@ -23,3 +25,11 @@ out
 /metadata-ingestion/tests
 /metadata-ingestion/examples
 /metadata-ingestion/docs
+docs/generated/
+metadata-ingestion/generated/
+docs-website/genDocs/
+docs-website/genStatic/
+scripts/generated/
+**/bin/
+# Play installDist launcher must stay in context (see datahub-frontend/build.gradle stage task).
+!datahub-frontend/build/stage/main/bin/**

--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -159,7 +159,8 @@ USER datahub
 
 # Build bundled venvs using our self-contained script (standard s3 with PySpark)
 WORKDIR /tmp
-RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions-bundled,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
     ./build_bundled_venvs_unified.sh
 
 USER datahub
@@ -204,7 +205,8 @@ USER datahub
 
 # Build bundled venvs using our self-contained script (s3-slim without PySpark)
 WORKDIR /tmp
-RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions-bundled,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
     ./build_bundled_venvs_unified.sh
 
 USER datahub
@@ -249,7 +251,8 @@ USER datahub
 
 # Build bundled venvs using our self-contained script (s3-slim without PySpark)
 WORKDIR /tmp
-RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions-bundled,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
     ./build_bundled_venvs_unified.sh
 
 USER datahub
@@ -276,21 +279,7 @@ ARG BUNDLED_VENV_SLIM_MODE="false"
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-full $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
 
-# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
-COPY --chown=datahub:datahub \
-    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
-    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
-    ./docker/snippets/ingestion/bundled_venv_config.py \
-    ./docker/snippets/ingestion/constraints.txt \
-    /opt/datahub/bundled-venv-build/
-RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
-    chown -R datahub:datahub /opt/datahub/bundled-venv-build
-
-COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
-COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
-
-RUN chmod a+x /start_datahub_actions.sh && \
-    mkdir -p /etc/datahub/actions && \
+RUN mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
 
@@ -341,6 +330,20 @@ RUN rm -rf $HOME/.config/uv && \
     # in site-packages remain the source of truth.
     find /home/datahub/.venv /opt/datahub/venvs -path '*/pip/_vendor/bom.cdx.json' -delete
 
+# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
+COPY --chown=datahub:datahub \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
+    ./docker/snippets/ingestion/bundled_venv_config.py \
+    ./docker/snippets/ingestion/constraints.txt \
+    /opt/datahub/bundled-venv-build/
+RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
+    chown -R datahub:datahub /opt/datahub/bundled-venv-build
+
+COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
+RUN chmod a+x /start_datahub_actions.sh
+
 ENTRYPOINT [ ]
 CMD ["/bin/bash", "/start_datahub_actions.sh"]
 
@@ -362,21 +365,7 @@ ARG BUNDLED_VENV_SLIM_MODE="true"
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-slim $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
 
-# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
-COPY --chown=datahub:datahub \
-    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
-    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
-    ./docker/snippets/ingestion/bundled_venv_config.py \
-    ./docker/snippets/ingestion/constraints.txt \
-    /opt/datahub/bundled-venv-build/
-RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
-    chown -R datahub:datahub /opt/datahub/bundled-venv-build
-
-COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
-COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
-
-RUN chmod a+x /start_datahub_actions.sh && \
-    mkdir -p /etc/datahub/actions && \
+RUN mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
 
@@ -426,6 +415,20 @@ RUN rm -rf $HOME/.config/uv && \
     # in site-packages remain the source of truth.
     find /home/datahub/.venv /opt/datahub/venvs -path '*/pip/_vendor/bom.cdx.json' -delete
 
+# Shipped for downstream Dockerfiles that extend the published image without cloning the repo (see docs/docker/bundled-ingestion-venvs.md).
+COPY --chown=datahub:datahub \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.py \
+    ./docker/snippets/ingestion/build_bundled_venvs_unified.sh \
+    ./docker/snippets/ingestion/bundled_venv_config.py \
+    ./docker/snippets/ingestion/constraints.txt \
+    /opt/datahub/bundled-venv-build/
+RUN chmod 755 /opt/datahub/bundled-venv-build/build_bundled_venvs_unified.sh && \
+    chown -R datahub:datahub /opt/datahub/bundled-venv-build
+
+COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
+RUN chmod a+x /start_datahub_actions.sh
+
 ENTRYPOINT [ ]
 CMD ["/bin/bash", "/start_datahub_actions.sh"]
 
@@ -447,11 +450,7 @@ ARG BUNDLED_VENV_SLIM_MODE="true"
 ENV BUNDLED_VENV_SLIM_MODE=${BUNDLED_VENV_SLIM_MODE}
 COPY --from=bundled-venvs-locked $DATAHUB_BUNDLED_VENV_PATH $DATAHUB_BUNDLED_VENV_PATH
 
-COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
-COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
-
-RUN chmod a+x /start_datahub_actions.sh && \
-    mkdir -p /etc/datahub/actions && \
+RUN mkdir -p /etc/datahub/actions && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
 
@@ -495,6 +494,10 @@ RUN rm -rf $HOME/.config/uv && \
     # pip's vendored CycloneDX BOM lists build-time setuptools/msgpack pins that Trivy
     # reports as installed packages (AnalyzedBy=sbom). Remove before strip_pip removes pip.
     find /home/datahub/.venv /opt/datahub/venvs -path '*/pip/_vendor/bom.cdx.json' -delete
+
+COPY --chown=datahub:datahub ./docker/datahub-actions/start.sh /start_datahub_actions.sh
+COPY --chown=datahub:datahub ./docker/datahub-actions/readiness-check.sh /readiness-check.sh
+RUN chmod a+x /start_datahub_actions.sh
 
 # No uv/pip in the final locked image: build is done; package managers are unnecessary attack surface.
 # Script file avoids Docker RUN treating $v / $sp as empty Docker env vars (see docker/snippets/strip_pip_uv_from_venvs.sh).

--- a/docker/datahub-ingestion-base/Dockerfile
+++ b/docker/datahub-ingestion-base/Dockerfile
@@ -63,9 +63,16 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_NO_CACHE=1
 RUN uv python install ${PYTHON_VERSION}
 
-ARG PIP_MIRROR_URL=https://pypi.python.org/simple
-RUN if [ "${PIP_MIRROR_URL}" != "https://pypi.python.org/simple" ] ; then uvx --no-cache pip config set global.index-url ${PIP_MIRROR_URL} ; fi
-ENV UV_DEFAULT_INDEX=${PIP_MIRROR_URL}
+ARG UV_PROFILE=default
+ARG DEFAULT_INDEX_URL=""
+ARG EXTRA_INDEX_URLS=""
+RUN --mount=type=bind,source=./docker/snippets/uv,target=/tmp/uv-config \
+    mkdir -p $HOME/.config/uv && \
+    if [ "${UV_PROFILE}" = "custom" ] || [ -n "${EXTRA_INDEX_URLS}" ]; then \
+        PROFILES_DIR=/tmp/uv-config/profiles BASE_PROFILE="${UV_PROFILE}" UV_PROFILE="${UV_PROFILE}" DEFAULT_INDEX_URL="${DEFAULT_INDEX_URL}" EXTRA_INDEX_URLS="${EXTRA_INDEX_URLS}" bash /tmp/uv-config/generate-config.sh > $HOME/.config/uv/uv.toml; \
+    else \
+        cp /tmp/uv-config/profiles/${UV_PROFILE}.toml $HOME/.config/uv/uv.toml; \
+    fi
 
 USER datahub
 WORKDIR $HOME

--- a/docker/datahub-ingestion-base/build.gradle
+++ b/docker/datahub-ingestion-base/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 apply from: "../../gradle/versioning/versioning.gradle"
 apply from: "../../gradle/docker/docker.gradle"
+apply from: "../../gradle/docker/python-docker.gradle"
 
 ext {
     docker_registry = rootProject.ext.docker_registry == 'linkedin' ? 'acryldata' : docker_registry
@@ -31,6 +32,5 @@ docker {
 
     // Add build args if they are defined (needed for some CI or enterprise environments)
     dockerBuildArgs.GITHUB_REPO_URL = gradle.ext['datahub.dependencies.github.baseURL']
-    dockerBuildArgs.PIP_MIRROR_URL = gradle.ext['datahub.dependencies.python.pipMirrorUrl']
-    buildArgs(dockerBuildArgs)
+    buildArgs(resolveUvBuildArgs(dockerBuildArgs))
 }

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -141,11 +141,65 @@ FROM ingestion-base-slim AS ingestion-base-locked
 # INLINE-END
 
 # =============================================================================
-# ADD-CODE STAGES - Separate stages for each variant to avoid caching issues
-# with parameterized FROM statements in multi-platform builds
+# DEPS + ADD-CODE STAGES - Split external dependency install from source copy
+# so routine Python edits do not re-run the expensive dependency download step.
 # =============================================================================
 
-FROM ingestion-base-slim AS add-code-slim
+FROM ingestion-base-slim AS add-deps-slim
+
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
+COPY --chown=datahub ./metadata-ingestion/setup.py /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/pyproject.toml /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/README.md /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/build-constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/src/datahub/_version.py /metadata-ingestion/src/datahub/
+
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+    echo "-e /metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,s3-slim,gcs-slim,abs-slim,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" \
+    | uv pip compile /dev/stdin \
+    | grep -v "\-e" \
+    | UV_LINK_MODE=copy uv pip install -r /dev/stdin
+
+FROM ingestion-base-full AS add-deps-full
+
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
+COPY --chown=datahub ./metadata-ingestion/setup.py /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/pyproject.toml /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/README.md /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/build-constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/src/datahub/_version.py /metadata-ingestion/src/datahub/
+
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+    echo "-e /metadata-ingestion/[all]" \
+    | uv pip compile /dev/stdin \
+    | grep -v "\-e" \
+    | UV_LINK_MODE=copy uv pip install -r /dev/stdin
+
+FROM ingestion-base-locked AS add-deps-locked
+
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
+COPY --chown=datahub ./metadata-ingestion/setup.py /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/pyproject.toml /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/README.md /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/build-constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/constraints.txt /metadata-ingestion/
+COPY --chown=datahub ./metadata-ingestion/src/datahub/_version.py /metadata-ingestion/src/datahub/
+
+RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
+    --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
+    echo "-e /metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" \
+    | uv pip compile /dev/stdin \
+    | grep -v "\-e" \
+    | UV_LINK_MODE=copy uv pip install -r /dev/stdin
+
+FROM add-deps-slim AS add-code-slim
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"  # RELEASE_VERSION is a required build arg
@@ -153,7 +207,7 @@ RUN test -d /metadata-ingestion/src/datahub/metadata  # codegen must be run prio
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
     python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-FROM ingestion-base-full AS add-code-full
+FROM add-deps-full AS add-code-full
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"
@@ -161,7 +215,7 @@ RUN test -d /metadata-ingestion/src/datahub/metadata
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
     python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-FROM ingestion-base-locked AS add-code-locked
+FROM add-deps-locked AS add-code-locked
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -6,7 +6,9 @@ FROM postgres:${POSTGRES_VERSION}
 # (pgQueue / pgTimeseries time-partitioned retention + in-DB maintenance scheduling).
 # The PG_MAJOR environment variable is set by the base PostgreSQL image; packages come from the
 # same PGDG/Debian repos as the base image.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     postgresql-${PG_MAJOR}-pgrouting \
     postgresql-${PG_MAJOR}-postgis-3 \
     postgresql-${PG_MAJOR}-postgis-3-scripts \


### PR DESCRIPTION
## Summary

- Split `datahub-ingestion` Docker builds into cached dependency layers (`add-deps-*`) and source layers (`add-code-*`) so routine Python edits no longer invalidate PyPI download/install steps.
- Reorder `datahub-actions` Dockerfile so `start.sh` / bundled-venv script COPY steps sit below dependency install layers; add uv cache mounts for bundled venv builds.
- Align `datahub-ingestion-base` with the UV profile bind-mount pattern used by other Python images.
- Add apt cache mounts to `postgres` image extension installs.
- Tighten `.dockerignore` to exclude generated docs, Gradle venvs, and IDE `bin/` dirs (with a carve-out for the frontend Play launcher).

## Test plan

- [x] `./gradlew :docker:buildImagesallImages -PbuildModules=:datahub-actions,:docker:datahub-ingestion` — baseline and source-only rebuild via bake
- [x] Source-only invalidation: `add-deps-full` layer CACHED, 0 PyPI downloads on rebuild (~41s vs ~170s baseline)
- [x] Script-only invalidation (`start.sh`): deps layer CACHED, only late COPY/chmod reran (~6s)
- [x] Image content equivalence: normalized filesystem hashes match pre-change images for actions, ingestion, ingestion-base, and postgres
- [ ] CI docker image builds


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Docker rebuild time for Python ingestion by caching dependency installs and reordering actions image layers. Previously, any Python/script change triggered full PyPI downloads; now dependency layers persist and only source/script layers rebuild, with no runtime behavior change.

- datahub-ingestion: adds add-deps-* stages that install requirements via `uv pip compile` + install with a cache mount and optional `.netrc`; add-code stages only copy sources and set the release version.
- datahub-actions: moves bundled-venv and start/readiness script COPY steps below dependency layers; adds `uv` cache mounts for bundled venv builds.
- datahub-ingestion-base: replaces `PIP_MIRROR_URL` with `uv` profile-based config via a bind-mounted template; new build args: UV_PROFILE, DEFAULT_INDEX_URL, EXTRA_INDEX_URLS. Gradle now applies `python-docker.gradle` and uses resolveUvBuildArgs.
- postgres: adds APT cache mounts to speed extension installs.
- .dockerignore: excludes generated docs, venvs (including `.venv`), and IDE `bin/`, keeping the frontend Play launcher path.
- Required migration: if you pass PIP_MIRROR_URL in external builds or CI, switch to UV_PROFILE=custom and/or set DEFAULT_INDEX_URL and EXTRA_INDEX_URLS.

<sup>Written for commit b7b5c28fdcb52c5980de57636924085c472bb4ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

