### PR TITLE
feat(cli): attribute CLI traffic to the invoking agent skill

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,7 @@ Options:
                                   printing sensitive information like passwords, this may still happen.
   --version                       Show the version and exit.
   -dl, --detect-memory-leaks      Run memory leak detection.
+  -C, --context KEY=VALUE         Additional context as key=value pairs (can be repeated).
   --help                          Show this message and exit.
 
 Commands:
@@ -106,6 +107,26 @@ Commands:
 
 The following top-level commands listed below are here mainly to give the reader a high-level picture of what are the kinds of things you can accomplish with the cli.
 We've ordered them roughly in the order we expect you to interact with these commands as you get deeper into the `datahub`-verse.
+
+### Attributing traffic to an agent skill
+
+When an AI agent drives the CLI, pass `-C skill=<name>` on the root command so the
+requests can be attributed to the skill that made them:
+
+```shell
+datahub -C skill=datahub-search search "revenue"
+```
+
+The skill name becomes the client component in the `User-Agent` header every request
+carries, alongside the automatically detected caller:
+
+```
+User-Agent: DataHub-Client/1.0 (cli; skill-datahub-search/claude-code; 1.7.0)
+```
+
+It takes precedence over the `DATAHUB_COMPONENT` environment variable for the
+commands it is passed to, and is normalized (lowercased, non-alphanumerics collapsed
+to `-`) before it is sent. No skill information is recorded when the flag is omitted.
 
 ### docker
 

--- a/metadata-ingestion/src/datahub/cli/skill_context.py
+++ b/metadata-ingestion/src/datahub/cli/skill_context.py
@@ -1,0 +1,75 @@
+"""Resolve the agent skill that invoked the CLI into a client component label.
+
+Agent harnesses pass ``-C skill=<name>`` on the root command (see
+``datahub --help``). That value becomes the ``component`` half of the
+User-Agent every request carries, so server-side usage attribution can tell
+which skill drove the traffic rather than just seeing "some CLI"::
+
+    DataHub-Client/1.0 (cli; skill-datahub-search/claude-code; 1.7.0)
+
+The ``caller`` half (``claude-code`` above) is detected separately by
+:mod:`datahub.utilities.caller_context`.
+"""
+
+import logging
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Key read from the `-C key=value` pairs parsed onto the Click context.
+SKILL_CONTEXT_KEY = "skill"
+
+# Namespaces skill values so they can't collide with the components real
+# integrations report (`airflow-plugin`, `datahub`, ...).
+COMPONENT_PREFIX = "skill-"
+
+# GMS parses the User-Agent by splitting the comment group on ";" and the
+# component/caller pair on "/", so those characters (and anything else that
+# would corrupt a header) cannot survive into the component. See
+# metadata-operation-context/src/main/resources/datahub_user_agents.yaml.
+_UNSAFE_CHARS = re.compile(r"[^a-z0-9._-]+")
+
+# Long enough for any real skill name; short enough that a junk value can't
+# bloat every request's headers.
+_MAX_LENGTH = 64
+
+
+def sanitize_skill_component(raw: str) -> Optional[str]:
+    """Normalize a raw `-C skill=` value into a User-Agent-safe component.
+
+    Returns None when nothing usable is left after cleaning.
+    """
+    cleaned = _UNSAFE_CHARS.sub("-", raw.strip().lower()).strip("-")
+    if not cleaned:
+        return None
+
+    if not cleaned.startswith(COMPONENT_PREFIX):
+        cleaned = f"{COMPONENT_PREFIX}{cleaned}"
+
+    return cleaned[:_MAX_LENGTH].rstrip("-")
+
+
+def infer_skill_component() -> Optional[str]:
+    """Component label for the skill that invoked this CLI process, if any.
+
+    Returns None outside the CLI (no Click context) and when no `-C skill=`
+    pair was passed, which leaves the component resolving to DATAHUB_COMPONENT
+    exactly as before.
+    """
+    try:
+        import click
+
+        ctx = click.get_current_context(silent=True)
+        if ctx is None or not isinstance(ctx.obj, dict):
+            return None
+
+        raw = (ctx.obj.get("context") or {}).get(SKILL_CONTEXT_KEY)
+        if not isinstance(raw, str) or not raw.strip():
+            return None
+
+        return sanitize_skill_component(raw)
+    except Exception as e:
+        # Attribution is best-effort telemetry; it must never fail a command.
+        logger.debug(f"Could not resolve skill attribution context: {e}")
+        return None

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -30,6 +30,7 @@ from typing_extensions import deprecated
 
 from datahub.cli import config_utils
 from datahub.cli.cli_utils import guess_frontend_url_from_gms_url
+from datahub.cli.skill_context import infer_skill_component
 from datahub.configuration.common import ConfigModel, GraphError, OperationalError
 from datahub.emitter.aspect import TIMESERIES_ASPECT_MAP
 from datahub.emitter.mce_builder import DEFAULT_ENV, Aspect
