### PR TITLE
feat(ingest): attribute batch rejections per record and record unparseable rows

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -92,6 +92,8 @@ Requirements:
 
 - **(Metadata Model / Data Products)** `dataProductProperties` now includes an optional `parentDataProduct` URN so Data Products can nest in a parent-child taxonomy (mirroring Domains' `parentDomain`). The field is additive; existing Data Products are unchanged (null parent). No migration or reindex is required. Free-text search may match child products on the parent URN string, the same way `parentDomain` already behaves.
 
+- **(Ingestion / DataHub source)** The `datahub` source (used for DataHub-to-DataHub migrations) now writes rows it cannot parse to a `parse-errors-{run_id}.jsonl` file, in addition to counting them in the run report as before. This makes it possible to find and fix the specific rows that were dropped during a migration. **Action:** none required; set `parse_error_log.enabled: false` in the source config to turn this off.
+
 ## v1.7.0
 
 Requirements:

--- a/metadata-ingestion/docs/sources/datahub/datahub_post.md
+++ b/metadata-ingestion/docs/sources/datahub/datahub_post.md
@@ -18,6 +18,14 @@ If you want to re-ingest all data, you can set a different `pipeline_name` in yo
 - Does not detect hard timeseries deletions, e.g. if via a datahub delete command using the CLI. Therefore, if you deleted data in this way, it will still exist in the destination instance.
 - If you have a significant amount of aspects with the exact same createdon timestamp, stateful ingestion will not be able to save checkpoints partially through that timestamp. On a subsequent run, all aspects for that timestamp will be ingested.
 
+#### Parse-Error Quarantine
+
+Database rows that cannot be parsed into a metadata change proposal are counted in `num_database_parse_errors` and, by default, also written to an NDJSON file (`parse_error_log`) — one JSON object per line, each with the original row and the error it raised. The file is only created once a row is actually dropped, so a clean run leaves nothing behind.
+
+This file is diagnostic, not replayable: since no valid metadata change proposal could be built from these rows in the first place, they cannot be re-ingested as-is. Use it to find and fix the underlying data, then re-run ingestion.
+
+Set `parse_error_log.enabled: false` to turn this off.
+
 #### Performance
 
 For large migrations, ensure `metadata_aspect_v2.createdon` is indexed (`timeIndex`), enable async ingestion on the destination, and scale consumers/GMS/Elasticsearch workers as needed.

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -52,6 +52,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
     MetadataChangeProposal,
 )
 from datahub.utilities.partition_executor import (
+    BatchItemFailures,
     BatchPartitionExecutor,
     PartitionExecutor,
 )
@@ -114,6 +115,13 @@ class DataHubRestSinkReport(SinkReport):
 
     async_batches_prepared: int = 0
     async_batches_split: int = 0
+
+    # Batch rejection is all-or-nothing server-side, so a rejected batch is re-emitted
+    # one record at a time to find the records that actually caused it. "recovered"
+    # counts records that would have been silently lost before this behaviour existed.
+    batches_rejected: int = 0
+    records_isolated_after_batch_rejection: int = 0
+    records_recovered_after_batch_rejection: int = 0
 
     main_thread_blocking_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
 
@@ -411,19 +419,31 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
             ]
         ],
     ) -> None:
-        events: List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]] = []
+        # Grouped per record, not flattened, so a rejected batch can be attributed to the
+        # record that caused it. The expansion is 1:N because an MCE unpacks into several MCPs.
+        events_by_record: List[
+            List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]]
+        ] = []
 
         for record in records:
             event = record[0]
 
             if isinstance(event, MetadataChangeEvent):
                 # Unpack MCEs into MCPs.
-                mcps = mcps_from_mce(event)
-                events.extend(mcps)
+                events_by_record.append(list(mcps_from_mce(event)))
             else:
-                events.append(event)
+                events_by_record.append([event])
 
-        trace_data = self.emitter.emit_mcps(events, emit_mode=self._gms_emit_mode)
+        events = [event for group in events_by_record for event in group]
+
+        try:
+            trace_data = self.emitter.emit_mcps(events, emit_mode=self._gms_emit_mode)
+        except Exception as batch_error:
+            if len(events_by_record) <= 1:
+                # Nothing to isolate: the single record's error is already precise.
+                raise
+            raise self._isolate_batch_failures(events_by_record) from batch_error
+
         num_chunks = len(trace_data)
         self.report.async_batches_prepared += 1
         if num_chunks > 1:
@@ -432,6 +452,38 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
                 f"In async_batch mode, the payload was split into {num_chunks} batches. "
                 "If there's many of these issues, consider decreasing `max_per_batch`."
             )
+
+    def _isolate_batch_failures(
+        self,
+        events_by_record: List[
+            List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]]
+        ],
+    ) -> BatchItemFailures:
+        # The server rejects a batch as a unit, so a single invalid record fails every
+        # record batched with it. Re-emitting one record at a time attributes the failure
+        # to the record that caused it and lets the rest through.
+        self.report.batches_rejected += 1
+        self.report.records_isolated_after_batch_rejection += len(events_by_record)
+
+        outcomes: List[Optional[BaseException]] = []
+        for events in events_by_record:
+            try:
+                self.emitter.emit_mcps(events, emit_mode=self._gms_emit_mode)
+            except Exception as e:
+                outcomes.append(e)
+            else:
+                outcomes.append(None)
+                self.report.records_recovered_after_batch_rejection += 1
+
+        recovered = sum(1 for outcome in outcomes if outcome is None)
+        logger.info(
+            "Batch of %d rejected; isolation recovered %d record(s) and identified "
+            "%d genuine failure(s)",
+            len(events_by_record),
+            recovered,
+            len(outcomes) - recovered,
+        )
+        return BatchItemFailures(outcomes)
 
     def write_record_async(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -66,6 +66,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_REST_SINK_MAX_THREADS = get_rest_sink_default_max_threads()
 
+# Isolation does one HTTP round trip per record, each with its own retry ladder, so a
+# systemic failure (an expired auth token, a model mismatch, an outage) turns "the batch
+# failed" into max_per_batch sequential failures per rejected batch. Once this many
+# consecutive isolation passes recover nothing, stop paying that cost and let the batch
+# exception propagate as it did before per-record isolation existed.
+_MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS = 3
+
 
 class RestSinkMode(ConfigEnum):
     SYNC = auto()
@@ -122,6 +129,9 @@ class DataHubRestSinkReport(SinkReport):
     batches_rejected: int = 0
     records_isolated_after_batch_rejection: int = 0
     records_recovered_after_batch_rejection: int = 0
+    # Incremented once isolation trips off (see _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS)
+    # so a systemic failure doesn't silently drop out of batches_rejected.
+    batches_rejected_while_isolation_suppressed: int = 0
 
     main_thread_blocking_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
 
@@ -191,6 +201,13 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
         self._gms_emit_mode = _resolve_gms_emit_mode(
             self.config.mode, _DEFAULT_EMIT_MODE
         )
+
+        # Guards the isolation circuit breaker's counters below, since
+        # _isolate_batch_failures runs on worker threads and several batches can be
+        # rejected concurrently.
+        self._isolation_lock = threading.Lock()
+        self._consecutive_zero_recovery_isolations = 0
+        self._isolation_suppressed = False
 
         try:
             gms_config = self.emitter.server_config
@@ -437,10 +454,19 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
         events = [event for group in events_by_record for event in group]
 
         try:
+            # emit_mcps chunks internally by payload size. If a later chunk fails after
+            # earlier chunks already landed, isolation below re-emits those
+            # already-succeeded records too, since it only sees the whole call failed.
+            # Server-side no-op detection on the duplicate emit makes this harmless; it
+            # just inflates "recovered" with records that were never actually lost.
             trace_data = self.emitter.emit_mcps(events, emit_mode=self._gms_emit_mode)
         except Exception as batch_error:
             if len(events_by_record) <= 1:
                 # Nothing to isolate: the single record's error is already precise.
+                raise
+            if self._isolation_suppressed:
+                with self._isolation_lock:
+                    self.report.batches_rejected_while_isolation_suppressed += 1
                 raise
             raise self._isolate_batch_failures(events_by_record) from batch_error
 
@@ -483,6 +509,30 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
             recovered,
             len(outcomes) - recovered,
         )
