### PR TITLE
docs: make town hall links evergreen and update community count to 16k

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,21 +767,16 @@ Join thousands of data practitioners building with DataHub!
 
 ### 🗓️ Town Halls
 
-**Next Town Hall:**
+Monthly community calls with roadmap updates, live demos, and user case studies.
 
-- 🎟️ [Register for the next Town Hall](https://luma.com/1vz73xnf)
-
-**Last Town Hall:**
-
-- 📺 [Context to Action with Grab, dltHub, and iFood](https://youtu.be/GsnX7edN6Rw) (May 2026)
-
-[→ View all past recordings](https://www.youtube.com/playlist?list=PLdCtLs64vZvHTXGqybmOfyxXbGDn2Reb9)
+- 🎟️ [Register for the next Town Hall](https://luma.com/datahubevents?tag=datahub%20town%20hall)
+- 📺 [Watch past recordings](https://www.youtube.com/playlist?list=PLdCtLs64vZvHTXGqybmOfyxXbGDn2Reb9)
 
 ### 💬 Get Help & Connect
 
 | Channel                | Purpose                                  | Link                                                                         |
 | ---------------------- | ---------------------------------------- | ---------------------------------------------------------------------------- |
-| **Slack Community**    | Real-time chat, questions, announcements | [Join 15,000+ members](https://datahub.com/slack)                            |
+| **Slack Community**    | Real-time chat, questions, announcements | [Join 16,000+ members](https://datahub.com/slack)                            |
 | **GitHub Discussions** | Technical discussions, feature requests  | [Start a Discussion](https://github.com/datahub-project/datahub/discussions) |
 | **GitHub Issues**      | Bug reports, feature requests            | [Open an Issue](https://github.com/datahub-project/datahub/issues)           |
 | **Stack Overflow**     | Technical Q&A (tag: `datahub`)           | [Ask a Question](https://stackoverflow.com/questions/tagged/datahub)         |

--- a/docs-website/static/llms.txt
+++ b/docs-website/static/llms.txt
@@ -95,7 +95,7 @@ DataHub goes beyond a traditional data catalog: it connects technical metadata, 
 
 ## Community
 
-- [Slack Community](https://docs.datahub.com/docs/slack): Join 15,000+ practitioners for support and discussion
+- [Slack Community](https://docs.datahub.com/docs/slack): Join 16,000+ practitioners for support and discussion
 - [Town Halls](https://docs.datahub.com/docs/townhalls): Monthly calls with customer stories, roadmap updates, demos, and Q&A
 - [Contributing Guide](https://docs.datahub.com/docs/contributing): How to contribute code, docs, and bug reports
 - [Code of Conduct](https://docs.datahub.com/docs/code_of_conduct): Community standards for respectful collaboration

--- a/docs/dev-guides/agent-context/skills.md
+++ b/docs/dev-guides/agent-context/skills.md
@@ -189,4 +189,4 @@ For full installation options and manual setup, see the [datahub-skills reposito
 - Set up the [MCP Server](../../features/feature-guides/mcp.md) if you haven't already — skills need tools to work
 - Explore the [Agent Context Kit](./agent-context.md) for building custom agents with the Python SDK
 - Browse the [datahub-skills repo](https://github.com/datahub-project/datahub-skills) to see skill definitions and contribute new ones
-- Join the [DataHub community](https://datahub.com/slack/) — 14,000+ members building in the open
+- Join the [DataHub community](https://datahub.com/slack/) — 16,000+ members building in the open

--- a/docs/townhalls.md
+++ b/docs/townhalls.md
@@ -4,11 +4,15 @@ Join us for community gatherings where we discuss roadmap updates, demo new feat
 
 ## 🗓️ Next Town Hall
 
-[Register for the July Town Hall](https://luma.com/77lmmyb5)
+Town Halls run monthly. [Register on our events calendar →](https://luma.com/datahubevents?tag=datahub%20town%20hall)
 
 ---
 
 ## 📺 Recent Town Halls
+
+**July 2026: Real Stories in Production feat. Miro & Just Eat Takeaway**
+
+- 📺 [Watch recording](https://youtu.be/B5cV9ZPgg30)
 
 **June 2026: Inside the Context Platform feat. TiDB / PingCAP**
 


### PR DESCRIPTION
The README and Town Halls page hardcoded a specific month's Luma link and a dated list of past sessions, so both went stale every month. Replaced them with a link to the tagged events calendar and the YouTube playlist, which stay correct on their own.

Also bumped the Slack community count to 16,000+ in the two places it was hardcoded.


### Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://docs.datahub.com/docs/contributing) (particularly [Commit Message Format](https://docs.datahub.com/docs/contributing#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] Any breaking changes have been [documented](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Town Hall links evergreen and updates Slack community mentions to 16,000+. The README and Town Halls page no longer hardcode a monthly Luma URL or a single “last Town Hall”; they now point to the tagged Luma calendar and the YouTube playlist so links stay current without monthly edits.

**Review notes**
- Verify the Luma calendar filter works: https://luma.com/datahubevents?tag=datahub%20town%20hall
- Confirm the playlist ID `PLdCtLs64vZvHTXGqybmOfyxXbGDn2Reb9` lists past recordings.
- Check “16,000+ members” appears in README, `docs/dev-guides/agent-context/skills.md`, and `docs-website/static/llms.txt`.

<sup>Written for commit 6de36706691b4e3698738e06df6df7e77d603c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

