### PR TITLE
fix(executor): address review findings from the executor port

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/default_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/default_executor.py
@@ -211,19 +211,10 @@ class DefaultExecutor(Executor):
         return secret_stores
 
     def _create_secret_store(self, config: SecretStoreConfig) -> SecretStore:
-        # Create a secret store registry
-        secret_store_registry: SecretStoreRegistry = SecretStoreRegistry()
-
-        # Get the secret store configs
-        secret_store_type: str = config.type
-
-        # Fetch the correct secret store, or register a new one
-        if not secret_store_registry.is_enabled(secret_store_type):
-            # Custom Secret Store found. Register it.
-            secret_store_registry.register_lazy(secret_store_type, secret_store_type)
-
-        # Instantiate the secret store class
-        secret_store_class = secret_store_registry.get(secret_store_type)
-
-        # Create & return new instance of secret store
+        # `get()` resolves both forms of `type`: a built-in short name ("env",
+        # "datahub", "aws-sm", ...) via the registry, and a dotted/colon import path
+        # ("my_pkg.stores.MyVaultStore") by importing it directly. Pre-registering an
+        # import path is not just unnecessary but impossible -- SecretStoreRegistry
+        # rejects keys containing "." or ":", so registering one raises KeyError.
+        secret_store_class = SecretStoreRegistry().get(config.type)
         return secret_store_class.create(config.config)

--- a/metadata-ingestion/src/datahub/executor/execution/default_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/default_executor.py
@@ -211,10 +211,5 @@ class DefaultExecutor(Executor):
         return secret_stores
 
     def _create_secret_store(self, config: SecretStoreConfig) -> SecretStore:
-        # `get()` resolves both forms of `type`: a built-in short name ("env",
-        # "datahub", "aws-sm", ...) via the registry, and a dotted/colon import path
-        # ("my_pkg.stores.MyVaultStore") by importing it directly. Pre-registering an
-        # import path is not possible -- SecretStoreRegistry rejects keys containing
-        # "." or ":", so registering one raises KeyError.
         secret_store_class = SecretStoreRegistry().get(config.type)
         return secret_store_class.create(config.config)

--- a/metadata-ingestion/src/datahub/executor/execution/default_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/default_executor.py
@@ -211,10 +211,5 @@ class DefaultExecutor(Executor):
         return secret_stores
 
     def _create_secret_store(self, config: SecretStoreConfig) -> SecretStore:
-        # `get()` resolves both forms of `type`: a built-in short name ("env",
-        # "datahub", "aws-sm", ...) via the registry, and a dotted/colon import path
-        # ("my_pkg.stores.MyVaultStore") by importing it directly. Pre-registering an
-        # import path is not just unnecessary but impossible -- SecretStoreRegistry
-        # rejects keys containing "." or ":", so registering one raises KeyError.
         secret_store_class = SecretStoreRegistry().get(config.type)
         return secret_store_class.create(config.config)

--- a/metadata-ingestion/src/datahub/executor/execution/default_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/default_executor.py
@@ -211,5 +211,10 @@ class DefaultExecutor(Executor):
         return secret_stores
 
     def _create_secret_store(self, config: SecretStoreConfig) -> SecretStore:
+        # `get()` resolves both forms of `type`: a built-in short name ("env",
+        # "datahub", "aws-sm", ...) via the registry, and a dotted/colon import path
+        # ("my_pkg.stores.MyVaultStore") by importing it directly. Pre-registering an
+        # import path is not possible -- SecretStoreRegistry rejects keys containing
+        # "." or ":", so registering one raises KeyError.
         secret_store_class = SecretStoreRegistry().get(config.type)
         return secret_store_class.create(config.config)

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -297,8 +297,10 @@ class ReportingExecutor(DefaultExecutor):
             exec_id = exec_request.exec_id if exec_request else "unknown"
             message = f"{exec_id} report exceeded limit of {max_length} chars and was truncated."
             logger.warning(message)
+            # Prefix first, then truncate: truncating before prepending leaves the
+            # result over the limit by the length of the prefix.
             prefix = f"WARNING: {message}\n"
