### PR TITLE
docs(search): document how ranking works and quality signal groups

### DIFF
--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -82,7 +82,7 @@ After creating a filter, you can choose whether results should or should not mat
 
 Search results appear ranked by their relevance.
 
-In self-hosted DataHub, keyword search ranking is based on how closely the query matched textual
+In DataHub OSS, keyword search ranking is based on how closely the query matched textual
 fields of an asset and its metadata, and deprecated assets are demoted. On the browse / explore-all
 view (an empty or `*` query) assets are additionally ranked by metadata completeness — having a
 description, owners, a domain, glossary terms, or tags each contributes a boost. These weights live
@@ -386,7 +386,7 @@ measurably improves where an asset lands among competing results, and cleaning u
 stale-looking assets is at least as effective as enriching the good ones. Naming conventions matter
 too, since assets whose names look like test, staging, or backup copies are deliberately demoted.
 
-To influence ranking beyond the defaults, self-hosted deployments can edit the `functionScore`
+To influence ranking beyond the defaults, DataHub OSS deployments can edit the `functionScore`
 weights in `search_config.yaml`. DataHub Cloud additionally supports per-tag ranking boosts and
 opting a structured property in as a ranking feature, which lets you promote a curated or certified
 subset of the catalog; contact your DataHub representative to tune these.

--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -80,7 +80,21 @@ After creating a filter, you can choose whether results should or should not mat
 
 ### Results
 
