### PR TITLE
fix(ingestion/grafana): parse the panel query as authored before cleaning it

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/lineage.py
@@ -1,6 +1,8 @@
 import logging
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+import sqlglot
 
 from datahub.emitter.mce_builder import (
     make_dataset_urn_with_platform_instance,
@@ -23,10 +25,12 @@ from datahub.metadata.schema_classes import (
     UpstreamClass,
     UpstreamLineageClass,
 )
+from datahub.metadata.urns import DatasetUrn
 from datahub.sql_parsing.sqlglot_lineage import (
     SqlParsingResult,
     create_lineage_sql_parsed_result,
 )
+from datahub.sql_parsing.sqlglot_utils import get_dialect
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +57,24 @@ _GRAFANA_BRACED_VAR_PATTERN = re.compile(r"\$\{[^}]+\}")
 # Simple variables NOT inside quotes: $var
 # Use negative lookbehind/lookahead to skip variables already in quotes
 _GRAFANA_SIMPLE_VAR_PATTERN = re.compile(r"(?<!')(\$[a-zA-Z_][a-zA-Z0-9_]*)(?!')")
+
+# What the cleaner substitutes for a variable. Named here rather than inline so
+# that _CLEANER_PLACEHOLDER_PATTERN below cannot drift away from them.
+_GRAFANA_VAR_PLACEHOLDER = "grafana_var"
+_GRAFANA_IDENTIFIER_PLACEHOLDER = "grafana_identifier"
+
+# A Grafana variable that survived into a parsed table name: ${var}, [[var]] or a
+# leading $var. The lookbehind leaves identifiers that merely contain a dollar
+# sign, such as Oracle's V$SESSION, alone.
+_UNRESOLVED_VARIABLE_PATTERN = re.compile(r"\$\{|\[\[|(?<![A-Za-z0-9_])\$[A-Za-z_]")
+
+# A name the cleaner invented because it did not know the real one. Only results
+# from the cleaned query are tested against this: a table authored as grafana_var
+# is a real table when it comes from the query as written.
+_CLEANER_PLACEHOLDER_PATTERN = re.compile(
+    rf"(?<![A-Za-z0-9_])(?:{_GRAFANA_VAR_PLACEHOLDER}|{_GRAFANA_IDENTIFIER_PLACEHOLDER})"
+    r"(?![A-Za-z0-9_])"
+)
 
 
 def _clean_grafana_template_variables(query: str) -> str:
@@ -112,16 +134,234 @@ def _clean_grafana_template_variables(query: str) -> str:
     query = _GRAFANA_GENERIC_MACRO_PATTERN.sub("1", query)
 
     # Replace [[...]] with identifier (deprecated syntax, often used for table/column names)
-    query = _GRAFANA_BRACKET_VAR_PATTERN.sub("grafana_identifier", query)
+    query = _GRAFANA_BRACKET_VAR_PATTERN.sub(_GRAFANA_IDENTIFIER_PLACEHOLDER, query)
 
     # Replace ${...} with string literal (handles ${var} and ${var:format})
-    query = _GRAFANA_BRACED_VAR_PATTERN.sub("'grafana_var'", query)
+    query = _GRAFANA_BRACED_VAR_PATTERN.sub(f"'{_GRAFANA_VAR_PLACEHOLDER}'", query)
 
     # Replace simple $variable format with string literal (but skip if already in quotes)
     # The regex already has negative lookbehind/lookahead to avoid double-quoting
     query = _GRAFANA_SIMPLE_VAR_PATTERN.sub(r"'\1'", query)
 
     return query
+
+
+def _dataset_name(urn: str) -> Optional[str]:
+    """The dataset-name component of an upstream URN, or None if it will not parse.
+
+    Only that component is a table name; the platform and env around it are not,
+    and matching against the whole URN would test them too - a platform instance
+    holding a "$" would make a perfectly good upstream look unresolved. So a URN
+    that cannot be read is treated as unresolvable rather than passed on whole.
+    """
+    try:
+        return DatasetUrn.from_string(urn).name
+    except Exception as e:
+        logger.debug(f"Could not read a dataset name from {urn}: {e}")
+        return None
+
+
+def _names_only_the_qualifier(
+    name: str, platform_config: PlatformConnectionConfig
+) -> bool:
+    """True when the name is nothing but the configured database/schema prefix.
+
+    A table-valued function gives the parser no name to qualify, so
+    "FROM some_func($1)" resolves to the prefix on its own - "database.schema" -
+    which is not a dataset. With a prefix configured, a real table always carries
+    a component after it, so the equality cannot catch one by accident.
+    """
+    prefix = ".".join(
+        part
+        for part in (platform_config.database, platform_config.database_schema)
+        if part
+    )
+    return bool(prefix) and name == prefix
+
+
+def _partition_upstreams(
+    result: SqlParsingResult,
+    platform_config: PlatformConnectionConfig,
+    from_cleaned_query: bool,
+) -> Tuple[List[str], List[str]]:
+    """Split the parsed upstreams into those naming a real dataset and those not.
+
+    Rejecting the whole result when a single table is unresolvable throws away
+    lineage we do know: "SELECT a.x FROM real_table a JOIN [[tbl]] b" names one
+    table we can resolve and one we cannot, and the first is still worth emitting.
+
+    This can only save what the chosen query form actually parsed. A bare "$var"
+    in a comma-separated FROM list is cleaned to a quoted string that some
+    dialects reject outright, and then there are no upstreams to partition and the
+    real table beside it is lost as well - as it is without this change.
+
+    from_cleaned_query additionally rejects the names the cleaner invents. Those
+    can only appear on that path, so a table genuinely authored as "grafana_var"
+    is still accepted when it comes from the query as written.
+
+    Not every invented name is recognisable. On BigQuery sqlglot resolves a
+    quoted "$tbl" to the default schema repeated in the table position, which is
+    indistinguishable from a table that really is named after its schema, so that
+    one is left alone rather than risk dropping a real upstream.
+
+    The cleaner's placeholders are also not unique per query, so a table actually
+    named "grafana_identifier" joined to a "[[var]]" collapses to a single name
+    when cleaned and is dropped here. Nothing downstream can tell the two apart by
+    then - the distinction is lost in the substitution, and today's behaviour of
+    emitting the placeholder is only coincidentally right for that one name - so
+    the drop is reported rather than guessed at.
+    """
+    kept: List[str] = []
+    dropped: List[str] = []
+    for urn in result.in_tables:
+        name = _dataset_name(urn)
+        unresolvable = name is None or (
+            _UNRESOLVED_VARIABLE_PATTERN.search(name) is not None
+            or _names_only_the_qualifier(name, platform_config)
+            or (
+                from_cleaned_query
+                and _CLEANER_PLACEHOLDER_PATTERN.search(name) is not None
+            )
+        )
+        (dropped if unresolvable else kept).append(urn)
+    return kept, dropped
+
+
+def _restrict_to_upstreams(
+    result: SqlParsingResult, kept: List[str]
+) -> SqlParsingResult:
+    """The same result with its upstreams narrowed to kept.
+
+    Column lineage is narrowed alongside them: a fine-grained edge pointing at a
+    dropped table would create in DataHub the very dataset the drop avoided.
+    """
+    keep = set(kept)
+    column_lineage = None
+    if result.column_lineage is not None:
+        column_lineage = []
+        for col_lineage in result.column_lineage:
+            upstreams = [ref for ref in col_lineage.upstreams if ref.table in keep]
+            # A column with no upstreams to begin with - a constant, say - is left
+            # as it is; only ones emptied by the narrowing are discarded.
+            if upstreams or not col_lineage.upstreams:
+                column_lineage.append(
+                    col_lineage.model_copy(update={"upstreams": upstreams})
+                )
+    return result.model_copy(
+        update={"in_tables": kept, "column_lineage": column_lineage}
+    )
+
+
+# What the probe below substitutes for a variable.
+_GRAFANA_PROBE_IDENTIFIER = "grafana_probe"
+
+# ${...}, matched unconditionally. The probe has to substitute inside string
+# literals too - an authored '${var}' must become 'grafana_probe' - so it cannot
+# share _GRAFANA_BRACED_VAR_PATTERN, which is a candidate for being narrowed to
+# leave already-quoted variables alone.
+_GRAFANA_ANY_BRACED_VAR_PATTERN = re.compile(r"\$\{[^}]+\}")
+
+# $var, but never a $__ macro and never a dollar sign inside a longer identifier.
+#
+# Macros are left exactly as the author wrote them. A macro is a Grafana built-in
+# standing for a time value or a predicate, so it can never be a table name and
+# substituting it would tell the comparison nothing - while the cleaner's macro
+# handling is itself capable of breaking a query that parses as authored, because
+# $__timeFrom() produces a value but is replaced with TRUE. Leaving macros alone
+# keeps the probe parseable wherever the query as authored is.
+#
+# The lookbehind is the same one _UNRESOLVED_VARIABLE_PATTERN carries, for the
+# same reason: "V$SESSION" is a table, not a variable. Substituting inside it
+# would make the two parses disagree over a name that was never in doubt, and the
+# query would be cleaned - which rewrites "v$session" to "v'$session'" and leaves
+# a truncated "v" behind. The cost is that a variable appended to a table name,
+# "metrics_$env", is indistinguishable from such an identifier and is emitted as
+# authored.
+_GRAFANA_PROBE_SIMPLE_VAR_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])\$(?!__)[a-zA-Z_][a-zA-Z0-9_]*"
+)
+
+
+def _probe_grafana_template_variables(query: str) -> str:
+    """Substitute every Grafana variable - and only those - with one fixed token.
+
+    This exists to be compared against the query as authored, never to be emitted.
+    Deciding whether a variable reached a table name needs a second parse, and the
+    cleaner is a poor source of one: it substitutes a quoted string, which is not
+    valid where a table name belongs and which mangles any literal the variable
+    sat inside, so it frequently fails to parse - and a failed parse leaves the
+    comparison blind.
+
+    Because the probe differs from the query as authored in variable positions
+    alone, a difference in the table names between the two parses can only have
+    come from a variable.
+    """
+    query = _GRAFANA_BRACKET_VAR_PATTERN.sub(_GRAFANA_PROBE_IDENTIFIER, query)
+    query = _GRAFANA_ANY_BRACED_VAR_PATTERN.sub(_GRAFANA_PROBE_IDENTIFIER, query)
+    return _GRAFANA_PROBE_SIMPLE_VAR_PATTERN.sub(_GRAFANA_PROBE_IDENTIFIER, query)
+
+
+def _parsed_table_names(
+    query: str, dialect: sqlglot.Dialect
+) -> Optional[FrozenSet[str]]:
+    """Table names as sqlglot renders them, or None if the query will not parse.
+
+    Rendering, rather than reading each table's name, is what makes the comparison
+    work across dialects: Postgres and Snowflake turn a leading "$" into a
+    parameter node whose name is empty, and only the rendering still shows the
+    sigil. The renderings are not normalised either - both sides of the comparison
+    come from the same dialect, so any difference is a real difference.
+
+    This is a bare parse - no schema resolution and no column lineage - so it is
+    cheap enough to run twice for every query.
+    """
+    try:
+        statement = sqlglot.parse_one(query, dialect=dialect)
+    except Exception as e:
+        logger.debug(f"Query did not parse as {dialect}: {e}")
+        return None
+
+    if statement is None:
+        return None
+
+    return frozenset(
+        table.sql(dialect=dialect) for table in statement.find_all(sqlglot.exp.Table)
+    )
+
+
+def _select_query_for_lineage(sql: str, dialect: sqlglot.Dialect) -> Optional[str]:
+    """Choose which form of the query to extract lineage from, or None for neither.
+
+    Parse the query as authored, parse a probe of it, and compare the table names:
+
+        names agree    -> no variable reached a table name -> use it as authored
+        names differ   -> a variable reached a table name   -> use the cleaned form
+        neither parses -> no lineage
+
+    Nothing here asks whether a given name was derived from a variable. The
+    cleaner already knows where the variables are - substituting them is its whole
+    job - so the *difference* between two parses is the signal. That makes the
+    choice dialect-agnostic (a sigil that Postgres drops and Trino keeps is
+    irrelevant when both forms are parsed the same way), position-agnostic (a
+    variable in a catalog or schema qualifier is caught as readily as one standing
+    in for the table itself) and substring-safe ("metrics_$env").
+    """
+    cleaned = _clean_grafana_template_variables(sql)
+    if cleaned == sql:
+        # Nothing was substituted, so no variable can have reached a table name.
+        return sql if _parsed_table_names(sql, dialect) is not None else None
+
+    authored_names = _parsed_table_names(sql, dialect)
+    probe_names = _parsed_table_names(_probe_grafana_template_variables(sql), dialect)
+
+    if authored_names is not None and probe_names is not None:
+        return sql if authored_names == probe_names else cleaned
+
+    # No usable comparison, so cleaning is the only remaining hope - it is what
+    # rescues [[var]] used as a table name, which no dialect parses. Never fall
+    # back to the query as authored here: with no comparison to rely on there is
+    # nothing to show that a variable did not reach a table name.
+    return cleaned if _parsed_table_names(cleaned, dialect) is not None else None
 
 
 class LineageExtractor:
@@ -235,18 +475,101 @@ class LineageExtractor:
     def _parse_sql(
         self, sql: str, platform_config: PlatformConnectionConfig
     ) -> Optional[SqlParsingResult]:
-        """Parse SQL query for lineage information."""
+        """Parse SQL query for lineage information.
+
+        Grafana template variables usually survive sqlglot unchanged - a quoted
+        '${var}' is an ordinary string literal, and an unquoted one parses as a
+        placeholder - so the query is used as authored wherever that is safe.
+        Cleaning is the fallback for the queries that genuinely need it, such as
+        [[var]] used as a table name.
+
+        Cleaning unconditionally, as it used to, breaks queries that parse
+        perfectly well as written: it substitutes a quoted string for every
+        variable, which turns '${var}' into ''grafana_var'' and mangles any
+        literal a variable sat inside. create_lineage_sql_parsed_result does not
+        raise on the result - it returns a truthy result carrying the error and no
+        tables - so the panel silently fell back to lineage naming the Grafana
+        datasource UID, a dataset that does not exist upstream.
+        """
         if not self.graph:
             logger.warning("No DataHub graph specified for SQL parsing.")
             return None
 
         try:
-            # Clean Grafana template variables before parsing
-            # Variables like ${__from}, $datasource, [[var]] break SQL parsers
-            cleaned_sql = _clean_grafana_template_variables(sql)
+            dialect = get_dialect(platform_config.platform)
+        except Exception as e:
+            # A misspelled platform used to be absorbed by the lineage parser and
+            # surfaced as a parse error on the result. Choosing the query form
+            # needs the dialect up front, so say so once per datasource instead of
+            # degrading every panel to the datasource fallback in silence.
+            self.report.warning(
+                title="Configured platform is not a known SQL dialect",
+                message="Panel queries for this datasource cannot be parsed, so "
+                "lineage falls back to the datasource, which names a dataset that "
+                "may not exist upstream. Check the platform name in "
+                "connection_to_platform_map.",
+                context=f"platform={platform_config.platform}",
+                exc=e,
+            )
+            return None
 
