### PR TITLE
fix(ci): Fix linting in playwright test

### DIFF
--- a/e2e-test/ui/playwright/pages/settings/policies.page.ts
+++ b/e2e-test/ui/playwright/pages/settings/policies.page.ts
@@ -93,6 +93,9 @@ export class PoliciesPage extends BaseSettingsPage {
     // for a moment after the last keystroke. Callers open a row menu immediately after searching,
     // and the debounced refetch then unmounts the table rows — silently closing that open menu.
     // Wait for the debounce to fire and its refetch to finish before handing control back.
+    // A fixed wait is required here: repeat searches for the same term short-circuit in the UI
+    // (no refetch is issued), so there is no network response or DOM change to wait on.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
     await this.page.waitForTimeout(TIMEOUTS.OPERATION);
     await this.page.waitForLoadState('networkidle');
   }


### PR DESCRIPTION
Fixes lint of a new playwright test where we are going to allow a fixed wait that we usually don't allow.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows a fixed wait in the Playwright policies page object and suppresses the lint rule to stabilize search-driven tests. Previously the lint rule blocked `waitForTimeout`; now we scope-disable `playwright/no-wait-for-timeout` where debounced and short-circuited searches make event-based waits impossible.

- Change is limited to tests (`e2e-test/ui/playwright/pages/settings/policies.page.ts`); no product behavior changes or migrations required.

<sup>Written for commit bb7a7017ce60c05b553b1846bc240978dc4eb055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