+
+        newly_suppressed = False
+        with self._isolation_lock:
+            if recovered > 0:
+                self._consecutive_zero_recovery_isolations = 0
+            else:
+                self._consecutive_zero_recovery_isolations += 1
+                if (
+                    self._consecutive_zero_recovery_isolations
+                    >= _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS
+                    and not self._isolation_suppressed
+                ):
+                    self._isolation_suppressed = True
+                    newly_suppressed = True
+        if newly_suppressed:
+            logger.warning(
+                "Isolation recovered zero records across %d consecutive rejected "
+                "batches; disabling per-record isolation for the rest of this run. "
+                "Later rejected batches will fail as a whole instead of being "
+                "re-emitted one record at a time. See "
+                "batches_rejected_while_isolation_suppressed in the report.",
+                _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS,
+            )
+
         return BatchItemFailures(outcomes)
 
     def write_record_async(

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/config.py
@@ -4,7 +4,7 @@ from typing import Optional, Set
 import pydantic
 from pydantic import Field, model_validator
 
-from datahub.configuration.common import AllowDenyPattern, HiddenFromDocs
+from datahub.configuration.common import AllowDenyPattern, ConfigModel, HiddenFromDocs
 from datahub.configuration.kafka import KafkaConsumerConnectionConfig
 from datahub.ingestion.source.sql.sql_config import SQLAlchemyConnectionConfig
 from datahub.ingestion.source.state.stateful_ingestion_base import (
@@ -28,6 +28,21 @@ DEFAULT_EXCLUDE_ASPECTS = {
     "datahubIngestionCheckpoint",
     "testResults",
 }
+
+
+class ParseErrorLogConfig(ConfigModel):
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Write rows that cannot be parsed to an NDJSON file so they are enumerable. "
+            "These rows never become work units, so the pipeline's failure_log never sees "
+            "them. The file is only created if at least one row is dropped."
+        ),
+    )
+    filename: Optional[str] = Field(
+        default=None,
+        description="Defaults to parse-errors-{run_id}.jsonl in the working directory.",
+    )
 
 
 class DataHubSourceConfig(StatefulIngestionConfigBase):
@@ -99,6 +114,11 @@ class DataHubSourceConfig(StatefulIngestionConfigBase):
             "Whether to update createdon timestamp and kafka offset despite parse errors. "
             "Enable if you want to ignore the errors."
         ),
+    )
+
+    parse_error_log: ParseErrorLogConfig = Field(
+        default_factory=ParseErrorLogConfig,
+        description="Where to record rows that could not be parsed",
     )
 
     pull_from_datahub_api: HiddenFromDocs[bool] = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -11,6 +11,7 @@ from datahub.emitter.aspect import ASPECT_MAP
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.serialization_helper import post_json_transform
 from datahub.ingestion.source.datahub.config import DataHubSourceConfig
+from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
 from datahub.ingestion.source.datahub.report import DataHubSourceReport
 from datahub.ingestion.source.sql.sql_config import SQLAlchemyConnectionConfig
 from datahub.metadata.schema_classes import SystemMetadataClass
@@ -79,9 +80,11 @@ class DataHubDatabaseReader:
         config: DataHubSourceConfig,
         connection_config: SQLAlchemyConnectionConfig,
         report: DataHubSourceReport,
+        quarantine: Optional[QuarantineWriter] = None,
     ):
         self.config = config
         self.report = report
+        self.quarantine = quarantine
         self.engine = create_engine(
             url=connection_config.get_sql_alchemy_url(),
             **connection_config.options,
@@ -403,4 +406,6 @@ class DataHubDatabaseReader:
             ).setdefault(row["aspect"], LossyList(max_elements=failure_size)).append(
                 row["urn"]
             )
+            if self.quarantine is not None:
+                self.quarantine.write(row, str(e))
             return None

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -407,5 +407,22 @@ class DataHubDatabaseReader:
                 row["urn"]
             )
             if self.quarantine is not None:
+                was_disabled = self.quarantine.disabled
                 self.quarantine.write(row, str(e))
+
+                if self.quarantine.disabled and not was_disabled:
+                    # The writer only disables itself on an unrecoverable (OSError)
+                    # write failure; surface that in the run summary too, not just
+                    # the writer's own log line, so it isn't buried in a long run.
+                    self.report.warning(
+                        message="Parse-error quarantine file disabled after a write failure",
+                        context=self.quarantine.disabled_reason,
+                        log=False,
+                    )
+
+                self.report.num_database_quarantined_rows = (
+                    self.quarantine.records_written
+                )
+                if self.quarantine.records_written:
+                    self.report.database_quarantine_file = self.quarantine.filename
             return None

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_source.py
@@ -25,6 +25,7 @@ from datahub.ingestion.source.datahub.datahub_database_reader import (
     DataHubDatabaseReader,
 )
 from datahub.ingestion.source.datahub.datahub_kafka_reader import DataHubKafkaReader
+from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
 from datahub.ingestion.source.datahub.report import DataHubSourceReport
 from datahub.ingestion.source.datahub.state import StatefulDataHubIngestionHandler
 from datahub.ingestion.source.state.stateful_ingestion_base import (
@@ -75,6 +76,14 @@ class DataHubSource(StatefulIngestionSourceBase):
                 message=warning_msg, context="urn_pattern_override", log=False
             )
 
+        self.quarantine: Optional[QuarantineWriter] = None
+        if self.config.parse_error_log.enabled:
+            filename = (
+                self.config.parse_error_log.filename
+                or f"parse-errors-{ctx.run_id}.jsonl"
+            )
+            self.quarantine = QuarantineWriter(filename)
+
         self.stateful_ingestion_handler = StatefulDataHubIngestionHandler(self)
 
     @classmethod
@@ -84,6 +93,11 @@ class DataHubSource(StatefulIngestionSourceBase):
 
     def get_report(self) -> SourceReport:
         return self.report
+
+    def close(self) -> None:
+        if self.quarantine is not None:
+            self.quarantine.close()
+        super().close()
 
     def get_allowed_workunit_processors(self):
         # Exactly replicate data from DataHub source — avoid processors that create/remove workunits
