### PR TITLE
feat(incidents): support incidents on mlFeatureTable (all six gates)

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
@@ -83,6 +83,11 @@ query listEntityIncidents(
                 ...entityIncidentsResultFields                         #[NEWER_GMS]
             }                                                          #[NEWER_GMS]
         }                                                              #[NEWER_GMS]
+        ... on MLFeatureTable {                                         #[NEWER_GMS]
+            incidents(state: $state, start: $start, count: $count) {   #[NEWER_GMS]
+                ...entityIncidentsResultFields                         #[NEWER_GMS]
+            }                                                          #[NEWER_GMS]
+        }                                                              #[NEWER_GMS]
         ... on SchemaFieldEntity {                                      #[NEWER_GMS]
             incidents(state: $state, start: $start, count: $count) {   #[NEWER_GMS]
                 ...entityIncidentsResultFields                         #[NEWER_GMS]
@@ -308,7 +313,7 @@ def raise_incident(
     an issue (e.g. a failing assertion, stale data, or a broken pipeline) to
     make the problem visible to the asset's owners and consumers.
 
-    ⚠️  IMPORTANT: Before calling this tool, you SHOULD confirm with the user
+    âš ï¸  IMPORTANT: Before calling this tool, you SHOULD confirm with the user
     that they want to raise this incident. Present the title, description, and
     affected asset, and ask for their approval before proceeding.
 

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/incidents.py
@@ -313,7 +313,7 @@ def raise_incident(
     an issue (e.g. a failing assertion, stale data, or a broken pipeline) to
     make the problem visible to the asset's owners and consumers.
 
-    âš ï¸  IMPORTANT: Before calling this tool, you SHOULD confirm with the user
+    ⚠️  IMPORTANT: Before calling this tool, you SHOULD confirm with the user
     that they want to raise this incident. Present the title, description, and
     affected asset, and ask for their approval before proceeding.
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3983,6 +3983,7 @@ public class GmsGraphQLEngine {
             "Chart",
             "MLModel",
             "MLFeature",
+            "MLFeatureTable",
             "SchemaFieldEntity");
     for (String entity : entitiesWithIncidents) {
       builder.type(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -502,6 +502,10 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
         .getResourceType()
         .equals(resourceType)) {
       return EntityType.MLFEATURE;
+    } else if (com.linkedin.metadata.authorization.PoliciesConfig.ML_FEATURE_TABLE_PRIVILEGES
+        .getResourceType()
+        .equals(resourceType)) {
+      return EntityType.MLFEATURE_TABLE;
     } else {
       return null;
     }

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -818,5 +818,5 @@ extend type MLFeatureTable {
     Optional number of results to return, defaults to 20.
     """
     count: Int
-  ): EntityIncidentsResult
+  ): EntityIncidentsResult @noAspects
 }

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -788,3 +788,35 @@ extend type SchemaFieldEntity {
     count: Int
   ): EntityIncidentsResult @noAspects
 }
+
+extend type MLFeatureTable {
+  """
+  Incidents associated with the MLFeatureTable
+  """
+  incidents(
+    """
+    Optional incident state to filter by, defaults to any state.
+    """
+    state: IncidentState
+    """
+    Optional incident stage to filter by, defaults to any stage.
+    """
+    stage: IncidentStage
+    """
+    Optional incident priority to filter by, defaults to any priority.
+    """
+    priority: IncidentPriority
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!]
+    """
+    Optional start offset, defaults to 0.
+    """
+    start: Int
+    """
+    Optional number of results to return, defaults to 20.
+    """
+    count: Int
+  ): EntityIncidentsResult
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolverTest.java
@@ -20,6 +20,7 @@ import com.linkedin.datahub.graphql.generated.EntityIncidentsResult;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.IncidentPriority;
 import com.linkedin.datahub.graphql.generated.MLFeature;
+import com.linkedin.datahub.graphql.generated.MLFeatureTable;
 import com.linkedin.datahub.graphql.generated.MLModel;
 import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
 import com.linkedin.entity.Aspect;
@@ -76,6 +77,16 @@ public class EntityIncidentsResolverTest {
     MLFeature parentEntity = new MLFeature();
     parentEntity.setUrn(mlFeatureUrn.toString());
     assertIncidentsResolvedForSource(mlFeatureUrn, parentEntity);
+  }
+
+  @Test
+  public void testGetSuccessMlFeatureTableEntity() throws Exception {
+    Urn mlFeatureTableUrn =
+        Urn.createFromString(
+            "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,test_feature_table)");
+    MLFeatureTable parentEntity = new MLFeatureTable();
+    parentEntity.setUrn(mlFeatureTableUrn.toString());
+    assertIncidentsResolvedForSource(mlFeatureTableUrn, parentEntity);
   }
 
   @Test

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -3,6 +3,7 @@ import { Database } from '@phosphor-icons/react/dist/csr/Database';
 import { FileText } from '@phosphor-icons/react/dist/csr/FileText';
 import { ListBullets } from '@phosphor-icons/react/dist/csr/ListBullets';
 import { Table } from '@phosphor-icons/react/dist/csr/Table';
+import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
 import i18next from 'i18next';
 import * as React from 'react';
 
@@ -27,6 +28,7 @@ import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/ut
 import SidebarNotesSection from '@app/entityV2/shared/sidebarSection/SidebarNotesSection';
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
+import { IncidentTab } from '@app/entityV2/shared/tabs/Incident/IncidentTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
 import { getDataProduct, isOutputPort } from '@app/entityV2/shared/utils';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
@@ -34,7 +36,11 @@ import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useGetMlFeatureTableQuery } from '@graphql/mlFeatureTable.generated';
 import { EntityType, MlFeatureTable, SearchResult } from '@types';
 
-const headerDropdownItems = new Set([EntityMenuItems.UPDATE_DEPRECATION, EntityMenuItems.ANNOUNCE]);
+const headerDropdownItems = new Set([
+    EntityMenuItems.UPDATE_DEPRECATION,
+    EntityMenuItems.RAISE_INCIDENT,
+    EntityMenuItems.ANNOUNCE,
+]);
 
 /**
  * Definition of the DataHub MLFeatureTable entity.
@@ -103,6 +109,14 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                     name: i18next.t('entity.types:tab.properties'),
                     component: PropertiesTab,
                     icon: ListBullets,
+                },
+                {
+                    name: i18next.t('entity.types:tab.incidents'),
+                    icon: WarningCircle,
+                    component: IncidentTab,
+                    getCount: (_, mlFeatureTable) => {
+                        return mlFeatureTable?.mlFeatureTable?.activeIncidents?.total;
+                    },
                 },
             ]}
             sidebarSections={this.getSidebarSections()}

--- a/datahub-web-react/src/graphql/incident.graphql
+++ b/datahub-web-react/src/graphql/incident.graphql
@@ -295,5 +295,13 @@ query getEntityIncidents(
                 canEditIncidents
             }
         }
+        ... on MLFeatureTable {
+            incidents(start: $start, count: $count, state: $state) {
+                ...incidentResultFields
+            }
+            privileges {
+                canEditIncidents
+            }
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mlFeatureTable.graphql
+++ b/datahub-web-react/src/graphql/mlFeatureTable.graphql
@@ -14,6 +14,9 @@ query getMLFeatureTable($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
+        activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
+            total
+        }
         ...notes
     }
 }

--- a/metadata-models/docs/entities/mlFeatureTable.md
+++ b/metadata-models/docs/entities/mlFeatureTable.md
@@ -214,6 +214,10 @@ Feature tables are associated with a specific data platform (e.g., Feast, Tecton
 - Enables filtering and organization by platform
 - Supports multi-platform feature store environments
 
+### Incidents
+
+ML Feature Tables participate in the shared incidents subsystem. Incidents can be raised on a feature table via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLFeatureTable` GraphQL type, and the feature table carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved.
+
 ## Notable Exceptions
 
 ### Feature Store Platform Variations

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl
@@ -12,7 +12,7 @@ import com.linkedin.common.Urn
  */
 @Aspect = {
   "name": "incidentInfo",
-  "schemaVersion": 2
+  "schemaVersion": 3
 }
 record IncidentInfo {
   /**
@@ -56,7 +56,7 @@ record IncidentInfo {
   @Relationship = {
     "/*": {
       "name": "IncidentOn",
-      "entityTypes": [ "dataset", "chart", "dashboard", "dataFlow", "dataJob", "schemaField", "mlModel", "mlFeature", "service", "aiAgent"]
+      "entityTypes": [ "dataset", "chart", "dashboard", "dataFlow", "dataJob", "schemaField", "mlModel", "mlFeature", "mlFeatureTable", "service", "aiAgent"]
     }
   }
   @Searchable = {

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -517,6 +517,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - incidentsSummary
       - subTypes
       - documentation
   - name: mlFeature

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -1002,6 +1002,14 @@ public class PoliciesConfig {
       ResourcePrivileges.of(
           "mlFeature", "ML Features", "ML Features indexed by DataHub", COMMON_ENTITY_PRIVILEGES);
 
+  // ML Feature Table Privileges
+  public static final ResourcePrivileges ML_FEATURE_TABLE_PRIVILEGES =
+      ResourcePrivileges.of(
+          "mlFeatureTable",
+          "ML Feature Tables",
+          "ML Feature Tables indexed by DataHub",
+          COMMON_ENTITY_PRIVILEGES);
+
   public static final List<ResourcePrivileges> ENTITY_RESOURCE_PRIVILEGES =
       ImmutableList.of(
           DATASET_PRIVILEGES,
@@ -1029,7 +1037,8 @@ public class PoliciesConfig {
           APPLICATION_PRIVILEGES,
           DATAHUB_VIEW_PRIVILEGES,
           ML_MODEL_PRIVILEGES,
-          ML_FEATURE_PRIVILEGES);
+          ML_FEATURE_PRIVILEGES,
+          ML_FEATURE_TABLE_PRIVILEGES);
 
   // Merge all entity specific resource privileges to create a superset of all resource privileges
   public static final ResourcePrivileges ALL_RESOURCE_PRIVILEGES =


### PR DESCRIPTION
PR3 of the plan on #18911, per the six-gate tracker on #19322. Rebased over #19115, so the resolver list and test include both new entries in order.

Unlike mlModel and mlFeature, mlFeatureTable was never added to the IncidentOn write allowlist, so this is the first slice that touches every gate:

| Gate | Change |
|---|---|
| 1 Write | `mlFeatureTable` added to IncidentOn entityTypes in IncidentInfo.pdl, with the schemaVersion bump (2 to 3) that bump_schema_versions.py requires for @Relationship changes (verified by running the checker locally: exit 0) |
| 2 Summary | `incidentsSummary` in the registry block, placed after testResults matching the ML siblings |
| 3 SDL | `extend type MLFeatureTable` in incident.graphql, copying the corrected docstring wording from the ML blocks |
| 4 Resolver | `"MLFeatureTable"` in entitiesWithIncidents |
| 5 Badge | `activeIncidents` alias on getMLFeatureTable |
| 6 Tab | entityV2 IncidentTab registration with count, plus `RAISE_INCIDENT` in headerDropdownItems, which this page never had |

Also included, matching the PR1 precedent: `ML_FEATURE_TABLE_PRIVILEGES` (COMMON_ENTITY_PRIVILEGES) registered in ENTITY_RESOURCE_PRIVILEGES with the AppConfigResolver mapping to `EntityType.MLFEATURE_TABLE`; an `MLFeatureTable` case in `assertIncidentsResolvedForSource`; and the entity docs section.

Not included: incidentLinkedAssetPreview already covered MLFeatureTable on master, and mlModelGroup stays out per the tracker (not in this wave).

**One note for maintainers on the PDL change:** per the NOTE at the top of IncidentInfo.pdl, the IncidentActivityEvent.pdl mirror needs the same entities-list update with the searchable and relationship annotations stripped. That file is not in this repository (verified against the full tree), so I could not make the change; flagging it here so the internal sync is not missed.

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Links to related issues: #18911, #19322
- [x] Tests: resolver test case added; schemaVersion checker passes; regression coverage arrives with #19097 once its KNOWN_GAPS empties
- [x] Docs: entity docs section added; the generated supported-types table comes from #18685 after this lands
- [x] Not a breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incidents to MLFeatureTable across model, GraphQL, UI, agent, and policy. Previously MLFeatureTable had no incidents; now you can raise, list, summarize, and permission them, with an Incidents tab and a Raise Incident action.

- PDL/registry: add `mlFeatureTable` to IncidentOn in `IncidentInfo.pdl` (schemaVersion 3) and `incidentsSummary` to `entity-registry.yml`.
- GraphQL: extend `MLFeatureTable { incidents(...) }` with `@noAspects` in `incident.graphql`; register in `GmsGraphQLEngine`; expose `activeIncidents` badge alias in `mlFeatureTable.graphql`.
- UI: add Incidents tab (with count) and `RAISE_INCIDENT` to the MLFeatureTable header in `datahub-web-react`.
- Agent: add MLFeatureTable block to `LIST_INCIDENTS_QUERY` in `datahub-agent-context` with `NEWER_GMS` guards; fix UTF-8 characters in the MCP incidents fragment.
- Privileges: add `ML_FEATURE_TABLE_PRIVILEGES` in `PoliciesConfig` and map in `AppConfigResolver` so `EDIT_ENTITY_INCIDENTS` is grantable per type.
- Tests/docs: resolver test for MLFeatureTable incidents and entity docs section added.

**Rollout**
- Reindex required due to the `@Relationship` schema version bump.
- Ensure the mirror update to `IncidentActivityEvent.pdl` adds `mlFeatureTable` without searchable/relationship annotations.

<sup>Written for commit 5921fc3dc9fd8b6004a7fee87e43e334e837c052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