+        try:
+            query = _select_query_for_lineage(sql, dialect)
+        except (TypeError, AttributeError) as e:
+            # GrafanaQueryTarget is Dict[str, Any], so rawSql can hold any JSON
+            # value despite _extract_raw_sql's Optional[str] annotation, and
+            # substitution over a non-string raises. Cleaning used to happen
+            # inside this method's try block; keep returning None as it did.
+            logger.warning(f"Panel SQL is not a string, so it cannot be parsed: {e}")
+            return None
+
+        result: Optional[SqlParsingResult] = None
+        kept: List[str] = []
+        dropped: List[str] = []
+        if query is not None:
+            result = self._run_sql_parser(query, platform_config)
+            if result is not None:
+                kept, dropped = _partition_upstreams(
+                    result, platform_config, from_cleaned_query=query != sql
+                )
+
+        if result is None or not kept:
+            # Returning None rather than a result holding invented names keeps
+            # unresolved variables from being emitted as though they were datasets.
+            # create_lineage_sql_parsed_result reports a parse failure on the result
+            # rather than raising, so the error has to be carried across explicitly
+            # or the warning cannot say why the query failed.
+            self.report.warning(
+                title="Panel SQL did not resolve to upstream tables",
+                message="Neither the query as authored nor its cleaned form "
+                "produced upstream tables naming real datasets. Lineage falls back "
+                "to the datasource, which names a dataset that may not exist "
+                "upstream.",
+                context=f"platform={platform_config.platform}, sql={sql[:200]}",
+                exc=result.debug_info.table_error if result is not None else None,
+            )
+            return None
+
+        if dropped:
+            self.report.warning(
+                title="Some panel SQL upstreams could not be resolved",
+                message="Part of the query names tables this connector cannot "
+                "resolve to real datasets, usually a Grafana variable standing in "
+                "for a table name. Those upstreams are dropped; the rest are "
+                "emitted.",
+                context=f"platform={platform_config.platform}, "
+                f"dropped={len(dropped)}, kept={len(kept)}, sql={sql[:200]}",
+            )
+
+        return _restrict_to_upstreams(result, kept)
+
+    def _run_sql_parser(
+        self, sql: str, platform_config: PlatformConnectionConfig
+    ) -> Optional[SqlParsingResult]:
+        """Run the SQL parser over one form of the query."""
+        try:
             return create_lineage_sql_parsed_result(
-                query=cleaned_sql,
+                query=sql,
                 platform=platform_config.platform,
                 platform_instance=platform_config.platform_instance,
                 env=platform_config.env,

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_lineage.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_lineage.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -5,17 +6,32 @@ import pytest
 from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.source.grafana.grafana_config import PlatformConnectionConfig
-from datahub.ingestion.source.grafana.lineage import LineageExtractor
+from datahub.ingestion.source.grafana.lineage import (
+    LineageExtractor,
+    _partition_upstreams,
+    _probe_grafana_template_variables,
+    _restrict_to_upstreams,
+    _select_query_for_lineage,
+)
 from datahub.ingestion.source.grafana.models import Panel
 from datahub.ingestion.source.grafana.report import GrafanaSourceReport
 from datahub.metadata.schema_classes import (
     DatasetLineageTypeClass,
     UpstreamLineageClass,
 )
+from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.sqlglot_lineage import (
     ColumnLineageInfo,
     ColumnRef,
     DownstreamColumnRef,
+    SqlParsingResult,
+)
+from datahub.sql_parsing.sqlglot_utils import get_dialect
+
+POSTGRES_CONNECTION = PlatformConnectionConfig(
+    platform="postgres",
+    database="test_db",
+    database_schema="public",
 )
 
 
@@ -103,6 +119,368 @@ def test_extract_panel_lineage_postgres(lineage_extractor):
     assert isinstance(lineage.aspect, UpstreamLineageClass)
     assert len(lineage.aspect.upstreams) == 1
     assert lineage.aspect.upstreams[0].type == DatasetLineageTypeClass.TRANSFORMED
+
+
+def _sql_panel(raw_sql: str) -> Panel:
+    return Panel(
+        id="1",
+        title="Test Panel",
+        type="graph",
+        datasource={"type": "postgres", "uid": "postgres_uid"},
+        targets=[{"rawSql": raw_sql, "format": "table"}],
+    )
+
+
+def _upstreams_of(lineage: Optional[MetadataChangeProposalWrapper]) -> List[str]:
+    assert lineage is not None
+    assert isinstance(lineage.aspect, UpstreamLineageClass)
+    return [upstream.dataset for upstream in lineage.aspect.upstreams]
+
+
+def _only_upstream_of(lineage: Optional[MetadataChangeProposalWrapper]) -> str:
+    upstreams = _upstreams_of(lineage)
+    assert len(upstreams) == 1
+    return upstreams[0]
+
+
+def _urn(name: str, platform: str = "postgres") -> str:
+    return f"urn:li:dataset:(urn:li:dataPlatform:{platform},{name},PROD)"
+
+
+@pytest.fixture
+def parsing_extractor(lineage_extractor, mock_graph):
+    # Without a real resolver a bare MagicMock graph makes every parse fail, so
+    # these tests would silently assert against the datasource-UID fallback.
+    mock_graph._make_schema_resolver.return_value = SchemaResolver(
+        platform="postgres", env="PROD", graph=None
+    )
+    return lineage_extractor
+
+
+def test_parse_sql_prefers_the_raw_query(parsing_extractor):
+    # A quoted '${var}' is a valid string literal, so the query parses as authored.
+    # Cleaning rewrites it to ''grafana_var'', which does not parse - so reaching
+    # the real table proves the raw query was tried first.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT value FROM test_table WHERE id = CAST('${id}' AS INTEGER)"),
+        "test-dashboard",
+    )
+
+    assert "test_db.public.test_table" in _only_upstream_of(lineage)
+
+
+def test_parse_sql_falls_back_to_cleaning_when_raw_fails(parsing_extractor):
+    # Braces are not SQL, so this does not parse as authored at all. Cleaning
+    # rewrites the variable to a string literal, which does - and every table name
+    # is real, so the lineage survives.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT v FROM test_table WHERE name = ${env}"), "test-dashboard"
+    )
+
+    assert "test_db.public.test_table" in _only_upstream_of(lineage)
+
+
+def test_parse_sql_keeps_identifiers_containing_a_dollar_sign(parsing_extractor):
+    # Oracle allows $ inside identifiers. Substituting into one would make the two
+    # parses disagree over a name that was never in doubt, and the query would be
+    # cleaned - leaving a truncated "v" behind.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT * FROM v$session"), "test-dashboard"
+    )
+
+    assert "test_db.public.v$session" in _only_upstream_of(lineage)
+
+
+def test_parse_sql_is_not_confused_by_a_macro(parsing_extractor):
+    # The cleaner replaces $__timeFrom() with TRUE even though it produces a value,
+    # which can break a query that parses perfectly well as authored. A macro can
+    # never be a table name, so the comparison must ignore macros entirely rather
+    # than be blinded by the cleaner's handling of them.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT v FROM test_table WHERE ts > $__timeFrom() AND x = 1"),
+        "test-dashboard",
+    )
+
+    assert "test_db.public.test_table" in _only_upstream_of(lineage)
+
+
+@pytest.mark.parametrize(
+    "raw_sql",
+    [
+        "SELECT * FROM $tbl",
+        "SELECT * FROM a, $tbl",
+        "SELECT * FROM ONLY $tbl",
+        "SELECT * FROM /* comment */ $tbl",
+        "WITH c AS (SELECT 1 AS x) SELECT * FROM c, $tbl",
+        "SELECT * FROM (SELECT y FROM $tbl) s",
+        "SELECT * FROM $schema.events",
+        "SELECT * FROM $cat.public.events",
+    ],
+    ids=[
+        "plain",
+        "comma_join",
+        "only",
+        "after_comment",
+        "after_cte",
+        "in_subquery",
+        "schema_position",
+        "catalog_position",
+    ],
+)
+def test_parse_sql_does_not_name_a_table_after_a_variable(parsing_extractor, raw_sql):
+    # In dialects that drop the $ sigil a raw parse of "FROM $tbl" yields a table
+    # called "tbl" - the variable's name, not the table it stands for - and the
+    # resulting URN looks entirely ordinary. The last two shapes are worse still:
+    # the variable is swallowed and the configured schema silently takes its place,
+    # so "$schema.events" resolves to "test_db.public.events".
+    #
+    # Asserted against _parse_sql rather than the emitted lineage on purpose:
+    # extract_panel_lineage always falls back to a datasource-named upstream, which
+    # can never contain these names, so an assertion made there would pass without
+    # testing anything.
+    assert parsing_extractor._parse_sql(raw_sql, POSTGRES_CONNECTION) is None
+
+
+def test_parse_sql_keeps_a_real_table_alongside_an_unresolvable_one(parsing_extractor):
+    # [[tbl]] is a table name we never learned, but test_table is one we did.
+    # Rejecting the whole result over the first would throw away the second.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT a.x FROM test_table a JOIN [[tbl]] b ON a.i = b.i"),
+        "test-dashboard",
+    )
+
+    upstreams = _upstreams_of(lineage)
+    assert any("test_db.public.test_table" in u for u in upstreams)
+    assert not any("grafana_identifier" in u for u in upstreams)
+
+
+def test_parse_sql_keeps_table_functions_with_positional_parameters(parsing_extractor):
+    # $1 is an ordinary database positional parameter, not a Grafana variable, and
+    # it lives in the same subtree as the table name. Treating that subtree as a
+    # variable check would discard the real table sitting next to it.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT t.v FROM test_table t, generate_series($1, $2) AS g"),
+        "test-dashboard",
+    )
+
+    assert "test_db.public.test_table" in _only_upstream_of(lineage)
+
+
+def test_parse_sql_drops_an_upstream_that_is_only_the_qualifier(parsing_extractor):
+    # A table function gives the parser no name to qualify, so this resolves to
+    # "test_db.public" on its own, which is not a dataset.
+    assert (
+        parsing_extractor._parse_sql(
+            "SELECT * FROM generate_series($1, $2)", POSTGRES_CONNECTION
+        )
+        is None
+    )
+
+
+def test_parse_sql_ignores_from_inside_a_string_literal(parsing_extractor):
+    # A text-level check for a variable after FROM/JOIN also fires on prose inside
+    # a string literal, which would discard a perfectly good raw parse.
+    lineage = parsing_extractor.extract_panel_lineage(
+        _sql_panel("SELECT 'imported from $source' AS note, v FROM test_table"),
+        "test-dashboard",
+    )
+
+    assert "test_db.public.test_table" in _only_upstream_of(lineage)
+
+
+def test_parse_sql_survives_a_non_string_raw_sql(parsing_extractor):
+    # GrafanaQueryTarget is Dict[str, Any], so rawSql can hold any JSON value
+    # despite _extract_raw_sql's Optional[str] annotation.
+    assert (
+        parsing_extractor._parse_sql({"not": "a string"}, POSTGRES_CONNECTION) is None
+    )
+
+
+def test_select_query_for_lineage_picks_the_form_to_parse():
+    postgres = get_dialect("postgres")
+    authored = "SELECT v FROM test_table WHERE s = '${env}'"
+    # The variable sits inside a string literal, so no table name changes.
+    assert _select_query_for_lineage(authored, postgres) == authored
+
+    # Here it stands in for the table name, so the cleaned form has to be used.
+    chosen = _select_query_for_lineage("SELECT v FROM ${tbl}", postgres)
+    assert chosen is not None and "grafana_var" in chosen
+
+    # Neither form parses.
+    assert _select_query_for_lineage("SELECT FROM WHERE ${x}", postgres) is None
+
+
+def test_parse_sql_reports_an_unknown_configured_platform(parsing_extractor):
+    # The platform comes from connection_to_platform_map, so a typo is reachable.
+    # Choosing a query form needs the dialect up front, and a misspelling used to be
+    # absorbed by the lineage parser - it must not degrade every panel in silence.
+    bad_platform = PlatformConnectionConfig(platform="postgress", database="test_db")
+
+    assert parsing_extractor._parse_sql("SELECT * FROM t", bad_platform) is None
+    assert any(
+        "known SQL dialect" in w.title for w in parsing_extractor.report.warnings
+    )
+
+
+def test_parse_sql_reports_when_nothing_resolves(parsing_extractor):
+    # The report is the whole point: a panel that falls back to datasource lineage
+    # has to say so, or the failure is invisible again.
+    assert (
+        parsing_extractor._parse_sql("SELECT * FROM ${tbl}", POSTGRES_CONNECTION)
+        is None
+    )
+    assert any(
+        "did not resolve to upstream tables" in w.title
+        for w in parsing_extractor.report.warnings
+    )
+
+
+def test_parse_sql_reports_the_upstreams_it_dropped(parsing_extractor):
+    # Dropping an unresolvable upstream while keeping the rest is only safe if the
+    # drop is announced; otherwise lineage quietly becomes incomplete.
+    result = parsing_extractor._parse_sql(
+        "SELECT a.x FROM test_table a JOIN [[tbl]] b ON a.i = b.i", POSTGRES_CONNECTION
+    )
+
+    assert result is not None and len(result.in_tables) == 1
+    assert any(
+        "could not be resolved" in w.title for w in parsing_extractor.report.warnings
+    )
+
+
+def test_partition_upstreams_drops_an_unreadable_urn():
+    # Feeding a whole URN to the name tests would match against the platform and
+    # env too, so a URN that cannot be read counts as unresolvable.
+    result = SqlParsingResult(in_tables=["not-a-urn-at-all"], out_tables=[])
+
+    kept, dropped = _partition_upstreams(
+        result, POSTGRES_CONNECTION, from_cleaned_query=False
+    )
+    assert not kept
+    assert dropped == ["not-a-urn-at-all"]
+
+
+def test_probe_substitutes_variables_but_not_macros():
+    probed = _probe_grafana_template_variables(
+        "SELECT $col FROM ${tbl} WHERE $__timeFilter(ts) AND x = [[v]]"
+    )
+
+    assert "$__timeFilter(ts)" in probed
+    assert "$col" not in probed
+    assert "${tbl}" not in probed
+    assert "[[v]]" not in probed
+
+
+def test_partition_upstreams_splits_resolvable_from_invented():
+    real = _urn("test_db.public.events")
+    result = SqlParsingResult(
+        in_tables=[
+            real,
+            _urn("test_db.${schema}.events"),
+            _urn("test_db.public.[[tbl]]"),
+            _urn("test_db.public.$tbl"),
+            _urn("test_db.public"),  # a table function, qualifier only
+        ],
+        out_tables=[],
+    )
+
+    kept, dropped = _partition_upstreams(
+        result, POSTGRES_CONNECTION, from_cleaned_query=False
+    )
+    assert kept == [real]
+    # identities, not a count: two compensating mis-partitions would pass a count
+    assert dropped == [
+        _urn("test_db.${schema}.events"),
+        _urn("test_db.public.[[tbl]]"),
+        _urn("test_db.public.$tbl"),
+        _urn("test_db.public"),
+    ]
+
+    # Oracle allows $ inside identifiers; those are real tables, not variables.
+    oracle_table = _urn("db.sys.V$SESSION", platform="oracle")
+    kept, dropped = _partition_upstreams(
+        SqlParsingResult(in_tables=[oracle_table], out_tables=[]),
+        POSTGRES_CONNECTION,
+        from_cleaned_query=False,
+    )
+    assert kept == [oracle_table]
+    assert not dropped
+
+
+def test_partition_upstreams_rejects_placeholders_only_from_the_cleaned_query():
+    invented = SqlParsingResult(
+        in_tables=[_urn("test_db.public.grafana_identifier")], out_tables=[]
+    )
+    # The cleaner invents that name, so on that path it stands for a table we never
+    # identified...
+    kept, _dropped = _partition_upstreams(
+        invented, POSTGRES_CONNECTION, from_cleaned_query=True
+    )
+    assert not kept
+
+    # ...but a table genuinely authored with that name is a real table.
+    kept, _dropped = _partition_upstreams(
+        invented, POSTGRES_CONNECTION, from_cleaned_query=False
+    )
+    assert kept == invented.in_tables
+
+    # A name that merely starts with the placeholder text is not the placeholder.
+    ok = SqlParsingResult(
+        in_tables=[_urn("grafana_var_store.public.events")], out_tables=[]
+    )
+    kept, _dropped = _partition_upstreams(
+        ok, POSTGRES_CONNECTION, from_cleaned_query=True
+    )
+    assert kept == ok.in_tables
+
+
+def test_restrict_to_upstreams_narrows_column_lineage_too():
+    kept_urn = _urn("test_db.public.events")
+    dropped_urn = _urn("test_db.public.grafana_identifier")
+    result = SqlParsingResult(
+        in_tables=[kept_urn, dropped_urn],
+        out_tables=[],
+        column_lineage=[
+            ColumnLineageInfo(
+                downstream=DownstreamColumnRef(table=None, column="x"),
+                upstreams=[
+                    ColumnRef(table=kept_urn, column="a"),
+                    ColumnRef(table=dropped_urn, column="b"),
+                ],
+            ),
+            ColumnLineageInfo(
+                downstream=DownstreamColumnRef(table=None, column="y"),
+                upstreams=[ColumnRef(table=dropped_urn, column="c")],
+            ),
+            # a constant column has no upstreams to begin with, so narrowing must
+            # not mistake it for one that was emptied
+            ColumnLineageInfo(
+                downstream=DownstreamColumnRef(table=None, column="literal"),
+                upstreams=[],
+            ),
+        ],
+    )
+
+    narrowed = _restrict_to_upstreams(result, [kept_urn])
+
+    assert narrowed.in_tables == [kept_urn]
+    # A fine-grained edge pointing at a dropped table would create in DataHub the
+    # very dataset the drop avoided, so the whole "y" entry goes.
+    assert narrowed.column_lineage is not None
+    assert [cl.downstream.column for cl in narrowed.column_lineage] == ["x", "literal"]
+    assert [ref.table for ref in narrowed.column_lineage[0].upstreams] == [kept_urn]
+    assert narrowed.column_lineage[1].upstreams == []
+
+
+def test_partition_upstreams_without_a_configured_database_or_schema():
+    # Both are Optional, so the qualifier-only test must not fire when there is no
+    # qualifier to match against.
+    config = PlatformConnectionConfig(platform="postgres")
+    result = SqlParsingResult(in_tables=[_urn("events")], out_tables=[])
+
+    kept, dropped = _partition_upstreams(result, config, from_cleaned_query=False)
+    assert kept == [_urn("events")]
+    assert not dropped
 
 
 def test_extract_panel_lineage_mysql(lineage_extractor):


