### PR TITLE
chore(system-update): default-disable completed pre-v1.0.0 backfills

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/assertions/GenerateAssertionEntityField.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/assertions/GenerateAssertionEntityField.java
@@ -33,6 +33,9 @@ public class GenerateAssertionEntityField implements NonBlockingSystemUpgrade {
               new GenerateAssertionEntityFieldStep(
                   opContext, entityService, aspectDao, batchSize, batchDelayMs, limit));
     } else {
+      log.info(
+          "{} is disabled (systemUpdate.assertionEntityField.enabled=false); no steps registered.",
+          id());
       _steps = ImmutableList.of();
     }
   }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/assertions/GenerateAssertionFieldPath.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/assertions/GenerateAssertionFieldPath.java
@@ -33,6 +33,9 @@ public class GenerateAssertionFieldPath implements NonBlockingSystemUpgrade {
               new GenerateAssertionFieldPathStep(
                   opContext, entityService, aspectDao, batchSize, batchDelayMs, limit));
     } else {
+      log.info(
+          "{} is disabled (systemUpdate.assertionFieldPath.enabled=false); no steps registered.",
+          id());
       _steps = ImmutableList.of();
     }
   }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2.java
@@ -7,7 +7,9 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.search.SearchService;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class BackfillBrowsePathsV2 implements NonBlockingSystemUpgrade {
 
   private final List<UpgradeStep> _steps;
@@ -25,6 +27,8 @@ public class BackfillBrowsePathsV2 implements NonBlockingSystemUpgrade {
               new BackfillBrowsePathsV2Step(
                   opContext, entityService, searchService, reprocessEnabled, batchSize));
     } else {
+      log.info(
+          "{} is disabled (systemUpdate.browsePathsV2.enabled=false); no steps registered.", id());
       _steps = ImmutableList.of();
     }
   }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/dataprocessinstances/BackfillDataProcessInstances.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/dataprocessinstances/BackfillDataProcessInstances.java
@@ -8,7 +8,9 @@ import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class BackfillDataProcessInstances implements NonBlockingSystemUpgrade {
 
   private final List<UpgradeStep> _steps;
@@ -38,6 +40,9 @@ public class BackfillDataProcessInstances implements NonBlockingSystemUpgrade {
                   totalDays,
                   windowDays));
     } else {
+      log.info(
+          "{} is disabled (systemUpdate.processInstanceHasRunEvents.enabled=false); no steps registered.",
+          id());
       _steps = ImmutableList.of();
     }
   }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/lineage/BackfillDatasetLineageIndexFields.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/lineage/BackfillDatasetLineageIndexFields.java
@@ -7,6 +7,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.search.SearchService;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Non-blocking system upgrade that backfills dataset lineage index fields.
@@ -17,6 +18,7 @@ import java.util.List;
  * (column-level) lineage - fineGrainedUpstreams: list of schema field URNs that provide lineage to
  * this dataset
  */
+@Slf4j
 public class BackfillDatasetLineageIndexFields implements NonBlockingSystemUpgrade {
   private final List<UpgradeStep> _steps;
 
@@ -33,6 +35,9 @@ public class BackfillDatasetLineageIndexFields implements NonBlockingSystemUpgra
               new BackfillDatasetLineageIndexFieldsStep(
                   opContext, entityService, searchService, reprocessEnabled, batchSize));
     } else {
+      log.info(
+          "{} is disabled (systemUpdate.lineageIndexFields.enabled=false); no steps registered.",
+          id());
       _steps = ImmutableList.of();
     }
   }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1407,7 +1407,14 @@ systemUpdate:
   restoreGlossaryIndices:
     enabled: ${RESTORE_GLOSSARY_INDICES_ENABLED:true}
   browsePathsV2:
