### PR TITLE
fix(ingest/sap-datasphere): prefix bare analytic-model business-layer upstreams with space

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/lineage.py
@@ -39,6 +39,17 @@ from datahub.ingestion.source.sap_datasphere.models import (
     dedup_preserving_order,
 )
 
+
+def is_qualified(name: str) -> bool:
+    # A dotted target is already space-qualified (cross-space or a built-in
+    # like SAP.TIME.*); a bare name is a same-space sibling to be prefixed.
+    # Dot-heuristic, not a real parse: a same-space object whose technical name
+    # legitimately contains a dot would be mis-treated as already-qualified, but
+    # Datasphere technical names are effectively alphanumeric/underscore so this
+    # is not observed in practice. Shared by query-FROM and business-layer keys.
+    return "." in name
+
+
 # CDS navigation element types — both name a target entity for lineage purposes.
 _NAVIGATION_TYPES = frozenset({CSN_TYPE_ASSOCIATION, CSN_TYPE_COMPOSITION})
 
@@ -161,7 +172,7 @@ class CsnLineageExtractor:
             if from_clause is not None:
                 self._walk_from(from_clause, names)
         return [
-            UpstreamRef(name=name, qualified=self._is_qualified(name))
+            UpstreamRef(name=name, qualified=is_qualified(name))
             for name in dedup_preserving_order(names)
         ]
 
@@ -278,7 +289,7 @@ class CsnLineageExtractor:
                     target = association_map[alias]
                     out.append(
                         UpstreamColRef(
-                            qname=target, col=col, qualified=self._is_qualified(target)
+                            qname=target, col=col, qualified=is_qualified(target)
                         )
                     )
                 elif alias in alias_map:
@@ -318,16 +329,6 @@ class CsnLineageExtractor:
                     visited,
                     association_map,
                 )