@@ -103,7 +117,10 @@ class DataHubSource(StatefulIngestionSourceBase):
 
         if self.config.database_connection is not None:
             database_reader = DataHubDatabaseReader(
-                self.config, self.config.database_connection, self.report
+                self.config,
+                self.config.database_connection,
+                self.report,
+                self.quarantine,
             )
 
             yield from self._get_database_workunits(

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
@@ -29,11 +29,10 @@ class QuarantineWriter:
         if self._disabled:
             return
 
-        # default=str because createdon is a datetime.
-        line = json.dumps({"error": error, "row": row}, default=str)
-
         with self._lock:
             try:
+                # default=str because createdon is a datetime.
+                line = json.dumps({"error": error, "row": row}, default=str)
                 if self._file is None:
                     self._file = open(self.filename, "a", encoding="utf-8")
                     logger.info(f"Writing unparseable rows to {self.filename}")
@@ -47,9 +46,22 @@ class QuarantineWriter:
                 )
                 self._disabled = True
                 self._file = None
+            except Exception as e:
+                # Catch any serialization or value conversion error (e.g., custom __str__ that raises).
+                logger.warning(
+                    f"Disabling the parse-error quarantine, could not serialize row: {e}"
+                )
+                self._disabled = True
+                self._file = None
 
     def close(self) -> None:
         with self._lock:
             if self._file is not None:
-                self._file.close()
-                self._file = None
+                try:
+                    self._file.close()
+                except OSError as e:
+                    logger.warning(
+                        f"Failed to close quarantine file {self.filename}: {e}"
+                    )
+                finally:
+                    self._file = None

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import threading
+from typing import Any, Dict, Optional, TextIO
+
+logger = logging.getLogger(__name__)
+
+
+class QuarantineWriter:
+    """Appends rows that could not be parsed to an NDJSON file, one JSON object per line.
+
+    Rows reach this writer when no valid MCP could be built from them, so they cannot go
+    to the pipeline's dead-letter queue, which stores replayable MCPs. The artifact is
+    diagnostic: it makes every dropped row enumerable so it can be fixed at the source.
+
+    The file is opened on first write, so a run that drops nothing leaves nothing behind.
+    Lines are flushed as they are written so the file survives an abrupt kill; parse
+    errors are rare enough that the per-line flush is not a throughput concern.
+    """
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self.records_written = 0
+        self._file: Optional[TextIO] = None
+        self._lock = threading.Lock()
+        self._disabled = False
+
+    def write(self, row: Dict[str, Any], error: str) -> None:
+        if self._disabled:
+            return
+
+        # default=str because createdon is a datetime.
+        line = json.dumps({"error": error, "row": row}, default=str)
+
+        with self._lock:
+            try:
+                if self._file is None:
+                    self._file = open(self.filename, "a", encoding="utf-8")
+                    logger.info(f"Writing unparseable rows to {self.filename}")
+                self._file.write(line + "\n")
+                self._file.flush()
+                self.records_written += 1
+            except OSError as e:
+                logger.warning(
+                    f"Disabling the parse-error quarantine, cannot write to "
+                    f"{self.filename}: {e}"
+                )
+                self._disabled = True
+                self._file = None
+
+    def close(self) -> None:
+        with self._lock:
+            if self._file is not None:
+                self._file.close()
+                self._file = None

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/quarantine.py
@@ -24,6 +24,11 @@ class QuarantineWriter:
         self._file: Optional[TextIO] = None
         self._lock = threading.Lock()
         self._disabled = False
+        self.disabled_reason: Optional[str] = None
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
 
     def write(self, row: Dict[str, Any], error: str) -> None:
         if self._disabled:
@@ -33,6 +38,13 @@ class QuarantineWriter:
             try:
                 # default=str because createdon is a datetime.
                 line = json.dumps({"error": error, "row": row}, default=str)
+            except Exception as e:
+                # A bad value on this one row (e.g. a custom __str__ that raises)
+                # shouldn't take every later dropped row down with it.
+                logger.warning(f"Skipping quarantine row that failed to serialize: {e}")
+                return
+
+            try:
                 if self._file is None:
                     self._file = open(self.filename, "a", encoding="utf-8")
                     logger.info(f"Writing unparseable rows to {self.filename}")
@@ -40,19 +52,15 @@ class QuarantineWriter:
                 self._file.flush()
                 self.records_written += 1
             except OSError as e:
+                self.disabled_reason = f"cannot write to {self.filename}: {e}"
                 logger.warning(
-                    f"Disabling the parse-error quarantine, cannot write to "
-                    f"{self.filename}: {e}"
+                    f"Disabling the parse-error quarantine, {self.disabled_reason}"
                 )
                 self._disabled = True
                 self._file = None
             except Exception as e:
-                # Catch any serialization or value conversion error (e.g., custom __str__ that raises).
-                logger.warning(
-                    f"Disabling the parse-error quarantine, could not serialize row: {e}"
-                )
-                self._disabled = True
-                self._file = None
+                # Not writer-fatal: skip this row and keep the channel open for later ones.
+                logger.warning(f"Skipping quarantine row that failed to write: {e}")
 
     def close(self) -> None:
         with self._lock:
@@ -65,3 +73,5 @@ class QuarantineWriter:
                     )
                 finally:
                     self._file = None
+            # A write() after close() must not silently reopen the file.
+            self._disabled = True

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/report.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Optional
 
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionReport,
@@ -17,6 +18,10 @@ class DataHubSourceReport(StatefulIngestionReport):
     database_parse_errors: LossyDict[str, LossyDict[str, LossyList[str]]] = field(
         default_factory=LossyDict
     )
+    num_database_quarantined_rows: int = 0
+    # Only set once the quarantine file actually exists, so a clean run doesn't
+    # advertise a file that was never created.
+    database_quarantine_file: Optional[str] = None
 
     num_kafka_aspects_ingested: int = 0
     num_kafka_parse_errors: int = 0

--- a/metadata-ingestion/src/datahub/utilities/partition_executor.py
+++ b/metadata-ingestion/src/datahub/utilities/partition_executor.py
@@ -173,6 +173,57 @@ class _BatchPartitionWorkItem(NamedTuple):
     done_callback: Optional[Callable[[Future], None]]
 
 
