### PR TITLE
fix(ingest): dispatch CLI telemetry off the startup critical path

### DIFF
--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -1,9 +1,12 @@
+import atexit
 import errno
 import json
 import logging
 import os
 import platform
+import queue
 import sys
+import threading
 import uuid
 from functools import wraps
 from pathlib import Path
@@ -120,6 +123,93 @@ def _default_global_properties() -> Dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Background telemetry dispatch
+#
+# Telemetry must never sit on the CLI's critical path. A *refused* connection to
+# the collector fails fast, but a *dropped* one -- a corporate proxy, firewall,
+# airgap, or any network that blackholes egress rather than rejecting it --
+# blocks for the full socket timeout on every call. Sending synchronously
+# therefore stalls startup by minutes on such networks, and silently, since it
+# is all logged at DEBUG.
+#
+# So we enqueue each send and drain it on a single daemon worker. Enqueue is
+# non-blocking and sheds load when the queue is full, so the caller never waits
+# on the network regardless of its state. At exit we flush with a small bounded
+# timeout, then abandon anything still in flight: losing best-effort telemetry
+# is fine, a multi-minute hang is not.
+# ---------------------------------------------------------------------------
+
+# The CLI emits only a handful of events per invocation, so a small bound is
+# plenty; it caps memory if the collector is unreachable and the worker stalls.
+_TELEMETRY_QUEUE_MAX_SIZE = 100
+
+# Upper bound on how long process exit waits for in-flight telemetry to drain.
+_TELEMETRY_EXIT_FLUSH_SECONDS = 1.0
+
+_telemetry_queue: queue.Queue = queue.Queue(maxsize=_TELEMETRY_QUEUE_MAX_SIZE)
+_telemetry_worker_thread: Optional[threading.Thread] = None
+_telemetry_worker_lock = threading.Lock()
+_TELEMETRY_STOP = object()
+
+
+def _telemetry_worker_loop() -> None:
+    while True:
+        task = _telemetry_queue.get()
+        if task is _TELEMETRY_STOP:
+            return
+        try:
+            task()
+        except Exception as e:
+            logger.debug(f"Error reporting telemetry: {e}")
+
+
+def _shutdown_telemetry_worker() -> None:
+    thread = _telemetry_worker_thread
+    if thread is None:
+        return
+    try:
+        _telemetry_queue.put_nowait(_TELEMETRY_STOP)
+    except queue.Full:
+        # Worker is still busy, most likely stuck on a dropped connection. It is a
+        # daemon thread, so the interpreter reaps it on exit; don't wait on it.
+        return
+    thread.join(timeout=_TELEMETRY_EXIT_FLUSH_SECONDS)
+
+
+def _ensure_telemetry_worker() -> None:
+    global _telemetry_worker_thread
+    if _telemetry_worker_thread is not None:
+        return
+    with _telemetry_worker_lock:
+        if _telemetry_worker_thread is not None:
+            return
+        thread = threading.Thread(
+            target=_telemetry_worker_loop, name="datahub-telemetry", daemon=True
+        )
+        thread.start()
+        _telemetry_worker_thread = thread
+        atexit.register(_shutdown_telemetry_worker)
+
+
+def _dispatch_telemetry(task: Callable[[], None]) -> None:
+    """Run a telemetry send on the background worker; never blocks the caller.
+
+    Starts the worker on first use and drops the event if the queue is full, so a
+    slow or blackholed collector can't stall the CLI's critical path. Never raises:
+    telemetry must not break the caller, so even a failed worker start is swallowed.
+    """
+    try:
+        _ensure_telemetry_worker()
+        _telemetry_queue.put_nowait(task)
+    except queue.Full:
+        logger.debug("Telemetry queue full, dropping event")
+    except Exception as e:
+        # Telemetry must never break the caller: swallow anything (e.g. a failed
+        # worker-thread start) rather than let it propagate into a CLI command.
+        logger.debug(f"Error dispatching telemetry: {e}")
+
+
 class Telemetry:
     client_id: str
     enabled: bool = True
