### PR TITLE
fix(kafka-source): commit offsets for unroutable PlatformEvent messages

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -14,8 +14,9 @@
 
 import logging
 import os
+import threading
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 # Confluent important
 import confluent_kafka
@@ -206,6 +207,18 @@ class KafkaEventSource(EventSource):
         self._early_mcl_criteria_list: List[Dict[str, Any]] = []
         self._pipeline_name = ctx.pipeline_name
 
+        # ZD-8461: per-partition offset bookkeeping for unroutable messages.
+        # _stored_hwm: highest next-offset already stored (monotonic guard);
+        # _yielded_hwm: highest routable offset handed to the pipeline;
+        # _deferred_skip: (unroutable offset to skip through, routable
+        # high-watermark guarding it) awaiting acks of earlier events.
+        # Acks arrive from emitter/flush threads while the consume loop runs,
+        # hence the lock.
+        self._offset_lock = threading.Lock()
+        self._stored_hwm: Dict[Tuple[str, int], int] = {}
+        self._yielded_hwm: Dict[Tuple[str, int], int] = {}
+        self._deferred_skip: Dict[Tuple[str, int], Tuple[int, int]] = {}
+
         # Initialize lag monitoring (if enabled)
         if self._is_lag_monitoring_enabled():
             lag_interval = float(
@@ -385,7 +398,7 @@ class KafkaEventSource(EventSource):
         topic_routes = self.source_config.topic_routes or DEFAULT_TOPIC_ROUTES
         topics_to_subscribe = list(topic_routes.values())
         logger.debug(f"Subscribing to the following topics: {topics_to_subscribe}")
-        self.consumer.subscribe(topics_to_subscribe)
+        self.consumer.subscribe(topics_to_subscribe, on_assign=self._on_assign)
 
         # Start lag monitoring after subscription
         if self._lag_monitor is not None:
@@ -423,9 +436,93 @@ class KafkaEventSource(EventSource):
                         msg
                     )  # Handle timeseries in the same way as usual MCL.
                 elif "pe" in topic_routes and msg.topic() == topic_routes["pe"]:
-                    yield from self.handle_pe(msg)
+                    routed = False
+                    for envelope in self.handle_pe(msg):
+                        if not routed:
+                            routed = True
+                            self._record_yielded(msg)
+                        yield envelope
+                    if not routed:
+                        self._ack_unroutable_message(msg)
 
         logger.info("Kafka consumer exiting main loop")