+class BatchItemFailures(Exception):
+    """Raised by a `process_batch` callable to report per-item outcomes.
+
+    A batch call is all-or-nothing at the transport layer, so one invalid item fails
+    every item batched with it. A processor that can determine each item's individual
+    outcome — typically by retrying them one at a time — raises this instead of the
+    underlying error, and the executor delivers each item its own outcome rather than
+    sharing one failure across the batch.
+
+    `outcomes` is positionally aligned with the list handed to `process_batch`.
+    `None` at an index means that item succeeded.
+    """
+
+    def __init__(self, outcomes: List[Optional[BaseException]]) -> None:
+        failed = sum(1 for outcome in outcomes if outcome is not None)
+        super().__init__(f"{failed} of {len(outcomes)} batch items failed")
+        self.outcomes = outcomes
+
+
+def _extract_per_item_outcomes(
+    batch: List[_BatchPartitionWorkItem], future: Future
+) -> Optional[List[Optional[BaseException]]]:
+    # Returns None whenever per-item outcomes are unavailable or untrustworthy, which
+    # keeps the caller on the pre-existing shared-future path.
+    if future.cancelled() or not future.done():
+        return None
+
+    exception = future.exception()
+    if not isinstance(exception, BatchItemFailures):
+        return None
+
+    if len(exception.outcomes) != len(batch):
+        logger.warning(
+            "Ignoring per-item batch outcomes: got %d outcomes for a batch of %d",
+            len(exception.outcomes),
+            len(batch),
+        )
+        return None
+
+    return exception.outcomes
+
+
+def _future_for_outcome(outcome: Optional[BaseException]) -> Future:
+    future: Future = Future()
+    if outcome is None:
+        future.set_result(None)
+    else:
+        future.set_exception(outcome)
+    return future
+
+
 def _now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
@@ -319,9 +370,14 @@ class BatchPartitionExecutor(Closeable):
                     self._pending_count.release()
 
             # Separate from the above loop to avoid holding the lock while calling the callbacks.
-            for item in batch:
-                if item.done_callback:
+            per_item_outcomes = _extract_per_item_outcomes(batch, future)
+            for index, item in enumerate(batch):
+                if not item.done_callback:
+                    continue
+                if per_item_outcomes is None:
                     item.done_callback(future)
+                else:
+                    item.done_callback(_future_for_outcome(per_item_outcomes[index]))
 
         def _find_ready_items(max_to_add: int) -> List[_BatchPartitionWorkItem]:
             with clearinghouse_state_lock:

--- a/metadata-ingestion/tests/unit/test_datahub_quarantine.py
+++ b/metadata-ingestion/tests/unit/test_datahub_quarantine.py
@@ -1,0 +1,56 @@
+import json
+from datetime import datetime, timezone
+
+from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
+
+
+def _row() -> dict:
+    return {
+        "urn": "urn:li:dashboard:(my_tool,my dashboard (copy))",
+        "aspect": "dashboardInfo",
+        "version": 0,
+        "createdon": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "metadata": '{"title": "x"}',
+        "systemmetadata": "{}",
+    }
+
+
+def test_creates_no_file_when_nothing_is_written(tmp_path):
+    """A clean run must leave no artifact behind."""
+    path = tmp_path / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+    writer.close()
+
+    assert not path.exists()
+    assert writer.records_written == 0
+
+
+def test_writes_one_ndjson_line_per_row(tmp_path):
+    path = tmp_path / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+    writer.write(_row(), "DashboardUrn dashboard_id contains reserved characters")
+    writer.write(_row(), "KeyError: 'someRemovedAspect'")
+    writer.close()
+
+    lines = path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 2
+    assert writer.records_written == 2
+
+    first = json.loads(lines[0])
+    assert first["error"] == "DashboardUrn dashboard_id contains reserved characters"
+    assert first["row"]["urn"] == "urn:li:dashboard:(my_tool,my dashboard (copy))"
+    assert first["row"]["aspect"] == "dashboardInfo"
+    # createdon is a datetime and must survive serialisation rather than blowing up.
+    assert first["row"]["createdon"].startswith("2026-01-01")
+
+
+def test_disables_itself_when_the_file_cannot_be_written(tmp_path):
+    """A diagnostic artifact must never fail the run."""
+    path = tmp_path / "no-such-dir" / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+
+    writer.write(_row(), "some error")  # must not raise
+    writer.write(_row(), "another error")
+
+    assert writer.records_written == 0
+    writer.close()

--- a/metadata-ingestion/tests/unit/test_datahub_quarantine.py
+++ b/metadata-ingestion/tests/unit/test_datahub_quarantine.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
 
@@ -54,3 +55,37 @@ def test_disables_itself_when_the_file_cannot_be_written(tmp_path):
 
     assert writer.records_written == 0
     writer.close()
+
+
+class RaisingStr:
+    def __str__(self):
+        raise ValueError("Intentional serialization failure")
+
+
+def test_disables_itself_when_serialization_fails(tmp_path):
+    """A serialization error must not raise."""
+    path = tmp_path / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+
+    bad_row = _row()
+    bad_row["bad_value"] = RaisingStr()
+
+    writer.write(bad_row, "some error")  # must not raise
+
+    assert writer.records_written == 0
+    writer.close()
+
+
+def test_handles_close_failure_gracefully(tmp_path):
+    """A close-time failure must not raise."""
+    path = tmp_path / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+    writer.write(_row(), "some error")
+
+    # Simulate a close failure
+    writer._file.close = MagicMock(side_effect=OSError("Simulated close failure"))
+
+    writer.close()  # must not raise
+
+    # _file should be cleared even on failure
+    assert writer._file is None

--- a/metadata-ingestion/tests/unit/test_datahub_quarantine.py
+++ b/metadata-ingestion/tests/unit/test_datahub_quarantine.py
@@ -83,7 +83,8 @@ def test_handles_close_failure_gracefully(tmp_path):
     writer.write(_row(), "some error")
 
     # Simulate a close failure
-    writer._file.close = MagicMock(side_effect=OSError("Simulated close failure"))
+    assert writer._file is not None
+    writer._file.close = MagicMock(side_effect=OSError("Simulated close failure"))  # type: ignore[method-assign]
 
     writer.close()  # must not raise
 

--- a/metadata-ingestion/tests/unit/test_datahub_quarantine.py
+++ b/metadata-ingestion/tests/unit/test_datahub_quarantine.py
@@ -1,11 +1,12 @@
 import json
 from datetime import datetime, timezone
+from typing import Any, Dict
 from unittest.mock import MagicMock
 
 from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
 
 
