### PR TITLE
fix(build): resolve @src/@app/@conf vite aliases from project root

### DIFF
--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -299,9 +299,9 @@ export default defineConfig(async ({ mode }) => {
         resolve: {
             alias: {
                 // Root Directories
-                '@src': path.resolve(__dirname, '/src'),
-                '@app': path.resolve(__dirname, '/src/app'),
-                '@conf': path.resolve(__dirname, '/src/conf'),
+                '@src': path.resolve(__dirname, 'src'),
+                '@app': path.resolve(__dirname, 'src/app'),
+                '@conf': path.resolve(__dirname, 'src/conf'),
                 '@components': path.resolve(__dirname, 'src/alchemy-components'),
                 '@graphql': path.resolve(__dirname, 'src/graphql'),
                 '@graphql-mock': path.resolve(__dirname, 'src/graphql-mock'),


### PR DESCRIPTION
The `@src`, `@app`, and `@conf` Vite aliases are built with a leading slash:

```ts
'@src': path.resolve(__dirname, '/src'),
'@app': path.resolve(__dirname, '/src/app'),
'@conf': path.resolve(__dirname, '/src/conf'),
```

`path.resolve` discards every preceding segment once it reaches an absolute path, so `__dirname` is
thrown away. The seven other aliases in the same map (`@components`, `@graphql`, `@graphql-mock`,
`@images`, `@providers`, `@utils`, `@types`) omit the slash, and `tsconfig.json` maps all three
correctly — these three lines are the odd ones out.

### Why CI has stayed green

On Linux and macOS the mistake cancels itself out. `path.resolve(__dirname, '/src')` returns the
string `/src`, and `vite:resolve` treats a leading-slash id as **root-relative**, re-resolving it
against `config.root`:

```js
// vite 6.3.6, dist/node/chunks/dep-Bu492Fnd.js
if (asSrc && id[0] === "/" && (rootInRoot || !id.startsWith(withTrailingSlash(root)))) {
  const fsPath = path$b.resolve(root, id.slice(1));
```

So `/src/...` lands back on `<root>/src/...`. `asSrc` is `true` unconditionally in the shared
plugin pipeline, so this holds for `vite build` as well as the dev server — which is why the bug
has never shown up in CI.

On Windows the same call returns `C:\src`. `id[0]` is `C`, so that branch never runs, and Vite's
alias `customResolver` returns the unresolved id tagged `meta['vite:alias'].noResolved`.

### Impact

Windows only. Tests are confirmed broken on the real repo; the build failure is reproduced in a
minimal project.

**Tests.** `vite:import-analysis` turns the `noResolved` marker into a hard error. `src/setupTests.ts`
is the global setup file (`setupFiles: './src/setupTests.ts'`), and it imports through `@src`, so
every test file is blocked, not just the one below (personal path elided):

```
FAIL  src/app/lineageV3/__tests__/useColumnHighlighting.test.ts
Error: Failed to resolve import "@src/i18n/locales/en/alchemy.json" from "src/setupTests.ts". Does the file exist?
  Plugin: vite:import-analysis
  File: C:/.../datahub-web-react/src/setupTests.ts:10:0
```

**Builds.** `vite build` fails on the same path, in a different plugin. I could not run a full
DataHub build (no JDK installed here), so this is from a minimal project built with this repo's own
Vite 6.3.6 and the same alias shape:

```
error during build:
[vite:load-fallback] Could not load C:\src/sub/dep.js (imported by entry.js): ENOENT: no such file or directory, open 'C:\src\sub\dep.js'
```

`yarnBuild` runs `vite build` against this same config, so I expect the production build to fail
the same way on Windows — I could not confirm that end to end.

746 files import through the `@src/` alias
(`git grep -lE "from '@src/" -- 'datahub-web-react/src/**' | wc -l`).

Introduced in #12054 (Dec 2024).

### Fix

Drop the leading slash so the three aliases resolve relative to `datahub-web-react/`, matching the
other aliases in the same map and the `paths` entries in `tsconfig.json`.

### Verification

Windows 11, Node 24.15.0, Vite 6.3.6, Vitest 3.2.2, run from `datahub-web-react/`:

```
# before (leading slash)
$ npx vitest run src/app/lineageV3/__tests__/useColumnHighlighting.test.ts --coverage.enabled=false
Test Files  1 failed (1)
     Tests  no tests
exit 1

# after
$ npx vitest run src/app/lineageV3/__tests__/useColumnHighlighting.test.ts --coverage.enabled=false
 ✓ src/app/lineageV3/__tests__/useColumnHighlighting.test.ts (3 tests)
Test Files  1 passed (1)
     Tests  3 passed (3)
exit 0
```

In the same minimal project, the fixed form builds cleanly (`✓ 2 modules transformed`).

No behaviour change on Linux or macOS: `config.root` is `datahub-web-react/` for every invocation
here (`package.json` scripts and `build.gradle`'s `nodeProjectDir`), so both forms resolve to the
same absolute paths. The fix additionally pins these aliases to the config directory rather than to
the working directory.

### Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues — none found
- [ ] Tests added/updated — n/a. On Linux the buggy and fixed configs are behaviourally identical,
      so any assertion about these aliases passes either way; catching a reintroduction needs a
      Windows runner. Happy to add a lint rule banning absolute second arguments to `path.resolve`
      in this file if you'd prefer one.
- [ ] Docs added/updated — n/a
- [ ] `Updating DataHub` entry — n/a, no breaking change