### PR DESCRIPTION
### The bug

`_clean_grafana_template_variables()` ran on every panel query before it was parsed. Cleaning
substitutes a **quoted string** for each Grafana variable, so an author-written `'${var}'` becomes
`''grafana_var''` and any literal a variable sat inside is mangled. No dialect parses the result.

The failure is invisible. `create_lineage_sql_parsed_result` does not raise on a malformed query —
it returns a *truthy* `SqlParsingResult` carrying the error with `in_tables=[]`. So
`_create_column_lineage` bails at its `if not parsed_sql.in_tables` guard, `extract_panel_lineage`
falls through to `_create_basic_lineage`, and the panel gets an upstream built from the **Grafana
datasource UID** — a dataset that does not exist upstream. `report_lineage_extracted()` counts it
as a success.

### The fix

Use the query **as authored** wherever that is safe, and clean only where cleaning is actually
needed (`[[var]]` standing in for a table name, which no dialect parses).

Deciding "wherever that is safe" is the whole problem, and it is decided by **parsing twice and
comparing the table names**:

```
parse the query as authored                     -> table names A
parse a probe of it, every variable replaced
by one fixed token                              -> table names P

A == P          ->  no variable reached a table name  ->  use the query as authored
A != P          ->  a variable reached a table name   ->  use the cleaned form
neither parses  ->  report, no lineage
```