-def _row() -> dict:
+def _row() -> Dict[str, Any]:
     return {
         "urn": "urn:li:dashboard:(my_tool,my dashboard (copy))",
         "aspect": "dashboardInfo",
@@ -62,18 +63,33 @@ class RaisingStr:
         raise ValueError("Intentional serialization failure")
 
 
-def test_disables_itself_when_serialization_fails(tmp_path):
-    """A serialization error must not raise."""
+def test_skips_row_that_fails_to_serialize_without_disabling(tmp_path):
+    """A row-local serialization failure must not take down every later dropped row."""
     path = tmp_path / "parse-errors.jsonl"
     writer = QuarantineWriter(str(path))
 
     bad_row = _row()
     bad_row["bad_value"] = RaisingStr()
 
-    writer.write(bad_row, "some error")  # must not raise
+    writer.write(bad_row, "some error")  # must not raise, and must not disable
+    writer.write(_row(), "a later, parseable error")
 
-    assert writer.records_written == 0
+    assert not writer.disabled
+    assert writer.records_written == 1
     writer.close()
+
+
+def test_write_after_close_does_not_reopen_file(tmp_path):
+    """A write() call after close() must not resurrect the file handle."""
+    path = tmp_path / "parse-errors.jsonl"
+    writer = QuarantineWriter(str(path))
+    writer.write(_row(), "some error")
+    writer.close()
+
+    writer.write(_row(), "a write after close")
+
+    assert writer._file is None
+    assert writer.records_written == 1
 
 
 def test_handles_close_failure_gracefully(tmp_path):

--- a/metadata-ingestion/tests/unit/test_datahub_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_source.py
@@ -514,5 +514,5 @@ def test_parse_error_log_default_filename_includes_run_id():
 
     source = DataHubSource(config, ctx)
     assert source.quarantine is not None
-    assert "my-run-id" in source.quarantine.filename
+    assert source.quarantine.filename == "parse-errors-my-run-id.jsonl"
     source.close()

--- a/metadata-ingestion/tests/unit/test_datahub_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_source.py
@@ -399,6 +399,81 @@ def test_parse_row_quarantines_unparseable_rows(tmp_path):
     assert "anAspectThisCliDoesNotKnow" in lines[0]
 
 
+def test_quarantine_state_surfaced_in_report(tmp_path):
+    """The report must reflect quarantine activity, not just a log line."""
+    from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
+
+    path = tmp_path / "parse-errors.jsonl"
+    quarantine = QuarantineWriter(str(path))
+
+    config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})
+    reader = DataHubDatabaseReader.__new__(DataHubDatabaseReader)
+    reader.config = config
+    reader.report = DataHubSourceReport()
+    reader.quarantine = quarantine
+
+    row = {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",
+        "aspect": "anAspectThisCliDoesNotKnow",
+        "version": 0,
+        "createdon": datetime(2026, 1, 1),
+        "metadata": "{}",
+        "systemmetadata": "{}",
+    }
+
+    reader._parse_row(row)
+
+    assert reader.report.num_database_quarantined_rows == 1
+    assert reader.report.database_quarantine_file == str(path)
+    quarantine.close()
+
+
+def test_quarantine_state_empty_on_clean_run(tmp_path):
+    """A run that drops nothing must not advertise a quarantine file."""
+    from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
+
+    path = tmp_path / "parse-errors.jsonl"
+    quarantine = QuarantineWriter(str(path))
+    reader = DataHubDatabaseReader.__new__(DataHubDatabaseReader)
+    reader.report = DataHubSourceReport()
+    reader.quarantine = quarantine
+
+    quarantine.close()
+
+    assert reader.report.num_database_quarantined_rows == 0
+    assert reader.report.database_quarantine_file is None
+
+
+def test_quarantine_disable_is_surfaced_as_a_report_warning(tmp_path):
+    """An unrecoverable quarantine write failure must show up in the run summary,
+    not just the writer's own log line."""
+    from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
+
+    path = tmp_path / "no-such-dir" / "parse-errors.jsonl"
+    quarantine = QuarantineWriter(str(path))
+
+    config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})
+    reader = DataHubDatabaseReader.__new__(DataHubDatabaseReader)
+    reader.config = config
+    reader.report = DataHubSourceReport()
+    reader.quarantine = quarantine
+
+    row = {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",
+        "aspect": "anAspectThisCliDoesNotKnow",
+        "version": 0,
+        "createdon": datetime(2026, 1, 1),
+        "metadata": "{}",
+        "systemmetadata": "{}",
+    }
+
+    reader._parse_row(row)
+
+    assert any("quarantine" in str(w).lower() for w in reader.report.warnings)
+    assert reader.report.num_database_quarantined_rows == 0
+    assert reader.report.database_quarantine_file is None
+
+
 def test_parse_row_without_quarantine_still_counts_the_error():
     """The quarantine is optional; disabling it must not change parsing behaviour."""
     config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})

--- a/metadata-ingestion/tests/unit/test_datahub_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_source.py
@@ -12,6 +12,7 @@ from datahub.ingestion.source.datahub.datahub_database_reader import (
     VersionOrderer,
 )
 from datahub.ingestion.source.datahub.datahub_source import DataHubSource
+from datahub.ingestion.source.datahub.report import DataHubSourceReport
 
 
 @pytest.fixture
@@ -365,3 +366,78 @@ def test_soft_deleted_urns_query_uses_dialect_aware_json_extraction(mock_reader)
     query = mock_reader.soft_deleted_urns_query
     assert "JSON_EXTRACT(metadata, '$.removed')" in query
     assert "aspect = 'status'" in query
+
+
+def test_parse_row_quarantines_unparseable_rows(tmp_path):
+    """A row that cannot be parsed must be recorded, not just counted."""
+    from datahub.ingestion.source.datahub.quarantine import QuarantineWriter
+
+    path = tmp_path / "parse-errors.jsonl"
+    quarantine = QuarantineWriter(str(path))
+
+    config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})
+    reader = DataHubDatabaseReader.__new__(DataHubDatabaseReader)
+    reader.config = config
+    reader.report = DataHubSourceReport()
+    reader.quarantine = quarantine
+
+    row = {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",
+        "aspect": "anAspectThisCliDoesNotKnow",
+        "version": 0,
+        "createdon": datetime(2026, 1, 1),
+        "metadata": "{}",
+        "systemmetadata": "{}",
+    }
+
+    assert reader._parse_row(row) is None
+    assert reader.report.num_database_parse_errors == 1
+
+    quarantine.close()
+    lines = path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 1
+    assert "anAspectThisCliDoesNotKnow" in lines[0]
+
+
+def test_parse_row_without_quarantine_still_counts_the_error():
+    """The quarantine is optional; disabling it must not change parsing behaviour."""
+    config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})
+    reader = DataHubDatabaseReader.__new__(DataHubDatabaseReader)
+    reader.config = config
+    reader.report = DataHubSourceReport()
+    reader.quarantine = None
+
+    row = {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",
+        "aspect": "anAspectThisCliDoesNotKnow",
+        "version": 0,
+        "createdon": datetime(2026, 1, 1),
+        "metadata": "{}",
+        "systemmetadata": "{}",
+    }
+
+    assert reader._parse_row(row) is None
+    assert reader.report.num_database_parse_errors == 1
+
+
+def test_parse_error_log_can_be_disabled():
+    config = DataHubSourceConfig.model_validate(
+        {"pull_from_datahub_api": True, "parse_error_log": {"enabled": False}}
+    )
+    ctx = PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+    ctx.graph = MagicMock()
+
+    source = DataHubSource(config, ctx)
+    assert source.quarantine is None
+    source.close()
+
+
+def test_parse_error_log_default_filename_includes_run_id():
+    config = DataHubSourceConfig.model_validate({"pull_from_datahub_api": True})
+    ctx = PipelineContext(run_id="my-run-id", pipeline_name="test-pipeline")
+    ctx.graph = MagicMock()
+
+    source = DataHubSource(config, ctx)
+    assert source.quarantine is not None
+    assert "my-run-id" in source.quarantine.filename
+    source.close()

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -9,14 +9,17 @@ import requests
 import time_machine
 
 import datahub.metadata.schema_classes as models
+from datahub.configuration.common import OperationalError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter, EmitMode
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.sink.datahub_rest import (
     DatahubRestSink,
     DatahubRestSinkConfig,
+    DataHubRestSinkReport,
     RestSinkMode,
 )
+from datahub.utilities.partition_executor import BatchItemFailures
 
 MOCK_GMS_ENDPOINT = "http://fakegmshost:8080"
 