@@ -2415,7 +2416,14 @@ def get_default_graph(
 ) -> DataHubGraph:
     graph_config = config_utils.load_client_config()
     graph_config.client_mode = client_mode
-    graph_config.datahub_component = datahub_component
+    # `-C skill=<name>` on the root command attributes every request this
+    # process makes to the invoking agent skill. Resolved here rather than at
+    # each call site so commands are attributed without opting in one by one.
+    # The value is parsed once on the root group and fixed for the life of a
+    # CLI process, so leaving it out of the lru_cache key can't serve a stale
+    # component. An explicit argument still wins, as does DATAHUB_COMPONENT
+    # when neither is set (resolved downstream in the emitter).
+    graph_config.datahub_component = datahub_component or infer_skill_component()
     graph = DataHubGraph(graph_config)
     graph.test_connection()
     telemetry_instance.set_context(server=graph)

--- a/metadata-ingestion/tests/unit/cli/test_skill_context.py
+++ b/metadata-ingestion/tests/unit/cli/test_skill_context.py
@@ -1,0 +1,72 @@
+from unittest import mock
+
+import click
+
+from datahub.cli.skill_context import infer_skill_component, sanitize_skill_component
+from datahub.ingestion.graph.config import ClientMode
+
+
+def _click_context(obj: object) -> click.Context:
+    return click.Context(click.Command("datahub"), obj=obj)
+
+
+def test_sanitize_namespaces_and_normalizes():
+    assert sanitize_skill_component("datahub-search") == "skill-datahub-search"
+    assert sanitize_skill_component("  DataHub-Search  ") == "skill-datahub-search"
+    assert sanitize_skill_component("skill-datahub-search") == "skill-datahub-search"
+
+
+def test_sanitize_strips_user_agent_breaking_characters():
+    # ";" and "/" delimit the component/caller field GMS parses out of the
+    # User-Agent, so they must never survive into the component.
+    assert sanitize_skill_component("my skill; datahub/search") == (
+        "skill-my-skill-datahub-search"
+    )
+    assert sanitize_skill_component("a\r\nb") == "skill-a-b"
+
+
+def test_sanitize_rejects_unusable_values():
+    assert sanitize_skill_component("") is None
+    assert sanitize_skill_component("   ") is None
+    assert sanitize_skill_component("!!!") is None
+
+
+def test_sanitize_truncates_long_values():
+    component = sanitize_skill_component("x" * 200)
+    assert component is not None
+    assert len(component) == 64
+
+
+def test_infer_returns_none_without_cli_context():
+    assert infer_skill_component() is None
+
+
+def test_infer_reads_skill_from_cli_context():
+    with _click_context({"context": {"skill": "datahub-lineage"}}):
+        assert infer_skill_component() == "skill-datahub-lineage"
+
+
+def test_infer_returns_none_when_other_context_pairs_passed():
+    with _click_context({"context": {"caller": "claude-code"}}):
+        assert infer_skill_component() is None
+
+
+def test_get_default_graph_attributes_the_invoking_skill():
+    from datahub.ingestion.graph import client as client_module
+
+    graph_config = mock.MagicMock()
+    with (
+        mock.patch.object(
+            client_module.config_utils, "load_client_config", return_value=graph_config
+        ),
+        mock.patch.object(client_module, "DataHubGraph"),
+        mock.patch.object(client_module.telemetry_instance, "set_context"),
+        _click_context({"context": {"skill": "datahub-enrich"}}),
+    ):
+        client_module.get_default_graph.cache_clear()
+        try:
+            client_module.get_default_graph(ClientMode.CLI)
+        finally:
+            client_module.get_default_graph.cache_clear()
+
+    assert graph_config.datahub_component == "skill-datahub-enrich"

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/RequestContextTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -570,6 +571,26 @@ public class RequestContextTest {
 
     assertEquals(context.getAgentClass(), AgentClass.ROBOT);
     assertEquals(context.getAgentName(), "DH/Automation-Client");
+  }
+
+  @Test
+  public void testRequestContextPreservesAgentSkillComponent() {
+    // `datahub -C skill=datahub-search ...` reports the skill as the component
+    // half of the User-Agent, which is what makes per-skill usage attribution
+    // possible. Compared case-insensitively because UsageDimensions lowercases
+    // the agent name before it becomes a rollup dimension.
+    when(mockHttpRequest.getHeader(HttpHeaders.USER_AGENT))
+        .thenReturn("DataHub-Client/1.0 (cli; skill-datahub-search/claude-code; 1.7.0)");
+
+    RequestContext context =
+        RequestContext.builder()
+            .buildGraphql("urn:li:corpuser:testuser", mockHttpRequest, "GetUserQuery", null)
+            .metricUtils(mockMetricUtils)
+            .build();
+
+    assertEquals(context.getAgentClass(), AgentClass.CLI);
+    assertEquals(
+        context.getAgentName().toLowerCase(Locale.ROOT), "skill-datahub-search/claude-code");
   }
 
   @Test


