### PR TITLE
fix(ingestion/grafana): don't break SQL parsing for quoted template variables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/lineage.py
@@ -48,7 +48,14 @@ _GRAFANA_GENERIC_MACRO_PATTERN = re.compile(r"\$__\w+(?:\([^)]*\))?")
 
 # Bracket and braced variables
 _GRAFANA_BRACKET_VAR_PATTERN = re.compile(r"\[\[[^\]]+\]\]")
-_GRAFANA_BRACED_VAR_PATTERN = re.compile(r"\$\{[^}]+\}")
+
+# Braced variables not flanked by quotes: ${variable}
+# Same negative lookbehind/lookahead as _GRAFANA_SIMPLE_VAR_PATTERN below: without
+# them '${var}' becomes ''grafana_var'', which no SQL dialect can parse. Both
+# patterns test for an adjacent quote rather than string-literal containment, so a
+# variable in the middle of a longer literal ('%${var}%') is still substituted and
+# still fails to parse.
+_GRAFANA_BRACED_VAR_PATTERN = re.compile(r"(?<!')\$\{[^}]+\}(?!')")
 
 # Simple variables NOT inside quotes: $var
 # Use negative lookbehind/lookahead to skip variables already in quotes
@@ -78,10 +85,11 @@ def _clean_grafana_template_variables(query: str) -> str:
     Replacement strategy:
     - Macros with args: $__timeFilter(column) -> TRUE (complete boolean expression)
     - Standalone macros: $__timeFilter -> > TIMESTAMP '2000-01-01' (valid predicate)
-    - ${...} variables -> 'grafana_var' (string literal)
+    - ${...} variables (not in quotes) -> 'grafana_var' (string literal)
     - [[...]] identifiers -> grafana_identifier (valid identifier)
     - $simple variables (not in quotes) -> 'grafana_var' (string literal)
-    - Variables already in quotes: '$var' -> left unchanged
+    - Variables that form an entire quoted literal: '$var', '${var}' -> left unchanged
+      (this is quote adjacency, not literal containment: '%${var}%' is still replaced)
 
     Examples:
         ${__from:date:'YYYY/MM/DD'} -> 'grafana_var'
@@ -91,6 +99,7 @@ def _clean_grafana_template_variables(query: str) -> str:
         WHERE event_timestamp $__timeFilter -> WHERE event_timestamp > TIMESTAMP '2000-01-01'
         $__interval -> 1
         WHERE status = '$status' -> WHERE status = '$status' (unchanged - already quoted)