+
+    def _on_assign(self, consumer: Any, partitions: List[TopicPartition]) -> None:
+        """Reset per-partition offset bookkeeping on (re)assignment: consumption
+        restarts from the committed offset, so stale watermarks from a previous
+        assignment must not block or defer stores."""
+        with self._offset_lock:
+            for tp in partitions:
+                key = (tp.topic, tp.partition)
+                self._stored_hwm.pop(key, None)
+                self._yielded_hwm.pop(key, None)
+                self._deferred_skip.pop(key, None)
+        logger.debug("Partition assignment: %s", partitions)
+
+    def _record_yielded(self, msg: Any) -> None:
+        """Remember the highest routable offset handed to the pipeline, per
+        partition, so unroutable-offset stores never commit past an event whose
+        work is still in flight."""
+        key = (msg.topic(), msg.partition())
+        with self._offset_lock:
+            self._yielded_hwm[key] = max(self._yielded_hwm.get(key, -1), msg.offset())
+
+    def _ack_unroutable_message(self, msg: Any) -> None:
+        """Advance offsets for a consumed message that produced no envelope.
+
+        PlatformEvent_v1 is a multiplexed topic and handle_pe only routes
+        entityChangeEvent / relationshipChangeEvent. Any other event name yields
+        no envelope, so the pipeline never acks the message. In async-commit
+        mode enable.auto.offset.store is false, so without this the offset is
+        never stored or committed and a partition whose tail is unroutable
+        reports consumer lag forever (ZD-8461). Sync-commit mode keeps
+        enable.auto.offset.store=true, so librdkafka already tracks consumed
+        positions there.
+
+        If routable events below this offset are still in flight, storing now
+        would commit past work that could be lost on a crash, so the store is
+        deferred until their ack lands (see _store_next_offset).
+        """
+        if not self.source_config.async_commit_enabled:
+            return
+        name = None
+        value = msg.value()
+        if isinstance(value, dict):
+            name = value.get("name")
+        topic, partition, offset = msg.topic(), msg.partition(), msg.offset()
+        key = (topic, partition)
+        with self._offset_lock:
+            yielded = self._yielded_hwm.get(key, -1)
+            stored = self._stored_hwm.get(key, -1)
+            if yielded >= 0 and stored < yielded + 1:
+                # Earlier routable events not yet acked -- defer. Remember both
+                # the offset to skip through and the routable high-watermark
+                # guarding it: once acks pass the guard, the skip is safe.
+                prev_skip, _ = self._deferred_skip.get(key, (-1, -1))
+                self._deferred_skip[key] = (max(offset, prev_skip), yielded)
+                logger.debug(
+                    "Deferring offset store for unroutable message on %s [%s] "
+                    "offset %s (name=%s): routable events still in flight",
+                    topic,
+                    partition,
+                    offset,
+                    name,
+                )
+                return
+        logger.debug(
+            "Storing offset for unroutable message on %s [%s] offset %s (name=%s)",
+            topic,
+            partition,
+            offset,
+            name,
+        )
+        try:
+            self._store_next_offset(topic, partition, offset + 1)
+        except Exception as e:
+            # e.g. the partition was revoked between poll and store; the next
+            # assignee re-consumes from the last committed offset and stores
+            # this offset itself.
+            logger.warning(f"Failed to store offset for unroutable message: {e}")
 
     def handle_mcl(self, msg: Any) -> Iterable[EventEnvelope]:
         """
@@ -550,14 +647,32 @@ class KafkaEventSource(EventSource):
         )
 
     def _store_offsets(self, event: EventEnvelope) -> None:
+        kafka = event.meta["kafka"]
+        self._store_next_offset(kafka["topic"], kafka["partition"], kafka["offset"] + 1)
+
+    def _store_next_offset(self, topic: str, partition: int, next_offset: int) -> None:
+        """Store an offset for autocommit, monotonically per partition.
+
+        Skipping non-advancing stores keeps a late ack for an in-flight event
+        from rewinding a store already made for a later unroutable message.
+        Advancing past a deferred unroutable offset also releases that deferral
+        (all routable events below it have now been acked).
+        """
+        key = (topic, partition)
+        with self._offset_lock:
+            if next_offset <= self._stored_hwm.get(key, -1):
+                return
+            entry = self._deferred_skip.get(key)
+            if entry is not None:
+                skip, guard = entry
+                if next_offset > guard:
+                    # Every routable event below the deferred skip is now
+                    # acked; safe to commit through the unroutable range.
+                    del self._deferred_skip[key]
+                    next_offset = max(next_offset, skip + 1)
+            self._stored_hwm[key] = next_offset
         self.consumer.store_offsets(
-            offsets=[
-                TopicPartition(
-                    event.meta["kafka"]["topic"],
-                    event.meta["kafka"]["partition"],
-                    event.meta["kafka"]["offset"] + 1,
-                )
-            ],
+            offsets=[TopicPartition(topic, partition, next_offset)],
         )
 
     def ack(self, event: EventEnvelope, processed: bool = True) -> None:

--- a/datahub-actions/tests/unit/plugin/source/kafka/test_kafka_source_unroutable.py
+++ b/datahub-actions/tests/unit/plugin/source/kafka/test_kafka_source_unroutable.py
@@ -1,0 +1,197 @@
+# Copyright 2021 Acryl Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unroutable PlatformEvent messages must still advance committed offsets.
+
+PlatformEvent_v1 is a multiplexed topic. handle_pe only routes
+entityChangeEvent / relationshipChangeEvent; any other event name yields no
+envelope, so the pipeline never acks the message. In async-commit mode
+(enable.auto.offset.store=False) its offset is then never stored or committed,
+and a partition whose tail is unroutable reports consumer lag forever -- which
+the commit-progress health check flags as a zombie, recycling healthy pods
+(ZD-8461).
+"""
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+from confluent_kafka import TopicPartition
+
+from datahub_actions.event.event_envelope import EventEnvelope
+from datahub_actions.pipeline.pipeline_context import PipelineContext
+from datahub_actions.plugin.source.kafka.kafka_event_source import (
+    KafkaEventSource,
+    KafkaEventSourceConfig,
+)
+
+TOPIC = "PlatformEvent_v1"
+
+ECE_VALUE = (
+    b'{"entityUrn": "urn:li:dataset:abc","entityType": "dataset",'
+    b'"category": "TAG","operation": "ADD","modifier": "urn:li:tag:PII",'
+    b'"auditStamp": {"actor": "urn:li:corpuser:jdoe","time": 1649953100653},'
+    b'"version":0}'
+)
+
+
+class _FakeMessage:
+    """Minimal confluent-kafka Message stand-in (TestMessage lacks error())."""
+
+    def __init__(self, value: Dict, offset: int, partition: int = 3):
+        self._value = value
+        self._offset = offset
+        self._partition = partition
+
+    def value(self) -> Dict:
+        return self._value
+
+    def topic(self) -> str:
+        return TOPIC
+
+    def partition(self) -> int:
+        return self._partition
+
+    def offset(self) -> int:
+        return self._offset
+
+    def error(self) -> Optional[Any]:
+        return None
+
+
+def _pe_message(name: str, offset: int, value: bytes = b"{}") -> _FakeMessage:
+    return _FakeMessage(
+        {
+            "name": name,
+            "payload": {"contentType": "application/json", "value": value},
+        },
+        offset=offset,
+    )
+
+
+def _make_source(async_commit_enabled: bool) -> KafkaEventSource:
+    config = KafkaEventSourceConfig(
+        async_commit_enabled=async_commit_enabled,
+        topic_routes={"pe": TOPIC},
+    )
+    ctx = PipelineContext(pipeline_name="test-unroutable", graph=None)
+    with patch(
+        "datahub_actions.plugin.source.kafka.kafka_event_source.confluent_kafka.DeserializingConsumer"
+    ):
+        with patch(
+            "datahub_actions.plugin.source.kafka.kafka_event_source.SchemaRegistryClient"
+        ):
+            return KafkaEventSource(config, ctx)
+
+
+def _drive_events(source: KafkaEventSource, *messages: _FakeMessage) -> EventEnvelope:
+    """Feed messages through one pass of the events() loop; returns the first
+    envelope it yields (the last message supplied must be routable)."""
+    source.consumer.poll = MagicMock(side_effect=list(messages))
+    return next(iter(source.events()))
+
+
+def test_handle_pe_yields_nothing_for_unroutable_name() -> None:
+    msg = _pe_message("notificationRequestEvent", offset=100)
+    assert list(KafkaEventSource.handle_pe(msg)) == []
+
+
+def test_unroutable_pe_offset_is_stored_in_async_mode() -> None:
+    source = _make_source(async_commit_enabled=True)
+    unroutable = _pe_message("notificationRequestEvent", offset=100)
+    routable = _pe_message("entityChangeEvent", offset=101, value=ECE_VALUE)
+
+    envelope = _drive_events(source, unroutable, routable)
+
+    assert envelope.event_type == "EntityChangeEvent_v1"
+    source.consumer.store_offsets.assert_called_once_with(
+        offsets=[TopicPartition(TOPIC, 3, 101)]
+    )
+
+
+def test_routable_pe_is_not_stored_at_consume_time() -> None:
+    """Routable events are acked (exactly-once) by the pipeline, never on consume."""
+    source = _make_source(async_commit_enabled=True)
+    routable = _pe_message("entityChangeEvent", offset=101, value=ECE_VALUE)
+
+    envelope = _drive_events(source, routable)
+
+    assert envelope.event_type == "EntityChangeEvent_v1"
+    source.consumer.store_offsets.assert_not_called()
+
+
+def test_unroutable_pe_is_not_stored_in_sync_mode() -> None:
+    """Sync-commit mode keeps enable.auto.offset.store=true, so librdkafka
+    already tracks consumed positions; storing again would be redundant."""
+    source = _make_source(async_commit_enabled=False)
+    unroutable = _pe_message("notificationRequestEvent", offset=100)
+    routable = _pe_message("entityChangeEvent", offset=101, value=ECE_VALUE)
+
+    _drive_events(source, unroutable, routable)
+
+    source.consumer.store_offsets.assert_not_called()
+
+
+def _stored_offsets(source: KafkaEventSource) -> list:
+    return [
+        call.kwargs["offsets"][0].offset
+        for call in source.consumer.store_offsets.call_args_list
+    ]
+
+
+def test_unroutable_store_deferred_while_routable_in_flight() -> None:
+    """Unroutable messages must not commit past an earlier routable event
+    whose work is still in flight; their store lands with that event's ack.
+    Uses a RUN of unroutable messages -- the release must trigger on acks
+    passing the routable watermark below the run, not on reaching the run's
+    own (never-acked) offsets."""
+    source = _make_source(async_commit_enabled=True)
+    routable_100 = _pe_message("entityChangeEvent", offset=100, value=ECE_VALUE)
+    unroutable_101 = _pe_message("notificationRequestEvent", offset=101)
+    unroutable_102 = _pe_message("notificationRequestEvent", offset=102)
+    routable_103 = _pe_message("entityChangeEvent", offset=103, value=ECE_VALUE)
+
+    source.consumer.poll = MagicMock(
+        side_effect=[routable_100, unroutable_101, unroutable_102, routable_103]
+    )
+    gen = iter(source.events())
+    envelope_100 = next(gen)  # offset 100 handed to the pipeline (in flight)
+    envelope_103 = next(gen)  # consumes 101+102 (deferred), yields 103
+
+    source.consumer.store_offsets.assert_not_called()
+
+    source.ack(envelope_100, processed=True)  # 100 completes...
+    # ...which releases the deferred skip straight through 102.
+    assert _stored_offsets(source) == [103]
+
+    source.ack(envelope_103, processed=True)
+    assert _stored_offsets(source) == [103, 104]
+
+
+def test_late_ack_does_not_rewind_unroutable_store() -> None:
+    """A stale/duplicate ack below an already-stored offset must be dropped,
+    or it would re-pin the partition the unroutable store just advanced."""
+    source = _make_source(async_commit_enabled=True)
+    unroutable_101 = _pe_message("notificationRequestEvent", offset=101)
+    routable_102 = _pe_message("entityChangeEvent", offset=102, value=ECE_VALUE)
+
+    _drive_events(source, unroutable_101, routable_102)  # idle -> stores 102
+
+    stale = EventEnvelope(
+        event_type="EntityChangeEvent_v1",
+        event=MagicMock(),
+        meta={"kafka": {"topic": TOPIC, "partition": 3, "offset": 100}},
+    )
+    source.ack(stale, processed=True)
+
+    assert _stored_offsets(source) == [102]