-
-    @staticmethod
-    def _is_qualified(name: str) -> bool:
-        # A dotted target is already space-qualified (cross-space or a built-in
-        # like SAP.TIME.*); a bare name is a same-space sibling to be prefixed.
-        # Dot-heuristic, not a real parse: a same-space object whose technical name
-        # legitimately contains a dot would be mis-treated as already-qualified, but
-        # Datasphere technical names are effectively alphanumeric/underscore so this
-        # is not observed in practice.
-        return "." in name
 
     def _resolve_projection_ref(
         self,
@@ -590,9 +591,7 @@ class CsnLineageExtractor:
             if target in seen:
                 continue
             seen.add(target)
-            targets.append(
-                UpstreamRef(name=target, qualified=self._is_qualified(target))
-            )
+            targets.append(UpstreamRef(name=target, qualified=is_qualified(target)))
         return targets
 
     def remote_source(self, csn_def: dict) -> Optional[str]:

--- a/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
@@ -1593,10 +1593,12 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
             return query_upstreams
 
         # One URN per key — shared by table upstreams and the FGL retention filter.
-        bl_upstream_urns_list = [
-            self._business_layer_upstream_urn(space_name, key)
-            for key in bl.upstream_keys
-        ]
+        bl_upstream_urns_list = list(
+            dict.fromkeys(
+                self._business_layer_upstream_urn(space_name, key)
+                for key in bl.upstream_keys
+            )
+        )
         bl_upstream_urns = set(bl_upstream_urns_list)
         upstreams = [
             UpstreamClass(dataset=urn, type=DatasetLineageTypeClass.VIEW)

--- a/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
@@ -101,6 +101,7 @@ from datahub.ingestion.source.sap_datasphere.graph_resolver import (
 )
 from datahub.ingestion.source.sap_datasphere.lineage import (
     CsnLineageExtractor,
+    is_qualified,
     parse_remote_table_source,
 )
 from datahub.ingestion.source.sap_datasphere.models import (
@@ -1515,8 +1516,17 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
     def _business_layer_upstream_urn(self, space_name: str, key: str) -> str:
         # Bare same-space BL keys need the AM's space; dotted keys are already
         # space-qualified (same heuristic as query-FROM lineage).
-        if CsnLineageExtractor._is_qualified(key):
+        if is_qualified(key):
+            logger.debug(
+                "Business-layer upstream key %r treated as already qualified",
+                key,
+            )
             return self._qualified_upstream_urn(key)
+        logger.debug(
+            "Business-layer upstream key %r prefixed with space %r",
+            key,
+            space_name,
+        )
         return self._qualified_upstream_urn(f"{space_name}.{key}")
 
     def _apply_business_layer_guarded(
@@ -1582,16 +1592,15 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
         if not bl.upstream_keys:
             return query_upstreams
 
-        bl_upstream_urns = {
+        # One URN per key — shared by table upstreams and the FGL retention filter.
+        bl_upstream_urns_list = [
             self._business_layer_upstream_urn(space_name, key)
             for key in bl.upstream_keys
-        }
+        ]
+        bl_upstream_urns = set(bl_upstream_urns_list)
         upstreams = [
-            UpstreamClass(
-                dataset=self._business_layer_upstream_urn(space_name, key),
-                type=DatasetLineageTypeClass.VIEW,
-            )
-            for key in bl.upstream_keys
+            UpstreamClass(dataset=urn, type=DatasetLineageTypeClass.VIEW)
+            for urn in bl_upstream_urns_list
         ]
 
         fine_grained = None

--- a/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
@@ -1512,6 +1512,13 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
             env=self.config.env,
         )
 
+    def _business_layer_upstream_urn(self, space_name: str, key: str) -> str:
+        # Bare same-space BL keys need the AM's space; dotted keys are already
+        # space-qualified (same heuristic as query-FROM lineage).
+        if CsnLineageExtractor._is_qualified(key):
+            return self._qualified_upstream_urn(key)
+        return self._qualified_upstream_urn(f"{space_name}.{key}")
+
     def _apply_business_layer_guarded(
         self,
         csn_obj: Optional[Dict],
@@ -1530,6 +1537,7 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
                 schema_fields,
                 custom_properties,
                 query_upstreams,
+                space_name,
             )
         except Exception as e:
             self.report.warning(
@@ -1549,6 +1557,7 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
         schema_fields: Optional[List[SchemaFieldClass]],
         custom_properties: Dict[str, str],
         query_upstreams: Optional[UpstreamLineageClass],
+        space_name: str,
     ) -> Optional[UpstreamLineageClass]:
         """Wire an analytic model's businessLayerDefinitions in as the authoritative table-level lineage, replacing the query-FROM upstreams (which may double-prefix the fact's space)."""
         bld = (csn_obj or {}).get(CSN_KEY_BUSINESS_LAYER)
@@ -1574,11 +1583,12 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
             return query_upstreams
 
         bl_upstream_urns = {
-            self._qualified_upstream_urn(key) for key in bl.upstream_keys
+            self._business_layer_upstream_urn(space_name, key)
+            for key in bl.upstream_keys
         }
         upstreams = [
             UpstreamClass(
-                dataset=self._qualified_upstream_urn(key),
+                dataset=self._business_layer_upstream_urn(space_name, key),
                 type=DatasetLineageTypeClass.VIEW,
             )
             for key in bl.upstream_keys

--- a/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sap_datasphere/source.py
@@ -122,6 +122,7 @@ from datahub.ingestion.source.sap_datasphere.models import (
     TransformOp,
     UnknownColumnType,
     UpstreamRef,
+    dedup_preserving_order,
 )
 from datahub.ingestion.source.sap_datasphere.platform_mapping import (
     PlatformMappingResolver,
@@ -1516,18 +1517,9 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
     def _business_layer_upstream_urn(self, space_name: str, key: str) -> str:
         # Bare same-space BL keys need the AM's space; dotted keys are already
         # space-qualified (same heuristic as query-FROM lineage).
-        if is_qualified(key):
-            logger.debug(
-                "Business-layer upstream key %r treated as already qualified",
-                key,
-            )
-            return self._qualified_upstream_urn(key)
-        logger.debug(
-            "Business-layer upstream key %r prefixed with space %r",
-            key,
-            space_name,
+        return self._qualified_upstream_urn(
+            key if is_qualified(key) else f"{space_name}.{key}"
         )
-        return self._qualified_upstream_urn(f"{space_name}.{key}")
 
     def _apply_business_layer_guarded(
         self,
@@ -1593,16 +1585,13 @@ class SapDatasphereSource(StatefulIngestionSourceBase, TestableSource):
             return query_upstreams
 
         # One URN per key — shared by table upstreams and the FGL retention filter.
-        bl_upstream_urns_list = list(
-            dict.fromkeys(
-                self._business_layer_upstream_urn(space_name, key)
-                for key in bl.upstream_keys
-            )
+        bl_upstream_urns = dedup_preserving_order(
+            self._business_layer_upstream_urn(space_name, key)
+            for key in bl.upstream_keys
         )
-        bl_upstream_urns = set(bl_upstream_urns_list)
         upstreams = [
             UpstreamClass(dataset=urn, type=DatasetLineageTypeClass.VIEW)
-            for urn in bl_upstream_urns_list
+            for urn in bl_upstream_urns
         ]
 
         fine_grained = None

--- a/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
+++ b/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
@@ -4573,11 +4573,88 @@ def test_business_layer_prefixes_bare_same_space_keys():
         "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
         "my_space.v_dim_region,PROD)",
     }
-    # Cross-space keys stay unprefixed by the AM's space.
+
+
+def test_business_layer_passthrough_qualified_cross_space_keys():
+    src = _bl_source("bl-qualified-passthrough")
     assert src._business_layer_upstream_urn("MY_SPACE", "OTHER_SPACE.BASE_TABLE") == (
         "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
         "other_space.base_table,PROD)"
     )
+
+
+def test_business_layer_mixed_bare_and_qualified_keys():
+    # Realistic star schema: same-space fact/dim plus a built-in time dimension.
+    src = _bl_source("bl-mixed-keys")
+    csn = _business_layer_csn(
+        "am_orders",
+        fact_key="v_fact_orders",
+        dim_key="SAP.TIME.M_TIME_DIMENSION",
+    )
+    result = src._apply_business_layer(
+        csn,
+        "am_orders",
+        schema_fields=[],
+        custom_properties={},
+        query_upstreams=None,
+        space_name="MY_SPACE",
+    )
+    assert result is not None
+    assert {u.dataset for u in result.upstreams} == {
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "my_space.v_fact_orders,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "sap.time.m_time_dimension,PROD)",
+    }
+
+
+def test_business_layer_keeps_fgl_for_bare_same_space_keys():
+    # Before space-prefixing bare BL keys, query FGL parents were already
+    # space-prefixed while BL upstreams were not — retention always failed.
+    src = _bl_source("bl-bare-fgl-keep")
+    fact_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "my_space.v_fact_orders,PROD)"
+    )
+    dim_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,my_space.v_dim_region,PROD)"
+    )
+    model_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,my_space.am_orders,PROD)"
+    )
+    fgl = FineGrainedLineageClass(
+        upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+        downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+        upstreams=[
+            f"urn:li:schemaField:({fact_urn},total)",
+            f"urn:li:schemaField:({dim_urn},region)",
+        ],
+        downstreams=[f"urn:li:schemaField:({model_urn},total)"],
+    )
+    query_upstreams = UpstreamLineageClass(
+        upstreams=[
+            UpstreamClass(dataset=fact_urn, type=DatasetLineageTypeClass.VIEW),
+        ],
+        fineGrainedLineages=[fgl],
+    )
+    csn = _business_layer_csn(
+        "am_orders",
+        fact_key="v_fact_orders",
+        dim_key="v_dim_region",
+    )
+    result = src._apply_business_layer(
+        csn,
+        "am_orders",
+        schema_fields=[],
+        custom_properties={},
+        query_upstreams=query_upstreams,
+        space_name="MY_SPACE",
+    )
+    assert result is not None
+    assert {u.dataset for u in result.upstreams} == {fact_urn, dim_urn}
+    assert result.fineGrainedLineages, "fineGrainedLineages should be kept"
+    assert len(result.fineGrainedLineages) == 1
+    assert result.fineGrainedLineages[0] is fgl
 
 
 def test_schema_field_parent_extracts_dataset_urn():

--- a/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
+++ b/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
@@ -4657,6 +4657,30 @@ def test_business_layer_keeps_fgl_for_bare_same_space_keys():
     assert result.fineGrainedLineages[0] is fgl
 
 
+def test_business_layer_dedups_qualified_and_bare_same_object():
+    # Qualified MY_SPACE.V_FACT and bare V_FACT resolve to the same URN after
+    # space-prefixing; emit once.
+    src = _bl_source("bl-dedup-keys")
+    csn = _business_layer_csn(
+        "am_orders",
+        fact_key="MY_SPACE.V_FACT",
+        dim_key="V_FACT",
+    )
+    result = src._apply_business_layer(
+        csn,
+        "am_orders",
+        schema_fields=[],
+        custom_properties={},
+        query_upstreams=None,
+        space_name="MY_SPACE",
+    )
+    assert result is not None
+    assert len(result.upstreams) == 1
+    assert result.upstreams[0].dataset == (
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,my_space.v_fact,PROD)"
+    )
+
+
 def test_schema_field_parent_extracts_dataset_urn():
     """``_schema_field_parent`` returns the inner dataset URN of a schemaField
     URN, and returns non-schemaField input unchanged (the current contract)."""

