### PR TITLE
fix(ingest/tableau): preserve Virtual Connection data in field upstream re-fetch query

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau_common.py
@@ -381,6 +381,15 @@ datasource_upstream_fields_graphql_query = """
         table {
             __typename
             id
+            name
+            ... on VirtualConnectionTable {
+                virtualConnection {
+                    id
+                    name
+                    luid
+                    projectName
+                }
+            }
         }
     }
 }

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_virtual_connections.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_virtual_connections.py
@@ -1026,3 +1026,263 @@ class TestTableauVCIntegration:
         assert isinstance(result, LineageResult)
         assert isinstance(result.upstream_tables, list)
         assert isinstance(result.fine_grained_lineages, list)
+
+
+class TestVCDataSurvivesFieldUpstreamRefetch:
+    """Tests that Virtual Connection data in upstreamColumns is preserved after
+    update_datasource_for_field_upstream re-fetches field data.
+
+    This is a regression test for the bug where datasource_upstream_fields_graphql_query
+    only fetched {__typename, id} for upstreamColumns.table, overwriting the richer
+    initial data that included table.name and ... on VirtualConnectionTable.
+    """
+
+    def setup_method(self, method):
+        self.config = TableauConfig.parse_obj(default_config)
+        self.ctx = PipelineContext(run_id="test")
+
+        with mock.patch("datahub.ingestion.source.tableau.tableau.Server"):
+            mock_site = mock.MagicMock(
+                spec=SiteItem, id="test-site-id", content_url="test-site"
+            )
+
+            self.tableau_source = TableauSiteSource(
+                config=self.config,
+                ctx=self.ctx,
+                platform="tableau",
+                site=mock_site,
+                server=mock.MagicMock(),
+                report=TableauSourceReport(),
+            )
+
+    def test_vc_refs_collected_after_field_upstream_update(self):
+        """Simulate the full flow: initial datasource fetch → field upstream re-fetch →
+        VC reference collection. Verifies that the re-fetched field data still contains
+        the VC table name and virtualConnection needed for lineage."""
+
+        # This simulates what datasource_upstream_fields_graphql_query returns
+        # AFTER the fix: it includes table.name and virtualConnection
+        field_upstream_response = [
+            {
+                c.ID: "field-1",
+                "upstreamFields": [
+                    {"name": "source_field", "datasource": {"id": "upstream-ds-1"}}
+                ],
+                c.UPSTREAM_COLUMNS: [
+                    {
+                        c.NAME: "customer_id",
+                        c.TABLE: {
+                            c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                            c.ID: "vc-table-abc",
+                            c.NAME: "Customers",
+                            "virtualConnection": {
+                                c.ID: "vc-001",
+                                c.NAME: "Sales_VC",
+                                "luid": "luid-001",
+                                "projectName": "Sales",
+                            },
+                        },
+                    }
+                ],
+            },
+            {
+                c.ID: "field-2",
+                "upstreamFields": [],
+                c.UPSTREAM_COLUMNS: [
+                    {
+                        c.NAME: "order_amount",
+                        c.TABLE: {
+                            c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                            c.ID: "vc-table-def",
+                            c.NAME: "Orders",
+                            "virtualConnection": {
+                                c.ID: "vc-001",
+                                c.NAME: "Sales_VC",
+                                "luid": "luid-001",
+                                "projectName": "Sales",
+                            },
+                        },
+                    }
+                ],
+            },
+        ]
+
+        # Simulate the initial embedded datasource response (before field upstream update)
+        datasource = {
+            c.ID: "embedded-ds-1",
+            c.NAME: "Embedded Sales DS",
+            c.FIELDS: [
+                {
+                    c.ID: "field-1",
+                    c.NAME: "customer_id",
+                    c.TYPE_NAME: "ColumnField",
+                    # Initial response has upstreamColumns but it will be overwritten
+                    c.UPSTREAM_COLUMNS: [
+                        {
+                            c.NAME: "customer_id",
+                            c.TABLE: {
+                                c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                                c.ID: "vc-table-abc",
+                                c.NAME: "Customers",
+                                "virtualConnection": {
+                                    c.ID: "vc-001",
+                                    c.NAME: "Sales_VC",
+                                    "luid": "luid-001",
+                                    "projectName": "Sales",
+                                },
+                            },
+                        }
+                    ],
+                },
+                {
+                    c.ID: "field-2",
+                    c.NAME: "order_amount",
+                    c.TYPE_NAME: "ColumnField",
+                    c.UPSTREAM_COLUMNS: [
+                        {
+                            c.NAME: "order_amount",
+                            c.TABLE: {
+                                c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                                c.ID: "vc-table-def",
+                                c.NAME: "Orders",
+                                "virtualConnection": {
+                                    c.ID: "vc-001",
+                                    c.NAME: "Sales_VC",
+                                    "luid": "luid-001",
+                                    "projectName": "Sales",
+                                },
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+
+        # Mock get_connection_objects to return the field upstream response
+        with mock.patch.object(
+            self.tableau_source, "get_connection_objects"
+        ) as mock_get:
+            mock_get.return_value = iter(field_upstream_response)
+
+            # This is what the connector does: re-fetch field upstreams
+            from datahub.ingestion.source.tableau.tableau_common import (
+                datasource_upstream_fields_graphql_query,
+            )
+
+            datasource = self.tableau_source.update_datasource_for_field_upstream(
+                datasource=datasource,
+                field_upstream_query=datasource_upstream_fields_graphql_query,
+                page_size=100,
+            )
+
+        # Verify the correct query was passed (guards against accidentally using
+        # a stripped-down query that omits VC fields)
+        call_kwargs = mock_get.call_args
+        assert call_kwargs is not None
+        assert "VirtualConnectionTable" in datasource_upstream_fields_graphql_query
+
+        # Now process VC refs — this should find the VC data after the update
+        self.tableau_source.vc_processor.process_datasource_for_vc_refs(
+            datasource, DatasourceType.EMBEDDED
+        )
+
+        # The key assertion: VC references should be found
+        assert (
+            "embedded-ds-1"
+            in self.tableau_source.vc_processor.datasource_vc_relationships
+        )
+
+        refs = self.tableau_source.vc_processor.datasource_vc_relationships[
+            "embedded-ds-1"
+        ]
+        assert len(refs) == 2
+
+        # Verify both VC table references were captured with full data
+        vc_table_ids = {r["vc_table_id"] for r in refs}
+        assert "vc-table-abc" in vc_table_ids
+        assert "vc-table-def" in vc_table_ids
+
+        # Verify vc_id was extracted from virtualConnection
+        for ref in refs:
+            assert ref["vc_id"] == "vc-001"
+            assert ref["vc_table_name"] in ("Customers", "Orders")
+
+    def test_vc_refs_lost_without_fix(self):
+        """Demonstrates what happens when the field upstream query returns
+        upstreamColumns WITHOUT table.name and virtualConnection — VC refs are lost.
+        This documents the pre-fix behavior as a regression guard."""
+
+        # Simulate the OLD (broken) field upstream response: only __typename + id
+        broken_field_upstream_response = [
+            {
+                c.ID: "field-1",
+                "upstreamFields": [],
+                c.UPSTREAM_COLUMNS: [
+                    {
+                        c.NAME: "customer_id",
+                        c.TABLE: {
+                            c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                            c.ID: "vc-table-abc",
+                            # name and virtualConnection MISSING — this is the bug
+                        },
+                    }
+                ],
+            },
+        ]
+
+        datasource = {
+            c.ID: "embedded-ds-broken",
+            c.NAME: "Broken DS",
+            c.FIELDS: [
+                {
+                    c.ID: "field-1",
+                    c.NAME: "customer_id",
+                    c.TYPE_NAME: "ColumnField",
+                    c.UPSTREAM_COLUMNS: [
+                        {
+                            c.NAME: "customer_id",
+                            c.TABLE: {
+                                c.TYPE_NAME: c.VIRTUAL_CONNECTION_TABLE,
+                                c.ID: "vc-table-abc",
+                                c.NAME: "Customers",
+                                "virtualConnection": {c.ID: "vc-001"},
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+
+        with mock.patch.object(
+            self.tableau_source, "get_connection_objects"
+        ) as mock_get:
+            mock_get.return_value = iter(broken_field_upstream_response)
+
+            from datahub.ingestion.source.tableau.tableau_common import (
+                datasource_upstream_fields_graphql_query,
+            )
+
+            datasource = self.tableau_source.update_datasource_for_field_upstream(
+                datasource=datasource,
+                field_upstream_query=datasource_upstream_fields_graphql_query,
+                page_size=100,
+            )
+
+        # After the overwrite with broken data, VC refs should NOT be found
+        # (table.name is missing, so the guard drops it)
+        self.tableau_source.vc_processor.process_datasource_for_vc_refs(
+            datasource, DatasourceType.EMBEDDED
+        )
+
+        # With broken upstream response, no VC relationships should be collected
+        # because table.name is None and the extraction logs a warning and continues
+        refs = self.tableau_source.vc_processor.datasource_vc_relationships.get(
+            "embedded-ds-broken", []
+        )
+        # The vc_table_id IS still collected (for the lookup step), but without
+        # table.name the reference has vc_table_name=None — get_upstream_vc_tables
+        # will skip it unless lookup_vc_ids_from_table_ids resolves the name later.
+        # The key point: no complete relationship with vc_id is captured inline.
+        assert len(refs) > 0, "Expected at least one incomplete ref to verify broken behavior"
+        for ref in refs:
+            assert ref.get("vc_table_name") is None or ref.get("vc_id") is None

--- a/metadata-ingestion/tests/unit/tableau/test_tableau_virtual_connections.py
+++ b/metadata-ingestion/tests/unit/tableau/test_tableau_virtual_connections.py
@@ -1283,6 +1283,8 @@ class TestVCDataSurvivesFieldUpstreamRefetch:
         # table.name the reference has vc_table_name=None — get_upstream_vc_tables
         # will skip it unless lookup_vc_ids_from_table_ids resolves the name later.
         # The key point: no complete relationship with vc_id is captured inline.
-        assert len(refs) > 0, "Expected at least one incomplete ref to verify broken behavior"
+        assert len(refs) > 0, (
+            "Expected at least one incomplete ref to verify broken behavior"
+        )
         for ref in refs:
             assert ref.get("vc_table_name") is None or ref.get("vc_id") is None


### PR DESCRIPTION
Fixes #19688

### The Problem

Virtual Connection Tables have no downstream lineage edges to Embedded Data Sources that consume them. In our production instance, 40 out of 41 sampled Virtual Connection Tables are lineage dead-ends — they have upstream edges (to Snowflake) but zero downstream edges to the Embedded Data Sources that connect through them.

### Root Cause

The connector fetches datasources in two phases:

1. **Initial fetch** (`embedded_datasource_graphql_query` / `published_datasource_graphql_query`) — returns fields with full `upstreamColumns` data including `table.name` and `... on VirtualConnectionTable { virtualConnection { id, name } }`

2. **Field upstream re-fetch** (`datasource_upstream_fields_graphql_query` via `update_datasource_for_field_upstream`) — re-fetches fields through paginated `fieldsConnection` to add `upstreamFields` for column-level lineage. This query only fetched `table { __typename, id }` for `upstreamColumns`.

The re-fetch merges results back with `field_dict.update()`, which **overwrites** the original `upstreamColumns` — destroying `table.name` and `virtualConnection` data.

When `process_datasource_for_vc_refs` later reads the field data, it finds `__typename == "VirtualConnectionTable"` but `table.name` is null and `virtualConnection` is missing. The guard in `get_upstream_vc_tables`:

```python
if not (vc_id and vc_table_name and vc_table_id):
    continue
```

drops the reference silently. The same happens in the empty-upstream-tables fallback path.

### The Fix

Add `name` and `... on VirtualConnectionTable { virtualConnection { id, name, luid, projectName } }` to `datasource_upstream_fields_graphql_query`, matching the shape already present in the initial datasource queries. This adds ~5 extra nodes per upstream column entry, which is modest and already paginated.

### Testing

- Added `TestVCDataSurvivesFieldUpstreamRefetch` with two tests:
  - `test_vc_refs_collected_after_field_upstream_update` — verifies the fix: VC data survives the re-fetch and lineage is created
  - `test_vc_refs_lost_without_fix` — documents the pre-fix broken behavior as a regression guard
- All 45 existing VC tests continue to pass

### Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added
- [ ] Docs added (not applicable — no user-facing config change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Virtual Connection metadata during the field upstream re-fetch so Embedded Data Sources regain downstream lineage to VC tables. Previously the re-fetch returned only `__typename` and `id` for `upstreamColumns.table` and overwrote `table.name` and `virtualConnection`; now it fetches the full shape to keep that data.

- Expands `datasource_upstream_fields_graphql_query` to include `table.name` and the VirtualConnectionTable fragment, matching the initial datasource queries.
- The merge in `update_datasource_for_field_upstream` no longer erases VC data, so VC lineage edges are produced as expected.
- Adds `TestVCDataSurvivesFieldUpstreamRefetch` with positive and regression cases; existing VC tests still pass.
- Impact: slightly larger GraphQL payload (paginated); no config changes or migrations.
- Addresses Linear TEDP-5720 (VC lineage missing behind Virtual Connections).

<sup>Written for commit 12f2d04bc7ecdb5b2117374875e0c745d25edeec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