### PR DESCRIPTION
## What

Makes `datahub -C skill=<name>` actually attribute the requests a command makes, by resolving it into the client component of the `User-Agent` that every request already carries:

```text
User-Agent: DataHub-Client/1.0 (cli; skill-datahub-search/claude-code; 1.7.0)
```

## Why

`-C skill=` was accepted but had no effect on any command that talks to GMS. The value landed on the Click context and was read only by the `with_telemetry` decorator — which `search`, `get`, `lineage`, and `graphql` do not use. So callers following the documented convention (`docs/cli.md`, and the agent skills that were told to pass it) emitted no telemetry, and nothing reached the server either.

The server side needs no change. `RequestContext` already parses `component/caller` out of the User-Agent into `agentClass`/`agentName` (`metadata-operation-context/src/main/resources/datahub_user_agents.yaml`), and `UsageDimensions` can roll `agentName` up as the opt-in `agent_name` usage dimension. The gap was purely that the value never got there.

## How

- New `datahub/cli/skill_context.py`: reads the `skill` pair off the Click context and normalizes it into a `skill-<name>` component.
- `get_default_graph` resolves it when no explicit `datahub_component` was passed.

Resolved inside `get_default_graph` rather than at its ~70 call sites, so commands are attributed without opting in one at a time and a new command cannot forget to. The value is parsed once on the root group and fixed for the life of a CLI process, so leaving it out of the `lru_cache` key cannot serve a stale component.

**Precedence** — explicit `datahub_component` argument > `-C skill=` > `DATAHUB_COMPONENT` > `datahub`. A flag passed for one invocation is more specific than an environment default.

**Normalization** — lowercased, non-`[a-z0-9._-]` runs collapsed to `-`, capped at 64 chars. `;` and `/` delimit the field GMS parses out of the User-Agent, so an unsanitized value would corrupt parsing for the whole request.

**No behavior change when the flag is absent**: `infer_skill_component()` returns `None` outside the CLI and when no `skill` pair was passed, leaving the existing `DATAHUB_COMPONENT` resolution untouched.

## Testing

`metadata-ingestion/tests/unit/cli/test_skill_context.py` — 8 tests covering normalization, User-Agent-breaking characters, unusable values, truncation, absent Click context, unrelated `-C` pairs, and that `get_default_graph` applies the resolved component.

`RequestContextTest.testRequestContextPreservesAgentSkillComponent` — proves the server-side leg: a skill-attributed CLI User-Agent parses to `AgentClass.CLI` with the skill preserved in the agent name. (`:metadata-operation-context:test` → 46 tests, green.)

Also verified end-to-end against a local socket sniffer:

```text
-C skill=datahub-search              → (cli; skill-datahub-search/claude-code; …)
no flag                              → (cli; datahub/claude-code; …)          # unchanged
-C "skill=My Skill; a/b"             → (cli; skill-my-skill-a-b/claude-code; …)
DATAHUB_COMPONENT=my-app + -C skill= → (cli; skill-datahub-lineage/claude-code; …)
```

`./gradlew :metadata-ingestion:lintFix` and `:metadata-operation-context:spotlessApply` clean.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Links to related issues — Linear AI-1017
- [x] Tests added
- [x] Docs updated — `docs/cli.md` documents `-C/--context` (it was missing from the options block) and the attribution behavior
- [x] No breaking change — attribution is additive and inert when the flag is absent

## Related

The agent-side half is acryldata/datahub-skills#48, which adds the hooks that pass this flag automatically. This PR is independently useful: it makes the documented convention work for anyone passing it by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes CLI requests to the invoking agent skill via `-C skill=<name>` by setting the client component in the `User-Agent`, enabling per-skill usage attribution in GMS. Previously the flag was accepted but had no effect; now it takes effect without changing individual commands. Addresses Linear AI-1017.

- Implemented in `datahub.cli.skill_context` and applied centrally in `get_default_graph`, so existing commands inherit attribution with no call-site changes.
- Precedence: explicit `datahub_component` > `-C skill=` > `DATAHUB_COMPONENT` > `datahub`.
- Sanitization: lowercase, collapse non `[a-z0-9._-]` to `-`, prefix `skill-`, max 64 chars; prevents breaking `User-Agent` parsing.
- No behavior change when the flag is absent; errors in resolution are ignored; server needs no changes (parsing already supported).
- Tests cover normalization and end-to-end parsing; docs now describe `-C/--context` and the attribution behavior.

<sup>Written for commit 93c5cb4c8b3111ce383ad24793271fc4823e61f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

