### PR TITLE
docs(cli): add datahub evals command reference

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1282,6 +1282,7 @@ module.exports = {
         { type: "doc", id: "docs/cli-commands/graphql", label: "graphql" },
         { type: "doc", id: "docs/cli-commands/dataset", label: "dataset" },
         { type: "doc", id: "docs/cli-commands/datapack", label: "datapack" },
+        { type: "doc", id: "docs/cli-commands/evals", label: "evals" },
         { type: "doc", id: "docs/datahub_lite", label: "lite" },
       ],
     },

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1282,7 +1282,12 @@ module.exports = {
         { type: "doc", id: "docs/cli-commands/graphql", label: "graphql" },
         { type: "doc", id: "docs/cli-commands/dataset", label: "dataset" },
         { type: "doc", id: "docs/cli-commands/datapack", label: "datapack" },
-        { type: "doc", id: "docs/cli-commands/evals", label: "evals" },
+        {
+          type: "doc",
+          id: "docs/cli-commands/evals",
+          label: "evals",
+          className: "saasOnly",
+        },
         { type: "doc", id: "docs/datahub_lite", label: "lite" },
       ],
     },

--- a/docs/cli-commands/evals.md
+++ b/docs/cli-commands/evals.md
@@ -1,0 +1,312 @@
+---
+description: "Use the datahub evals CLI command to manage, run, and report DataHub Context Evals from the terminal or from CI."
+---
+
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
+
+# datahub evals
+
+<FeatureAvailability saasOnly stage="private-beta" />
+
+The `datahub evals` command manages **Context Evals** — question-and-answer checks that measure whether
+DataHub answers questions about your metadata correctly. An eval pairs a question with one or more
+pass conditions; running it records a verdict you can track over time or gate a CI job on.
+
+Context Evals are in private beta, so the command surface can change between releases.
+
+The command ships with DataHub Cloud rather than with the open source CLI. Install it alongside
+`acryl-datahub`:
+
+```shell
+pip install -U 'acryl-datahub[datahub-evals]'
+```
+
+This pulls in `acryl-datahub-cloud`, which provides the command. It requires
+`acryl-datahub-cloud` 2.1.4rc1 or later — pass `-U` so an older installed copy is upgraded rather
+than left in place. Without the plugin, `datahub evals` is registered as a stub that prints an
+install hint instead of failing with an import error.
+
+## Quick Start
+
+```shell
+# Create or update evals from a definition file
+datahub evals upsert -f evals.yml
+
+# List what exists
+datahub evals list
+
+# Run one eval and wait for the verdict
+datahub evals run urn:li:eval:my-eval
+
+# Run everything for one agent and fail the shell on any FAIL or ERROR
+datahub evals run --all --agent-urn urn:li:aiAgent:my-agent --fail-on-fail
+```
+
+`upsert` is the default subcommand, so `datahub evals -f evals.yml` is equivalent to
+`datahub evals upsert -f evals.yml`.
+
+## Defining Evals
+
+`upsert` reads a YAML or JSON file containing either one eval object or a list of them. An entry
+with a `urn` updates that eval; an entry without one creates a new eval.
+
+```yaml
+- name: Revenue table owner
+  description: Ask DataHub who owns the revenue table.
+  question: Who owns the revenue table?
+  evalType: METADATA
+  origin: CONTEXT_HUB
+  executor:
+    type: NATIVE
+  conditions:
+    - type: LLM_JUDGE
+      llmJudge:
+        guidelines: The answer names the owning team and links the dataset.
+    - type: ASSET_REFERENCE
+      assetReference:
+        mustReference:
+          - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.revenue,PROD)
+        mustNotReference:
+          - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.revenue_staging,PROD)
+```
+
+### Eval fields
+
+| Field             | Required on create | Description                                               |
+| ----------------- | ------------------ | --------------------------------------------------------- |
+| `name`            | Yes                | Display name. Must be a non-empty string.                 |
+| `question`        | Yes                | The question put to DataHub.                              |
+| `conditions`      | Yes                | At least one pass condition. See below.                   |
+| `executor`        | Yes                | Who produces the answer. See below.                       |
+| `origin`          | Yes                | `CONTEXT_HUB` or `CUSTOM_AGENT`. Set once at create time. |
+| `description`     | No                 | Free text describing what the eval covers.                |
+| `evalType`        | No                 | `METADATA` or `SQL`.                                      |
+| `referenceOutput` | No                 | An example of a good answer, used as judging context.     |
+| `agentUrn`        | No                 | The agent the eval belongs to. Set once at create time.   |
+| `urn`             | —                  | Present means update. Omit to create.                     |
+
+`origin` and `agentUrn` are fixed at creation: they are accepted in an update entry but ignored, so
+an exported definition can be re-applied unchanged.
+
+### Conditions
+
+Each condition is either an LLM judgement or an assertion about which assets the answer cites.
+
+```yaml
+conditions:
+  - type: LLM_JUDGE
+    llmJudge:
+      guidelines: What a correct answer must contain.
+  - type: ASSET_REFERENCE
+    assetReference:
+      mustReference:
+        - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.orders,PROD)
+      mustNotReference:
+        - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.orders_tmp,PROD)
+```
+
+An `LLM_JUDGE` condition requires non-empty `llmJudge.guidelines`. An `ASSET_REFERENCE` condition
+requires at least one URN across `mustReference` and `mustNotReference`, and every entry must be a
+DataHub URN. A condition carries one shape or the other, never both.
+
+### Executor
+
+```yaml
+executor:
+  type: NATIVE # or EXTERNAL
+  externalClient: my-harness # optional label for EXTERNAL
+```
+
+`NATIVE` means DataHub answers the question itself. `EXTERNAL` means your own harness answers it and
+submits the result with [`report`](#report).
+
+## Commands
+
+### list
+
+List eval definitions.
+
+```shell
+datahub evals list
+datahub evals list --agent-urn urn:li:aiAgent:my-agent --eval-type METADATA
+datahub evals list --start 20 --limit 20
+```
+
+| Option              | Default | Description                                      |
+| ------------------- | ------- | ------------------------------------------------ |
+| `--agent-urn`       | —       | Only evals for this agent.                       |
+| `--base-agent-only` | —       | Only evals for the Ask DataHub base agent.       |
+| `--eval-type`       | —       | `METADATA` or `SQL`.                             |
+| `--eval-executor`   | —       | `NATIVE` or `EXTERNAL`.                          |
+| `--query`           | —       | Free-text search over evals.                     |
+| `--start`           | `0`     | Zero-based offset for the page. Also `--offset`. |
+| `--limit`           | `10`    | Number of evals to return.                       |
+| `--format`          | auto    | `json` or `table`.                               |
+
+`--agent-urn` and `--base-agent-only` are mutually exclusive.
+
+### get
+
+Fetch one eval and its latest run summary.
+
+```shell
+datahub evals get urn:li:eval:my-eval
+datahub evals get urn:li:eval:my-eval --history 5
+datahub evals get urn:li:eval:my-eval --format upsert > my-eval.yml
+```
+
+| Option      | Default | Description                          |
+| ----------- | ------- | ------------------------------------ |
+| `--history` | —       | Include this many recent run events. |
+| `--format`  | auto    | `json`, `table`, or `upsert`.        |
+
+`--format upsert` prints the definition without read-only run fields, so the output can be edited and
+fed straight back to `upsert`.
+
+### upsert
+
+Create or update evals from a file.
+
+```shell
+datahub evals upsert -f evals.yml
+datahub evals upsert -f evals.yml --dry-run
+```
+
+| Option         | Description                                                     |
+| -------------- | --------------------------------------------------------------- |
+| `-f`, `--file` | Required. Path to the YAML or JSON definition file.             |
+| `--dry-run`    | Validate and report create-vs-update per entry without writing. |
+
+If one entry in a multi-eval file fails, the CLI prints the entries that already succeeded with their
+URNs, then exits non-zero. Reuse those URNs when retrying — a repeated create makes a duplicate eval.
+
+### delete
+
+```shell
+datahub evals delete urn:li:eval:my-eval
+```
+
+### run
+
+Start a run and wait for every selected eval to reach a terminal event.
+
+```shell
+datahub evals run urn:li:eval:my-eval urn:li:eval:my-other-eval
+datahub evals run --all --agent-urn urn:li:aiAgent:my-agent
+datahub evals run --all --wait 600 --fail-on-fail
+```
+
+| Option            | Default | Description                                                  |
+| ----------------- | ------- | ------------------------------------------------------------ |
+| `--all`           | —       | Run every matching eval instead of listed URNs.              |
+| `--agent-urn`     | —       | Restrict `--all` to one agent.                               |
+| `--eval-executor` | —       | Filter `--all` by executor type. Requires `--all`.           |
+| `--page-size`     | `10`    | Page size used to collect evals for `--all`. Also `--limit`. |
+| `--wait`          | `300`   | Seconds to wait for terminal events.                         |
+| `--fail-on-fail`  | —       | Exit non-zero when a result is `FAIL` or `ERROR`.            |
+| `--format`        | auto    | `json` or `table`.                                           |
+| `--dry-run`       | —       | Show what would run without starting anything.               |
+
+Pass either URNs or `--all`, not both.
+
+With `--fail-on-fail`, the command exits `1` when any result is `FAIL` or `ERROR`, when a target never
+reaches a terminal event within `--wait`, or when a queued or running event has gone stale — older
+than 15 minutes. Without `--fail-on-fail`, a timeout still exits `0`, so CI jobs that must catch
+regressions should always pass the flag.
+
+A single run selects at most 1000 evals, matching the executor's per-run limit. A larger `--all`
+selection is refused before anything is queued rather than failing after the run has started.
+
+`--eval-executor EXTERNAL` is rejected: starting a run always queues native execution, which would
+answer the eval itself and race your harness reporting back under the same run ID. Run those evals in
+your own harness and submit the answers with `report`.
+
+Note that `--all` without `--agent-urn` covers only the Ask DataHub base agent, whereas `list` without
+a filter spans every agent, so the two can return different counts.
+
+### report
+
+Submit an answer produced outside DataHub, using the run ID returned by `run`.
+
+```shell
+datahub evals report urn:li:eval:my-eval \
+  --run-id "$RUN_ID" \
+  --answer "The revenue table is owned by the analytics team."
+
+# Read a long answer from stdin
+my-harness answer | datahub evals report urn:li:eval:my-eval --run-id "$RUN_ID" --answer -
+```
+
+| Option                | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `--answer`            | Required. Answer text, or `-` to read stdin.                             |
+| `--run-id`            | Required. Run ID from `run`.                                             |
+| `--agent-model`       | Model that produced the answer.                                          |
+| `--external-client`   | Identifier for the harness submitting the report.                        |
+| `--session-id`        | Session identifier from your harness.                                    |
+| `--type`              | `PASS`, `FAIL`, or `ERROR`. Supply only when reporting your own verdict. |
+| `--condition-results` | JSON list of per-condition verdicts. Requires `--type`.                  |
+| `--judge-model`       | Model that judged the answer. Requires `--type`.                         |
+| `--judge-reasoning`   | Why the judge reached that verdict. Requires `--type`.                   |
+| `--error`             | Error detail for an `ERROR` result. Requires `--type`.                   |
+| `--dry-run`           | Validate the report without writing.                                     |
+
+Omit `--type` and the verdict fields to let DataHub judge the submitted answer. Reports are recorded
+with `executorType=EXTERNAL` and confirmed by reading the stored run event back: a server-judged
+report is accepted once its matching queued or running event is visible, while a caller-supplied
+verdict waits for the stored complete event. Reporting twice against a run ID that is already
+terminal is deduplicated rather than duplicated.
+
+### history
+
+List run events for one eval.
+
+```shell
+datahub evals history urn:li:eval:my-eval
+datahub evals history urn:li:eval:my-eval --limit 50
+```
+
+| Option                    | Default | Description                                 |
+| ------------------------- | ------- | ------------------------------------------- |
+| `--include-proposal-runs` | —       | Include runs triggered by change proposals. |
+| `--action-request-urn`    | —       | Only runs for this change proposal.         |
+| `--limit`                 | `10`    | Number of run events to return.             |
+| `--format`                | auto    | `json` or `table`.                          |
+
+`--include-proposal-runs` and `--action-request-urn` are mutually exclusive.
+
+## Output and Exit Codes
+
+Output defaults to a table when stdout is a terminal and to JSON when it is not, so piping into `jq`
+works without extra flags. Pass `--format` explicitly when you need one or the other regardless.
+
+| Exit code | Meaning                                                                    |
+| --------- | -------------------------------------------------------------------------- |
+| `0`       | Success.                                                                   |
+| `1`       | Command failed, or `--fail-on-fail` saw a failing, errored, or stale eval. |
+| `2`       | Invalid command input or an invalid eval definition.                       |
+| `5`       | Could not reach DataHub, or the instance does not support evals.           |
+
+Errors print as human-readable text on a terminal and as `{"error": ..., "message": ...}` on stderr
+otherwise.
+
+## Using the Command from an Agent
+
+`datahub evals --agent-context` prints a condensed reference covering every subcommand, the exit-code
+contract, and the run and report semantics. The same text is appended to `--help` output when stdout
+is not a terminal, so a coding agent that shells out to `datahub evals --help` gets the full contract
+without a separate call.
+
+## CI Example
+
+```shell
+pip install -U 'acryl-datahub[datahub-evals]'
+
+export DATAHUB_GMS_URL=https://your-instance.acryl.io/gms
+export DATAHUB_GMS_TOKEN=your-token
+
+datahub evals upsert -f evals.yml
+datahub evals run --all --agent-urn "$AGENT_URN" --wait 900 --fail-on-fail
+```
+
+The run exits non-zero on any failing, errored, or stale eval, which fails the job.

--- a/docs/cli-commands/evals.md
+++ b/docs/cli-commands/evals.md
@@ -183,25 +183,6 @@ acryl-datahub-cloud evals history urn:li:eval:my-eval --limit 50
 Returns `--limit` run events (default 10). Add `--include-proposal-runs`, or `--action-request-urn`
 for one change proposal, but not both.
 
-## Output and Exit Codes
-
-`list`, `get`, `run`, and `history` accept `--format json|table`, defaulting to a table on a terminal
-and JSON otherwise, so piping into `jq` works without extra flags. `upsert`, `delete`, and `report`
-always emit JSON.
-
-| Exit code | Meaning                                                          |
-| --------- | ---------------------------------------------------------------- |
-| `0`       | Success.                                                         |
-| `1`       | Command failed, or `--fail-on-fail` saw a failed run.            |
-| `2`       | Invalid command input or an invalid eval definition.             |
-| `5`       | Could not reach DataHub, or the instance does not support evals. |
-
-Errors the command raises print as text on a terminal and as `{"error": ..., "message": ...}` on
-stderr otherwise. Argument-parsing errors stay plain-text usage messages and exit `2`.
-
-`acryl-datahub-cloud evals --agent-context` prints a condensed reference for coding agents, and the
-same text is appended to `--help` when stdout is not a terminal.
-
 ## CI Example
 
 ```shell

--- a/docs/cli-commands/evals.md
+++ b/docs/cli-commands/evals.md
@@ -17,32 +17,16 @@ Context Evals are in private beta, so the command surface can change between rel
 ## Installation
 
 The command lives in the `acryl-datahub-cloud` package only — it is not part of the open source
-`acryl-datahub` CLI. Install that package and run the command from it:
+`acryl-datahub` CLI. It needs Python 3.10 or later.
 
 ```shell
 pip install 'acryl-datahub-cloud[datahub-evals]>=2.1.4rc1'
 ```
 
-The package requires Python 3.10 or later.
-
-The `datahub-evals` extra pulls in the GraphQL client the command needs, so installing the package
-without it leaves `evals` unusable. The version floor matters too: `evals` first shipped in
-2.1.4rc1, and because that is a pre-release, pip only considers it when the requirement names it
-explicitly as above.
-
-Install it into an isolated environment — a virtualenv, or `pipx install` — rather than alongside an
-existing DataHub CLI. `acryl-datahub-cloud` depends on a specific `acryl-datahub` version and will
-install or change it, so a shared environment can end up with a different `datahub` CLI than the one
-you had.
-
-Every command below is invoked through the package's own entry point:
-
-```shell
-acryl-datahub-cloud evals --help
-```
-
-Connection details come from the same place as the rest of the DataHub CLI — `~/.datahubenv` written
-by `datahub init`, or the `DATAHUB_GMS_URL` and `DATAHUB_GMS_TOKEN` environment variables.
+Install it into a virtualenv or with `pipx`: the package pins its own `acryl-datahub` version, so a
+shared environment can end up with a different `datahub` CLI than the one you had. Connection details
+come from `~/.datahubenv` (written by `datahub init`) or from `DATAHUB_GMS_URL` and
+`DATAHUB_GMS_TOKEN`.
 
 ## Quick Start
 
@@ -60,13 +44,13 @@ acryl-datahub-cloud evals run urn:li:eval:my-eval
 acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent --fail-on-fail
 ```
 
-`upsert` is the default subcommand, so `acryl-datahub-cloud evals -f evals.yml` is equivalent to
-`acryl-datahub-cloud evals upsert -f evals.yml`.
+`upsert` is the default subcommand, so `acryl-datahub-cloud evals -f evals.yml` works too. Run any
+subcommand with `--help` for its full option list.
 
 ## Defining Evals
 
-`upsert` reads a YAML or JSON file containing either one eval object or a list of them. An entry
-with a `urn` updates that eval; an entry without one creates a new eval.
+`upsert` reads a YAML or JSON file containing either one eval object or a list of them. An entry with
+a `urn` updates that eval; an entry without one creates a new eval.
 
 ```yaml
 - name: Revenue table owner
@@ -88,46 +72,27 @@ with a `urn` updates that eval; an entry without one creates a new eval.
           - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.revenue_staging,PROD)
 ```
 
-### Eval fields
+| Field             | Required | Description                                                      |
+| ----------------- | -------- | ---------------------------------------------------------------- |
+| `name`            | Yes      | Display name.                                                    |
+| `question`        | Yes      | The question put to DataHub.                                     |
+| `conditions`      | Yes      | At least one pass condition.                                     |
+| `executor`        | Yes      | `NATIVE` for DataHub to answer, `EXTERNAL` for your own harness. |
+| `origin`          | Yes      | `CONTEXT_HUB` or `CUSTOM_AGENT`.                                 |
+| `evalType`        | No       | `METADATA` or `SQL`.                                             |
+| `description`     | No       | What the eval covers.                                            |
+| `referenceOutput` | No       | An example of a good answer, used as judging context.            |
+| `agentUrn`        | No       | The agent the eval belongs to.                                   |
+| `urn`             | No       | Present means update, absent means create.                       |
 
-| Field             | Required on create | Description                                               |
-| ----------------- | ------------------ | --------------------------------------------------------- |
-| `name`            | Yes                | Display name. Must be a non-empty string.                 |
-| `question`        | Yes                | The question put to DataHub.                              |
-| `conditions`      | Yes                | At least one pass condition. See below.                   |
-| `executor`        | Yes                | Who produces the answer. See below.                       |
-| `origin`          | Yes                | `CONTEXT_HUB` or `CUSTOM_AGENT`. Set once at create time. |
-| `description`     | No                 | Free text describing what the eval covers.                |
-| `evalType`        | No                 | `METADATA` or `SQL`.                                      |
-| `referenceOutput` | No                 | An example of a good answer, used as judging context.     |
-| `agentUrn`        | No                 | The agent the eval belongs to. Set once at create time.   |
-| `urn`             | —                  | Present means update. Omit to create.                     |
-
-`origin` and `agentUrn` are fixed at creation: they are accepted in an update entry but ignored, so
-an exported definition can be re-applied unchanged.
-
-### Conditions
-
-Each condition is either an LLM judgement or an assertion about which assets the answer cites, both
-shown in the example above. A condition carries one shape or the other, never both.
-
-| `type`            | Required fields                                                                                                                      |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `LLM_JUDGE`       | `llmJudge.guidelines` — non-empty text describing what a correct answer must contain.                                                |
-| `ASSET_REFERENCE` | `assetReference.mustReference` and/or `assetReference.mustNotReference` — lists of DataHub URNs, with at least one URN between them. |
-
-### Executor
-
-| Field            | Required | Meaning                                                                                                                                   |
-| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`           | Yes      | `NATIVE` — DataHub answers the question itself. `EXTERNAL` — your own harness answers it and submits the result with [`report`](#report). |
-| `externalClient` | No       | Label identifying the harness behind an `EXTERNAL` executor.                                                                              |
+A condition is either an `LLM_JUDGE` — requiring `llmJudge.guidelines` — or an `ASSET_REFERENCE`,
+requiring at least one DataHub URN across `assetReference.mustReference` and
+`assetReference.mustNotReference`. `origin` and `agentUrn` are fixed once an eval is created, so an
+exported definition can be re-applied unchanged.
 
 ## Commands
 
 ### list
-
-List eval definitions.
 
 ```shell
 acryl-datahub-cloud evals list
@@ -135,22 +100,10 @@ acryl-datahub-cloud evals list --agent-urn urn:li:aiAgent:my-agent --eval-type M
 acryl-datahub-cloud evals list --start 20 --limit 20
 ```
 
-| Option              | Default | Description                                      |
-| ------------------- | ------- | ------------------------------------------------ |
-| `--agent-urn`       | —       | Only evals for this agent.                       |
-| `--base-agent-only` | —       | Only evals for the Ask DataHub base agent.       |
-| `--eval-type`       | —       | `METADATA` or `SQL`.                             |
-| `--eval-executor`   | —       | `NATIVE` or `EXTERNAL`.                          |
-| `--query`           | —       | Free-text search over evals.                     |
-| `--start`           | `0`     | Zero-based offset for the page. Also `--offset`. |
-| `--limit`           | `10`    | Number of evals to return.                       |
-| `--format`          | auto    | `json` or `table`.                               |
-
-`--agent-urn` and `--base-agent-only` are mutually exclusive.
+Filter with `--agent-urn` or `--base-agent-only` (not both), `--eval-type`, `--eval-executor`, and
+`--query`. Pages are `--limit` results (default 10) from the zero-based `--start` offset.
 
 ### get
-
-Fetch one eval and its latest run summary.
 
 ```shell
 acryl-datahub-cloud evals get urn:li:eval:my-eval
@@ -158,30 +111,19 @@ acryl-datahub-cloud evals get urn:li:eval:my-eval --history 5
 acryl-datahub-cloud evals get urn:li:eval:my-eval --format upsert > my-eval.yml
 ```
 
-| Option      | Default | Description                          |
-| ----------- | ------- | ------------------------------------ |
-| `--history` | —       | Include this many recent run events. |
-| `--format`  | auto    | `json`, `table`, or `upsert`.        |
-
-`--format upsert` prints the definition without read-only run fields, so the output can be edited and
-fed straight back to `upsert`.
+`--format upsert` drops the read-only run fields, so the output can be edited and fed back to
+`upsert`.
 
 ### upsert
-
-Create or update evals from a file.
 
 ```shell
 acryl-datahub-cloud evals upsert -f evals.yml
 acryl-datahub-cloud evals upsert -f evals.yml --dry-run
 ```
 
-| Option         | Description                                                     |
-| -------------- | --------------------------------------------------------------- |
-| `-f`, `--file` | Required. Path to the YAML or JSON definition file.             |
-| `--dry-run`    | Validate and report create-vs-update per entry without writing. |
-
-If one entry in a multi-eval file fails, the CLI prints the entries that already succeeded with their
-URNs, then exits non-zero. Reuse those URNs when retrying — a repeated create makes a duplicate eval.
+`--dry-run` validates the file and reports create-versus-update per entry without writing. If one
+entry of a multi-eval file fails, the CLI prints the entries that already succeeded with their URNs
+and exits non-zero — reuse those URNs when retrying, since a repeated create makes a duplicate eval.
 
 ### delete
 
@@ -191,50 +133,26 @@ acryl-datahub-cloud evals delete urn:li:eval:my-eval
 
 ### run
 
-Start a run and wait for every selected eval to reach a terminal event.
-
 ```shell
 acryl-datahub-cloud evals run urn:li:eval:my-eval urn:li:eval:my-other-eval
 acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent
 acryl-datahub-cloud evals run --all --wait 600 --fail-on-fail
 ```
 
-| Option            | Default | Description                                                                                                      |
-| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
-| `--all`           | —       | Run every matching eval instead of listed URNs.                                                                  |
-| `--agent-urn`     | —       | Agent to run against. Selects the evals for `--all`, and is recorded with the run when explicit URNs are passed. |
-| `--eval-executor` | —       | Filter `--all` by executor type. Requires `--all`; `EXTERNAL` is rejected, see below.                            |
-| `--page-size`     | `10`    | Page size used to collect evals for `--all`. Also `--limit`.                                                     |
-| `--wait`          | `300`   | Seconds to wait for terminal events.                                                                             |
-| `--fail-on-fail`  | —       | Exit `1` on a failed run. See [Run failure contract](#run-failure-contract).                                     |
-| `--format`        | auto    | `json` or `table`.                                                                                               |
-| `--dry-run`       | —       | Show what would run without starting anything.                                                                   |
+Pass either URNs or `--all`, not both, and wait up to `--wait` seconds (default 300) for every
+selected eval to reach a terminal event.
 
-Pass either URNs or `--all`, not both.
+With `--fail-on-fail`, the command exits `1` when any selected eval ends up **FAIL**, **ERROR**,
+**stale** (queued or running for more than 15 minutes), or **incomplete** (no terminal event within
+`--wait`). Without the flag all four still exit `0`, so CI jobs should always pass it.
 
-#### Run failure contract
+Other things worth knowing:
 
-With `--fail-on-fail`, the command exits `1` when any selected eval ends in one of four states:
-
-| State          | Meaning                                                  |
-| -------------- | -------------------------------------------------------- |
-| **FAIL**       | The answer did not satisfy the eval's conditions.        |
-| **ERROR**      | The run errored instead of producing a verdict.          |
-| **Stale**      | A queued or running event is older than 15 minutes.      |
-| **Incomplete** | A target never reached a terminal event within `--wait`. |
-
-Without `--fail-on-fail` the command exits `0` in all four cases, so CI jobs that must catch
-regressions should always pass the flag.
-
-A single run selects at most 1000 evals, matching the executor's per-run limit. A larger `--all`
-selection is refused before anything is queued rather than failing after the run has started.
-
-`--eval-executor EXTERNAL` is rejected: starting a run always queues native execution, which would
-answer the eval itself and race your harness reporting back under the same run ID. Run those evals in
-your own harness and submit the answers with `report`.
-
-Note that `--all` without `--agent-urn` covers only the Ask DataHub base agent, whereas `list` without
-a filter spans every agent, so the two can return different counts.
+- `--all` without `--agent-urn` covers only the Ask DataHub base agent, whereas `list` without a
+  filter spans every agent, so the two can return different counts.
+- A run selects at most 1000 evals. A larger `--all` selection is refused before anything is queued.
+- `--eval-executor EXTERNAL` is rejected — starting a run always queues native execution, which would
+  answer the eval itself and race your harness. Run those in your harness and use `report`.
 
 ### report
 
@@ -249,69 +167,40 @@ acryl-datahub-cloud evals report urn:li:eval:my-eval \
 my-harness answer | acryl-datahub-cloud evals report urn:li:eval:my-eval --run-id "$RUN_ID" --answer -
 ```
 
-| Option                | Description                                                              |
-| --------------------- | ------------------------------------------------------------------------ |
-| `--answer`            | Required. Answer text, or `-` to read stdin.                             |
-| `--run-id`            | Required. Run ID from `run`.                                             |
-| `--agent-model`       | Model that produced the answer.                                          |
-| `--external-client`   | Identifier for the harness submitting the report.                        |
-| `--session-id`        | Session identifier from your harness.                                    |
-| `--type`              | `PASS`, `FAIL`, or `ERROR`. Supply only when reporting your own verdict. |
-| `--condition-results` | JSON list of per-condition verdicts. Requires `--type`.                  |
-| `--judge-model`       | Model that judged the answer. Requires `--type`.                         |
-| `--judge-reasoning`   | Why the judge reached that verdict. Requires `--type`.                   |
-| `--error`             | Error detail for an `ERROR` result. Requires `--type`.                   |
-| `--dry-run`           | Validate the report without writing.                                     |
-
-Omit `--type` and the verdict fields to let DataHub judge the submitted answer. Reports are recorded
-with `executorType=EXTERNAL` and confirmed by reading the stored run event back: a server-judged
-report is accepted once its matching queued or running event is visible, while a caller-supplied
-verdict waits for the stored complete event. Reporting twice against a run ID that is already
+Omit `--type` to let DataHub judge the submitted answer. To report your own verdict, pass `--type`
+(`PASS`, `FAIL`, or `ERROR`) — it is required alongside the verdict options `--condition-results`,
+`--judge-model`, `--judge-reasoning`, and `--error`. `--agent-model`, `--external-client`, and
+`--session-id` record where the answer came from. Reporting twice against a run ID that is already
 terminal is deduplicated rather than duplicated.
 
 ### history
-
-List run events for one eval.
 
 ```shell
 acryl-datahub-cloud evals history urn:li:eval:my-eval
 acryl-datahub-cloud evals history urn:li:eval:my-eval --limit 50
 ```
 
-| Option                    | Default | Description                                 |
-| ------------------------- | ------- | ------------------------------------------- |
-| `--include-proposal-runs` | —       | Include runs triggered by change proposals. |
-| `--action-request-urn`    | —       | Only runs for this change proposal.         |
-| `--limit`                 | `10`    | Number of run events to return.             |
-| `--format`                | auto    | `json` or `table`.                          |
-
-`--include-proposal-runs` and `--action-request-urn` are mutually exclusive.
+Returns `--limit` run events (default 10). Add `--include-proposal-runs`, or `--action-request-urn`
+for one change proposal, but not both.
 
 ## Output and Exit Codes
 
-For the commands that accept `--format` — `list`, `get`, `run`, and `history` — output defaults to a
-table when stdout is a terminal and to JSON when it is not, so piping into `jq` works without extra
-flags. Pass `--format` explicitly when you need one or the other regardless. `upsert`, `delete`, and
-`report` always emit JSON, including on a terminal.
+`list`, `get`, `run`, and `history` accept `--format json|table`, defaulting to a table on a terminal
+and JSON otherwise, so piping into `jq` works without extra flags. `upsert`, `delete`, and `report`
+always emit JSON.
 
-| Exit code | Meaning                                                                                                   |
-| --------- | --------------------------------------------------------------------------------------------------------- |
-| `0`       | Success.                                                                                                  |
-| `1`       | Command failed, or `--fail-on-fail` saw a failed run — see [Run failure contract](#run-failure-contract). |
-| `2`       | Invalid command input or an invalid eval definition.                                                      |
-| `5`       | Could not reach DataHub, or the instance does not support evals.                                          |
+| Exit code | Meaning                                                          |
+| --------- | ---------------------------------------------------------------- |
+| `0`       | Success.                                                         |
+| `1`       | Command failed, or `--fail-on-fail` saw a failed run.            |
+| `2`       | Invalid command input or an invalid eval definition.             |
+| `5`       | Could not reach DataHub, or the instance does not support evals. |
 
-Errors raised by the command itself — a bad eval definition, an unreachable instance, a failed run —
-print as human-readable text on a terminal and as `{"error": ..., "message": ...}` on stderr
-otherwise. Argument-parsing errors caught before the command runs, such as a non-numeric `--wait`,
-stay plain-text usage messages on stderr and still exit `2`.
+Errors the command raises print as text on a terminal and as `{"error": ..., "message": ...}` on
+stderr otherwise. Argument-parsing errors stay plain-text usage messages and exit `2`.
 
-## Using the Command from an Agent
-
-`acryl-datahub-cloud evals --agent-context` prints a condensed reference covering every subcommand, the exit-code
-contract, and the run and report semantics. The same text is appended to `--help` output when stdout
-is not a terminal, so a coding agent that shells out to `acryl-datahub-cloud evals --help` gets the full contract
-without a separate call.
+`acryl-datahub-cloud evals --agent-context` prints a condensed reference for coding agents, and the
+same text is appended to `--help` when stdout is not a terminal.
 
 ## CI Example
 
@@ -325,5 +214,4 @@ acryl-datahub-cloud evals upsert -f evals.yml
 acryl-datahub-cloud evals run --all --agent-urn "$AGENT_URN" --wait 900 --fail-on-fail
 ```
 
-The run exits non-zero on any failed eval, which fails the job — see the
-[run failure contract](#run-failure-contract) for what counts.
+The run exits non-zero on any failed eval, which fails the job.

--- a/docs/cli-commands/evals.md
+++ b/docs/cli-commands/evals.md
@@ -23,10 +23,17 @@ The command lives in the `acryl-datahub-cloud` package only — it is not part o
 pip install 'acryl-datahub-cloud[datahub-evals]>=2.1.4rc1'
 ```
 
+The package requires Python 3.10 or later.
+
 The `datahub-evals` extra pulls in the GraphQL client the command needs, so installing the package
 without it leaves `evals` unusable. The version floor matters too: `evals` first shipped in
 2.1.4rc1, and because that is a pre-release, pip only considers it when the requirement names it
 explicitly as above.
+
+Install it into an isolated environment — a virtualenv, or `pipx install` — rather than alongside an
+existing DataHub CLI. `acryl-datahub-cloud` depends on a specific `acryl-datahub` version and will
+install or change it, so a shared environment can end up with a different `datahub` CLI than the one
+you had.
 
 Every command below is invoked through the package's own entry point:
 
@@ -49,7 +56,7 @@ acryl-datahub-cloud evals list
 # Run one eval and wait for the verdict
 acryl-datahub-cloud evals run urn:li:eval:my-eval
 
-# Run everything for one agent and fail the shell on any FAIL or ERROR
+# Run everything for one agent and fail the shell on any failed eval
 acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent --fail-on-fail
 ```
 
@@ -101,35 +108,20 @@ an exported definition can be re-applied unchanged.
 
 ### Conditions
 
-Each condition is either an LLM judgement or an assertion about which assets the answer cites.
+Each condition is either an LLM judgement or an assertion about which assets the answer cites, both
+shown in the example above. A condition carries one shape or the other, never both.
 
-```yaml
-conditions:
-  - type: LLM_JUDGE
-    llmJudge:
-      guidelines: What a correct answer must contain.
-  - type: ASSET_REFERENCE
-    assetReference:
-      mustReference:
-        - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.orders,PROD)
-      mustNotReference:
-        - urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.orders_tmp,PROD)
-```
-
-An `LLM_JUDGE` condition requires non-empty `llmJudge.guidelines`. An `ASSET_REFERENCE` condition
-requires at least one URN across `mustReference` and `mustNotReference`, and every entry must be a
-DataHub URN. A condition carries one shape or the other, never both.
+| `type`            | Required fields                                                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `LLM_JUDGE`       | `llmJudge.guidelines` — non-empty text describing what a correct answer must contain.                                                |
+| `ASSET_REFERENCE` | `assetReference.mustReference` and/or `assetReference.mustNotReference` — lists of DataHub URNs, with at least one URN between them. |
 
 ### Executor
 
-```yaml
-executor:
-  type: NATIVE # or EXTERNAL
-  externalClient: my-harness # optional label for EXTERNAL
-```
-
-`NATIVE` means DataHub answers the question itself. `EXTERNAL` means your own harness answers it and
-submits the result with [`report`](#report).
+| Field            | Required | Meaning                                                                                                                                   |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`           | Yes      | `NATIVE` — DataHub answers the question itself. `EXTERNAL` — your own harness answers it and submits the result with [`report`](#report). |
+| `externalClient` | No       | Label identifying the harness behind an `EXTERNAL` executor.                                                                              |
 
 ## Commands
 
@@ -207,22 +199,31 @@ acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent
 acryl-datahub-cloud evals run --all --wait 600 --fail-on-fail
 ```
 
-| Option            | Default | Description                                                  |
-| ----------------- | ------- | ------------------------------------------------------------ |
-| `--all`           | —       | Run every matching eval instead of listed URNs.              |
-| `--agent-urn`     | —       | Restrict `--all` to one agent.                               |
-| `--eval-executor` | —       | Filter `--all` by executor type. Requires `--all`.           |
-| `--page-size`     | `10`    | Page size used to collect evals for `--all`. Also `--limit`. |
-| `--wait`          | `300`   | Seconds to wait for terminal events.                         |
-| `--fail-on-fail`  | —       | Exit non-zero when a result is `FAIL` or `ERROR`.            |
-| `--format`        | auto    | `json` or `table`.                                           |
-| `--dry-run`       | —       | Show what would run without starting anything.               |
+| Option            | Default | Description                                                                                                      |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--all`           | —       | Run every matching eval instead of listed URNs.                                                                  |
+| `--agent-urn`     | —       | Agent to run against. Selects the evals for `--all`, and is recorded with the run when explicit URNs are passed. |
+| `--eval-executor` | —       | Filter `--all` by executor type. Requires `--all`; `EXTERNAL` is rejected, see below.                            |
+| `--page-size`     | `10`    | Page size used to collect evals for `--all`. Also `--limit`.                                                     |
+| `--wait`          | `300`   | Seconds to wait for terminal events.                                                                             |
+| `--fail-on-fail`  | —       | Exit `1` on a failed run. See [Run failure contract](#run-failure-contract).                                     |
+| `--format`        | auto    | `json` or `table`.                                                                                               |
+| `--dry-run`       | —       | Show what would run without starting anything.                                                                   |
 
 Pass either URNs or `--all`, not both.
 
-With `--fail-on-fail`, the command exits `1` when any result is `FAIL` or `ERROR`, when a target never
-reaches a terminal event within `--wait`, or when a queued or running event has gone stale — older
-than 15 minutes. Without `--fail-on-fail`, a timeout still exits `0`, so CI jobs that must catch
+#### Run failure contract
+
+With `--fail-on-fail`, the command exits `1` when any selected eval ends in one of four states:
+
+| State          | Meaning                                                  |
+| -------------- | -------------------------------------------------------- |
+| **FAIL**       | The answer did not satisfy the eval's conditions.        |
+| **ERROR**      | The run errored instead of producing a verdict.          |
+| **Stale**      | A queued or running event is older than 15 minutes.      |
+| **Incomplete** | A target never reached a terminal event within `--wait`. |
+
+Without `--fail-on-fail` the command exits `0` in all four cases, so CI jobs that must catch
 regressions should always pass the flag.
 
 A single run selects at most 1000 evals, matching the executor's per-run limit. A larger `--all`
@@ -288,18 +289,22 @@ acryl-datahub-cloud evals history urn:li:eval:my-eval --limit 50
 
 ## Output and Exit Codes
 
-Output defaults to a table when stdout is a terminal and to JSON when it is not, so piping into `jq`
-works without extra flags. Pass `--format` explicitly when you need one or the other regardless.
+For the commands that accept `--format` — `list`, `get`, `run`, and `history` — output defaults to a
+table when stdout is a terminal and to JSON when it is not, so piping into `jq` works without extra
+flags. Pass `--format` explicitly when you need one or the other regardless. `upsert`, `delete`, and
+`report` always emit JSON, including on a terminal.
 
-| Exit code | Meaning                                                                    |
-| --------- | -------------------------------------------------------------------------- |
-| `0`       | Success.                                                                   |
-| `1`       | Command failed, or `--fail-on-fail` saw a failing, errored, or stale eval. |
-| `2`       | Invalid command input or an invalid eval definition.                       |
-| `5`       | Could not reach DataHub, or the instance does not support evals.           |
+| Exit code | Meaning                                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------------------- |
+| `0`       | Success.                                                                                                  |
+| `1`       | Command failed, or `--fail-on-fail` saw a failed run — see [Run failure contract](#run-failure-contract). |
+| `2`       | Invalid command input or an invalid eval definition.                                                      |
+| `5`       | Could not reach DataHub, or the instance does not support evals.                                          |
 
-Errors print as human-readable text on a terminal and as `{"error": ..., "message": ...}` on stderr
-otherwise.
+Errors raised by the command itself — a bad eval definition, an unreachable instance, a failed run —
+print as human-readable text on a terminal and as `{"error": ..., "message": ...}` on stderr
+otherwise. Argument-parsing errors caught before the command runs, such as a non-numeric `--wait`,
+stay plain-text usage messages on stderr and still exit `2`.
 
 ## Using the Command from an Agent
 
@@ -320,4 +325,5 @@ acryl-datahub-cloud evals upsert -f evals.yml
 acryl-datahub-cloud evals run --all --agent-urn "$AGENT_URN" --wait 900 --fail-on-fail
 ```
 
-The run exits non-zero on any failing, errored, or stale eval, which fails the job.
+The run exits non-zero on any failed eval, which fails the job — see the
+[run failure contract](#run-failure-contract) for what counts.

--- a/docs/cli-commands/evals.md
+++ b/docs/cli-commands/evals.md
@@ -1,49 +1,60 @@
 ---
-description: "Use the datahub evals CLI command to manage, run, and report DataHub Context Evals from the terminal or from CI."
+description: "Use the acryl-datahub-cloud evals command to manage, run, and report DataHub Context Evals from the terminal or from CI."
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
-# datahub evals
+# acryl-datahub-cloud evals
 
 <FeatureAvailability saasOnly stage="private-beta" />
 
-The `datahub evals` command manages **Context Evals** — question-and-answer checks that measure whether
+The `evals` command manages **Context Evals** — question-and-answer checks that measure whether
 DataHub answers questions about your metadata correctly. An eval pairs a question with one or more
 pass conditions; running it records a verdict you can track over time or gate a CI job on.
 
 Context Evals are in private beta, so the command surface can change between releases.
 
-The command ships with DataHub Cloud rather than with the open source CLI. Install it alongside
-`acryl-datahub`:
+## Installation
+
+The command lives in the `acryl-datahub-cloud` package only — it is not part of the open source
+`acryl-datahub` CLI. Install that package and run the command from it:
 
 ```shell
-pip install -U 'acryl-datahub[datahub-evals]'
+pip install 'acryl-datahub-cloud[datahub-evals]>=2.1.4rc1'
 ```
 
-This pulls in `acryl-datahub-cloud`, which provides the command. It requires
-`acryl-datahub-cloud` 2.1.4rc1 or later — pass `-U` so an older installed copy is upgraded rather
-than left in place. Without the plugin, `datahub evals` is registered as a stub that prints an
-install hint instead of failing with an import error.
+The `datahub-evals` extra pulls in the GraphQL client the command needs, so installing the package
+without it leaves `evals` unusable. The version floor matters too: `evals` first shipped in
+2.1.4rc1, and because that is a pre-release, pip only considers it when the requirement names it
+explicitly as above.
+
+Every command below is invoked through the package's own entry point:
+
+```shell
+acryl-datahub-cloud evals --help
+```
+
+Connection details come from the same place as the rest of the DataHub CLI — `~/.datahubenv` written
+by `datahub init`, or the `DATAHUB_GMS_URL` and `DATAHUB_GMS_TOKEN` environment variables.
 
 ## Quick Start
 
 ```shell
 # Create or update evals from a definition file
-datahub evals upsert -f evals.yml
+acryl-datahub-cloud evals upsert -f evals.yml
 
 # List what exists
-datahub evals list
+acryl-datahub-cloud evals list
 
 # Run one eval and wait for the verdict
-datahub evals run urn:li:eval:my-eval
+acryl-datahub-cloud evals run urn:li:eval:my-eval
 
 # Run everything for one agent and fail the shell on any FAIL or ERROR
-datahub evals run --all --agent-urn urn:li:aiAgent:my-agent --fail-on-fail
+acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent --fail-on-fail
 ```
 
-`upsert` is the default subcommand, so `datahub evals -f evals.yml` is equivalent to
-`datahub evals upsert -f evals.yml`.
+`upsert` is the default subcommand, so `acryl-datahub-cloud evals -f evals.yml` is equivalent to
+`acryl-datahub-cloud evals upsert -f evals.yml`.
 
 ## Defining Evals
 
@@ -127,9 +138,9 @@ submits the result with [`report`](#report).
 List eval definitions.
 
 ```shell
-datahub evals list
-datahub evals list --agent-urn urn:li:aiAgent:my-agent --eval-type METADATA
-datahub evals list --start 20 --limit 20
+acryl-datahub-cloud evals list
+acryl-datahub-cloud evals list --agent-urn urn:li:aiAgent:my-agent --eval-type METADATA
+acryl-datahub-cloud evals list --start 20 --limit 20
 ```
 
 | Option              | Default | Description                                      |
@@ -150,9 +161,9 @@ datahub evals list --start 20 --limit 20
 Fetch one eval and its latest run summary.
 
 ```shell
-datahub evals get urn:li:eval:my-eval
-datahub evals get urn:li:eval:my-eval --history 5
-datahub evals get urn:li:eval:my-eval --format upsert > my-eval.yml
+acryl-datahub-cloud evals get urn:li:eval:my-eval
+acryl-datahub-cloud evals get urn:li:eval:my-eval --history 5
+acryl-datahub-cloud evals get urn:li:eval:my-eval --format upsert > my-eval.yml
 ```
 
 | Option      | Default | Description                          |
@@ -168,8 +179,8 @@ fed straight back to `upsert`.
 Create or update evals from a file.
 
 ```shell
-datahub evals upsert -f evals.yml
-datahub evals upsert -f evals.yml --dry-run
+acryl-datahub-cloud evals upsert -f evals.yml
+acryl-datahub-cloud evals upsert -f evals.yml --dry-run
 ```
 
 | Option         | Description                                                     |
@@ -183,7 +194,7 @@ URNs, then exits non-zero. Reuse those URNs when retrying — a repeated create 
 ### delete
 
 ```shell
-datahub evals delete urn:li:eval:my-eval
+acryl-datahub-cloud evals delete urn:li:eval:my-eval
 ```
 
 ### run
@@ -191,9 +202,9 @@ datahub evals delete urn:li:eval:my-eval
 Start a run and wait for every selected eval to reach a terminal event.
 
 ```shell
-datahub evals run urn:li:eval:my-eval urn:li:eval:my-other-eval
-datahub evals run --all --agent-urn urn:li:aiAgent:my-agent
-datahub evals run --all --wait 600 --fail-on-fail
+acryl-datahub-cloud evals run urn:li:eval:my-eval urn:li:eval:my-other-eval
+acryl-datahub-cloud evals run --all --agent-urn urn:li:aiAgent:my-agent
+acryl-datahub-cloud evals run --all --wait 600 --fail-on-fail
 ```
 
 | Option            | Default | Description                                                  |
@@ -229,12 +240,12 @@ a filter spans every agent, so the two can return different counts.
 Submit an answer produced outside DataHub, using the run ID returned by `run`.
 
 ```shell
-datahub evals report urn:li:eval:my-eval \
+acryl-datahub-cloud evals report urn:li:eval:my-eval \
   --run-id "$RUN_ID" \
   --answer "The revenue table is owned by the analytics team."
 
 # Read a long answer from stdin
-my-harness answer | datahub evals report urn:li:eval:my-eval --run-id "$RUN_ID" --answer -
+my-harness answer | acryl-datahub-cloud evals report urn:li:eval:my-eval --run-id "$RUN_ID" --answer -
 ```
 
 | Option                | Description                                                              |
@@ -262,8 +273,8 @@ terminal is deduplicated rather than duplicated.
 List run events for one eval.
 
 ```shell
-datahub evals history urn:li:eval:my-eval
-datahub evals history urn:li:eval:my-eval --limit 50
+acryl-datahub-cloud evals history urn:li:eval:my-eval
+acryl-datahub-cloud evals history urn:li:eval:my-eval --limit 50
 ```
 
 | Option                    | Default | Description                                 |
@@ -292,21 +303,21 @@ otherwise.
 
 ## Using the Command from an Agent
 
-`datahub evals --agent-context` prints a condensed reference covering every subcommand, the exit-code
+`acryl-datahub-cloud evals --agent-context` prints a condensed reference covering every subcommand, the exit-code
 contract, and the run and report semantics. The same text is appended to `--help` output when stdout
-is not a terminal, so a coding agent that shells out to `datahub evals --help` gets the full contract
+is not a terminal, so a coding agent that shells out to `acryl-datahub-cloud evals --help` gets the full contract
 without a separate call.
 
 ## CI Example
 
 ```shell
-pip install -U 'acryl-datahub[datahub-evals]'
+pip install 'acryl-datahub-cloud[datahub-evals]>=2.1.4rc1'
 
 export DATAHUB_GMS_URL=https://your-instance.acryl.io/gms
 export DATAHUB_GMS_TOKEN=your-token
 
-datahub evals upsert -f evals.yml
-datahub evals run --all --agent-urn "$AGENT_URN" --wait 900 --fail-on-fail
+acryl-datahub-cloud evals upsert -f evals.yml
+acryl-datahub-cloud evals run --all --agent-urn "$AGENT_URN" --wait 900 --fail-on-fail
 ```
 
 The run exits non-zero on any failing, errored, or stale eval, which fails the job.


### PR DESCRIPTION
## Summary

Adds a public CLI reference page for the `evals` command, which manages, runs, and reports DataHub Context Evals.

The command ships only in the `acryl-datahub-cloud` package and runs through that package's own entry point (`acryl-datahub-cloud evals ...`), so the page documents installing and using it there rather than through the open source `acryl-datahub` CLI.

- `docs/cli-commands/evals.md` — installation, eval definition schema (fields, conditions, executor), every subcommand with its options and defaults, output and exit-code contract, agent usage, and a CI example.
- Badged `<FeatureAvailability saasOnly stage="private-beta" />`, plus a prose note that the command surface can change between releases.
- Sidebar entry under **DataHub CLI**.

Two installation details the page calls out explicitly:

- The `datahub-evals` extra supplies the GraphQL client the command needs, so the bare package leaves `evals` unusable.
- `evals` first shipped in `2.1.4rc1`; since that is a pre-release, pip only selects it when the requirement names it, hence `pip install 'acryl-datahub-cloud[datahub-evals]>=2.1.4rc1'`.

## Testing

- `./gradlew :datahub-web-react:mdPrettierWrite` — formatted; the pre-commit Docusaurus markdown lint passes.
- Options, defaults, enum values, exit codes, and validation rules were read off the command implementation rather than inferred.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Docs added/updated
- [ ] Tests added/updated — n/a, docs only
- [ ] Breaking changes — none