### PR TITLE
fix(ingest/redshift): stop the user-info join gating provisioned lineage rows

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -586,14 +586,16 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                     query_txt AS (
                         SELECT
                             query,
-                            userid,
                             RTRIM(LISTAGG(RTRIM(text) || CASE WHEN LEN(RTRIM(text)) < {_PROVISIONED_SEGMENT_SIZE} THEN ' ' ELSE '' END, '')
                                 WITHIN GROUP (ORDER BY sequence)) AS querytxt
                         FROM STL_QUERYTEXT
                         WHERE sequence < {_QUERY_SEQUENCE_LIMIT}
                         -- Scope by query id: the query-text tables carry no timestamp.
                         AND query IN (SELECT query FROM target_tables)
-                        GROUP BY query, userid
+                        -- One row per query. Grouping by userid as well would emit a
+                        -- second row, and so duplicate every source row for that query,
+                        -- if STL_QUERYTEXT ever held two userids for one query id.
+                        GROUP BY query
                     )
                         select
                             distinct cluster,
@@ -630,10 +632,17 @@ class RedshiftProvisionedQuery(RedshiftCommonQuery):
                                 sti.table_id = ss.tbl
                             left join query_txt sq on
                                 ss.query = sq.query
+                            -- LEFT (enrichment only): svl_user_info supplies the
+                            -- username but must not gate the row. rdsdb is excluded by
+                            -- its system userid because a name comparison drops every
+                            -- user the view cannot resolve, via NULL propagation.
+                            -- ss.userid rather than sq.userid: query_txt is LEFT joined
+                            -- and so nullable, and a nullable column cannot carry this
+                            -- predicate without gating on it in turn.
                             left join svl_user_info sui on
-                                sq.userid = sui.usesysid
+                                ss.userid = sui.usesysid
                             where
-                                sui.usename <> 'rdsdb')
+                                ss.userid <> 1)
                         ) as source_tables
                                 using (query)
                         where
@@ -738,6 +747,9 @@ select
     ANY_VALUE(sq.pid) as session_id
 from
     target_queries si
+-- LEFT (enrichment only): svl_user_info supplies the username but must not gate the
+-- row. rdsdb is excluded by its system userid because a name comparison drops every
+-- user the view cannot resolve, via NULL propagation.
 left join svl_user_info sui on
     si.userid = sui.usesysid
 left join query_txt sq on
@@ -745,7 +757,7 @@ left join query_txt sq on
 left join stl_load_commits slc on
     slc.query = si.query
 where
-        sui.usename <> 'rdsdb'
+        si.userid <> 1
         and slc.query IS NULL
 group by
     target_table_id,

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_queries.py
@@ -488,6 +488,22 @@ class TestUserInfoJoinResilience:
         _assert_no_inner_join_on(sql, "svv_user_info")
         assert "qd.user_id <> 1" in sql
 
