### PR TITLE
fix(gms): add @noAspects to SchemaFieldEntity incidents field

### DIFF
--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -786,5 +786,5 @@ extend type SchemaFieldEntity {
     Optional number of results to return, defaults to 20.
     """
     count: Int
-  ): EntityIncidentsResult
+  ): EntityIncidentsResult @noAspects
 }


### PR DESCRIPTION
AspectMappingCompletenessTest failed on master after merging the GraphQL aspect-fetch optimization because SchemaFieldEntity.incidents was added without an aspect directive. Mark it @noAspects like other entity incidents fields.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks SchemaFieldEntity.incidents as @noAspects to align with other entity incidents fields and fix AspectMappingCompletenessTest after the GraphQL aspect-fetch optimization. Previously this field was treated as aspect-backed; now it resolves without aspect fetch. No API shape changes.

- One-line change in datahub-graphql-core/src/main/resources/incident.graphql.
- No migration or client updates required; removes unnecessary aspect reads and restores test pass.

<sup>Written for commit 61dd8e5705b9c982fe55aea58e46fe77537f0286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

