### PR TITLE
fix(auth): stop trusting client appSource for aspect authorization

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCPStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCPStep.java
@@ -182,7 +182,7 @@ public abstract class AbstractMCPStep implements UpgradeStep {
                       if (continueOnValidationFailure()) {
                         ValidationExceptionCollection exceptions =
                             AspectsBatch.validateProposed(
-                                opContext, batchItems, opContext.getRetrieverContext(), null);
+                                opContext, batchItems, opContext.getRetrieverContext(), opContext);
                         if (!exceptions.isEmpty()) {
                           validItems = new ArrayList<>(exceptions.successful(batchItems));
                           log.error(

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
@@ -66,7 +66,13 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
         continue;
       }
 
-      CorpUserInfo current = loadCorpUserInfo(operationContext, aspectRetriever, item.getUrn());
+      // AspectRetriever requires a non-null fingerprint for lookups. When the batch was built
+      // without an OperationContext, use EMPTY only for reading current state — never as a trust
+      // signal for authorization.
+      OperationFingerprint lookupContext =
+          operationContext != null ? operationContext : OperationFingerprint.EMPTY;
+
+      CorpUserInfo current = loadCorpUserInfo(lookupContext, aspectRetriever, item.getUrn());
       CorpUserInfo proposed = resolveProposedCorpUserInfo(item, current);
       if (proposed == null) {
         continue;

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
@@ -84,6 +84,12 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
         continue;
       }
 
+      if (operationContext == null) {
+        exceptions.addException(
+            authFailure(item, "Unauthorized to modify privileged CorpUserInfo flags."));
+        continue;
+      }
+
       Urn authActor = resolveAuthorizingActor(item, operationContext);
 
       CorpUserInfo actorInfo = loadCorpUserInfo(operationContext, aspectRetriever, authActor);
@@ -206,10 +212,10 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
   /**
    * Bootstrap, upgrade steps, and other system-mediated writes are trusted via {@link
    * OperationFingerprint#isSystemAuth()}, never via client-writable {@code appSource} or a
-   * hardcoded system URN.
+   * hardcoded system URN. A null fingerprint is untrusted (fail closed).
    */
-  private static boolean isTrustedInternalWrite(@Nonnull OperationFingerprint operationContext) {
-    return operationContext.isSystemAuth();
+  private static boolean isTrustedInternalWrite(@Nullable OperationFingerprint operationContext) {
+    return operationContext != null && operationContext.isSystemAuth();
   }
 
   private static AspectValidationException authFailure(

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/validation/CorpUserPrivilegedFlagsValidator.java
@@ -1,9 +1,6 @@
 package com.linkedin.metadata.aspect.validation;
 
-import static com.linkedin.metadata.Constants.APP_SOURCE;
 import static com.linkedin.metadata.Constants.CORP_USER_INFO_ASPECT_NAME;
-import static com.linkedin.metadata.Constants.SYSTEM_ACTOR;
-import static com.linkedin.metadata.Constants.SYSTEM_UPDATE_SOURCE;
 
 import com.datahub.context.OperationFingerprint;
 import com.datahub.util.RecordUtils;
@@ -23,7 +20,6 @@ import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
 import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
-import com.linkedin.mxe.SystemMetadata;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonPatch;
@@ -84,14 +80,11 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
         continue;
       }
 
-      if (isTrustedInternalWrite(item)) {
+      if (isTrustedInternalWrite(operationContext)) {
         continue;
       }
 
       Urn authActor = resolveAuthorizingActor(item, operationContext);
-      if (isIntrinsicSystemActor(authActor)) {
-        continue;
-      }
 
       CorpUserInfo actorInfo = loadCorpUserInfo(operationContext, aspectRetriever, authActor);
       if (actorInfo == null) {
@@ -131,11 +124,6 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
       return contextAudit.getActor();
     }
     return operationContext.getActor();
-  }
-
-  /** Service principal {@link Constants#SYSTEM_ACTOR} has no {@link CorpUserInfo} aspect. */
-  private static boolean isIntrinsicSystemActor(@Nonnull Urn authActor) {
-    return SYSTEM_ACTOR.equals(authActor.toString());
   }
 
   @Override
@@ -215,17 +203,13 @@ public class CorpUserPrivilegedFlagsValidator extends AspectPayloadValidator {
         && Boolean.TRUE.equals(info.data().getBoolean(IS_SUPPORT_USER_FIELD));
   }
 
-  private static boolean isTrustedInternalWrite(@Nonnull BatchItem item) {
-    SystemMetadata systemMetadata = item.getSystemMetadata();
-    if (systemMetadata != null
-        && systemMetadata.hasProperties()
-        && SYSTEM_UPDATE_SOURCE.equals(systemMetadata.getProperties().get(APP_SOURCE))) {
-      return true;
-    }
-    AuditStamp auditStamp = item.getAuditStamp();
-    return auditStamp != null
-        && auditStamp.hasActor()
-        && SYSTEM_ACTOR.equals(auditStamp.getActor().toString());
+  /**
+   * Bootstrap, upgrade steps, and other system-mediated writes are trusted via {@link
+   * OperationFingerprint#isSystemAuth()}, never via client-writable {@code appSource} or a
+   * hardcoded system URN.
+   */
+  private static boolean isTrustedInternalWrite(@Nonnull OperationFingerprint operationContext) {
+    return operationContext.isSystemAuth();
   }
 
   private static AspectValidationException authFailure(

--- a/entity-registry/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
@@ -1,7 +1,9 @@
 package com.linkedin.metadata.utils;
 
+import static com.linkedin.metadata.Constants.APP_SOURCE;
 import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
 import static com.linkedin.metadata.Constants.SYSTEM_ACTOR;
+import static com.linkedin.metadata.Constants.SYSTEM_UPDATE_SOURCE;
 
 import com.datahub.util.RecordUtils;
 import com.linkedin.common.AuditStamp;
@@ -42,6 +44,25 @@ public class SystemMetadataUtils {
       result.setLastObserved(System.currentTimeMillis());
     }
     return result;
+  }
+
+  /**
+   * Removes the reserved {@code appSource=systemUpdate} trust token from client-supplied system
+   * metadata. System principals may keep the stamp for provenance/indexing; non-system writers must
+   * not be able to attach it.
+   *
+   * @return {@code true} if a reserved value was stripped
+   */
+  public static boolean stripReservedAppSource(@Nullable SystemMetadata systemMetadata) {
+    if (systemMetadata == null || !systemMetadata.hasProperties()) {
+      return false;
+    }
+    StringMap properties = systemMetadata.getProperties();
+    if (SYSTEM_UPDATE_SOURCE.equals(properties.get(APP_SOURCE))) {
+      properties.remove(APP_SOURCE);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
@@ -140,6 +140,14 @@ public class CorpUserPrivilegedFlagsValidatorTest {
   }
 
   @Test
+  public void testNullFingerprintDoesNotBypassOrThrow() {
+    CorpUserInfo proposed = corpUserInfo(true, false);
+
+    long violations = validate(proposed, null, null, null).count();
+    assertEquals(violations, 1);
+  }
+
+  @Test
   public void testSystemActorAuditStampAloneDoesNotBypass() {
     // Hardcoded SYSTEM_ACTOR on the audit stamp is not a trust signal without isSystemAuth().
     CorpUserInfo proposed = corpUserInfo(true, false);

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/validators/CorpUserPrivilegedFlagsValidatorTest.java
@@ -120,17 +120,28 @@ public class CorpUserPrivilegedFlagsValidatorTest {
   }
 
   @Test
-  public void testSystemUpdateSourceBypass() {
+  public void testClientAppSourceSystemUpdateDoesNotBypass() {
+    // Spoof regression: client-writable appSource must not elevate privilege.
     CorpUserInfo proposed = corpUserInfo(true, false);
     SystemMetadata systemMetadata = systemMetadataWithSource(SYSTEM_UPDATE_SOURCE);
 
     long violations =
         validate(proposed, null, operationContext(REGULAR_ACTOR_URN), systemMetadata).count();
+    assertEquals(violations, 1);
+  }
+
+  @Test
+  public void testSystemAuthFingerprintBypass() {
+    CorpUserInfo proposed = corpUserInfo(true, false);
+
+    long violations =
+        validate(proposed, null, systemAuthOperationContext(REGULAR_ACTOR_URN), null).count();
     assertEquals(violations, 0);
   }
 
   @Test
-  public void testSystemActorAuditStampBypass() {
+  public void testSystemActorAuditStampAloneDoesNotBypass() {
+    // Hardcoded SYSTEM_ACTOR on the audit stamp is not a trust signal without isSystemAuth().
     CorpUserInfo proposed = corpUserInfo(true, false);
     AuditStamp auditStamp =
         new AuditStamp()
@@ -139,7 +150,7 @@ public class CorpUserPrivilegedFlagsValidatorTest {
 
     long violations =
         validate(proposed, null, operationContext(REGULAR_ACTOR_URN), null, auditStamp).count();
-    assertEquals(violations, 0);
+    assertEquals(violations, 1);
   }
 
   @Test
@@ -335,6 +346,7 @@ public class CorpUserPrivilegedFlagsValidatorTest {
 
   @Test
   public void testIntrinsicSystemActorAllowedWithoutCorpUserInfo() {
+    // Service principal has no CorpUserInfo; trust comes from isSystemAuth(), not URN equality.
     CorpUserInfo proposed = corpUserInfo(false, true);
     AuditStamp sessionAudit =
         new AuditStamp().setActor(INTRINSIC_SYSTEM_ACTOR_URN).setTime(System.currentTimeMillis());
@@ -343,7 +355,7 @@ public class CorpUserPrivilegedFlagsValidatorTest {
         validate(
                 proposed,
                 null,
-                operationContext(INTRINSIC_SYSTEM_ACTOR_URN, INTRINSIC_SYSTEM_ACTOR_URN),
+                systemAuthOperationContext(INTRINSIC_SYSTEM_ACTOR_URN),
                 null,
                 sessionAudit)
             .count();
@@ -405,10 +417,19 @@ public class CorpUserPrivilegedFlagsValidatorTest {
   }
 
   private static OperationFingerprint operationContext(Urn actorUrn) {
-    return operationContext(actorUrn, actorUrn);
+    return operationContext(actorUrn, actorUrn, false);
+  }
+
+  private static OperationFingerprint systemAuthOperationContext(Urn actorUrn) {
+    return operationContext(actorUrn, actorUrn, true);
   }
 
   private static OperationFingerprint operationContext(Urn effectiveActorUrn, Urn auditActorUrn) {
+    return operationContext(effectiveActorUrn, auditActorUrn, false);
+  }
+
+  private static OperationFingerprint operationContext(
+      Urn effectiveActorUrn, Urn auditActorUrn, boolean systemAuth) {
     AuditStamp auditStamp =
         new AuditStamp().setActor(auditActorUrn).setTime(System.currentTimeMillis());
     return new OperationFingerprint() {
@@ -440,6 +461,11 @@ public class CorpUserPrivilegedFlagsValidatorTest {
       @Override
       public String getEntityContextId() {
         return "test-entity";
+      }
+
+      @Override
+      public boolean isSystemAuth() {
+        return systemAuth;
       }
     };
   }

--- a/entity-registry/src/test/java/com/linkedin/metadata/utils/SystemMetadataUtilsTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/utils/SystemMetadataUtilsTest.java
@@ -1,7 +1,9 @@
 package com.linkedin.metadata.utils;
 
+import static com.linkedin.metadata.Constants.APP_SOURCE;
 import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
 import static com.linkedin.metadata.Constants.SYSTEM_ACTOR;
+import static com.linkedin.metadata.Constants.SYSTEM_UPDATE_SOURCE;
 import static org.testng.Assert.*;
 
 import com.linkedin.common.AuditStamp;
@@ -227,5 +229,35 @@ public class SystemMetadataUtilsTest {
     SystemMetadataUtils.setSchemaVersion(metadata, 5L);
 
     assertEquals(metadata.getSchemaVersion(), (Long) 2L);
+  }
+
+  @Test
+  public void testStripReservedAppSourceRemovesSystemUpdate() {
+    SystemMetadata metadata = new SystemMetadata();
+    StringMap properties = new StringMap();
+    properties.put(APP_SOURCE, SYSTEM_UPDATE_SOURCE);
+    properties.put("other", "keep");
+    metadata.setProperties(properties);
+
+    assertTrue(SystemMetadataUtils.stripReservedAppSource(metadata));
+    assertFalse(metadata.getProperties().containsKey(APP_SOURCE));
+    assertEquals(metadata.getProperties().get("other"), "keep");
+  }
+
+  @Test
+  public void testStripReservedAppSourceLeavesOtherSources() {
+    SystemMetadata metadata = new SystemMetadata();
+    StringMap properties = new StringMap();
+    properties.put(APP_SOURCE, "ui");
+    metadata.setProperties(properties);
+
+    assertFalse(SystemMetadataUtils.stripReservedAppSource(metadata));
+    assertEquals(metadata.getProperties().get(APP_SOURCE), "ui");
+  }
+
+  @Test
+  public void testStripReservedAppSourceNullSafe() {
+    assertFalse(SystemMetadataUtils.stripReservedAppSource(null));
+    assertFalse(SystemMetadataUtils.stripReservedAppSource(new SystemMetadata()));
   }
 }

--- a/li-utils/src/main/java/com/datahub/context/OperationFingerprint.java
+++ b/li-utils/src/main/java/com/datahub/context/OperationFingerprint.java
@@ -83,6 +83,18 @@ public interface OperationFingerprint {
   String getEntityContextId();
 
   /**
+   * Whether this operation is running as the configured system principal.
+   *
+   * <p>Defaults to {@code false} for shims/tests. {@code OperationContext} overrides this with the
+   * canonical system-auth check (session actor equals configured system authentication). Do not
+   * substitute client-writable provenance fields (e.g. {@code appSource}) or a hardcoded system
+   * URN.
+   */
+  default boolean isSystemAuth() {
+    return false;
+  }
+
+  /**
    * Return the {@link Enrichment} of the given concrete class stamped onto this operation, or
    * {@link Optional#empty()} if no such enrichment is present.
    *

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImpl.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImpl.java
@@ -15,7 +15,9 @@ import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
 import com.linkedin.metadata.entity.validation.ValidationException;
+import com.linkedin.metadata.utils.SystemMetadataUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
@@ -281,6 +283,20 @@ public class AspectsBatchImpl implements AspectsBatch {
       if (this.items == null) {
         this.items = Collections.emptyList();
       }
+
+      // Defense in depth: non-system writers must not retain reserved appSource=systemUpdate.
+      // Auth validators no longer trust that stamp; stripping prevents other consumers from
+      // treating client-supplied provenance as a system-upgrade signal.
+      if (operationContext == null || !operationContext.isSystemAuth()) {
+        for (BatchItem item : this.items) {
+          SystemMetadata systemMetadata = item.getSystemMetadata();
+          if (SystemMetadataUtils.stripReservedAppSource(systemMetadata)
+              && item instanceof MCPItem) {
+            ((MCPItem) item).setSystemMetadata(systemMetadata);
+          }
+        }
+      }
+
       this.nonRepeatedItems = filterRepeats(this.items);
 
       // operationContext serves dual roles here: OperationFingerprint for routing (1st arg)

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/AbstractAspectAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/AbstractAspectAuthorizationValidator.java
@@ -55,11 +55,12 @@ public abstract class AbstractAspectAuthorizationValidator extends AspectPayload
 
   /**
    * Trusted when the operation fingerprint or authorization session is the configured system
-   * principal. Client-writable provenance (e.g. {@code appSource}) must never gate this decision.
+   * principal. Client-writable provenance (e.g. {@code appSource}) must never gate this decision. A
+   * null fingerprint (e.g. {@code AspectsBatchImpl.build(null)}) is untrusted.
    */
   protected static boolean isTrustedSystemOperation(
-      @Nonnull OperationFingerprint operationContext, @Nullable AuthorizationSession session) {
-    if (operationContext.isSystemAuth()) {
+      @Nullable OperationFingerprint operationContext, @Nullable AuthorizationSession session) {
+    if (operationContext != null && operationContext.isSystemAuth()) {
       return true;
     }
     return session instanceof OperationContext && ((OperationContext) session).isSystemAuth();

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/AbstractAspectAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/AbstractAspectAuthorizationValidator.java
@@ -1,8 +1,5 @@
 package com.linkedin.metadata.aspect.validation;
 
-import static com.linkedin.metadata.Constants.APP_SOURCE;
-import static com.linkedin.metadata.Constants.SYSTEM_UPDATE_SOURCE;
-
 import com.datahub.authorization.AuthorizationSession;
 import com.datahub.context.OperationFingerprint;
 import com.linkedin.metadata.aspect.RetrieverContext;
@@ -11,9 +8,10 @@ import com.linkedin.metadata.aspect.batch.ChangeMCP;
 import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
 import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -35,11 +33,12 @@ public abstract class AbstractAspectAuthorizationValidator extends AspectPayload
       return exceptions.streamAllExceptions();
     }
 
-    List<? extends BatchItem> itemsRequiringValidation = filterItemsRequiringValidation(mcpItems);
-
-    if (itemsRequiringValidation.isEmpty()) {
+    // Trusted system principals skip aspect auth entirely. Never trust client-writable appSource.
+    if (isTrustedSystemOperation(operationContext, session)) {
       return exceptions.streamAllExceptions();
     }
+
+    List<? extends BatchItem> itemsRequiringValidation = new ArrayList<>(mcpItems);
 
     if (session == null) {
       exceptions.addException(
@@ -54,20 +53,16 @@ public abstract class AbstractAspectAuthorizationValidator extends AspectPayload
     return exceptions.streamAllExceptions();
   }
 
-  protected List<? extends BatchItem> filterItemsRequiringValidation(
-      @Nonnull Collection<? extends BatchItem> mcpItems) {
-    return mcpItems.stream()
-        .filter(AbstractAspectAuthorizationValidator::requiresValidation)
-        .collect(Collectors.toList());
-  }
-
-  /** Skip system upgrade sources; all other sources including UI are validated. */
-  protected static boolean requiresValidation(@Nonnull BatchItem item) {
-    String appSource =
-        item.getSystemMetadata() != null && item.getSystemMetadata().getProperties() != null
-            ? item.getSystemMetadata().getProperties().get(APP_SOURCE)
-            : null;
-    return !SYSTEM_UPDATE_SOURCE.equals(appSource);
+  /**
+   * Trusted when the operation fingerprint or authorization session is the configured system
+   * principal. Client-writable provenance (e.g. {@code appSource}) must never gate this decision.
+   */
+  protected static boolean isTrustedSystemOperation(
+      @Nonnull OperationFingerprint operationContext, @Nullable AuthorizationSession session) {
+    if (operationContext.isSystemAuth()) {
+      return true;
+    }
+    return session instanceof OperationContext && ((OperationContext) session).isSystemAuth();
   }
 
   protected abstract List<AspectValidationException> validateItems(

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.aspect.validation;
 
 import static com.linkedin.metadata.Constants.DOMAINS_ASPECT_NAME;
-import static com.linkedin.metadata.Constants.SYSTEM_ACTOR;
 
 import com.datahub.authorization.AuthorizationSession;
 import com.datahub.context.OperationFingerprint;
@@ -213,10 +212,10 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
       return false;
     }
     OperationContext opContext = (OperationContext) session;
+    // Async MCE re-processing has no request context; auth already ran on the API thread.
     if (opContext.getRequestContext() == null) {
       return true;
     }
-    Urn actor = opContext.getSessionActorContext().getActorUrn();
-    return actor != null && SYSTEM_ACTOR.equals(actor.toString());
+    return opContext.isSystemAuth();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
@@ -169,6 +169,26 @@ public class PrivilegeConstraintsValidatorTest {
     Assert.assertTrue(exception.getMessage().contains("No authentication details found"));
   }
 
+  /** Null fingerprint (AspectsBatchImpl.build(null)) must fail closed, not NPE. */
+  @Test
+  public void testValidateGlobalTagsWithNullFingerprintFailsClosed() {
+    GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
+    BatchItem item =
+        TestMCP.ofOneUpsertItem(TEST_DATASET_URN, globalTags, TEST_REGISTRY).stream()
+            .findFirst()
+            .get();
+
+    AspectValidationException exception =
+        validator
+            .validateProposedAspectsWithAuth(
+                null, Collections.singletonList(item), retrieverContext, null)
+            .findFirst()
+            .orElse(null);
+
+    Assert.assertNotNull(exception);
+    Assert.assertTrue(exception.getMessage().contains("No authentication details found"));
+  }
+
   @Test
   public void testValidateGlobalTagsAuthorized() {
     GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/PrivilegeConstraintsValidatorTest.java
@@ -949,9 +949,9 @@ public class PrivilegeConstraintsValidatorTest {
     Assert.assertTrue(result.findAny().isPresent());
   }
 
-  /** Test that system update source items are skipped during validation. */
+  /** System auth fingerprint skips tag privilege checks (upgrade / system-mediated writes). */
   @Test
-  public void testValidateGlobalTagsWithSystemUpdateSourceSkipped() {
+  public void testValidateGlobalTagsWithSystemAuthSkipped() {
     GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
     TestMCP item =
         TestMCP.ofOneUpsertItem(TEST_DATASET_URN, globalTags, TEST_REGISTRY).stream()
@@ -959,17 +959,9 @@ public class PrivilegeConstraintsValidatorTest {
             .findFirst()
             .get();
 
-    // Set system update source in system metadata
-    SystemMetadata systemMetadata = new SystemMetadata();
-    StringMap properties = new StringMap();
-    properties.put(APP_SOURCE, SYSTEM_UPDATE_SOURCE);
-    systemMetadata.setProperties(properties);
-    item.setSystemMetadata(systemMetadata);
-
-    // System update source items should be skipped, no authorization check needed
     Stream<AspectValidationException> result =
         validator.validateProposedAspectsWithAuth(
-            OperationFingerprint.EMPTY,
+            systemAuthFingerprint(),
             Collections.singletonList(item),
             retrieverContext,
             mockAuthSession);
@@ -977,9 +969,13 @@ public class PrivilegeConstraintsValidatorTest {
     Assert.assertTrue(result.findAny().isEmpty());
   }
 
-  /** Test that system update source items are skipped even with null session. */
+  /**
+   * #15960 escape hatch: upgrades historically had a null AuthorizationSession. Trust must come
+   * from {@link OperationFingerprint#isSystemAuth()}, not from client-writable appSource — so a
+   * system fingerprint alone (null session) still skips aspect auth.
+   */
   @Test
-  public void testValidateGlobalTagsWithSystemUpdateSourceAndNullSession() {
+  public void testValidateGlobalTagsWithSystemAuthAndNullSessionSkipped() {
     GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
     TestMCP item =
         TestMCP.ofOneUpsertItem(TEST_DATASET_URN, globalTags, TEST_REGISTRY).stream()
@@ -987,20 +983,109 @@ public class PrivilegeConstraintsValidatorTest {
             .findFirst()
             .get();
 
-    // Set system update source in system metadata
+    Stream<AspectValidationException> result =
+        validator.validateProposedAspectsWithAuth(
+            systemAuthFingerprint(), Collections.singletonList(item), retrieverContext, null);
+
+    Assert.assertTrue(result.findAny().isEmpty());
+  }
+
+  /**
+   * Client-supplied appSource=systemUpdate alone must not skip auth (even with null session).
+   * Upgrade paths must pass a system OperationContext as fingerprint/session.
+   */
+  @Test
+  public void testValidateGlobalTagsWithSystemUpdateSourceAndNullSessionFailsClosed() {
+    GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
+    TestMCP item =
+        TestMCP.ofOneUpsertItem(TEST_DATASET_URN, globalTags, TEST_REGISTRY).stream()
+            .map(i -> (TestMCP) i)
+            .findFirst()
+            .get();
+
     SystemMetadata systemMetadata = new SystemMetadata();
     StringMap properties = new StringMap();
     properties.put(APP_SOURCE, SYSTEM_UPDATE_SOURCE);
     systemMetadata.setProperties(properties);
     item.setSystemMetadata(systemMetadata);
 
-    // System update source items should be skipped even with null session
-    // This ensures upgrade steps can process tags without failing on auth
     Stream<AspectValidationException> result =
         validator.validateProposedAspectsWithAuth(
             OperationFingerprint.EMPTY, Collections.singletonList(item), retrieverContext, null);
 
-    Assert.assertTrue(result.findAny().isEmpty());
+    Assert.assertTrue(result.findAny().isPresent());
+  }
+
+  /** Spoof regression: appSource=systemUpdate with a non-system session still validates. */
+  @Test
+  public void testValidateGlobalTagsWithSpoofedSystemUpdateSourceStillValidated() {
+    GlobalTags globalTags = createGlobalTags(TEST_TAG_URN);
+    TestMCP item =
+        TestMCP.ofOneUpsertItem(TEST_DATASET_URN, globalTags, TEST_REGISTRY).stream()
+            .map(i -> (TestMCP) i)
+            .findFirst()
+            .get();
+
+    SystemMetadata systemMetadata = new SystemMetadata();
+    StringMap properties = new StringMap();
+    properties.put(APP_SOURCE, SYSTEM_UPDATE_SOURCE);
+    systemMetadata.setProperties(properties);
+    item.setSystemMetadata(systemMetadata);
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAPIAuthorizedForTagModification(
+                    any(AuthorizationSession.class), any(Urn.class), any(), any()))
+        .thenReturn(false);
+
+    Stream<AspectValidationException> result =
+        validator.validateProposedAspectsWithAuth(
+            OperationFingerprint.EMPTY,
+            Collections.singletonList(item),
+            retrieverContext,
+            mockAuthSession);
+
+    Assert.assertTrue(result.findAny().isPresent());
+  }
+
+  private static OperationFingerprint systemAuthFingerprint() {
+    return new OperationFingerprint() {
+      @Override
+      public Urn getActor() {
+        return OperationFingerprint.EMPTY.getActor();
+      }
+
+      @Override
+      public String getRequestID() {
+        return "system";
+      }
+
+      @Override
+      public AuditStamp getAuditStamp() {
+        return OperationFingerprint.EMPTY.getAuditStamp();
+      }
+
+      @Override
+      public String getGlobalContextId() {
+        return "system";
+      }
+
+      @Override
+      public String getSearchContextId() {
+        return "system";
+      }
+
+      @Override
+      public String getEntityContextId() {
+        return "system";
+      }
+
+      @Override
+      public boolean isSystemAuth() {
+        return true;
+      }
+    };
   }
 
   /** Test that items without system metadata properties still get validated. */

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -409,10 +409,10 @@ public class OperationContext implements AuthorizationSession, OperationFingerpr
   }
 
   /**
-   * Whether default authentication is system level
-   *
-   * @return
+   * Whether default authentication is system level. Implements {@link
+   * com.datahub.context.OperationFingerprint#isSystemAuth()}.
    */
+  @Override
   public boolean isSystemAuth() {
     return operationContextConfig.isAllowSystemAuthentication()
         && sessionActorContext.isSystemAuth();


### PR DESCRIPTION
## Summary

Fixes [PFP-5736](https://linear.app/acryl-data/issue/PFP-5736/high-aspectpayloadvalidator-authorization-bypass-via-client-controlled): aspect authorization validators skipped checks when `systemMetadata.properties.appSource=systemUpdate`, a value clients can set on OpenAPI / Rest.li / GraphQL `patchEntity`.

- Trust only `OperationFingerprint` / `OperationContext.isSystemAuth()` (configured system principal), not client-writable `appSource` or a hardcoded `SYSTEM_ACTOR` URN
- Strip reserved `appSource=systemUpdate` for non-system writers in `AspectsBatchImpl.build`
- Pass system `opContext` into `AbstractMCPStep` `validateProposed` pre-filter (was `null`)
- Regression tests for spoofing, system-auth skip, and system fingerprint + null session (the #15960 upgrade escape hatch)

## Test plan

- [x] `./gradlew :entity-registry:test --tests CorpUserPrivilegedFlagsValidatorTest --tests SystemMetadataUtilsTest`
- [x] `./gradlew :metadata-io:test --tests PrivilegeConstraintsValidatorTest --tests DomainWriteAuthorizationValidatorTest`
- [x] Spotless on touched modules
- [ ] Optional: live PoC from PFP-5736 (OpenAPI corpuser write with spoofed `appSource=systemUpdate`) against a running instance — expect 403


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop trusting client systemMetadata.properties.appSource=systemUpdate for aspect authorization; only operations authenticated as the system principal skip validators. Old: appSource=systemUpdate bypassed checks; new: only isSystemAuth() does, null fingerprints/sessions fail closed; appSource and SYSTEM_ACTOR stamps are ignored; corp-user privileged-flag lookups use a null-safe EMPTY fingerprint for reads only.

- **Review focus**
  - `metadata-io`: `AbstractAspectAuthorizationValidator` gates on null-safe isSystemAuth() via isTrustedSystemOperation(...); removes appSource-based skips. `DomainWriteAuthorizationValidator` skips for async reprocessing (no request context) and when `OperationContext.isSystemAuth()` is true.
  - `metadata-io-api`: `AspectsBatchImpl.build` strips reserved appSource=systemUpdate for non-system operations and updates `MCPItem` system metadata.
  - `entity-registry`: `CorpUserPrivilegedFlagsValidator` trusts only `OperationFingerprint.isSystemAuth()`; uses `OperationFingerprint.EMPTY` for lookups when the batch lacks an `OperationContext` and still treats null fingerprints as untrusted.
  - `li-utils` and `metadata-operation-context`: add `OperationFingerprint.isSystemAuth()` default; `OperationContext` implements it.
  - `upgrade`: `AbstractMCPStep` passes `opContext` into `validateProposed` so system-auth upgrades still skip validation. Tests cover spoofed appSource, true system-auth, and null fingerprint/session behavior.

- **Rollout/migration**
  - Ensure upgrade jobs and system-mediated writes run with a system `OperationContext` so `isSystemAuth()` is true; null fingerprints/sessions are untrusted.
  - Clients must not set appSource=systemUpdate; it is stripped and ignored.

<sup>Written for commit 6f4a97e0384ed983b113d5dca47a0d9296e6ca63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