-            report = (prefix + report[: max(0, max_length - len(prefix))])[:max_length]
+            report = (prefix + report)[:max_length]
 
         # Build the arguments for ExecutionRequestResultClass
         result_args = {

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -316,9 +316,6 @@ class ReportingExecutor(DefaultExecutor):
             exec_id = exec_request.exec_id if exec_request else "unknown"
             message = f"{exec_id} report exceeded limit of {max_length} chars and was truncated."
             logger.warning(message)
-            # Reserve room for the prefix, then clamp: prepending after truncating
-            # overshoots by len(prefix), and reserving alone still overshoots when
-            # max_length < len(prefix).
             prefix = f"WARNING: {message}\n"
             report = (prefix + report[: max(0, max_length - len(prefix))])[:max_length]
 

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -47,12 +47,9 @@ DATAHUB_EXECUTION_REQUEST_ENTITY_NAME = "dataHubExecutionRequest"
 DATAHUB_EXECUTION_REQUEST_RESULT_ASPECT_NAME = "dataHubExecutionRequestResult"
 REPORTS_TO_EMIT_MAX_SIZE = 10
 
-# `executorInstanceId` is not declared by the OSS ExecutionRequestResult aspect, but is
-# by some deployments' models (either a fork of metadata-models or a custom models
-# package registered via datahub.custom_packages -- see
-# datahub.utilities._custom_package_loader). Generated aspect classes take explicit
-# keyword arguments with no **kwargs, so passing the field to a build that does not
-# declare it raises TypeError. Probe once at import rather than per-MCP.
+# Only some models builds declare executorInstanceId (a metadata-models fork, or a
+# custom models package). Generated aspect classes take explicit kwargs, so passing it
+# to a build without the field raises TypeError.
 _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID = (
     "executorInstanceId"
     in inspect.signature(ExecutionRequestResultClass.__init__).parameters
@@ -96,8 +93,7 @@ class ReportingExecutor(DefaultExecutor):
             exec_config.executor_instance_id is not None
             and not _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
         ):
-            # Warned once here rather than per aspect: this method builds an MCP on every
-            # progress heartbeat, so warning there floods the log for a whole run.
+            # Warned here, not per aspect: an MCP is built on every progress heartbeat.
             logger.warning(
                 "executor_instance_id is configured but the installed "
                 "ExecutionRequestResult aspect does not declare executorInstanceId; "
@@ -320,11 +316,9 @@ class ReportingExecutor(DefaultExecutor):
             exec_id = exec_request.exec_id if exec_request else "unknown"
             message = f"{exec_id} report exceeded limit of {max_length} chars and was truncated."
             logger.warning(message)
-            # Reserve room for the warning line. Truncating to max_length and *then*
-            # prepending the warning would put the result back over the limit by the
-            # length of the prefix, defeating the guard this block exists for. The outer
-            # slice keeps the guarantee unconditional: if max_length is smaller than the
-            # prefix itself, the warning gets cut rather than blowing the budget.
+            # Reserve room for the prefix, then clamp: prepending after truncating
+            # overshoots by len(prefix), and reserving alone still overshoots when
+            # max_length < len(prefix).
             prefix = f"WARNING: {message}\n"
             report = (prefix + report[: max(0, max_length - len(prefix))])[:max_length]
 
@@ -343,11 +337,7 @@ class ReportingExecutor(DefaultExecutor):
             else None,
         }
 
-        # Included only when configured and supported by the installed models. Without
-        # the guard, a deployment that sets executor_instance_id against the OSS aspect
-        # would raise TypeError here -- and since this method builds every kickoff,
-        # progress and completion MCP, that would fail all reporting for the executor
-        # rather than degrading a single field.
+        # Skipped when the installed models lack the field; warned about at construction.
         if (
             self._config.executor_instance_id is not None
             and _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import inspect
 import logging
 import time
 from collections import OrderedDict
@@ -47,14 +46,6 @@ DATAHUB_EXECUTION_REQUEST_ENTITY_NAME = "dataHubExecutionRequest"
 DATAHUB_EXECUTION_REQUEST_RESULT_ASPECT_NAME = "dataHubExecutionRequestResult"
 REPORTS_TO_EMIT_MAX_SIZE = 10
 
-# Only some models builds declare executorInstanceId (a metadata-models fork, or a
-# custom models package). Generated aspect classes take explicit kwargs, so passing it
-# to a build without the field raises TypeError.
-_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID = (
-    "executorInstanceId"
-    in inspect.signature(ExecutionRequestResultClass.__init__).parameters
-)
-
 logger = logging.getLogger(__name__)
 
 
@@ -89,16 +80,6 @@ class ReportingExecutor(DefaultExecutor):
         # Implements LRU cache via OrderedDict to avoid memory leak
         self.results_to_emit: OrderedDict[str, ExecutionResult] = OrderedDict()
         self.dropped_reports: set[str] = set()  # Leaks memory slowly, like task_futures
-        if (
-            exec_config.executor_instance_id is not None
-            and not _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
-        ):
-            # Warned here, not per aspect: an MCP is built on every progress heartbeat.
-            logger.warning(
-                "executor_instance_id is configured but the installed "
-                "ExecutionRequestResult aspect does not declare executorInstanceId; "
-                "it will be omitted from execution results."
-            )
         if exec_config.graph_client is not None:
             self._datahub_graph = exec_config.graph_client
         elif exec_config.graph_client_config is not None:
@@ -333,13 +314,6 @@ class ReportingExecutor(DefaultExecutor):
             if structured_report and exec_request
             else None,
         }
-
-        # Skipped when the installed models lack the field; warned about at construction.
-        if (
-            self._config.executor_instance_id is not None
-            and _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
-        ):
-            result_args["executorInstanceId"] = self._config.executor_instance_id
 
         return ExecutionRequestResultClass(**result_args)  # type: ignore[arg-type]
 

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import inspect
 import logging
 import time
 from collections import OrderedDict
@@ -45,6 +46,17 @@ from datahub.secret.secret_store import SecretStoreConfig
 DATAHUB_EXECUTION_REQUEST_ENTITY_NAME = "dataHubExecutionRequest"
 DATAHUB_EXECUTION_REQUEST_RESULT_ASPECT_NAME = "dataHubExecutionRequestResult"
 REPORTS_TO_EMIT_MAX_SIZE = 10
+
+# `executorInstanceId` is not declared by the OSS ExecutionRequestResult aspect, but is
+# by some deployments' models (either a fork of metadata-models or a custom models
+# package registered via datahub.custom_packages -- see
+# datahub.utilities._custom_package_loader). Generated aspect classes take explicit
+# keyword arguments with no **kwargs, so passing the field to a build that does not
+# declare it raises TypeError. Probe once at import rather than per-MCP.
+_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID = (
+    "executorInstanceId"
+    in inspect.signature(ExecutionRequestResultClass.__init__).parameters
+)
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +300,7 @@ class ReportingExecutor(DefaultExecutor):
             and ((len(structured_report) + len(report)) > max_length)
         ):
             exec_id = exec_request.exec_id if exec_request else "unknown"
-            message = f"{exec_id} structured report exceeded limit of {max_length} chars and was truncated."
+            message = f"{exec_id} report and structured report exceeded the combined limit of {max_length} chars, so the structured report was removed."
             logger.warning(message)
             structured_report = None
             report = f"WARNING: {message}\n{report}"
@@ -297,8 +309,13 @@ class ReportingExecutor(DefaultExecutor):
             exec_id = exec_request.exec_id if exec_request else "unknown"
             message = f"{exec_id} report exceeded limit of {max_length} chars and was truncated."
             logger.warning(message)
-            report = report[:max_length]
-            report = f"WARNING: {message}\n{report}"
+            # Reserve room for the warning line. Truncating to max_length and *then*
+            # prepending the warning would put the result back over the limit by the
+            # length of the prefix, defeating the guard this block exists for. The outer
+            # slice keeps the guarantee unconditional: if max_length is smaller than the
+            # prefix itself, the warning gets cut rather than blowing the budget.
+            prefix = f"WARNING: {message}\n"
+            report = (prefix + report[: max(0, max_length - len(prefix))])[:max_length]
 
         # Build the arguments for ExecutionRequestResultClass
         result_args = {
@@ -315,13 +332,20 @@ class ReportingExecutor(DefaultExecutor):
             else None,
         }
 
-        # Included only when configured. The ExecutionRequestResult aspect does not
-        # declare executorInstanceId, and generated aspect classes reject unknown
-        # keyword arguments, so passing it unconditionally would fail. Deployments
-        # that set it supply a custom models package whose aspect declares the field
-        # (see datahub.utilities._custom_package_loader).
+        # Included only when configured and supported by the installed models. Without
+        # the guard, a deployment that sets executor_instance_id against the OSS aspect
+        # would raise TypeError here -- and since this method builds every kickoff,
+        # progress and completion MCP, that would fail all reporting for the executor
+        # rather than degrading a single field.
         if self._config.executor_instance_id is not None:
-            result_args["executorInstanceId"] = self._config.executor_instance_id
+            if _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID:
+                result_args["executorInstanceId"] = self._config.executor_instance_id
+            else:
+                logger.warning(
+                    "executor_instance_id is configured but the installed "
+                    "ExecutionRequestResult aspect does not declare executorInstanceId; "
+                    "omitting it from the execution result."
+                )
 
         return ExecutionRequestResultClass(**result_args)  # type: ignore[arg-type]
 

--- a/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/reporting_executor.py
@@ -92,6 +92,17 @@ class ReportingExecutor(DefaultExecutor):
         # Implements LRU cache via OrderedDict to avoid memory leak
         self.results_to_emit: OrderedDict[str, ExecutionResult] = OrderedDict()
         self.dropped_reports: set[str] = set()  # Leaks memory slowly, like task_futures
+        if (
+            exec_config.executor_instance_id is not None
+            and not _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
+        ):
+            # Warned once here rather than per aspect: this method builds an MCP on every
+            # progress heartbeat, so warning there floods the log for a whole run.
+            logger.warning(
+                "executor_instance_id is configured but the installed "
+                "ExecutionRequestResult aspect does not declare executorInstanceId; "
+                "it will be omitted from execution results."
+            )
         if exec_config.graph_client is not None:
             self._datahub_graph = exec_config.graph_client
         elif exec_config.graph_client_config is not None:
@@ -337,15 +348,11 @@ class ReportingExecutor(DefaultExecutor):
         # would raise TypeError here -- and since this method builds every kickoff,
         # progress and completion MCP, that would fail all reporting for the executor
         # rather than degrading a single field.