@@ -492,3 +495,128 @@ def test_rest_sink_config_accepts_client_config_dump():
     client = DatahubClientConfig(server="http://localhost:8080")
     cfg = DatahubRestSinkConfig(**client.model_dump())
     assert cfg.server == "http://localhost:8080"
+
+
+def _make_sink(mock_emitter) -> DatahubRestSink:
+    sink = DatahubRestSink.__new__(DatahubRestSink)
+    sink._emitter_thread_local = threading.local()
+    sink._emitter_thread_local.emitter = mock_emitter
+    sink._gms_emit_mode = EmitMode.ASYNC
+    sink.report = DataHubRestSinkReport()
+    return sink
+
+
+def _status_mcp(name: str) -> MetadataChangeProposalWrapper:
+    return MetadataChangeProposalWrapper(
+        entityUrn=f"urn:li:dataset:(urn:li:dataPlatform:foo,{name},PROD)",
+        aspect=models.StatusClass(removed=False),
+    )
+
+
+def test_emit_batch_wrapper_isolates_the_record_that_caused_the_rejection():
+    """One invalid record must not take the valid records batched with it down."""
+    good1 = _status_mcp("good1")
+    poison = _status_mcp("poison")
+    good2 = _status_mcp("good2")
+
+    batch_error = OperationalError("batch rejected", {"status": 422})
+    poison_error = OperationalError("record rejected", {"status": 422})
+
+    def emit_mcps(events, emit_mode=None):
+        if len(events) > 1:
+            raise batch_error
+        if events[0] is poison:
+            raise poison_error
+        return [MagicMock()]
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = emit_mcps
+    sink = _make_sink(mock_emitter)
+
+    with pytest.raises(BatchItemFailures) as exc_info:
+        sink._emit_batch_wrapper([(good1,), (poison,), (good2,)])
+
+    outcomes = exc_info.value.outcomes
+    assert outcomes[0] is None
+    assert outcomes[1] is poison_error
+    assert outcomes[2] is None
+
+    assert sink.report.batches_rejected == 1
+    assert sink.report.records_isolated_after_batch_rejection == 3
+    assert sink.report.records_recovered_after_batch_rejection == 2
+
+
+def test_emit_batch_wrapper_does_not_isolate_a_single_record_batch():
+    """With one record the error is already precise, so re-emitting it is pure waste."""
+    poison = _status_mcp("poison")
+    poison_error = OperationalError("record rejected", {"status": 422})
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = poison_error
+    sink = _make_sink(mock_emitter)
+
+    with pytest.raises(OperationalError):
+        sink._emit_batch_wrapper([(poison,)])
+
+    assert mock_emitter.emit_mcps.call_count == 1
+    assert sink.report.batches_rejected == 0
+
+
+def test_emit_batch_wrapper_isolation_when_every_record_fails():
+    """A block applied to the whole request, not one poison record.
+
+    Isolation cannot recover anything here, but it must still attribute an error to
+    every record rather than sharing one, and uniform failure is itself diagnostic:
+    it proves no single record was at fault.
+    """
+    records = [_status_mcp(f"rec{i}") for i in range(3)]
+    error = OperationalError("forbidden", {"message": "403 Client Error: Forbidden"})
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = error
+    sink = _make_sink(mock_emitter)
+
+    with pytest.raises(BatchItemFailures) as exc_info:
+        sink._emit_batch_wrapper([(record,) for record in records])
+
+    outcomes = exc_info.value.outcomes
+    assert len(outcomes) == 3
+    assert all(outcome is error for outcome in outcomes)
+
+    assert sink.report.batches_rejected == 1
+    assert sink.report.records_isolated_after_batch_rejection == 3
+    assert sink.report.records_recovered_after_batch_rejection == 0
+
+
+def test_emit_batch_wrapper_isolation_keeps_an_mce_record_whole():
+    """An MCE expands to several MCPs; isolation must re-emit them together as one record."""
+    mce = models.MetadataChangeEventClass(
+        proposedSnapshot=models.DatasetSnapshotClass(
+            urn="urn:li:dataset:(urn:li:dataPlatform:foo,mce,PROD)",
+            aspects=[
+                models.StatusClass(removed=False),
+                models.DatasetPropertiesClass(name="mce"),
+            ],
+        )
+    )
+    good = _status_mcp("good")
+
+    single_record_calls = []
+
+    def emit_mcps(events, emit_mode=None):
+        if len(events) > 2:  # the whole batch: 2 MCPs from the MCE + 1 MCP
+            raise OperationalError("batch rejected", {"status": 422})
+        single_record_calls.append(list(events))
+        return [MagicMock()]
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = emit_mcps
+    sink = _make_sink(mock_emitter)
+
+    with pytest.raises(BatchItemFailures) as exc_info:
+        sink._emit_batch_wrapper([(mce,), (good,)])
+
+    assert exc_info.value.outcomes == [None, None]
+    # Two isolation calls: the MCE's two MCPs together, then the lone MCP.
+    assert [len(call) for call in single_record_calls] == [2, 1]
+    assert sink.report.records_recovered_after_batch_rejection == 2

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -497,7 +497,7 @@ def test_rest_sink_config_accepts_client_config_dump():
     assert cfg.server == "http://localhost:8080"
 
 
