### PR TITLE
feat(ingest/sql-parsing): make the SQL lineage timeout configurable

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -415,6 +415,16 @@ def get_sql_parse_cache_size() -> int:
     return int(os.getenv("DATAHUB_SQL_PARSE_CACHE_SIZE", "1000"))
 
 
+def get_sql_lineage_timeout_seconds() -> int:
+    """Budget for generating column-level lineage for one query, in seconds.
+
+    Measured on the wall clock, so a host that stalls under load spends the budget
+    without the parser doing any work. Raise it where lineage is being dropped on
+    queries that are merely slow to parse rather than pathological.
+    """
+    return _get_int_env("SQL_LINEAGE_TIMEOUT_SECONDS", 10)
+
+
 def get_dataset_urn_to_lower() -> str:
     """Convert dataset URNs to lowercase."""
     return os.getenv("DATAHUB_DATASET_URN_TO_LOWER", "false")

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -37,6 +37,7 @@ from sqlglot.optimizer.scope import find_all_in_scope
 from datahub.cli.env_utils import get_boolean_env_variable
 from datahub.configuration.env_vars import (
     get_sql_agg_skip_joins,
+    get_sql_lineage_timeout_seconds,
     get_sql_parse_cache_size,
 )
 from datahub.emitter.mce_builder import make_schema_field_urn
@@ -230,7 +231,7 @@ SQL_PARSE_RESULT_CACHE_SIZE = get_sql_parse_cache_size()
 SQL_LINEAGE_TIMEOUT_ENABLED = get_boolean_env_variable(
     "SQL_LINEAGE_TIMEOUT_ENABLED", True
 )
-SQL_LINEAGE_TIMEOUT_SECONDS = 10
+SQL_LINEAGE_TIMEOUT_SECONDS = get_sql_lineage_timeout_seconds()
 SQL_PARSER_TRACE = get_boolean_env_variable("DATAHUB_SQL_PARSER_TRACE", False)
 
 # These rules are a subset of the rules in sqlglot.optimizer.optimizer.RULES.

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -27,6 +27,14 @@ os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 # between retries.
 os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
 
+# Give column-level lineage a large budget rather than the 10s default. The deadline
+# is wall-clock (time.perf_counter_ns), so a CI runner that stalls under load exhausts
+# it without the parser doing any work; column lineage is then dropped and the affected
+# node is emitted with an empty schema and no fineGrainedLineages, which reads as a
+# golden-file mismatch rather than the graceful degradation it is in production. A 30x
+# budget makes that vanishingly unlikely while still bounding a pathological parse.
+os.environ["SQL_LINEAGE_TIMEOUT_SECONDS"] = "300"
+
 
 @atexit.register
 def _report_threads_alive_at_exit() -> None:
@@ -46,6 +54,9 @@ def _report_threads_alive_at_exit() -> None:
 
 # We need our imports to go below the os.environ updates, since mere act
 # of importing some datahub modules will load env variables.
