### PR TITLE
feat(ingest/powerbi): report why an M-Query expression yielded no lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -265,6 +265,15 @@ class PowerBiDashboardSourceReport(StaleEntityRemovalSourceReport):
     m_query_resolver_errors: int = 0
     m_query_resolver_no_lineage: int = 0
     m_query_resolver_successes: int = 0
+    # NodeKinds the resolver walk could not follow, against the number of tables
+    # each affected. Non-empty means some M shape is unsupported, which is the
+    # usual reason an expression parses and still yields no lineage.
+    m_query_unhandled_node_kinds: Dict[str, int] = dataclass_field(default_factory=dict)
+    # Sample of tables whose expression parsed but produced no lineage, so the
+    # count above has concrete examples behind it.
+    m_query_tables_without_lineage: LossyList[str] = dataclass_field(
+        default_factory=LossyList
+    )
 
     def report_dashboards_scanned(self, count: int = 1) -> None:
         self.dashboards_scanned += count

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -274,6 +274,12 @@ class PowerBiDashboardSourceReport(StaleEntityRemovalSourceReport):
     m_query_tables_without_lineage: LossyList[str] = dataclass_field(
         default_factory=LossyList
     )
+    # Sample of "<table> -> <name>" pairs where the expression references a name
+    # it does not define. A name recurring across many tables is usually a query
+    # that is not loaded into the model.
+    m_query_unresolved_identifiers: LossyList[str] = dataclass_field(
+        default_factory=LossyList
+    )
 
     def report_dashboards_scanned(self, count: int = 1) -> None:
         self.dashboards_scanned += count

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
@@ -53,10 +53,14 @@ class DataAccessResolution:
     # an M shape the resolver does not model, which is the usual reason an
     # expression parses cleanly and still yields no lineage.
     unhandled_node_kinds: Set[str] = field(default_factory=set)
-    # Names the expression references but does not define: another query in the
-    # model, or an outer-scope name reached from a nested let. Known dataset
-    # parameters are excluded, since those are values rather than tables.
+    # Names the expression references but does not define anywhere -- typically
+    # another query in the model that is not loaded. Dataset parameters are
+    # excluded, since those are values rather than tables.
     unresolved_identifiers: Set[str] = field(default_factory=set)
+    # Every name bound by any let in the expression. A name in here that the walk
+    # fails to resolve is merely out of the walk's reach, not absent from the
+    # model, so it is kept out of unresolved_identifiers.
+    let_bound_names: Set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
@@ -57,9 +57,10 @@ class DataAccessResolution:
     # another query in the model that is not loaded. Dataset parameters are
     # excluded, since those are values rather than tables.
     unresolved_identifiers: Set[str] = field(default_factory=set)
-    # Every name bound by any let in the expression. A name in here that the walk
-    # fails to resolve is merely out of the walk's reach, not absent from the
-    # model, so it is kept out of unresolved_identifiers.
+    # Every name bound by any let in the expression, casefolded to agree with
+    # identifier lookup. A name in here that the walk fails to resolve is merely
+    # out of the walk's reach, not absent from the model, so it is kept out of
+    # unresolved_identifiers.
     let_bound_names: Set[str] = field(default_factory=set)
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from datahub.configuration.env_vars import get_trace_powerbi_mquery_parser
 from datahub.ingestion.source.powerbi.config import DataPlatformPair
@@ -44,6 +44,15 @@ class DataAccessFunctionDetail:
     identifier_accessor: Optional[IdentifierAccessor]
     node_map: Dict[int, dict] = field(repr=False)  # full NodeIdMap for ast_utils
     parameters: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DataAccessResolution:
+    functions: List[DataAccessFunctionDetail]
+    # NodeKinds the walk could not follow. Non-empty means the expression uses
+    # an M shape the resolver does not model, which is the usual reason an
+    # expression parses cleanly and still yields no lineage.
+    unhandled_node_kinds: Set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
@@ -53,6 +53,10 @@ class DataAccessResolution:
     # an M shape the resolver does not model, which is the usual reason an
     # expression parses cleanly and still yields no lineage.
     unhandled_node_kinds: Set[str] = field(default_factory=set)
