### PR TITLE
refactor(ingest): expose SqlParsingAggregator.schema_resolver

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -2075,18 +2075,7 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
         )
         table_urn = self.identifiers.gen_dataset_urn(table_identifier)
 
-        # Access aggregator's internal schema resolver to verify column existence.
-        # NOTE: This uses private members (_schema_resolver, _resolve_schema_info) which
-        # creates coupling to SqlParsingAggregator internals. Consider exposing a public
-        # method if this pattern is needed more broadly.
-        try:
-            schema_info = self.aggregator._schema_resolver._resolve_schema_info(
-                table_urn
-            )
-        except AttributeError:
-            # Schema resolver API changed - fail open (assume column exists)
-            return fallback
-
+        _, schema_info = self.aggregator.schema_resolver.resolve_urn(table_urn)
         if not schema_info:
             # Schema not found - assume column exists (may not be ingested yet)
             return fallback
@@ -3140,7 +3129,7 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
                     db_name, snowflake_schema.name
                 ),
                 schema_resolver=(
-                    self.aggregator._schema_resolver if self.aggregator else None
+                    self.aggregator.schema_resolver if self.aggregator else None
                 ),
             )
         except Exception as e:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -738,7 +738,7 @@ class SnowflakeV2Source(
                 yield from auto_workunit(self.aggregator.gen_metadata())
 
             with self.report.new_stage(f"*: {QUERIES_EXTRACTION}"):
-                schema_resolver = self.aggregator._schema_resolver
+                schema_resolver = self.aggregator.schema_resolver
 
                 redundant_queries_run_skip_handler: Optional[
                     RedundantQueriesRunSkipHandler

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -638,6 +638,17 @@ class SqlParsingAggregator(Closeable):
         self._exit_stack.close()
 
     @property
+    def schema_resolver(self) -> SchemaResolver:
+        """The resolver backing this aggregator's SQL parsing.
+
+        Borrowed, not given: when the aggregator created the resolver it also
+        closes it (via ``_exit_stack``), so callers must not close it themselves.
+        """
+        if self._closed:
+            raise AssertionError("SqlParsingAggregator is closed")
+        return self._schema_resolver
+
+    @property
     def _need_schemas(self) -> bool:
         # Unless the aggregator is totally disabled, we will need schema information.
         return (

--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -641,8 +641,12 @@ class SqlParsingAggregator(Closeable):
     def schema_resolver(self) -> SchemaResolver:
         """The resolver backing this aggregator's SQL parsing.
 
-        Borrowed, not given: when the aggregator created the resolver it also
-        closes it (via ``_exit_stack``), so callers must not close it themselves.
+        Borrowed, not given — but the aggregator only manages the lifecycle of a
+        resolver it lazily constructed (that one is registered in
+        ``_exit_stack``). A resolver passed in by the caller, or one built by the
+        eager ``provide_schema_resolver`` bulk load, is never entered into the
+        stack and so is not closed by ``close()``. Either way, closing it is not
+        this object's caller's business: leave it to whoever owns it.
         """
         if self._closed:
             raise AssertionError("SqlParsingAggregator is closed")

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_column_case.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_column_case.py
@@ -203,9 +203,10 @@ class TestColumnExistenceCheck:
     ) -> SnowflakeSchemaGenerator:
         gen = _make_gen(SnowflakeV2Report(), **overrides)
         assert isinstance(gen.aggregator, MagicMock)
-        gen.aggregator._schema_resolver._resolve_schema_info.return_value = {
-            path: "VARCHAR" for path in field_paths
-        }
+        gen.aggregator.schema_resolver.resolve_urn.side_effect = lambda urn: (
+            urn,
+            {path: "VARCHAR" for path in field_paths},
+        )
         return gen
 
     @pytest.mark.parametrize(
@@ -256,7 +257,7 @@ class TestColumnExistenceCheck:
         # lineage would be worse than naming it the way this run names columns.
         gen = _make_gen(SnowflakeV2Report(), preserve_column_case=True)
         assert isinstance(gen.aggregator, MagicMock)
-        gen.aggregator._schema_resolver._resolve_schema_info.return_value = {}
+        gen.aggregator.schema_resolver.resolve_urn.side_effect = lambda urn: (urn, None)
 
         assert gen._declared_field_path("DB", "SCHEMA", "TBL", "MixedCol") == "MixedCol"
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_integration.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_integration.py
@@ -397,8 +397,11 @@ class TestSemanticViewLineageGeneration:
             "order_total": {},
             "customer_id": {},
         }
-        aggregator._schema_resolver = MagicMock()
-        aggregator._schema_resolver._resolve_schema_info.return_value = schema_info
+        aggregator.schema_resolver = MagicMock()
+        aggregator.schema_resolver.resolve_urn.side_effect = lambda urn: (
+            urn,
+            schema_info,
+        )
 
         gen = SnowflakeSchemaGenerator(
             config=config,
@@ -597,8 +600,8 @@ class TestSemanticViewOrchestrationFlow:
         )
 
         aggregator = MagicMock()
-        aggregator._schema_resolver = MagicMock()
-        aggregator._schema_resolver._resolve_schema_info.return_value = {}
+        aggregator.schema_resolver = MagicMock()
+        aggregator.schema_resolver.resolve_urn.side_effect = lambda urn: (urn, None)
 
         gen = SnowflakeSchemaGenerator(
             config=config,
@@ -907,8 +910,8 @@ class TestSemanticViewOrchestrationFlowLegacyDatasetMode:
         )
 
         aggregator = MagicMock()
-        aggregator._schema_resolver = MagicMock()
-        aggregator._schema_resolver._resolve_schema_info.return_value = {}
+        aggregator.schema_resolver = MagicMock()
+        aggregator.schema_resolver.resolve_urn.side_effect = lambda urn: (urn, None)
 
         gen = SnowflakeSchemaGenerator(
             config=config,

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sql_aggregator.py
@@ -1159,6 +1159,23 @@ def test_table_swap_id() -> None:
     )
 
 
+def test_schema_resolver_rejected_after_close():
+    """The resolver's backing store is gone once the aggregator is closed, so
+    handing it out afterwards would be handing out something unusable. Raised
+    rather than asserted, so the guard survives `python -O`."""
+    aggregator = SqlParsingAggregator(
+        platform="redshift",
+        generate_lineage=True,
+        generate_usage_statistics=False,
+        generate_operations=False,
+    )
+    assert aggregator.schema_resolver is not None
+
+    aggregator.close()
+    with pytest.raises(AssertionError):
+        _ = aggregator.schema_resolver
+
+
 def test_sql_aggreator_close_cleans_tmp(tmp_path):
     frozen_timestamp = parse_user_datetime(FROZEN_TIME)
     with patch("tempfile.tempdir", str(tmp_path)):


### PR DESCRIPTION
## Summary

Callers that need the `SchemaResolver` backing an aggregator's SQL parsing were reaching into `_schema_resolver` across module boundaries. This adds a read-only property with the ownership rules stated in its docstring, and migrates the Snowflake call sites off the private member.

`_verify_column_exists_in_table` also went through the resolver's private `_resolve_schema_info`, wrapped in an `except AttributeError` that failed *open* — reporting a column as present when the lookup broke. It now uses the public `SchemaResolver.resolve_urn`, so the guard is unnecessary.

`sql_common.py` still uses the private member; that is deliberately left for a separate shared-code change.

**Stack.** Split out of #17318 so the shared-code changes can be reviewed apart from the Snowflake connector work. Merge in order — each PR's diff is against its parent branch, not master:

1. #19379 — public `SqlParsingAggregator.schema_resolver` accessor
2. #19380 — stored-procedure CALL-target resolution and parse reporting (cross-connector: Snowflake, Oracle, MSSQL, MySQL)
3. #17318 — Snowflake task SQL lineage

This is **PR 1**, and it is the only one that can merge into master as-is.

## Test plan

- [x] `pytest tests/unit/snowflake tests/unit/sql_parsing` — 1319 passed
- [x] Mocks in the two semantic-view test files updated from the private method to `resolve_urn`
- [x] `./gradlew :metadata-ingestion:lint` clean

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Tests for the changes have been added/updated (existing mocks migrated)
- [ ] Docs — n/a, internal accessor
- [ ] Breaking change — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes a read-only SqlParsingAggregator.schema_resolver and migrates Snowflake call sites off private members. Replaces the resolver’s private _resolve_schema_info with public SchemaResolver.resolve_urn, removing a fail-open path and making column checks deterministic; adds a guard that rejects use after close.

- Review and migration
  - Use aggregator.schema_resolver instead of aggregator._schema_resolver.
  - Use schema_resolver.resolve_urn(urn) instead of _resolve_schema_info.
  - Accessing aggregator.schema_resolver after close raises AssertionError; tests pin this.
  - Do not close the resolver from callers; the aggregator closes only its lazily created resolver. Eagerly provided or external resolvers are not closed by the aggregator.
  - Tests updated to mock schema_resolver.resolve_urn; update remaining mocks accordingly.
  - sql_common.py still uses the private member and will be addressed separately.

<sup>Written for commit fde079636c12557692e568107a0a7cff211982c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