Nothing here asks "was this name derived from a variable?" — the difference between the two parses
*is* the signal. That makes the decision:

- **dialect-agnostic** — Postgres and Snowflake drop the `$` sigil while Trino, MySQL and Oracle
  keep it, and BigQuery treats `$tbl` as a plain identifier. Irrelevant when both forms are parsed
  the same way.
- **position-agnostic** — a variable in a catalog or schema qualifier (`FROM $env.metrics`) is
  caught as readily as one standing in for the table itself. This is the case that matters most: the
  qualifier is silently swallowed and the configured default schema takes its place, so the emitted
  URN looks completely ordinary while naming the wrong dataset.
- **not fooled by table-valued functions** — `FROM some_func($1)` uses an ordinary positional
  parameter, not a Grafana variable, and keeps its lineage.
- **not fooled by string literals** — `SELECT 'imported from $source' … FROM real_table` and
  `EXTRACT(EPOCH FROM ts)` both keep their lineage.

Two supporting details:

- **The probe substitutes a bare token, not a quoted string.** The cleaner is a poor source of the
  second parse precisely because its quoting breaks queries — it fails to parse in 21 of 138
  shape × dialect combinations, and a failed parse leaves the comparison blind. A bare identifier is
  valid in every position a variable can occupy, so the probe parses wherever the query as authored
  does: 998 of the 1026 corpus queries end up using the query as authored, and only one reaches
  "neither parses".