@@ -165,7 +255,13 @@ class Telemetry:
                 self.mp = Mixpanel(
                     MIXPANEL_TOKEN,
                     consumer=Consumer(
-                        request_timeout=int(TIMEOUT), api_host=MIXPANEL_ENDPOINT
+                        request_timeout=int(TIMEOUT),
+                        api_host=MIXPANEL_ENDPOINT,
+                        # Telemetry is best-effort: never retry a failed send. The
+                        # mixpanel default (retry_limit=4 -> 5 attempts) turns a
+                        # dropped connection into 5x the timeout; the background
+                        # worker below relies on each send failing fast instead.
+                        retry_limit=0,
                     ),
                 )
             except Exception as e:
@@ -313,14 +409,14 @@ class Telemetry:
             return
 
         logger.debug("Sending init telemetry")
-        try:
-            self.mp.people_set(
-                self.client_id,
-                self.global_properties,
-            )
-        except Exception as e:
-            logger.debug(f"Error initializing telemetry: {e}")
-        self.init_track = True
+        mp = self.mp
+        client_id = self.client_id
+        # Snapshot: global_properties is mutated elsewhere (add_global_property and
+        # the lazy "caller" population in ping) and would otherwise be read by the
+        # worker thread mid-send.
+        properties = dict(self.global_properties)
+        _dispatch_telemetry(lambda: mp.people_set(client_id, properties))
+        self.tracking_init = True
 
     def ping(
         self,
@@ -358,7 +454,9 @@ class Telemetry:
                 **self.context_properties,
                 **properties,
             }
-            self.mp.track(self.client_id, event_name, properties)
+            mp = self.mp
+            client_id = self.client_id
+            _dispatch_telemetry(lambda: mp.track(client_id, event_name, properties))
         except Exception as e:
             logger.debug(f"Error reporting telemetry: {e}")
 