+from datahub.sql_parsing.sqlglot_lineage import (  # noqa: E402
+    SQL_LINEAGE_TIMEOUT_SECONDS,
+)
 from datahub.testing.pytest_hooks import (  # noqa: F401,E402
     load_golden_flags,
     local_timezone,
@@ -59,6 +70,17 @@ from tests.test_helpers.docker_helpers import (  # noqa: F401,E402
 from tests.test_helpers.state_helpers import (  # noqa: F401,E402
     mock_datahub_graph,
     mock_datahub_graph_instance,
+)
+
+# sqlglot_lineage reads SQL_LINEAGE_TIMEOUT_SECONDS into a module constant at import
+# time, so the env var above only has an effect while it is set before that import.
+# Moving these imports above the env block would silently restore the 10s deadline and
+# with it the flake, so assert the outcome rather than trusting the ordering to survive
+# a tidy-up.
+assert SQL_LINEAGE_TIMEOUT_SECONDS >= 300, (
+    f"SQL lineage timeout is {SQL_LINEAGE_TIMEOUT_SECONDS}s, not the 300s set above:"
+    " the os.environ block in this file has to stay above the datahub imports for it"
+    " to take effect."
 )
 
 _MOCK_TIME = 1615443388.0975091  # 2021-03-11 06:16:28.097509+00:00


### PR DESCRIPTION
### Problem

`integration-tests-gate` fails intermittently on unrelated PRs, and on master itself. In the runs I looked at the failing leg was `ci (3.11, testIntegrationBatch3)`, and the failing test was a dbt golden comparison.

Column-level lineage generation is bounded by a 10 second budget, and `cooperative_timeout` measures that deadline with `time.perf_counter_ns()` — wall clock, not CPU. When a CI runner stalls under load, the budget is exhausted without the parser doing any work.

The failure chain, quoted from a failing job's own DEBUG output:

```
sqlglot_lineage.py:2241  Timed out while generating column-level lineage: CooperativeTimeout deadline exceeded
dbt_common.py:2565       Failed to generate CLL for model.sample_dbt.customer_details: CooperativeTimeout deadline exceeded
dbt_common.py:2496       No columns found for model.sample_dbt.customer_details
```

Column lineage is dropped, so the affected node is emitted with an empty `SchemaMetadata`, an `UpstreamLineage` carrying no `fineGrainedLineages`, and the aspects in a different order. The golden encodes the non-degraded output, so it fails.

### Evidence that this is load, not code

Three runs, three different victim nodes, one of them on master with no PR changes in play:

| Run | Node that lost column lineage |
| --- | --- |
| [job 96353598962](https://github.com/datahub-project/datahub/actions/runs/32345530141/job/96353598962) | `model.sample_dbt.customer_details` |
| [job 96349186252](https://github.com/datahub-project/datahub/actions/runs/32344124867/job/96349186252) | `model.sample_dbt.monthly_billing_with_cust` |
| [job 96340873392](https://github.com/datahub-project/datahub/actions/runs/32341256530/job/96340873392) (master) | `model.sample_dbt.payments_base` |

Which node gets hit is whichever happened to be parsing when the runner stalled. For scale: locally the entire `tests/integration/dbt` directory finishes in ~10s, against a 10s *per-node* budget.

### Change

`SQL_LINEAGE_TIMEOUT_ENABLED` was already an env knob, but the seconds were hardcoded — so an operator could switch the guard off entirely and could not raise it. `get_sql_lineage_timeout_seconds()` completes the pair, keeping the 10s default and reusing `_get_int_env` so a non-numeric value names the offending variable rather than raising a bare `int()` error:

```
default (no env)                   -> seconds=10
SQL_LINEAGE_TIMEOUT_SECONDS=300    -> seconds=300
bad value                          -> ValueError: Environment variable SQL_LINEAGE_TIMEOUT_SECONDS='not-a-number' is not a valid integer.
```

`tests/conftest.py` then asks for 300s. That keeps a backstop against a genuinely pathological parse — which switching the guard off would have removed — while making the deadline vanishingly unlikely to fire.

The budget only applies while the `os.environ` block in that file stays above the datahub imports, since `sqlglot_lineage` reads the value into a module constant at import time. Imported before the env is set it is 10, so the assertion added there fails collection on a reordering instead of silently restoring the flake.

The three autouse fixtures under `tests/unit/sql_parsing` that switch the guard off per module are left in place: any finite budget still expires while sitting on a `breakpoint()`, which is what the comment on the first of them describes.

### Testing

- `tests/unit/sql_parsing`: 498 passed, 3 skipped
- `tests/unit/utilities`: 304 passed, 2 skipped
- `tests/integration/dbt`: 35 passed
- `./gradlew :metadata-ingestion:lint`: ruff clean, mypy clean over 2693 files
- The env knob verified end to end at the default, at 300, and on a bad value (output above)

No golden files change. The full integration matrix runs on this PR via the `run-all-ingestion-tests` label — worth noting that without it a change to `tests/conftest` resolves to an *empty* integration matrix, because `selective_ci_checks.py` lists that path under `SAFE_PREFIXES`, and `integration-tests-gate` then passes with nothing to gate.

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Tests for the changes have been added/updated (if applicable) — the conftest assertion covers the wiring; the thin env accessor follows the existing untested pattern of its siblings in `env_vars.py`
- [x] Docs related to the changes have been added/updated (if applicable) — n/a
- [x] Breaking changes documented in `docs/how/updating-datahub.md` — n/a, the default is unchanged at 10s

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3ocyZTjW9Sj3GWievuRng
