### PR TITLE
fix(ingest/informix): correct VARCHAR length decoding, harden catalog joins, resolve extended types

### DIFF
--- a/metadata-ingestion/docs/sources/informix/informix_post.md
+++ b/metadata-ingestion/docs/sources/informix/informix_post.md
@@ -73,7 +73,10 @@ against `sysxtdtypes` to recover the real type name.
 
 `LVARCHAR`, `BOOLEAN`, `BLOB` and `CLOB` map to their DataHub equivalents. A `DISTINCT` type
 reports its own name (for example `MONEY_USD`) and takes its DataHub type from the built-in it
-was defined over. A named `ROW` type maps to a record.
+was defined over — read from `coltype` for an ordinary built-in, and from `sysxtdtypes.source`
+when it was defined over `LVARCHAR`, `BOOLEAN`, `BLOB` or `CLOB`, which `coltype` cannot express.
+A `DISTINCT` type defined over another `DISTINCT` type maps to a null type. A named `ROW` type
+maps to a record.
 
 User-defined opaque types (`JSON`, `BSON`, time series, and spatial types such as
 `ST_Geometry`) have no DataHub equivalent and still map to a null type, but the native type name

--- a/metadata-ingestion/docs/sources/informix/informix_post.md
+++ b/metadata-ingestion/docs/sources/informix/informix_post.md
@@ -67,7 +67,17 @@ skipped rather than emitted misaligned. Skipped constraints are counted as
 
 #### Extended type mapping
 
-Informix extended types (`JSON`, `BSON`, time series, and spatial types such as `ST_Geometry`) are not in the base `syscolumns.coltype` map and fall back to an unknown/null DataHub type. The native type name is still preserved for display.
+`syscolumns.coltype` cannot identify an extended type on its own — `LVARCHAR` is type 40, and
+`BOOLEAN`, `BLOB` and `CLOB` all share type 41 — so the column's `extended_id` is resolved
+against `sysxtdtypes` to recover the real type name.
+
+`LVARCHAR`, `BOOLEAN`, `BLOB` and `CLOB` map to their DataHub equivalents. A `DISTINCT` type
+reports its own name (for example `MONEY_USD`) and takes its DataHub type from the built-in it
+was defined over. A named `ROW` type maps to a record.
+
+User-defined opaque types (`JSON`, `BSON`, time series, and spatial types such as
+`ST_Geometry`) have no DataHub equivalent and still map to a null type, but the native type name
+is reported rather than a placeholder. Each one is counted as a warning in the ingestion report.
 
 ### Troubleshooting
 

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/client.py
@@ -20,6 +20,7 @@ from datahub.ingestion.source.informix.constants import (
 from datahub.ingestion.source.informix.driver import resolve_driver_jars
 from datahub.ingestion.source.informix.mapping import build_jdbc_url
 from datahub.ingestion.source.informix.models import (
+    ExtendedType,
     InformixColumn,
     InformixForeignKey,
     InformixTable,
@@ -51,6 +52,16 @@ class InformixClientProtocol(Protocol):
 
 def _opt_str(value: object) -> Optional[str]:
     return str(value).strip() if value is not None else None
+
+
+def _parse_extended_type(row: List[object]) -> Optional[ExtendedType]:
+    # The sysxtdtypes outer joins yield SQL NULLs for a column with no extended
+    # type (extended_id = 0), and for the source of anything but a DISTINCT
+    # declared over another extended type.
+    name = _opt_str(row[4])
+    if name is None:
+        return None
+    return ExtendedType(name=name, mode=_opt_str(row[5]), source_name=_opt_str(row[6]))
 
 
 def _safe_close(closeable: object) -> None:
@@ -156,9 +167,7 @@ class InformixClient:
                 length=int(str(r[2])),
                 colno=int(str(r[3])),
                 is_pk=str(r[0]).strip() in pk_names,
-                # NULL for a column with no extended type (extended_id = 0).
-                extended_name=_opt_str(r[4]),
-                extended_mode=_opt_str(r[5]),
+                extended=_parse_extended_type(r),
             )
             for r in rows
         ]

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/client.py
@@ -49,6 +49,10 @@ class InformixClientProtocol(Protocol):
     def close(self) -> None: ...
 
 
+def _opt_str(value: object) -> Optional[str]:
+    return str(value).strip() if value is not None else None
+
+
 def _safe_close(closeable: object) -> None:
     try:
         closeable.close()  # type: ignore[attr-defined]
@@ -152,6 +156,9 @@ class InformixClient:
                 length=int(str(r[2])),
                 colno=int(str(r[3])),
                 is_pk=str(r[0]).strip() in pk_names,
+                # NULL for a column with no extended type (extended_id = 0).
+                extended_name=_opt_str(r[4]),
+                extended_mode=_opt_str(r[5]),
             )
             for r in rows
         ]

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
@@ -88,11 +88,14 @@ SQL_COLUMNS = (
     "FROM syscolumns c JOIN systables t ON c.tabid = t.tabid "
     "WHERE TRIM(t.tabname) = ? AND TRIM(t.owner) = ? ORDER BY c.colno"
 )