--- a/metadata-ingestion/tests/unit/telemetry/test_async_dispatch.py
+++ b/metadata-ingestion/tests/unit/telemetry/test_async_dispatch.py
@@ -1,0 +1,176 @@
+import queue
+import threading
+import time
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+import pytest
+
+from datahub.telemetry import telemetry as t
+
+
+@pytest.fixture(autouse=True)
+def _isolate_telemetry_worker() -> Iterator[None]:
+    # Each test gets a fresh queue and no worker, so a worker started by one test
+    # can't leak its thread/atexit registration into the next.
+    t._telemetry_queue = queue.Queue(maxsize=t._TELEMETRY_QUEUE_MAX_SIZE)
+    t._telemetry_worker_thread = None
+    yield
+    t._shutdown_telemetry_worker()
+
+
+def _wait(cond: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class FakeMixpanel:
+    def __init__(self, block: Optional[threading.Event] = None) -> None:
+        self.tracked: List[Any] = []
+        self.people: List[Any] = []
+        self._block = block
+        self.called = threading.Event()
+
+    def track(
+        self, client_id: str, event_name: str, properties: Dict[str, Any]
+    ) -> None:
+        if self._block is not None:
+            self._block.wait(timeout=10)
+        self.tracked.append((client_id, event_name, properties))
+        self.called.set()
+
+    def people_set(self, client_id: str, properties: Dict[str, Any]) -> None:
+        self.people.append((client_id, properties))
+        self.called.set()
+
+
+def _enabled_telemetry(mp: FakeMixpanel) -> t.Telemetry:
+    inst = t.Telemetry.__new__(t.Telemetry)
+    inst.enabled = True
+    inst.sentry_enabled = False
+    inst.tracking_init = False
+    inst.client_id = "client-1"
+    inst.mp = mp
+    # Pre-populate "caller" so ping() doesn't shell out via identify_caller().
+    inst.global_properties = {"datahub_version": "test", "caller": "test"}
+    inst.context_properties = {}
+    return inst
+
+
+def test_ping_returns_immediately_even_when_send_blocks() -> None:
+    block = threading.Event()
+    mp = FakeMixpanel(block=block)
+    inst = _enabled_telemetry(mp)
+    try:
+        start = time.time()
+        inst.ping("test-event", {"k": "v"})
+        elapsed = time.time() - start
+        # A synchronous send would block on the fake's block.wait (~10s); the async
+        # dispatch returns instantly. The bound is generous so a slow CI runner
+        # (e.g. a rare thread-start stall) can't flake while still cleanly
+        # distinguishing async from sync.
+        assert elapsed < 4.0
+        assert not mp.called.is_set()
+    finally:
+        block.set()
+    assert _wait(mp.called.is_set)
+    assert mp.tracked[0][1] == "test-event"
+
+
+def test_ping_delivers_merged_properties() -> None:
+    mp = FakeMixpanel()
+    inst = _enabled_telemetry(mp)
+    inst.ping("evt", {"k": "v"})
+    assert _wait(mp.called.is_set)
+    client_id, event_name, props = mp.tracked[0]
+    assert client_id == "client-1"
+    assert event_name == "evt"
+    assert props["k"] == "v"
+    assert props["datahub_version"] == "test"
+
+
+def test_init_tracking_dispatches_people_set_once() -> None:
+    mp = FakeMixpanel()
+    inst = _enabled_telemetry(mp)
+    inst.init_tracking()
+    inst.init_tracking()  # second call must be a no-op (dedup guard)
+    assert _wait(mp.called.is_set)
+    assert _wait(lambda: len(mp.people) == 1)
+    time.sleep(0.05)
+    assert len(mp.people) == 1
+    assert inst.tracking_init is True
+
+
+def test_disabled_telemetry_starts_no_worker() -> None:
+    mp = FakeMixpanel()
+    inst = _enabled_telemetry(mp)
+    inst.enabled = False
+    inst.ping("evt", {"k": "v"})
+    inst.init_tracking()
+    assert t._telemetry_worker_thread is None
+    assert not mp.tracked and not mp.people
+
+
+def test_dispatch_drops_when_queue_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    full_q: queue.Queue = queue.Queue(maxsize=1)
+    full_q.put_nowait(t._TELEMETRY_STOP)
+    monkeypatch.setattr(t, "_telemetry_queue", full_q)
+    # Pretend a worker is already running so no real thread is spawned.
+    monkeypatch.setattr(t, "_telemetry_worker_thread", threading.current_thread())
+
+    t._dispatch_telemetry(lambda: None)  # must not raise when full
+
+    assert full_q.qsize() == 1  # event was dropped, not enqueued
+
+
+def test_dispatch_never_raises_on_worker_start_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom() -> None:
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(t, "_ensure_telemetry_worker", boom)
+    # Telemetry must not break the caller: a failed worker start is swallowed.
+    t._dispatch_telemetry(lambda: None)
+
+
+def test_shutdown_returns_promptly_when_idle() -> None:
+    t._ensure_telemetry_worker()
+    thread = t._telemetry_worker_thread
+    assert thread is not None and thread.is_alive()
+    start = time.time()
+    t._shutdown_telemetry_worker()
+    assert time.time() - start < 1.0  # idle worker stops on the sentinel at once
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+
+
+def test_shutdown_is_bounded_when_send_is_in_flight() -> None:
+    # The core guarantee: if a send is wedged (e.g. a blackholed collector),
+    # shutdown must still return within ~_TELEMETRY_EXIT_FLUSH_SECONDS and abandon
+    # the daemon worker, rather than wait for the stuck send.
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_task() -> None:
+        started.set()
+        release.wait(timeout=30)
+
+    try:
+        t._ensure_telemetry_worker()
+        thread = t._telemetry_worker_thread
+        assert thread is not None
+        t._telemetry_queue.put_nowait(blocking_task)
+        assert started.wait(timeout=5)  # worker is now wedged mid-"send"
+
+        start = time.time()
+        t._shutdown_telemetry_worker()
+        elapsed = time.time() - start
+
+        assert elapsed < t._TELEMETRY_EXIT_FLUSH_SECONDS + 1.0
+        assert thread.is_alive()  # abandoned as a daemon, not joined to completion
+    finally:
+        release.set()


### PR DESCRIPTION
## Problem

DataHub CLI telemetry is sent **synchronously on the startup critical path**. When the mixpanel collector (`track.datahubproject.io`) _drops_ packets rather than refusing them — any corporate proxy, firewall, airgap, or restrictive VPC that blackholes egress — each send blocks for the full socket timeout.

With mixpanel's default of 5 attempts (`retry_limit=4`) at a 10s timeout, that is **~53s per call** (5 × 10s + urllib3 backoff). A single command makes several telemetry calls (one `people_set` + two `track`), so **startup silently hangs for ~2–3.5 minutes**. Because it is all logged at `DEBUG`, the user just sees an unexplained pause, then normal operation.

A _refused_ connection fails fast and is harmless. A _dropped_ one is the problem, and for any environment behind a default-drop egress policy it recurs on **every single invocation**, indefinitely — which also makes it near-impossible to self-diagnose: the CLI works and produces correct results, it is just inexplicably slow to start.

## Fix

Move telemetry off the critical path:

- **Enqueue each send** on a small bounded queue drained by a single daemon worker. Enqueue is non-blocking (`put_nowait`, drops on backpressure), so the caller never waits on the network regardless of its state. At process exit we flush with a bounded ~1s timeout, then abandon anything still in flight — losing best-effort telemetry is fine, a multi-minute hang is not.
- **`retry_limit=0`** on the mixpanel `Consumer` — best-effort analytics should never retry a failed send, and it keeps the worker cycling instead of pinned on a dead endpoint.
- Fix a latent typo where `init_tracking()` set `self.init_track` instead of `self.tracking_init`, so the one-time "engage" call now actually dedups.

The worker starts lazily on first dispatch, so when telemetry is disabled (CI, `DATAHUB_TELEMETRY_ENABLED=false`, custom metadata package) no thread is ever created. `DATAHUB_TELEMETRY_TIMEOUT` still applies (now to the background worker).

## Verification

- Measured against a blackholed endpoint (non-routable TEST-NET IP, the CLI's exact mixpanel config): `init_tracking` + 4 `ping`s now return in **~0.00s** on the caller (previously ~3.5 min synchronously).
- Adds focused unit tests (`tests/unit/telemetry/test_async_dispatch.py`): non-blocking dispatch, event delivery, init dedup, drop-on-full backpressure, and worker shutdown.

## Checklist

- [x] Conforms to the Contributing Guideline (Conventional Commit title: `fix(ingest): …`)
- [ ] Links to related issues (n/a)
- [x] Tests added
- [ ] Docs — n/a (internal reliability fix, no user-facing API or config change)
- [ ] Breaking change — none; telemetry semantics are unchanged, only made non-blocking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispatches CLI telemetry off the startup critical path to prevent multi‑minute hangs when egress is dropped. Old: synchronous sends with retries blocked startup; New: background, non‑blocking dispatch with no retries and a bounded exit flush.

- Enqueue sends on a bounded queue (size 100) drained by one daemon worker; enqueue is non‑blocking and drops on backpressure.
- Set retry_limit=0 on the Mixpanel consumer; request timeout still comes from DATAHUB_TELEMETRY_TIMEOUT.
- Flush in‑flight telemetry at process exit with ~1s bound; abandon pending work after the timeout.
- Lazy worker start; no thread when telemetry is disabled. Fix dedup and race: init_tracking() now uses tracking_init and snapshots properties.
- Add unit tests for non‑blocking dispatch, property merge and delivery, drop‑on‑full, disabled‑telemetry no‑thread, and bounded shutdown. No user‑facing API/config changes; telemetry may be dropped and failed sends are not retried.

<sup>Written for commit 0c2d3fab8dee2d8eade0d4f58b74034c6721289e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

