### PR TITLE
feat(lineage): show column descriptions on hover in lineage graph

### DIFF
--- a/datahub-web-react/src/app/entityV2/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entityV2/EntityRegistry.tsx
@@ -298,6 +298,7 @@ export default class EntityRegistry {
                         type: LineageAssetType.Column,
                         dataType: field.type,
                         nativeDataType: field.nativeDataType,
+                        description: field.description,
                     };
                     return [name, value];
                 }),

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
@@ -224,7 +224,14 @@ export default function Column({
                     <CompactFieldIconWithTooltip type={type} nativeDataType={nativeDataType} />
                 </TypeWrapper>
             )}
-            <ColumnText ellipsis={{ tooltip: { showArrow: false } }}>{columnName}</ColumnText>
+            {/* When the field has a description, show it instead of the name-truncation tooltip:
+                it is the more useful thing to surface on hover, and antd's ellipsis tooltip only
+                fires when the name actually overflows. */}
+            <Tooltip title={lineageAsset.description || undefined} mouseEnterDelay={0.3}>
+                <ColumnText ellipsis={{ tooltip: lineageAsset.description ? false : { showArrow: false } }}>
+                    {columnName}
+                </ColumnText>
+            </Tooltip>
             {loading && !hasLineage && <Spin indicator={<StyledLoadingIndicator />} />}
             {config.featureFlags.schemaFieldCLLEnabled && (
                 <ColumnLinkWrapper

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Column.tsx
@@ -106,6 +106,11 @@ const ColumnText = styled(Typography.Text)`
     color: inherit;
 `;
 
+const TooltipColumnName = styled.div`
+    font-weight: 600;
+    word-break: break-all;
+`;
+
 const StyledLoadingIndicator = styled(LoadingOutlined)`
     display: flex;
     font-size: inherit;
@@ -224,10 +229,20 @@ export default function Column({
                     <CompactFieldIconWithTooltip type={type} nativeDataType={nativeDataType} />
                 </TypeWrapper>
             )}
-            {/* When the field has a description, show it instead of the name-truncation tooltip:
-                it is the more useful thing to surface on hover, and antd's ellipsis tooltip only
-                fires when the name actually overflows. */}
-            <Tooltip title={lineageAsset.description || undefined} mouseEnterDelay={0.3}>
+            {/* Show the description on hover. This replaces antd's ellipsis tooltip, which only
+                fires when the name overflows, so the name is repeated above the description to
+                keep a truncated name readable. */}
+            <Tooltip
+                title={
+                    lineageAsset.description ? (
+                        <>
+                            <TooltipColumnName>{columnName}</TooltipColumnName>
+                            {lineageAsset.description}
+                        </>
+                    ) : undefined
+                }
+                mouseEnterDelay={0.3}
+            >
                 <ColumnText ellipsis={{ tooltip: lineageAsset.description ? false : { showArrow: false } }}>
                     {columnName}
                 </ColumnText>

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.test.tsx
@@ -1,0 +1,98 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ReactFlowProvider } from 'reactflow';
+
+import Column from '@app/lineageV3/LineageEntityNode/Column';
+import { ColumnAsset, LineageAssetType } from '@app/lineageV3/types';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType, SchemaFieldDataType } from '@types';
+
+vi.mock('@app/useAppConfig', () => ({
+    useAppConfig: () => ({
+        config: {
+            featureFlags: {
+                schemaFieldCLLEnabled: false,
+                schemaFieldLineageIgnoreStatus: false,
+            },
+        },
+    }),
+}));
+
+vi.mock('@app/lineageV3/utils/lineageUtils', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@app/lineageV3/utils/lineageUtils')>()),
+    useGetLineageUrl: () => '/lineage/test',
+}));
+
+vi.mock('@app/lineage/utils/useGetLineageTimeParams', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@app/lineage/utils/useGetLineageTimeParams')>()),
+    useGetLineageTimeParams: () => ({ startTimeMillis: undefined, endTimeMillis: undefined }),
+}));
+
+vi.mock('@graphql/lineage.generated', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@graphql/lineage.generated')>()),
+    useGetLineageCountsLazyQuery: () => [vi.fn(), { loading: false }],
+}));
+
+function buildColumnAsset(description?: string | null): ColumnAsset {
+    return {
+        name: 'user_id',
+        type: LineageAssetType.Column,
+        dataType: SchemaFieldDataType.String,
+        nativeDataType: 'varchar',
+        description,
+    };
+}
+
+function renderColumn(lineageAsset: ColumnAsset) {
+    return render(
+        <MockedProvider mocks={[]}>
+            <TestPageContainer>
+                <ReactFlowProvider>
+                    <Column
+                        parentUrn="urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)"
+                        entityType={EntityType.Dataset}
+                        fieldPath={lineageAsset.name}
+                        highlighted={false}
+                        hasLineage={false}
+                        connectedToHomeNode={false}
+                        type={lineageAsset.dataType}
+                        nativeDataType={lineageAsset.nativeDataType}
+                        lineageAsset={lineageAsset}
+                        allNeighborsFetched
+                        selectedColumn={null}
+                        setSelectedColumn={vi.fn()}
+                        hoveredColumn={null}
+                        setHoveredColumn={vi.fn()}
+                    />
+                </ReactFlowProvider>
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+}
+
+describe('Column description tooltip', () => {
+    it('shows the field description on hover', async () => {
+        renderColumn(buildColumnAsset('Unique identifier for the user'));
+
+        fireEvent.mouseOver(screen.getByText('user_id'));
+
+        await waitFor(() => {
+            expect(screen.getByText('Unique identifier for the user')).toBeInTheDocument();
+        });
+    });
+
+    it('renders the column without a tooltip body when there is no description', async () => {
+        renderColumn(buildColumnAsset(null));
+
+        const columnText = screen.getByText('user_id');
+        fireEvent.mouseOver(columnText);
+
+        // The column still renders; only the description tooltip is absent.
+        expect(columnText).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.queryByText('Unique identifier for the user')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/__tests__/Column.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { ReactFlowProvider } from 'reactflow';
 
@@ -83,16 +83,25 @@ describe('Column description tooltip', () => {
         });
     });
 
-    it('renders the column without a tooltip body when there is no description', async () => {
+    it('repeats the column name in the tooltip so a truncated name stays readable', async () => {
+        renderColumn(buildColumnAsset('Unique identifier for the user'));
+
+        fireEvent.mouseOver(screen.getByText('user_id'));
+
+        const tooltip = await screen.findByRole('tooltip');
+        expect(within(tooltip).getByText('user_id')).toBeInTheDocument();
+        expect(within(tooltip).getByText('Unique identifier for the user')).toBeInTheDocument();
+    });
+
+    it('renders no tooltip on hover when there is no description', async () => {
         renderColumn(buildColumnAsset(null));
 
-        const columnText = screen.getByText('user_id');
-        fireEvent.mouseOver(columnText);
+        fireEvent.mouseOver(screen.getByText('user_id'));
 
-        // The column still renders; only the description tooltip is absent.
-        expect(columnText).toBeInTheDocument();
+        // Guard, not a red-green case: with no description there is nothing to show, and antd's
+        // ellipsis tooltip does not fire because the name does not overflow in jsdom.
         await waitFor(() => {
-            expect(screen.queryByText('Unique identifier for the user')).not.toBeInTheDocument();
+            expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
         });
     });
 });

--- a/datahub-web-react/src/app/lineageV3/types.ts
+++ b/datahub-web-react/src/app/lineageV3/types.ts
@@ -32,6 +32,7 @@ export interface ColumnAsset extends LineageAssetBase {
     type: LineageAssetType.Column;
     dataType?: SchemaFieldDataType;
     nativeDataType?: string | null;
+    description?: string | null;
 }
 
 interface EntityAsset extends LineageAssetBase {

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -758,6 +758,7 @@ fragment lineageSchemaField on SchemaField {
     fieldPath
     type
     nativeDataType
+    description
 }
 
 fragment entityLineageV2 on Entity {


### PR DESCRIPTION
### Summary

Fixes #18320.

Column nodes in the v3 lineage graph render only the field name, so a user exploring lineage has to leave the graph to find out what a column actually means. This adds the field's description as a hover tooltip on the column label.

### Changes

- `graphql/lineage.graphql` — request `description` on the `lineageSchemaField` fragment.
- `lineageV3/types.ts` — add `description?: string | null` to `ColumnAsset`.
- `entityV2/EntityRegistry.tsx` — populate it in `getLineageAssets`.
- `lineageV3/LineageEntityNode/Column.tsx` — wrap the column label in a `Tooltip` showing the description. When a description exists, antd's ellipsis tooltip is disabled: it only fires when the name overflows and shows nothing beyond the name itself, so the description is strictly the more useful hover target.

Only the source (ingested) description is used. Editable schema metadata is deliberately not fetched here — it would mean widening the lineage query for every column on the graph.

### Testing

- New `LineageEntityNode/__tests__/Column.test.tsx`: description renders on hover; no tooltip body when the description is null. The hover test is red-green verified: it fails with the `Column.tsx` change reverted and passes with it restored. The null-description case is a guard that passes either way.
- Existing lineageV3 suite passes (147 tests).
- `tsc` clean.

### Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issues
- [x] Tests for the changes have been added
- [ ] Docs related to the changes have been added/updated — n/a, no user-facing config or API surface
- [ ] Updating DataHub entry — n/a, not a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show column descriptions on hover in the v3 lineage graph so users can understand fields without leaving the graph. Previously column nodes showed only the name with an `antd` ellipsis tooltip; now we show the source description and repeat the column name in the tooltip, suppressing the ellipsis tooltip when a description exists.

- Request `description` in the `lineageSchemaField` GraphQL fragment and plumb it through `ColumnAsset` via `EntityRegistry`.
- Render a tooltip on the column label that shows the column name above the description; use the ellipsis tooltip only when no description exists.
- Use only the source (ingested) description to avoid widening queries for editable schema metadata.
- Add tests for description on hover, name-in-tooltip, and the null-description case.

<sup>Written for commit 34b2c1b937b43c55d8fea981e94c009de6139902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

