### PR TITLE
fix(ingest/clickhouse): resolve query-log lineage to database-qualified URNs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/clickhouse.py
@@ -795,11 +795,11 @@ ORDER BY event_time ASC
                 session_id=row.get("query_id"),
                 timestamp=event_time,
                 user=CorpUserUrn(user) if user else None,
-                # Don't pass current_database as default_db. ClickHouse uses 2-level
-                # naming (database.table), but sqlglot expects 3-level (database.schema.table).
-                # Passing current_database causes sqlglot to prepend it to already-qualified
-                # names, creating incorrect URNs like "default.analytics_marts.table".
+                # ClickHouse is 2-level: the database goes in the schema slot (as in
+                # TwoTierSQLAlchemySource.get_db_schema); default_db would fill the
+                # unused catalog slot, over-qualifying to "default.my_db.table".
                 default_db=None,
+                default_schema=row.get("current_database") or None,
                 query_hash=str(row.get("normalized_query_hash", "")),
             )
         except Exception as e:

--- a/metadata-ingestion/tests/unit/test_clickhouse_source.py
+++ b/metadata-ingestion/tests/unit/test_clickhouse_source.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timezone
+
 import pytest
 from sqlalchemy.engine.url import make_url
 
-from datahub.ingestion.source.sql.clickhouse import ClickHouseConfig
+import datahub.ingestion.source.sql.clickhouse as clickhouse
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.sql.clickhouse import ClickHouseConfig, ClickHouseSource
 from datahub.ingestion.source.sql.clickhouse_connection import CLICKHOUSE_CLIENT_NAME
+from datahub.metadata.schema_classes import UpstreamLineageClass
 
 
 def test_clickhouse_uri_https():
@@ -204,3 +210,113 @@ def test_is_temp_table_custom_patterns():
     assert config.is_temp_table("test_table")
     # Default patterns no longer match with custom patterns
     assert not config.is_temp_table("_temp_table")
+
+
+class _FakeRow:
+    def __init__(self, mapping: dict):
+        self._mapping = mapping
+
+
+class _FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, *args, **kwargs):
+        return iter(self._rows)
+
+
+def test_query_log_lineage_resolves_unqualified_tables(monkeypatch):
+    # Both sides must pick the database up from current_database, or the lineage
+    # lands on orphan URNs with no database part.
+    config = ClickHouseConfig.model_validate(
+        {
+            "host_port": "localhost:8123",
+            "include_query_log_lineage": True,
+            "start_time": "2020-04-14T00:00:00Z",
+            "end_time": "2020-04-15T00:00:00Z",
+        }
+    )
+    source = ClickHouseSource(config, PipelineContext(run_id="test"))
+
+    rows = [
+        _FakeRow(
+            {
+                "query_id": "q1",
+                "query": "INSERT INTO daily_agg SELECT col_a FROM raw_events",
+                "query_kind": "Insert",
+                "user": "alice",
+                "event_time": datetime(2020, 4, 14, 6, 0, 0, tzinfo=timezone.utc),
+                "current_database": "my_db",
+                "normalized_query_hash": 12345,
+            }
+        )
+    ]
+    monkeypatch.setattr(clickhouse, "create_engine", lambda *a, **kw: _FakeEngine(rows))
+
+    lineage = [
+        wu.metadata
+        for wu in source._extract_query_log()
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and isinstance(wu.metadata.aspect, UpstreamLineageClass)
+    ]
+
+    assert len(lineage) == 1
+    aspect = lineage[0].aspect
+    assert isinstance(aspect, UpstreamLineageClass)
+    assert (
+        lineage[0].entityUrn
+        == "urn:li:dataset:(urn:li:dataPlatform:clickhouse,my_db.daily_agg,PROD)"
+    )
+    assert [u.dataset for u in aspect.upstreams] == [
+        "urn:li:dataset:(urn:li:dataPlatform:clickhouse,my_db.raw_events,PROD)"
+    ]
+
+
+def test_query_log_lineage_does_not_over_qualify(monkeypatch):
+    # current_database must only fill an empty slot: names that already carry their own
+    # database must not become my_db.analytics_marts.daily_agg.
+    config = ClickHouseConfig.model_validate(
+        {
+            "host_port": "localhost:8123",
+            "include_query_log_lineage": True,
+            "start_time": "2020-04-14T00:00:00Z",
+            "end_time": "2020-04-15T00:00:00Z",
+        }
+    )
+    source = ClickHouseSource(config, PipelineContext(run_id="test"))
+
+    rows = [
+        _FakeRow(
+            {
+                "query_id": "q1",
+                "query": (
+                    "INSERT INTO analytics_marts.daily_agg "
+                    "SELECT col_a FROM analytics_raw.raw_events"
+                ),
+                "query_kind": "Insert",
+                "user": "alice",
+                "event_time": datetime(2020, 4, 14, 6, 0, 0, tzinfo=timezone.utc),
+                "current_database": "my_db",
+                "normalized_query_hash": 12345,
+            }
+        )
+    ]
+    monkeypatch.setattr(clickhouse, "create_engine", lambda *a, **kw: _FakeEngine(rows))
+
+    lineage = [
+        wu.metadata
+        for wu in source._extract_query_log()
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and isinstance(wu.metadata.aspect, UpstreamLineageClass)
+    ]
+
+    assert len(lineage) == 1
+    aspect = lineage[0].aspect
+    assert isinstance(aspect, UpstreamLineageClass)
+    assert (
+        lineage[0].entityUrn
+        == "urn:li:dataset:(urn:li:dataPlatform:clickhouse,analytics_marts.daily_agg,PROD)"
+    )
+    assert [u.dataset for u in aspect.upstreams] == [
+        "urn:li:dataset:(urn:li:dataPlatform:clickhouse,analytics_raw.raw_events,PROD)"
+    ]


### PR DESCRIPTION
`system.query_log` stores the statement as submitted, so a query that ran inside a database without qualifying its tables arrives as `INSERT INTO daily_agg SELECT ... FROM raw_events`. Both sides resolved to `clickhouse,daily_agg,PROD` rather than `clickhouse,analytics.daily_agg,PROD`, so query-log lineage attached to a second dataset that has no schema or container and does not appear in browse, alongside the one the metadata scan creates.

ClickHouse is two-tier, so the database belongs in the schema slot — the same convention as `TwoTierSQLAlchemySource.get_db_schema`, which is why definition-based view lineage always resolved correctly. `current_database` was already selected by the query-log fetch and then discarded; it is now passed as `default_schema`. Passing it as `default_db` instead fills the catalog slot that a two-tier platform never uses, over-qualifying already-qualified names into `default.my_db.table`.

Unqualified names now pick up the database the query ran in, and qualified names are untouched because `default_schema` only fills an empty slot. Cross-database joins mixing both forms resolve each side correctly.

Views and materialized views were never affected: they are read from `system.tables.create_table_query`, which ClickHouse returns already normalized and fully qualified.

## Testing

Unit tests assert that an unqualified INSERT ... SELECT from the query log produces database-qualified upstream and downstream URNs, and that a statement already carrying its own database qualifiers is not over-qualified. Each guards one direction: the first fails if current_database is dropped entirely (the pre-fix behaviour), the second fails if it is passed as default_db instead of default_schema. A fully unqualified name resolves identically either way, since the URN joins only the non-None parts.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline, particularly PR Title Format
- [x] Tests for the changes have been added/updated
