### PR TITLE
docs(managed-datahub): release notes for v2.1.3

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -12,7 +12,7 @@ This release rolls up hotfixes on top of v2.1.2. There are no breaking changes o
 
 #### Release Availability Date
 
-TBD
+19-Aug-2026
 
 #### Recommended Versions
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,40 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.3
+
+This release rolls up hotfixes on top of v2.1.2. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+TBD
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
+#### Product
+
+- **Default "View Self" policy** — the built-in self policy now grants only read access (view page / get entity) on a user's own profile and no longer confers edit or delete permissions on self.
+
+#### AI / Ask DataHub
+
+- **Reliable agent tool palettes** — the integrations-service agent registry now resolves lazily, so a boot-time circular import can no longer silently leave SYSTEM agents (Ingestion Agent, CDE Steward, and others) with an empty tool palette for the life of the process. Resolution failures now log a full traceback and retry on the next access instead of failing silently.
+- **MCP document-body reads** — the `search_documents` and `grep_documents` tool descriptions now direct callers to `grep_documents` for a document's full body.
+
+#### Platform
+
+- **Semantic search admin console** — an on-demand document reindex API with coverage and health endpoints, populated semantic relevance scores, and a search admin console (Coverage, Check an asset, Run history, Try a search) are now available on the v2.1.x line.
+- **Reduced GMS and primary-database load under heavy writes** — a set of caching and asynchronous optimizations trims redundant database work on the aspect-write path: cached data-platform lookups in default-aspect generation, cached resolved retention policies, `EntityClient` default reads routed through the cached `batchGetV2` path, and asynchronous ingestion of assertion-summary patches.
+
+#### Security / Dependencies
+
+- **DuckDB analytics SQL injection (CWE-89)** — the Forms analytics query path is hardened against SQL injection: user queries run on a read-only sandboxed DuckDB connection with external access disabled, SQL is validated by a sqlglot allowlist parser instead of a regex denylist, and the Forms analytics resolver now enforces a `canViewForms` authorization check.
+
 ### v2.1.2
 
 This release rolls up hotfixes on top of v2.1.1.


### PR DESCRIPTION
DataHub Cloud v2.1.3 release notes.

Patch rollup on top of v2.1.2 — prepends a `### v2.1.3` block to `docs/managed-datahub/release-notes/v_2_1_0.md`. No `sidebars.js` change (patch rollup).

## Test plan
- [x] `markdown_format / markdown_format_check (pull_request)` passes
- [x] Release Availability Date filled in before marking ready
- [x] Recommended Versions confirmed by release manager before marking ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v2.1.3 patch-rollup release notes to Managed DataHub and sets the Release Availability Date. No breaking changes or sidebar updates. Highlights: default “View Self” policy is now read-only on a user’s profile; Ask DataHub fixes ensure reliable agent tool palettes and clarify document-body retrieval; semantic search admin console and on-demand reindex API are now available; caching and async writes reduce GMS/DB load; Forms analytics hardened against SQL injection with read-only DuckDB, `sqlglot` allowlist validation, and `canViewForms` authorization.

**Review**
- Change is docs-only: prepends v2.1.3 to `docs/managed-datahub/release-notes/v_2_1_0.md`.
- Confirm Recommended Versions with the release manager.
- Verify `markdown_format` checks pass.

<sup>Written for commit 9ab5f5e5cc943ba278bd01db49546d71950b24a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

