### PR TITLE
fix(ingest/powerbi): follow a native query's source argument to the connector

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/pattern_handler.py
@@ -2,7 +2,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, Type
+from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 
 import sqlglot
 from sqlglot import ParseError, expressions as exp
@@ -113,36 +113,73 @@ def _get_record_args(node_map: Dict[int, dict], invoke_node: dict) -> Dict[str, 
     return result
 
 
+def _resolve_step(
+    node_map: Dict[int, dict], node: dict, seen: Set[str]
+) -> Optional[dict]:
+    """Follow an identifier to the expression the let binds it to.
+
+    Returns None when the name is not a let variable, which is how a connector
+    call such as ``Snowflake.Databases`` is told apart from a step name.
+    """
+    if node.get("kind") != "IdentifierExpression":
+        return None
+    name = node.get("identifier", {}).get("literal", "")
+    if not name or name in seen:
+        return None
+    let_nodes = sorted(
+        find_nodes_by_kind(node_map, "LetExpression"),
+        key=lambda n: n.get("id", 0),
+    )
+    if not let_nodes:
+        return None
+    resolved = resolve_identifier(node_map, let_nodes[0], name)
+    if resolved is not None:
+        seen.add(name)
+    return resolved
+
+
 def _get_data_source_tokens(
     node_map: Dict[int, dict],
     arg_node: dict,
     parameters: Optional[Dict[str, str]] = None,
+    seen: Optional[Set[str]] = None,
 ) -> List[str]:
     """Extract [platform_name, server, ...other_args] from a data source node.
 
-    If arg_node is an IdentifierExpression, resolves it through the let scope.
+    A step may sit any number of navigation steps away from the connector call,
+    e.g. ``Value.NativeQuery(db, ...)`` where ``db = Source{[Name=..]}[Data]``
+    and ``Source`` is the call. Each hop's navigation record is appended after
+    the connector's own arguments, so the platform stays at index 0 and the
+    server at index 1 however deep the chain runs.
     """
-    # Resolve through let scope if identifier
-    if arg_node.get("kind") == "IdentifierExpression":
-        name = arg_node.get("identifier", {}).get("literal", "")
-        let_nodes = sorted(
-            find_nodes_by_kind(node_map, "LetExpression"),
-            key=lambda n: n.get("id", 0),
-        )
-        if let_nodes:
-            resolved = resolve_identifier(node_map, let_nodes[0], name)
-            if resolved is not None:
-                arg_node = resolved
+    seen = seen if seen is not None else set()
+
+    # A step may be a plain alias of another step, so follow the chain rather
+    # than a single hop.
+    while True:
+        resolved = _resolve_step(node_map, arg_node, seen)
+        if resolved is None:
+            break
+        arg_node = resolved
 
     if arg_node.get("kind") != "RecursivePrimaryExpression":
         return []
 
     head = arg_node.get("head", {})
-    platform_name = ""
-    if head.get("kind") == "IdentifierExpression":
-        platform_name = head.get("identifier", {}).get("literal", "")
-
-    tokens: List[str] = [platform_name]
+    resolved_head = _resolve_step(node_map, head, seen)
+    if resolved_head is not None:
+        # The head is another step, so the connector is further back. Its tokens
+        # come first; this level's navigation steps are appended below.
+        tokens = _get_data_source_tokens(
+            node_map, resolved_head, parameters=parameters, seen=seen
+        )
+        if not tokens:
+            return []
+    else:
+        platform_name = ""
+        if head.get("kind") == "IdentifierExpression":
+            platform_name = head.get("identifier", {}).get("literal", "")
+        tokens = [platform_name]
 
     rec_exprs = arg_node.get("recursiveExpressions", {})
     elements = rec_exprs.get("elements", []) if isinstance(rec_exprs, dict) else []

--- a/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_m_parser.py
@@ -1958,3 +1958,93 @@ def test_native_query_cll_downstream_column_remapped_to_pbi_field_casing():
 
     assert lineage[0].column_lineage
     assert lineage[0].column_lineage[0].downstream.column == "CustomerId"
+
+
+# Value.NativeQuery whose first argument is reached through a navigation step
+# rather than being the connector call itself.
+_SNOWFLAKE_MULTI_HOP_NATIVE_QUERY: str = (
+    "let\n"
+    '    Source = Snowflake.Databases("srv.snowflakecomputing.com", "wh"),\n'
+    '    db = Source{[Name="MYDB",Kind="Database"]}[Data],\n'
+    "    q = Value.NativeQuery(db,"
+    ' "select a from myschema.mytable", null, [EnableFolding=true])\n'
+    "in\n"
+    "    q"
+)
+
+_DATABRICKS_MULTI_CLOUD_MULTI_HOP_NATIVE_QUERY: str = (
+    "let\n"
+    "    Source = DatabricksMultiCloud.Catalogs("
+    '"adb-123.azuredatabricks.net", "/sql/1.0/endpoints/abc",'
+    ' [Catalog="my_catalog", Database=null, EnableAutomaticProxyDiscovery=null]),\n'
+    '    db = Source{[Name="my_catalog",Kind="Database"]}[Data],\n'
+    "    q = Value.NativeQuery(db,"
+    ' "select a, b from my_schema.my_table", null, [EnableFolding=true])\n'
+    "in\n"
+    "    q"
+)
+
+
+@pytest.mark.integration
+def test_snowflake_native_query_with_multi_hop_source():
+    """The source argument may be a navigation step rather than the connector
+    call, so the head has to be followed back to the connector."""
+    lineages: List[Lineage] = get_data_platform_tables_with_dummy_table(
+        q=_SNOWFLAKE_MULTI_HOP_NATIVE_QUERY
+    )
+
+    data_platform_tables = combine_upstreams_from_lineage(lineages)
+
+    assert len(data_platform_tables) == 1
+    assert (
+        data_platform_tables[0].urn
+        == "urn:li:dataset:(urn:li:dataPlatform:snowflake,mydb.myschema.mytable,PROD)"
+    )
+
+
+@pytest.mark.integration
+def test_databricks_multi_cloud_native_query_with_multi_hop_source():
+    """Same shape on a record-first connector, where the catalog comes from the
+    connector arguments rather than the navigation step."""
+    lineages: List[Lineage] = get_data_platform_tables_with_dummy_table(
+        q=_DATABRICKS_MULTI_CLOUD_MULTI_HOP_NATIVE_QUERY
+    )
+
+    data_platform_tables = combine_upstreams_from_lineage(lineages)
+
+    assert len(data_platform_tables) == 1
+    assert (
+        data_platform_tables[0].urn == "urn:li:dataset:(urn:li:dataPlatform:databricks,"
+        "my_catalog.my_schema.my_table,PROD)"
+    )
+
+
+@pytest.mark.integration
+def test_native_query_source_cycle_does_not_recurse():
+    """Steps defined in terms of each other must not send the head walk into
+    unbounded recursion."""
+    lineages: List[Lineage] = get_data_platform_tables_with_dummy_table(
+        q="let a = b, b = a,"
+        ' q = Value.NativeQuery(a, "select x from s.t", null, [EnableFolding=true])'
+        " in q"
+    )
+
+    assert combine_upstreams_from_lineage(lineages) == []
+
+
+@pytest.mark.integration
+def test_multi_hop_source_with_unresolved_parameters_yields_no_lineage():
+    """Following the head must not invent a server: when the connector's
+    positional arguments are unresolved parameters, the navigation record shifts
+    into the server position and the query is left alone rather than guessed."""
+    lineages: List[Lineage] = get_data_platform_tables_with_dummy_table(
+        q="let\n"
+        "    Source = Snowflake.Databases(SnowflakeURL, SnowflakeWarehouse),\n"
+        '    db = Source{[Name="MYDB",Kind="Database"]}[Data],\n'
+        '    q = Value.NativeQuery(db, "select a from myschema.mytable",'
+        " null, [EnableFolding=true])\n"
+        "in\n"
+        "    q"
+    )
+
+    assert combine_upstreams_from_lineage(lineages) == []


### PR DESCRIPTION
## Summary

`Value.NativeQuery` names its data source as the first argument, and in real M that argument is usually a navigation step rather than the connector call itself:

```m
Source       = Snowflake.Databases(host, warehouse),
DatabaseStep = Source{[Name="MYDB", Kind="Database"]}[Data],
QueryStep    = Value.NativeQuery(DatabaseStep, "select ... from ...")
```

`_get_data_source_tokens` resolved that identifier **once**, landed on `Source{...}[Data]`, read its head as the literal name `Source`, and gave up — no connector is called that. Measured on master:

| source argument | `tokens[0]` |
| --- | --- |
| inline `Snowflake.Databases(...){...}[Data]` | `Snowflake.Databases` ✅ |
| one hop — `NativeQuery(Source, ...)` | `Snowflake.Databases` ✅ |
| two hops — `NativeQuery(DatabaseStep, ...)` | `Source` ❌ |

**Not Databricks-specific.** The same shape was losing lineage on Snowflake, Redshift, MSSQL, Postgres and BigQuery. It survived because every existing native-query test uses the inline form, where the head *is* the connector.

## Approach

Follow the head back until it reaches something the `let` does not bind — that is what distinguishes a connector call from a step name — and append each hop's navigation record *after* the connector's own arguments. The platform stays at index 0 and the server at index 1 however deep the chain runs, so `get_db_name` and `create_lineage` are unaffected. Aliases of aliases are followed too.

## Safety

The inline path is byte-for-byte unchanged; I verified the emitted token list is identical before and after.

Two properties are pinned by tests:

- **Cycles.** `a = b, b = a` would otherwise spin in the alias loop rather than raise — hanging an ingestion run instead of failing it. Guarded by a seen-set; returns no lineage.
- **Unresolved parameters.** When the connector's positional arguments are parameter references that cannot be resolved, the navigation record shifts into the server position. The guard added in #18724 still declines to guess a host, and this change does not undermine it.

Also verified: three-hop chains accumulate both navigation records; multi-table native SQL (join / union / CTE) still yields one upstream per table.

## Relationship to other PRs

This is the last piece of the M-Query native-query work. #19364 registers the `Databricks.Catalogs` connector for native queries; **both are needed** for a two-hop Databricks native query, since this PR fixes the traversal and that one fixes the registration. They touch different regions of `pattern_handler.py` and can merge in either order.

## Testing

`360 passed, 1 xfailed` · ruff, format and mypy clean · no existing goldens touched.

New tests use Snowflake and `DatabricksMultiCloud.Catalogs`, since plain `Databricks.Catalogs` is not a registered native-query platform until #19364 lands.

## Checklist

- [x] PR conforms to the Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added
- [ ] Docs — n/a, no user-facing config change
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lineage extraction for Power BI M `Value.NativeQuery` when the source argument is a multi-hop step. Previously, resolving only one hop treated the head as a step name (e.g., "Source") and dropped lineage for Snowflake, Redshift, MSSQL, Postgres, and BigQuery; now the parser walks back through aliases/navigation to the connector and preserves argument positions.

- Follows let-bound aliases until the unbound connector, then appends each hop’s navigation record after the connector’s args, keeping platform at index 0 and server at index 1. Inline paths are unchanged byte-for-byte.
- Guards cycles with a seen-set (no hangs) and keeps the “no guessed host” behavior when connector args are unresolved parameters; multi-table SQL lineage unaffected.
- Adds integration tests for Snowflake and `DatabricksMultiCloud.Catalogs` multi-hop, cycle handling, and unresolved parameters; no existing goldens changed.
- For two-hop Databricks native queries, this and #19364 (registers `Databricks.Catalogs`) are both required; they touch different parts of `pattern_handler.py` and can merge in any order.

<sup>Written for commit e6414fd99dc85a92f5f98f88f3f74f0f8872f0c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

