### PR TITLE
fix(search): do not expand container filters on non-hierarchical conditions

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/ContainerExpansionRewriter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/ContainerExpansionRewriter.java
@@ -103,22 +103,6 @@ public class ContainerExpansionRewriter extends BaseQueryFilterRewriter {
               RelationshipDirection.OUTGOING,
               config.getPageSize(),
               config.getLimit());
-        default:
-          T defaultDescendantQuery =
-              expandUrnsByGraph(
-                  opContext,
-                  filterQuery,
-                  Set.of("IsPartOf"),
-                  RelationshipDirection.INCOMING,
-                  config.getPageSize(),
-                  config.getLimit());
-          return expandUrnsByGraph(
-              opContext,
-              defaultDescendantQuery,
-              Set.of("IsPartOf"),
-              RelationshipDirection.OUTGOING,
-              config.getPageSize(),
-              config.getLimit());
       }
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
@@ -1,16 +1,22 @@
 package com.linkedin.metadata.search.query.filter;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 
+import com.linkedin.metadata.aspect.GraphRetriever;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.search.elasticsearch.query.filter.BaseQueryFilterRewriter;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterContext;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterSearchType;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.List;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermsQueryBuilder;
 import org.testng.annotations.Test;
 
 public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewriter> {
@@ -71,5 +77,40 @@ public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewri
             testQuery),
         expectedRewrite,
         "Expected preservation of minimumShouldMatch");
+  }
+
+  /**
+   * A hierarchy rewriter must expand only for the explicit hierarchical conditions and leave
+   * EQUAL/IEQUAL alone. A catch-all {@code default:} in the condition switch instead gives every
+   * equality filter hierarchy semantics -- for container filters that means matching the parent's
+   * other children, so a container's contents list its siblings and itself.
+   */
+  @Test
+  public void testEqualityConditionsNotExpanded() {
+    BaseQueryFilterRewriter test = getTestRewriter();
+    GraphRetriever graphRetriever = getOpContext().getRetrieverContext().getGraphRetriever();
+
+    for (Condition condition : List.of(Condition.EQUAL, Condition.IEQUAL)) {
+      TermsQueryBuilder testQuery =
+          QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue());
+
+      assertEquals(
+          test.rewrite(
+              getOpContext(),
+              QueryFilterRewriterContext.builder()
+                  .condition(condition)
+                  .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                  .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                  .build(false),
+              testQuery),
+          QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()),
+          String.format("Expected no rewrite for condition %s", condition));
+    }
+
+    // An unstubbed retriever expands to nothing, so the equality assertion alone would pass even
+    // when the rewriter traverses. Assert no traversal was attempted at all.
+    verify(graphRetriever, never())
+        .scrollRelatedEntities(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
   }
 }


### PR DESCRIPTION
## Summary

`ContainerExpansionRewriter`'s condition switch ends in a catch-all `default:` that runs the descendants-then-ancestors expansion — i.e. `RELATED_INCL` semantics. Any condition the switch does not explicitly name therefore gets hierarchy expansion applied, including plain equality.

Today this branch is unreachable: `ESUtils.getQueryBuilderFromCriterionForSingleField` routes only `ANCESTORS_INCL`, `DESCENDANTS_INCL` and `RELATED_INCL` into the rewriter chain, and all three have explicit `case` labels. It is still a latent trap — any caller that invokes the rewriter with `EQUAL`/`IEQUAL`, whether directly or because that routing is ever widened, silently gets hierarchy semantics applied to an exact-match filter.

For a container filter the consequence is concrete and surprising. The ancestors half of the expansion adds the **parent** container to the terms filter, so the filter then matches every entity contained by that parent. A container's contents would list its sibling containers and itself, and container-filtered search, autocomplete and facet counts would inflate the same way. Severity scales with the number of siblings, so a container holding a single child can report every entity under its parent.

## How it got here

- #11279 introduced the rewriter with the catch-all `default:`. Harmless at the time.
- #17886 split that catch-all into an explicit `case RELATED_INCL:`. For `DomainExpansionRewriter` it dropped `default:` entirely; for `ContainerExpansionRewriter` it re-added a full descendants+ancestors body under `default:`.

This PR restores the symmetry between the two.

## Fix

Drop the catch-all so non-hierarchical conditions fall through untouched, matching `DomainExpansionRewriter`. Only the three hierarchical conditions expand.

Worth noting this is strictly *less* work per query, not more. The deleted branch's body was two `expandUrnsByGraph` calls, and each of those means "read the entity graph cache, else scroll the graph store". Removing the branch removes both tiers, and it does not touch the cache read in `BaseQueryFilterRewriter.expandTerms` — every path that legitimately needs hierarchy data still expands and still consults the cache first, including `RELATED_INCL`'s explicit two-direction attempt. For an exact-match filter there is nothing to fetch from either tier, since the answer is the URN the caller already supplied.

## Related rewriters — audited, no changes needed

| Rewriter | Field | Status |
| --- | --- | --- |
| `ContainerExpansionRewriter` | `container.keyword` | fixed here |
| `DomainExpansionRewriter` | `domains.keyword` | already correct — no `default:` |
| `DocumentExpansionRewriter` | `parentDocument.keyword` | already correct — `default:` is a no-op `return filterQuery` |

These are the only `QueryFilterRewriter` implementations in the repository.

## Tests

The guard lives on `BaseQueryFilterRewriterTest`, so it covers every rewriter including any added later. It asserts both that the query is returned unchanged **and** that no graph traversal is attempted.

The second assertion is load-bearing. An unstubbed graph retriever expands to nothing, so the equality assertion alone passes even while the rewriter traverses — pre-fix the observed failure was `NeverWantedButInvoked: graphRetriever.scrollRelatedEntities(...)`, not an equality mismatch. A test written without the `never()` verify would have been a false green.

Verified red → green:

- pre-fix: `ContainerExpansionRewriterTest.testEqualityConditionsNotExpanded` fails; `DomainExpansionRewriterTest` and `DocumentExpansionRewriterTest` pass
- post-fix: all pass, together with `ESUtilsTest` and `SearchRequestHandlerTest` as adjacent-regression cover

```
./gradlew :metadata-io:test \
  --tests 'com.linkedin.metadata.search.query.filter.*' \
  --tests 'com.linkedin.metadata.search.utils.ESUtilsTest' \
  --tests 'com.linkedin.metadata.search.query.request.SearchRequestHandlerTest'
```

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline, particularly PR Title Format
- [x] Tests for the changes have been added
- [ ] Docs — none needed; no documented behaviour changes, and the removed branch is currently unreachable
- [ ] Updating DataHub — not a breaking change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops hierarchy expansion for container filters on non-hierarchical conditions. Previously, `ContainerExpansionRewriter` applied RELATED_INCL semantics via a catch-all default, so EQUAL/IEQUAL on `container.keyword` could match a container’s siblings and inflate search, autocomplete, and facet counts; now only ANCESTORS_INCL, DESCENDANTS_INCL, and RELATED_INCL expand, others pass through unchanged.

- Review notes
  - Removes the `default:` branch to match `DomainExpansionRewriter`; prevents latent equality mis-expansion even if `ESUtils` routing widens.
  - Slight perf win for equality filters by removing two graph expansion calls; no change for legitimate hierarchical queries.
  - Tests added in `BaseQueryFilterRewriterTest` assert equality is untouched and verify no graph traversal is invoked.

<sup>Written for commit dbf83537d3b02188207b0f58453fc71077669927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