+    # Names the expression references but does not define: another query in the
+    # model, or an outer-scope name reached from a nested let. Known dataset
+    # parameters are excluded, since those are values rather than tables.
+    unresolved_identifiers: Set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
@@ -140,9 +140,17 @@ def get_upstream_tables(
     reporter.m_query_parse_successes += 1
 
     try:
-        data_access_func_details = mquery_resolver.resolve_to_data_access_functions(
+        resolution = mquery_resolver.resolve_to_data_access_functions(
             node_map, parameters=parameters
         )
+        data_access_func_details = resolution.functions
+
+        # Count each kind once per table, so the tally reads as "tables affected"
+        # rather than "nodes encountered".
+        for node_kind in resolution.unhandled_node_kinds:
+            reporter.m_query_unhandled_node_kinds[node_kind] = (
+                reporter.m_query_unhandled_node_kinds.get(node_kind, 0) + 1
+            )
 
         if not data_access_func_details:
             logger.debug(
@@ -178,6 +186,7 @@ def get_upstream_tables(
             reporter.m_query_resolver_successes += 1
         else:
             reporter.m_query_resolver_no_lineage += 1
+            reporter.m_query_tables_without_lineage.append(table.full_name)
             if data_access_func_details:
                 # Function(s) were recognized but all handlers returned empty —
                 # the per-handler debug logs above explain why. Log the expression

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
@@ -152,6 +152,11 @@ def get_upstream_tables(
                 reporter.m_query_unhandled_node_kinds.get(node_kind, 0) + 1
             )
 
+        for unresolved in sorted(resolution.unresolved_identifiers):
+            reporter.m_query_unresolved_identifiers.append(
+                f"{table.full_name} -> {unresolved}"
+            )
+
         if not data_access_func_details:
             logger.debug(
                 "No recognized data-access function found in expression for table %s."

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
@@ -373,6 +373,11 @@ def _walk_identifier_name(
     seen.add(guard_key)
 
     resolved = resolve_identifier(node_map, current_let, name)
+    if resolved is None and name not in (parameters or {}):
+        # Not a variable in this scope and not a dataset parameter, so the walk
+        # ends here without reaching an unhandled node kind.
+        resolution.unresolved_identifiers.add(name)
+
     _walk(
         node_map,
         resolved,

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
@@ -10,6 +10,7 @@ from datahub.ingestion.source.powerbi.m_query.ast_utils import (
     NodeIdMap,
     get_record_field_values,
     resolve_identifier,
+    resolve_parameter_value,
 )
 from datahub.ingestion.source.powerbi.m_query.data_classes import (
     DataAccessFunctionDetail,
@@ -21,6 +22,11 @@ from datahub.ingestion.source.powerbi.m_query.data_classes import (
 logger = logging.getLogger(__name__)
 
 _RECOGNIZED_FUNCTIONS: FrozenSet[str] = frozenset(f.value for f in FunctionName)
+
+# Where the walk ends on a plain value rather than on a shape it cannot model.
+# An unrecognized source recurses into its first argument, so its URL or path
+# literal would otherwise dominate the unhandled-kind tally.
+_VALUE_LEAF_NODE_KINDS: FrozenSet[str] = frozenset({"LiteralExpression"})
 
 
 def resolve_to_data_access_functions(
@@ -37,6 +43,8 @@ def resolve_to_data_access_functions(
     let_nodes = [
         (k, v) for k, v in node_map.items() if v.get("kind") == "LetExpression"
     ]
+    for _, let_node in let_nodes:
+        resolution.let_bound_names.update(_let_variable_names(let_node))
     if not let_nodes:
         logger.debug("No LetExpression found in node map")
         return resolution
@@ -211,7 +219,8 @@ def _walk(
         )
         return
 
-    resolution.unhandled_node_kinds.add(kind)
+    if kind not in _VALUE_LEAF_NODE_KINDS:
+        resolution.unhandled_node_kinds.add(kind)
     logger.debug("Unhandled node kind '%s', returning empty for this branch", kind)
 
 
@@ -321,6 +330,14 @@ def _walk_invoke(
                 parameters=parameters or {},
             )
         )
+        # The handler still needs a server and database out of these arguments,
+        # so an argument naming something the expression never defines loses the
+        # lineage even though the function itself was recognized. Only identifier
+        # arguments are examined -- walking the whole argument list would file
+        # option records as unmodelled shapes.
+        _record_unresolved_arguments(
+            node_map, invoke_node, current_let, resolution, parameters
+        )
         return
 
     # Unrecognized wrapper (Table.RenameColumns, Table.AddColumn, etc.)
@@ -341,6 +358,73 @@ def _walk_invoke(
                     parameters,
                 )
                 return  # only first arg
+
+
+def _record_unresolved_arguments(
+    node_map: NodeIdMap,
+    invoke_node: dict,
+    current_let: dict,
+    resolution: DataAccessResolution,
+    parameters: Optional[Dict[str, str]],
+) -> None:
+    """Note identifier arguments of a recognized call that resolve to nothing."""
+    content = invoke_node.get("content", {})
+    if not isinstance(content, dict) or content.get("kind") != "ArrayWrapper":
+        return
+
+    for elem in content.get("elements", []):
+        inner = _unwrap_csv(elem)
+        if not isinstance(inner, dict) or inner.get("kind") != "IdentifierExpression":
+            continue
+        name = inner.get("identifier", {}).get("literal", "")
+        if name.startswith('#"') and name.endswith('"'):
+            name = name[2:-1]
+        if not name:
+            continue
+        if resolve_identifier(node_map, current_let, name) is None:
+            _record_unresolved(resolution, name, parameters)
+
+
+def _let_variable_names(let_node: dict) -> Set[str]:
+    """Names bound by one LetExpression, with any #"..." quoting stripped."""
+    names: Set[str] = set()
+    var_list = let_node.get("variableList", {})
+    if not isinstance(var_list, dict):
+        return names
+
+    for elem in var_list.get("elements", []):
+        inner = _unwrap_csv(elem)
+        if not isinstance(inner, dict):
+            continue
+        key = inner.get("key", {})
+        if not isinstance(key, dict):
+            continue
+        literal = key.get("literal", "")
+        if literal.startswith('#"') and literal.endswith('"'):
+            literal = literal[2:-1]
+        if literal:
+            names.add(literal)
+
+    return names
+
+
+def _record_unresolved(
+    resolution: DataAccessResolution,
+    name: str,
+    parameters: Optional[Dict[str, str]],
+) -> None:
+    """Note a name the walk could not resolve to anything.
+
+    Skips dataset parameters, which are values rather than tables, and names the
+    expression binds in another let -- those are in scope for the model even when
+    this walk cannot reach them, so reporting them would point at a query that
+    does not exist.
+    """
+    if name in resolution.let_bound_names:
+        return
+    if resolve_parameter_value(parameters, name) is not None:
+        return
+    resolution.unresolved_identifiers.add(name)
 
 
 def _unwrap_csv(elem: object) -> Optional[dict]:
@@ -373,10 +457,8 @@ def _walk_identifier_name(
     seen.add(guard_key)
 
     resolved = resolve_identifier(node_map, current_let, name)
-    if resolved is None and name not in (parameters or {}):
-        # Not a variable in this scope and not a dataset parameter, so the walk
-        # ends here without reaching an unhandled node kind.
-        resolution.unresolved_identifiers.add(name)
+    if resolved is None:
+        _record_unresolved(resolution, name, parameters)
 
     _walk(
         node_map,

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
@@ -386,7 +386,12 @@ def _record_unresolved_arguments(
 
 
 def _let_variable_names(let_node: dict) -> Set[str]:
-    """Names bound by one LetExpression, with any #"..." quoting stripped."""
+    """Casefolded names bound by one LetExpression, with #"..." quoting stripped.
+
+    Folded because resolve_identifier matches names case-insensitively, so the
+    in-scope check has to agree with it or a binding spelled `Sch` referenced as
+    `sch` reads as a missing query.
+    """
     names: Set[str] = set()
     var_list = let_node.get("variableList", {})
     if not isinstance(var_list, dict):
@@ -403,7 +408,7 @@ def _let_variable_names(let_node: dict) -> Set[str]:
         if literal.startswith('#"') and literal.endswith('"'):
             literal = literal[2:-1]
         if literal:
-            names.add(literal)
+            names.add(literal.casefold())
 
     return names
 
@@ -420,7 +425,7 @@ def _record_unresolved(
     this walk cannot reach them, so reporting them would point at a query that
     does not exist.
     """
-    if name in resolution.let_bound_names:
+    if name.casefold() in resolution.let_bound_names:
         return
     if resolve_parameter_value(parameters, name) is not None:
         return

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
@@ -4,7 +4,7 @@ entries (recognized data-source function calls with their navigation chain).
 """
 
 import logging
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, Optional, Set, Tuple
 
 from datahub.ingestion.source.powerbi.m_query.ast_utils import (
     NodeIdMap,
@@ -13,6 +13,7 @@ from datahub.ingestion.source.powerbi.m_query.ast_utils import (
 )
 from datahub.ingestion.source.powerbi.m_query.data_classes import (
     DataAccessFunctionDetail,
+    DataAccessResolution,
     FunctionName,
     IdentifierAccessor,
 )
@@ -25,18 +26,20 @@ _RECOGNIZED_FUNCTIONS: FrozenSet[str] = frozenset(f.value for f in FunctionName)
 def resolve_to_data_access_functions(
     node_map: NodeIdMap,
     parameters: Optional[Dict[str, str]] = None,
-) -> List[DataAccessFunctionDetail]:
+) -> DataAccessResolution:
     """
-    Entry point: walk the NodeIdMap and return all DataAccessFunctionDetail entries
-    for recognized data-access function calls in the expression.
+    Entry point: walk the NodeIdMap and return the recognized data-access function
+    calls in the expression, along with any NodeKinds the walk could not follow.
     """
     parameters = parameters or {}
+    resolution = DataAccessResolution(functions=[])
+
     let_nodes = [
         (k, v) for k, v in node_map.items() if v.get("kind") == "LetExpression"
     ]
     if not let_nodes:
         logger.debug("No LetExpression found in node map")
-        return []
+        return resolution
 
     # Use the outermost let (smallest id = parsed first / outermost scope)
     root_let_id, root_let = min(let_nodes, key=lambda kv: kv[0])
@@ -48,9 +51,8 @@ def resolve_to_data_access_functions(
             "LetExpression (id=%d) has no output expression — cannot resolve lineage",
             root_let_id,
         )
-        return []
+        return resolution
 
-    results: List[DataAccessFunctionDetail] = []
     seen: Set[Tuple[int, str]] = set()
 
     _walk(
@@ -59,11 +61,11 @@ def resolve_to_data_access_functions(
         current_let=root_let,
         current_let_id=root_let_id,
         accessor_chain=None,
-        results=results,
+        resolution=resolution,
         seen=seen,
         parameters=parameters,
     )
-    return results
+    return resolution
 
 
 def _walk(
@@ -72,7 +74,7 @@ def _walk(
     current_let: dict,
     current_let_id: int,
     accessor_chain: Optional[IdentifierAccessor],
-    results: List[DataAccessFunctionDetail],
+    resolution: DataAccessResolution,
     seen: Set[Tuple[int, str]],
     parameters: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -94,7 +96,7 @@ def _walk(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -111,7 +113,7 @@ def _walk(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -127,7 +129,7 @@ def _walk(
             node,
             inner_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -143,7 +145,7 @@ def _walk(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -163,7 +165,7 @@ def _walk(
                     current_let,
                     current_let_id,
                     accessor_chain,
-                    results,
+                    resolution,
                     seen.copy(),
                     parameters,
                 )
@@ -179,7 +181,7 @@ def _walk(
                 current_let,
                 current_let_id,
                 accessor_chain,
-                results,
+                resolution,
                 seen,
                 parameters,
             )
@@ -193,7 +195,7 @@ def _walk(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -203,12 +205,13 @@ def _walk(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen.copy(),
             parameters,
         )
         return
 
+    resolution.unhandled_node_kinds.add(kind)
     logger.debug("Unhandled node kind '%s', returning empty for this branch", kind)
 
 
@@ -218,7 +221,7 @@ def _walk_recursive_primary(
     current_let: dict,
     current_let_id: int,
     accessor_chain: Optional[IdentifierAccessor],
-    results: List[DataAccessFunctionDetail],
+    resolution: DataAccessResolution,
     seen: Set[Tuple[int, str]],
     parameters: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -233,7 +236,7 @@ def _walk_recursive_primary(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -250,7 +253,7 @@ def _walk_recursive_primary(
             current_let,
             current_let_id,
             accessor_chain,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -274,7 +277,7 @@ def _walk_recursive_primary(
             current_let,
             current_let_id,
             new_accessor,
-            results,
+            resolution,
             seen,
             parameters,
         )
@@ -287,7 +290,7 @@ def _walk_recursive_primary(
         current_let,
         current_let_id,
         accessor_chain,
-        results,
+        resolution,
         seen,
         parameters,
     )
@@ -300,7 +303,7 @@ def _walk_invoke(
     current_let: dict,
     current_let_id: int,
     accessor_chain: Optional[IdentifierAccessor],
-    results: List[DataAccessFunctionDetail],
+    resolution: DataAccessResolution,
     seen: Set[Tuple[int, str]],
     parameters: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -309,7 +312,7 @@ def _walk_invoke(
         callee = head.get("identifier", {}).get("literal")
 
     if callee and callee in _RECOGNIZED_FUNCTIONS:
-        results.append(
+        resolution.functions.append(
             DataAccessFunctionDetail(
                 arg_list=invoke_node,
                 data_access_function_name=callee,
@@ -333,7 +336,7 @@ def _walk_invoke(
                     current_let,
                     current_let_id,
                     accessor_chain,
-                    results,
+                    resolution,
                     seen,
                     parameters,
                 )
@@ -355,7 +358,7 @@ def _walk_identifier_name(
     current_let: dict,
     current_let_id: int,
     accessor_chain: Optional[IdentifierAccessor],
-    results: List[DataAccessFunctionDetail],
+    resolution: DataAccessResolution,
     seen: Set[Tuple[int, str]],
     parameters: Optional[Dict[str, str]] = None,
 ) -> None:
@@ -376,7 +379,7 @@ def _walk_identifier_name(
         current_let,
         current_let_id,
         accessor_chain,
-        results,
+        resolution,
         seen,
         parameters,
     )

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -2009,3 +2009,49 @@ def test_table_without_lineage_is_sampled():
 
     assert reporter.m_query_resolver_no_lineage == 1
     assert "MyDataSet.web_table" in reporter.m_query_tables_without_lineage
+
+
+@pytest.mark.integration
+def test_unresolved_identifier_is_reported():
+    """A reference to a name the expression does not define -- another query, or
+    an outer-scope name seen from a nested let -- is named in the report."""
+    reporter = _resolve_and_report(
+        'let Source = #"Hidden Base Query",'
+        " out = Table.SelectRows(Source, each true) in out",
+        "MyDataSet.combined_table",
+    )
+
+    unresolved = list(reporter.m_query_unresolved_identifiers)
+    assert any("Hidden Base Query" in entry for entry in unresolved), (
+        f"Expected the unresolved query name to be reported; got: {unresolved}"
+    )
+    assert any("MyDataSet.combined_table" in entry for entry in unresolved), (
+        f"Expected the referencing table to be reported; got: {unresolved}"
+    )
+
+
+@pytest.mark.integration
+def test_known_parameter_is_not_reported_as_unresolved():
+    """A dataset parameter is not a missing query reference, so it must not be
+    reported as one -- otherwise every unsupported source produces noise."""
+    table: powerbi_data_classes.Table = powerbi_data_classes.Table(
+        columns=[],
+        measures=[],
+        expression="let Source = Web.Contents(BaseUrl) in Source",
+        name="param_table",
+        full_name="MyDataSet.param_table",
+    )
+
+    reporter = PowerBiDashboardSourceReport()
+    ctx, config, platform_instance_resolver = get_default_instances()
+
+    parser.get_upstream_tables(
+        table,
+        reporter,
+        ctx=ctx,
+        config=config,
+        platform_instance_resolver=platform_instance_resolver,
+        parameters={"BaseUrl": "https://example.com"},
+    )
+
+    assert list(reporter.m_query_unresolved_identifiers) == []

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -2130,3 +2130,22 @@ def test_parameter_matched_case_insensitively_is_not_reported():
     )
 
     assert list(reporter.m_query_unresolved_identifiers) == []
+
+
+@pytest.mark.integration
+def test_outer_scope_name_differing_only_by_case_is_not_reported():
+    """Identifier lookup folds case, so the in-scope check must too -- otherwise
+    an outer binding spelled `Sch` and referenced as `sch` is reported as a
+    missing query."""
+    reporter = _resolve_and_report(
+        "let"
+        '    Source = Databricks.Catalogs("adb-123.azuredatabricks.net",'
+        ' "/sql/1.0/endpoints/abc", [Database=null, Catalog="c"]),'
+        '    db = Source{[Name="c",Kind="Database"]}[Data],'
+        '    Sch = db{[Name="s",Kind="Schema"]}[Data],'
+        '    out = let t = sch{[Name="t",Kind="Table"]}[Data] in t'
+        " in out",
+        "MyDataSet.cased_table",
+    )
+
+    assert list(reporter.m_query_unresolved_identifiers) == []

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -2055,3 +2055,78 @@ def test_known_parameter_is_not_reported_as_unresolved():
     )
 
     assert list(reporter.m_query_unresolved_identifiers) == []
+
+
+@pytest.mark.integration
+def test_value_leaf_is_not_reported_as_unhandled_kind():
+    """An unsupported source's argument literal is a value, not an M shape the
+    resolver cannot model, so it must not dilute the unhandled-kind tally."""
+    reporter = _resolve_and_report(
+        'let Source = Web.Contents("https://example.com/data.json") in Source',
+        "MyDataSet.web_table",
+    )
+
+    assert "LiteralExpression" not in reporter.m_query_unhandled_node_kinds
+
+
+@pytest.mark.integration
+def test_undefined_argument_of_recognized_function_is_reported():
+    """A recognized data-access call whose argument is undefined still loses its
+    lineage, so the undefined name must be named."""
+    reporter = _resolve_and_report(
+        'let Source = Snowflake.Databases(MissingServer, "wh") in Source',
+        "MyDataSet.snowflake_table",
+    )
+
+    unresolved = list(reporter.m_query_unresolved_identifiers)
+    assert any("MissingServer" in entry for entry in unresolved), (
+        f"Expected the undefined argument to be reported; got: {unresolved}"
+    )
+
+
+@pytest.mark.integration
+def test_outer_scope_name_is_not_reported_as_unresolved():
+    """A name the expression binds in an enclosing let is in scope for the model
+    even when this walk cannot reach it, so reporting it as a missing reference
+    would point at a query that does not exist."""
+    reporter = _resolve_and_report(
+        "let"
+        '    Source = Databricks.Catalogs("adb-123.azuredatabricks.net",'
+        ' "/sql/1.0/endpoints/abc", [Database=null, Catalog="c"]),'
+        '    db = Source{[Name="c",Kind="Database"]}[Data],'
+        '    sch = db{[Name="s",Kind="Schema"]}[Data],'
+        '    out = let t = sch{[Name="t",Kind="Table"]}[Data] in t'
+        " in out",
+        "MyDataSet.nested_table",
+    )
+
+    unresolved = list(reporter.m_query_unresolved_identifiers)
+    assert not any("-> sch" in entry for entry in unresolved), (
+        f"`sch` is bound by the enclosing let and must not be reported; got: {unresolved}"
+    )
+
+
+@pytest.mark.integration
+def test_parameter_matched_case_insensitively_is_not_reported():
+    """Parameter lookup is case-insensitive, so the exclusion must be too."""
+    table: powerbi_data_classes.Table = powerbi_data_classes.Table(
+        columns=[],
+        measures=[],
+        expression='let Source = Web.Contents(#"SERVER HOSTNAME") in Source',
+        name="param_table",
+        full_name="MyDataSet.param_table",
+    )
+
+    reporter = PowerBiDashboardSourceReport()
+    ctx, config, platform_instance_resolver = get_default_instances()
+
+    parser.get_upstream_tables(
+        table,
+        reporter,
+        ctx=ctx,
+        config=config,
+        platform_instance_resolver=platform_instance_resolver,
+        parameters={"Server Hostname": "adb-123.azuredatabricks.net"},
+    )
+
+    assert list(reporter.m_query_unresolved_identifiers) == []

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -1958,3 +1958,54 @@ def test_native_query_cll_downstream_column_remapped_to_pbi_field_casing():
 
     assert lineage[0].column_lineage
     assert lineage[0].column_lineage[0].downstream.column == "CustomerId"
+
+
+# Resolver observability. A table whose expression parses but yields no lineage
+# is otherwise invisible: the reason is only ever logged at debug level.
+
+
+def _resolve_and_report(q: str, full_name: str) -> PowerBiDashboardSourceReport:
+    table: powerbi_data_classes.Table = powerbi_data_classes.Table(
+        columns=[],
+        measures=[],
+        expression=q,
+        name=full_name.split(".")[-1],
+        full_name=full_name,
+    )
+
+    reporter = PowerBiDashboardSourceReport()
+    ctx, config, platform_instance_resolver = get_default_instances()
+
+    parser.get_upstream_tables(
+        table,
+        reporter,
+        ctx=ctx,
+        config=config,
+        platform_instance_resolver=platform_instance_resolver,
+    )
+
+    return reporter
+
+
+@pytest.mark.integration
+def test_unhandled_node_kind_is_reported():
+    """An M shape the resolver walk cannot follow is named in the report, so an
+    unsupported expression form is visible without enabling debug logging."""
+    reporter = _resolve_and_report(
+        "let Source = 1 + 2 in Source", "MyDataSet.arithmetic_table"
+    )
+
+    assert "ArithmeticExpression" in reporter.m_query_unhandled_node_kinds
+
+
+@pytest.mark.integration
+def test_table_without_lineage_is_sampled():
+    """A table that parses but produces no lineage is sampled by name, so the
+    resolver_no_lineage count has something behind it."""
+    reporter = _resolve_and_report(
+        'let Source = Web.Contents("https://example.com/data.json") in Source',
+        "MyDataSet.web_table",
+    )
+
+    assert reporter.m_query_resolver_no_lineage == 1
+    assert "MyDataSet.web_table" in reporter.m_query_tables_without_lineage


### PR DESCRIPTION
## Summary

`m_query_resolver_no_lineage` was a single opaque count. Every reason behind it was logged at debug level only, so an operator running at INFO saw a number with nothing behind it — and no way to tell an unsupported source from a shape the resolver cannot follow.

On one real tenant, 829 of 1,279 successfully-parsed expressions produced no lineage, with no operator-visible explanation for any of them.

Two additions:

**`m_query_unhandled_node_kinds`** — AST NodeKinds the walk gave up on, counted once per table. A non-empty tally means some M shape is unsupported.

**`m_query_unresolved_identifiers`** — `<table> -> <name>` pairs where an expression references a name it does not define: another query in the model, or an outer-scope name reached from a nested `let`. A name recurring across many tables is a query that is not loaded into the model. Dataset parameters are excluded — they reach the same dead end as a *value* rather than a table, and recording them would bury the real references under one entry per unsupported source.

Both are needed because they catch disjoint failure modes: an identifier resolving to nothing ends the walk *before* reaching the unhandled-kind branch, so the node-kind tally alone cannot see it.

## Implementation note

`resolve_to_data_access_functions` now returns a `DataAccessResolution` carrying both the functions it found and what it could not follow. This replaces the bare list accumulator rather than adding parameters — `_walk` already takes eight, and threading two more sets through four functions would be worse.

## Example

A model where one hidden query feeds two others, which a visible table combines:

```
unresolved_identifiers:
    DS.combined_actions   -> Intercom Only
    DS.combined_actions   -> Intercom Excluded
    DS.other_report_table -> Actions Base
    DS.nested_let         -> sch
```

## Testing

Four tests, each watched failing first. No change to emitted metadata — report fields only, so all existing goldens are unchanged.

`360 passed, 1 xfailed` · ruff, format and mypy clean.

## Note for reviewers

This and #19364 both touch `resolver.py` — this PR renames the walk's accumulator, the other adds a `ParenthesizedExpression` case. Whichever merges second needs a one-block rebase with no logic overlap. Either order is fine.

## Checklist

- [x] PR conforms to the Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added
- [ ] Docs — n/a, report fields are not user-configured
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports why a parsed M‑Query expression yielded no lineage at INFO and tightens diagnostics to avoid false positives. Previously we only incremented `m_query_resolver_no_lineage` and logged reasons at DEBUG; now we surface unhandled AST shapes, unresolved identifiers, and sample tables without lineage.

- Adds report fields: `m_query_unhandled_node_kinds` (counted once per table), `m_query_unresolved_identifiers` (`<table> -> <name>` for names not defined by the expression), and `m_query_tables_without_lineage` (sample of affected tables). Excludes value leaves (e.g., `LiteralExpression`) from unhandled kinds, ignores dataset parameters case‑insensitively, skips names bound by any let case‑insensitively, and records undefined identifier arguments of recognized data‑access calls.
- Resolver API: `resolve_to_data_access_functions` now returns `DataAccessResolution` with `functions`, `unhandled_node_kinds`, `unresolved_identifiers`, and `let_bound_names`. If you call the resolver directly, update call sites to consume `DataAccessResolution`.
- No change to emitted metadata or lineage behavior.

<sup>Written for commit 3a8c59d2d33c5e323cc1c4f0ecef2c5dab3a8af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