+        WHERE id = '${id}' -> WHERE id = '${id}' (unchanged - already quoted)
         WHERE status = $status -> WHERE status = 'grafana_var'
     """
 
@@ -114,7 +123,8 @@ def _clean_grafana_template_variables(query: str) -> str:
     # Replace [[...]] with identifier (deprecated syntax, often used for table/column names)
     query = _GRAFANA_BRACKET_VAR_PATTERN.sub("grafana_identifier", query)
 
-    # Replace ${...} with string literal (handles ${var} and ${var:format})
+    # Replace ${...} with string literal (handles ${var} and ${var:format}, but skip
+    # if quote-flanked - '${var}' is already a valid string literal)
     query = _GRAFANA_BRACED_VAR_PATTERN.sub("'grafana_var'", query)
 
     # Replace simple $variable format with string literal (but skip if already in quotes)

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_lineage.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_lineage.py
@@ -12,6 +12,7 @@ from datahub.metadata.schema_classes import (
     DatasetLineageTypeClass,
     UpstreamLineageClass,
 )
+from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.sqlglot_lineage import (
     ColumnLineageInfo,
     ColumnRef,
@@ -103,6 +104,49 @@ def test_extract_panel_lineage_postgres(lineage_extractor):
     assert isinstance(lineage.aspect, UpstreamLineageClass)
     assert len(lineage.aspect.upstreams) == 1
     assert lineage.aspect.upstreams[0].type == DatasetLineageTypeClass.TRANSFORMED
+
+
+def test_extract_panel_lineage_with_quoted_template_variable(
+    lineage_extractor, mock_graph
+):
+    # A quoted '${var}' is already a valid SQL string literal. If cleaning turns it
+    # into ''grafana_var'' the query stops parsing and lineage silently degrades to
+    # an upstream named after the Grafana datasource UID, which does not exist.
+    #
+    # The $__timeFilter macro is deliberate: it is the half of the query that
+    # genuinely needs cleaning, so this query cannot resolve without cleaning
+    # running and the quoted variable surviving it. Without the macro the query
+    # parses as authored, and the test would stop covering the substitution.
+    #
+    # The resolver injection is load-bearing, not boilerplate: create_schema_resolver
+    # delegates to graph._make_schema_resolver, and a bare MagicMock graph returns a
+    # MagicMock resolver, which makes parsing fail and silently drops this test onto
+    # the same fallback path it is meant to detect.
+    mock_graph._make_schema_resolver.return_value = SchemaResolver(
+        platform="postgres", env="PROD", graph=None
+    )
+    panel = Panel(
+        id="1",
+        title="Test Panel",
+        type="graph",
+        datasource={"type": "postgres", "uid": "postgres_uid"},
+        targets=[
+            {
+                "rawSql": "SELECT value FROM test_table WHERE $__timeFilter(ts) "
+                "AND run_id = CAST('${run_id}' AS INTEGER)",
+                "format": "table",
+            }
+        ],
+    )
+
+    lineage = lineage_extractor.extract_panel_lineage(panel, "test-dashboard")
+
+    assert lineage is not None
+    assert isinstance(lineage.aspect, UpstreamLineageClass)
+    assert len(lineage.aspect.upstreams) == 1
+    upstream_urn = lineage.aspect.upstreams[0].dataset
+    assert "test_db.public.test_table" in upstream_urn
+    assert "postgres_uid" not in upstream_urn
 
 
 def test_extract_panel_lineage_mysql(lineage_extractor):

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_query_extraction.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_query_extraction.py
@@ -1,6 +1,7 @@
 """Unit tests for Grafana query extraction and QueryInfo model."""
 
 import pytest
+import sqlglot
 
 from datahub.ingestion.source.grafana.entity_mcp_builder import (
     _extract_query_from_panel,
@@ -145,6 +146,17 @@ class TestGrafanaTemplateVariableCleaning:
                 "WHERE lower(sensor_serial) = lower('$serial')",
                 "WHERE lower(sensor_serial) = lower('$serial')",
             ),
+            # Braced variable inside quotes (preserved - already quoted)
+            (
+                "WHERE run_id = CAST('${run_id}' AS INTEGER)",
+                "WHERE run_id = CAST('${run_id}' AS INTEGER)",
+            ),
+            # Quoted and unquoted braced variables in one query - only the
+            # unquoted one is replaced
+            (
+                "WHERE a = '${a}' AND b = ${b}",
+                "WHERE a = '${a}' AND b = 'grafana_var'",
+            ),
             # Real-world user query with standalone macro and quoted variable
             (
                 "select cast(event_timestamp as timestamp) from datalake_agg.devices where event_timestamp $__timeFilter and lower(sensor_serial) = lower('$serial') order by 1",
@@ -162,6 +174,8 @@ class TestGrafanaTemplateVariableCleaning:
             "time_macros",
             "macro_without_parens",
             "variable_in_quotes",
+            "braced_variable_in_quotes",
+            "braced_variables_quoted_and_unquoted",
             "realworld_user_query",
         ],
     )
@@ -169,6 +183,23 @@ class TestGrafanaTemplateVariableCleaning:
         """Test all Grafana variable formats are replaced with context-appropriate values."""
         result = _clean_grafana_template_variables(input_query)
         assert result == expected_pattern
+
+    def test_cleaned_query_remains_parseable_with_quoted_variables(self):
+        """Cleaning must not break SQL that sqlglot could already parse."""
+        query = (
+            "SELECT ts FROM my_catalog.my_schema.my_table "
+            "WHERE run_id = CAST('${run_id}' AS INTEGER)"
+        )
+
+        cleaned = _clean_grafana_template_variables(query)
+
+        tables = {
+            table.sql(dialect="trino")
+            for table in sqlglot.parse_one(cleaned, dialect="trino").find_all(
+                sqlglot.exp.Table
+            )
+        }
+        assert tables == {"my_catalog.my_schema.my_table"}
 
 
 class TestSqlFormatting:


### PR DESCRIPTION


Fixes #19346

## Problem

`_clean_grafana_template_variables()` replaces `${var}` with the quoted literal `'grafana_var'`
without checking whether the variable is already inside quotes. Panel SQL containing `'${var}'` —
the common way to interpolate a Grafana variable into a SQL string or cast — becomes
`''grafana_var''`, which no dialect can parse:

```sql
-- input (valid, parses as-is)
WHERE run_id = CAST('${run_id}' AS INTEGER)
-- after cleaning
WHERE run_id = CAST(''grafana_var'' AS INTEGER)   -- ParseError: Expected AS after CAST
```

The irony is that the *unmodified* query is fine — sqlglot treats `'${var}'` as an ordinary string
literal. The cleaning step is what breaks it.

The failure is then invisible. `create_lineage_sql_parsed_result` swallows the `ParseError` and
returns a **truthy** `SqlParsingResult` with `in_tables=[]`, so `_parse_sql` returns non-`None`,
`_create_column_lineage` bails at its `if not parsed_sql.in_tables` guard, and
`extract_panel_lineage` falls through to `_create_basic_lineage` — which builds the upstream URN
from the **Grafana datasource UID**:

```
actual:   urn:li:dataset:(urn:li:dataPlatform:postgres,test_db.postgres_uid,PROD)     <- datasource UID
expected: urn:li:dataset:(urn:li:dataPlatform:postgres,test_db.public.test_table,PROD)
```

That dataset does not exist in the upstream platform, so ingestion materialises a phantom entity
that looks like genuine lineage. Nothing warns — `panel_parsing_warnings` stays at 0 and
`warnings` stays empty.

Measured on a production Grafana instance with ~800 dashboards: **143 of 940 `upstreamLineage`
aspects (15.2%)** pointed at a fabricated UUID-named dataset; 101 of those are caused by this
issue.

## Fix

The sibling `_GRAFANA_SIMPLE_VAR_PATTERN` already carries `(?<!')...(?!')` for exactly this
reason, and the function's docstring documents that `'$var'` is left unchanged. This gives the
braced pattern the same guard, so the documented contract holds for both syntaxes:

```diff
-_GRAFANA_BRACED_VAR_PATTERN = re.compile(r"\$\{[^}]+\}")
+_GRAFANA_BRACED_VAR_PATTERN = re.compile(r"(?<!')\$\{[^}]+\}(?!')")
```

Both lookarounds must hold for a substitution, so `'${var}'` is left untouched — which is correct,
because it is already a valid SQL string literal. Everything else in the diff is the matching
docstring and comment update.

The ordering of the other passes makes this sufficient on its own:
`_GRAFANA_GENERIC_MACRO_PATTERN` (`\$__\w+`) runs earlier but cannot match `${__from}`, because
`$` is followed by `{` rather than `_`; and `_GRAFANA_SIMPLE_VAR_PATTERN` runs later but cannot
match `'${run_id}'` for the same reason. A quoted braced variable now survives all passes
unchanged.

**Known limitation**, shared with the existing sibling pattern and deliberately not addressed here:
a single-quote lookaround is a proxy for "inside a string literal", and it only fires when a quote
is *immediately adjacent* to the variable. A variable in the middle of a longer literal is still
substituted and still breaks parsing:

```
'${var}'              -> unchanged                      (fixed by this PR)
'${var}xyz'           -> unchanged                      (fixed by this PR)
'xyz${var}'           -> unchanged                      (fixed by this PR)
'prefix${var}suffix'  -> 'prefix'grafana_var'suffix'    (still broken, unchanged by this PR)
```

That last case produces byte-identical output before and after this change, so it is a pre-existing
gap rather than a regression, and it is exactly how `_GRAFANA_SIMPLE_VAR_PATTERN` already behaves.
Closing it properly needs string-literal-aware scanning rather than a wider regex, which is a
larger change than this fix warrants.

## Testing

Three tests added, each confirmed **failing before** the change and passing after.

1. `test_removes_all_grafana_variable_formats[braced_variable_in_quotes]` — one new case in the
   existing parametrized list, mirroring the `variable_in_quotes` case that already asserts this
   contract for `'$var'`. A second case,
   `[braced_variables_quoted_and_unquoted]`, puts a quoted and an unquoted braced variable in one
   query, pinning the fix as *selective* rather than "stopped substituting braced variables".
2. `test_cleaned_query_remains_parseable_with_quoted_variables` — feeds the cleaned query back
   through sqlglot and asserts the upstream table is still extractable. The existing suite only
   asserted string equality on the cleaner's output, never that the output parses, which is why an
   11-case suite passed throughout.
3. `test_extract_panel_lineage_with_quoted_template_variable` — end-to-end, asserts the emitted
   upstream URN is the real table and not the datasource UID. This is the user-visible regression;
   the existing `test_extract_panel_lineage_postgres` asserts only `len(upstreams) == 1`, which
   passes identically on both the correct and the fabricated-URN path.

Before:

```
FAILED test_grafana_lineage.py::test_extract_panel_lineage_with_quoted_template_variable
  - AssertionError: assert 'test_db.public.test_table' in
    'urn:li:dataset:(urn:li:dataPlatform:postgres,test_db.postgres_uid,PROD)'
FAILED test_grafana_query_extraction.py::...::test_removes_all_grafana_variable_formats[braced_variable_in_quotes]
  - assert "WHERE run_id = CAST(''grafana_var'' AS INTEGER)" == "WHERE run_id = CAST('${run_id}' AS INTEGER)"
FAILED test_grafana_query_extraction.py::...::test_cleaned_query_remains_parseable_with_quoted_variables
  - sqlglot.errors.ParseError: Expected AS after CAST. Line 1, Col: 78.
3 failed, 107 passed in 0.68s
```

After:

```
111 passed in 0.58s
```

No existing assertion was changed. `./gradlew :metadata-ingestion:lint` is clean (ruff check, ruff
format, mypy).

## Follow-up, not in this PR

Four further defects in the same function, each producing the same silent fallback, are
deliberately left out — each is independently arguable and would stall review of a one-line fix.
They are described in the linked issue:

- `$__timeFrom()` / `$__timeTo()` / `$__timeGroup(...)` are value-producing macros replaced with
  `TRUE`. An existing test asserts the current behaviour, so fixing it means changing that
  expectation.
- Macro argument matching uses `[^)]*`, which is not nesting-aware.
- `_GRAFANA_SIMPLE_VAR_PATTERN` treats `$` as a sigil mid-identifier, mangling Oracle identifiers
  such as `SOME$COL`.
- `_parse_sql` discards `parsed_sql.debug_info.table_error`. Surfacing it as a source warning would
  make this whole class of failure discoverable rather than silent. Note also that
  `GrafanaSourceReport.report_sql_parsing_{attempt,success,failure}` are called only from
  `field_utils.py` and never from `lineage.py`, so `sql_parsing_failures` is structurally always 0
  for the lineage path, while `report_lineage_extracted()` counts the fabricated URN as a success.
- The quote guard is adjacency-based, so `'%${var}%'` — a very common Grafana `LIKE` idiom — is
  still substituted and still unparseable. Closing it properly means masking string literals before
  substituting, which would let both this pattern and its sibling drop their lookarounds entirely.
- The integration fixtures in `tests/integration/grafana/` contain no Grafana template variables at
  all, so the whole cleaning path has no end-to-end coverage.

Whether `_create_basic_lineage` should emit a made-up dataset name at all is a design question for
maintainers, and is also left alone here.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated — n/a, no config or API surface change
- [ ] Entry in Updating DataHub — n/a, bugfix with no breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves quoted braced Grafana variables during cleaning so SQL keeps parsing. Previously `'${var}'` became `''grafana_var''`, parsing failed, and lineage fell back to a datasource-UID dataset; now quoted `${...}` is left as-is so upstreams resolve to the real table.

- Replace the braced-var regex with `(?<!')\$\{[^}]+\}(?!')` and align docs/comments; pass ordering continues to substitute unquoted variables.
- Tests: add quoted braced-var, mixed quoted/unquoted, a parseability check using `sqlglot`, and an end-to-end lineage test that asserts the real table URN with a real `SchemaResolver`.
- Limitation unchanged: the guard is quote-adjacent, not literal-aware; `%${var}%` can still be substituted and fail to parse. No config or migration changes.

<sup>Written for commit d2d8de455303aaa8d74f2f05a6b6734760388411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