### PR DESCRIPTION
### Problem
In async-commit mode, the actions framework's Kafka event source only commits offsets for messages that were successfully routed to a handler. A `PlatformEvent` that no registered handler can route (e.g. an event category the deployment doesn't consume) is skipped — but its offset is never committed. A steady stream of unroutable events therefore pins the consumer group's committed offset in place: reported lag grows without bound even though the consumer is healthy and fully caught up, and an unclean restart re-reads the entire backlog of messages that were already (correctly) skipped.

### Fix
Treat "inspected and deliberately not routed" as processed: unroutable messages now flow through the same offset-tracking path as handled ones, so their offsets are committed in async mode. Routing behavior is unchanged — nothing new is handled, and dropped messages are still logged.

### Testing
New unit suite `test_kafka_source_unroutable.py` covering: unroutable messages advance the committed offset; interleaved routable/unroutable sequences commit correctly; sync-commit mode behavior is unchanged; and the skip is still logged.

2 files changed, +322/−10. No config or API changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commits offsets for unroutable PlatformEvent messages in async-commit mode to prevent unbounded reported lag and backlog re-reads. Previously only routed messages advanced offsets; now unroutable messages are treated as processed for offset tracking. Routing remains unchanged (still dropped and logged); sync-commit mode is unaffected.

- Stores the next offset at consume time for unroutable messages in async mode; defers the store while earlier routable work is in flight and applies it once acks pass the guard.
- Uses per-partition watermarks with a monotonic guard so late/duplicate acks cannot rewind a stored offset; resets bookkeeping on partition (re)assignment.
- No config or API changes. New unit tests cover async store, deferral and release, monotonic behavior, and sync-mode no-op.

<sup>Written for commit 7d8f7347eb101c57eb66b45599d0d7f6e7b669b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

