### PR TITLE
fix(): Improve structure of github-documents source

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_report.py
@@ -13,5 +13,8 @@ class GitHubDocumentsSourceReport(StaleEntityRemovalSourceReport):
     folders_processed: int = 0
     files_skipped: int = 0
     files_skipped_unchanged: int = 0
+    documents_resurrected: int = 0
+    identity_fast_path_errors: int = 0
     tree_truncated: bool = False
     files_truncated_by_limit: bool = False
+    hidden_lifecycle_search_unsupported: bool = False

--- a/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/github_documents/github_documents_source.py
@@ -7,12 +7,13 @@ import json
 import logging
 import os
 from functools import partial
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from datahub.emitter.mce_builder import (
     make_data_platform_urn,
     make_dataplatform_instance_urn,
 )
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SupportStatus,
@@ -29,6 +30,7 @@ from datahub.ingestion.api.source import (
     TestConnectionReport,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.graph.filters import RemovedStatusFilter
 from datahub.ingestion.source.documents.document_import_mode import DocumentImportMode
 from datahub.ingestion.source.github_documents.github_api import (
     GitHubApiClient,
@@ -65,13 +67,19 @@ from datahub.metadata.schema_classes import (
     DataPlatformInstanceClass,
     DocumentInfoClass,
     DocumentStateClass,
+    StatusClass,
 )
+from datahub.metadata.urns import DocumentUrn
 from datahub.sdk.document import Document
 
 logger = logging.getLogger(__name__)
 
 EXTRACTION_ALGO_VERSION = "1"
 LAST_EXPORTED_CONTENT_HASH_KEY = "last_exported_content_hash"
+PROP_IMPORT_SOURCE_ID = "import_source_id"
+PROP_GITHUB_FILE_PATH = "github_file_path"
+PROP_GITHUB_DIRECTORY_PATH = "github_directory_path"
+_DOCUMENT_URN_PREFIX = "urn:li:document:"
 
 
 def compute_file_content_hash(content: str) -> str:
@@ -128,6 +136,9 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             if config.parent_document_urn or not config.create_repo_root_document
             else make_repo_source_id(config.repository)
         )
+        # Cache of import_source_id -> existing document URN (sync-back round-trip).
+        self._resolved_source_id_urns: Dict[str, Optional[str]] = {}
+        self._soft_deleted_cache: Optional[Set[str]] = None
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "GitHubDocumentsSource":
@@ -226,7 +237,7 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             "github_repo": owner_repo,
             "github_branch": branch,
             "is_repo_root_document": "true",
-            "import_source_id": source_id,
+            PROP_IMPORT_SOURCE_ID: source_id,
         }
 
         doc = self._build_document(
@@ -252,7 +263,12 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
         dir_path: str,
         path_prefix: str,
     ) -> Iterable[MetadataWorkUnit]:
-        source_id = make_dir_source_id(owner_repo, dir_path)
+        """Emit a metadata-only folder document for a GitHub directory.
+
+        Folder bodies are not synced from GitHub files. DataHub may hold richer
+        folder content than GitHub (a deliberate DH ⊇ GH split).
+        """
+        dir_source_id = make_dir_source_id(owner_repo, dir_path)
         parent_source_id = resolve_parent_dir_source_id(
             owner_repo,
             dir_path,
@@ -262,29 +278,40 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
         parent_urn = self._resolve_parent_urn(parent_source_id)
 
         title = os.path.basename(dir_path.rstrip("/")) or dir_path
-        doc_id = normalize_document_id(source_id)
-        custom_properties = {
-            "import_source": "github",
-            "github_repo": owner_repo,
-            "github_branch": branch,
-            "github_directory_path": dir_path,
-            "is_folder_document": "true",
-            "import_source_id": source_id,
-        }
-
-        doc = self._build_document(
-            doc_id=doc_id,
-            title=title,
-            text="",
-            owner_repo=owner_repo,
-            branch=branch,
-            github_path=dir_path,
-            parent_document=parent_urn,
-            custom_properties=custom_properties,
+        doc_id, _document_urn = self._resolve_document_identity(
+            dir_source_id, owner_repo, dir_path, is_directory=True
         )
-        self._register_hierarchy(source_id, title, parent_source_id=parent_source_id)
-        self._source_id_to_urn[source_id] = str(doc.urn)
-        self._attach_browse_path(doc, source_id)
+
+        # Folders are metadata-only on import. Re-emitting DocumentInfo for an
+        # existing folder (including DataHub-native URNs stamped by sync-back)
+        # would UPSERT empty text and replace title/status/customProperties.
+        if self._resolved_source_id_urns.get(dir_source_id):
+            doc = Document(urn=DocumentUrn(doc_id))
+            self._attach_platform_instance(doc, owner_repo)
+        else:
+            doc = self._build_document(
+                doc_id=doc_id,
+                title=title,
+                text="",
+                owner_repo=owner_repo,
+                branch=branch,
+                github_path=dir_path,
+                parent_document=parent_urn,
+                custom_properties={
+                    "import_source": "github",
+                    "github_repo": owner_repo,
+                    "github_branch": branch,
+                    "github_directory_path": dir_path,
+                    "is_folder_document": "true",
+                    PROP_IMPORT_SOURCE_ID: dir_source_id,
+                },
+            )
+        doc._set_aspect(StatusClass(removed=False))
+        self._register_hierarchy(
+            dir_source_id, title, parent_source_id=parent_source_id
+        )
+        self._source_id_to_urn[dir_source_id] = str(doc.urn)
+        self._attach_browse_path(doc, dir_source_id)
         self.report.folders_processed += 1
         yield from doc.as_workunits()
 
@@ -303,14 +330,16 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             return
 
         source_id = make_file_source_id(owner_repo, file_path)
-        doc_id = normalize_document_id(source_id)
-        document_urn = f"urn:li:document:{doc_id}"
+        doc_id, document_urn = self._resolve_document_identity(
+            source_id, owner_repo, file_path
+        )
         content_hash = compute_file_content_hash(content)
 
         if self._should_skip_unchanged_file(document_urn, content_hash):
             logger.info("Skipping unchanged file document: %s", file_path)
             self.report.files_skipped_unchanged += 1
             self._register_document_for_stale_removal(document_urn)
+            yield from self._resurrect_unchanged_document(document_urn, owner_repo)
             return
 
         parent_source_id = resolve_parent_dir_source_id(
@@ -328,7 +357,7 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             "github_branch": branch,
             "github_file_path": file_path,
             "github_commit_sha": commit_sha,
-            "import_source_id": source_id,
+            PROP_IMPORT_SOURCE_ID: source_id,
             "content_hash": content_hash,
             "extraction_algo_version": EXTRACTION_ALGO_VERSION,
         }
@@ -345,6 +374,11 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
             parent_document=parent_urn,
             custom_properties=custom_properties,
         )
+        # GitHub is source of truth for import: if the file still exists, clear
+        # Status.removed so a previously soft-deleted DataHub doc is resurrected.
+        # The unchanged-file short-circuit above resurrects too, so this does not
+        # depend on whether the content happened to change.
+        doc._set_aspect(StatusClass(removed=False))
         self._register_hierarchy(source_id, title, parent_source_id=parent_source_id)
         self._source_id_to_urn[source_id] = str(doc.urn)
         self._attach_browse_path(doc, source_id)
@@ -372,6 +406,216 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
         stored_hash = props.get("content_hash")
         exported_hash = props.get(LAST_EXPORTED_CONTENT_HASH_KEY)
         return content_hash in (stored_hash, exported_hash)
+
+    def _resolve_document_identity(
+        self, source_id: str, owner_repo: str, path: str, *, is_directory: bool = False
+    ) -> Tuple[str, str]:
+        """Return ``(doc_id, document_urn)`` for a GitHub file or directory.
+
+        Prefers an existing document already stamped with this
+        ``import_source_id`` (e.g. created in DataHub and synced back) so
+        re-import does not mint a second URN and soft-delete the original via
+        stale entity removal.
+        """
+        canonical_doc_id = normalize_document_id(source_id)
+        canonical_urn = f"{_DOCUMENT_URN_PREFIX}{canonical_doc_id}"
+        existing_urn = self._find_existing_document_urn(
+            source_id, owner_repo, path, canonical_urn, is_directory=is_directory
+        )
+        if existing_urn and existing_urn.startswith(_DOCUMENT_URN_PREFIX):
+            return existing_urn[len(_DOCUMENT_URN_PREFIX) :], existing_urn
+        return canonical_doc_id, canonical_urn
+
+    def _search_documents_by_properties(
+        self, extra_filters: List[Dict[str, Any]]
+    ) -> List[str]:
+        """Search documents by customProperties, tolerating older servers.
+
+        ``include_hidden_lifecycle_stages`` is what surfaces documents parked in a
+        hideInSearch stage (e.g. ``urn:li:lifecycleStageType:DRAFT``). Servers that
+        predate the flag reject it outright, which is a permanent condition rather
+        than a transient one, so degrade once instead of failing every run.
+        """
+        assert self.ctx.graph is not None
+        if not self.report.hidden_lifecycle_search_unsupported:
+            try:
+                return list(
+                    self.ctx.graph.get_urns_by_filter(
+                        entity_types=["document"],
+                        status=RemovedStatusFilter.ALL,
+                        include_hidden_lifecycle_stages=True,
+                        extraFilters=extra_filters,
+                    )
+                )
+            except ValueError as exc:
+                self.report.hidden_lifecycle_search_unsupported = True
+                self.report.warning(
+                    title="Search flag unsupported by this DataHub server",
+                    message=(
+                        "includeHiddenLifecycleStages is unavailable, so documents "
+                        "in hidden lifecycle stages (for example drafts) cannot be "
+                        "matched when reusing document identity. Upgrade GMS to "
+                        "reuse their URNs instead of minting new ones."
+                    ),
+                    exc=exc,
+                )
+        return list(
+            self.ctx.graph.get_urns_by_filter(
+                entity_types=["document"],
+                status=RemovedStatusFilter.ALL,
+                extraFilters=extra_filters,
+            )
+        )
+
+    def _find_existing_document_urn(
+        self,
+        source_id: str,
+        owner_repo: str,
+        path: str,
+        canonical_urn: str,
+        *,
+        is_directory: bool,
+    ) -> Optional[str]:
+        if source_id in self._resolved_source_id_urns:
+            return self._resolved_source_id_urns[source_id]
+        if not self.ctx.graph:
+            self._resolved_source_id_urns[source_id] = None
+            return None
+
+        # Fast path: classic GitHub imports already live at the canonical URN
+        # with this import_source_id. Avoid a search round-trip per file.
+        try:
+            aspect = self.ctx.graph.get_aspect(canonical_urn, DocumentInfoClass)
+            if (
+                aspect
+                and aspect.customProperties
+                and aspect.customProperties.get(PROP_IMPORT_SOURCE_ID) == source_id
+            ):
+                self._resolved_source_id_urns[source_id] = canonical_urn
+                return canonical_urn
+        except Exception as exc:
+            # Counted, not just logged: a persistent condition here (expired token,
+            # permission denied) silently degrades every file to the slow path, and
+            # operators read the report rather than executor logs.
+            self.report.identity_fast_path_errors += 1
+            logger.debug(
+                "Could not load canonical document %s for identity short-circuit: %s",
+                canonical_urn,
+                exc,
+            )
+
+        # Slow path: DataHub-native URNs stamped by sync-back (import_source_id
+        # on a non-canonical URN). Pure GitHub imports set import_source_id on
+        # first ingest; DataHub-created docs get it on first successful sync-back.
+        try:
+            matches = self._search_documents_by_properties(
+                [
+                    {
+                        "field": "customProperties",
+                        "condition": "EQUAL",
+                        "values": [f"{PROP_IMPORT_SOURCE_ID}={source_id}"],
+                    }
+                ]
+            )
+        except Exception as exc:
+            # Reported as a failure, not a warning: StaleEntityRemovalHandler skips
+            # soft-deletion entirely when the source has failures. Without that,
+            # falling back to the canonical URN would mint a duplicate and reap the
+            # real document (and its children). The URN we would need to pass to
+            # add_urn_to_skip() is exactly what this lookup failed to determine.
+            self.report.failure(
+                title="Document identity lookup failed",
+                message=(
+                    "Could not search for an existing document for this GitHub "
+                    "path. Stale entity removal is skipped for this run so no "
+                    "document is soft-deleted; re-run once search is reachable."
+                ),
+                context=f"path={path}, source_id={source_id}",
+                exc=exc,
+            )
+            self._resolved_source_id_urns[source_id] = None
+            return None
+
+        if not matches:
+            # Fallback for documents whose import_source_id predates this scheme:
+            # match the stamped GitHub path instead. The key differs by kind: a
+            # folder document carries github_directory_path and no
+            # github_file_path, so querying the file key for a directory could
+            # never match.
+            path_property = (
+                PROP_GITHUB_DIRECTORY_PATH if is_directory else PROP_GITHUB_FILE_PATH
+            )
+            try:
+                matches = self._search_documents_by_properties(
+                    [
+                        {
+                            "field": "customProperties",
+                            "condition": "EQUAL",
+                            "values": [f"{path_property}={path}"],
+                        },
+                        {
+                            "field": "customProperties",
+                            "condition": "EQUAL",
+                            "values": [f"github_repo={owner_repo}"],
+                        },
+                    ]
+                )
+            except Exception as exc:
+                self.report.failure(
+                    title="Document identity lookup failed",
+                    message=(
+                        "Fallback github_file_path search failed for this GitHub "
+                        "path. Stale entity removal is skipped for this run so no "
+                        "document is soft-deleted; re-run once search is reachable."
+                    ),
+                    context=f"path={path}, source_id={source_id}",
+                    exc=exc,
+                )
+                self._resolved_source_id_urns[source_id] = None
+                return None
+
+        chosen = self._prefer_existing_document_urn(
+            matches, canonical_urn, path=path, source_id=source_id
+        )
+        if chosen and chosen != canonical_urn:
+            logger.info(
+                "Reusing existing document %s for GitHub path %s (source_id=%s)",
+                chosen,
+                path,
+                source_id,
+            )
+        self._resolved_source_id_urns[source_id] = chosen
+        return chosen
+
+    def _prefer_existing_document_urn(
+        self,
+        matches: List[str],
+        canonical_urn: str,
+        *,
+        path: str,
+        source_id: str,
+    ) -> Optional[str]:
+        """Prefer a DataHub-native (non-canonical) URN so children are preserved."""
+        if not matches:
+            return None
+        unique = sorted(dict.fromkeys(matches))
+        if len(unique) > 1:
+            self.report.warning(
+                title="Ambiguous document identity for GitHub path",
+                message=(
+                    "More than one DataHub document claims this GitHub path. One was "
+                    "reused; the others were left in place this run. Merge or delete "
+                    "the duplicates, or rename them so their titles map to distinct "
+                    "file names."
+                ),
+                context=f"path={path}, source_id={source_id}, candidates={unique}",
+            )
+        non_canonical = [urn for urn in unique if urn != canonical_urn]
+        chosen = non_canonical[0] if non_canonical else unique[0]
+        for urn in unique:
+            if urn != chosen:
+                self._register_document_for_stale_removal(urn)
+        return chosen
 
     def _register_document_for_stale_removal(self, document_urn: str) -> None:
         self.stale_entity_removal_handler.add_entity_to_state("document", document_urn)
@@ -509,6 +753,52 @@ class GitHubDocumentsSource(StatefulIngestionSourceBase, TestableSource):
 
         self._attach_platform_instance(doc, owner_repo)
         return doc
+
+    def _soft_deleted_urns(self, owner_repo: str) -> Set[str]:
+        """URNs this repo previously imported that are currently soft-deleted.
+
+        Loaded with a single search so the unchanged-file path can resurrect a
+        document without paying a Status lookup per file.
+        """
+        if self._soft_deleted_cache is not None:
+            return self._soft_deleted_cache
+
+        urns: Set[str] = set()
+        if self.ctx.graph:
+            try:
+                urns = set(
+                    self.ctx.graph.get_urns_by_filter(
+                        entity_types=["document"],
+                        platform=self.platform,
+                        platform_instance=make_dataplatform_instance_urn(
+                            self.platform, owner_repo
+                        ),
+                        status=RemovedStatusFilter.ONLY_SOFT_DELETED,
+                    )
+                )
+            except Exception as exc:
+                # Non-fatal: only costs us resurrection of documents whose file came
+                # back to GitHub unchanged. Import itself is unaffected.
+                logger.debug("Could not list soft-deleted documents: %s", exc)
+        self._soft_deleted_cache = urns
+        return urns
+
+    def _resurrect_unchanged_document(
+        self, document_urn: str, owner_repo: str
+    ) -> Iterable[MetadataWorkUnit]:
+        """Clear Status.removed for an unchanged file that exists in GitHub again.
+
+        Without this, deleting a file, letting stale removal soft-delete its
+        document, then restoring the file with identical content would leave the
+        document soft-deleted forever, since the unchanged-file short-circuit
+        returns before any Status is emitted.
+        """
+        if document_urn not in self._soft_deleted_urns(owner_repo):
+            return
+        self.report.documents_resurrected += 1
+        yield MetadataChangeProposalWrapper(
+            entityUrn=document_urn, aspect=StatusClass(removed=False)
+        ).as_workunit()
 
     def _attach_platform_instance(self, doc: Document, owner_repo: str) -> None:
         doc._set_aspect(

--- a/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/github_documents/test_github_documents_source.py
@@ -7,6 +7,7 @@ from pydantic import SecretStr
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.graph.filters import RemovedStatusFilter
 from datahub.ingestion.source.documents.document_import_mode import DocumentImportMode
 from datahub.ingestion.source.github_documents.github_api import (
     GitHubFileInfo,
@@ -27,6 +28,7 @@ from datahub.metadata.schema_classes import (
     DataPlatformInstanceClass,
     DocumentInfoClass,
     DocumentSourceTypeClass,
+    StatusClass,
 )
 
 
@@ -725,6 +727,7 @@ def test_skipping_unchanged_file_registers_entity_for_stale_removal(
         file_content=content,
     )
     source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = []
     mock_info = MagicMock()
     mock_info.customProperties = {"content_hash": content_hash}
     source.ctx.graph.get_aspect.return_value = mock_info
@@ -738,3 +741,535 @@ def test_skipping_unchanged_file_registers_entity_for_stale_removal(
         "document",
         expected_urn,
     )
+
+
+def test_prefer_existing_document_urn_prefers_non_canonical(
+    source: GitHubDocumentsSource,
+) -> None:
+    source.stale_entity_removal_handler.add_entity_to_state = MagicMock()  # type: ignore[method-assign]
+    canonical = "urn:li:document:canonical"
+    native = "urn:li:document:native-uuid"
+    assert (
+        source._prefer_existing_document_urn(
+            [canonical, native],
+            canonical,
+            path="docs/a.md",
+            source_id="github.acme.docs.a",
+        )
+        == native
+    )
+    assert (
+        source._prefer_existing_document_urn(
+            [canonical],
+            canonical,
+            path="docs/a.md",
+            source_id="github.acme.docs.a",
+        )
+        == canonical
+    )
+    assert (
+        source._prefer_existing_document_urn(
+            [],
+            canonical,
+            path="docs/a.md",
+            source_id="github.acme.docs.a",
+        )
+        is None
+    )
+
+
+def test_prefer_existing_document_urn_is_deterministic_and_warns(
+    source: GitHubDocumentsSource,
+) -> None:
+    source.stale_entity_removal_handler.add_entity_to_state = MagicMock()  # type: ignore[method-assign]
+    canonical = "urn:li:document:canonical"
+    first = source._prefer_existing_document_urn(
+        ["urn:li:document:z", "urn:li:document:a"],
+        canonical,
+        path="docs/a.md",
+        source_id="github.acme.docs.a",
+    )
+    second = source._prefer_existing_document_urn(
+        ["urn:li:document:a", "urn:li:document:z"],
+        canonical,
+        path="docs/a.md",
+        source_id="github.acme.docs.a",
+    )
+    assert first == second == "urn:li:document:a"
+    assert any(
+        "Ambiguous document identity" in (entry.title or "")
+        for entry in source.report.warnings
+    )
+
+
+def test_reuses_existing_document_urn_from_import_source_id(
+    source: GitHubDocumentsSource,
+) -> None:
+    existing_urn = "urn:li:document:native-uuid-1234"
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello from sync-back",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = [existing_urn]
+    source.ctx.graph.get_aspect.return_value = None
+
+    workunits = list(source.get_workunits_internal())
+    urns = {wu.get_urn() for wu in workunits if isinstance(wu, MetadataWorkUnit)}
+    assert existing_urn in urns
+    # Must not also emit the deterministic canonical URN for the same file.
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    assert canonical_urn not in urns
+
+
+def test_skip_unchanged_uses_resolved_existing_urn(
+    source: GitHubDocumentsSource,
+) -> None:
+    existing_urn = "urn:li:document:native-uuid-1234"
+    content = "# Hello"
+    content_hash = compute_file_content_hash(content)
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content=content,
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = [existing_urn]
+    mock_info = MagicMock()
+    mock_info.customProperties = {
+        "content_hash": content_hash,
+        "import_source_id": source_id,
+    }
+
+    def get_aspect(urn: str, _aspect: object) -> object:
+        # Canonical URN has no matching stamp; only the DataHub-native URN does.
+        if urn == existing_urn:
+            return mock_info
+        return None
+
+    source.ctx.graph.get_aspect.side_effect = get_aspect
+    source.stale_entity_removal_handler.add_entity_to_state = MagicMock()  # type: ignore[method-assign]
+
+    list(source.get_workunits_internal())
+
+    assert source.report.files_skipped_unchanged == 1
+    source.stale_entity_removal_handler.add_entity_to_state.assert_called_once_with(
+        "document",
+        existing_urn,
+    )
+
+
+def _file_document_urns(workunits: list, file_path: str) -> set[str]:
+    urns: set[str] = set()
+    for wu in workunits:
+        if not isinstance(wu, MetadataWorkUnit):
+            continue
+        info = wu.get_aspect_of_type(DocumentInfoClass)
+        if (
+            info
+            and info.customProperties
+            and info.customProperties.get("github_file_path") == file_path
+        ):
+            urns.add(wu.get_urn())
+    return urns
+
+
+def test_import_without_graph_still_uses_canonical_urn(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Regression: plain GitHub import (no graph) must keep deterministic URNs."""
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    assert source.ctx.graph is None
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+
+
+def test_import_with_empty_identity_lookup_uses_canonical_urn(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Regression: when no sync-back stamp exists, import still mints canonical URN."""
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = []
+    source.ctx.graph.get_aspect.return_value = None
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+    source.ctx.graph.get_urns_by_filter.assert_called()
+
+
+def test_import_identity_lookup_failure_falls_back_to_canonical_urn(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Regression: search failures must not break import of new GitHub files.
+
+    Reported via report.failure so StaleEntityRemovalHandler skips soft-deletion:
+    falling back to the canonical URN could otherwise reap a stamped document.
+    """
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.side_effect = RuntimeError("search unavailable")
+    source.ctx.graph.get_aspect.return_value = None
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+    assert any(
+        getattr(failure, "title", None) == "Document identity lookup failed"
+        for failure in source.report.failures
+    )
+
+
+def test_import_identity_lookup_includes_hidden_lifecycle_stages(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Stamped docs in hideInSearch stages must be discoverable during identity reuse."""
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = []
+    source.ctx.graph.get_aspect.return_value = None
+
+    list(source.get_workunits_internal())
+
+    kwargs = source.ctx.graph.get_urns_by_filter.call_args.kwargs
+    assert kwargs.get("include_hidden_lifecycle_stages") is True
+    assert "include_draft" not in kwargs
+
+
+def test_import_identity_fallback_lookup_failure_fails_run(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Fallback github_file_path search errors must not look like empty results."""
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_aspect.return_value = None
+
+    def urns_by_filter(**kwargs):
+        values = kwargs.get("extraFilters", [{}])[0].get("values", [""])[0]
+        if values.startswith("import_source_id="):
+            return []
+        raise RuntimeError("fallback search unavailable")
+
+    source.ctx.graph.get_urns_by_filter.side_effect = urns_by_filter
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+    assert any(
+        getattr(failure, "title", None) == "Document identity lookup failed"
+        for failure in source.report.failures
+    )
+
+
+def test_import_prefers_canonical_when_only_canonical_match_exists(
+    source: GitHubDocumentsSource,
+) -> None:
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = [canonical_urn]
+    source.ctx.graph.get_aspect.return_value = None
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+
+
+def test_unsupported_search_flag_degrades_once_instead_of_failing(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Older servers reject includeHiddenLifecycleStages permanently.
+
+    Failing the run would make every file fail forever, so retry without the flag
+    and warn once. Draft-stage documents simply cannot be matched there.
+    """
+    _mock_github_client(
+        source,
+        files=[
+            GitHubFileInfo(path="docs/a.md", size=12),
+            GitHubFileInfo(path="docs/b.md", size=12),
+        ],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_aspect.return_value = None
+
+    def urns_by_filter(**kwargs):
+        if kwargs.get("include_hidden_lifecycle_stages"):
+            raise ValueError(
+                "SearchFlags.includeHiddenLifecycleStages is not supported"
+            )
+        return []
+
+    source.ctx.graph.get_urns_by_filter.side_effect = urns_by_filter
+
+    list(source.get_workunits_internal())
+
+    assert source.report.failures == []
+    assert source.report.hidden_lifecycle_search_unsupported is True
+    titles = [getattr(w, "title", None) for w in source.report.warnings]
+    assert titles.count("Search flag unsupported by this DataHub server") == 1
+    # Only the first attempt pays the rejected call; later lookups skip the flag.
+    flagged = [
+        call
+        for call in source.ctx.graph.get_urns_by_filter.call_args_list
+        if call.kwargs.get("include_hidden_lifecycle_stages")
+    ]
+    assert len(flagged) == 1
+
+
+def test_unchanged_file_resurrects_soft_deleted_document(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Restoring a deleted file with identical content must un-delete its document.
+
+    The unchanged-file short-circuit returns before any DocumentInfo is emitted, so
+    without an explicit Status the document would stay soft-deleted forever.
+    """
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    content = "# Hello"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content=content,
+    )
+    source.ctx.graph = MagicMock()
+    existing = MagicMock()
+    existing.customProperties = {"content_hash": compute_file_content_hash(content)}
+    source.ctx.graph.get_aspect.return_value = existing
+
+    def urns_by_filter(**kwargs):
+        if kwargs.get("status") == RemovedStatusFilter.ONLY_SOFT_DELETED:
+            return [canonical_urn]
+        return []
+
+    source.ctx.graph.get_urns_by_filter.side_effect = urns_by_filter
+
+    workunits = list(source.get_workunits_internal())
+
+    assert source.report.files_skipped_unchanged == 1
+    assert source.report.documents_resurrected == 1
+    statuses = [
+        wu.get_aspect_of_type(StatusClass)
+        for wu in workunits
+        if isinstance(wu, MetadataWorkUnit) and wu.get_urn() == canonical_urn
+    ]
+    assert any(s is not None and s.removed is False for s in statuses)
+
+
+def test_unchanged_file_not_soft_deleted_emits_nothing(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Unchanged files that are not soft-deleted must not pay a write per run."""
+    content = "# Hello"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content=content,
+    )
+    source.ctx.graph = MagicMock()
+    existing = MagicMock()
+    existing.customProperties = {"content_hash": compute_file_content_hash(content)}
+    source.ctx.graph.get_aspect.return_value = existing
+    source.ctx.graph.get_urns_by_filter.return_value = []
+
+    workunits = list(source.get_workunits_internal())
+
+    assert source.report.files_skipped_unchanged == 1
+    assert source.report.documents_resurrected == 0
+    assert not [
+        wu
+        for wu in workunits
+        if isinstance(wu, MetadataWorkUnit)
+        and wu.get_aspect_of_type(StatusClass) is not None
+    ]
+
+
+def test_folder_identity_fallback_queries_directory_path(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Folders carry github_directory_path; the file key could never match them."""
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/child.md", size=12)],
+        file_content="# Child",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_aspect.return_value = None
+    source.ctx.graph.get_urns_by_filter.return_value = []
+
+    list(source.get_workunits_internal())
+
+    queried = {
+        value
+        for call in source.ctx.graph.get_urns_by_filter.call_args_list
+        for rule in (call.kwargs.get("extraFilters") or [])
+        for value in (rule.get("values") or [])
+    }
+    assert "github_directory_path=docs/guides" in queried
+    assert "github_file_path=docs/guides" not in queried
+
+
+def test_import_emits_status_not_removed_for_file_documents(
+    source: GitHubDocumentsSource,
+) -> None:
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    source.ctx.graph.get_urns_by_filter.return_value = []
+    source.ctx.graph.get_aspect.return_value = None
+
+    workunits = list(source.get_workunits_internal())
+    statuses = [
+        wu.get_aspect_of_type(StatusClass)
+        for wu in workunits
+        if isinstance(wu, MetadataWorkUnit)
+    ]
+    file_statuses = [status for status in statuses if status is not None]
+    assert file_statuses
+    assert all(status.removed is False for status in file_statuses)
+
+
+def test_same_name_file_remains_sibling_of_folder(
+    source: GitHubDocumentsSource,
+) -> None:
+    """``guides/guides.md`` stays a normal file; folder docs are metadata-only."""
+    owner_repo = "acme/docs"
+    _mock_github_client(
+        source,
+        files=[
+            GitHubFileInfo(path="docs/guides/guides.md", size=20, sha="idx"),
+            GitHubFileInfo(path="docs/guides/child.md", size=12, sha="child"),
+        ],
+        file_content="# Guides body",
+    )
+
+    workunits = list(source.get_workunits())
+    infos = _document_infos_by_source_id(workunits)
+    urns = _entity_urns_by_source_id(workunits)
+
+    file_source_id = make_file_source_id(owner_repo, "docs/guides/guides.md")
+    child_source_id = make_file_source_id(owner_repo, "docs/guides/child.md")
+    dir_source_id = make_dir_source_id(owner_repo, "docs/guides")
+
+    assert dir_source_id in infos
+    assert infos[dir_source_id].customProperties["is_folder_document"] == "true"
+    assert infos[dir_source_id].contents is not None
+    assert infos[dir_source_id].contents.text == ""
+
+    assert file_source_id in infos
+    assert infos[file_source_id].customProperties.get("is_folder_document") is None
+    assert infos[file_source_id].contents is not None
+    assert infos[file_source_id].contents.text == "# Guides body"
+
+    child_parent = infos[child_source_id].parentDocument
+    assert child_parent is not None
+    assert child_parent.document == urns[dir_source_id]
+
+
+def test_identity_short_circuit_skips_search_for_canonical_match(
+    source: GitHubDocumentsSource,
+) -> None:
+    """Classic imports at the canonical URN must not pay for a search round-trip."""
+    source_id = make_file_source_id("acme/docs", "docs/readme.md")
+    canonical_urn = f"urn:li:document:{normalize_document_id(source_id)}"
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/readme.md", size=12)],
+        file_content="# Hello",
+    )
+    source.ctx.graph = MagicMock()
+    mock_info = MagicMock()
+    mock_info.customProperties = {"import_source_id": source_id}
+    source.ctx.graph.get_aspect.return_value = mock_info
+
+    workunits = list(source.get_workunits_internal())
+    assert _file_document_urns(workunits, "docs/readme.md") == {canonical_urn}
+    source.ctx.graph.get_urns_by_filter.assert_not_called()
+
+
+def test_existing_folder_document_does_not_overwrite_body(
+    source: GitHubDocumentsSource,
+) -> None:
+    existing_urn = "urn:li:document:native-folder"
+    dir_source_id = make_dir_source_id("acme/docs", "docs/guides")
+    _mock_github_client(
+        source,
+        files=[GitHubFileInfo(path="docs/guides/child.md", size=12)],
+        file_content="# Child",
+    )
+    source.ctx.graph = MagicMock()
+    existing_info = MagicMock()
+    existing_info.customProperties = {"import_source_id": dir_source_id}
+    existing_info.title = "Guides"
+    existing_info.contents = MagicMock()
+    existing_info.contents.text = "rich body"
+
+    def get_aspect(urn: str, _aspect: object) -> object:
+        if urn == existing_urn:
+            return existing_info
+        return None
+
+    source.ctx.graph.get_aspect.side_effect = get_aspect
+
+    def urns_by_filter(**kwargs):  # type: ignore[no-untyped-def]
+        for rule in kwargs.get("extraFilters") or []:
+            values = rule.get("values") or []
+            if any(f"import_source_id={dir_source_id}" == value for value in values):
+                return [existing_urn]
+        return []
+
+    source.ctx.graph.get_urns_by_filter.side_effect = urns_by_filter
+
+    workunits = list(source.get_workunits_internal())
+    folder_infos = [
+        wu.get_aspect_of_type(DocumentInfoClass)
+        for wu in workunits
+        if isinstance(wu, MetadataWorkUnit) and wu.get_urn() == existing_urn
+    ]
+    folder_infos = [info for info in folder_infos if info is not None]
+    assert folder_infos == []
+    statuses = [
+        wu.get_aspect_of_type(StatusClass)
+        for wu in workunits
+        if isinstance(wu, MetadataWorkUnit) and wu.get_urn() == existing_urn
+    ]
+    assert any(status is not None and status.removed is False for status in statuses)


### PR DESCRIPTION
Mainly aligning with the datahub-cloud implementation of github-document source.

## Summary

Three re-import bugs in the `github-documents` source, all of which cost users data on the second run rather than the first.

The source derives a document's URN deterministically from `repo` + `path`. That is correct when GitHub is the only thing that ever creates these documents, but a document representing a GitHub file can already exist in DataHub at a *different* URN — created natively in DataHub and later landed in the repo, or imported under an earlier id scheme. In that case re-import minted a second URN for the same file, and because the original was no longer emitted, stale entity removal soft-deleted it along with its children.

### 1. Re-import no longer duplicates a document and reaps the original

Identity is now resolved before building the document, preferring an existing document already stamped with this `import_source_id`:

- **Fast path:** read `DocumentInfo` at the canonical URN and confirm its `import_source_id`. Classic GitHub-only imports resolve here, so they do not pay a search per file. Failures here are counted in `identity_fast_path_errors` rather than only logged, since a persistent condition (expired token, permission denied) silently degrades every file to the slow path.
- **Slow path:** search `customProperties` for `import_source_id`.
- **Fallback:** for documents predating the `import_source_id` stamp, match the stamped GitHub path plus `github_repo`. The path key depends on kind — a folder carries `github_directory_path` and no `github_file_path` — so querying the file key for a directory could never match.

When more than one document claims the same path, the candidates are sorted so every run picks the same one, a warning names the ambiguity, and only the *unchosen* duplicates are registered for stale removal.

If the identity lookup itself fails, it is reported as a **failure**, not a warning. `StaleEntityRemovalHandler` skips soft-deletion entirely when the source reports failures, and that is the only safe outcome here: falling back to the canonical URN would mint a duplicate and reap the real document, and the URN we would need to pass to `add_urn_to_skip()` is exactly what the failed lookup could not determine.

### 2. Re-importing a folder no longer wipes it

Folder documents are metadata-only on import; their bodies are not sourced from GitHub files. Re-emitting a full `DocumentInfo` for an existing folder UPSERTed empty text over it, discarding `contents`, `title`, and any `customProperties` this source does not own. When identity resolves to an existing folder, only the URN, `Status`, and `DataPlatformInstance` are emitted now.

### 3. A restored file resurrects its document

Deleting a file, letting stale removal soft-delete its document, then restoring the file with identical content left the document soft-deleted forever: the unchanged-content short-circuit returns before any `Status` is emitted. File documents now clear `Status.removed`, and the unchanged path checks a single up-front `ONLY_SOFT_DELETED` search (`documents_resurrected`) so the resurrection costs one query per run rather than a `Status` lookup per file.

### Compatibility

Matching documents parked in a hidden lifecycle stage (for example drafts) requires `includeHiddenLifecycleStages`. Servers predating that flag reject it outright, which is permanent rather than transient, so the search degrades once — warn, set `hidden_lifecycle_search_unsupported`, and retry without the flag — instead of failing every run.

New report fields: `documents_resurrected`, `identity_fast_path_errors`, `hidden_lifecycle_search_unsupported`.

### Behavior note

Not a breaking change and no config changes, but worth calling out for reviewers: a run can now resolve to an existing non-canonical document URN instead of always minting the deterministic one. That is the fix, and it only happens when a document is stamped with the same `import_source_id`, or with the same GitHub path within the same repository.

## Test plan

- [x] 18 new unit tests (29 → 47 in `test_github_documents_source.py`); 90 pass across the `github_documents` package
- [x] Identity: canonical URN with no graph and on empty lookup; reuse of a stamped URN; identity short-circuit skips the search; deterministic pick plus warning on ambiguous matches; lookup failure reports a failure so stale removal is skipped; fallback queries `github_directory_path` for folders
- [x] Folders: existing folder keeps its body, title, and foreign custom properties; a same-name file such as `guides/guides.md` stays a normal sibling
- [x] Lifecycle: unchanged restored file resurrects a soft-deleted document; unchanged non-deleted file emits nothing; unsupported search flag degrades once instead of failing
- [x] `./gradlew :metadata-ingestion:lint` — ruff, ruff-format, and mypy clean (2548 source files)

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated (no user-facing config or behavior surface changed)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub (not breaking)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss on re-import in `github-documents` by resolving document identity before emission. Previously re-import minted a new URN from repo+path and stale removal soft-deleted the original; now the source reuses an existing document stamped with `import_source_id` or matching GitHub path and repo.

- Resolves identity via: fast path (canonical URN with matching `import_source_id`), slow path (search `customProperties` for `import_source_id`), and fallback (path + repo, using `github_directory_path` for folders). Picks deterministically, warns on ambiguity, and registers non-chosen duplicates for stale removal.
- Does not overwrite folder documents: when identity matches an existing folder, emits only URN + platform instance + `Status(removed=False)`; preserves body, title, and foreign custom properties.
- Resurrects soft-deleted file documents: always emits `Status(removed=False)` for files; unchanged-file short-circuit also resurrects via a single upfront `ONLY_SOFT_DELETED` search.
- On identity lookup failure, reports a failure and causes stale removal to skip deletes for the run.
- Includes hidden lifecycle stages in search; if the server rejects that flag, warns once, sets `hidden_lifecycle_search_unsupported`, and retries without it.

**Rollout notes**
- Runs may now reuse a non-canonical URN when a document carries the same `import_source_id` or the same GitHub path within the repo.
- New report fields: `documents_resurrected`, `identity_fast_path_errors`, `hidden_lifecycle_search_unsupported`.

<sup>Written for commit 6bbce2ac5916be2d5b9d4d62b81933f3e0c8212c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