- **Macros are left exactly as authored.** A `$__` macro is a Grafana built-in standing for a time
  value or a predicate, so it can never be a table name — and the cleaner's own macro handling can
  break a query that parses fine as written (`$__timeFrom()` produces a value but is replaced with
  `TRUE`). Ignoring macros keeps the comparison from being blinded by that.

### Unresolvable upstreams are dropped individually

Previously a single unresolvable table discarded the whole result. `SELECT a.x FROM real_table a
JOIN [[tbl]] b …` names one table we know and one we do not, and the one we know is worth emitting.
Names that cannot denote a dataset are now dropped one at a time and reported, and column lineage
is narrowed with them — a fine-grained edge pointing at a dropped table would create in DataHub the
very dataset the drop avoided.

Three shapes are dropped: a name still carrying Grafana syntax; a name that is nothing but the
configured `database.schema` prefix (a table-valued function gives the parser no name to qualify);
and, on the cleaned path only, the cleaner's own invented placeholders.

This can only save what the chosen form actually parsed. A bare `$var` in a comma-separated `FROM`
list cleans to a quoted string that Postgres and Snowflake reject outright, so there are no
upstreams to partition and the real table beside it is lost too — exactly as it is on master. It
works on the `[[var]]` and `${var}` forms, and on `$var` in the four dialects that do parse the
cleaned form.