-Search results appear ranked by their relevance. In self-hosted DataHub ranking is based on how closely the query matched textual fields of an asset and its metadata. In DataHub Cloud, ranking is based on a combination of textual relevance, usage (queries / views), and change frequency.
+Search results appear ranked by their relevance.
+
+In self-hosted DataHub, keyword search ranking is based on how closely the query matched textual
+fields of an asset and its metadata, and deprecated assets are demoted. On the browse / explore-all
+view (an empty or `*` query) assets are additionally ranked by metadata completeness — having a
+description, owners, a domain, glossary terms, or tags each contributes a boost. These weights live
+in `search_config.yaml` and are fully customizable; see [Customizing Search](#customizing-search).
+
+In DataHub Cloud, ranking additionally applies a second-stage reranking pass over the top results of
+the text-relevance pass. That pass combines textual relevance with usage (queries, views, and
+distinct users), recency, query-intent signals such as exact name and fully-qualified-name matches,
+and metadata completeness — so completeness influences ranking for ordinary keyword searches, not
+just the browse view. Assets that are deprecated, or that look non-production or internal (for
+example staging and test naming conventions, or backup-copy name prefixes), are demoted. See
+[How ranking works](#how-ranking-works) for the full picture.
 
 With better metadata comes better results. Learn more about ingestion technical metadata in the [metadata ingestion](../../metadata-ingestion/README.md) guide.
 
@@ -334,6 +348,48 @@ the **term** `orders` is the same, however one location may be more important an
 **Note:** The customized query is a pass-through to Elasticsearch and must comply with their API, syntax errors are possible.
 It is recommended to test the customized queries prior to production deployment and knowledge of the Elasticsearch query
 language is required.
+
+### How ranking works
+
+DataHub ranks results in stages.
+
+**Stage 1 — retrieval and text relevance.** Elasticsearch/OpenSearch scores documents with BM25
+across the searchable fields, adjusted by per-field boosts and by the `functionScore` weights of the
+matching search profile described above. This stage decides _which_ assets are candidates, and
+provides the baseline ordering.
+
+**Stage 2 — reranking (DataHub Cloud).** DataHub Cloud reranks the top slice of the Stage 1 results
+using a configurable formula over named signals. The signals fall into these groups:
+
+| Group                     | Examples                                                                      | Effect             |
+| ------------------------- | ----------------------------------------------------------------------------- | ------------------ |
+| Query intent              | exact name match, fully-qualified-name match, all query terms present in name | Strong promotion   |
+| Text relevance            | the Stage 1 BM25 score                                                        | Primary ordering   |
+| Curation and completeness | description, owners, tags, glossary terms, curated structured properties      | Moderate promotion |
+| Usage and freshness       | queries, views, distinct users, last-modified recency                         | Tie-breaking       |
+| Demotions                 | deprecated, non-production naming, internal/backup copies, system tags        | Strong demotion    |
+
+Signals combine multiplicatively and each carries a configurable weight, so an asset that is strong
+on several signals compounds those gains.
+
+Two properties are worth understanding when reasoning about result order:
+
+- **Reranking operates on a window.** Only the top slice of the Stage 1 result set is reranked.
+  Improving an asset's metadata will not surface it for a query it does not match in the first place
+  — completeness reorders candidates, it does not create them.
+- **Query intent outranks curation.** When a query looks navigational — a quoted exact name, or a
+  dotted `database.schema.table` style identifier — the intent signals are designed to dominate
+  every other signal, so the asset the user asked for lands first regardless of its curation state.
+
+The practical implication for data teams: curating descriptions, owners, tags and glossary terms
+measurably improves where an asset lands among competing results, and cleaning up deprecated or
+stale-looking assets is at least as effective as enriching the good ones. Naming conventions matter
+too, since assets whose names look like test, staging, or backup copies are deliberately demoted.
+
+To influence ranking beyond the defaults, self-hosted deployments can edit the `functionScore`
+weights in `search_config.yaml`. DataHub Cloud additionally supports per-tag ranking boosts and
+opting a structured property in as a ranking feature, which lets you promote a curated or certified
+subset of the catalog; contact your DataHub representative to tune these.
 
 ### Default search entity types
 


### PR DESCRIPTION
## Summary

`docs/how/search.md` described search ranking in a way that was incomplete for both DataHub OSS and DataHub Cloud. The `Results` section said:

> In self-hosted DataHub ranking is based on how closely the query matched textual fields of an asset and its metadata. In DataHub Cloud, ranking is based on a combination of textual relevance, usage (queries / views), and change frequency.

Two gaps:

1. **DataHub OSS does more than text relevance.** `search_config.yaml` has ranked the browse / explore-all view (`[*]|` query profile) by metadata completeness — `hasDescription`, `hasOwners`, `hasDomain`, `hasGlossaryTerms`, `hasTags`, plus row/column counts and active incidents — since #10774. Keyword-search profiles also demote deprecated assets. None of this was mentioned.
2. **DataHub Cloud's quality and intent signals were undocumented.** Cloud reranks the top slice of the text-relevance results using metadata completeness, query-intent signals (exact name and fully-qualified-name matches), recency, usage, and demotions for deprecated / non-production / internal-copy assets. The docs listed only relevance, usage, and change frequency.

This came up from a customer asking specifically how metadata quality affects search ranking — the docs couldn't answer it, and the two behaviours people most often trip over (reranking works within a window; query intent outranks curation) weren't written down anywhere.

## Changes

- Rewrote the `Results` ranking paragraph to describe DataHub OSS and Cloud behaviour accurately, including demotions.
- Added a `How ranking works` subsection under `Customizing Search` covering:
  - the two-stage model (BM25 retrieval → reranking)
  - the signal groups and their relative strength, as a table
  - reranking operates on a window, so completeness reorders candidates but does not create them
  - query-intent signals intentionally dominate curation signals
  - where to tune ranking (`functionScore` weights in DataHub OSS; per-tag boosts and structured-property rank features on Cloud)

## Note on specific weights

This documents **signal groups and their relative ordering, not the numeric weights**. Two reasons:

- Ranking constants are tuned regularly; baking them into docs turns every retune into a docs migration.
- Some demotion signals are name-pattern heuristics, and publishing exact multipliers alongside the patterns they match is a gaming surface.

Happy to add a numbers table if reviewers prefer — flagging the tradeoff rather than deciding it unilaterally.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (n/a)
- [ ] Tests added/updated (n/a — docs only)
- [x] Docs added/updated
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` (n/a — no behaviour change)

## Verification

Docs-only change; no code touched.

- `prettier --check docs/how/search.md` passes using the repo-pinned prettier (3.5.3) with the same resolution CI uses. Confirmed the file was prettier-clean on `master` first, so the diff introduces no unrelated reformatting.
- `python3 .github/scripts/check_docusaurus_markdown.py` passes.
- Both new intra-page anchors (`#customizing-search`, `#how-ranking-works`) resolve to headings that exist in the file.
