### PR TITLE
feat(agent-context): add SchemaFieldEntity incident fragment to list_incidents

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
@@ -83,6 +83,11 @@ query listEntityIncidents(
                 ...entityIncidentsResultFields                         #[NEWER_GMS]
             }                                                          #[NEWER_GMS]
         }                                                              #[NEWER_GMS]
+        ... on SchemaFieldEntity {                                      #[NEWER_GMS]
+            incidents(state: $state, start: $start, count: $count) {   #[NEWER_GMS]
+                ...entityIncidentsResultFields                         #[NEWER_GMS]
+            }                                                          #[NEWER_GMS]
+        }                                                              #[NEWER_GMS]
     }
 }
 


### PR DESCRIPTION
Follow-up to #18341 per the post-merge request: #19115 landed SchemaFieldEntity incident support, so LIST_INCIDENTS_QUERY now carries the matching inline fragment. Gated behind #[NEWER_GMS] like the ML fragments, so older servers are unaffected. MLFeatureTable to follow when PR3 opens.

---

*AI-assisted.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SchemaFieldEntity incident support to the list_incidents query, enabling field-level incident retrieval on newer GMS. Previously, list_incidents omitted SchemaFieldEntity; now it includes an inline fragment gated by NEWER_GMS so older servers behave the same.

- Adds an inline fragment for SchemaFieldEntity incidents using the existing entityIncidentsResultFields, guarded by NEWER_GMS.
- No API changes; responses on compatible servers may now include SchemaFieldEntity incidents.
- No migration required; behavior on older servers is unchanged.

<sup>Written for commit 220a8f72897d1027070ea77b733cf51036a7fe33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

