### PR TITLE
fix(auth): accept LoginSource enum names in getSource

### DIFF
--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceControllerTest.java
@@ -280,6 +280,38 @@ public class AuthServiceControllerTest extends AbstractTestNGSpringContextTests 
   }
 
   @Test
+  public void testGenerateSessionTokenForUserEnumNameLoginSourceHeader() throws Exception {
+    // Some clients send LoginSource.name() (PASSWORD_LOGIN) rather than getSource()
+    // (passwordLogin). Both must resolve so loginSource is retained on the usage event.
+    String userId = "testUser";
+    String generatedToken = "test-token";
+
+    Authentication systemAuth = mock(Authentication.class);
+    Actor systemActor = new Actor(ActorType.USER, SYSTEM_CLIENT_ID);
+    when(systemAuth.getActor()).thenReturn(systemActor);
+    when(systemAuth.getCredentials())
+        .thenReturn(String.format("Basic %s:%s", SYSTEM_CLIENT_ID, "systemSecret"));
+    AuthenticationContext.setAuthentication(systemAuth);
+
+    when(mockTokenService.generateAccessToken(eq(TokenType.SESSION), any(Actor.class), anyLong()))
+        .thenReturn(generatedToken);
+    when(mockConfigProvider.getAuthentication()).thenReturn(new AuthenticationConfiguration());
+
+    ObjectNode requestBody = objectMapper.createObjectNode();
+    requestBody.put("userId", userId);
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(DATAHUB_LOGIN_SOURCE_HEADER_NAME, "PASSWORD_LOGIN");
+    HttpEntity<String> httpEntity =
+        new HttpEntity<>(objectMapper.writeValueAsString(requestBody), headers);
+
+    ResponseEntity<String> response =
+        authServiceController.generateSessionTokenForUser(request, httpEntity).join();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    verifyLoginMetric("success", LoginSource.PASSWORD_LOGIN.getSource(), "none");
+  }
+
+  @Test
   public void testGenerateSessionTokenForUserUnauthorized() throws Exception {
     setNonSystemAuthentication();
     ObjectNode requestBody = objectMapper.createObjectNode();

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/event/LoginSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/event/LoginSource.java
@@ -17,10 +17,17 @@ public enum LoginSource {
     this.source = source;
   }
 
+  /**
+   * Resolve a login source from either the camelCase wire value (e.g. {@code passwordLogin}) or the
+   * enum constant name (e.g. {@code PASSWORD_LOGIN}). Matching is case-insensitive.
+   */
   @Nullable
-  public static LoginSource getSource(String name) {
+  public static LoginSource getSource(@Nullable final String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
     for (LoginSource loginSource : LoginSource.values()) {
-      if (loginSource.source.equalsIgnoreCase(name)) {
+      if (loginSource.source.equalsIgnoreCase(name) || loginSource.name().equalsIgnoreCase(name)) {
         return loginSource;
       }
     }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/datahubusage/event/LoginSourceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/datahubusage/event/LoginSourceTest.java
@@ -1,0 +1,45 @@
+package com.linkedin.metadata.datahubusage.event;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.testng.annotations.Test;
+
+public class LoginSourceTest {
+
+  @Test
+  public void testGetSourceAcceptsCamelCaseWireValue() {
+    assertEquals(LoginSource.getSource("passwordLogin"), LoginSource.PASSWORD_LOGIN);
+    assertEquals(LoginSource.getSource("ssoLogin"), LoginSource.SSO_LOGIN);
+  }
+
+  @Test
+  public void testGetSourceAcceptsEnumConstantName() {
+    // Clients and older tests sometimes send the enum name instead of the camelCase source.
+    assertEquals(LoginSource.getSource("PASSWORD_LOGIN"), LoginSource.PASSWORD_LOGIN);
+    assertEquals(LoginSource.getSource("SSO_LOGIN"), LoginSource.SSO_LOGIN);
+    assertEquals(LoginSource.getSource("password_login"), LoginSource.PASSWORD_LOGIN);
+  }
+
+  @Test
+  public void testGetSourceCaseInsensitive() {
+    assertEquals(LoginSource.getSource("PasswordLogin"), LoginSource.PASSWORD_LOGIN);
+    assertEquals(LoginSource.getSource("Password_Login"), LoginSource.PASSWORD_LOGIN);
+  }
+
+  @Test
+  public void testGetSourceUnknownOrBlankReturnsNull() {
+    assertNull(LoginSource.getSource("not-a-real-source"));
+    assertNull(LoginSource.getSource(""));
+    assertNull(LoginSource.getSource("   "));
+    assertNull(LoginSource.getSource(null));
+  }
+
+  @Test
+  public void testGetSourceRoundTripForAllValues() {
+    for (LoginSource loginSource : LoginSource.values()) {
+      assertEquals(LoginSource.getSource(loginSource.getSource()), loginSource);
+      assertEquals(LoginSource.getSource(loginSource.name()), loginSource);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Teach `LoginSource.getSource` to accept both camelCase wire values (`passwordLogin`) and enum constant names (`PASSWORD_LOGIN`), case-insensitively
- Prevents `resolveLoginSource` from treating enum-name headers as `unknown` and dropping `loginSource` from login usage events
- Adds unit coverage in `LoginSourceTest` and an `AuthServiceController` header regression test

Fixes defense-in-depth part of [PFP-5610](https://linear.app/acryl-data/issue/PFP-5610/fix-persistent-ci-failure-in-test-login-events-on-oss-master). Companion smoke-test PR addresses the observed CI flake (`/logIn` 400 under xdist).

## Test plan
- [x] `./gradlew :metadata-service:services:test --tests com.linkedin.metadata.datahubusage.event.LoginSourceTest`
- [x] `./gradlew :metadata-service:auth-servlet-impl:test --tests '*testGenerateSessionTokenForUserEnumNameLoginSourceHeader'`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts enum-name login source headers in addition to camelCase wire values. Previously only camelCase (e.g., passwordLogin) was recognized; now `LoginSource.getSource` also accepts enum constant names (e.g., PASSWORD_LOGIN), case-insensitively, so login usage events retain `loginSource` instead of recording it as unknown. Addresses the defense-in-depth part of PFP-5610.

- Resolves headers in `resolveLoginSource` whether sent as `passwordLogin`, `PASSWORD_LOGIN`, or case variants; blank/unknown still return null.
- Adds `LoginSourceTest` for both formats, case-insensitivity, and null/blank handling, plus an `AuthServiceController` header regression test.

<sup>Written for commit eeb613a66277a3c615ee075220dbcf125842b981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