+    def test_provisioned_stl_scan_lineage_excludes_rdsdb_by_id_not_name(self):
+        sql = RedshiftProvisionedQuery.stl_scan_based_lineage_query(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        _assert_no_inner_join_on(sql, "svl_user_info")
+        assert "ss.userid <> 1" in sql
+        assert "usename <> 'rdsdb'" not in sql
+
+    def test_provisioned_insert_lineage_excludes_rdsdb_by_id_not_name(self):
+        sql = RedshiftProvisionedQuery.list_insert_create_queries_sql(
+            db_name="test_db", start_time=START_TIME, end_time=END_TIME
+        )
+        _assert_no_inner_join_on(sql, "svl_user_info")
+        assert "si.userid <> 1" in sql
+        assert "usename <> 'rdsdb'" not in sql
+
     def test_serverless_insert_lineage_excludes_rdsdb_by_id_not_name(self):
         # rdsdb has no row in SVV_USER_INFO, so a name-based `<> 'rdsdb'` relied on NULL
         # propagation and also dropped any real user the view couldn't resolve. Excluding


### PR DESCRIPTION
## Problem

`svl_user_info` is joined `LEFT` in the provisioned lineage queries because it only supplies a username — the row should survive whether or not the user resolves. But both queries then filtered on:

```sql
left join svl_user_info sui on ... = sui.usesysid
where sui.usename <> 'rdsdb'
```

`NULL <> 'rdsdb'` evaluates to `NULL`, not `true`, so any user the view cannot resolve is silently dropped. The `LEFT` join behaves as an inner one, and that row's lineage is lost — no error, no warning, nothing in the report.

On Redshift editions that keep the user-info views superuser-or-self-only, a non-superuser ingestion user cannot resolve other people, so this discards real users' lineage, not just `rdsdb`'s.

## This completes #18518

This is not a new pattern. #18518 ("make user-info join enrichment-only, exclude rdsdb by id") fixed exactly this in July, converting the joins to `LEFT` and excluding `rdsdb` by system `userid`. It covered the usage and operations paths but not the two lineage ones, which kept the name comparison and so remained gated.

Auditing every user-info join in `query.py` on `master`:

| Flavour | Method | State on master |
| --- | --- | --- |
| provisioned | `usage_query` | ✅ safe — #18518 |
| provisioned | `operation_aspect_query` | ✅ safe — #18518, both branches |
| provisioned | `list_all_queries_sql` | ✅ safe — name filter, but written `IS NULL OR …` |
| provisioned | **`stl_scan_based_lineage_query`** | ❌ **gates, drops lineage** |
| provisioned | **`list_insert_create_queries_sql`** | ❌ **gates, drops lineage** |
| serverless | all five | ✅ safe |

Every join in the file is already `LEFT`; the two stragglers re-gate themselves through the name comparison. Both `list_all_queries_sql` variants also filter by name but spell it `(sui.usename IS NULL OR sui.usename <> 'rdsdb')` — that explicit null branch is exactly what the two broken methods are missing.

The invariant is already encoded in the test suite as `_assert_no_inner_join_on`; it had simply never been applied to these two methods. `TestUserInfoJoinResilience` now covers them.

## It also makes the existing docs true

`docs/sources/redshift/redshift_post.md`, added by #18518, already tells users:

> The user-info views (`SVL_USER_INFO` / `SVV_USER_INFO`) are used only to enrich those log rows with a username — they never decide which rows are kept.
>
> If a query's user can't be resolved in the user-info views … usage, **lineage**, and operations are **still extracted**; the row is simply attributed to an `unknown` user (usage) or emitted without an actor (operations) rather than being dropped.

That is currently inaccurate for lineage. This PR makes it accurate, so no doc change is needed.

## Fix

| Query | Was | Now |
| --- | --- | --- |
| `stl_scan_based_lineage_query` | `sui.usename <> 'rdsdb'` | `ss.userid <> 1` |
| `list_insert_create_queries_sql` | `sui.usename <> 'rdsdb'` | `si.userid <> 1` |

Nothing downstream depends on the restored rows carrying a username: `LineageRow` has no `username` field, so `get_lineage_rows` never reads that column.

### Two consequences worth calling out

**The join key moves from `sq.userid` to `ss.userid`** in the scan query. `query_txt` is `LEFT` joined and therefore nullable, and a nullable column cannot carry this predicate without gating on it in turn. `stl_scan` is always present.

**That leaves `userid` unreferenced in `query_txt`, which now groups by `query` alone.** Grouping by `userid` as well would emit a second row — and so duplicate every source row for that query — if `STL_QUERYTEXT` ever held two userids for one query id.

## This changes output

Affected deployments will emit lineage that was previously dropped. That is the fix working. If a golden file moves after this lands, this is the likely reason.

## Testing

- `tests/unit/redshift/` passes, 130 tests.
- `./gradlew :metadata-ingestion:lint` clean (ruff + mypy).
- `TestUserInfoJoinResilience` extended to both provisioned methods: the join must be `LEFT`, and `rdsdb` must be excluded by id rather than by name.
- Both queries still resolve under sqlglot's `qualify()` against a schema of the Redshift system tables, with CTE order asserted.

**Not verified on a live cluster, and the available one cannot reach it.** `SVL_USER_INFO` there is not self-restricted: the ingestion user is not a superuser (`usesuper = false`) and still sees all seven rows, identical to what a superuser sees, with `rdsdb` correctly absent. So every user resolves, the broken predicate never fires, and old and new return identical rows regardless of which user connects. That is a property of the cluster's configuration rather than of the test setup — reproducing this needs an edition that keeps the user-info views superuser-or-self-only.

The reasoning is straightforward — `NULL <> 'literal'` is `NULL`, and a `WHERE` discards `NULL` — but it is reasoning rather than measurement, which is part of why this is separate from #19167 (now merged).

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated — the existing `redshift_post.md` text already describes the fixed behaviour; this PR makes it true
- [ ] Entry in Updating DataHub — this is a bug fix rather than a breaking change, but it does change output on affected deployments. Happy to add an entry if maintainers would like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `svl_user_info` from gating provisioned lineage rows in Redshift so unresolved users no longer drop lineage. Previously both lineage queries filtered on `sui.usename <> 'rdsdb'`, which NULL-propagated and eliminated rows; now we exclude `rdsdb` by system `userid` and keep all rows.

- Excludes `rdsdb` by id: `stl_scan_based_lineage_query` uses `ss.userid <> 1` and joins `svl_user_info` on `ss.userid` (not `sq.userid`); `query_txt` now groups by `query` only since `userid` is unused.
- Excludes `rdsdb` by id in `list_insert_create_queries_sql`: `si.userid <> 1`. Both queries retain LEFT joins so user-info remains enrichment-only.
- Tests enforce the invariant: LEFT join to user-info and id-based exclusion, no name-based filters.

**Rollout and impact**
- Output will increase on clusters where user-info is superuser-or-self-only; previously dropped lineage will appear. Update snapshots/golden files if they move.
- No configuration or migration required.

<sup>Written for commit b6748d8b66c87bdeb4ba1e38b4a9aa3d2d02eaa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