-        if self._config.executor_instance_id is not None:
-            if _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID:
-                result_args["executorInstanceId"] = self._config.executor_instance_id
-            else:
-                logger.warning(
-                    "executor_instance_id is configured but the installed "
-                    "ExecutionRequestResult aspect does not declare executorInstanceId; "
-                    "omitting it from the execution result."
-                )
+        if (
+            self._config.executor_instance_id is not None
+            and _RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
+        ):
+            result_args["executorInstanceId"] = self._config.executor_instance_id
 
         return ExecutionRequestResultClass(**result_args)  # type: ignore[arg-type]
 

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -75,15 +75,6 @@ class SubProcessTestConnectionTask(Task):
 
         exec_out_dir = f"{self.tmp_dir}/{exec_id}"
 
-        # The connection report is written in here, and nothing else creates it:
-        # setup_venv only makes this directory as a side effect of `uv venv`, which the
-        # "bundled" and "native" versions skip entirely. Without it the CLI's
-        # `--report-to` write raises inside _test_source_connection, whose single
-        # `except Exception` also covers the connection test itself -- so it returns 1
-        # and a perfectly healthy connection is reported as FAILURE.
-        # Mirrors _setup_directories in SubProcessIngestionTask.
-        Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
-
         # 0. Validate arguments
         validated_args = SubProcessTestConnectionTaskArgs.model_validate(args)
 
@@ -94,6 +85,20 @@ class SubProcessTestConnectionTask(Task):
         plugin: str = SubProcessTaskUtil._get_plugin_from_recipe(recipe)
 
         # 2. Prepare or resolve venv
