### PR TITLE
test(smoke): harden login_as against xdist /logIn 400s

### DIFF
--- a/smoke-test/tests/audit_events/audit_events_test.py
+++ b/smoke-test/tests/audit_events/audit_events_test.py
@@ -57,9 +57,15 @@ def _provision_audit_user(
     from tests.privileges.utils import create_user
 
     admin_user, admin_pass = get_admin_credentials()
-    return TestSessionWrapper(
+    admin_session = TestSessionWrapper(
         create_user(login_as(admin_user, admin_pass), email, password)
     )
+    # Prove native credentials are usable before the test hits /logIn under xdist.
+    # A brief post-signUp window can still return 400 Invalid Credentials even after
+    # MAE sync; absorb that here so test_login_events is not the first caller.
+    probe_session = login_as(email, password)
+    probe_session.cookies.clear()
+    return admin_session
 
 
 def _teardown_audit_user(admin_session: TestSessionWrapper, user_urn: str) -> None:

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -61,8 +61,10 @@ def get_frontend_session():
 
 @tenacity.retry(
     retry=tenacity.retry_if_exception(_is_transient_login_error),
-    stop=tenacity.stop_after_attempt(5),
-    wait=tenacity.wait_exponential(multiplier=1, min=1, max=8),
+    # Under xdist, parallel /logIn traffic can return transient 400s for longer than
+    # five attempts cover (see PFP-5610 test_login_events). Give more runway.
+    stop=tenacity.stop_after_attempt(10),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=12),
     reraise=True,
 )
 def login_as(username: str, password: str):


### PR DESCRIPTION
## Summary
- Increase `login_as` retry budget for transient `/logIn` 400/429 under pytest-xdist
- After provisioning audit users, probe a successful login so credentials are usable before `test_login_events` runs

Root cause for [PFP-5610](https://linear.app/acryl-data/issue/PFP-5610/fix-persistent-ci-failure-in-test-login-events-on-oss-master): CI failed at `login_as` with `HTTP 400` on `/logIn`, not on the `loginSource` assertion. Companion production PR hardens `LoginSource.getSource` for enum-name headers.

## Test plan
- [x] `./gradlew :metadata-ingestion:lintFix` on touched smoke-test files
- [ ] CI smoke batch covering `tests/audit_events/audit_events_test.py::test_login_events`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces CI flakiness in smoke tests by hardening logins under `pytest-xdist`. Previously `login_as` often failed with transient `/logIn` 400/429 before assertions in `test_login_events`; now it retries longer and we verify audit-user credentials upfront to avoid first-call failures.

**Changes and impact**
- `login_as`: increase `tenacity` retries 5→10 and max backoff 8s→12s; failures take longer to declare, success path unchanged.
- After audit-user provisioning, perform a one-time login probe and clear cookies to absorb brief post-signup “Invalid Credentials” windows.
- Addresses Linear PFP-5610 (persistent `test_login_events` failures under parallel workers); adds one extra `/logIn` per audit user and may add a few seconds to failing runs.

<sup>Written for commit c1a2d1319092e55800e0961c2e859824d3bd7fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