-def _make_sink(mock_emitter) -> DatahubRestSink:
+def _make_sink(mock_emitter: MagicMock) -> DatahubRestSink:
     sink = DatahubRestSink.__new__(DatahubRestSink)
     sink._emitter_thread_local = threading.local()
     sink._emitter_thread_local.emitter = mock_emitter

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -14,6 +14,7 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter, EmitMode
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.sink.datahub_rest import (
+    _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS,
     DatahubRestSink,
     DatahubRestSinkConfig,
     DataHubRestSinkReport,
@@ -503,6 +504,9 @@ def _make_sink(mock_emitter: MagicMock) -> DatahubRestSink:
     sink._emitter_thread_local.emitter = mock_emitter
     sink._gms_emit_mode = EmitMode.ASYNC
     sink.report = DataHubRestSinkReport()
+    sink._isolation_lock = threading.Lock()
+    sink._consecutive_zero_recovery_isolations = 0
+    sink._isolation_suppressed = False
     return sink
 
 
@@ -620,3 +624,61 @@ def test_emit_batch_wrapper_isolation_keeps_an_mce_record_whole():
     # Two isolation calls: the MCE's two MCPs together, then the lone MCP.
     assert [len(call) for call in single_record_calls] == [2, 1]
     assert sink.report.records_recovered_after_batch_rejection == 2
+
+
+def test_isolation_stops_after_consecutive_zero_recovery_batches(caplog):
+    """A systemic failure (e.g. an expired token) must not turn one rejected batch
+    into max_per_batch sequential failures forever; isolation should give up."""
+    records = [_status_mcp(f"rec{i}") for i in range(3)]
+    error = OperationalError("forbidden", {"message": "403 Client Error: Forbidden"})
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = error
+    sink = _make_sink(mock_emitter)
+
+    for _ in range(_MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS):
+        with pytest.raises(BatchItemFailures):
+            sink._emit_batch_wrapper([(record,) for record in records])
+
+    assert sink.report.batches_rejected == _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS
+    assert sink.report.batches_rejected_while_isolation_suppressed == 0
+
+    mock_emitter.emit_mcps.reset_mock()
+    with caplog.at_level("WARNING"):
+        with pytest.raises(OperationalError):
+            sink._emit_batch_wrapper([(record,) for record in records])
+
+    # Only the single failed batch call — no per-record isolation attempts.
+    assert mock_emitter.emit_mcps.call_count == 1
+    assert sink.report.batches_rejected == _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS
+    assert sink.report.batches_rejected_while_isolation_suppressed == 1
+    assert "disabling per-record isolation" in caplog.text
+
+
+def test_isolation_continues_when_a_pass_recovers_at_least_one_record():
+    """One recovered record per pass must reset the zero-recovery streak, so an
+    unlucky run of partial failures never trips the circuit breaker."""
+    poison = _status_mcp("poison")
+    good = _status_mcp("good")
+    poison_error = OperationalError("record rejected", {"status": 422})
+
+    def emit_mcps(events, emit_mode=None):
+        if len(events) > 1:
+            raise OperationalError("batch rejected", {"status": 422})
+        if events[0] is poison:
+            raise poison_error
+        return [MagicMock()]
+
+    mock_emitter = MagicMock()
+    mock_emitter.emit_mcps.side_effect = emit_mcps
+    sink = _make_sink(mock_emitter)
+
+    passes = _MAX_CONSECUTIVE_ZERO_RECOVERY_ISOLATIONS + 2
+    for _ in range(passes):
+        with pytest.raises(BatchItemFailures):
+            sink._emit_batch_wrapper([(poison,), (good,)])
+
+    # Isolation ran on every pass — it was never suppressed, because `good` was
+    # recovered each time.
+    assert sink.report.batches_rejected == passes
+    assert sink.report.batches_rejected_while_isolation_suppressed == 0

--- a/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
@@ -3,7 +3,7 @@ import math
 import time
 from concurrent.futures import Future
 from datetime import timedelta
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import pytest
 
@@ -221,7 +221,7 @@ def test_batch_partition_executor_delivers_per_item_outcomes():
         if any(r is not None for r in results):
             raise BatchItemFailures(results)
 
-    def make_callback(task_id: str):
+    def make_callback(task_id: str) -> Callable[[Future], None]:
         def _callback(future: Future) -> None:
             outcomes[task_id] = future.exception()
 
@@ -249,7 +249,7 @@ def test_batch_partition_executor_falls_back_to_shared_future():
     def process_batch(batch):
         raise error
 
-    def make_callback(task_id: str):
+    def make_callback(task_id: str) -> Callable[[Future], None]:
         def _callback(future: Future) -> None:
             outcomes[task_id] = future.exception()
 

--- a/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
@@ -241,6 +241,36 @@ def test_batch_partition_executor_delivers_per_item_outcomes():
     assert isinstance(outcomes["task2"], ValueError)
 
 
+def test_batch_partition_executor_falls_back_to_shared_future():
+    """A plain exception (not BatchItemFailures) must fall back to shared-Future dispatch."""
+    error = ValueError("whole batch rejected")
+    outcomes: Dict[str, Optional[BaseException]] = {}
+
+    def process_batch(batch):
+        raise error
+
+    def make_callback(task_id: str):
+        def _callback(future: Future) -> None:
+            outcomes[task_id] = future.exception()
+
+        return _callback
+
+    with BatchPartitionExecutor(
+        max_workers=1,
+        max_pending=10,
+        max_per_batch=3,
+        process_batch=process_batch,
+    ) as executor:
+        for task_id in ("task1", "task2", "task3"):
+            executor.submit("key1", task_id, done_callback=make_callback(task_id))
+
+    # `error` is the same instance regardless of how many batches these get split
+    # into, so this holds no matter the batch boundaries.
+    assert outcomes["task1"] is error
+    assert outcomes["task2"] is error
+    assert outcomes["task3"] is error
+
+
 def test_extract_per_item_outcomes_rejects_length_mismatch():
     """A malformed outcome list must fall back to shared-future dispatch, not mis-attribute."""
     batch = [_work_item("a"), _work_item("b")]

--- a/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
@@ -3,12 +3,17 @@ import math
 import time
 from concurrent.futures import Future
 from datetime import timedelta
+from typing import Dict, List, Optional
 
 import pytest
 
 from datahub.utilities.partition_executor import (
+    BatchItemFailures,
     BatchPartitionExecutor,
     PartitionExecutor,
+    _BatchPartitionWorkItem,
+    _extract_per_item_outcomes,
+    _future_for_outcome,
 )
 from datahub.utilities.perf_timer import PerfTimer
 
@@ -197,3 +202,73 @@ def test_empty_batch_partition_executor():
         max_workers=5, max_pending=20, process_batch=lambda batch: None, max_per_batch=2
     ) as executor:
         assert executor is not None
+
+
+def _work_item(key: str) -> _BatchPartitionWorkItem:
+    return _BatchPartitionWorkItem(key=key, args=(key,), done_callback=None)
+
+
+def test_batch_partition_executor_delivers_per_item_outcomes():
+    """A batch processor that reports per-item outcomes must not fail the whole batch."""
+    outcomes: Dict[str, Optional[BaseException]] = {}
+
+    def process_batch(batch):
+        # Deliberately keyed off the args rather than the index, so the assertions
+        # hold no matter how the executor happens to split these into batches.
+        results: List[Optional[BaseException]] = []
+        for (task_id,) in batch:
+            results.append(ValueError("bad record") if task_id == "task2" else None)
+        if any(r is not None for r in results):
+            raise BatchItemFailures(results)
+
+    def make_callback(task_id: str):
+        def _callback(future: Future) -> None:
+            outcomes[task_id] = future.exception()
+
+        return _callback
+
+    with BatchPartitionExecutor(
+        max_workers=1,
+        max_pending=10,
+        max_per_batch=3,
+        process_batch=process_batch,
+    ) as executor:
+        for task_id in ("task1", "task2", "task3"):
+            executor.submit("key1", task_id, done_callback=make_callback(task_id))
+
+    assert outcomes["task1"] is None
+    assert outcomes["task3"] is None
+    assert isinstance(outcomes["task2"], ValueError)
+
+
+def test_extract_per_item_outcomes_rejects_length_mismatch():
+    """A malformed outcome list must fall back to shared-future dispatch, not mis-attribute."""
+    batch = [_work_item("a"), _work_item("b")]
+    future: Future = Future()
+    future.set_exception(BatchItemFailures([None]))
+
+    assert _extract_per_item_outcomes(batch, future) is None
+
+
+def test_extract_per_item_outcomes_ignores_plain_exceptions():
+    batch = [_work_item("a"), _work_item("b")]
+    future: Future = Future()
+    future.set_exception(ValueError("whole batch failed"))
+
+    assert _extract_per_item_outcomes(batch, future) is None
+
+
+def test_extract_per_item_outcomes_handles_cancelled_future():
+    """future.exception() raises on a cancelled future, so it must not be called."""
+    batch = [_work_item("a")]
+    future: Future = Future()
+    future.cancel()
+
+    assert _extract_per_item_outcomes(batch, future) is None
+
+
+def test_future_for_outcome():
+    assert _future_for_outcome(None).exception() is None
+
+    err = ValueError("nope")
+    assert _future_for_outcome(err).exception() is err