+        #
+        # The connection report is written into exec_out_dir, and nothing else creates
+        # it: setup_venv only makes it as a side effect of `uv venv`, which the
+        # "bundled" and "native" versions skip entirely. Without it the CLI's
+        # `--report-to` write raises inside _test_source_connection, whose single
+        # `except Exception` also covers the connection test itself -- so it returns 1
+        # and a perfectly healthy connection is reported as FAILURE.
+        #
+        # Created here rather than at the top of execute() so argument-validation and
+        # recipe-resolution failures do not leave an empty directory behind: the cleanup
+        # that removes it only runs once the subprocess block below is entered.
+        # Mirrors _setup_directories in SubProcessIngestionTask.
+        Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
+
         venv_config = VenvConfig(
             version=validated_args.version,
             main_plugin=plugin,

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -75,6 +75,15 @@ class SubProcessTestConnectionTask(Task):
 
         exec_out_dir = f"{self.tmp_dir}/{exec_id}"
 
+        # The connection report is written in here, and nothing else creates it:
+        # setup_venv only makes this directory as a side effect of `uv venv`, which the
+        # "bundled" and "native" versions skip entirely. Without it the CLI's
+        # `--report-to` write raises inside _test_source_connection, whose single
+        # `except Exception` also covers the connection test itself -- so it returns 1
+        # and a perfectly healthy connection is reported as FAILURE.
+        # Mirrors _setup_directories in SubProcessIngestionTask.
+        Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
+
         # 0. Validate arguments
         validated_args = SubProcessTestConnectionTaskArgs.model_validate(args)
 

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -85,18 +85,11 @@ class SubProcessTestConnectionTask(Task):
         plugin: str = SubProcessTaskUtil._get_plugin_from_recipe(recipe)
 
         # 2. Prepare or resolve venv
-        #
-        # The connection report is written into exec_out_dir, and nothing else creates
-        # it: setup_venv only makes it as a side effect of `uv venv`, which the
-        # "bundled" and "native" versions skip entirely. Without it the CLI's
-        # `--report-to` write raises inside _test_source_connection, whose single
-        # `except Exception` also covers the connection test itself -- so it returns 1
-        # and a perfectly healthy connection is reported as FAILURE.
-        #
-        # Created here rather than at the top of execute() so argument-validation and
-        # recipe-resolution failures do not leave an empty directory behind: the cleanup
-        # that removes it only runs once the subprocess block below is entered.
-        # Mirrors _setup_directories in SubProcessIngestionTask.
+        # The connection report is written here. Only the dynamic venv path creates this
+        # directory (via `uv venv`); "bundled" and "native" return before that, and the
+        # missing directory makes the CLI's --report-to write fail, which
+        # _test_source_connection reports as a failed connection test. Created after
+        # validation so earlier failures leave no empty directory behind.
         Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
 
         venv_config = VenvConfig(

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -85,11 +85,6 @@ class SubProcessTestConnectionTask(Task):
         plugin: str = SubProcessTaskUtil._get_plugin_from_recipe(recipe)
 
         # 2. Prepare or resolve venv
-        # The connection report is written here. Only the dynamic venv path creates this
-        # directory (via `uv venv`); "bundled" and "native" return before that, and the
-        # missing directory makes the CLI's --report-to write fail, which
-        # _test_source_connection reports as a failed connection test. Created after
-        # validation so earlier failures leave no empty directory behind.
         Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
 
         venv_config = VenvConfig(

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -85,8 +85,6 @@ class SubProcessTestConnectionTask(Task):
         plugin: str = SubProcessTaskUtil._get_plugin_from_recipe(recipe)
 
         # 2. Prepare or resolve venv
-        Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
-
         venv_config = VenvConfig(
             version=validated_args.version,
             main_plugin=plugin,
@@ -114,6 +112,7 @@ class SubProcessTestConnectionTask(Task):
         command_script: str = resolve_wrapper_script(
             "datahub.executor.wrappers.run_test_connection"
         )
+        Path(exec_out_dir).mkdir(0o755, parents=True, exist_ok=True)
         report_out_file: str = f"{exec_out_dir}/connection_report.json"
         stdout_lines: deque = deque(maxlen=SubProcessTaskUtil.MAX_LOG_LINES)
 

--- a/metadata-ingestion/tests/unit/executor/test_default_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_default_executor.py
@@ -56,12 +56,7 @@ def _build_store(store_type: str) -> SecretStore:
 
 
 class TestSecretStoreResolution:
-    """`SecretStoreConfig.type` accepts a built-in short name or an import path.
-
-    The import-path form used to be unreachable: `_create_secret_store` pre-registered
-    the path as its own registry key, and SecretStoreRegistry rejects keys containing
-    "." or ":", so it raised KeyError before the class was ever imported.
-    """
+    """`SecretStoreConfig.type` accepts a built-in short name or an import path."""
 
     def test_builtin_short_name_resolves_via_the_registry(self) -> None:
         assert isinstance(_build_store("env"), EnvironmentSecretStore)
@@ -74,8 +69,6 @@ class TestSecretStoreResolution:
         assert isinstance(_build_store(f"{module}:{name}"), DummySecretStore)
 
     def test_unknown_short_name_reports_that_no_class_is_registered(self) -> None:
-        # Not "disabled due to an error in initialization", which is what the old
-        # register-then-import path produced for a name that simply does not exist.
         with pytest.raises(KeyError, match="Did not find a registered class"):
             _build_store("no-such-store")
 

--- a/metadata-ingestion/tests/unit/executor/test_default_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_default_executor.py
@@ -1,5 +1,14 @@
-from datahub.executor.execution.default_executor import DefaultExecutorConfig
+from typing import Dict, List, Optional
+
+import pytest
+
+from datahub.executor.execution.default_executor import (
+    DefaultExecutor,
+    DefaultExecutorConfig,
+)
 from datahub.executor.execution.task import TaskConfig
+from datahub.secret.environment_secret_store import EnvironmentSecretStore
+from datahub.secret.secret_store import SecretStore, SecretStoreConfig
 
 
 class TestDefaultExecutorConfig:
@@ -15,3 +24,63 @@ class TestDefaultExecutorConfig:
         assert config.secret_stores == []
         assert config.executor_instance_id is None
         assert config.executor_version is None
+
+
+class DummySecretStore(SecretStore):
+    """A stand-in for an operator's own secret store class, referenced by import path."""
+
+    @classmethod
+    def create(cls, configs: dict) -> "DummySecretStore":
+        return cls()
+
+    def get_secret_values(self, secret_names: List[str]) -> Dict[str, Optional[str]]:
+        return {name: None for name in secret_names}
+
+    def get_id(self) -> str:
+        return "dummy"
+
+    def close(self) -> None:
+        pass
+
+
+_DUMMY_PATH = "tests.unit.executor.test_default_executor.DummySecretStore"
+
+
+def _build_store(store_type: str) -> SecretStore:
+    config = DefaultExecutorConfig(
+        id="test-executor",
+        task_configs=[],
+        secret_stores=[SecretStoreConfig(type=store_type, config={})],
+    )
+    return DefaultExecutor(config).secret_stores[0]
+
+
+class TestSecretStoreResolution:
+    """`SecretStoreConfig.type` accepts a built-in short name or an import path.
+
+    The import-path form used to be unreachable: `_create_secret_store` pre-registered
+    the path as its own registry key, and SecretStoreRegistry rejects keys containing
+    "." or ":", so it raised KeyError before the class was ever imported.
+    """
+
+    def test_builtin_short_name_resolves_via_the_registry(self) -> None:
+        assert isinstance(_build_store("env"), EnvironmentSecretStore)
+
+    def test_dotted_import_path_resolves_to_the_class(self) -> None:
+        assert isinstance(_build_store(_DUMMY_PATH), DummySecretStore)
+
+    def test_colon_import_path_resolves_to_the_class(self) -> None:
+        module, _, name = _DUMMY_PATH.rpartition(".")
+        assert isinstance(_build_store(f"{module}:{name}"), DummySecretStore)
+
+    def test_unknown_short_name_reports_that_no_class_is_registered(self) -> None:
+        # Not "disabled due to an error in initialization", which is what the old
+        # register-then-import path produced for a name that simply does not exist.
+        with pytest.raises(KeyError, match="Did not find a registered class"):
+            _build_store("no-such-store")
+
+    def test_import_path_to_a_non_secret_store_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be derived from"):
+            _build_store(
+                "tests.unit.executor.test_default_executor.TestSecretStoreResolution"
+            )

--- a/metadata-ingestion/tests/unit/executor/test_default_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_default_executor.py
@@ -61,12 +61,10 @@ class TestSecretStoreResolution:
     def test_builtin_short_name_resolves_via_the_registry(self) -> None:
         assert isinstance(_build_store("env"), EnvironmentSecretStore)
 
-    def test_dotted_import_path_resolves_to_the_class(self) -> None:
-        assert isinstance(_build_store(_DUMMY_PATH), DummySecretStore)
-
-    def test_colon_import_path_resolves_to_the_class(self) -> None:
+    @pytest.mark.parametrize("separator", [".", ":"])
+    def test_import_path_resolves_to_the_class(self, separator: str) -> None:
         module, _, name = _DUMMY_PATH.rpartition(".")
-        assert isinstance(_build_store(f"{module}:{name}"), DummySecretStore)
+        assert isinstance(_build_store(f"{module}{separator}{name}"), DummySecretStore)
 
     def test_unknown_short_name_reports_that_no_class_is_registered(self) -> None:
         with pytest.raises(KeyError, match="Did not find a registered class"):

--- a/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
@@ -58,7 +58,8 @@ class TestResultAspectSizeGuard:
         )
 
         assert aspect.report is not None
-        assert len(aspect.report) <= MAX_LENGTH
+        # Exactly the budget, not merely under it -- catches over-truncation.
+        assert len(aspect.report) == MAX_LENGTH
         assert aspect.report.startswith("WARNING: ")
 
     @pytest.mark.parametrize("limit", [10, 40, 80, 200, MAX_LENGTH])
@@ -77,7 +78,7 @@ class TestResultAspectSizeGuard:
         )
 
         assert aspect.report is not None
-        assert len(aspect.report) <= limit
+        assert len(aspect.report) == limit
 
     def test_report_under_the_limit_is_passed_through_untouched(
         self, executor: ReportingExecutor
@@ -102,7 +103,8 @@ class TestResultAspectSizeGuard:
 
         assert aspect.structuredReport is None
         assert aspect.report is not None
-        assert len(aspect.report) <= MAX_LENGTH
+        # Exactly the budget, not merely under it -- catches over-truncation.
+        assert len(aspect.report) == MAX_LENGTH
 
     def test_both_over_the_limit_stays_within_the_limit(
         self, executor: ReportingExecutor
@@ -119,7 +121,8 @@ class TestResultAspectSizeGuard:
 
         assert aspect.structuredReport is None
         assert aspect.report is not None
-        assert len(aspect.report) <= MAX_LENGTH
+        # Exactly the budget, not merely under it -- catches over-truncation.
+        assert len(aspect.report) == MAX_LENGTH
 
 
 class TestExecutorInstanceId:
@@ -173,29 +176,33 @@ class TestExecutorInstanceId:
             accepted is reporting_executor._RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
         )
 
-    def test_unsupported_field_is_omitted_with_a_warning(
+    def test_unsupported_field_is_omitted_and_warned_about_only_once(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
+        # This method builds an MCP on every progress heartbeat, so warning per build
+        # would flood the log for a whole run. The warning belongs at construction.
         monkeypatch.setattr(
             reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", False
         )
-        executor = ReportingExecutor(
-            ReportingExecutorConfig(
-                id="test-executor",
-                task_configs=[],
-                secret_stores=[],
-                graph_client=Mock(spec=DataHubGraph),
-                executor_instance_id="pool-a",
-            )
-        )
 
         with caplog.at_level(logging.WARNING):
-            aspect = executor._build_execution_request_result_aspect(
-                status="SUCCESS", start_time_ms=0, exec_request=_request()
+            executor = ReportingExecutor(
+                ReportingExecutorConfig(
+                    id="test-executor",
+                    task_configs=[],
+                    secret_stores=[],
+                    graph_client=Mock(spec=DataHubGraph),
+                    executor_instance_id="pool-a",
+                )
             )
+            for _ in range(5):
+                aspect = executor._build_execution_request_result_aspect(
+                    status="SUCCESS", start_time_ms=0, exec_request=_request()
+                )
 
         assert getattr(aspect, "executorInstanceId", None) is None
-        assert "executorInstanceId" in caplog.text
+        warnings = [r for r in caplog.records if "executorInstanceId" in r.getMessage()]
+        assert len(warnings) == 1
 
     def test_supported_field_is_forwarded_to_the_aspect(
         self, monkeypatch: pytest.MonkeyPatch

--- a/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
@@ -1,15 +1,20 @@
 import logging
-from typing import Any, Dict
+from datetime import datetime, timezone
+from typing import Any, Dict, cast
 from unittest.mock import Mock
 
 import pytest
 
+from datahub.configuration.common import OperationalError
+from datahub.executor.context.execution_context import ExecutionContext
 from datahub.executor.execution import reporting_executor
 from datahub.executor.execution.reporting_executor import (
     ReportingExecutor,
     ReportingExecutorConfig,
 )
 from datahub.executor.request.execution_request import ExecutionRequest
+from datahub.executor.request.signal_request import SignalRequest
+from datahub.executor.result.execution_result import ExecutionResult, Type
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import ExecutionRequestResultClass
 
@@ -38,6 +43,12 @@ def _request() -> ExecutionRequest:
     return ExecutionRequest(exec_id="test-exec-id", name="RUN_INGEST", args={})
 
 
+def _context() -> ExecutionContext:
+    return ExecutionContext(
+        ExecutionRequest(exec_id="exec-1", name="RUN_INGEST", args={})
+    )
+
+
 class TestResultAspectSizeGuard:
     """The guard must leave the aspect at exactly `max_length`, not over it."""
 
@@ -56,7 +67,7 @@ class TestResultAspectSizeGuard:
         assert len(aspect.report) == MAX_LENGTH
         assert aspect.report.startswith("WARNING: ")
 
-    @pytest.mark.parametrize("limit", [10, 40, 80, 200, MAX_LENGTH])
+    @pytest.mark.parametrize("limit", [10, 40, 80, 200])
     def test_report_stays_within_even_a_limit_smaller_than_the_warning(
         self, executor: ReportingExecutor, monkeypatch: pytest.MonkeyPatch, limit: int
     ) -> None:
@@ -91,23 +102,6 @@ class TestResultAspectSizeGuard:
             start_time_ms=0,
             report="r" * (MAX_LENGTH - 100),
             structured_report="s" * (MAX_LENGTH - 100),
-            exec_request=_request(),
-        )
-
-        assert aspect.structuredReport is None
-        assert aspect.report is not None
-        # Exactly the budget, not merely under it -- catches over-truncation.
-        assert len(aspect.report) == MAX_LENGTH
-
-    def test_both_over_the_limit_stays_within_the_limit(
-        self, executor: ReportingExecutor
-    ) -> None:
-        # Both guards fire, so the report carries two stacked warning lines.
-        aspect = executor._build_execution_request_result_aspect(
-            status="SUCCESS",
-            start_time_ms=0,
-            report="r" * (MAX_LENGTH * 2),
-            structured_report="s" * (MAX_LENGTH * 2),
             exec_request=_request(),
         )
 
@@ -184,33 +178,61 @@ class TestExecutorInstanceId:
         warnings = [r for r in caplog.records if "executorInstanceId" in r.getMessage()]
         assert len(warnings) == 1
 
-    def test_supported_field_is_forwarded_to_the_aspect(
-        self, monkeypatch: pytest.MonkeyPatch
+
+class TestCompletionMcpEmission:
+    """`_emit_completion_mcp` returning True means "stop retrying", not "succeeded"."""
+
+    @pytest.mark.parametrize("status", [401, 404, 422])
+    def test_permanent_failures_are_not_retried(
+        self, executor: ReportingExecutor, status: int
     ) -> None:
-        captured: dict = {}
-
-        def fake_aspect(**kwargs: object) -> object:
-            captured.update(kwargs)
-            return Mock()
-
-        monkeypatch.setattr(
-            reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", True
-        )
-        monkeypatch.setattr(
-            reporting_executor, "ExecutionRequestResultClass", fake_aspect
-        )
-        executor = ReportingExecutor(
-            ReportingExecutorConfig(
-                id="test-executor",
-                task_configs=[],
-                secret_stores=[],
-                graph_client=Mock(spec=DataHubGraph),
-                executor_instance_id="pool-a",
-            )
+        executor._datahub_graph.emit_mcp = Mock(  # type: ignore[method-assign]
+            side_effect=OperationalError("nope", {"status": status})
         )
 
-        executor._build_execution_request_result_aspect(
-            status="SUCCESS", start_time_ms=0, exec_request=_request()
+        assert executor._emit_completion_mcp("exec-1", Mock()) is True
+
+    def test_transient_failures_are_retried(self, executor: ReportingExecutor) -> None:
+        executor._datahub_graph.emit_mcp = Mock(  # type: ignore[method-assign]
+            side_effect=OperationalError("boom", {"status": 503})
         )
 
-        assert captured["executorInstanceId"] == "pool-a"
+        assert executor._emit_completion_mcp("exec-1", Mock()) is False
+
+    def test_a_successful_emit_releases_the_stored_result(
+        self, executor: ReportingExecutor
+    ) -> None:
+        executor.results_to_emit["exec-1"] = Mock()
+
+        assert executor._emit_completion_mcp("exec-1", Mock()) is True
+        assert "exec-1" not in executor.results_to_emit
+
+
+class TestKillSignal:
+    def test_kill_for_an_untracked_exec_emits_a_cancellation(
+        self, executor: ReportingExecutor
+    ) -> None:
+        # What marks a run CANCELLED in the UI when the executor no longer holds it.
+        executor.signal(SignalRequest(exec_id="exec-1", signal="KILL"))
+
+        emitted = cast(Mock, executor._datahub_graph.emit_mcp)
+        assert emitted.call_count == 1
+        assert emitted.call_args[0][0].entityKeyAspect.id == "exec-1"
+
+    def test_kill_prefers_the_stored_result_over_a_bare_cancellation(
+        self, executor: ReportingExecutor
+    ) -> None:
+        result = ExecutionResult(_context(), Type.CANCELLED)
+        result.context.request.start_time = datetime.now(timezone.utc)
+        executor.results_to_emit["exec-1"] = result
+
+        executor.signal(SignalRequest(exec_id="exec-1", signal="KILL"))
+
+        # The stored result was emitted and consumed, so no empty cancellation follows.
+        assert cast(Mock, executor._datahub_graph.emit_mcp).call_count == 1
+        assert "exec-1" not in executor.results_to_emit
+
+    def test_unknown_signals_are_ignored(self, executor: ReportingExecutor) -> None:
+        executor.signal(SignalRequest(exec_id="exec-1", signal="PAUSE"))
+
+        cast(Mock, executor._datahub_graph.emit_mcp).assert_not_called()

--- a/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
@@ -18,8 +18,7 @@ MAX_LENGTH = 500
 
 @pytest.fixture(autouse=True)
 def payload_limit(monkeypatch: pytest.MonkeyPatch) -> None:
-    # get_payload_max_length() reads the env var on every call, so a small limit here
-    # keeps the fixtures readable instead of needing multi-megabyte strings.
+    # Read per call, so a small limit keeps fixtures readable.
     monkeypatch.setenv("ACRYL_EXECUTOR_GMS_PAYLOAD_MAX_LENGTH", str(MAX_LENGTH))
 
 
@@ -40,12 +39,7 @@ def _request() -> ExecutionRequest:
 
 
 class TestResultAspectSizeGuard:
-    """The oversized-payload guard must leave the aspect within `max_length`.
-
-    It previously truncated `report` to exactly max_length and *then* prepended the
-    "WARNING: ..." line, so every truncated report came out over the limit by the
-    length of that prefix.
-    """
+    """The guard must leave the aspect at exactly `max_length`, not over it."""
 
     def test_report_over_the_limit_stays_within_the_limit(
         self, executor: ReportingExecutor
@@ -66,8 +60,7 @@ class TestResultAspectSizeGuard:
     def test_report_stays_within_even_a_limit_smaller_than_the_warning(
         self, executor: ReportingExecutor, monkeypatch: pytest.MonkeyPatch, limit: int
     ) -> None:
-        # The warning prefix is ~75 chars, so for small limits reserving room for it
-        # yields an empty body and the prefix alone would still exceed the budget.
+        # The prefix is ~75 chars: below that, reserving room leaves an empty body.
         monkeypatch.setenv("ACRYL_EXECUTOR_GMS_PAYLOAD_MAX_LENGTH", str(limit))
 
         aspect = executor._build_execution_request_result_aspect(
@@ -109,8 +102,7 @@ class TestResultAspectSizeGuard:
     def test_both_over_the_limit_stays_within_the_limit(
         self, executor: ReportingExecutor
     ) -> None:
-        # Both guards fire: the structured report is dropped and the report is
-        # truncated, so the report is prefixed with two stacked warning lines.
+        # Both guards fire, so the report carries two stacked warning lines.
         aspect = executor._build_execution_request_result_aspect(
             status="SUCCESS",
             start_time_ms=0,
@@ -126,18 +118,10 @@ class TestResultAspectSizeGuard:
 
 
 class TestExecutorInstanceId:
-    """`executorInstanceId` is only declared by some models builds.
-
-    The OSS `ExecutionRequestResult` aspect does not declare it; forks and custom
-    models packages do. Generated aspect classes take explicit keyword arguments, so
-    passing the field to a build that lacks it raises TypeError -- and because this
-    method builds every kickoff, progress and completion MCP, that would fail all
-    reporting for the executor rather than degrading one field.
-    """
+    """The field must be omitted, not passed, when the installed models lack it."""
 
     def test_configured_instance_id_never_breaks_aspect_construction(self) -> None:
-        # The original failure mode, independent of the guard's internals: against the
-        # OSS aspect this raised TypeError, taking out every MCP for the executor.
+        # The original failure mode: against the OSS aspect this raised TypeError.
         executor = ReportingExecutor(
             ReportingExecutorConfig(
                 id="test-executor",
@@ -155,11 +139,8 @@ class TestExecutorInstanceId:
         assert aspect.status == "SUCCESS"
 
     def test_probe_agrees_with_the_installed_aspect(self) -> None:
-        # Pins the guard to reality in whichever models build is installed, so it stays
-        # correct for OSS (field absent) and for forks/custom packages (field present).
-        # Splatted so the deliberately-unsupported kwarg is a runtime question, not a
-        # static one: mypy would reject it inline against the OSS models, and a
-        # `type: ignore` would go unused against models that do declare the field.
+        # Keeps the probe honest under whichever models build is installed.
+        # Splatted so mypy does not reject the deliberately-unsupported kwarg inline.
         kwargs: Dict[str, Any] = {
             "status": "SUCCESS",
             "startTimeMs": 0,
@@ -179,8 +160,7 @@ class TestExecutorInstanceId:
     def test_unsupported_field_is_omitted_and_warned_about_only_once(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        # This method builds an MCP on every progress heartbeat, so warning per build
-        # would flood the log for a whole run. The warning belongs at construction.
+        # An MCP is built on every progress heartbeat, so warn once at construction.
         monkeypatch.setattr(
             reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", False
         )

--- a/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
@@ -1,0 +1,229 @@
+import logging
+from typing import Any, Dict
+from unittest.mock import Mock
+
+import pytest
+
+from datahub.executor.execution import reporting_executor
+from datahub.executor.execution.reporting_executor import (
+    ReportingExecutor,
+    ReportingExecutorConfig,
+)
+from datahub.executor.request.execution_request import ExecutionRequest
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import ExecutionRequestResultClass
+
+MAX_LENGTH = 500
+
+
+@pytest.fixture(autouse=True)
+def payload_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    # get_payload_max_length() reads the env var on every call, so a small limit here
+    # keeps the fixtures readable instead of needing multi-megabyte strings.
+    monkeypatch.setenv("ACRYL_EXECUTOR_GMS_PAYLOAD_MAX_LENGTH", str(MAX_LENGTH))
+
+
+@pytest.fixture
+def executor() -> ReportingExecutor:
+    return ReportingExecutor(
+        ReportingExecutorConfig(
+            id="test-executor",
+            task_configs=[],
+            secret_stores=[],
+            graph_client=Mock(spec=DataHubGraph),
+        )
+    )
+
+
+def _request() -> ExecutionRequest:
+    return ExecutionRequest(exec_id="test-exec-id", name="RUN_INGEST", args={})
+
+
+class TestResultAspectSizeGuard:
+    """The oversized-payload guard must leave the aspect within `max_length`.
+
+    It previously truncated `report` to exactly max_length and *then* prepended the
+    "WARNING: ..." line, so every truncated report came out over the limit by the
+    length of that prefix.
+    """
+
+    def test_report_over_the_limit_stays_within_the_limit(
+        self, executor: ReportingExecutor
+    ) -> None:
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS",
+            start_time_ms=0,
+            report="r" * (MAX_LENGTH * 2),
+            exec_request=_request(),
+        )
+
+        assert aspect.report is not None
+        assert len(aspect.report) <= MAX_LENGTH
+        assert aspect.report.startswith("WARNING: ")
+
+    @pytest.mark.parametrize("limit", [10, 40, 80, 200, MAX_LENGTH])
+    def test_report_stays_within_even_a_limit_smaller_than_the_warning(
+        self, executor: ReportingExecutor, monkeypatch: pytest.MonkeyPatch, limit: int
+    ) -> None:
+        # The warning prefix is ~75 chars, so for small limits reserving room for it
+        # yields an empty body and the prefix alone would still exceed the budget.
+        monkeypatch.setenv("ACRYL_EXECUTOR_GMS_PAYLOAD_MAX_LENGTH", str(limit))
+
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS",
+            start_time_ms=0,
+            report="r" * (limit * 3),
+            exec_request=_request(),
+        )
+
+        assert aspect.report is not None
+        assert len(aspect.report) <= limit
+
+    def test_report_under_the_limit_is_passed_through_untouched(
+        self, executor: ReportingExecutor
+    ) -> None:
+        report = "r" * 10
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS", start_time_ms=0, report=report, exec_request=_request()
+        )
+
+        assert aspect.report == report
+
+    def test_oversized_combination_drops_the_structured_report(
+        self, executor: ReportingExecutor
+    ) -> None:
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS",
+            start_time_ms=0,
+            report="r" * (MAX_LENGTH - 100),
+            structured_report="s" * (MAX_LENGTH - 100),
+            exec_request=_request(),
+        )
+
+        assert aspect.structuredReport is None
+        assert aspect.report is not None
+        assert len(aspect.report) <= MAX_LENGTH
+
+    def test_both_over_the_limit_stays_within_the_limit(
+        self, executor: ReportingExecutor
+    ) -> None:
+        # Both guards fire: the structured report is dropped and the report is
+        # truncated, so the report is prefixed with two stacked warning lines.
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS",
+            start_time_ms=0,
+            report="r" * (MAX_LENGTH * 2),
+            structured_report="s" * (MAX_LENGTH * 2),
+            exec_request=_request(),
+        )
+
+        assert aspect.structuredReport is None
+        assert aspect.report is not None
+        assert len(aspect.report) <= MAX_LENGTH
+
+
+class TestExecutorInstanceId:
+    """`executorInstanceId` is only declared by some models builds.
+
+    The OSS `ExecutionRequestResult` aspect does not declare it; forks and custom
+    models packages do. Generated aspect classes take explicit keyword arguments, so
+    passing the field to a build that lacks it raises TypeError -- and because this
+    method builds every kickoff, progress and completion MCP, that would fail all
+    reporting for the executor rather than degrading one field.
+    """
+
+    def test_configured_instance_id_never_breaks_aspect_construction(self) -> None:
+        # The original failure mode, independent of the guard's internals: against the
+        # OSS aspect this raised TypeError, taking out every MCP for the executor.
+        executor = ReportingExecutor(
+            ReportingExecutorConfig(
+                id="test-executor",
+                task_configs=[],
+                secret_stores=[],
+                graph_client=Mock(spec=DataHubGraph),
+                executor_instance_id="pool-a",
+            )
+        )
+
+        aspect = executor._build_execution_request_result_aspect(
+            status="SUCCESS", start_time_ms=0, exec_request=_request()
+        )
+
+        assert aspect.status == "SUCCESS"
+
+    def test_probe_agrees_with_the_installed_aspect(self) -> None:
+        # Pins the guard to reality in whichever models build is installed, so it stays
+        # correct for OSS (field absent) and for forks/custom packages (field present).
+        # Splatted so the deliberately-unsupported kwarg is a runtime question, not a
+        # static one: mypy would reject it inline against the OSS models, and a
+        # `type: ignore` would go unused against models that do declare the field.
+        kwargs: Dict[str, Any] = {
+            "status": "SUCCESS",
+            "startTimeMs": 0,
+            "executorInstanceId": "pool-a",
+        }
+        try:
+            ExecutionRequestResultClass(**kwargs)
+        except TypeError:
+            accepted = False
+        else:
+            accepted = True
+
+        assert (
+            accepted is reporting_executor._RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
+        )
+
+    def test_unsupported_field_is_omitted_with_a_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", False
+        )
+        executor = ReportingExecutor(
+            ReportingExecutorConfig(
+                id="test-executor",
+                task_configs=[],
+                secret_stores=[],
+                graph_client=Mock(spec=DataHubGraph),
+                executor_instance_id="pool-a",
+            )
+        )
+
+        with caplog.at_level(logging.WARNING):
+            aspect = executor._build_execution_request_result_aspect(
+                status="SUCCESS", start_time_ms=0, exec_request=_request()
+            )
+
+        assert getattr(aspect, "executorInstanceId", None) is None
+        assert "executorInstanceId" in caplog.text
+
+    def test_supported_field_is_forwarded_to_the_aspect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        def fake_aspect(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return Mock()
+
+        monkeypatch.setattr(
+            reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", True
+        )
+        monkeypatch.setattr(
+            reporting_executor, "ExecutionRequestResultClass", fake_aspect
+        )
+        executor = ReportingExecutor(
+            ReportingExecutorConfig(
+                id="test-executor",
+                task_configs=[],
+                secret_stores=[],
+                graph_client=Mock(spec=DataHubGraph),
+                executor_instance_id="pool-a",
+            )
+        )
+
+        executor._build_execution_request_result_aspect(
+            status="SUCCESS", start_time_ms=0, exec_request=_request()
+        )
+
+        assert captured["executorInstanceId"] == "pool-a"

--- a/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
+++ b/metadata-ingestion/tests/unit/executor/test_reporting_executor.py
@@ -1,13 +1,11 @@
-import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, cast
+from typing import cast
 from unittest.mock import Mock
 
 import pytest
 
 from datahub.configuration.common import OperationalError
 from datahub.executor.context.execution_context import ExecutionContext
-from datahub.executor.execution import reporting_executor
 from datahub.executor.execution.reporting_executor import (
     ReportingExecutor,
     ReportingExecutorConfig,
@@ -16,7 +14,6 @@ from datahub.executor.request.execution_request import ExecutionRequest
 from datahub.executor.request.signal_request import SignalRequest
 from datahub.executor.result.execution_result import ExecutionResult, Type
 from datahub.ingestion.graph.client import DataHubGraph
-from datahub.metadata.schema_classes import ExecutionRequestResultClass
 
 MAX_LENGTH = 500
 
@@ -112,10 +109,15 @@ class TestResultAspectSizeGuard:
 
 
 class TestExecutorInstanceId:
-    """The field must be omitted, not passed, when the installed models lack it."""
+    def test_the_field_is_never_put_on_the_result_aspect(self) -> None:
+        """`executorInstanceId` is not an OSS aspect field.
 
-    def test_configured_instance_id_never_breaks_aspect_construction(self) -> None:
-        # The original failure mode: against the OSS aspect this raised TypeError.
+        It is declared only by a custom models package, so OSS must not set it: the
+        generated class takes explicit kwargs and would raise TypeError. Deployments
+        whose models do declare it add it by overriding
+        `_build_execution_request_result_aspect`. The config field itself stays, since
+        DefaultExecutor uses it for the pool-claim log line.
+        """
         executor = ReportingExecutor(
             ReportingExecutorConfig(
                 id="test-executor",
@@ -131,52 +133,7 @@ class TestExecutorInstanceId:
         )
 
         assert aspect.status == "SUCCESS"
-
-    def test_probe_agrees_with_the_installed_aspect(self) -> None:
-        # Keeps the probe honest under whichever models build is installed.
-        # Splatted so mypy does not reject the deliberately-unsupported kwarg inline.
-        kwargs: Dict[str, Any] = {
-            "status": "SUCCESS",
-            "startTimeMs": 0,
-            "executorInstanceId": "pool-a",
-        }
-        try:
-            ExecutionRequestResultClass(**kwargs)
-        except TypeError:
-            accepted = False
-        else:
-            accepted = True
-
-        assert (
-            accepted is reporting_executor._RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID
-        )
-
-    def test_unsupported_field_is_omitted_and_warned_about_only_once(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        # An MCP is built on every progress heartbeat, so warn once at construction.
-        monkeypatch.setattr(
-            reporting_executor, "_RESULT_ASPECT_SUPPORTS_EXECUTOR_INSTANCE_ID", False
-        )
-
-        with caplog.at_level(logging.WARNING):
-            executor = ReportingExecutor(
-                ReportingExecutorConfig(
-                    id="test-executor",
-                    task_configs=[],
-                    secret_stores=[],
-                    graph_client=Mock(spec=DataHubGraph),
-                    executor_instance_id="pool-a",
-                )
-            )
-            for _ in range(5):
-                aspect = executor._build_execution_request_result_aspect(
-                    status="SUCCESS", start_time_ms=0, exec_request=_request()
-                )
-
         assert getattr(aspect, "executorInstanceId", None) is None
-        warnings = [r for r in caplog.records if "executorInstanceId" in r.getMessage()]
-        assert len(warnings) == 1
 
 
 class TestCompletionMcpEmission:

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -364,31 +364,40 @@ async def test_cancellation_terminates_the_subprocess(
 
 
 @pytest.mark.asyncio
-async def test_exec_out_dir_exists_before_venv_setup(
+async def test_exec_out_dir_exists_when_the_subprocess_is_launched(
     executor_ctx: ExecutorContext,
     exec_ctx: ExecutionContext,
     sample_args: dict[str, str],
     tmp_path: Path,
 ) -> None:
-    """exec_out_dir must exist before setup_venv, which skips creating it for the
-    "bundled" and "native" versions -- leaving the connection report unwritable."""
+    """The connection report is written into exec_out_dir, so it must exist by launch.
+
+    Only the dynamic venv path creates it, via `uv venv`. "bundled" and "native" reuse a
+    prebuilt venv and return without touching it, so the task has to create it itself.
+    """
     config = SubProcessTestConnectionTaskConfig(tmp_dir=str(tmp_path / "ingest"))
     task = SubProcessTestConnectionTask(config, executor_ctx)
+    exec_out_dir = Path(config.tmp_dir) / exec_ctx.exec_id
 
     observed: dict[str, bool] = {}
 
-    async def stop_after_recording(*_args: Any, **kwargs: Any) -> None:
-        # tmp_dir is exec_out_dir; record whether it exists at the moment a bundled or
-        # native run would have returned without creating anything.
-        observed["exec_out_dir_exists"] = Path(kwargs["tmp_dir"]).is_dir()
-        raise RuntimeError("stop the test here; the directory is all we care about")
+    def record_and_stop(*_args: Any, **_kwargs: Any) -> Mock:
+        observed["exec_out_dir_exists"] = exec_out_dir.is_dir()
+        raise RuntimeError("stop here; the directory is all this test cares about")
+
+    venv_ref = Mock()
+    venv_ref.venv_loc = tmp_path / "opt" / "datahub" / "venvs" / "demo-data-bundled"
 
     with (
         patch(
             "datahub.executor.execution.sub_process_test_connection_task.setup_venv",
-            side_effect=stop_after_recording,
+            return_value=venv_ref,
         ),
-        pytest.raises(TaskError),
+        patch(
+            "datahub.executor.execution.sub_process_test_connection_task.subprocess.Popen",
+            side_effect=record_and_stop,
+        ),
+        pytest.raises(RuntimeError),
     ):
         await task.execute(sample_args, exec_ctx)
 

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -363,7 +363,6 @@ async def test_cancellation_terminates_the_subprocess(
     mock_process.terminate.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_exec_out_dir_exists_when_the_subprocess_is_launched(
     executor_ctx: ExecutorContext,
     exec_ctx: ExecutionContext,

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -361,3 +361,41 @@ async def test_cancellation_terminates_the_subprocess(
             await pending
 
     mock_process.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_exec_out_dir_exists_before_venv_setup(
+    executor_ctx: ExecutorContext,
+    exec_ctx: ExecutionContext,
+    sample_args: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """The connection report is written into exec_out_dir, so the task must create it.
+
+    setup_venv only creates that directory as a side effect of `uv venv`, which the
+    "bundled" and "native" versions skip entirely -- they return early without touching
+    tmp_dir. When the directory is missing, the CLI's --report-to write raises inside
+    _test_source_connection, whose single `except Exception` also wraps the connection
+    test, so it returns 1 and a healthy connection is reported as FAILURE.
+    """
+    config = SubProcessTestConnectionTaskConfig(tmp_dir=str(tmp_path / "ingest"))
+    task = SubProcessTestConnectionTask(config, executor_ctx)
+
+    observed: dict[str, bool] = {}
+
+    async def stop_after_recording(*_args: Any, **kwargs: Any) -> None:
+        # tmp_dir is exec_out_dir; record whether it exists at the moment a bundled or
+        # native run would have returned without creating anything.
+        observed["exec_out_dir_exists"] = Path(kwargs["tmp_dir"]).is_dir()
+        raise RuntimeError("stop the test here; the directory is all we care about")
+
+    with (
+        patch(
+            "datahub.executor.execution.sub_process_test_connection_task.setup_venv",
+            side_effect=stop_after_recording,
+        ),
+        pytest.raises(TaskError),
+    ):
+        await task.execute(sample_args, exec_ctx)
+
+    assert observed["exec_out_dir_exists"]

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -370,14 +370,8 @@ async def test_exec_out_dir_exists_before_venv_setup(
     sample_args: dict[str, str],
     tmp_path: Path,
 ) -> None:
-    """The connection report is written into exec_out_dir, so the task must create it.
-
-    setup_venv only creates that directory as a side effect of `uv venv`, which the
-    "bundled" and "native" versions skip entirely -- they return early without touching
-    tmp_dir. When the directory is missing, the CLI's --report-to write raises inside
-    _test_source_connection, whose single `except Exception` also wraps the connection
-    test, so it returns 1 and a healthy connection is reported as FAILURE.
-    """
+    """exec_out_dir must exist before setup_venv, which skips creating it for the
+    "bundled" and "native" versions -- leaving the connection report unwritable."""
     config = SubProcessTestConnectionTaskConfig(tmp_dir=str(tmp_path / "ingest"))
     task = SubProcessTestConnectionTask(config, executor_ctx)
 


### PR DESCRIPTION
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated
- [ ] Docs added/updated — n/a
- [ ] Breaking changes in `docs/how/updating-datahub.md` — n/a

Follow-up to #18942, addressing review comments we deferred on that PR. All four are inherited from
acryl-executor, so each is a behaviour change relative to the old package.

**Secret stores. _create_secret_store** used to register the store type in the registry before looking it up. That step is gone, it now just looks the type up and instantiates it.

SecretStoreConfig.type is either a built-in short name (env, datahub, file, aws-sm, gcp-sm) or an import path to your own class. The registration step could only ever be skipped or fatal: short names are already registered so it never ran, and for an import path it ran and always raised KeyError, because the registry rejects keys containing . or :. Nothing read the registration back either, since the lookup imports a path directly when it sees one. So custom secret stores referenced by class path now load, and short names behave exactly as before.

So custom secret stores referenced by class path now load, and short names behave exactly as before.

**Report truncation.** The size guard prepended its `WARNING:` line after truncating, so a truncated
report always came out over `max_length`. It now reserves room for the prefix and clamps. Also fixes
the first guard's message, which said the structured report was truncated when that branch removes
it.

**executorInstanceId.** OSS no longer sets this field. Its `ExecutionRequestResult` aspect doesn't
declare it, and generated aspect classes take explicit kwargs, so setting it raised `TypeError` in the
method that builds every MCP. Deployments whose models do declare the field now add it by overriding
`_build_execution_request_result_aspect` in a `ReportingExecutor` subclass. `executor_instance_id`
stays on the config — `DefaultExecutor` uses it for the pool-claim log line.

**Test connection.** `exec_out_dir` only existed as a side effect of `uv venv`, which `setup_venv`
skips for `bundled` and `native`. Without it the CLI's `--report-to` write fails inside
`_test_source_connection`, whose `except` also covers the connection test, so a healthy connection
reported FAILURE. The task now creates it, after venv setup so a failed setup leaves nothing behind.