-    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration); dataHubUpgradeResult marker already written on any deploy
+    # that passed through v1.0.0.
+    # Forcing a re-run needs THREE env vars, not just this one — the step also gates on the raw
+    # BACKFILL_BROWSE_PATHS_V2 env var and skips once the marker exists:
+    #   BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED=true  (register the step)
+    #   BACKFILL_BROWSE_PATHS_V2=true                         (BackfillBrowsePathsV2Step.skip)
+    #   REPROCESS_DEFAULT_BROWSE_PATHS_V2=true                (ignore the existing marker)
+    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED:false}
     batchSize: ${BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_BATCH_SIZE:5000}
     reprocess:
       enabled: ${REPROCESS_DEFAULT_BROWSE_PATHS_V2:false}
@@ -1430,7 +1437,14 @@ systemUpdate:
     reprocess:
       enabled: ${BOOTSTRAP_SYSTEM_UPDATE_OWNERSHIP_TYPES_REPROCESS:false}
   lineageIndexFields:
-    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration); dataHubUpgradeResult marker
+    # "BackfillDatasetLineageIndexFieldsStep_V1" already written on any deploy that passed through
+    # v1.0.0. Env override kept for emergency reprocess.
+    # NOTE: Helm may set BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_ENABLED explicitly, so this
+    # default mainly governs quickstart / non-helm deploys.
+    # NOTE: bumping the step id (…_V2) yields a fresh marker so the step would re-run — flip this
+    # default back to true in the same change, or the new version silently never runs.
+    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_ENABLED:false}
     batchSize: ${BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_BATCH_SIZE:100}
     reprocess:
       enabled: ${BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_REPROCESS:false}
@@ -1463,7 +1477,11 @@ systemUpdate:
       # Force re-run for the current MCP domain/ownership fingerprint even if already SUCCEEDED
       enabled: ${SYSTEM_UPDATE_SCHEMA_FIELDS_FROM_SCHEMA_METADATA_REPROCESS:false}
   assertionEntityField:
-    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration); AbstractMCPStep marker "assertion-entity-field-v3" already
+    # written on any deploy that passed through v1.0.0. Env override kept for emergency reprocess.
+    # NOTE: bumping the step id (…-v4) yields a fresh marker so the step would re-run — flip this
+    # default back to true in the same change, or the new version silently never runs.
+    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_ENABLED:false}
     batchSize: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_BATCH_SIZE:500}
     delayMs: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_DELAY_MS:1000}
     limit: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_LIMIT:0}
@@ -1473,7 +1491,11 @@ systemUpdate:
     delayMs: ${SYSTEM_UPDATE_ASSERTION_NOTE_MIGRATION_DELAY_MS:0}
     limit: ${SYSTEM_UPDATE_ASSERTION_NOTE_MIGRATION_LIMIT:0}
   assertionFieldPath:
-    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration); AbstractMCPStep marker "assertion-field-path-v1" already
+    # written on any deploy that passed through v1.0.0. Env override kept for emergency reprocess.
+    # NOTE: bumping the step id (…-v2) yields a fresh marker so the step would re-run — flip this
+    # default back to true in the same change, or the new version silently never runs.
+    enabled: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_ENABLED:false}
     batchSize: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_BATCH_SIZE:500}
     delayMs: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_DELAY_MS:1000}
     limit: ${BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_LIMIT:0}
@@ -1483,7 +1505,10 @@ systemUpdate:
     delayMs: ${SYSTEM_UPDATE_SCHEMA_FIELDS_DOC_IDS_DELAY_MS:5000}
     limit: ${SYSTEM_UPDATE_SCHEMA_FIELDS_DOC_IDS_LIMIT:0}
   processInstanceHasRunEvents:
-    enabled: ${SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration); dataHubUpgradeResult marker already written on any deploy
+    # that passed through v1.0.0. Env override kept for emergency reprocess (pair with
+    # SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_REPROCESS=true to ignore the existing marker).
+    enabled: ${SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_ENABLED:false}
     batchSize: ${SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_BATCH_SIZE:100}
     delayMs: ${SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_DELAY_MS:1000}
     totalDays: ${SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_TOTAL_DAYS:90}
@@ -1557,7 +1582,11 @@ systemUpdate:
   ingestPolicies:
     enabled: ${SYSTEM_UPDATE_INGEST_POLICIES_ENABLED:true}
   ingestDataPlatformInstances:
-    enabled: ${SYSTEM_UPDATE_INGEST_DATA_PLATFORM_INSTANCES_ENABLED:true}
+    # Pre-v1.0.0 backfill (dead migration). Unlike the other disabled backfills this step writes NO
+    # dataHubUpgradeResult marker — it skips when any dataPlatformInstance aspect exists, which is
+    # true of every live DB. Env override kept for emergency reprocess; a DB with zero
+    # dataPlatformInstance aspects (e.g. restored from a pre-v1.0.0 dump) needs it set explicitly.
+    enabled: ${SYSTEM_UPDATE_INGEST_DATA_PLATFORM_INSTANCES_ENABLED:false}
   kubernetesScaleDown:
     enabled: ${DATAHUB_UPGRADE_K8_SCALE_DOWN_ENABLED:true}
     useJavaImplementation: ${DATAHUB_UPGRADE_K8_SCALE_DOWN_JAVA_ENABLED:false}


### PR DESCRIPTION
## Summary

Default-disable write-once system-update backfills that finished for any deploy that upgraded through **v1.0.0**.

These steps already no-op after writing a `dataHubUpgradeResult` marker (or equivalent skip condition). Flipping the default to `false` avoids constructing/registering them on every system-update and makes “this migration is done” explicit. Env-var overrides stay for emergency reprocess.

### Defaults changed (`application.yaml` → `systemUpdate:`)

| Step | YAML key | Env | Default |
| --- | --- | --- | --- |
| BackfillBrowsePathsV2 | `browsePathsV2` | `BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED` | true → false |
| BackfillDatasetLineageIndexFields | `lineageIndexFields` | `BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_ENABLED` | true → false |
| GenerateAssertionEntityField | `assertionEntityField` | `BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_ENTITY_FIELD_ENABLED` | true → false |
| GenerateAssertionFieldPath | `assertionFieldPath` | `BOOTSTRAP_SYSTEM_UPDATE_ASSERTION_FIELD_PATH_ENABLED` | true → false |
| BackfillDataProcessInstancesHasRunEvents | `processInstanceHasRunEvents` | `SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_ENABLED` | true → false |
| IngestDataPlatformInstances | `ingestDataPlatformInstances` | `SYSTEM_UPDATE_INGEST_DATA_PLATFORM_INSTANCES_ENABLED` | true → false |

Also logs when a disabled upgrade registers no steps.

### Intentionally left enabled

Still needed or always-run by design (examples): `assertionNote`, `indexDataPlatforms`, Kafka non-blocking setup, default policies/settings ingest, etc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default-disables pre-v1.0.0 write-once system-update backfills so they no longer register steps by default, reducing overhead and making “migration is done” explicit. Previously these backfills defaulted to enabled and no-oped after seeing upgrade markers; now they default to disabled and log when skipped.

- Defaults flipped to false in `application.yaml` for: `browsePathsV2`, `lineageIndexFields`, `assertionEntityField`, `assertionFieldPath`, `processInstanceHasRunEvents`, and `ingestDataPlatformInstances`. Corresponding env vars (e.g., `BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED`, `BOOTSTRAP_SYSTEM_UPDATE_LINEAGE_INDEX_FIELDS_ENABLED`, etc.) still override.
- Added info logs in each upgrade when disabled so reviewers see “no steps registered.”
- To force re-run:
  - `browsePathsV2` requires all: `BOOTSTRAP_SYSTEM_UPDATE_BROWSE_PATHS_V2_ENABLED=true`, `BACKFILL_BROWSE_PATHS_V2=true`, `REPROCESS_DEFAULT_BROWSE_PATHS_V2=true`.
  - Others typically need the enable env plus their `..._REPROCESS=true` flag (e.g., `SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_ENABLED=true` with `SYSTEM_UPDATE_PROCESS_INSTANCE_HAS_RUN_EVENTS_REPROCESS=true`).
- Notes: Helm charts may explicitly set some enable flags; keep that in mind when validating behavior. If a step id is bumped in the future, re-enable its default or the new version will not run.

<sup>Written for commit 6747eda4153139283de4f55748f476d92356dffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