### PR DESCRIPTION
Two independent changes to `metadata-ingestion` that make large DataHub-to-DataHub migrations diagnosable. Both were motivated by a ~6M-aspect migration that lost ~2,000 aspects, of which only about half were genuinely bad data — the rest were lost to instrumentation, with no way to tell the two apart.

## 1. Attribute batch rejections to the record that caused them

`ingestProposalBatch` is rejected as a unit server-side, so a single invalid record fails every record batched with it. At the default `max_per_batch: 100` that means up to 99 valid records lost per invalid one — and because `BatchPartitionExecutor` handed the same failed `Future` to every item's `done_callback`, all of them reported the identical error. The culprit was indistinguishable from the bystanders, in the report and in the dead-letter queue alike. The sink already logged "N members below rode along in the same failed HTTP call"; it just could not act on it.

On a rejected batch the sink now re-emits each record individually and reports per-record outcomes through a new `BatchItemFailures` exception, which the executor unpacks into one `Future` per record. Everything downstream — `records_written`, `on_success`/`on_failure`, the dead-letter queue — then works per record with no interface changes.

Details worth noting for review:

- **Unconditional, no flag.** Silently discarding up to `max_per_batch - 1` valid records is never a desired outcome.
- **Degrades to current behaviour.** If the outcome list is absent, malformed, or the batch future was cancelled, dispatch falls back to the pre-existing shared-`Future` path.
- **The 1:N expansion is preserved.** An MCE unpacks into several MCPs, so the record→events grouping is kept and isolation re-emits an MCE's MCPs together as one record.
- **One record at a time, not bisected.** Bisect is worse in the observed shape: with many culprits in one batch it costs several times more requests than a linear pass, and the failure path is not the hot path.
- **Bounded.** Isolation turns one rejected request into N, so a systemic failure (an expiring token, a model mismatch, an outage outlasting the retry budget) could otherwise amplify request volume by `max_per_batch` against an already-unhealthy server. After three consecutive isolation passes that recover nothing, isolation switches off with a single warning and a counter records the batches rejected while suppressed.

New report counters: `batches_rejected`, `records_isolated_after_batch_rejection`, `records_recovered_after_batch_rejection`. The third is the one that matters — on the migration above it would have read ~1,000 records recovered that were previously lost.

## 2. Record rows that cannot be parsed, instead of only counting them

Rows that fail `_parse_row` in the `datahub` source were counted, sampled to ten URNs, and otherwise discarded. They never become work units, so the pipeline's `failure_log` never saw them — a second loss channel, invisible by default. In the migration above this silently dropped a handful of dashboards whose URNs contained characters the URN model reserves.

These rows **cannot** go to the existing dead-letter queue: that queue stores replayable MCPs, and these rows failed precisely because no valid MCP could be built from them (an invalid URN, or an aspect name this CLI does not know). They now stream to an NDJSON file, one row per line, created lazily so a clean run leaves nothing behind. The artifact is diagnostic rather than replayable, which matches reality — these rows need fixing at the source before they can ever be ingested.

The writer streams and flushes per line rather than buffering, deliberately not reusing `FileSink`, which accumulates every record and serialises at `close()`. Row-local failures skip the row and continue; only an `OSError` is writer-fatal, and a write failure disables the channel with a warning rather than raising — a diagnostic artifact must never fail a run. The row count and file path are surfaced on `DataHubSourceReport`, and a self-disable is surfaced as a report warning, so an operator sees it in the run summary rather than having to grep a multi-gigabyte log.

**This is the one default-behaviour change here:** `parse_error_log.enabled` defaults to `true`, so a run that drops rows writes `parse-errors-{run_id}.jsonl`. Set `parse_error_log.enabled: false` to disable.

To pre-empt an obvious question: the pipeline-level `failure_log.enabled` defaults to `false`, so this default inverts its sibling. That is deliberate. This channel being invisible by default is exactly how the dropped rows went unnoticed, the file is only created when data is actually being lost, and the `datahub` source already defaults `commit_with_parse_errors` to `false` — it has always treated source-side parse errors as serious by default.

## Testing

- 25 new unit tests across `test_partition_executor.py`, `test_rest_sink.py`, `test_datahub_source.py`, and `test_datahub_quarantine.py`; 65 passing in those four files.
- `./gradlew :metadata-ingestion:testQuick` — 16,568 passing. The only failures in my environment are missing optional dependencies (`debug-recording`, `azure.mgmt`, and `pyodbc`'s native `libodbc`); no dependency declaration is touched by this PR.
- `./gradlew :metadata-ingestion:lint` — clean, ruff and mypy.
- **Verified end-to-end against a live GMS**, since this is a failure mode that only appears when a real validator rejects a real batch: one `ASYNC_BATCH` batch of five records — one invalid plus four valid — produced 1 failure, 4 recovered, 4 written, and all four valid records readable back afterwards. Before this change all five failed and none were written.

## Known limitation

The isolation circuit breaker is one-way: once suppressed it stays suppressed for the rest of the run, so a transient failure long enough to trip it costs per-record attribution for the remainder. Its worst case equals the current behaviour (no attribution), so this is a lost improvement rather than a regression, but a re-arm after a run of successful batches would be a strict improvement and is worth a follow-up.

## Checklist

- [x] PR conforms to the Contributing Guideline, including PR Title Format
- [x] Tests added
- [x] Docs added — `metadata-ingestion/docs/sources/datahub/datahub_post.md` and an entry in `docs/how/updating-datahub.md` for the new default-on artifact
- [x] Entry in Updating DataHub for the default-behaviour change
- [ ] Links to related issues — none


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes rejected ingest batches to the specific record that caused them and records unparseable `datahub` source rows to NDJSON. This prevents valid records from being silently lost and makes migration drop causes enumerable. Previously, a batch rejection failed all records with the same error and parse failures were only counted; now the sink isolates per record on rejection and the source writes `parse-errors-{run_id}.jsonl` by default.

- Preserves record boundaries: an MCE’s MCPs are re-emitted together; single-record batches are not re-emitted; falls back to shared-failure behavior if per-item outcomes are unavailable.
- Adds per-item outcomes to the batch executor via `BatchItemFailures`; the REST sink uses it to deliver one result per record.
- Bounds request amplification with a circuit breaker after 3 consecutive zero-recovery isolations; new counters: batches_rejected, records_isolated_after_batch_rejection, records_recovered_after_batch_rejection, batches_rejected_while_isolation_suppressed.
- Parse-error quarantine writes one JSON object per line and never fails the run; the report surfaces num_database_quarantined_rows and database_quarantine_file.

**Rollout**
- Default change: parse-error quarantine is on by default. To disable, set `parse_error_log.enabled: false` (optionally set `parse_error_log.filename`).
- No interface changes to sources/sinks. Isolation only runs on rejected batches; in systemic failures it stops automatically via the circuit breaker.

<sup>Written for commit bf7526a0c585bf53bec94b7e0bf19aaee3546d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