### Measurements

1026 panel and annotation queries from a production Grafana instance. "Panels resolved" counts
panels with at least one upstream that can denote a real dataset; "fabricated" counts emitted
upstream names that cannot.

| variant | panels resolved | real upstreams | fabricated upstreams |
| --- | --- | --- | --- |
| master | 898 | 1389 | 40 |
| master + #19349 | 947 | 1484 | 43 |
| **this change** | **968** | **1525** | **0** |
| no cleaning at all | 970 | 1527 | 41 |

The last row is the ceiling any design can reach on this corpus — cleaning never rescued a parse
that the raw query failed, in a single one of the 1026 queries. The two panels between it and this
change are ones where a variable genuinely stands in for a table name; those are now reported
instead of guessed at.

Per panel against `master + #19349`: 20 panels gain real lineage, **none lose any**, 35 panels stop
emitting a fabricated upstream, and **none start**.

Also verified across 25 query shapes × 6 dialects (150 combinations): no shape loses lineage that
master resolves, and none emits a fabricated upstream — except one BigQuery corner where sqlglot
resolves a quoted `$tbl` to the default schema repeated in the table position. Master fabricates
there too; it is indistinguishable from a table genuinely named after its schema, so it is left
alone and documented in the code rather than risk dropping a real upstream.