+# A constraint's backing index is looked up by (tabid, idxname), not idxname
+# alone: that is the join IBM's catalog documentation specifies, and it keeps
+# resolution correct even where an index name is not unique database-wide.
 SQL_PK = (
     "SELECT TRIM(c.colname) AS colname "
     "FROM sysconstraints cn "
     "JOIN systables t ON cn.tabid = t.tabid "
-    "JOIN sysindexes ix ON cn.idxname = ix.idxname "
+    "JOIN sysindexes ix ON cn.tabid = ix.tabid AND cn.idxname = ix.idxname "
     "JOIN syscolumns c ON c.tabid = t.tabid AND c.colno IN "
     f"({_index_part_cols('ix')}) "
     "WHERE cn.constrtype = 'P' AND TRIM(t.tabname) = ? AND TRIM(t.owner) = ?"
@@ -108,13 +111,13 @@ SQL_FK = (
     "TRIM(pc.colname) AS parent_col "
     "FROM sysconstraints cn "
     "JOIN systables ct ON cn.tabid = ct.tabid "
-    "JOIN sysindexes cix ON cn.idxname = cix.idxname "
+    "JOIN sysindexes cix ON cn.tabid = cix.tabid AND cn.idxname = cix.idxname "
     "JOIN syscolumns cc ON cc.tabid = ct.tabid AND cc.colno IN "
     f"({_index_part_cols('cix')}) "
     "JOIN sysreferences r ON cn.constrid = r.constrid "
     "JOIN sysconstraints pcn ON r.primary = pcn.constrid "
     "JOIN systables pt ON pcn.tabid = pt.tabid "
-    "JOIN sysindexes pix ON pcn.idxname = pix.idxname "
+    "JOIN sysindexes pix ON pcn.tabid = pix.tabid AND pcn.idxname = pix.idxname "
     "JOIN syscolumns pc ON pc.tabid = pt.tabid AND pc.colno IN "
     f"({_index_part_cols('pix')}) "
     "WHERE cn.constrtype = 'R' AND TRIM(ct.tabname) = ? AND TRIM(ct.owner) = ?"

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from datahub.ingestion.source.informix.models import InformixType, MappedColumn
 from datahub.metadata.schema_classes import (
@@ -58,15 +58,72 @@ INFORMIX_TYPE_MAP: Dict[int, InformixType] = {
 }
 
 
-def map_coltype(coltype: int) -> MappedColumn:
+# sysxtdtypes.mode says what kind of extended type an extended_id refers to.
+_XTD_BUILTIN = "B"  # server built-in: lvarchar, boolean, blob, clob, ...
+_XTD_DISTINCT = "D"  # CREATE DISTINCT TYPE
+_XTD_ROW = "R"  # CREATE ROW TYPE
+_XTD_COLLECTION = "C"  # SET/LIST/MULTISET; sysxtdtypes.name is empty for these
+
+# Built-in extended types that can legitimately be a user column. Their base
+# coltype is 40 or 41, which says only "some opaque type" -- without the
+# sysxtdtypes name, LVARCHAR, BOOLEAN, BLOB and CLOB are indistinguishable.
+_XTD_BUILTIN_TYPE_MAP: Dict[str, type] = {
+    "LVARCHAR": StringTypeClass,
+    "BOOLEAN": BooleanTypeClass,
+    "BLOB": BytesTypeClass,
+    "CLOB": StringTypeClass,
+}
+
+
+def _resolve_extended_type(
+    mapped: InformixType,
+    extended_name: Optional[str],
+    extended_mode: Optional[str],
+) -> InformixType:
+    """Recover a real type name from sysxtdtypes, falling back to the base type.
+
+    Verified against Informix 15.0.1: LVARCHAR is coltype 40 with extended_id 1,
+    while BOOLEAN/BLOB/CLOB all share coltype 41, so the base code alone resolves
+    every one of them to UNKNOWN. DISTINCT and ROW types carry a user-defined
+    name that is more informative than their base code, and a DISTINCT keeps its
+    source built-in in the low byte of coltype -- so ``mapped`` already holds the
+    right DataHub type for it.
+    """
+    if not extended_name or extended_mode == _XTD_COLLECTION:
+        # Collections store an empty name, and their base coltype (SET, LIST,
+        # MULTISET) is already correct.
+        return mapped
+    native = extended_name.upper()
+    if extended_mode == _XTD_BUILTIN:
+        builtin = _XTD_BUILTIN_TYPE_MAP.get(native)
+        if builtin is not None:
+            return InformixType(builtin, native)
+        # An internal built-in (pointer, sendrecv, ...) that should never surface
+        # as a user column. Keep the real name; leave the type unresolved.
+        return InformixType(NullTypeClass, native)
+    if extended_mode == _XTD_ROW:
+        return InformixType(RecordTypeClass, native)
+    if extended_mode == _XTD_DISTINCT:
+        return InformixType(mapped.datahub_type, native)
+    # Opaque (mode 'O': JSON, BSON, spatial, user-defined UDTs) and anything
+    # else. The real type name still beats UNKNOWN(40).
+    return InformixType(NullTypeClass, native)
+
+
+def map_coltype(
+    coltype: int,
+    extended_name: Optional[str] = None,
+    extended_mode: Optional[str] = None,
+) -> MappedColumn:
     base = coltype & _BASE_TYPE_MASK
     mapped = INFORMIX_TYPE_MAP.get(
         base, InformixType(NullTypeClass, f"UNKNOWN({base})")
     )
+    resolved = _resolve_extended_type(mapped, extended_name, extended_mode)
     return MappedColumn(
-        data_type=SchemaFieldDataTypeClass(type=mapped.datahub_type()),
+        data_type=SchemaFieldDataTypeClass(type=resolved.datahub_type()),
         nullable=(coltype & _NOT_NULL_BIT) == 0,
-        native=mapped.native_name,
+        native=resolved.native_name,
     )
 
 
@@ -83,9 +140,14 @@ SQL_TABLES = (
     "SELECT TRIM(tabname) AS tabname, TRIM(owner) AS owner, tabtype, nrows "
     f"FROM systables WHERE tabid >= 100 AND tabtype IN ('{TABTYPE_TABLE}', '{TABTYPE_VIEW}')"
 )
+# syscolumns.extended_id is 0 for ordinary types, so the sysxtdtypes lookup has
+# to be an outer join. sysxtdtypes.name/mode recover LVARCHAR, BOOLEAN, BLOB,
+# CLOB, DISTINCT, ROW and opaque types, all of which base coltype cannot express.
 SQL_COLUMNS = (
-    "SELECT TRIM(c.colname) AS colname, c.coltype, c.collength, c.colno "
+    "SELECT TRIM(c.colname) AS colname, c.coltype, c.collength, c.colno, "
+    "TRIM(x.name) AS xtdname, x.mode AS xtdmode "
     "FROM syscolumns c JOIN systables t ON c.tabid = t.tabid "
+    "LEFT JOIN sysxtdtypes x ON c.extended_id = x.extended_id "
     "WHERE TRIM(t.tabname) = ? AND TRIM(t.owner) = ? ORDER BY c.colno"
 )
 # A constraint's backing index is looked up by (tabid, idxname), not idxname

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/constants.py
@@ -1,6 +1,10 @@
 from typing import Dict, Optional
 
-from datahub.ingestion.source.informix.models import InformixType, MappedColumn
+from datahub.ingestion.source.informix.models import (
+    ExtendedType,
+    InformixType,
+    MappedColumn,
+)
 from datahub.metadata.schema_classes import (
     BooleanTypeClass,
     BytesTypeClass,
@@ -64,9 +68,10 @@ _XTD_DISTINCT = "D"  # CREATE DISTINCT TYPE
 _XTD_ROW = "R"  # CREATE ROW TYPE
 _XTD_COLLECTION = "C"  # SET/LIST/MULTISET; sysxtdtypes.name is empty for these
 
-# Built-in extended types that can legitimately be a user column. Their base
-# coltype is 40 or 41, which says only "some opaque type" -- without the
-# sysxtdtypes name, LVARCHAR, BOOLEAN, BLOB and CLOB are indistinguishable.
+# Built-in extended types that can legitimately be a user column, keyed by
+# sysxtdtypes.name. Their base coltype is 40 or 41, which says only "some opaque
+# type" -- without the sysxtdtypes name, LVARCHAR, BOOLEAN, BLOB and CLOB are
+# indistinguishable. The same map resolves a DISTINCT declared over one of them.
 _XTD_BUILTIN_TYPE_MAP: Dict[str, type] = {
     "LVARCHAR": StringTypeClass,
     "BOOLEAN": BooleanTypeClass,
@@ -76,50 +81,53 @@ _XTD_BUILTIN_TYPE_MAP: Dict[str, type] = {
 
 
 def _resolve_extended_type(
-    mapped: InformixType,
-    extended_name: Optional[str],
-    extended_mode: Optional[str],
+    mapped: InformixType, extended: Optional[ExtendedType]
 ) -> InformixType:
     """Recover a real type name from sysxtdtypes, falling back to the base type.
 
     Verified against Informix 15.0.1: LVARCHAR is coltype 40 with extended_id 1,
     while BOOLEAN/BLOB/CLOB all share coltype 41, so the base code alone resolves
     every one of them to UNKNOWN. DISTINCT and ROW types carry a user-defined
-    name that is more informative than their base code, and a DISTINCT keeps its
-    source built-in in the low byte of coltype -- so ``mapped`` already holds the
-    right DataHub type for it.
+    name that is more informative than their base code.
     """
-    if not extended_name or extended_mode == _XTD_COLLECTION:
+    if extended is None or not extended.name or extended.mode == _XTD_COLLECTION:
         # Collections store an empty name, and their base coltype (SET, LIST,
         # MULTISET) is already correct.
         return mapped
-    native = extended_name.upper()
-    if extended_mode == _XTD_BUILTIN:
-        builtin = _XTD_BUILTIN_TYPE_MAP.get(native)
-        if builtin is not None:
-            return InformixType(builtin, native)
-        # An internal built-in (pointer, sendrecv, ...) that should never surface
-        # as a user column. Keep the real name; leave the type unresolved.
-        return InformixType(NullTypeClass, native)
-    if extended_mode == _XTD_ROW:
+    native = extended.name.upper()
+    if extended.mode == _XTD_BUILTIN:
+        # An unmapped built-in is an internal one (pointer, sendrecv, ...) that
+        # should never surface as a user column. Keep the real name; leave the
+        # DataHub type unresolved.
+        return InformixType(_XTD_BUILTIN_TYPE_MAP.get(native, NullTypeClass), native)
+    if extended.mode == _XTD_ROW:
         return InformixType(RecordTypeClass, native)
-    if extended_mode == _XTD_DISTINCT:
-        return InformixType(mapped.datahub_type, native)
+    if extended.mode == _XTD_DISTINCT:
+        # A DISTINCT over an ordinary built-in keeps it in coltype's low byte
+        # (2053 = 2048 | 5, DECIMAL), so `mapped` is already right. A DISTINCT
+        # over an opaque built-in cannot be read that way: measured on 15.0.1,
+        # DISTINCT-of-BLOB and DISTINCT-of-CLOB are *both* coltype 2089 (low
+        # byte 41), so no coltype bit tells them apart. sysxtdtypes.source names
+        # the type it was declared over, which resolves all four.
+        #
+        # A DISTINCT of a DISTINCT reports the intermediate type as its source,
+        # so a chain over an opaque built-in still falls back to NullType. That
+        # would need a recursive walk of sysxtdtypes.source for no known gain.
+        source = (extended.source_name or "").upper()
+        return InformixType(
+            _XTD_BUILTIN_TYPE_MAP.get(source, mapped.datahub_type), native
+        )
     # Opaque (mode 'O': JSON, BSON, spatial, user-defined UDTs) and anything
     # else. The real type name still beats UNKNOWN(40).
     return InformixType(NullTypeClass, native)
 
 
-def map_coltype(
-    coltype: int,
-    extended_name: Optional[str] = None,
-    extended_mode: Optional[str] = None,
-) -> MappedColumn:
+def map_coltype(coltype: int, extended: Optional[ExtendedType] = None) -> MappedColumn:
     base = coltype & _BASE_TYPE_MASK
     mapped = INFORMIX_TYPE_MAP.get(
         base, InformixType(NullTypeClass, f"UNKNOWN({base})")
     )
-    resolved = _resolve_extended_type(mapped, extended_name, extended_mode)
+    resolved = _resolve_extended_type(mapped, extended)
     return MappedColumn(
         data_type=SchemaFieldDataTypeClass(type=resolved.datahub_type()),
         nullable=(coltype & _NOT_NULL_BIT) == 0,
@@ -143,11 +151,15 @@ SQL_TABLES = (
 # syscolumns.extended_id is 0 for ordinary types, so the sysxtdtypes lookup has
 # to be an outer join. sysxtdtypes.name/mode recover LVARCHAR, BOOLEAN, BLOB,
 # CLOB, DISTINCT, ROW and opaque types, all of which base coltype cannot express.
+# The second, self-referential outer join resolves sysxtdtypes.source -- the type
+# a DISTINCT was declared over -- back to its name; it is 0 (and so matches no
+# row, sysxtdtypes has no extended_id 0) for every other mode.
 SQL_COLUMNS = (
     "SELECT TRIM(c.colname) AS colname, c.coltype, c.collength, c.colno, "
-    "TRIM(x.name) AS xtdname, x.mode AS xtdmode "
+    "TRIM(x.name) AS xtdname, x.mode AS xtdmode, TRIM(xs.name) AS xtdsource "
     "FROM syscolumns c JOIN systables t ON c.tabid = t.tabid "
     "LEFT JOIN sysxtdtypes x ON c.extended_id = x.extended_id "
+    "LEFT JOIN sysxtdtypes xs ON x.source = xs.extended_id "
     "WHERE TRIM(t.tabname) = ? AND TRIM(t.owner) = ? ORDER BY c.colno"
 )
 # A constraint's backing index is looked up by (tabid, idxname), not idxname

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
@@ -11,6 +11,7 @@ from datahub.ingestion.source.informix.constants import PLATFORM, map_coltype
 from datahub.ingestion.source.informix.models import InformixColumn, InformixForeignKey
 from datahub.metadata.schema_classes import (
     ForeignKeyConstraintClass,
+    NullTypeClass,
     OwnerClass,
     OwnershipTypeClass,
     SchemaFieldClass,
@@ -71,16 +72,19 @@ def columns_to_schema_fields(
 ) -> List[SchemaFieldClass]:
     fields: List[SchemaFieldClass] = []
     for col in columns:
-        mapped = map_coltype(col.coltype)
+        mapped = map_coltype(col.coltype, col.extended_name, col.extended_mode)
         native = mapped.native
         length = _declared_length(native, col.length)
         if native in _LENGTH_TYPES and length > 0:
             native = f"{native}({length})"
-        if native.startswith("UNKNOWN"):
+        if isinstance(mapped.data_type.type, NullTypeClass):
+            # Checked on the resolved DataHub type rather than an "UNKNOWN" name
+            # prefix: an opaque type recovered from sysxtdtypes has a real name
+            # but still no DataHub equivalent, and is worth reporting.
             report.warning(
                 title="Unmapped Informix column type",
                 message="Column type has no DataHub mapping; using NullType.",
-                context=f"{col.name} coltype={col.coltype}",
+                context=f"{col.name} coltype={col.coltype} native={native}",
             )
         fields.append(
             SchemaFieldClass(

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
@@ -30,14 +30,15 @@ _LENGTH_TYPES = {"CHAR", "VARCHAR", "NCHAR", "NVARCHAR", "LVARCHAR"}
 _PACKED_LENGTH_TYPES = {"VARCHAR", "NVARCHAR"}
 
 
-def _declared_length(native: str, collength: int) -> int:
-    if native not in _PACKED_LENGTH_TYPES:
-        return collength
-    if collength < 0:
-        collength += 65536
-    # Only the low byte (the declared maximum) is reported; the reserved minimum
-    # is a storage hint, not part of the column's size contract.
-    return collength % 256
+def _native_with_length(native: str, collength: int) -> str:
+    if native not in _LENGTH_TYPES:
+        return native
+    # Only the low byte (the declared maximum) of a packed collength is
+    # reported; the reserved minimum is a storage hint, not part of the column's
+    # size contract. Python's % already normalizes the negative wrap, so the
+    # signed SMALLINT needs no separate unwrapping step.
+    length = collength % 256 if native in _PACKED_LENGTH_TYPES else collength
+    return f"{native}({length})" if length > 0 else native
 
 
 def build_jdbc_url(config: InformixSourceConfig) -> str:
@@ -72,11 +73,8 @@ def columns_to_schema_fields(
 ) -> List[SchemaFieldClass]:
     fields: List[SchemaFieldClass] = []
     for col in columns:
-        mapped = map_coltype(col.coltype, col.extended_name, col.extended_mode)
-        native = mapped.native
-        length = _declared_length(native, col.length)
-        if native in _LENGTH_TYPES and length > 0:
-            native = f"{native}({length})"
+        mapped = map_coltype(coltype=col.coltype, extended=col.extended)
+        native = _native_with_length(mapped.native, col.length)
         if isinstance(mapped.data_type.type, NullTypeClass):
             # Checked on the resolved DataHub type rather than an "UNKNOWN" name
             # prefix: an opaque type recovered from sysxtdtypes has a real name

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/mapping.py
@@ -20,6 +20,24 @@ from datahub.metadata.schema_classes import (
 # plain character length, so length is only meaningful for these string types.
 _LENGTH_TYPES = {"CHAR", "VARCHAR", "NCHAR", "NVARCHAR", "LVARCHAR"}
 
+# VARCHAR/NVARCHAR go further and pack the whole declaration into collength as
+# (reserved_min_space * 256) + max_size. collength is a signed SMALLINT, so a
+# reserved minimum of 128 or more wraps it negative. Measured on Informix
+# 15.0.1: VARCHAR(100) -> 100, VARCHAR(100,10) -> 2660, VARCHAR(200,150) ->
+# -26936, NVARCHAR(80,20) -> 5200. CHAR/NCHAR/LVARCHAR store the length as-is.
+# See the IBM Informix SQL Reference (SYSCOLUMNS).
+_PACKED_LENGTH_TYPES = {"VARCHAR", "NVARCHAR"}
+
+
+def _declared_length(native: str, collength: int) -> int:
+    if native not in _PACKED_LENGTH_TYPES:
+        return collength
+    if collength < 0:
+        collength += 65536
+    # Only the low byte (the declared maximum) is reported; the reserved minimum
+    # is a storage hint, not part of the column's size contract.
+    return collength % 256
+
 
 def build_jdbc_url(config: InformixSourceConfig) -> str:
     user = config.username or ""
@@ -55,8 +73,9 @@ def columns_to_schema_fields(
     for col in columns:
         mapped = map_coltype(col.coltype)
         native = mapped.native
-        if native in _LENGTH_TYPES and col.length > 0:
-            native = f"{native}({col.length})"
+        length = _declared_length(native, col.length)
+        if native in _LENGTH_TYPES and length > 0:
+            native = f"{native}({length})"
         if native.startswith("UNKNOWN"):
             report.warning(
                 title="Unmapped Informix column type",

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/models.py
@@ -26,6 +26,10 @@ class InformixColumn(BaseModel):
     length: int
     colno: int
     is_pk: bool = False
+    # sysxtdtypes.name/mode for the column's extended_id, absent for ordinary
+    # types. See constants._resolve_extended_type.
+    extended_name: Optional[str] = None
+    extended_mode: Optional[str] = None
 
 
 class InformixTable(BaseModel):

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/models.py
@@ -14,6 +14,22 @@ class InformixType:
 
 
 @dataclass(frozen=True)
+class ExtendedType:
+    """A column's ``sysxtdtypes`` row, joined via ``syscolumns.extended_id``.
+
+    ``source_name`` is the name of the type a DISTINCT was declared over
+    (``sysxtdtypes.source`` resolved back through ``sysxtdtypes``), and is None
+    for every other mode -- and for a DISTINCT over an ordinary built-in, whose
+    ``source`` is 0. The three fields always arrive together from one catalog
+    row, so bundling them keeps a half-populated combination unrepresentable.
+    """
+
+    name: str
+    mode: Optional[str]
+    source_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
 class MappedColumn:
     data_type: SchemaFieldDataTypeClass
     nullable: bool
@@ -26,10 +42,9 @@ class InformixColumn(BaseModel):
     length: int
     colno: int
     is_pk: bool = False
-    # sysxtdtypes.name/mode for the column's extended_id, absent for ordinary
-    # types. See constants._resolve_extended_type.
-    extended_name: Optional[str] = None
-    extended_mode: Optional[str] = None
+    # The column's sysxtdtypes row, absent for ordinary types (extended_id = 0).
+    # See constants._resolve_extended_type.
+    extended: Optional[ExtendedType] = None
 
 
 class InformixTable(BaseModel):

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/report.py
@@ -8,6 +8,9 @@ from datahub.utilities.lossy_collections import LossyList
 
 @dataclass
 class InformixSourceReport(StaleEntityRemovalSourceReport):
+    # Tables and views that passed every filter, so "selected but not ingested"
+    # is distinguishable from "nothing matched" -- see source.get_workunits_internal.
+    objects_selected: int = 0
     tables_scanned: int = 0
     views_scanned: int = 0
     filtered: LossyList[str] = field(default_factory=LossyList)

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/source.py
@@ -300,6 +300,7 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
             views: List[_PendingView] = []
 
             seen_owners = set()
+            selected = 0
             for table in client.get_tables():
                 name = make_table_identifier(
                     self.config.database,
@@ -325,6 +326,7 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
                     self.report.report_dropped(name)
                     continue
 
+                selected += 1
                 schema_key = self._schema_key(table.owner)
                 owners = self._owners(table.owner)
 
@@ -397,6 +399,21 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
                         context=f"{table.owner}.{table.name}",
                         exc=e,
                     )
+
+            # Per-object failures above are only warnings, so a systemic problem
+            # (revoked catalog privileges, a dropped connection mid-scan) would
+            # otherwise finish as a successful run that emitted nothing but
+            # containers. Escalate once here instead.
+            ingested = self.report.tables_scanned + self.report.views_scanned
+            if selected and not ingested:
+                self.report.failure(
+                    title="No tables or views could be ingested",
+                    message="Every table and view selected from the catalog failed "
+                    "extraction. This usually indicates a systemic problem such as "
+                    "missing privileges on the system catalogs rather than a "
+                    "per-object issue; see the preceding warnings.",
+                    context=f"{selected} objects selected, 0 ingested",
+                )
 
             # Pass 2: emit viewProperties for every view with stored SQL, and
             # optionally parse that SQL for upstream lineage.

--- a/metadata-ingestion/src/datahub/ingestion/source/informix/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/informix/source.py
@@ -300,7 +300,6 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
             views: List[_PendingView] = []
 
             seen_owners = set()
-            selected = 0
             for table in client.get_tables():
                 name = make_table_identifier(
                     self.config.database,
@@ -326,7 +325,7 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
                     self.report.report_dropped(name)
                     continue
 
-                selected += 1
+                self.report.objects_selected += 1
                 schema_key = self._schema_key(table.owner)
                 owners = self._owners(table.owner)
 
@@ -405,14 +404,15 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
             # otherwise finish as a successful run that emitted nothing but
             # containers. Escalate once here instead.
             ingested = self.report.tables_scanned + self.report.views_scanned
-            if selected and not ingested:
+            if self.report.objects_selected and not ingested:
                 self.report.failure(
                     title="No tables or views could be ingested",
                     message="Every table and view selected from the catalog failed "
                     "extraction. This usually indicates a systemic problem such as "
                     "missing privileges on the system catalogs rather than a "
                     "per-object issue; see the preceding warnings.",
-                    context=f"{selected} objects selected, 0 ingested",
+                    context=f"{self.report.objects_selected} objects selected, "
+                    "0 ingested",
                 )
 
             # Pass 2: emit viewProperties for every view with stored SQL, and
@@ -469,6 +469,21 @@ class InformixSource(StatefulIngestionSourceBase, TestableSource):
                         context=f"{pending.table.owner}.{pending.table.name}",
                         exc=e,
                     )
+
+            # The empty-viewtext path above only bumps a counter, so the same
+            # systemic failure the pass 1 escalation catches -- privileges
+            # revoked on sysviews specifically, leaving syscolumns readable --
+            # would emit no diagnostic at all. Every single view coming back
+            # empty is that, not a database of views with no stored SQL.
+            if views and self.report.views_without_definition == len(views):
+                self.report.warning(
+                    title="No view definitions could be read",
+                    message="Every view returned an empty sysviews.viewtext, so "
+                    "no viewProperties or view lineage was emitted. This usually "
+                    "indicates missing privileges on sysviews rather than views "
+                    "without stored SQL.",
+                    context=f"{len(views)} views, 0 definitions read",
+                )
         finally:
             client.close()
 

--- a/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
+++ b/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
@@ -633,6 +633,126 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:informix"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554598,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "",
+            "platform": "urn:li:dataPlatform:informix",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "doc_id",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "INTEGER",
+                    "recursive": false,
+                    "isPartOfKey": true
+                },
+                {
+                    "fieldPath": "body",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "LVARCHAR(4000)",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "archived",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "BOOLEAN",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "payload",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BytesType": {}
+                        }
+                    },
+                    "nativeDataType": "BLOB",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "summary",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "CLOB",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "price",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "MONEY_USD",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.active_customers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
@@ -705,6 +825,24 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "documents",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.active_customers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
@@ -718,6 +856,22 @@
     "systemMetadata": {
         "lastObserved": 1784882571226,
         "runId": "informix-2026_07_24-10_42_50-rnmkrm",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:bf206720da8d6f00abc4200f14303780"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -739,6 +893,24 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.active_customers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
@@ -752,6 +924,57 @@
     "systemMetadata": {
         "lastObserved": 1784882571226,
         "runId": "informix-2026_07_24-10_42_50-rnmkrm",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:informix",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:db06006ca0cdab7bcb66fd0e0b672606",
+                    "urn": "urn:li:container:db06006ca0cdab7bcb66fd0e0b672606"
+                },
+                {
+                    "id": "urn:li:container:bf206720da8d6f00abc4200f14303780",
+                    "urn": "urn:li:container:bf206720da8d6f00abc4200f14303780"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554599,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1262,6 +1485,22 @@
     "systemMetadata": {
         "lastObserved": 1784892553265,
         "runId": "informix-2026_07_24-13_29_10-by4mtf",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:informix,testdb.informix.documents,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1787307554752,
+        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
+++ b/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
@@ -265,13 +265,25 @@
                     "nativeDataType": "VARCHAR(255)",
                     "recursive": false,
                     "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "notes",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR(60)",
+                    "recursive": false,
+                    "isPartOfKey": false
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1784884360260,
-        "runId": "informix-2026_07_24-11_12_38-604ngs",
+        "lastObserved": 1787306792341,
+        "runId": "informix-2026_08_21-12_06_31-aki6wq",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
+++ b/metadata-ingestion/tests/integration/informix/informix_mces_golden.json
@@ -277,13 +277,25 @@
                     "nativeDataType": "VARCHAR(60)",
                     "recursive": false,
                     "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "bio",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "VARCHAR(200)",
+                    "recursive": false,
+                    "isPartOfKey": false
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1787306792341,
-        "runId": "informix-2026_08_21-12_06_31-aki6wq",
+        "lastObserved": 1787315200875,
+        "runId": "informix-2026_08_21-14_26_30-jkpj83",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -741,13 +753,49 @@
                     "nativeDataType": "MONEY_USD",
                     "recursive": false,
                     "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "published",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "FLAG_TYPE",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "abstract",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "DOC_TEXT",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "mailing_address",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.RecordType": {}
+                        }
+                    },
+                    "nativeDataType": "ADDRESS_T",
+                    "recursive": false,
+                    "isPartOfKey": false
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1787307554599,
-        "runId": "informix-2026_08_21-12_19_13-a2sjfx",
+        "lastObserved": 1787315200892,
+        "runId": "informix-2026_08_21-14_26_30-jkpj83",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/informix/setup/setup.sql
+++ b/metadata-ingestion/tests/integration/informix/setup/setup.sql
@@ -6,7 +6,11 @@ CREATE TABLE customers (
   email VARCHAR(255),
   -- Declared with reserved minimum space, so syscolumns.collength packs it as
   -- (10 * 256) + 60 = 2620. Guards the collength decode in mapping.py.
-  notes VARCHAR(60,10)
+  notes VARCHAR(60,10),
+  -- A reserved minimum of 128 or more overflows collength's signed SMALLINT:
+  -- (150 * 256) + 200 = 38600 is stored as -26936. Guards the sign-flip path
+  -- against the real driver, not just a literal in the unit tests.
+  bio VARCHAR(200,150)
 );
 
 CREATE TABLE orders (
@@ -17,8 +21,15 @@ CREATE TABLE orders (
 
 -- Extended types: LVARCHAR is coltype 40 and BOOLEAN/BLOB/CLOB all share
 -- coltype 41, so none of them can be identified without the sysxtdtypes join.
--- A DISTINCT type keeps its source built-in in the low byte of coltype.
+-- A DISTINCT over an ordinary built-in keeps it in the low byte of coltype
+-- (money_usd is 2053 = 2048 | 5, DECIMAL), but a DISTINCT over an opaque
+-- built-in cannot: flag_type is 18473 and doc_text is 2089, both low byte 41,
+-- so only sysxtdtypes.source names what they were declared over.
 CREATE DISTINCT TYPE money_usd AS DECIMAL(12,2);
+CREATE DISTINCT TYPE flag_type AS BOOLEAN;
+CREATE DISTINCT TYPE doc_text AS CLOB;
+
+CREATE ROW TYPE address_t (street VARCHAR(50), city VARCHAR(30));
 
 CREATE TABLE documents (
   doc_id INTEGER PRIMARY KEY,
@@ -26,7 +37,10 @@ CREATE TABLE documents (
   archived BOOLEAN,
   payload BLOB,
   summary CLOB,
-  price money_usd
+  price money_usd,
+  published flag_type,
+  abstract doc_text,
+  mailing_address address_t
 );
 
 CREATE VIEW active_customers AS SELECT id, name FROM customers;

--- a/metadata-ingestion/tests/integration/informix/setup/setup.sql
+++ b/metadata-ingestion/tests/integration/informix/setup/setup.sql
@@ -15,6 +15,20 @@ CREATE TABLE orders (
   amount DECIMAL(10,2)
 );
 
+-- Extended types: LVARCHAR is coltype 40 and BOOLEAN/BLOB/CLOB all share
+-- coltype 41, so none of them can be identified without the sysxtdtypes join.
+-- A DISTINCT type keeps its source built-in in the low byte of coltype.
+CREATE DISTINCT TYPE money_usd AS DECIMAL(12,2);
+
+CREATE TABLE documents (
+  doc_id INTEGER PRIMARY KEY,
+  body LVARCHAR(4000),
+  archived BOOLEAN,
+  payload BLOB,
+  summary CLOB,
+  price money_usd
+);
+
 CREATE VIEW active_customers AS SELECT id, name FROM customers;
 
 CREATE VIEW customer_orders AS

--- a/metadata-ingestion/tests/integration/informix/setup/setup.sql
+++ b/metadata-ingestion/tests/integration/informix/setup/setup.sql
@@ -3,7 +3,10 @@ CREATE DATABASE testdb WITH LOG;
 CREATE TABLE customers (
   id INTEGER PRIMARY KEY,
   name VARCHAR(100),
-  email VARCHAR(255)
+  email VARCHAR(255),
+  -- Declared with reserved minimum space, so syscolumns.collength packs it as
+  -- (10 * 256) + 60 = 2620. Guards the collength decode in mapping.py.
+  notes VARCHAR(60,10)
 );
 
 CREATE TABLE orders (

--- a/metadata-ingestion/tests/unit/informix/test_informix_client.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_client.py
@@ -13,7 +13,7 @@ from datahub.ingestion.source.informix.constants import (
     SQL_TABLES,
     SQL_VIEW_DEF,
 )
-from datahub.ingestion.source.informix.models import InformixTable
+from datahub.ingestion.source.informix.models import ExtendedType, InformixTable
 
 _PASSWORD = "sup3rs3cr3t"
 
@@ -87,8 +87,8 @@ def test_get_columns_marks_primary_keys():
         {
             SQL_PK: [["id"]],
             SQL_COLUMNS: [
-                ["id", 258, 4, 1, None, None],
-                ["email", 13, 100, 2, None, None],
+                ["id", 258, 4, 1, None, None, None],
+                ["email", 13, 100, 2, None, None, None],
             ],
         }
     )
@@ -98,19 +98,22 @@ def test_get_columns_marks_primary_keys():
 
 def test_get_columns_carries_extended_type_columns():
     # extended_id = 0 yields SQL NULLs from the outer join; an extended type
-    # yields its sysxtdtypes name and mode.
+    # yields its sysxtdtypes name and mode, plus the source type's name when the
+    # column is a DISTINCT declared over another extended type.
     client = _client_with_rows(
         {
             SQL_COLUMNS: [
-                ["plain", 258, 4, 1, None, None],
-                ["flag", 41, 1, 2, "  boolean  ", "B"],
+                ["plain", 258, 4, 1, None, None, None],
+                ["flag", 41, 1, 2, "  boolean  ", "B", None],
+                ["published", 18473, 1, 3, "flag_type", "D", "  boolean  "],
             ],
         }
     )
     columns = client.get_columns(_table())
-    assert [(c.extended_name, c.extended_mode) for c in columns] == [
-        (None, None),
-        ("boolean", "B"),
+    assert [c.extended for c in columns] == [
+        None,
+        ExtendedType(name="boolean", mode="B", source_name=None),
+        ExtendedType(name="flag_type", mode="D", source_name="boolean"),
     ]
 
 

--- a/metadata-ingestion/tests/unit/informix/test_informix_client.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_client.py
@@ -86,11 +86,32 @@ def test_get_columns_marks_primary_keys():
     client = _client_with_rows(
         {
             SQL_PK: [["id"]],
-            SQL_COLUMNS: [["id", 258, 4, 1], ["email", 13, 100, 2]],
+            SQL_COLUMNS: [
+                ["id", 258, 4, 1, None, None],
+                ["email", 13, 100, 2, None, None],
+            ],
         }
     )
     columns = client.get_columns(_table())
     assert [(c.name, c.is_pk) for c in columns] == [("id", True), ("email", False)]
+
+
+def test_get_columns_carries_extended_type_columns():
+    # extended_id = 0 yields SQL NULLs from the outer join; an extended type
+    # yields its sysxtdtypes name and mode.
+    client = _client_with_rows(
+        {
+            SQL_COLUMNS: [
+                ["plain", 258, 4, 1, None, None],
+                ["flag", 41, 1, 2, "  boolean  ", "B"],
+            ],
+        }
+    )
+    columns = client.get_columns(_table())
+    assert [(c.extended_name, c.extended_mode) for c in columns] == [
+        (None, None),
+        ("boolean", "B"),
+    ]
 
 
 def test_get_foreign_keys_pairs_single_column_key():

--- a/metadata-ingestion/tests/unit/informix/test_informix_constants.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_constants.py
@@ -10,7 +10,10 @@ from datahub.ingestion.source.informix.constants import (
     SQL_PK,
     map_coltype,
 )
-from datahub.ingestion.source.informix.models import InformixForeignKey
+from datahub.ingestion.source.informix.models import (
+    ExtendedType,
+    InformixForeignKey,
+)
 from datahub.metadata.schema_classes import (
     BooleanTypeClass,
     BytesTypeClass,
@@ -131,49 +134,81 @@ def test_informix_type_map_keys_match_parametrized_coverage():
 
 
 @pytest.mark.parametrize(
-    "coltype,xtdname,xtdmode,native,type_cls",
+    "coltype,xtdname,xtdmode,xtdsource,native,type_cls",
     [
         # Every row measured against Informix 15.0.1 (see the integration
         # fixture). Base coltype 40/41 carries no type information on its own.
-        (40, "lvarchar", "B", "LVARCHAR", StringTypeClass),
-        (41, "boolean", "B", "BOOLEAN", BooleanTypeClass),
-        (41, "blob", "B", "BLOB", BytesTypeClass),
-        (41, "clob", "B", "CLOB", StringTypeClass),
+        (40, "lvarchar", "B", None, "LVARCHAR", StringTypeClass),
+        (41, "boolean", "B", None, "BOOLEAN", BooleanTypeClass),
+        (41, "blob", "B", None, "BLOB", BytesTypeClass),
+        (41, "clob", "B", None, "CLOB", StringTypeClass),
         # An internal built-in should never be a user column; keep its name but
         # do not invent a DataHub type for it.
-        (41, "pointer", "B", "POINTER", NullTypeClass),
-        # DISTINCT keeps its source built-in in the low byte of coltype:
-        # 2053 = 2048 | 5 (DECIMAL), 2050 = 2048 | 2 (INTEGER).
-        (2053, "money_usd", "D", "MONEY_USD", NumberTypeClass),
-        (2050, "cust_id", "D", "CUST_ID", NumberTypeClass),
+        (41, "pointer", "B", None, "POINTER", NullTypeClass),
+        # A DISTINCT over an ordinary built-in keeps it in the low byte of
+        # coltype: 2053 = 2048 | 5 (DECIMAL), 2050 = 2048 | 2 (INTEGER). Its
+        # sysxtdtypes.source is 0, so no source name comes back.
+        (2053, "money_usd", "D", None, "MONEY_USD", NumberTypeClass),
+        (2050, "cust_id", "D", None, "CUST_ID", NumberTypeClass),
+        # A DISTINCT over an opaque built-in cannot use the low byte -- it is 40
+        # or 41 there -- so it resolves through sysxtdtypes.source instead.
+        # Measured: DISTINCT-of-BOOLEAN is 18473 and DISTINCT-of-LVARCHAR 10280
+        # (both carry a dedicated coltype bit), but DISTINCT-of-BLOB and
+        # DISTINCT-of-CLOB are *both* 2089, so only the source name tells them
+        # apart.
+        (18473, "flag_type", "D", "boolean", "FLAG_TYPE", BooleanTypeClass),
+        (10280, "long_text", "D", "lvarchar", "LONG_TEXT", StringTypeClass),
+        (2089, "doc_blob", "D", "blob", "DOC_BLOB", BytesTypeClass),
+        (2089, "doc_text", "D", "clob", "DOC_TEXT", StringTypeClass),
+        # A DISTINCT of a DISTINCT reports the intermediate type as its source,
+        # which is not a built-in, so the chain is not walked further.
+        (18473, "flag2_type", "D", "flag_type", "FLAG2_TYPE", NullTypeClass),
         # ROW types are structs; base code 22 has no mapping of its own.
-        (20502, "addr_t", "R", "ADDR_T", RecordTypeClass),
+        (20502, "addr_t", "R", None, "ADDR_T", RecordTypeClass),
         # Opaque types (mode 'O') have no DataHub equivalent, but the real name
         # still beats UNKNOWN(40).
-        (40, "json", "O", "JSON", NullTypeClass),
+        (40, "json", "O", None, "JSON", NullTypeClass),
         # Collections store an empty name; the base coltype already resolves.
-        (19, "", "C", "SET", RecordTypeClass),
-        (21, "", "C", "LIST", RecordTypeClass),
-        # extended_id 0 -> no sysxtdtypes row at all.
-        (2, None, None, "INTEGER", NumberTypeClass),
+        (19, "", "C", None, "SET", RecordTypeClass),
+        (21, "", "C", None, "LIST", RecordTypeClass),
     ],
 )
 def test_map_coltype_resolves_extended_types(
     coltype: int,
     xtdname: str,
     xtdmode: str,
+    xtdsource: str,
     native: str,
     type_cls: type,
 ) -> None:
-    mapped = map_coltype(coltype, xtdname, xtdmode)
+    mapped = map_coltype(
+        coltype=coltype,
+        extended=ExtendedType(name=xtdname, mode=xtdmode, source_name=xtdsource),
+    )
     assert mapped.native == native
     assert isinstance(mapped.data_type.type, type_cls)
 
 
+def test_map_coltype_without_extended_type_uses_base_coltype():
+    # extended_id 0 -> no sysxtdtypes row at all.
+    mapped = map_coltype(coltype=2)
+    assert mapped.native == "INTEGER"
+    assert isinstance(mapped.data_type.type, NumberTypeClass)
+
+
 def test_map_coltype_extended_resolution_preserves_not_null_bit():
-    mapped = map_coltype(41 + 256, "boolean", "B")
+    mapped = map_coltype(
+        coltype=41 + 256, extended=ExtendedType(name="boolean", mode="B")
+    )
     assert mapped.native == "BOOLEAN"
     assert mapped.nullable is False
+
+
+def test_sql_columns_resolves_distinct_source_type():
+    # sysxtdtypes.source is 0 for everything but a DISTINCT over another
+    # extended type, so resolving its name needs a second outer self-join.
+    assert SQL_COLUMNS.count("LEFT JOIN sysxtdtypes") == 2
+    assert "LEFT JOIN sysxtdtypes xs ON x.source = xs.extended_id" in SQL_COLUMNS
 
 
 def test_sql_columns_outer_joins_sysxtdtypes():

--- a/metadata-ingestion/tests/unit/informix/test_informix_constants.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_constants.py
@@ -5,6 +5,7 @@ import pytest
 from datahub.ingestion.source.informix.config import InformixSourceConfig
 from datahub.ingestion.source.informix.constants import (
     INFORMIX_TYPE_MAP,
+    SQL_COLUMNS,
     SQL_FK,
     SQL_PK,
     map_coltype,
@@ -127,6 +128,58 @@ def test_informix_type_map_keys_match_parametrized_coverage():
         52,
         53,
     }
+
+
+@pytest.mark.parametrize(
+    "coltype,xtdname,xtdmode,native,type_cls",
+    [
+        # Every row measured against Informix 15.0.1 (see the integration
+        # fixture). Base coltype 40/41 carries no type information on its own.
+        (40, "lvarchar", "B", "LVARCHAR", StringTypeClass),
+        (41, "boolean", "B", "BOOLEAN", BooleanTypeClass),
+        (41, "blob", "B", "BLOB", BytesTypeClass),
+        (41, "clob", "B", "CLOB", StringTypeClass),
+        # An internal built-in should never be a user column; keep its name but
+        # do not invent a DataHub type for it.
+        (41, "pointer", "B", "POINTER", NullTypeClass),
+        # DISTINCT keeps its source built-in in the low byte of coltype:
+        # 2053 = 2048 | 5 (DECIMAL), 2050 = 2048 | 2 (INTEGER).
+        (2053, "money_usd", "D", "MONEY_USD", NumberTypeClass),
+        (2050, "cust_id", "D", "CUST_ID", NumberTypeClass),
+        # ROW types are structs; base code 22 has no mapping of its own.
+        (20502, "addr_t", "R", "ADDR_T", RecordTypeClass),
+        # Opaque types (mode 'O') have no DataHub equivalent, but the real name
+        # still beats UNKNOWN(40).
+        (40, "json", "O", "JSON", NullTypeClass),
+        # Collections store an empty name; the base coltype already resolves.
+        (19, "", "C", "SET", RecordTypeClass),
+        (21, "", "C", "LIST", RecordTypeClass),
+        # extended_id 0 -> no sysxtdtypes row at all.
+        (2, None, None, "INTEGER", NumberTypeClass),
+    ],
+)
+def test_map_coltype_resolves_extended_types(
+    coltype: int,
+    xtdname: str,
+    xtdmode: str,
+    native: str,
+    type_cls: type,
+) -> None:
+    mapped = map_coltype(coltype, xtdname, xtdmode)
+    assert mapped.native == native
+    assert isinstance(mapped.data_type.type, type_cls)
+
+
+def test_map_coltype_extended_resolution_preserves_not_null_bit():
+    mapped = map_coltype(41 + 256, "boolean", "B")
+    assert mapped.native == "BOOLEAN"
+    assert mapped.nullable is False
+
+
+def test_sql_columns_outer_joins_sysxtdtypes():
+    # extended_id is 0 for ordinary types, so an inner join would silently drop
+    # every non-extended column.
+    assert "LEFT JOIN sysxtdtypes" in SQL_COLUMNS
 
 
 def test_every_sysindexes_join_is_scoped_by_tabid():

--- a/metadata-ingestion/tests/unit/informix/test_informix_constants.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_constants.py
@@ -1,7 +1,14 @@
+import re
+
 import pytest
 
 from datahub.ingestion.source.informix.config import InformixSourceConfig
-from datahub.ingestion.source.informix.constants import INFORMIX_TYPE_MAP, map_coltype
+from datahub.ingestion.source.informix.constants import (
+    INFORMIX_TYPE_MAP,
+    SQL_FK,
+    SQL_PK,
+    map_coltype,
+)
 from datahub.ingestion.source.informix.models import InformixForeignKey
 from datahub.metadata.schema_classes import (
     BooleanTypeClass,
@@ -120,6 +127,17 @@ def test_informix_type_map_keys_match_parametrized_coverage():
         52,
         53,
     }
+
+
+def test_every_sysindexes_join_is_scoped_by_tabid():
+    # A constraint's backing index must be looked up by (tabid, idxname). Joining
+    # on idxname alone can attach another table's index parts, which would flag
+    # the wrong columns as primary keys and mislink foreign key fields.
+    for sql in (SQL_PK, SQL_FK):
+        aliases = re.findall(r"JOIN sysindexes (\w+) ON", sql)
+        assert aliases
+        for alias in aliases:
+            assert f".tabid = {alias}.tabid" in sql
 
 
 def test_foreign_key_rejects_mismatched_column_counts():

--- a/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
@@ -9,8 +9,13 @@ from datahub.ingestion.source.informix.mapping import (
     columns_to_schema_fields,
     make_table_identifier,
 )
-from datahub.ingestion.source.informix.models import InformixColumn, InformixForeignKey
+from datahub.ingestion.source.informix.models import (
+    ExtendedType,
+    InformixColumn,
+    InformixForeignKey,
+)
 from datahub.ingestion.source.informix.report import InformixSourceReport
+from datahub.metadata.schema_classes import BooleanTypeClass, StringTypeClass
 
 
 def test_build_jdbc_url():
@@ -117,21 +122,46 @@ def test_columns_to_schema_fields_uses_extended_type_name():
             coltype=40,
             length=4000,
             colno=1,
-            extended_name="lvarchar",
-            extended_mode="B",
+            extended=ExtendedType(name="lvarchar", mode="B"),
         ),
         InformixColumn(
             name="flag",
             coltype=41,
             length=1,
             colno=2,
-            extended_name="boolean",
-            extended_mode="B",
+            extended=ExtendedType(name="boolean", mode="B"),
         ),
     ]
     report = InformixSourceReport()
     fields = columns_to_schema_fields(cols, report)
     assert [f.nativeDataType for f in fields] == ["LVARCHAR(4000)", "BOOLEAN"]
+    assert len(report.warnings) == 0
+
+
+def test_columns_to_schema_fields_resolves_distinct_over_opaque_builtin():
+    # coltype's low byte is 41 for a DISTINCT over BOOLEAN and over CLOB alike,
+    # so without sysxtdtypes.source both kept NullType despite a resolved name.
+    cols = [
+        InformixColumn(
+            name="published",
+            coltype=18473,
+            length=1,
+            colno=1,
+            extended=ExtendedType(name="flag_type", mode="D", source_name="boolean"),
+        ),
+        InformixColumn(
+            name="abstract",
+            coltype=2089,
+            length=72,
+            colno=2,
+            extended=ExtendedType(name="doc_text", mode="D", source_name="clob"),
+        ),
+    ]
+    report = InformixSourceReport()
+    fields = columns_to_schema_fields(cols, report)
+    assert [f.nativeDataType for f in fields] == ["FLAG_TYPE", "DOC_TEXT"]
+    assert isinstance(fields[0].type.type, BooleanTypeClass)
+    assert isinstance(fields[1].type.type, StringTypeClass)
     assert len(report.warnings) == 0
 
 
@@ -144,8 +174,7 @@ def test_columns_to_schema_fields_warns_for_opaque_type_but_keeps_its_name():
             coltype=40,
             length=0,
             colno=1,
-            extended_name="json",
-            extended_mode="O",
+            extended=ExtendedType(name="json", mode="O"),
         )
     ]
     report = InformixSourceReport()

--- a/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datahub.emitter.mce_builder import make_dataset_urn, make_schema_field_urn
 from datahub.ingestion.source.informix.config import InformixSourceConfig
 from datahub.ingestion.source.informix.constants import PLATFORM
@@ -77,6 +79,33 @@ def test_columns_to_schema_fields_maps_types_and_nullable():
     assert fields[1].nativeDataType == "VARCHAR(100)"
     assert fields[1].isPartOfKey is False
     assert len(report.warnings) == 0
+
+
+@pytest.mark.parametrize(
+    "coltype,collength,expected",
+    [
+        # Values measured against Informix 15.0.1. VARCHAR/NVARCHAR pack
+        # (reserved_min * 256) + max_size into a signed SMALLINT collength.
+        (13, 100, "VARCHAR(100)"),  # VARCHAR(100), no reserved minimum
+        (13, 2660, "VARCHAR(100)"),  # VARCHAR(100,10) -> 10 * 256 + 100
+        (13, -26936, "VARCHAR(200)"),  # VARCHAR(200,150) wraps negative
+        (16, 5200, "NVARCHAR(80)"),  # NVARCHAR(80,20) -> 20 * 256 + 80
+        (0, 30, "CHAR(30)"),  # CHAR stores the length verbatim
+        (15, 30, "NCHAR(30)"),
+        (43, 4000, "LVARCHAR(4000)"),
+        (2, 4, "INTEGER"),  # non-length types get no suffix
+    ],
+)
+def test_columns_to_schema_fields_decodes_declared_length(
+    coltype: int, collength: int, expected: str
+) -> None:
+    cols = [
+        InformixColumn(
+            name="c", coltype=coltype, length=collength, colno=1, is_pk=False
+        )
+    ]
+    fields = columns_to_schema_fields(cols, InformixSourceReport())
+    assert fields[0].nativeDataType == expected
 
 
 def test_columns_to_schema_fields_warns_on_unknown_type():

--- a/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_mapping.py
@@ -108,6 +108,52 @@ def test_columns_to_schema_fields_decodes_declared_length(
     assert fields[0].nativeDataType == expected
 
 
+def test_columns_to_schema_fields_uses_extended_type_name():
+    # LVARCHAR/BOOLEAN/BLOB share base coltypes 40 and 41, so before the
+    # sysxtdtypes lookup all three resolved to UNKNOWN + NullType.
+    cols = [
+        InformixColumn(
+            name="body",
+            coltype=40,
+            length=4000,
+            colno=1,
+            extended_name="lvarchar",
+            extended_mode="B",
+        ),
+        InformixColumn(
+            name="flag",
+            coltype=41,
+            length=1,
+            colno=2,
+            extended_name="boolean",
+            extended_mode="B",
+        ),
+    ]
+    report = InformixSourceReport()
+    fields = columns_to_schema_fields(cols, report)
+    assert [f.nativeDataType for f in fields] == ["LVARCHAR(4000)", "BOOLEAN"]
+    assert len(report.warnings) == 0
+
+
+def test_columns_to_schema_fields_warns_for_opaque_type_but_keeps_its_name():
+    # An opaque type has no DataHub equivalent, so it still warns -- but the
+    # recovered name is more useful than UNKNOWN(40).
+    cols = [
+        InformixColumn(
+            name="doc",
+            coltype=40,
+            length=0,
+            colno=1,
+            extended_name="json",
+            extended_mode="O",
+        )
+    ]
+    report = InformixSourceReport()
+    fields = columns_to_schema_fields(cols, report)
+    assert fields[0].nativeDataType == "JSON"
+    assert len(report.warnings) == 1
+
+
 def test_columns_to_schema_fields_warns_on_unknown_type():
     cols = [InformixColumn(name="weird", coltype=99, length=1, colno=1, is_pk=False)]
     report = InformixSourceReport()

--- a/metadata-ingestion/tests/unit/informix/test_informix_source.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_source.py
@@ -307,6 +307,63 @@ def test_source_fails_when_every_selected_object_fails():
     assert [e for e in entities if isinstance(e, Dataset)] == []
     assert len(source.report.failures) == 1
     assert source.report.tables_scanned == 0
+    assert source.report.objects_selected == 2
+    # The escalation adds a run failure; it must not swallow the per-object
+    # warnings saying which objects failed and why. The report collapses repeats
+    # of one title into a single entry, so both objects show up as contexts.
+    per_object = [
+        w for w in source.report.warnings if "Failed to ingest table" in str(w.title)
+    ]
+    assert len(per_object) == 1
+    assert len(per_object[0].context) == 2
+
+
+class _NoViewDefinitionClient(_ViewLineageClient):
+    def get_tables(self):
+        return super().get_tables() + [
+            InformixTable(name="active_customers", owner="informix", is_view=True),
+        ]
+
+    def get_view_definition(self, table):
+        return None
+
+
+def test_source_warns_when_no_view_definition_could_be_read():
+    # sysviews returning empty for every view only bumped a counter, so a
+    # permissions problem scoped to sysviews produced no diagnostic at all --
+    # the pass 1 escalation does not cover it, the datasets still ingest fine.
+    config = InformixSourceConfig.parse_obj(
+        {"server": "informix", "database": "testdb"}
+    )
+    source = InformixSource(
+        PipelineContext(run_id="test"), config, client=_NoViewDefinitionClient()
+    )
+    entities = list(source.get_workunits_internal())
+
+    assert [e for e in entities if isinstance(e, Dataset)]
+    assert source.report.views_without_definition == 2
+    assert len(source.report.failures) == 0
+    assert any(
+        "No view definitions could be read" in str(w.title)
+        for w in source.report.warnings
+    )
+
+
+def test_source_does_not_warn_when_some_view_definitions_are_read():
+    # One view has stored SQL and one does not, which is an ordinary catalog
+    # state rather than a systemic read failure.
+    config = InformixSourceConfig.parse_obj(
+        {"server": "informix", "database": "testdb"}
+    )
+    source = InformixSource(
+        PipelineContext(run_id="test"), config, client=_ViewLineageClient()
+    )
+    list(source.get_workunits_internal())
+
+    assert not any(
+        "No view definitions could be read" in str(w.title)
+        for w in source.report.warnings
+    )
 
 
 def test_source_does_not_fail_when_everything_is_filtered_out():

--- a/metadata-ingestion/tests/unit/informix/test_informix_source.py
+++ b/metadata-ingestion/tests/unit/informix/test_informix_source.py
@@ -89,6 +89,11 @@ class _PartialFailureClient:
         pass
 
 
+class _TotalFailureClient(_TwoTableClient):
+    def get_columns(self, table):
+        raise RuntimeError("catalog unreadable")
+
+
 class _FkClient:
     def get_tables(self):
         return [
@@ -286,6 +291,52 @@ def test_source_isolates_per_table_failures():
     names = sorted(d.urn.name for d in datasets)
     assert names == ["testdb.informix.customers"]
     assert len(source.report.warnings) == 1
+
+
+def test_source_fails_when_every_selected_object_fails():
+    # A systemic catalog problem must not finish as a successful run that emitted
+    # only containers -- per-object warnings are escalated to one run failure.
+    config = InformixSourceConfig.parse_obj(
+        {"server": "informix", "database": "testdb"}
+    )
+    source = InformixSource(
+        PipelineContext(run_id="test"), config, client=_TotalFailureClient()
+    )
+    entities = list(source.get_workunits_internal())
+
+    assert [e for e in entities if isinstance(e, Dataset)] == []
+    assert len(source.report.failures) == 1
+    assert source.report.tables_scanned == 0
+
+
+def test_source_does_not_fail_when_everything_is_filtered_out():
+    # Nothing was selected, so there is no failure to escalate.
+    config = InformixSourceConfig.parse_obj(
+        {
+            "server": "informix",
+            "database": "testdb",
+            "table_pattern": {"deny": [".*"]},
+        }
+    )
+    source = InformixSource(
+        PipelineContext(run_id="test"), config, client=_TotalFailureClient()
+    )
+    list(source.get_workunits_internal())
+
+    assert len(source.report.failures) == 0
+
+
+def test_source_does_not_fail_when_some_objects_succeed():
+    config = InformixSourceConfig.parse_obj(
+        {"server": "informix", "database": "testdb"}
+    )
+    source = InformixSource(
+        PipelineContext(run_id="test"), config, client=_PartialFailureClient()
+    )
+    list(source.get_workunits_internal())
+
+    assert len(source.report.failures) == 0
+    assert source.report.tables_scanned == 1
 
 
 def test_source_applies_table_pattern_deny():


### PR DESCRIPTION
Follow-up to #18589. Addresses three findings from an automated review that landed after approval, plus the `sysxtdtypes` resolution logged as a follow-up during review.

Every claim below was measured against `icr.io/informix/informix-developer-database` (Informix 15.0.1), not inferred from documentation.

## VARCHAR/NVARCHAR length was reported wrong

`syscolumns.collength` packs a VARCHAR declaration as `(reserved_min_space * 256) + max_size`, in a signed `SMALLINT` that wraps negative once the reserved minimum reaches 128. The raw value was reported verbatim:

| Declaration | `collength` | Before | After |
| --- | --- | --- | --- |
| `VARCHAR(100)` | 100 | `VARCHAR(100)` | `VARCHAR(100)` |
| `VARCHAR(60,10)` | 2620 | `VARCHAR(2620)` | `VARCHAR(60)` |
| `VARCHAR(200,150)` | −26936 | `VARCHAR` (length lost) | `VARCHAR(200)` |
| `NVARCHAR(80,20)` | 5200 | `NVARCHAR(5200)` | `NVARCHAR(80)` |

The negative-wrap case dropped the length entirely, because the old guard was `collength > 0`. `CHAR`/`NCHAR`/`LVARCHAR` store the length verbatim and are unaffected.

## Extended types could not be identified

`coltype` alone cannot distinguish an extended type: `LVARCHAR` is type 40, and `BOOLEAN`, `BLOB` and `CLOB` all share type 41. All of them resolved to a null DataHub type with a placeholder name, one warning each:

| Column | Before | After |
| --- | --- | --- |
| `body LVARCHAR(4000)` | `UNKNOWN(40)` / NullType | `LVARCHAR(4000)` / StringType |
| `archived BOOLEAN` | `UNKNOWN(41)` / NullType | `BOOLEAN` / BooleanType |
| `payload BLOB` | `UNKNOWN(41)` / NullType | `BLOB` / BytesType |
| `summary CLOB` | `UNKNOWN(41)` / NullType | `CLOB` / StringType |
| `price money_usd` | `DECIMAL` / NumberType | `MONEY_USD` / NumberType |

`SQL_COLUMNS` now outer-joins `sysxtdtypes` on the column's `extended_id` (an outer join is required — `extended_id` is 0 for ordinary types) and resolves by `sysxtdtypes.mode`:

- `B` built-ins — `LVARCHAR`, `BOOLEAN`, `BLOB`, `CLOB` map to their DataHub equivalents.
- `D` DISTINCT — reports its own name; the DataHub type comes from the source built-in, which `coltype`'s low byte already carries (`2053 = 2048 | 5`, DECIMAL).
- `R` named ROW — maps to a record.
- `C` collection — `sysxtdtypes.name` is empty for these and the base `coltype` (SET/LIST/MULTISET) is already correct, so they are left alone.
- `O` opaque and anything else — no DataHub equivalent, so still a null type, but reporting the real name (`JSON`) rather than `UNKNOWN(40)`.

The unmapped-type warning now keys off the resolved DataHub type instead of an `UNKNOWN` name prefix, so a named-but-unmappable opaque type is still reported rather than silently passing.

Routing native names through the shared `resolve_sql_type` registry — the other half of that review thread — is deliberately **not** in this PR: it moves `nativeDataType` and the type class for existing columns and deserves its own change.

## `sysindexes` joins scoped to `(tabid, idxname)`

The primary- and foreign-key queries joined a constraint's backing index on `idxname` alone. This is now `(tabid, idxname)`, the join IBM's catalog documentation specifies.

Reported as a wrong-data bug on the grounds that ANSI-mode index names are only unique per owner. **That premise does not hold for Informix.** In an ANSI-mode database with two owners, `CREATE UNIQUE INDEX bob.ix_shared` fails with `316: Index (ix_shared) already exists in database`, and `SELECT idxname, COUNT(*) FROM sysindexes GROUP BY 1 HAVING COUNT(*) > 1` returns no rows. Both join forms return identical primary-key columns on a composite-key table.

So this is hardening, not a live bug fix: the previous join was under-constrained, the correction is free, and it holds if any version ever relaxes that uniqueness. No behaviour change on 15.0.1.

## A run where nothing could be ingested now fails

Per-object extraction failures are isolated as warnings by design, so a systemic problem — revoked privileges on the system catalogs, a connection dropped mid-scan — finished as a *successful* run that emitted only containers. When objects were selected from the catalog but none could be ingested, the run now reports a failure.

Guarded in both directions: an all-filtered run does not fail (nothing was selected), and a partially-failing run does not fail (some objects succeeded).

## Verification

- 126 unit tests pass. Each new assertion was red-checked — reverting any one fix fails its test.
- `./gradlew :metadata-ingestion:lint` — ruff and mypy clean.
- The integration test passes against the regenerated golden, then again as a plain run against the committed golden.
- Before/after tables above are live ingestion output from the same fixture, taken by toggling only the code under test.
- The integration fixture gains a reserved-space `VARCHAR` column and a `documents` table covering `LVARCHAR`, `BOOLEAN`, `BLOB`, `CLOB` and a `DISTINCT` type, so all of this has real-catalog regression coverage.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [x] Docs updated — the connector's "Extended type mapping" note described the old behaviour
- [x] No breaking changes, so no `docs/how/updating-datahub.md` entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Informix type decoding and catalog handling to produce correct schemas and surface systemic failures. Previously we misreported `VARCHAR` sizes, treated many extended types as unknown, under-constrained index joins, and finished “successful” runs that ingested nothing.

- Decode `VARCHAR`/`NVARCHAR` lengths from `syscolumns.collength` (old: reported raw value or dropped length on negative wrap; new: report declared max size; affects `nativeDataType`).
- Resolve extended types via `sysxtdtypes` (old: `LVARCHAR`/`BOOLEAN`/`BLOB`/`CLOB`/`DISTINCT`/`ROW` appeared as unknown with NullType; new: map built-ins, name `DISTINCT`/`ROW`, leave opaque names with NullType; warnings now key off NullType):
  - `DISTINCT` over ordinary built-ins keeps the base type.
  - `DISTINCT` over `LVARCHAR`/`BOOLEAN`/`BLOB`/`CLOB` is now resolved via a second outer self-join on `sysxtdtypes.source`.
- Scope primary/foreign key index joins to `(tabid, idxname)` (hardening; no behavior change on 15.0.1).
- Mark the run as failed when some objects were selected but none ingested (old: success with only containers; new: single run failure; all-filtered and partially successful runs remain successful).
- Warn when every view returns an empty `sysviews.viewtext` (old: silent counter; new: one warning to flag likely privilege issues).

<sup>Written for commit 4c856435fe5540f4a065b33b760e2b5d1f4410ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

