### PR TITLE
feat(ingest/sql): resolve stored-procedure CALL targets and report parse failures

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -1317,11 +1317,13 @@ def _parse_oracle_procedure_dependencies(
     Note: Only extracts procedure/function/package dependencies. Table/view dependencies
     are handled separately by the SQL parser analyzing the procedure code.
 
-    ``is_schema_in_scope`` filters out dependencies living in schemas this run does
-    not ingest. Every PL/SQL unit depends on ``SYS.STANDARD`` and
-    ``SYS.SYS_STUB_FOR_PURITY_ANALYSIS``, and SYS is normally outside
-    ``schema_pattern`` — so without the filter every procedure gains edges to
-    DataJobs that were never emitted.
+    Dependencies in schemas this run does not ingest are dropped, since no DataJob
+    is emitted for them and the edge would dangle. Two filters apply:
+    ``ORACLE_SYSTEM_SCHEMAS`` always, because ``PROCEDURES_QUERY`` excludes those
+    unconditionally and ``schema_pattern`` defaults to allow-all; plus the caller's
+    ``is_schema_in_scope``. Every PL/SQL unit depends on ``SYS.STANDARD`` and
+    ``SYS.SYS_STUB_FOR_PURITY_ANALYSIS``, so without the first filter every single
+    procedure gains two dangling edges.
 
     Returns:
         List of DataJob URNs for procedure dependencies. Empty list if no procedure
@@ -1349,7 +1351,10 @@ def _parse_oracle_procedure_dependencies(
 
         dep_schema, dep_name = parts
 
-        if is_schema_in_scope is not None and not is_schema_in_scope(dep_schema):
+        out_of_scope = dep_schema.upper() in ORACLE_SYSTEM_SCHEMAS or (
+            is_schema_in_scope is not None and not is_schema_in_scope(dep_schema)
+        )
+        if out_of_scope:
             # No DataJob is emitted for a schema we don't ingest, so an edge here
             # would dangle.
             logger.debug(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -1307,6 +1307,7 @@ def _parse_oracle_procedure_dependencies(
     database_key: DatabaseKey,
     schema_key: Optional[SchemaKey],
     procedure_registry: Optional[Dict[str, str]] = None,
+    is_schema_in_scope: Optional[Callable[[str], bool]] = None,
 ) -> List[str]:
     """
     Parse Oracle ALL_DEPENDENCIES string to DataJob URNs for procedure-to-procedure dependencies.
@@ -1315,6 +1316,12 @@ def _parse_oracle_procedure_dependencies(
 
     Note: Only extracts procedure/function/package dependencies. Table/view dependencies
     are handled separately by the SQL parser analyzing the procedure code.
+
+    ``is_schema_in_scope`` filters out dependencies living in schemas this run does
+    not ingest. Every PL/SQL unit depends on ``SYS.STANDARD`` and
+    ``SYS.SYS_STUB_FOR_PURITY_ANALYSIS``, and SYS is normally outside
+    ``schema_pattern`` — so without the filter every procedure gains edges to
+    DataJobs that were never emitted.
 
     Returns:
         List of DataJob URNs for procedure dependencies. Empty list if no procedure
@@ -1341,6 +1348,14 @@ def _parse_oracle_procedure_dependencies(
             continue
 
         dep_schema, dep_name = parts
+
+        if is_schema_in_scope is not None and not is_schema_in_scope(dep_schema):
+            # No DataJob is emitted for a schema we don't ingest, so an edge here
+            # would dangle.
+            logger.debug(
+                f"Skipping procedure dependency {full_name}: schema not in scope"
+            )
+            continue
 
         # Normalize to lowercase for case-insensitive matching (Oracle default behavior)
         registry_key = f"{dep_schema.lower()}.{dep_name.lower()}"
@@ -1678,7 +1693,13 @@ class OracleSource(SQLAlchemySource):
                         env=self.config.env,
                     )
                     additional_input_jobs = _parse_oracle_procedure_dependencies(
-                        upstream_deps, database_key, schema_key, procedure_registry
+                        upstream_deps,
+                        database_key,
+                        schema_key,
+                        procedure_registry,
+                        is_schema_in_scope=lambda dep_schema: (
+                            self.config.schema_pattern.allowed(dep_schema)
+                        ),
                     )
                 except (ValueError, KeyError, AttributeError) as e:
                     logger.warning(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Iterable, List, Optional, Set
+from typing import Callable, Iterable, List, Optional
 
 from datahub.emitter.mce_builder import (
     DEFAULT_ENV,
@@ -178,22 +178,8 @@ def generate_procedure_lineage(
             is_temp_table=is_temp_table,
             raise_=raise_,
             procedure_name=procedure.name,
+            additional_input_jobs=additional_input_jobs or (),
         )
-
-        if datajob_input_output and additional_input_jobs:
-            # ``additional_input_jobs`` comes from sources that read procedure
-            # dependencies from a system catalogue (e.g. Oracle's
-            # ALL_DEPENDENCIES). ``parse_procedure_code`` may have already
-            # populated ``inputDatajobs`` by parsing CALL/EXEC out of the
-            # procedure body. Both paths are authoritative, so we merge them
-            # but deduplicate to keep ``inputDatajobs`` a true set.
-            existing = list(datajob_input_output.inputDatajobs or [])
-            seen: Set[str] = set(existing)
-            for urn in additional_input_jobs:
-                if urn not in seen:
-                    existing.append(urn)
-                    seen.add(urn)
-            datajob_input_output.inputDatajobs = existing
 
         if datajob_input_output:
             yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
@@ -483,8 +483,9 @@ def parse_procedure_code(
             from a source the code can't reveal — a system catalogue of procedure
             dependencies (Oracle's ALL_DEPENDENCIES) or Snowflake's task
             predecessor list. Merged into the CALL-derived ``inputDatajobs``,
-            deduplicated, CALL-derived first. Dropped when the body has neither
-            DML nor calls in it.
+            deduplicated, CALL-derived first. Kept even when the body yields no
+            lineage of its own — the caller learned these from somewhere the code
+            cannot show.
         resolve_procedure_urn: Maps a CALL target onto a procedure the source
             actually ingested. Without it the target urn is composed from the
             call text, which carries neither the argument-signature hash nor the
@@ -529,7 +530,7 @@ def parse_procedure_code(
     ]
     input_datajobs: List[str] = list(dict.fromkeys(urn for urn in call_urns if urn))
 
-    if not dml_statements and not input_datajobs:
+    if not dml_statements and not input_datajobs and not additional_input_jobs:
         logger.debug(
             f"No DML statements or procedure calls found in procedure {procedure_name}, "
             "skipping lineage extraction"

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
@@ -1,7 +1,9 @@
+import contextlib
 import logging
 import re
 import uuid
-from typing import Callable, List, Optional, Set, Tuple
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence, Tuple
 
 import sqlglot
 from sqlglot.dialects.dialect import Dialect
@@ -10,7 +12,10 @@ from datahub.emitter.mce_builder import DEFAULT_ENV, make_data_job_urn
 from datahub.ingestion.source.sql.stored_procedures.constants import (
     STORED_PROCEDURES_CONTAINER,
 )
-from datahub.ingestion.source.sql.stored_procedures.models import ProcedureCall
+from datahub.ingestion.source.sql.stored_procedures.models import (
+    ProcedureCall,
+    ProcedureReference,
+)
 from datahub.metadata.schema_classes import DataJobInputOutputClass
 from datahub.sql_parsing.datajob import to_datajob_input_output
 from datahub.sql_parsing.query_types import get_query_type_of_sql
@@ -65,6 +70,44 @@ _BLOCK_CLOSER_RE = re.compile(
 )
 
 
+def _count_call_arguments(literal: str) -> Optional[int]:
+    """Count top-level arguments in the first parenthesised group of ``literal``.
+
+    Returns ``None`` if no argument list is present or the parens are unbalanced.
+    Commas inside nested calls and string literals don't count.
+    """
+    start = literal.find("(")
+    if start == -1:
+        return None
+
+    depth = 0
+    commas = 0
+    has_content = False
+    quote: Optional[str] = None
+    for char in literal[start:]:
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+        if char in ("'", '"', "`"):
+            quote = char
+            has_content = True
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return commas + 1 if has_content else 0
+            if depth < 0:
+                return None
+        elif char == "," and depth == 1:
+            commas += 1
+        elif depth >= 1 and not char.isspace():
+            has_content = True
+
+    return None
+
+
 def _strip_identifier_quotes(ident: str) -> str:
     """Drop surrounding ``[]``, ``""``, or backtick quoting from an identifier."""
     if len(ident) >= 2 and ident[0] == ident[-1] and ident[0] in ('"', "`"):
@@ -89,14 +132,27 @@ def _parse_call_target(literal: str) -> Optional[ProcedureCall]:
         for p in (match.group("part1"), match.group("part2"), match.group("part3"))
         if p is not None
     ]
+    argument_count = _count_call_arguments(literal[match.end() :])
 
     if len(parts) == 1:
-        return ProcedureCall(database=None, db_schema=None, name=parts[0])
+        return ProcedureCall(
+            database=None, db_schema=None, name=parts[0], argument_count=argument_count
+        )
     if len(parts) == 2:
         # Caller resolves the leading qualifier against default_db / default_schema
         # based on whether the source is two-tier or three-tier.
-        return ProcedureCall(database=None, db_schema=parts[0], name=parts[1])
-    return ProcedureCall(database=parts[0], db_schema=parts[1], name=parts[2])
+        return ProcedureCall(
+            database=None,
+            db_schema=parts[0],
+            name=parts[1],
+            argument_count=argument_count,
+        )
+    return ProcedureCall(
+        database=parts[0],
+        db_schema=parts[1],
+        name=parts[2],
+        argument_count=argument_count,
+    )
 
 
 def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[ProcedureCall]:
@@ -129,6 +185,14 @@ def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[Procedur
         # Rebuild the surface form sqlglot saw so the regex sees the keyword too.
         expression = parsed.args.get("expression")
         literal = expression.name if expression is not None else ""
+        if keyword in {"EXEC", "EXECUTE"} and literal.lstrip().upper().startswith(
+            "IMMEDIATE"
+        ):
+            # ``EXECUTE IMMEDIATE '<sql>'`` (Snowflake, Oracle) runs SQL assembled
+            # at runtime — there is no static call target. Without this guard the
+            # regex reads the ``IMMEDIATE`` keyword as the procedure name and we
+            # emit an edge to a DataJob that cannot exist.
+            return None
         return _parse_call_target(f"{keyword} {literal}")
 
     return None
@@ -140,6 +204,9 @@ def _build_call_datajob_urn(
     schema_resolver: SchemaResolver,
     default_db: Optional[str],
     default_schema: Optional[str],
+    resolve_procedure_urn: Optional[
+        Callable[[ProcedureReference], Optional[str]]
+    ] = None,
 ) -> Optional[str]:
     """Compose a DataJob URN for ``call`` using caller defaults to fill gaps.
 
@@ -148,13 +215,22 @@ def _build_call_datajob_urn(
     treated as the database rather than the schema, matching how table URNs
     are composed for the same sources.
 
-    Note: the called procedure's argument signature is unavailable at the call
-    site, so the resulting URN never carries the ``_<hash>`` suffix that
-    ``BaseProcedure.get_procedure_identifier`` adds for procedures with
-    arguments. For sources that emit argument-hashed procedure URNs (Oracle,
-    MSSQL), call-site lineage will only match procedures whose URNs are
-    unhashed. Two-tier sources (MySQL/MariaDB) never hash, so this caveat is
-    only relevant for three-tier sources that populate ``argument_signature``.
+    Without ``resolve_procedure_urn`` the target URN is composed from the call
+    text, which cannot carry the ``_<hash>`` suffix that
+    ``BaseProcedure.get_procedure_identifier`` adds, nor any identifier casing the
+    source applies. The hash covers the *declared* signature — parameter names and
+    type spellings included, so ``(arg1 VARCHAR)`` and ``(a VARCHAR)`` differ — and
+    a call site sees neither, so no amount of argument parsing recovers it.
+    Composition is therefore only correct for sources that pass
+    ``argument_signature=None`` (MySQL, MariaDB, DB2, MSSQL) and don't normalise
+    identifiers.
+
+    TODO: Oracle and Postgres populate ``argument_signature`` and still rely on
+    composition here, so their call-site edges dangle whenever a signature is
+    present. Both should supply a ``resolve_procedure_urn`` the way
+    ``SnowflakeTasksExtractor`` does. Snowflake's own procedure-to-procedure path
+    (``snowflake_schema_gen`` -> ``generate_procedure_lineage``) needs the same
+    treatment; only the task path resolves today.
     """
     is_two_tier = default_schema is None
 
@@ -166,6 +242,24 @@ def _build_call_datajob_urn(
     else:
         database = call.database or default_db
         schema = call.db_schema or default_schema
+
+    if resolve_procedure_urn is not None:
+        if not database:
+            # ProcedureReference promises the caller's defaults are already
+            # applied; without a database there is nothing to resolve against.
+            return None
+        # The source can map this onto a procedure it actually ingested, which is
+        # the only way to recover the argument-signature hash and the source's own
+        # identifier casing. Returning None means "no such procedure here", so we
+        # emit no edge rather than a composed urn that would dangle.
+        return resolve_procedure_urn(
+            ProcedureReference(
+                database=database,
+                db_schema=schema,
+                name=call.name,
+                argument_count=call.argument_count,
+            )
+        )
 
     if not database and not schema:
         # Can't compose a flow URN with nothing — skip silently.
@@ -234,12 +328,39 @@ def _is_tsql_control_flow_statement(stmt_upper: str) -> bool:
     return False
 
 
+@dataclass
+class ProcedureParseReport:
+    """What went wrong while parsing a procedure body, for callers that warn on it.
+
+    ``parse_procedure_code`` returns ``None`` both for a body with nothing
+    lineage-bearing in it (``TRUNCATE``, ``COPY INTO``, ``ALTER TASK``) and for
+    one whose statements all failed to parse. Only the caller knows how loudly to
+    say so, so the counts are handed back rather than logged here.
+    """
+
+    statements_failed: int = 0
+    queries_failed: int = 0
+    queries_column_failed: int = 0
+    # First error seen, for the caller's warning context.
+    first_error: Optional[str] = None
+
+    @property
+    def failed(self) -> bool:
+        """Whether anything lineage-bearing was lost to a parse error."""
+        return bool(self.statements_failed or self.queries_failed)
+
+    def record_error(self, message: str) -> None:
+        if self.first_error is None:
+            self.first_error = message
+
+
 def _classify_statements(
     *,
     statements: List[str],
     dialect: Dialect,
     platform: str,
     procedure_name: Optional[str],
+    parse_report: ProcedureParseReport,
 ) -> Tuple[List[str], List[ProcedureCall]]:
     """Classify each statement as DML, a procedure call, or neither.
 
@@ -281,7 +402,9 @@ def _classify_statements(
         try:
             parsed = parse_statement(stmt_stripped, dialect=dialect)
         except Exception as e:
-            logger.debug(f"Skipping statement in {procedure_name}: {type(e).__name__}")
+            parse_report.statements_failed += 1
+            parse_report.record_error(f"{type(e).__name__}: {e}")
+            logger.debug(f"Skipping statement in {procedure_name}: {e}")
             continue
 
         # Procedure calls produce datajob-to-datajob lineage. Detect them
@@ -301,7 +424,9 @@ def _classify_statements(
         try:
             query_type, _ = get_query_type_of_sql(parsed, dialect=platform)
         except Exception as e:
-            logger.debug(f"Skipping statement in {procedure_name}: {type(e).__name__}")
+            parse_report.statements_failed += 1
+            parse_report.record_error(f"{type(e).__name__}: {e}")
+            logger.debug(f"Skipping statement in {procedure_name}: {e}")
             continue
 
         # Skip non-DML statements that don't produce lineage
@@ -331,6 +456,11 @@ def parse_procedure_code(
     raise_: bool = False,
     procedure_name: Optional[str] = None,
     session_id: Optional[str] = None,
+    additional_input_jobs: Sequence[str] = (),
+    resolve_procedure_urn: Optional[
+        Callable[[ProcedureReference], Optional[str]]
+    ] = None,
+    parse_report: Optional[ProcedureParseReport] = None,
 ) -> Optional[DataJobInputOutputClass]:
     """
     Parse stored procedure code and extract lineage.
@@ -349,7 +479,26 @@ def parse_procedure_code(
         procedure_name: Name of the procedure for logging
         session_id: Optional session ID for deterministic temp table resolution.
             If not provided, generates a random UUID. Useful for testing.
+        additional_input_jobs: DataJob urns the caller already knows to be inputs,
+            from a source the code can't reveal — a system catalogue of procedure
+            dependencies (Oracle's ALL_DEPENDENCIES) or Snowflake's task
+            predecessor list. Merged into the CALL-derived ``inputDatajobs``,
+            deduplicated, CALL-derived first. Dropped when the body has neither
+            DML nor calls in it.
+        resolve_procedure_urn: Maps a CALL target onto a procedure the source
+            actually ingested. Without it the target urn is composed from the
+            call text, which carries neither the argument-signature hash nor the
+            source's identifier casing — so for any source that hashes
+            (Snowflake always; Oracle and Postgres when a signature is present)
+            the composed urn cannot match the procedure that was emitted.
+            Returning None from the callback means "not ingested here", and no
+            edge is emitted.
+        parse_report: Filled in with the statement- and query-level parse
+            failures, so a caller can tell "this body failed to parse" from
+            "this body carries no lineage" — both of which return None.
     """
+    report = parse_report if parse_report is not None else ProcedureParseReport()
+
     # Derive dialect from schema_resolver's platform to support multiple databases
     platform = schema_resolver.platform
     dialect = get_dialect(platform)
@@ -363,23 +512,22 @@ def parse_procedure_code(
         dialect=dialect,
         platform=platform,
         procedure_name=procedure_name,
+        parse_report=report,
     )
 
     # Resolve procedure calls to DataJob URNs. Deduplicate while preserving
     # first-call order so the output is deterministic for golden files.
-    input_datajobs: List[str] = []
-    seen_input_datajobs: Set[str] = set()
-    for call in procedure_calls:
-        urn = _build_call_datajob_urn(
+    call_urns = [
+        _build_call_datajob_urn(
             call=call,
             schema_resolver=schema_resolver,
             default_db=default_db,
             default_schema=default_schema,
+            resolve_procedure_urn=resolve_procedure_urn,
         )
-        if urn is None or urn in seen_input_datajobs:
-            continue
-        seen_input_datajobs.add(urn)
-        input_datajobs.append(urn)
+        for call in procedure_calls
+    ]
+    input_datajobs: List[str] = list(dict.fromkeys(urn for urn in call_urns if urn))
 
     if not dml_statements and not input_datajobs:
         logger.debug(
@@ -395,57 +543,70 @@ def parse_procedure_code(
         if session_id is None:
             session_id = str(uuid.uuid4())
 
-        aggregator = SqlParsingAggregator(
-            platform=schema_resolver.platform,
-            platform_instance=schema_resolver.platform_instance,
-            env=schema_resolver.env,
-            schema_resolver=schema_resolver,
-            generate_lineage=True,
-            generate_queries=False,
-            generate_usage_statistics=False,
-            generate_operations=False,
-            generate_query_subject_fields=False,
-            generate_query_usage_statistics=False,
-            is_temp_table=is_temp_table,
-        )
-
-        # Add each DML statement as a separate ObservedQuery
-        # All share the same session_id to enable temp table resolution
-        for query in dml_statements:
-            aggregator.add_observed_query(
-                observed=ObservedQuery(
-                    default_db=default_db,
-                    default_schema=default_schema,
-                    query=query,
-                    session_id=session_id,
+        # Closed on the way out: the aggregator opens a sqlite connection and a
+        # temp directory per file-backed store, and this runs once per procedure
+        # or task body. The schema_resolver is injected, so the aggregator never
+        # took ownership of it and leaves it alone.
+        with contextlib.closing(
+            SqlParsingAggregator(
+                platform=schema_resolver.platform,
+                platform_instance=schema_resolver.platform_instance,
+                env=schema_resolver.env,
+                schema_resolver=schema_resolver,
+                generate_lineage=True,
+                generate_queries=False,
+                generate_usage_statistics=False,
+                generate_operations=False,
+                generate_query_subject_fields=False,
+                generate_query_usage_statistics=False,
+                is_temp_table=is_temp_table,
+            )
+        ) as aggregator:
+            # Add each DML statement as a separate ObservedQuery
+            # All share the same session_id to enable temp table resolution
+            for query in dml_statements:
+                aggregator.add_observed_query(
+                    observed=ObservedQuery(
+                        default_db=default_db,
+                        default_schema=default_schema,
+                        query=query,
+                        session_id=session_id,
+                    )
                 )
+
+            if aggregator.report.num_observed_queries_failed and raise_:
+                logger.info(aggregator.report.as_string())
+                raise ValueError(
+                    f"Failed to parse {aggregator.report.num_observed_queries_failed} queries."
+                )
+
+            # The aggregator is discarded here, so anything the caller might want
+            # to warn about has to be copied out first.
+            report.queries_failed += aggregator.report.num_observed_queries_failed
+            report.queries_column_failed += (
+                aggregator.report.num_observed_queries_column_failed
+            )
+            for failure in aggregator.report.observed_query_parse_failures:
+                report.record_error(failure)
+
+            result = to_datajob_input_output(
+                mcps=list(aggregator.gen_metadata()),
+                ignore_extra_mcps=True,
             )
 
-        if aggregator.report.num_observed_queries_failed and raise_:
-            logger.info(aggregator.report.as_string())
-            raise ValueError(
-                f"Failed to parse {aggregator.report.num_observed_queries_failed} queries."
-            )
+    # CALL-derived edges first, then the caller's, deduplicated.
+    all_input_jobs = list(dict.fromkeys([*input_datajobs, *additional_input_jobs]))
 
-        mcps = list(aggregator.gen_metadata())
-
-        result = to_datajob_input_output(
-            mcps=mcps,
-            ignore_extra_mcps=True,
-        )
-
-    if input_datajobs:
+    if all_input_jobs:
         if result is None:
             result = DataJobInputOutputClass(
                 inputDatasets=[],
                 outputDatasets=[],
-                inputDatajobs=list(input_datajobs),
+                inputDatajobs=all_input_jobs,
             )
-        elif result.inputDatajobs:
-            for urn in input_datajobs:
-                if urn not in result.inputDatajobs:
-                    result.inputDatajobs.append(urn)
         else:
-            result.inputDatajobs = list(input_datajobs)
+            # to_datajob_input_output only ever builds dataset lineage, so there
+            # is nothing here to merge with.
+            result.inputDatajobs = all_input_jobs
 
     return result

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
@@ -66,7 +66,7 @@ _LEADING_BLOCK_OPENER_RE = re.compile(
 # ``EXECUTE IMMEDIATE '<sql>'`` is dynamic SQL, while ``EXEC immediate_refresh``
 # is an ordinary call.
 _IMMEDIATE_KEYWORD = "IMMEDIATE"
-_IMMEDIATE_KEYWORD_RE = re.compile(r"\s*IMMEDIATE\b", re.IGNORECASE)
+_IMMEDIATE_KEYWORD_RE = re.compile(r"\s*IMMEDIATE(?=\s)", re.IGNORECASE)
 
 # A block/control closer carries no lineage: bare ``END``, a labeled MariaDB block
 # closer (``END my_label``), or a compound-statement closer (``END IF/WHILE/LOOP/CASE``).
@@ -161,6 +161,15 @@ def _parse_call_target(literal: str) -> Optional[ProcedureCall]:
     )
 
 
+def _is_dynamic_sql_operand(parsed: sqlglot.exp.Expression) -> bool:
+    """Whether an ``Execute`` node carries a single string literal, i.e. the
+    ``EXECUTE IMMEDIATE '<sql>'`` shape rather than a call with arguments."""
+    operands = parsed.args.get("expressions") or []
+    return len(operands) == 1 and (
+        isinstance(operands[0], sqlglot.exp.Literal) and operands[0].is_string
+    )
+
+
 def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[ProcedureCall]:
     """Return the called procedure for a CALL/EXEC statement, or ``None``.
 
@@ -183,11 +192,14 @@ def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[Procedur
                 not catalog
                 and not db_schema
                 and target.name.upper() == _IMMEDIATE_KEYWORD
+                and _is_dynamic_sql_operand(parsed)
             ):
                 # Some dialects parse ``EXECUTE IMMEDIATE '<sql>'`` into this
                 # structured form, where the keyword lands in the target slot and
                 # reads as a procedure named IMMEDIATE. Same dynamic SQL, same
-                # non-existent target as the Command branch below.
+                # non-existent target as the Command branch below. The operand
+                # check keeps a procedure genuinely named IMMEDIATE callable:
+                # ``EXEC IMMEDIATE`` and ``EXEC IMMEDIATE @p=1`` still resolve.
                 return None
             return ProcedureCall(
                 database=catalog,

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/lineage.py
@@ -62,6 +62,12 @@ _LEADING_BLOCK_OPENER_RE = re.compile(
     re.IGNORECASE,
 )
 
+# ``IMMEDIATE`` as a standalone keyword, not as the start of a procedure name:
+# ``EXECUTE IMMEDIATE '<sql>'`` is dynamic SQL, while ``EXEC immediate_refresh``
+# is an ordinary call.
+_IMMEDIATE_KEYWORD = "IMMEDIATE"
+_IMMEDIATE_KEYWORD_RE = re.compile(r"\s*IMMEDIATE\b", re.IGNORECASE)
+
 # A block/control closer carries no lineage: bare ``END``, a labeled MariaDB block
 # closer (``END my_label``), or a compound-statement closer (``END IF/WHILE/LOOP/CASE``).
 _BLOCK_CLOSER_RE = re.compile(
@@ -169,11 +175,23 @@ def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[Procedur
     if isinstance(parsed, sqlglot.exp.Execute):
         target = parsed.this
         if isinstance(target, sqlglot.exp.Table):
+            catalog = (
+                target.args["catalog"].name if target.args.get("catalog") else None
+            )
+            db_schema = target.args["db"].name if target.args.get("db") else None
+            if (
+                not catalog
+                and not db_schema
+                and target.name.upper() == _IMMEDIATE_KEYWORD
+            ):
+                # Some dialects parse ``EXECUTE IMMEDIATE '<sql>'`` into this
+                # structured form, where the keyword lands in the target slot and
+                # reads as a procedure named IMMEDIATE. Same dynamic SQL, same
+                # non-existent target as the Command branch below.
+                return None
             return ProcedureCall(
-                database=target.args["catalog"].name
-                if target.args.get("catalog")
-                else None,
-                db_schema=target.args["db"].name if target.args.get("db") else None,
+                database=catalog,
+                db_schema=db_schema,
                 name=target.name,
             )
         return None
@@ -185,9 +203,7 @@ def _extract_procedure_call(parsed: sqlglot.exp.Expression) -> Optional[Procedur
         # Rebuild the surface form sqlglot saw so the regex sees the keyword too.
         expression = parsed.args.get("expression")
         literal = expression.name if expression is not None else ""
-        if keyword in {"EXEC", "EXECUTE"} and literal.lstrip().upper().startswith(
-            "IMMEDIATE"
-        ):
+        if keyword in {"EXEC", "EXECUTE"} and _IMMEDIATE_KEYWORD_RE.match(literal):
             # ``EXECUTE IMMEDIATE '<sql>'`` (Snowflake, Oracle) runs SQL assembled
             # at runtime — there is no static call target. Without this guard the
             # regex reads the ``IMMEDIATE`` keyword as the procedure name and we
@@ -575,20 +591,21 @@ def parse_procedure_code(
                     )
                 )
 
-            if aggregator.report.num_observed_queries_failed and raise_:
-                logger.info(aggregator.report.as_string())
-                raise ValueError(
-                    f"Failed to parse {aggregator.report.num_observed_queries_failed} queries."
-                )
-
-            # The aggregator is discarded here, so anything the caller might want
-            # to warn about has to be copied out first.
+            # Copied out before the raise below: the aggregator is discarded on
+            # the way out either way, and a caller that asked to raise still
+            # wants the counts.
             report.queries_failed += aggregator.report.num_observed_queries_failed
             report.queries_column_failed += (
                 aggregator.report.num_observed_queries_column_failed
             )
             for failure in aggregator.report.observed_query_parse_failures:
                 report.record_error(failure)
+
+            if aggregator.report.num_observed_queries_failed and raise_:
+                logger.info(aggregator.report.as_string())
+                raise ValueError(
+                    f"Failed to parse {aggregator.report.num_observed_queries_failed} queries."
+                )
 
             result = to_datajob_input_output(
                 mcps=list(aggregator.gen_metadata()),

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/stored_procedures/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from datahub.emitter.mce_builder import (
     DEFAULT_ENV,
@@ -82,9 +82,38 @@ def get_procedure_flow_name(
 class ProcedureCall(BaseModel):
     """A reference to a stored procedure invoked from another procedure body."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     database: Optional[str]
     # Named ``db_schema`` because ``schema`` shadows a BaseModel attribute.
     db_schema: Optional[str]
     name: str
+    # Number of arguments passed at the call site, or None when the argument list
+    # couldn't be read. Narrows overloads; see ProcedureReference.
+    argument_count: Optional[int] = Field(default=None, ge=0)
+
+
+class ProcedureReference(BaseModel):
+    """A call target, with the caller's database/schema defaults already applied.
+
+    Handed to a ``resolve_procedure_urn`` callback so a source can map the
+    reference onto a procedure it actually ingested. That lookup is the only way
+    to name the target correctly: the urn's job id ends in a hash of the
+    *declared* argument signature — parameter names and type spellings included,
+    so ``(arg1 VARCHAR)`` and ``(a VARCHAR)`` differ — and a call site carries
+    neither, so no amount of argument parsing reconstructs it.
+
+    ``argument_count`` narrows overloads but cannot identify one alone: two
+    overloads taking the same number of arguments stay ambiguous.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    # Always populated: the caller applies its own default before constructing
+    # this, and gives up rather than handing over a reference with no database.
+    database: str
+    # Named ``db_schema`` for the same reason as ProcedureCall. None only for
+    # two-tier sources, which have no schema tier to resolve against.
+    db_schema: Optional[str]
+    name: str
+    argument_count: Optional[int] = Field(default=None, ge=0)

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
@@ -636,9 +636,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_count,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_total_sales,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -652,27 +649,6 @@
                     "transformOperation": "SQL: NVL(\"EMPLOYEE_SALES_SUMMARY\".\"TOTAL_SALES\", 0) AS \"_col_0\"",
                     "confidenceScore": 0.2
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -1569,27 +1545,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1685,27 +1640,6 @@
                         "language": "SQL"
                     }
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -2553,10 +2487,6 @@
             "outputDatasets": [
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_total,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -2701,10 +2631,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.orders,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_emp_name,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_sales_rep_id,PROD)"
-            ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ],
             "fineGrainedLineages": [
                 {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
@@ -436,112 +436,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "REFRESH_ANALYTICS_DATA",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
-                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -661,6 +555,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
+                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "REFRESH_ANALYTICS_DATA",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1464,112 +1464,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "GET_EMPLOYEE_INFO",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
-                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -1652,6 +1546,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
+                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "GET_EMPLOYEE_INFO",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -2403,7 +2403,8 @@
             "customProperties": {
                 "object_type": "FUNCTION",
                 "status": "VALID",
-                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)",
+                "downstream_dependencies": "SALES_SCHEMA.SUMMARIZE_ORDER (PROCEDURE)"
             },
             "name": "GET_ORDER_TOTAL",
             "type": {
@@ -2513,6 +2514,132 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:6e9764c5a9db406997c912cf91316bd2",
+                    "urn": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_OUTPUT (SYNONYM), SALES_SCHEMA.GET_ORDER_TOTAL (FUNCTION), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "SUMMARIZE_ORDER",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE summarize_order(p_order_id IN NUMBER) AS\n    v_total NUMBER;\nBEGIN\n    v_total := get_order_total(p_order_id);\n    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -19235,6 +19362,22 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),PROCESS_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
@@ -678,7 +678,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-b9til8",
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1584,7 +1584,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-b9til8",
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1711,7 +1711,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-b9til8",
+        "runId": "oracle-2022_02_03-07_00_00-mhwum5",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_all_tables.json
@@ -663,6 +663,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-b9til8",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1548,6 +1569,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-b9til8",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1649,6 +1691,27 @@
     "systemMetadata": {
         "lastObserved": 1643871600000,
         "runId": "oracle-2022_02_03-07_00_00-mhwum5",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-b9til8",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
@@ -18220,27 +18220,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -18336,27 +18315,6 @@
                         "language": "SQL"
                     }
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -19204,10 +19162,6 @@
             "outputDatasets": [
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_total,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -19352,10 +19306,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.orders,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_emp_name,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_sales_rep_id,PROD)"
-            ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ],
             "fineGrainedLineages": [
                 {
@@ -19966,9 +19916,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_count,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_total_sales,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -19982,27 +19929,6 @@
                     "transformOperation": "SQL: NVL(\"EMPLOYEE_SALES_SUMMARY\".\"TOTAL_SALES\", 0) AS \"_col_0\"",
                     "confidenceScore": 0.2
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
@@ -18220,6 +18220,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -18321,6 +18342,27 @@
     "systemMetadata": {
         "lastObserved": 1643871600000,
         "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -19946,6 +19988,27 @@
     "systemMetadata": {
         "lastObserved": 1643871600000,
         "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
@@ -18139,112 +18139,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "GET_EMPLOYEE_INFO",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
-                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -18327,6 +18221,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
+                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "GET_EMPLOYEE_INFO",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -19078,7 +19078,8 @@
             "customProperties": {
                 "object_type": "FUNCTION",
                 "status": "VALID",
-                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)",
+                "downstream_dependencies": "SALES_SCHEMA.SUMMARIZE_ORDER (PROCEDURE)"
             },
             "name": "GET_ORDER_TOTAL",
             "type": {
@@ -19188,6 +19189,132 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:6e9764c5a9db406997c912cf91316bd2",
+                    "urn": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_OUTPUT (SYNONYM), SALES_SCHEMA.GET_ORDER_TOTAL (FUNCTION), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "SUMMARIZE_ORDER",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE summarize_order(p_order_id IN NUMBER) AS\n    v_total NUMBER;\nBEGIN\n    v_total := get_order_total(p_order_id);\n    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -19716,112 +19843,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "REFRESH_ANALYTICS_DATA",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
-                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-6au4md",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -19941,6 +19962,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
+                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "REFRESH_ANALYTICS_DATA",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -20783,6 +20910,22 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),PROCESS_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_dba_tables.json
@@ -18235,7 +18235,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -18362,7 +18362,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -20008,7 +20008,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "oracle-2022_02_03-07_00_00-8jqqo4",
+        "runId": "oracle-2022_02_03-07_00_00-6au4md",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
@@ -665,6 +665,27 @@
         "entityType": "dataJob",
         "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
         "changeType": "UPSERT",
+        "aspectName": "dataJobInputOutput",
+        "aspect": {
+            "json": {
+                "inputDatasets": [],
+                "outputDatasets": [],
+                "inputDatajobs": [
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+        "changeType": "UPSERT",
         "aspectName": "browsePathsV2",
         "aspect": {
             "json": {
@@ -1550,6 +1571,27 @@
         "entityType": "dataJob",
         "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
         "changeType": "UPSERT",
+        "aspectName": "dataJobInputOutput",
+        "aspect": {
+            "json": {
+                "inputDatasets": [],
+                "outputDatasets": [],
+                "inputDatajobs": [
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+        "changeType": "UPSERT",
         "aspectName": "browsePathsV2",
         "aspect": {
             "json": {
@@ -1643,6 +1685,27 @@
                             "language": "SQL"
                         }
                     }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+        "changeType": "UPSERT",
+        "aspectName": "dataJobInputOutput",
+        "aspect": {
+            "json": {
+                "inputDatasets": [],
+                "outputDatasets": [],
+                "inputDatajobs": [
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
                 ]
             }
         },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
@@ -530,9 +530,6 @@
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_count,PROD)",
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_total_sales,PROD)"
                 ],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)"
-                ],
                 "fineGrainedLineages": [
                     {
                         "upstreamType": "FIELD_SET",
@@ -652,27 +649,6 @@
                             "language": "SQL"
                         }
                     }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "oracle-query-usage-test",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-        "changeType": "UPSERT",
-        "aspectName": "dataJobInputOutput",
-        "aspect": {
-            "json": {
-                "inputDatasets": [],
-                "outputDatasets": [],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
                 ]
             }
         },
@@ -1571,27 +1547,6 @@
         "entityType": "dataJob",
         "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
         "changeType": "UPSERT",
-        "aspectName": "dataJobInputOutput",
-        "aspect": {
-            "json": {
-                "inputDatasets": [],
-                "outputDatasets": [],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "oracle-query-usage-test",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
-        "changeType": "UPSERT",
         "aspectName": "browsePathsV2",
         "aspect": {
             "json": {
@@ -1685,27 +1640,6 @@
                             "language": "SQL"
                         }
                     }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "oracle-query-usage-test",
-            "lastRunId": "no-run-id-provided"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-        "changeType": "UPSERT",
-        "aspectName": "dataJobInputOutput",
-        "aspect": {
-            "json": {
-                "inputDatasets": [],
-                "outputDatasets": [],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
                 ]
             }
         },
@@ -2553,10 +2487,6 @@
                 "outputDatasets": [
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_total,PROD)"
                 ],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-                ],
                 "fineGrainedLineages": [
                     {
                         "upstreamType": "FIELD_SET",
@@ -2701,10 +2631,6 @@
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.orders,PROD)",
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_emp_name,PROD)",
                     "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_sales_rep_id,PROD)"
-                ],
-                "inputDatajobs": [
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
                 ],
                 "fineGrainedLineages": [
                     {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_query_usage.json
@@ -2403,7 +2403,8 @@
                 "customProperties": {
                     "object_type": "FUNCTION",
                     "status": "VALID",
-                    "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                    "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)",
+                    "downstream_dependencies": "SALES_SCHEMA.SUMMARIZE_ORDER (PROCEDURE)"
                 },
                 "name": "GET_ORDER_TOTAL",
                 "type": {
@@ -2513,6 +2514,132 @@
     {
         "entityType": "dataJob",
         "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "browsePathsV2",
+        "aspect": {
+            "json": {
+                "path": [
+                    {
+                        "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                        "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                    },
+                    {
+                        "id": "urn:li:container:6e9764c5a9db406997c912cf91316bd2",
+                        "urn": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "dataJobInfo",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "object_type": "PROCEDURE",
+                    "status": "VALID",
+                    "upstream_dependencies": "PUBLIC.DBMS_OUTPUT (SYNONYM), SALES_SCHEMA.GET_ORDER_TOTAL (FUNCTION), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                },
+                "name": "SUMMARIZE_ORDER",
+                "type": {
+                    "string": "Stored Procedure"
+                }
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Stored Procedure"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "dataTransformLogic",
+        "aspect": {
+            "json": {
+                "transforms": [
+                    {
+                        "queryStatement": {
+                            "value": "PROCEDURE summarize_order(p_order_id IN NUMBER) AS\n    v_total NUMBER;\nBEGIN\n    v_total := get_order_total(p_order_id);\n    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);\nEND;",
+                            "language": "SQL"
+                        }
+                    }
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "dataJobInputOutput",
+        "aspect": {
+            "json": {
+                "inputDatasets": [],
+                "outputDatasets": [],
+                "inputDatajobs": [
+                    "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)"
+                ]
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
         "changeType": "UPSERT",
         "aspectName": "browsePathsV2",
         "aspect": {
@@ -3260,6 +3387,22 @@
     {
         "entityType": "dataJob",
         "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),PROCESS_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        },
+        "systemMetadata": {
+            "lastObserved": 1643871600000,
+            "runId": "oracle-query-usage-test",
+            "lastRunId": "no-run-id-provided"
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
         "changeType": "UPSERT",
         "aspectName": "status",
         "aspect": {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
@@ -436,112 +436,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "REFRESH_ANALYTICS_DATA",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
-                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -661,6 +555,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
+                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "REFRESH_ANALYTICS_DATA",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1464,112 +1464,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "GET_EMPLOYEE_INFO",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
-                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -1652,6 +1546,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
+                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "GET_EMPLOYEE_INFO",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -2403,7 +2403,8 @@
             "customProperties": {
                 "object_type": "FUNCTION",
                 "status": "VALID",
-                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)",
+                "downstream_dependencies": "SALES_SCHEMA.SUMMARIZE_ORDER (PROCEDURE)"
             },
             "name": "GET_ORDER_TOTAL",
             "type": {
@@ -2513,6 +2514,132 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:6e9764c5a9db406997c912cf91316bd2",
+                    "urn": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_OUTPUT (SYNONYM), SALES_SCHEMA.GET_ORDER_TOTAL (FUNCTION), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "SUMMARIZE_ORDER",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE summarize_order(p_order_id IN NUMBER) AS\n    v_total NUMBER;\nBEGIN\n    v_total := get_order_total(p_order_id);\n    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -19235,6 +19362,22 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),PROCESS_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
@@ -663,6 +663,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1548,6 +1569,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1643,6 +1685,27 @@
                         "language": "SQL"
                     }
                 }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-stored-procedures-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_stored_procedures.json
@@ -636,9 +636,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_count,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_total_sales,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -652,27 +649,6 @@
                     "transformOperation": "SQL: NVL(\"EMPLOYEE_SALES_SUMMARY\".\"TOTAL_SALES\", 0) AS \"_col_0\"",
                     "confidenceScore": 0.2
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -1569,27 +1545,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1685,27 +1640,6 @@
                         "language": "SQL"
                     }
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-stored-procedures-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -2553,10 +2487,6 @@
             "outputDatasets": [
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_total,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -2701,10 +2631,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.orders,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_emp_name,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_sales_rep_id,PROD)"
-            ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ],
             "fineGrainedLineages": [
                 {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
@@ -436,112 +436,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "REFRESH_ANALYTICS_DATA",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
-                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -661,6 +555,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d",
+                    "urn": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_MVIEW (SYNONYM), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "REFRESH_ANALYTICS_DATA",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:c5142abc6f25940cbb060fc5ff05126d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE refresh_analytics_data AS\nBEGIN\n    -- Refresh materialized views (creates dependencies)\n    DBMS_MVIEW.REFRESH('employee_sales_summary');\n    DBMS_MVIEW.REFRESH('monthly_order_summary');\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1464,112 +1464,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "object_type": "PROCEDURE",
-                "status": "VALID",
-                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
-            },
-            "name": "GET_EMPLOYEE_INFO",
-            "type": {
-                "string": "Stored Procedure"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Stored Procedure"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataTransformLogic",
-    "aspect": {
-        "json": {
-            "transforms": [
-                {
-                    "queryStatement": {
-                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
-                        "language": "SQL"
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
-                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
-                },
-                {
-                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
-                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -1652,6 +1546,112 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:95eca163199143e2636cac2685c9d809",
+                    "urn": "urn:li:container:95eca163199143e2636cac2685c9d809"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "HR_SCHEMA.DEPARTMENTS (TABLE), HR_SCHEMA.EMPLOYEES (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "GET_EMPLOYEE_INFO",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:95eca163199143e2636cac2685c9d809"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE get_employee_info(p_emp_id IN NUMBER, p_cursor OUT SYS_REFCURSOR) AS\nBEGIN\n    OPEN p_cursor FOR\n    SELECT e.employee_id, e.first_name, e.last_name, e.salary, d.department_name\n    FROM employees e\n    JOIN departments d ON e.department_id = d.department_id\n    WHERE e.employee_id = p_emp_id;\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -2403,7 +2403,8 @@
             "customProperties": {
                 "object_type": "FUNCTION",
                 "status": "VALID",
-                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+                "upstream_dependencies": "SALES_SCHEMA.ORDER_ITEMS (TABLE), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)",
+                "downstream_dependencies": "SALES_SCHEMA.SUMMARIZE_ORDER (PROCEDURE)"
             },
             "name": "GET_ORDER_TOTAL",
             "type": {
@@ -2513,6 +2514,132 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3",
+                    "urn": "urn:li:container:9ae6f135ca378cf8219b9a0b86da07a3"
+                },
+                {
+                    "id": "urn:li:container:6e9764c5a9db406997c912cf91316bd2",
+                    "urn": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "object_type": "PROCEDURE",
+                "status": "VALID",
+                "upstream_dependencies": "PUBLIC.DBMS_OUTPUT (SYNONYM), SALES_SCHEMA.GET_ORDER_TOTAL (FUNCTION), SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE)"
+            },
+            "name": "SUMMARIZE_ORDER",
+            "type": {
+                "string": "Stored Procedure"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Stored Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:6e9764c5a9db406997c912cf91316bd2"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataTransformLogic",
+    "aspect": {
+        "json": {
+            "transforms": [
+                {
+                    "queryStatement": {
+                        "value": "PROCEDURE summarize_order(p_order_id IN NUMBER) AS\n    v_total NUMBER;\nBEGIN\n    v_total := get_order_total(p_order_id);\n    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);\nEND;",
+                        "language": "SQL"
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),GET_ORDER_TOTAL_261b636f7a5da1ca0277dc8c8299d392)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -19235,6 +19362,22 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),PROCESS_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sales_schema.stored_procedures,PROD),SUMMARIZE_ORDER_261b636f7a5da1ca0277dc8c8299d392)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
@@ -663,6 +663,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),ANALYTICS_PKG)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1548,6 +1569,27 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1643,6 +1685,27 @@
                         "language": "SQL"
                     }
                 }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "oracle-usage-lineage-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [],
+            "outputDatasets": [],
+            "inputDatajobs": [
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
+                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },

--- a/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
+++ b/metadata-ingestion/tests/integration/oracle/golden_files/golden_mces_oracle_to_file_with_usage_and_lineage.json
@@ -636,9 +636,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_count,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,analytics_schema.v_total_sales,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -652,27 +649,6 @@
                     "transformOperation": "SQL: NVL(\"EMPLOYEE_SALES_SUMMARY\".\"TOTAL_SALES\", 0) AS \"_col_0\"",
                     "confidenceScore": 0.2
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.analytics_schema.stored_procedures,PROD),REFRESH_ANALYTICS_DATA)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -1569,27 +1545,6 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),CALCULATE_ANNUAL_SALARY_80fcded156e41b6f562fc1438f132bbb)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
@@ -1685,27 +1640,6 @@
                         "language": "SQL"
                     }
                 }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "oracle-usage-lineage-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.hr_schema.stored_procedures,PROD),GET_EMPLOYEE_INFO_ae548124ee515a556f8cee0139839057)",
-    "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
-    "aspect": {
-        "json": {
-            "inputDatasets": [],
-            "outputDatasets": [],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ]
         }
     },
@@ -2553,10 +2487,6 @@
             "outputDatasets": [
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_total,PROD)"
             ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
-            ],
             "fineGrainedLineages": [
                 {
                     "upstreamType": "FIELD_SET",
@@ -2701,10 +2631,6 @@
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.orders,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_emp_name,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:oracle,sales_schema.v_sales_rep_id,PROD)"
-            ],
-            "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),standard)",
-                "urn:li:dataJob:(urn:li:dataFlow:(oracle,xepdb1.sys.stored_procedures,PROD),sys_stub_for_purity_analysis)"
             ],
             "fineGrainedLineages": [
                 {

--- a/metadata-ingestion/tests/integration/oracle/startup/01_setup.sql
+++ b/metadata-ingestion/tests/integration/oracle/startup/01_setup.sql
@@ -179,6 +179,28 @@ BEGIN
 END;
 /
 
+-- The only unit here whose lineage comes purely from the data dictionary. Its
+-- body carries no DML, and an assignment from a function is not a CALL
+-- statement, so the SQL parser finds nothing in it either -- the sole edge is
+-- the ALL_DEPENDENCIES entry for GET_ORDER_TOTAL. That combination is what
+-- covers catalogue-derived `inputDatajobs` surviving a body with no lineage of
+-- its own; without it, a procedure like this emits no dataJobInputOutput at all
+-- and the dependency is silently lost.
+--
+-- Same schema on purpose: the procedure registry is built per schema, so the
+-- target is a registry hit and the edge carries the same
+-- argument-signature-hashed job id as the DataJob emitted for GET_ORDER_TOTAL.
+-- Declared after that function so it compiles VALID rather than with an
+-- unresolved reference. DBMS_OUTPUT adds a SYS dependency, which the
+-- system-schema filter drops while keeping the real one.
+CREATE OR REPLACE PROCEDURE summarize_order(p_order_id IN NUMBER) AS
+    v_total NUMBER;
+BEGIN
+    v_total := get_order_total(p_order_id);
+    DBMS_OUTPUT.PUT_LINE('Order total: ' || v_total);
+END;
+/
+
 -- Create ANALYTICS_SCHEMA objects with materialized views
 ALTER SESSION SET CURRENT_SCHEMA = analytics_schema;
 

--- a/metadata-ingestion/tests/unit/sql_parsing/test_oracle_stored_procedure_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_oracle_stored_procedure_lineage.py
@@ -780,6 +780,34 @@ def test_oracle_parse_dependencies_cross_schema():
     assert any("sales.stored_procedures" in urn for urn in result)
 
 
+def test_oracle_parse_dependencies_drops_system_schemas():
+    """Every PL/SQL unit depends on SYS.STANDARD and SYS.SYS_STUB_FOR_PURITY_ANALYSIS,
+    and PROCEDURES_QUERY never ingests system schemas — so those edges would dangle.
+    The drop cannot rely on schema_pattern, which defaults to allow-all."""
+    database_key = DatabaseKey(
+        database="ORCL", platform="oracle", instance=None, env="PROD"
+    )
+    schema_key = SchemaKey(
+        database="ORCL", schema="hr", platform="oracle", instance=None, env="PROD"
+    )
+
+    deps = (
+        "SYS.STANDARD (PACKAGE), SYS.SYS_STUB_FOR_PURITY_ANALYSIS (PACKAGE), "
+        "sys.dbms_output (PACKAGE), HR.PROC1 (PROCEDURE)"
+    )
+
+    # No is_schema_in_scope at all, i.e. the allow-all default.
+    result = _parse_oracle_procedure_dependencies(deps, database_key, schema_key, None)
+    assert len(result) == 1
+    assert "proc1" in result[0].lower()
+
+    # And an explicitly permissive callback doesn't reopen the hole.
+    result = _parse_oracle_procedure_dependencies(
+        deps, database_key, schema_key, None, is_schema_in_scope=lambda _: True
+    )
+    assert len(result) == 1
+
+
 def test_oracle_parse_dependencies_case_sensitivity():
     """Test that dependency parsing handles mixed case correctly."""
     database_key = DatabaseKey(

--- a/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
@@ -453,3 +453,42 @@ def test_count_call_arguments_counts_top_level_arguments_only():
     assert _count_call_arguments("(  )") == 0
     assert _count_call_arguments("(a, b") is None
     assert _count_call_arguments("") is None
+
+
+def test_catalogue_input_jobs_survive_a_body_with_no_lineage():
+    """`additional_input_jobs` comes from a system catalogue (Oracle's
+    ALL_DEPENDENCIES), not from the code. A body the parser finds nothing in —
+    an `EXECUTE IMMEDIATE`, a bare `BEGIN NULL; END` — must not take those edges
+    down with it, or the caller silently loses dependencies it knows about."""
+    schema_resolver = SchemaResolver(platform="oracle", env="PROD")
+    catalogue_edge = (
+        "urn:li:dataJob:(urn:li:dataFlow:"
+        "(oracle,test_db.test_schema.stored_procedures,PROD),upstream_proc)"
+    )
+
+    for code in (
+        "EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src'",
+        "BEGIN NULL; END;",
+    ):
+        result = parse_procedure_code(
+            schema_resolver=schema_resolver,
+            default_db="test_db",
+            default_schema="test_schema",
+            code=code,
+            is_temp_table=lambda _: False,
+            additional_input_jobs=[catalogue_edge],
+        )
+        assert result is not None, code
+        assert result.inputDatajobs == [catalogue_edge], code
+
+    # With nothing from either source there is still no aspect to emit.
+    assert (
+        parse_procedure_code(
+            schema_resolver=schema_resolver,
+            default_db="test_db",
+            default_schema="test_schema",
+            code="BEGIN NULL; END;",
+            is_temp_table=lambda _: False,
+        )
+        is None
+    )

--- a/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
@@ -21,6 +21,8 @@ These are the same composition rules used by ``BaseProcedure.to_urn`` /
 DataJob URNs emitted for the called procedures elsewhere in ingestion.
 """
 
+from typing import List
+
 from datahub.ingestion.source.sql.stored_procedures.lineage import (
     ProcedureParseReport,
     _count_call_arguments,
@@ -529,6 +531,33 @@ def test_tsql_execute_immediate_is_not_a_call_target():
         "urn:li:dataJob:(urn:li:dataFlow:"
         "(mssql,test_db.test_schema.stored_procedures,PROD),immediate_refresh)"
     ]
+
+
+def test_immediate_guard_does_not_swallow_real_calls():
+    """The guard has to separate dynamic SQL from anything merely *named* like it.
+    `IMMEDIATE` is a legal identifier, so a procedure called IMMEDIATE, and a
+    schema called IMMEDIATE, both have to stay callable."""
+    schema_resolver = SchemaResolver(platform="mssql", env="PROD")
+
+    def edges(code: str) -> List[str]:
+        result = parse_procedure_code(
+            schema_resolver=schema_resolver,
+            default_db="test_db",
+            default_schema="test_schema",
+            code=code,
+            is_temp_table=lambda _: False,
+        )
+        return [] if result is None else (result.inputDatajobs or [])
+
+    # Dynamic SQL: dropped on both the structured and the literal path.
+    assert not edges("EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src'")
+
+    # A procedure that happens to be named IMMEDIATE, with and without args.
+    assert edges("EXEC IMMEDIATE")
+    assert edges("EXEC IMMEDIATE @p=1")
+
+    # A qualifier that merely starts with the keyword.
+    assert edges("CALL immediate_refresh()")
 
 
 def test_resolve_procedure_urn_callback_owns_the_target_urn():

--- a/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
@@ -537,11 +537,10 @@ def test_immediate_guard_does_not_swallow_real_calls():
     """The guard has to separate dynamic SQL from anything merely *named* like it.
     `IMMEDIATE` is a legal identifier, so a procedure called IMMEDIATE, and a
     schema called IMMEDIATE, both have to stay callable."""
-    schema_resolver = SchemaResolver(platform="mssql", env="PROD")
 
-    def edges(code: str) -> List[str]:
+    def edges(code: str, platform: str = "mssql") -> List[str]:
         result = parse_procedure_code(
-            schema_resolver=schema_resolver,
+            schema_resolver=SchemaResolver(platform=platform, env="PROD"),
             default_db="test_db",
             default_schema="test_schema",
             code=code,
@@ -551,6 +550,9 @@ def test_immediate_guard_does_not_swallow_real_calls():
 
     # Dynamic SQL: dropped on both the structured and the literal path.
     assert not edges("EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src'")
+    assert not edges(
+        "EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src'", platform="snowflake"
+    )
 
     # A procedure that happens to be named IMMEDIATE, with and without args.
     assert edges("EXEC IMMEDIATE")
@@ -558,6 +560,14 @@ def test_immediate_guard_does_not_swallow_real_calls():
 
     # A qualifier that merely starts with the keyword.
     assert edges("CALL immediate_refresh()")
+
+    # A schema named IMMEDIATE, on both branches. tsql gives the structured
+    # `Execute` node, where the guard's "no catalog, no db" condition lets the
+    # qualified target through; snowflake falls back to `Command`, where the
+    # regex sees `IMMEDIATE.proc` — the case that ruled out a word boundary in
+    # favour of the whitespace lookahead.
+    assert edges("EXEC IMMEDIATE.proc")
+    assert edges("EXECUTE IMMEDIATE.proc", platform="snowflake")
 
 
 def test_resolve_procedure_urn_callback_owns_the_target_urn():

--- a/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
@@ -21,7 +21,11 @@ These are the same composition rules used by ``BaseProcedure.to_urn`` /
 DataJob URNs emitted for the called procedures elsewhere in ingestion.
 """
 
-from datahub.ingestion.source.sql.stored_procedures.lineage import parse_procedure_code
+from datahub.ingestion.source.sql.stored_procedures.lineage import (
+    ProcedureParseReport,
+    _count_call_arguments,
+    parse_procedure_code,
+)
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 
 
@@ -375,3 +379,77 @@ def test_begin_end_wrapped_body_recovers_first_dml_and_call():
     assert result.outputDatasets == [
         "urn:li:dataset:(urn:li:dataPlatform:mariadb,test_db.target_table,PROD)"
     ]
+
+
+def test_execute_immediate_is_not_a_call_target():
+    """``EXECUTE IMMEDIATE '<sql>'`` builds its SQL at runtime, so there is no
+    static call target. Without the guard the regex reads ``IMMEDIATE`` as the
+    procedure name, and sources that compose the target urn (rather than
+    resolving it) emit an edge to a DataJob that cannot exist."""
+    schema_resolver = SchemaResolver(platform="oracle", env="PROD")
+
+    code = """
+    EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src';
+    INSERT INTO real_target (id) SELECT id FROM real_source;
+    """
+    result = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code=code,
+        is_temp_table=lambda _: False,
+    )
+
+    assert result is not None
+    # The static INSERT still produces lineage; the dynamic one contributes nothing.
+    assert result.outputDatasets == [
+        "urn:li:dataset:(urn:li:dataPlatform:oracle,test_db.test_schema.real_target,PROD)"
+    ]
+    assert not result.inputDatajobs
+    assert not any("immediate" in urn.lower() for urn in result.inputDatajobs or [])
+
+
+def test_unparseable_body_is_reported_as_a_failure_not_as_empty():
+    """A body whose statements fail to parse returns None, exactly like a body
+    with nothing lineage-bearing in it. The parse report is what tells a caller
+    which of the two it got."""
+    schema_resolver = SchemaResolver(platform="snowflake", env="PROD")
+
+    parse_report = ProcedureParseReport()
+    result = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code="INSERT INTO tgt SELECT FROM WHERE ((",
+        is_temp_table=lambda _: False,
+        parse_report=parse_report,
+    )
+
+    assert result is None
+    assert parse_report.failed
+    assert parse_report.first_error
+
+    quiet_report = ProcedureParseReport()
+    assert (
+        parse_procedure_code(
+            schema_resolver=schema_resolver,
+            default_db="test_db",
+            default_schema="test_schema",
+            code="TRUNCATE TABLE tgt",
+            is_temp_table=lambda _: False,
+            parse_report=quiet_report,
+        )
+        is None
+    )
+    assert not quiet_report.failed
+
+
+def test_count_call_arguments_counts_top_level_arguments_only():
+    """Overload disambiguation rests on this count, so pin the awkward cases:
+    commas inside string literals and nested calls don't separate arguments."""
+    assert _count_call_arguments("('a,b')") == 1
+    assert _count_call_arguments("(f(a,b), c)") == 2
+    assert _count_call_arguments("()") == 0
+    assert _count_call_arguments("(  )") == 0
+    assert _count_call_arguments("(a, b") is None
+    assert _count_call_arguments("") is None

--- a/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_procedure_call_lineage.py
@@ -492,3 +492,96 @@ def test_catalogue_input_jobs_survive_a_body_with_no_lineage():
         )
         is None
     )
+
+
+def test_tsql_execute_immediate_is_not_a_call_target():
+    """TSQL parses `EXECUTE IMMEDIATE '<sql>'` into a structured Execute node,
+    where the keyword lands in the target slot and reads as a procedure named
+    IMMEDIATE. That is the same dynamic SQL as the Command-literal form, and the
+    same non-existent target — guarding only one of the two paths left MSSQL and
+    any other structured-Execute dialect emitting a bogus edge."""
+    schema_resolver = SchemaResolver(platform="mssql", env="PROD")
+
+    result = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code="""
+        EXECUTE IMMEDIATE 'INSERT INTO tgt SELECT a FROM src';
+        INSERT INTO real_target (id) SELECT id FROM real_source;
+        """,
+        is_temp_table=lambda _: False,
+    )
+
+    assert result is not None
+    assert not result.inputDatajobs
+    # An ordinary EXEC on the same path still resolves, so the guard is not
+    # swallowing real calls.
+    with_call = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code="EXEC test_db.test_schema.immediate_refresh",
+        is_temp_table=lambda _: False,
+    )
+    assert with_call is not None
+    assert with_call.inputDatajobs == [
+        "urn:li:dataJob:(urn:li:dataFlow:"
+        "(mssql,test_db.test_schema.stored_procedures,PROD),immediate_refresh)"
+    ]
+
+
+def test_resolve_procedure_urn_callback_owns_the_target_urn():
+    """The callback is the whole point of the hook: the source maps a call onto a
+    procedure it actually ingested, because the urn's job id carries an
+    argument-signature hash the call site cannot see. Cover all three paths —
+    resolution, refusal, and what the reference carries."""
+    schema_resolver = SchemaResolver(platform="snowflake", env="PROD")
+    seen = []
+
+    def resolver(ref):
+        seen.append(ref)
+        return (
+            "urn:li:dataJob:(urn:li:dataFlow:"
+            "(snowflake,test_db.test_schema.stored_procedures,PROD),"
+            "my_proc_deadbeef)"
+        )
+
+    result = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code="CALL my_proc('a', 'b')",
+        is_temp_table=lambda _: False,
+        resolve_procedure_urn=resolver,
+    )
+
+    # The composed form would have been ...,my_proc) with no hash; the callback's
+    # answer is used verbatim instead.
+    assert result is not None
+    assert result.inputDatajobs == [
+        "urn:li:dataJob:(urn:li:dataFlow:"
+        "(snowflake,test_db.test_schema.stored_procedures,PROD),my_proc_deadbeef)"
+    ]
+
+    # The reference arrives with the caller's defaults already applied, and with
+    # the call-site arity that lets a source narrow overloads.
+    assert len(seen) == 1
+    assert (seen[0].database, seen[0].db_schema, seen[0].name) == (
+        "test_db",
+        "test_schema",
+        "my_proc",
+    )
+    assert seen[0].argument_count == 2
+
+    # Refusal means "not ingested here": no edge at all, rather than a composed
+    # urn pointing at a DataJob that was never emitted.
+    refused = parse_procedure_code(
+        schema_resolver=schema_resolver,
+        default_db="test_db",
+        default_schema="test_schema",
+        code="CALL my_proc('a')",
+        is_temp_table=lambda _: False,
+        resolve_procedure_urn=lambda ref: None,
+    )
+    assert refused is None


### PR DESCRIPTION
## Summary

A procedure's DataJob urn ends in a hash of its **declared** argument signature, which a `CALL` site cannot see. Composing the target urn from the call text therefore produces an edge to a DataJob that was never emitted — it carries neither the hash nor the source's identifier casing.

Sources can now pass a `resolve_procedure_urn` callback that maps a `ProcedureReference` onto a procedure they actually ingested. Returning `None` means "not ingested here", and no edge is emitted rather than a dangling one. `argument_count` (top-level arguments, quote- and paren-aware) rides along to narrow overloads.

Also in this change:

- **`EXECUTE IMMEDIATE '<sql>'` no longer parses as a call to a procedure named `IMMEDIATE`.** Its SQL is assembled at runtime, so there is no static target. This affects Oracle and MSSQL, which compose the urn.
- **Parse failures are reportable.** `parse_procedure_code` accepts a `ProcedureParseReport`, so a caller can distinguish "this body failed to parse" from "this body carries no lineage" — both return `None` today, with the failure counts dying inside the throwaway aggregator. Statement-level failures now log the exception message, not just its class name.
- **The per-body aggregator is closed.** It opens a sqlite connection and temp directory per file-backed store, once per procedure body, and released neither.
- **`additional_input_jobs` moved into `parse_procedure_code`**, replacing the post-hoc merge in `generate_procedure_lineage`, so catalogue-derived edges (Oracle's `ALL_DEPENDENCIES`) survive a body whose DML yields no lineage.
- The dead `elif result.inputDatajobs` branch is gone — `to_datajob_input_output` only ever builds dataset lineage.

**Stack.** Split out of #17318 so the shared-code changes can be reviewed apart from the Snowflake connector work. Merge in order — each PR's diff is against its parent branch, not master:

1. #19379 — public `SqlParsingAggregator.schema_resolver` accessor
2. #19380 — stored-procedure CALL-target resolution and parse reporting (cross-connector: Snowflake, Oracle, MSSQL, MySQL)
3. #17318 — Snowflake task SQL lineage

This is **PR 2**. It is based on #19379, so review that one first; #17318 sits on top of this.

## Test plan

- [x] New tests in `tests/unit/sql_parsing/test_procedure_call_lineage.py`: `EXECUTE IMMEDIATE` yields no call target (mutation-checked — replacing the guard with `if False:` fails the test), parse-report distinguishes failure from no-lineage, `_count_call_arguments` edge cases (commas in string literals, nested calls, empty parens, unbalanced)
- [x] `pytest tests/unit/sql_parsing tests/unit/test_oracle_source.py tests/unit/test_mssql.py tests/unit/snowflake` — 1419 passed
- [x] `pytest tests/integration/mysql tests/integration/mariadb` — 13 passed (two-tier composition path)
- [x] `./gradlew :metadata-ingestion:lint` clean

## Note for whoever next regenerates the Oracle goldens

Five Oracle goldens gain three `dataJobInputOutput` aspects each: procedures whose bodies yield no lineage now emit their `ALL_DEPENDENCIES` `inputDatajobs` instead of no aspect at all. The edges (`SYS.STANDARD`, `SYS_STUB_FOR_PURITY_ANALYSIS`) are what Oracle already emits for procedures whose bodies *do* parse — this applies the same treatment consistently rather than introducing a new kind of edge.

I merged those aspects in rather than regenerating wholesale, for two reasons worth knowing about:

1. `--update-golden-files` also rewrites every `runId`, which is ~450 lines of pure snapshot churn per file against an ignored path.
2. **`--update-golden-files` cannot update `golden_mces_oracle_to_file_with_query_usage.json` at all.** That branch of `test_oracle_ingest` filters volatile V$SQL entries into copies under `tmp_path` and calls `check_golden_file` against the *temp* golden, so update mode rewrites a throwaway file and leaves the committed golden untouched. It is also why a plain regeneration of that file would commit run-specific query hashes and `upstreamLineage` for V$SQL-derived queries.

Pre-existing, not introduced here, and filed separately.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline
- [x] Tests for the changes have been added/updated
- [ ] Docs — n/a, no user-facing config
- [ ] Breaking change — none; `resolve_procedure_urn` and `parse_report` are optional, and the `EXECUTE IMMEDIATE` change only removes edges that could not resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves stored-procedure CALL targets via a source callback and reports parse failures, eliminating dangling CALL edges and distinguishing “no lineage” from “parse failed.” Treats EXECUTE IMMEDIATE as dynamic SQL only, not a procedure call, so real procedures named IMMEDIATE still resolve.

- Adds optional resolve_procedure_urn(ProcedureReference) -> Optional[str] to parse_procedure_code; suppresses the CALL edge when the resolver returns None. ProcedureCall now carries argument_count to narrow overloads.
- Narrows EXECUTE IMMEDIATE handling on both parsed forms: matches IMMEDIATE as a standalone keyword (whitespace lookahead) and, for structured Execute, requires a single string-literal operand; ordinary EXEC IMMEDIATE calls still resolve.
- Enhances parse_procedure_code: accepts additional_input_jobs and ProcedureParseReport; de-duplicates inputs; keeps catalogue-only edges when the body has no DML; records exception messages; copies failure counts even when raise_=True; closes the per-body aggregator.
- Oracle: drops ORACLE_SYSTEM_SCHEMAS dependencies unconditionally and filters remaining ALL_DEPENDENCIES edges to in-scope schemas, preventing SYS-only dangling edges; goldens updated accordingly.
- generate_procedure_lineage now passes additional_input_jobs through; the post-hoc merge is removed.

**Rollout**
- Optional: implement resolve_procedure_urn in sources that hash or normalize procedure identifiers to avoid dangling CALL edges. No config changes; existing call sites remain compatible.

<sup>Written for commit b222569068e3d24564b857b0dca4d89b48ea5f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