### Cost

The decision runs two *bare* sqlglot parses (no optimizer, no schema qualification). Over the same corpus that is **0.99 ms per query against 11.25 ms for the lineage
parse it guards — 8.8% overhead**, and in a real ingestion run the schema-resolver round trips
dominate both, so the true share is smaller. In exchange, 27 queries that previously ran a full
lineage parse against a mangled query now skip it.

### Relationship to the other two PRs

- Independent of **#19349** (quoted `${var}` cleaner fix). This PR does not need it; with it the
  corpus figures rise from 965/1514 to 968/1525. Either order works.
- Conflicts textually with **#19347** (report unparseable panel SQL) — both rewrite `_parse_sql`.
  Landing #19347 first is easier, since its reporting helpers replace the ad-hoc warnings here.

### Known limitations

- A variable appended to a table name (`metrics_$env`) is emitted as authored. It is
  indistinguishable from an identifier that merely contains a dollar sign, and Oracle's `V$SESSION`
  is a real table of exactly that shape — the corpus contains 3 such tables (11 upstreams) and zero
  of the `metrics_$env` shape, so the tie is broken in favour of keeping the real ones.
- A bare `$var` alongside a real table in a comma-separated `FROM` list still loses both on
  Postgres and Snowflake (see above). Recovering it would need the comparison applied per name
  rather than per query — a different mechanism, deliberately not bolted on here unmeasured.
- The cleaner's placeholders are not unique per query, so a table genuinely named
  `grafana_identifier` joined to a `[[var]]` collapses to one name when cleaned and is dropped.
  The distinction is destroyed by the substitution before anything downstream can see it; master
  emits the placeholder, which is only coincidentally right for that one name. The drop is
  reported rather than silent. A query-unique sentinel would fix it properly, in the cleaner.
- The Grafana integration fixtures contain no template variables at all, so
  `grafana_mcps_golden.json` is unchanged by this PR and none of this behaviour has end-to-end
  coverage. Worth a follow-up.

### Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [x] Links to related issues — #19346
- [x] Tests added/updated — 134 unit tests in `tests/unit/grafana` (was 122)
- [ ] Docs added/updated — n/a, no user-facing configuration change
- [ ] Breaking changes documented in `docs/how/updating-datahub.md` — n/a