--- a/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
+++ b/metadata-ingestion/tests/unit/sap_datasphere/test_sap_datasphere_source.py
@@ -4484,6 +4484,7 @@ def test_business_layer_keeps_fgl_when_upstreams_match():
         schema_fields=[],
         custom_properties={},
         query_upstreams=query_upstreams,
+        space_name="finance",
     )
 
     assert result is not None
@@ -4537,6 +4538,7 @@ def test_business_layer_drops_fgl_when_upstreams_mismatch():
         schema_fields=[],
         custom_properties={},
         query_upstreams=query_upstreams,
+        space_name="finance",
     )
 
     assert result is not None
@@ -4545,6 +4547,37 @@ def test_business_layer_drops_fgl_when_upstreams_mismatch():
     # FGL DROPPED: its upstream parent is the double-prefixed fact, not in the
     # business-layer set -> set to None (not an empty list).
     assert result.fineGrainedLineages is None
+
+
+def test_business_layer_prefixes_bare_same_space_keys():
+    # Same-space BL keys are bare names; without a space prefix they become
+    # ghost lineage URNs that only show as hidden edges.
+    src = _bl_source("bl-bare-same-space")
+    csn = _business_layer_csn(
+        "am_orders",
+        fact_key="v_fact_orders",
+        dim_key="v_dim_region",
+    )
+    result = src._apply_business_layer(
+        csn,
+        "am_orders",
+        schema_fields=[],
+        custom_properties={},
+        query_upstreams=None,
+        space_name="MY_SPACE",
+    )
+    assert result is not None
+    assert {u.dataset for u in result.upstreams} == {
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "my_space.v_fact_orders,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "my_space.v_dim_region,PROD)",
+    }
+    # Cross-space keys stay unprefixed by the AM's space.
+    assert src._business_layer_upstream_urn("MY_SPACE", "OTHER_SPACE.BASE_TABLE") == (
+        "urn:li:dataset:(urn:li:dataPlatform:sap-datasphere,"
+        "other_space.base_table,PROD)"
+    )
 
 
 def test_schema_field_parent_extracts_dataset_urn():


### PR DESCRIPTION
## Summary
- Analytic Model `businessLayerDefinitions` fact/dim keys that are bare same-space names were passed through `_qualified_upstream_urn` unchanged, emitting space-less ghost URNs instead of the ingested `space.object` view URNs.
- Reuse the same dotted-name qualification heuristic as query-FROM lineage: bare keys are prefixed with the analytic model's space; already-qualified cross-space keys stay as-is.
- Adds a regression test for the bare same-space case.

## Test plan
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/sap_datasphere/test_sap_datasphere_source.py`
- [x] `./gradlew :metadata-ingestion:lintFix`