### PR TITLE
fix(smoke-test): Fix flaky tests caused by self-referential domains

### DIFF
--- a/metadata-ingestion/examples/library/domain_create_nested.py
+++ b/metadata-ingestion/examples/library/domain_create_nested.py
@@ -9,7 +9,7 @@ from datahub.metadata.schema_classes import DomainPropertiesClass
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-domain_urn = make_domain_urn("marketing")
+domain_urn = make_domain_urn("verticals")
 domain_properties_aspect = DomainPropertiesClass(
     name="Verticals",
     description="Entities related to the verticals sub-domain",


### PR DESCRIPTION
https://github.com/datahub-project/datahub/pull/19288 fixed a bug that prevented the domain graph cache from working as expected. With the domain graph cache no longer dormant, this caused a bad example-based test that creates a self-referential domain (A domain being its own `parentDomain`) to poison the JGraphT-based cache.

It should be noted that  failure happens not at graph construction time but when subsequent tests that rely on the domain graph try to read the poisoned cache - They run into a JGraphT `No loops allowed` error [and end up failing](https://github.com/datahub-project/datahub/actions/runs/32304682856/job/96237056566). 

This PR fixes the example to not be self-referential anymore.
Fixes PFP-5705