### PR TITLE
feat(system-update): add progress ETA for entity-consistency scans

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
@@ -345,13 +345,20 @@ public class FixEntityConsistencyStep implements UpgradeStep {
         for (String entityType : typesToProcess) {
           log.info("Processing entity type: {}", entityType);
 
-          int[] typeResults =
+          EntityTypeProcessResult typeResults =
               processEntityType(
                   entityType, ctx, context, runStartTime, incrementalFilterTime, effectiveCheckIds);
-          totalEntitiesScanned += typeResults[0];
-          totalIssuesFound += typeResults[1];
-          totalFixed += typeResults[2];
-          totalFailed += typeResults[3];
+          if (typeResults.cancelled()) {
+            log.info(
+                "Scan interrupted during {}; preserving IN_PROGRESS checkpoints for resume",
+                entityType);
+            return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.IN_PROGRESS);
+          }
+
+          totalEntitiesScanned += typeResults.scanned();
+          totalIssuesFound += typeResults.issues();
+          totalFixed += typeResults.fixed();
+          totalFailed += typeResults.failed();
 
           // Clear caches between entity types to prevent memory buildup
           ctx.clearCaches();
@@ -475,9 +482,9 @@ public class FixEntityConsistencyStep implements UpgradeStep {
   /**
    * Process an entity type with pagination, supporting resume and incremental processing.
    *
-   * @return array of [scanned, issues, fixed, failed]
+   * @return scan counters; {@code cancelled} when interrupted during an inter-batch delay
    */
-  private int[] processEntityType(
+  private EntityTypeProcessResult processEntityType(
       String entityType,
       CheckContext ctx,
       UpgradeContext upgradeContext,
@@ -507,7 +514,7 @@ public class FixEntityConsistencyStep implements UpgradeStep {
 
       if (typeCheckIds.isEmpty()) {
         log.info("No applicable checks for entity type {}, skipping", entityType);
-        return new int[] {scanned, issues, fixed, failed};
+        return new EntityTypeProcessResult(0, 0, 0, 0, false);
       }
     }
 
@@ -621,6 +628,15 @@ public class FixEntityConsistencyStep implements UpgradeStep {
                                 : ""))
                 .build());
 
+    if (scanResult.isCancelled()) {
+      return new EntityTypeProcessResult(
+          (int) scanResult.getEntitiesScanned(),
+          scanResult.getIssuesFound(),
+          scanResult.getIssuesFixed(),
+          scanResult.getIssuesFailed(),
+          true);
+    }
+
     // Mark entity type as completed (clear IN_PROGRESS state)
     Map<String, String> doneState = new HashMap<>();
     doneState.put(KEY_ENTITIES_SCANNED, String.valueOf(scanResult.getEntitiesScanned()));
@@ -637,13 +653,16 @@ public class FixEntityConsistencyStep implements UpgradeStep {
         DataHubUpgradeState.SUCCEEDED,
         doneState);
 
-    return new int[] {
-      (int) scanResult.getEntitiesScanned(),
-      scanResult.getIssuesFound(),
-      scanResult.getIssuesFixed(),
-      scanResult.getIssuesFailed()
-    };
+    return new EntityTypeProcessResult(
+        (int) scanResult.getEntitiesScanned(),
+        scanResult.getIssuesFound(),
+        scanResult.getIssuesFixed(),
+        scanResult.getIssuesFailed(),
+        false);
   }
+
+  private record EntityTypeProcessResult(
+      int scanned, int issues, int fixed, int failed, boolean cancelled) {}
 
   /**
    * Apply fixes partitioned by per-check mode. Job-level dryRun is a ceiling.

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
@@ -585,11 +585,6 @@ public class FixEntityConsistencyStep implements UpgradeStep {
                                 + " (count-based total; time ETA appears after warmup)",
                             entityType,
                             start.getTotalEstimate());
-                      } else if (start.getTotalEstimate() != null) {
-                        log.info(
-                            "entity-check[{}]: starting scan, matchingDocs={} (entity time-ETA disabled)",
-                            entityType,
-                            start.getTotalEstimate());
                       } else {
                         log.info(
                             "entity-check[{}]: starting scan, total unknown (rate-only progress,"

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
@@ -352,7 +352,8 @@ public class FixEntityConsistencyStep implements UpgradeStep {
             log.info(
                 "Scan interrupted during {}; preserving IN_PROGRESS checkpoints for resume",
                 entityType);
-            return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.IN_PROGRESS);
+            return new DefaultUpgradeStepResult(
+                id(), DataHubUpgradeState.IN_PROGRESS, UpgradeStepResult.Action.ABORT);
           }
 
           totalEntitiesScanned += typeResults.scanned();

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/entityconsistency/FixEntityConsistencyStep.java
@@ -8,11 +8,14 @@ import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
 import com.linkedin.metadata.aspect.consistency.ConsistencyIssue;
 import com.linkedin.metadata.aspect.consistency.ConsistencyService;
 import com.linkedin.metadata.aspect.consistency.SystemMetadataFilter;
-import com.linkedin.metadata.aspect.consistency.check.CheckBatchRequest;
 import com.linkedin.metadata.aspect.consistency.check.CheckContext;
-import com.linkedin.metadata.aspect.consistency.check.CheckResult;
 import com.linkedin.metadata.aspect.consistency.check.ConsistencyCheck;
 import com.linkedin.metadata.aspect.consistency.fix.ConsistencyFixResult;
+import com.linkedin.metadata.aspect.consistency.scan.BatchHandleResult;
+import com.linkedin.metadata.aspect.consistency.scan.ConsistencyScanCheckpoint;
+import com.linkedin.metadata.aspect.consistency.scan.ConsistencyScanRequest;
+import com.linkedin.metadata.aspect.consistency.scan.ConsistencyScanResult;
+import com.linkedin.metadata.aspect.consistency.scan.ConsistencyScanRunner;
 import com.linkedin.metadata.boot.BootstrapStep;
 import com.linkedin.metadata.config.ConsistencyCheckMode;
 import com.linkedin.metadata.config.ConsistencyCheckSchedule;
@@ -61,6 +64,9 @@ public class FixEntityConsistencyStep implements UpgradeStep {
   private static final String KEY_ISSUES_FOUND = "issuesFound";
   private static final String KEY_ISSUES_FIXED = "issuesFixed";
   private static final String KEY_ISSUES_FAILED = "issuesFailed";
+  private static final String KEY_TOTAL_ESTIMATE = "totalEstimate";
+  private static final String KEY_LAST_ETA_SEC = "lastEtaSec";
+  private static final String KEY_LAST_ETA_HUMAN = "lastEtaHuman";
   private static final String KEY_RUN_START_TIME = "runStartTime";
   private static final String KEY_LAST_COMPLETED_TIME =
       ConsistencyCheckCadence.KEY_LAST_COMPLETED_TIME;
@@ -68,6 +74,7 @@ public class FixEntityConsistencyStep implements UpgradeStep {
   private final OperationContext opContext;
   private final EntityService<?> entityService;
   private final ConsistencyService consistencyService;
+  private final ConsistencyScanRunner scanRunner;
   private final EntityConsistencyConfiguration config;
   private final Clock clock;
 
@@ -91,14 +98,17 @@ public class FixEntityConsistencyStep implements UpgradeStep {
     this.opContext = opContext;
     this.entityService = entityService;
     this.consistencyService = consistencyService;
+    this.scanRunner = new ConsistencyScanRunner(consistencyService);
     this.config = config;
     this.clock = clock;
     this.configFingerprint = computeConfigFingerprint();
 
+    long progressInterval =
+        config.getProgressLogIntervalMs() > 0 ? config.getProgressLogIntervalMs() : 60_000L;
     log.info(
         "{} initialized: dryRun={}, batchSize={}, batchDelayMs={}, limit={}, gracePeriodSeconds={}, "
             + "reprocessEnabled={}, entityTypes={}, checkIds={}, filterConfig={}, fingerprint={}, targetedRun={}, "
-            + "orphanMode={}, orphanSchedule={}",
+            + "orphanMode={}, orphanSchedule={}, progressLogIntervalMs={}",
         id(),
         config.isDryRun(),
         config.getBatchSize(),
@@ -119,7 +129,8 @@ public class FixEntityConsistencyStep implements UpgradeStep {
         configFingerprint,
         isTargetedRun(),
         config.getCheckMode(EntityConsistencyConfiguration.ORPHAN_INDEX_DOCUMENT_CHECK_ID),
-        config.getCheckSchedule(EntityConsistencyConfiguration.ORPHAN_INDEX_DOCUMENT_CHECK_ID));
+        config.getCheckSchedule(EntityConsistencyConfiguration.ORPHAN_INDEX_DOCUMENT_CHECK_ID),
+        progressInterval);
   }
 
   @Override
@@ -532,73 +543,111 @@ public class FixEntityConsistencyStep implements UpgradeStep {
     // Build filter config, applying incremental filter if specified
     SystemMetadataFilterConfig effectiveFilterConfig =
         buildEffectiveFilterConfig(incrementalFilterTime);
-    // Convert to service-layer filter type
     SystemMetadataFilter serviceFilter = SystemMetadataFilter.from(effectiveFilterConfig);
+    boolean keyAspectOnly =
+        effectiveFilterConfig == null || effectiveFilterConfig.isKeyAspectOnly();
 
-    do {
-      // Fetch and check a batch for this entity type
-      CheckResult checkResult =
-          consistencyService.checkBatch(
-              opContext,
-              CheckBatchRequest.builder()
-                  .entityType(entityType)
-                  .checkIds(typeCheckIds)
-                  .batchSize(config.getBatchSize())
-                  .scrollId(scrollId)
-                  .filter(serviceFilter)
-                  .build(),
-              ctx);
+    long progressInterval =
+        config.getProgressLogIntervalMs() > 0 ? config.getProgressLogIntervalMs() : 60_000L;
+    long progressWarmup =
+        config.getProgressWarmupMs() >= 0 ? config.getProgressWarmupMs() : 30_000L;
 
-      if (checkResult.getEntitiesScanned() == 0) {
-        break;
-      }
+    final int resumeScanned = scanned;
+    final int resumeIssues = issues;
+    final int resumeFixed = fixed;
+    final int resumeFailed = failed;
+    final String resumeScrollId = scrollId;
 
-      scanned += checkResult.getEntitiesScanned();
-      issues += checkResult.getIssuesFound();
-
-      // Log and fix issues with per-check mode
-      List<ConsistencyIssue> issuesList = checkResult.getIssues();
-      if (!issuesList.isEmpty()) {
-        logIssues(issuesList);
-        int[] fixCounts = fixIssuesByMode(issuesList);
-        fixed += fixCounts[0];
-        failed += fixCounts[1];
-      }
-
-      scrollId = checkResult.getScrollId();
-
-      // Save progress after each batch (limited runs don't support resume)
-      if (!isLimitedRun()) {
-        saveProgress(
-            upgradeContext, entityType, scrollId, scanned, issues, fixed, failed, runStartTime);
-      }
-
-      // Check limit
-      if (config.getLimit() > 0 && scanned >= config.getLimit()) {
-        log.info("Reached limit of {} entities for {}", config.getLimit(), entityType);
-        break;
-      }
-
-      // Apply delay between batches
-      applyBatchDelay();
-
-    } while (scrollId != null);
+    ConsistencyScanResult scanResult =
+        scanRunner.run(
+            opContext,
+            ConsistencyScanRequest.builder()
+                .entityType(entityType)
+                .checkIds(typeCheckIds)
+                .filter(serviceFilter)
+                .batchSize(config.getBatchSize())
+                .delayMs(config.getDelayMs())
+                .limit(config.getLimit())
+                .scrollId(resumeScrollId)
+                .initialProcessed(resumeScanned)
+                .initialIssues(resumeIssues)
+                .initialFixed(resumeFixed)
+                .initialFailed(resumeFailed)
+                .progressLogIntervalMs(progressInterval)
+                .progressWarmupMs(progressWarmup)
+                .entityEtaEligible(keyAspectOnly)
+                .checkContext(ctx)
+                .onStart(
+                    start -> {
+                      if (start.isEtaEnabled() && start.getTotalEstimate() != null) {
+                        log.info(
+                            "entity-check[{}]: starting scan, ~{} entities to check"
+                                + " (count-based total; time ETA appears after warmup)",
+                            entityType,
+                            start.getTotalEstimate());
+                      } else if (start.getTotalEstimate() != null) {
+                        log.info(
+                            "entity-check[{}]: starting scan, matchingDocs={} (entity time-ETA disabled)",
+                            entityType,
+                            start.getTotalEstimate());
+                      } else {
+                        log.info(
+                            "entity-check[{}]: starting scan, total unknown (rate-only progress,"
+                                + " no time ETA)",
+                            entityType);
+                      }
+                    })
+                .onBatch(
+                    checkResult -> {
+                      List<ConsistencyIssue> issuesList = checkResult.getIssues();
+                      if (issuesList.isEmpty()) {
+                        return BatchHandleResult.none();
+                      }
+                      logIssues(issuesList);
+                      int[] fixCounts = fixIssuesByMode(issuesList);
+                      return BatchHandleResult.of(fixCounts[0], fixCounts[1]);
+                    })
+                .onCheckpoint(
+                    checkpoint -> {
+                      if (!isLimitedRun()) {
+                        saveProgress(upgradeContext, entityType, checkpoint, runStartTime);
+                      }
+                    })
+                .onProgress(progress -> log.info("{}", progress.getMessage()))
+                .onComplete(
+                    result ->
+                        log.info(
+                            "Completed {}: {} entities scanned, {} issues found{}",
+                            entityType,
+                            result.getEntitiesScanned(),
+                            result.getIssuesFound(),
+                            result.getTotalEstimate() != null
+                                ? " (~" + result.getTotalEstimate() + " entities estimated)"
+                                : ""))
+                .build());
 
     // Mark entity type as completed (clear IN_PROGRESS state)
+    Map<String, String> doneState = new HashMap<>();
+    doneState.put(KEY_ENTITIES_SCANNED, String.valueOf(scanResult.getEntitiesScanned()));
+    doneState.put(KEY_ISSUES_FOUND, String.valueOf(scanResult.getIssuesFound()));
+    doneState.put(KEY_ISSUES_FIXED, String.valueOf(scanResult.getIssuesFixed()));
+    doneState.put(KEY_ISSUES_FAILED, String.valueOf(scanResult.getIssuesFailed()));
+    if (scanResult.getTotalEstimate() != null) {
+      doneState.put(KEY_TOTAL_ESTIMATE, String.valueOf(scanResult.getTotalEstimate()));
+    }
     BootstrapStep.setUpgradeResult(
         opContext,
         getUpgradeIdUrn(entityType),
         entityService,
         DataHubUpgradeState.SUCCEEDED,
-        Map.of(
-            KEY_ENTITIES_SCANNED, String.valueOf(scanned),
-            KEY_ISSUES_FOUND, String.valueOf(issues),
-            KEY_ISSUES_FIXED, String.valueOf(fixed),
-            KEY_ISSUES_FAILED, String.valueOf(failed)));
+        doneState);
 
-    log.info("Completed {}: {} entities scanned, {} issues found", entityType, scanned, issues);
-
-    return new int[] {scanned, issues, fixed, failed};
+    return new int[] {
+      (int) scanResult.getEntitiesScanned(),
+      scanResult.getIssuesFound(),
+      scanResult.getIssuesFixed(),
+      scanResult.getIssuesFailed()
+    };
   }
 
   /**
@@ -715,27 +764,32 @@ public class FixEntityConsistencyStep implements UpgradeStep {
     return effective;
   }
 
-  /** Save progress state for resume capability. */
+  /** Save progress state for resume capability (silent — no INFO log). */
   private void saveProgress(
       UpgradeContext upgradeContext,
       String entityType,
-      @Nullable String scrollId,
-      int scanned,
-      int issues,
-      int fixed,
-      int failed,
+      @Nonnull ConsistencyScanCheckpoint checkpoint,
       long runStartTime) {
 
     Map<String, String> state = new HashMap<>();
     state.put(KEY_CURRENT_ENTITY_TYPE, entityType);
-    if (scrollId != null) {
-      state.put(KEY_SCROLL_ID, scrollId);
+    if (checkpoint.getScrollId() != null) {
+      state.put(KEY_SCROLL_ID, checkpoint.getScrollId());
     }
-    state.put(KEY_ENTITIES_SCANNED, String.valueOf(scanned));
-    state.put(KEY_ISSUES_FOUND, String.valueOf(issues));
-    state.put(KEY_ISSUES_FIXED, String.valueOf(fixed));
-    state.put(KEY_ISSUES_FAILED, String.valueOf(failed));
+    state.put(KEY_ENTITIES_SCANNED, String.valueOf(checkpoint.getEntitiesScanned()));
+    state.put(KEY_ISSUES_FOUND, String.valueOf(checkpoint.getIssuesFound()));
+    state.put(KEY_ISSUES_FIXED, String.valueOf(checkpoint.getIssuesFixed()));
+    state.put(KEY_ISSUES_FAILED, String.valueOf(checkpoint.getIssuesFailed()));
     state.put(KEY_RUN_START_TIME, String.valueOf(runStartTime));
+    if (checkpoint.getProgress().getTotal() != null) {
+      state.put(KEY_TOTAL_ESTIMATE, String.valueOf(checkpoint.getProgress().getTotal()));
+    }
+    if (checkpoint.getProgress().getEtaSeconds() != null) {
+      state.put(KEY_LAST_ETA_SEC, String.valueOf(checkpoint.getProgress().getEtaSeconds()));
+    }
+    if (checkpoint.getProgress().getEtaHuman() != null) {
+      state.put(KEY_LAST_ETA_HUMAN, checkpoint.getProgress().getEtaHuman());
+    }
 
     // Save per-entity-type progress
     upgradeContext
@@ -807,18 +861,6 @@ public class FixEntityConsistencyStep implements UpgradeStep {
           issue.getEntityUrn(),
           issue.getCheckId(),
           issue.getDescription());
-    }
-  }
-
-  /** Apply delay between batches if configured. */
-  private void applyBatchDelay() {
-    if (config.getDelayMs() > 0) {
-      try {
-        Thread.sleep(config.getDelayMs());
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        log.warn("Batch delay interrupted");
-      }
     }
   }
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 import org.apache.lucene.search.TotalHits;
 import org.mockito.ArgumentCaptor;
@@ -937,6 +938,80 @@ public class FixEntityConsistencyStepTest {
             any(Urn.class),
             any(EntityService.class),
             eq(DataHubUpgradeState.IN_PROGRESS),
+            any(Map.class));
+  }
+
+  /** Interrupt during inter-batch delay preserves IN_PROGRESS and does not mark SUCCEEDED. */
+  @Test
+  public void testInterruptDuringDelayPreservesInProgress() throws Exception {
+    FixEntityConsistencyStep step =
+        new FixEntityConsistencyStep(
+            mockOpContext,
+            mockEntityService,
+            consistencyService,
+            createTestConfig(false, 10, 60_000, 0, false, List.of(ASSERTION_ENTITY_NAME), null));
+
+    UpgradeContext mockContext = mock(UpgradeContext.class);
+    Upgrade mockUpgrade = mock(Upgrade.class);
+    UpgradeReport mockReport = mock(UpgradeReport.class);
+    when(mockContext.upgrade()).thenReturn(mockUpgrade);
+    when(mockContext.report()).thenReturn(mockReport);
+    when(mockContext.opContext()).thenReturn(mockOpContext);
+    when(mockUpgrade.getUpgradeResult(any(), any(Urn.class), any())).thenReturn(Optional.empty());
+
+    when(mockEsSystemMetadataDAO.count(any(), any(BoolQueryBuilder.class), anyBoolean()))
+        .thenReturn(Optional.of(1L));
+
+    Urn assertionUrn = UrnUtils.getUrn("urn:li:assertion:test-assertion");
+    Urn validEntityUrn = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:test,test,PROD)");
+    SearchResponse assertionSearchResponse = createSearchResponseWithUrns(assertionUrn.toString());
+    when(mockEsSystemMetadataDAO.scroll(
+            any(OperationContext.class),
+            any(BoolQueryBuilder.class),
+            anyBoolean(),
+            any(),
+            any(),
+            anyString(),
+            anyInt()))
+        .thenReturn(assertionSearchResponse);
+
+    AssertionInfo assertionInfo = new AssertionInfo();
+    EnvelopedAspectMap aspects = new EnvelopedAspectMap();
+    aspects.put(
+        ASSERTION_INFO_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(assertionInfo.data())));
+    EntityResponse assertionResponse = new EntityResponse();
+    assertionResponse.setUrn(assertionUrn);
+    assertionResponse.setEntityName(ASSERTION_ENTITY_NAME);
+    assertionResponse.setAspects(aspects);
+
+    when(mockEntityService.getEntitiesV2(
+            any(OperationContext.class),
+            eq(ASSERTION_ENTITY_NAME),
+            any(Set.class),
+            any(Set.class),
+            anyBoolean()))
+        .thenReturn(Map.of(assertionUrn, assertionResponse));
+    when(mockEntityService.exists(any(OperationContext.class), any(Set.class), anyBoolean()))
+        .thenReturn(Set.of(validEntityUrn));
+    when(mockEntityService.exists(any(OperationContext.class), any(Urn.class), anyBoolean()))
+        .thenReturn(true);
+
+    AtomicReference<UpgradeStepResult> resultHolder = new AtomicReference<>();
+    Thread runnerThread = new Thread(() -> resultHolder.set(step.executable().apply(mockContext)));
+    runnerThread.start();
+    Thread.sleep(300);
+    runnerThread.interrupt();
+    runnerThread.join(10_000);
+
+    assertFalse(runnerThread.isAlive());
+    assertEquals(resultHolder.get().result(), DataHubUpgradeState.IN_PROGRESS);
+    verify(mockUpgrade, never())
+        .setUpgradeResult(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(EntityService.class),
+            eq(DataHubUpgradeState.SUCCEEDED),
             any(Map.class));
   }
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
@@ -1006,6 +1006,7 @@ public class FixEntityConsistencyStepTest {
 
     assertFalse(runnerThread.isAlive());
     assertEquals(resultHolder.get().result(), DataHubUpgradeState.IN_PROGRESS);
+    assertEquals(resultHolder.get().action(), UpgradeStepResult.Action.ABORT);
     verify(mockUpgrade, never())
         .setUpgradeResult(
             any(OperationContext.class),

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/entityconsistency/FixEntityConsistencyStepTest.java
@@ -125,6 +125,9 @@ public class FixEntityConsistencyStepTest {
     consistencyService =
         new ConsistencyService(
             mockEntityService, mockEsSystemMetadataDAO, null, checkRegistry, fixRegistry);
+
+    // Soft-fail count for ETA (scan runner calls countMatching once per entity type)
+    when(mockEsSystemMetadataDAO.count(any(), any(), anyBoolean())).thenReturn(Optional.empty());
   }
 
   /** Helper method to create a mock ConsistencyCheck for testing. */

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -42,7 +43,8 @@ import org.opensearch.search.SearchHit;
  * upgrade jobs) are responsible for:
  *
  * <ul>
- *   <li>Looping through batches
+ *   <li>Looping through batches (or use {@link
+ *       com.linkedin.metadata.aspect.consistency.scan.ConsistencyScanRunner} for full scans)
  *   <li>Managing batch size and delays
  *   <li>Handling pagination via scrollId
  * </ul>
@@ -50,8 +52,10 @@ import org.opensearch.search.SearchHit;
  * <p>Key methods:
  *
  * <ul>
- *   <li>{@link #checkBatch(OperationContext, String, List, int, String, SystemMetadataFilterConfig,
- *       CheckContext)} - Run checks for a single entity type
+ *   <li>{@link #checkBatch(OperationContext, CheckBatchRequest, CheckContext)} - Run checks for a
+ *       single entity type batch
+ *   <li>{@link #countMatching(OperationContext, CheckBatchRequest)} - Estimate matching SM docs for
+ *       progress/ETA
  *   <li>{@link #fixIssues} - Apply fixes to a list of issues
  * </ul>
  *
@@ -276,6 +280,36 @@ public class ConsistencyService {
    * @throws IllegalArgumentException if checkIds span multiple entity types or if neither
    *     entityType nor checkIds is provided
    */
+  /**
+   * Count system-metadata documents matching the same discovery query used by {@link #checkBatch}.
+   *
+   * <p>With {@code keyAspectOnly=true} (upgrade default), the count approximates unique entities.
+   * Soft-fails to empty on ES errors so callers can continue rate-only without a fake ETA.
+   *
+   * @param opContext operation context
+   * @param request same shape as checkBatch (entity type, check IDs, filter, URNs)
+   * @return matching document count, or empty when count cannot be obtained
+   */
+  @Nonnull
+  public Optional<Long> countMatching(
+      @Nonnull OperationContext opContext, @Nonnull CheckBatchRequest request) {
+    try {
+      String resolvedEntityType = resolveEntityType(request);
+      List<ConsistencyCheck> checks =
+          checkRegistry.getDefaultByEntityTypeAndIds(resolvedEntityType, request.getCheckIds());
+      if (checks.isEmpty()) {
+        return Optional.of(0L);
+      }
+      BoolQueryBuilder query =
+          buildSystemMetadataQuery(
+              opContext, resolvedEntityType, checks, request.getFilter(), request.getUrns());
+      return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
+    } catch (Exception e) {
+      log.warn("countMatching failed (continuing without total): {}", e.getMessage());
+      return Optional.empty();
+    }
+  }
+
   public CheckResult checkBatch(
       @Nonnull OperationContext opContext,
       @Nonnull CheckBatchRequest request,

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
@@ -420,7 +420,12 @@ public class ConsistencyService {
     BoolQueryBuilder query =
         buildSystemMetadataQuery(
             opContext, resolvedEntityType, checks, request.getFilter(), request.getUrns());
-    return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
+    try {
+      return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
+    } catch (RuntimeException e) {
+      log.warn("countMatching failed (continuing without total): {}", e.getMessage());
+      return Optional.empty();
+    }
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
@@ -423,7 +423,7 @@ public class ConsistencyService {
     try {
       return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
     } catch (RuntimeException e) {
-      log.warn("countMatching failed (continuing without total): {}", e.getMessage());
+      log.warn("countMatching failed (continuing without total): {}", e.getMessage(), e);
       return Optional.empty();
     }
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/ConsistencyService.java
@@ -280,36 +280,6 @@ public class ConsistencyService {
    * @throws IllegalArgumentException if checkIds span multiple entity types or if neither
    *     entityType nor checkIds is provided
    */
-  /**
-   * Count system-metadata documents matching the same discovery query used by {@link #checkBatch}.
-   *
-   * <p>With {@code keyAspectOnly=true} (upgrade default), the count approximates unique entities.
-   * Soft-fails to empty on ES errors so callers can continue rate-only without a fake ETA.
-   *
-   * @param opContext operation context
-   * @param request same shape as checkBatch (entity type, check IDs, filter, URNs)
-   * @return matching document count, or empty when count cannot be obtained
-   */
-  @Nonnull
-  public Optional<Long> countMatching(
-      @Nonnull OperationContext opContext, @Nonnull CheckBatchRequest request) {
-    try {
-      String resolvedEntityType = resolveEntityType(request);
-      List<ConsistencyCheck> checks =
-          checkRegistry.getDefaultByEntityTypeAndIds(resolvedEntityType, request.getCheckIds());
-      if (checks.isEmpty()) {
-        return Optional.of(0L);
-      }
-      BoolQueryBuilder query =
-          buildSystemMetadataQuery(
-              opContext, resolvedEntityType, checks, request.getFilter(), request.getUrns());
-      return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
-    } catch (Exception e) {
-      log.warn("countMatching failed (continuing without total): {}", e.getMessage());
-      return Optional.empty();
-    }
-  }
-
   public CheckResult checkBatch(
       @Nonnull OperationContext opContext,
       @Nonnull CheckBatchRequest request,
@@ -425,6 +395,32 @@ public class ConsistencyService {
         .issues(issues)
         .scrollId(nextScrollId)
         .build();
+  }
+
+  /**
+   * Count system-metadata documents matching the same discovery query used by {@link #checkBatch}.
+   *
+   * <p>With {@code keyAspectOnly=true} (upgrade default), the count approximates unique entities.
+   * Returns empty when the ES count query fails ({@link ESSystemMetadataDAO#count} soft-fails).
+   * Validation errors from entity-type resolution propagate to the caller.
+   *
+   * @param opContext operation context
+   * @param request same shape as checkBatch (entity type, check IDs, filter, URNs)
+   * @return matching document count, or empty when count cannot be obtained
+   */
+  @Nonnull
+  public Optional<Long> countMatching(
+      @Nonnull OperationContext opContext, @Nonnull CheckBatchRequest request) {
+    String resolvedEntityType = resolveEntityType(request);
+    List<ConsistencyCheck> checks =
+        checkRegistry.getDefaultByEntityTypeAndIds(resolvedEntityType, request.getCheckIds());
+    if (checks.isEmpty()) {
+      return Optional.of(0L);
+    }
+    BoolQueryBuilder query =
+        buildSystemMetadataQuery(
+            opContext, resolvedEntityType, checks, request.getFilter(), request.getUrns());
+    return esSystemMetadataDAO.count(opContext, query, request.isIncludeSoftDeleted());
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/check/CheckContext.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/check/CheckContext.java
@@ -129,6 +129,14 @@ public class CheckContext {
   }
 
   /**
+   * Clear accumulated orphan URNs for one entity type before the next batch so orphan checks do not
+   * re-run on URNs from prior batches. Entity/aspect caches are preserved.
+   */
+  public void clearOrphanUrns(@Nonnull String entityType) {
+    orphanUrnsByType.remove(entityType);
+  }
+
+  /**
    * Add orphan URNs for a specific entity type.
    *
    * @param entityType the entity type

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/BatchHandleResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/BatchHandleResult.java
@@ -1,0 +1,21 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import javax.annotation.Nonnull;
+import lombok.Value;
+
+/** Outcome of handling one check batch (e.g. applying fixes). */
+@Value
+public class BatchHandleResult {
+  int fixed;
+  int failed;
+
+  @Nonnull
+  public static BatchHandleResult none() {
+    return new BatchHandleResult(0, 0);
+  }
+
+  @Nonnull
+  public static BatchHandleResult of(int fixed, int failed) {
+    return new BatchHandleResult(fixed, failed);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/BatchHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/BatchHandler.java
@@ -1,0 +1,11 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import com.linkedin.metadata.aspect.consistency.check.CheckResult;
+import javax.annotation.Nonnull;
+
+/** Handles a check batch and returns fix counters. */
+@FunctionalInterface
+public interface BatchHandler {
+  @Nonnull
+  BatchHandleResult handle(@Nonnull CheckResult result);
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanCheckpoint.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanCheckpoint.java
@@ -1,0 +1,25 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import com.linkedin.metadata.utils.progress.ProgressSnapshot;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/** Cumulative counters and progress for silent checkpoint persistence. */
+@Value
+@Builder
+public class ConsistencyScanCheckpoint {
+
+  @Nonnull String entityType;
+
+  /** Next scroll id; null when the current batch was the last. */
+  @Nullable String scrollId;
+
+  long entitiesScanned;
+  int issuesFound;
+  int issuesFixed;
+  int issuesFailed;
+
+  @Nonnull ProgressSnapshot progress;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRequest.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRequest.java
@@ -1,0 +1,86 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import com.linkedin.metadata.aspect.consistency.SystemMetadataFilter;
+import com.linkedin.metadata.aspect.consistency.check.CheckContext;
+import com.linkedin.metadata.utils.progress.ProgressSnapshot;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/** Options for a multi-batch entity-check scan over one entity type. */
+@Value
+@Builder
+public class ConsistencyScanRequest {
+
+  @Nonnull String entityType;
+
+  /** Check IDs for this entity type; empty means defaults. */
+  @Nullable List<String> checkIds;
+
+  @Nullable SystemMetadataFilter filter;
+
+  @Builder.Default int batchSize = 100;
+
+  /** Delay between batches in milliseconds (0 = no delay). */
+  @Builder.Default long delayMs = 0L;
+
+  /**
+   * Max entities to scan for this type (0 = unlimited). Absolute scanned count including resume.
+   */
+  @Builder.Default int limit = 0;
+
+  /** Resume scroll cursor; null to start fresh. */
+  @Nullable String scrollId;
+
+  /** Entities already scanned when resuming. */
+  @Builder.Default long initialProcessed = 0L;
+
+  /** Issues / fixed / failed already accumulated when resuming. */
+  @Builder.Default int initialIssues = 0;
+
+  @Builder.Default int initialFixed = 0;
+
+  @Builder.Default int initialFailed = 0;
+
+  /** Progress INFO throttle interval. */
+  @Builder.Default long progressLogIntervalMs = 60_000L;
+
+  /** Warmup before first ETA report. */
+  @Builder.Default long progressWarmupMs = 30_000L;
+
+  /**
+   * When false, skip entity ETA even if a count is available (e.g. keyAspectOnly=false so SM doc
+   * count does not match unique entities).
+   */
+  @Builder.Default boolean entityEtaEligible = true;
+
+  @Nullable CheckContext checkContext;
+
+  /** Invoked after each non-empty batch for issue handling / fix application. */
+  @Nullable BatchHandler onBatch;
+
+  /**
+   * Silent checkpoint every batch. Receives scroll id (may be null at end of batch), cumulative
+   * counters, and latest progress snapshot.
+   */
+  @Nullable Consumer<ConsistencyScanCheckpoint> onCheckpoint;
+
+  /** Throttled progress for INFO logging. */
+  @Nullable Consumer<ProgressSnapshot> onProgress;
+
+  /** Called once after count (or count failure) before the batch loop. */
+  @Nullable Consumer<ConsistencyScanStart> onStart;
+
+  /** Called once after the scan finishes (success path). */
+  @Nullable Consumer<ConsistencyScanResult> onComplete;
+
+  /** Return true to stop early (e.g. global limit). */
+  @Nullable BooleanSupplier shouldStop;
+
+  /** Optional delay hook for tests; when null, Thread.sleep is used. */
+  @Nullable Runnable delayHook;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanResult.java
@@ -20,4 +20,7 @@ public class ConsistencyScanResult {
   @Nullable Long totalEstimate;
 
   @Nonnull ProgressSnapshot finalProgress;
+
+  /** True when the scan stopped early due to thread interrupt during an inter-batch delay. */
+  @Builder.Default boolean cancelled = false;
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanResult.java
@@ -1,0 +1,23 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import com.linkedin.metadata.utils.progress.ProgressSnapshot;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/** Final result of a consistency scan over one entity type. */
+@Value
+@Builder
+public class ConsistencyScanResult {
+
+  @Nonnull String entityType;
+  long entitiesScanned;
+  int issuesFound;
+  int issuesFixed;
+  int issuesFailed;
+
+  @Nullable Long totalEstimate;
+
+  @Nonnull ProgressSnapshot finalProgress;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
@@ -70,6 +70,7 @@ public class ConsistencyScanRunner {
     int fixed = request.getInitialFixed();
     int failed = request.getInitialFailed();
     String scrollId = request.getScrollId();
+    boolean cancelled = false;
 
     do {
       if (request.getShouldStop() != null && request.getShouldStop().getAsBoolean()) {
@@ -135,6 +136,7 @@ public class ConsistencyScanRunner {
 
       if (request.getDelayMs() > 0 && scrollId != null) {
         if (!applyDelay(request)) {
+          cancelled = true;
           break;
         }
       }
@@ -151,9 +153,10 @@ public class ConsistencyScanRunner {
             .issuesFailed(failed)
             .totalEstimate(totalForTracker)
             .finalProgress(finalSnap)
+            .cancelled(cancelled)
             .build();
 
-    if (request.getOnComplete() != null) {
+    if (!cancelled && request.getOnComplete() != null) {
       request.getOnComplete().accept(result);
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
@@ -77,6 +77,16 @@ public class ConsistencyScanRunner {
         break;
       }
 
+      if (request.getLimit() > 0 && scanned >= request.getLimit()) {
+        break;
+      }
+
+      int batchSize = request.getBatchSize();
+      if (request.getLimit() > 0) {
+        long remaining = request.getLimit() - scanned;
+        batchSize = (int) Math.min(batchSize, remaining);
+      }
+
       CheckContext batchContext = request.getCheckContext();
       if (batchContext != null) {
         batchContext.clearOrphanUrns(request.getEntityType());
@@ -88,7 +98,7 @@ public class ConsistencyScanRunner {
               CheckBatchRequest.builder()
                   .entityType(request.getEntityType())
                   .checkIds(request.getCheckIds())
-                  .batchSize(request.getBatchSize())
+                  .batchSize(batchSize)
                   .scrollId(scrollId)
                   .filter(request.getFilter())
                   .build(),

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
@@ -1,0 +1,179 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import com.linkedin.metadata.aspect.consistency.ConsistencyService;
+import com.linkedin.metadata.aspect.consistency.check.CheckBatchRequest;
+import com.linkedin.metadata.aspect.consistency.check.CheckResult;
+import com.linkedin.metadata.utils.progress.ProgressSnapshot;
+import com.linkedin.metadata.utils.progress.ProgressTracker;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Multi-batch entity-check scan over a single entity type.
+ *
+ * <p>Owns counting, the {@code checkBatch} loop, progress tracking, and callback dispatch. Does
+ * <b>not</b> log INFO itself — adapters decide logging vs silent persistence.
+ *
+ * <p>Designed for upgrade full-scans. OpenAPI stays page-oriented and should call {@link
+ * ConsistencyService#checkBatch} / {@link ConsistencyService#countMatching} directly.
+ */
+@RequiredArgsConstructor
+public class ConsistencyScanRunner {
+
+  @Nonnull private final ConsistencyService consistencyService;
+
+  /**
+   * Run a full scan for one entity type until scroll is exhausted, limit is hit, or {@code
+   * shouldStop} returns true.
+   */
+  @Nonnull
+  public ConsistencyScanResult run(
+      @Nonnull OperationContext opContext, @Nonnull ConsistencyScanRequest request) {
+
+    CheckBatchRequest countRequest =
+        CheckBatchRequest.builder()
+            .entityType(request.getEntityType())
+            .checkIds(request.getCheckIds())
+            .filter(request.getFilter())
+            .batchSize(request.getBatchSize())
+            .build();
+    Optional<Long> counted = consistencyService.countMatching(opContext, countRequest);
+    Optional<Long> count = counted != null ? counted : Optional.empty();
+
+    Long totalForTracker = resolveTrackerTotal(request, count);
+
+    if (request.getOnStart() != null) {
+      request
+          .getOnStart()
+          .accept(
+              ConsistencyScanStart.builder()
+                  .entityType(request.getEntityType())
+                  .totalEstimate(request.isEntityEtaEligible() ? count.orElse(null) : null)
+                  .etaEnabled(totalForTracker != null)
+                  .build());
+    }
+
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("entity-check[" + request.getEntityType() + "]")
+            .total(totalForTracker)
+            .initialProcessed(request.getInitialProcessed())
+            .reportIntervalMs(request.getProgressLogIntervalMs())
+            .warmupMs(request.getProgressWarmupMs())
+            .build();
+
+    long scanned = request.getInitialProcessed();
+    int issues = request.getInitialIssues();
+    int fixed = request.getInitialFixed();
+    int failed = request.getInitialFailed();
+    String scrollId = request.getScrollId();
+
+    do {
+      if (request.getShouldStop() != null && request.getShouldStop().getAsBoolean()) {
+        break;
+      }
+
+      CheckResult checkResult =
+          consistencyService.checkBatch(
+              opContext,
+              CheckBatchRequest.builder()
+                  .entityType(request.getEntityType())
+                  .checkIds(request.getCheckIds())
+                  .batchSize(request.getBatchSize())
+                  .scrollId(scrollId)
+                  .filter(request.getFilter())
+                  .build(),
+              request.getCheckContext());
+
+      if (checkResult.getEntitiesScanned() == 0) {
+        break;
+      }
+
+      scanned += checkResult.getEntitiesScanned();
+      issues += checkResult.getIssuesFound();
+      tracker.record(checkResult.getEntitiesScanned());
+
+      if (request.getOnBatch() != null) {
+        BatchHandleResult handleResult = request.getOnBatch().handle(checkResult);
+        fixed += handleResult.getFixed();
+        failed += handleResult.getFailed();
+      }
+
+      scrollId = checkResult.getScrollId();
+
+      ProgressSnapshot snap = tracker.snapshot();
+      if (request.getOnCheckpoint() != null) {
+        request
+            .getOnCheckpoint()
+            .accept(
+                ConsistencyScanCheckpoint.builder()
+                    .entityType(request.getEntityType())
+                    .scrollId(scrollId)
+                    .entitiesScanned(scanned)
+                    .issuesFound(issues)
+                    .issuesFixed(fixed)
+                    .issuesFailed(failed)
+                    .progress(snap)
+                    .build());
+      }
+
+      if (request.getOnProgress() != null) {
+        tracker.maybeReport(request.getOnProgress());
+      }
+
+      if (request.getLimit() > 0 && scanned >= request.getLimit()) {
+        break;
+      }
+
+      if (request.getDelayMs() > 0 && scrollId != null) {
+        applyDelay(request);
+      }
+
+    } while (scrollId != null);
+
+    ProgressSnapshot finalSnap = tracker.snapshot();
+    ConsistencyScanResult result =
+        ConsistencyScanResult.builder()
+            .entityType(request.getEntityType())
+            .entitiesScanned(scanned)
+            .issuesFound(issues)
+            .issuesFixed(fixed)
+            .issuesFailed(failed)
+            .totalEstimate(totalForTracker)
+            .finalProgress(finalSnap)
+            .build();
+
+    if (request.getOnComplete() != null) {
+      request.getOnComplete().accept(result);
+    }
+
+    return result;
+  }
+
+  @javax.annotation.Nullable
+  private static Long resolveTrackerTotal(
+      @Nonnull ConsistencyScanRequest request, @Nonnull Optional<Long> count) {
+    if (!request.isEntityEtaEligible() || count.isEmpty()) {
+      return null;
+    }
+    long counted = count.get();
+    if (request.getLimit() > 0) {
+      return Math.min(counted, (long) request.getLimit());
+    }
+    return counted;
+  }
+
+  private void applyDelay(@Nonnull ConsistencyScanRequest request) {
+    if (request.getDelayHook() != null) {
+      request.getDelayHook().run();
+      return;
+    }
+    try {
+      Thread.sleep(request.getDelayMs());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunner.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.aspect.consistency.scan;
 
 import com.linkedin.metadata.aspect.consistency.ConsistencyService;
 import com.linkedin.metadata.aspect.consistency.check.CheckBatchRequest;
+import com.linkedin.metadata.aspect.consistency.check.CheckContext;
 import com.linkedin.metadata.aspect.consistency.check.CheckResult;
 import com.linkedin.metadata.utils.progress.ProgressSnapshot;
 import com.linkedin.metadata.utils.progress.ProgressTracker;
@@ -50,7 +51,7 @@ public class ConsistencyScanRunner {
           .accept(
               ConsistencyScanStart.builder()
                   .entityType(request.getEntityType())
-                  .totalEstimate(request.isEntityEtaEligible() ? count.orElse(null) : null)
+                  .totalEstimate(request.isEntityEtaEligible() ? totalForTracker : null)
                   .etaEnabled(totalForTracker != null)
                   .build());
     }
@@ -75,6 +76,11 @@ public class ConsistencyScanRunner {
         break;
       }
 
+      CheckContext batchContext = request.getCheckContext();
+      if (batchContext != null) {
+        batchContext.clearOrphanUrns(request.getEntityType());
+      }
+
       CheckResult checkResult =
           consistencyService.checkBatch(
               opContext,
@@ -85,7 +91,7 @@ public class ConsistencyScanRunner {
                   .scrollId(scrollId)
                   .filter(request.getFilter())
                   .build(),
-              request.getCheckContext());
+              batchContext);
 
       if (checkResult.getEntitiesScanned() == 0) {
         break;
@@ -128,7 +134,9 @@ public class ConsistencyScanRunner {
       }
 
       if (request.getDelayMs() > 0 && scrollId != null) {
-        applyDelay(request);
+        if (!applyDelay(request)) {
+          break;
+        }
       }
 
     } while (scrollId != null);
@@ -165,15 +173,20 @@ public class ConsistencyScanRunner {
     return counted;
   }
 
-  private void applyDelay(@Nonnull ConsistencyScanRequest request) {
+  /**
+   * @return false when interrupted — caller should stop the scan loop
+   */
+  private boolean applyDelay(@Nonnull ConsistencyScanRequest request) {
     if (request.getDelayHook() != null) {
       request.getDelayHook().run();
-      return;
+      return true;
     }
     try {
       Thread.sleep(request.getDelayMs());
+      return true;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      return false;
     }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanStart.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanStart.java
@@ -1,0 +1,19 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/** Emitted once before the batch loop after attempting a total count. */
+@Value
+@Builder
+public class ConsistencyScanStart {
+
+  @Nonnull String entityType;
+
+  /** Matching SM doc count when available; null when count failed or ETA ineligible. */
+  @Nullable Long totalEstimate;
+
+  boolean etaEnabled;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
@@ -265,6 +265,47 @@ public class ESSystemMetadataDAO {
     return null;
   }
 
+  /**
+   * Count documents matching the query on the system-metadata index.
+   *
+   * <p>Uses size=0 and track_total_hits. Soft-deleted documents are excluded unless {@code
+   * includeSoftDeleted} is true (same semantics as {@link #scroll}).
+   *
+   * @return total hit count, or empty on search failure
+   */
+  @Nonnull
+  public Optional<Long> count(
+      @Nonnull OperationContext opContext,
+      @Nonnull BoolQueryBuilder queryBuilder,
+      boolean includeSoftDeleted) {
+    BoolQueryBuilder query = QueryBuilders.boolQuery().must(queryBuilder);
+    if (!includeSoftDeleted) {
+      query.mustNot(QueryBuilders.termQuery(FIELD_REMOVED, "true"));
+    }
+
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+    searchSourceBuilder.query(query);
+    searchSourceBuilder.size(0);
+    searchSourceBuilder.trackTotalHits(true);
+
+    SearchRequest searchRequest = new SearchRequest();
+    searchRequest.source(searchSourceBuilder);
+    searchRequest.indices(indexConvention.getIndexName(opContext, INDEX_NAME));
+
+    try {
+      SearchResponse response = client.search(opContext, searchRequest, RequestOptions.DEFAULT);
+      if (response == null
+          || response.getHits() == null
+          || response.getHits().getTotalHits() == null) {
+        return Optional.empty();
+      }
+      return Optional.of(response.getHits().getTotalHits().value);
+    } catch (IOException e) {
+      log.error("Error while counting system-metadata documents.", e);
+      return Optional.empty();
+    }
+  }
+
   public SearchResponse findByRegistry(
       @Nonnull OperationContext opContext,
       String registryName,

--- a/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressSnapshot.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressSnapshot.java
@@ -1,0 +1,47 @@
+package com.linkedin.metadata.utils.progress;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+/** Immutable view of progress for logging or persistence. */
+@Value
+@Builder
+public class ProgressSnapshot {
+
+  @Nonnull String label;
+
+  /** Units processed so far (may include resume offset). */
+  long processed;
+
+  /**
+   * Estimated total units, or empty when unknown. When present, progress percent and ETA may be
+   * computed.
+   */
+  @Nullable Long total;
+
+  /** Overall throughput in units per second since tracker start (0 if no elapsed time). */
+  double ratePerSecond;
+
+  /**
+   * Estimated remaining time in seconds when total is known, rate &gt; 0, and past warmup;
+   * otherwise null.
+   */
+  @Nullable Long etaSeconds;
+
+  /**
+   * Human-readable form of {@link #etaSeconds} (e.g. {@code 1h 2m}, {@code 45s}); null when ETA is
+   * unavailable.
+   */
+  @Nullable String etaHuman;
+
+  /** Progress percent capped at 99 until finished; null when total unknown. */
+  @Nullable Integer percentComplete;
+
+  /** Whether this snapshot is considered finished (processed &gt;= total when total known). */
+  boolean finished;
+
+  /** Compact single-line message suitable for INFO logs. */
+  @Nonnull String message;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
@@ -1,0 +1,184 @@
+package com.linkedin.metadata.utils.progress;
+
+import java.time.Clock;
+import java.util.Optional;
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+
+/**
+ * Tracks processed work units and estimates remaining time for long-running scans.
+ *
+ * <p>ETA is only available when a total is known, throughput is positive, and warmup has elapsed.
+ * Reporting is time-throttled so callers may invoke {@link #maybeReport} every batch without
+ * flooding logs.
+ *
+ * <p>{@link #snapshot()} is always cheap and suitable for silent checkpoint persistence.
+ */
+public class ProgressTracker {
+
+  public static final long DEFAULT_REPORT_INTERVAL_MS = 60_000L;
+  public static final long DEFAULT_WARMUP_MS = 30_000L;
+
+  private final String label;
+  @Nullable private final Long total;
+  private final long reportIntervalMs;
+  private final long warmupMs;
+  private final Clock clock;
+  private final long startTimeMs;
+
+  private long processed;
+  private long lastReportTimeMs;
+  private boolean hasReported;
+
+  @Builder
+  private ProgressTracker(
+      @Nonnull String label,
+      @Nullable Long total,
+      long initialProcessed,
+      long reportIntervalMs,
+      long warmupMs,
+      @Nullable Clock clock) {
+    this.label = label;
+    this.total = total != null && total > 0 ? total : null;
+    this.processed = Math.max(0, initialProcessed);
+    this.reportIntervalMs = reportIntervalMs > 0 ? reportIntervalMs : DEFAULT_REPORT_INTERVAL_MS;
+    this.warmupMs = warmupMs >= 0 ? warmupMs : DEFAULT_WARMUP_MS;
+    this.clock = clock != null ? clock : Clock.systemUTC();
+    this.startTimeMs = this.clock.millis();
+    this.lastReportTimeMs = 0L;
+    this.hasReported = false;
+  }
+
+  /** Record additional completed work units. */
+  public void record(long delta) {
+    if (delta > 0) {
+      processed += delta;
+    }
+  }
+
+  public long getProcessed() {
+    return processed;
+  }
+
+  @Nonnull
+  public Optional<Long> getTotal() {
+    return Optional.ofNullable(total);
+  }
+
+  /**
+   * Build a snapshot for persistence or logging. Does not apply throttling and does not side-effect
+   * report state.
+   */
+  @Nonnull
+  public ProgressSnapshot snapshot() {
+    long now = clock.millis();
+    long elapsedMs = Math.max(0L, now - startTimeMs);
+    double elapsedSec = elapsedMs / 1000.0;
+    double rate = elapsedSec > 0 ? processed / elapsedSec : 0.0;
+
+    boolean finished = total != null && processed >= total;
+    Integer percent = null;
+    Long etaSeconds = null;
+
+    if (total != null && total > 0) {
+      if (finished) {
+        percent = 100;
+      } else {
+        percent = (int) Math.min(99, (processed * 100L) / total);
+      }
+    }
+
+    boolean pastWarmup = elapsedMs >= warmupMs;
+    if (total != null && rate > 0 && pastWarmup && !finished) {
+      long remaining = Math.max(0L, total - processed);
+      etaSeconds = (long) Math.ceil(remaining / rate);
+    }
+
+    return ProgressSnapshot.builder()
+        .label(label)
+        .processed(processed)
+        .total(total)
+        .ratePerSecond(rate)
+        .etaSeconds(etaSeconds)
+        .etaHuman(etaSeconds != null ? formatDuration(etaSeconds) : null)
+        .percentComplete(percent)
+        .finished(finished)
+        .message(formatMessage(processed, total, percent, rate, etaSeconds, finished))
+        .build();
+  }
+
+  /**
+   * Invoke {@code reporter} with a fresh snapshot when throttling allows.
+   *
+   * @return true if a report was emitted
+   */
+  public boolean maybeReport(@Nonnull Consumer<ProgressSnapshot> reporter) {
+    long now = clock.millis();
+    long elapsedMs = now - startTimeMs;
+    if (elapsedMs < warmupMs && !hasReported) {
+      // Still warming up — allow first report only after warmup
+      return false;
+    }
+    if (hasReported && (now - lastReportTimeMs) < reportIntervalMs) {
+      return false;
+    }
+    ProgressSnapshot snap = snapshot();
+    reporter.accept(snap);
+    lastReportTimeMs = now;
+    hasReported = true;
+    return true;
+  }
+
+  /** Force a report regardless of throttle (e.g. final summary). */
+  public void forceReport(@Nonnull Consumer<ProgressSnapshot> reporter) {
+    ProgressSnapshot snap = snapshot();
+    reporter.accept(snap);
+    lastReportTimeMs = clock.millis();
+    hasReported = true;
+  }
+
+  @Nonnull
+  private String formatMessage(
+      long processed,
+      @Nullable Long total,
+      @Nullable Integer percent,
+      double rate,
+      @Nullable Long etaSeconds,
+      boolean finished) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(label).append(": ");
+    if (total != null) {
+      sb.append(processed).append('/').append(total);
+      if (percent != null) {
+        sb.append(" (").append(percent).append("%)");
+      }
+    } else {
+      sb.append(processed).append(" processed");
+    }
+    sb.append(String.format(" %.1f/sec", rate));
+    if (etaSeconds != null && !finished) {
+      sb.append(" est. ETA ").append(formatDuration(etaSeconds));
+    }
+    return sb.toString();
+  }
+
+  /** Format a duration for ops logs, e.g. {@code 1h 2m}, {@code 2m 5s}, {@code 45s}. */
+  @Nonnull
+  public static String formatDuration(long totalSeconds) {
+    if (totalSeconds < 0) {
+      totalSeconds = 0;
+    }
+    long hours = totalSeconds / 3600;
+    long minutes = (totalSeconds % 3600) / 60;
+    long seconds = totalSeconds % 60;
+    if (hours > 0) {
+      return String.format("%dh %dm", hours, minutes);
+    }
+    if (minutes > 0) {
+      return String.format("%dm %ds", minutes, seconds);
+    }
+    return String.format("%ds", seconds);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
@@ -45,11 +45,17 @@ public class ProgressTracker {
       @Nullable Long warmupMs,
       @Nullable Clock clock) {
     this.label = label;
-    this.total = total;
+    this.total = total != null && total < 0 ? null : total;
     this.processed = Math.max(0, initialProcessed);
     this.rateBaselineProcessed = this.processed;
     this.reportIntervalMs = reportIntervalMs > 0 ? reportIntervalMs : DEFAULT_REPORT_INTERVAL_MS;
-    this.warmupMs = warmupMs != null ? warmupMs : DEFAULT_WARMUP_MS;
+    if (warmupMs == null) {
+      this.warmupMs = DEFAULT_WARMUP_MS;
+    } else if (warmupMs < 0) {
+      this.warmupMs = DEFAULT_WARMUP_MS;
+    } else {
+      this.warmupMs = warmupMs;
+    }
     this.clock = clock != null ? clock : Clock.systemUTC();
     this.startTimeMs = this.clock.millis();
     this.lastReportTimeMs = 0L;

--- a/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/utils/progress/ProgressTracker.java
@@ -14,6 +14,9 @@ import lombok.Builder;
  * Reporting is time-throttled so callers may invoke {@link #maybeReport} every batch without
  * flooding logs.
  *
+ * <p>Rate and ETA use only work completed since tracker construction ({@link #record} deltas), not
+ * {@code initialProcessed}, so resume after checkpoint does not inflate throughput.
+ *
  * <p>{@link #snapshot()} is always cheap and suitable for silent checkpoint persistence.
  */
 public class ProgressTracker {
@@ -27,6 +30,7 @@ public class ProgressTracker {
   private final long warmupMs;
   private final Clock clock;
   private final long startTimeMs;
+  private final long rateBaselineProcessed;
 
   private long processed;
   private long lastReportTimeMs;
@@ -38,13 +42,14 @@ public class ProgressTracker {
       @Nullable Long total,
       long initialProcessed,
       long reportIntervalMs,
-      long warmupMs,
+      @Nullable Long warmupMs,
       @Nullable Clock clock) {
     this.label = label;
-    this.total = total != null && total > 0 ? total : null;
+    this.total = total;
     this.processed = Math.max(0, initialProcessed);
+    this.rateBaselineProcessed = this.processed;
     this.reportIntervalMs = reportIntervalMs > 0 ? reportIntervalMs : DEFAULT_REPORT_INTERVAL_MS;
-    this.warmupMs = warmupMs >= 0 ? warmupMs : DEFAULT_WARMUP_MS;
+    this.warmupMs = warmupMs != null ? warmupMs : DEFAULT_WARMUP_MS;
     this.clock = clock != null ? clock : Clock.systemUTC();
     this.startTimeMs = this.clock.millis();
     this.lastReportTimeMs = 0L;
@@ -76,14 +81,15 @@ public class ProgressTracker {
     long now = clock.millis();
     long elapsedMs = Math.max(0L, now - startTimeMs);
     double elapsedSec = elapsedMs / 1000.0;
-    double rate = elapsedSec > 0 ? processed / elapsedSec : 0.0;
+    long processedSinceStart = Math.max(0L, processed - rateBaselineProcessed);
+    double rate = elapsedSec > 0 ? processedSinceStart / elapsedSec : 0.0;
 
     boolean finished = total != null && processed >= total;
     Integer percent = null;
     Long etaSeconds = null;
 
-    if (total != null && total > 0) {
-      if (finished) {
+    if (total != null) {
+      if (total == 0 || finished) {
         percent = 100;
       } else {
         percent = (int) Math.min(99, (processed * 100L) / total);
@@ -91,7 +97,7 @@ public class ProgressTracker {
     }
 
     boolean pastWarmup = elapsedMs >= warmupMs;
-    if (total != null && rate > 0 && pastWarmup && !finished) {
+    if (total != null && total > 0 && rate > 0 && pastWarmup && !finished) {
       long remaining = Math.max(0L, total - processed);
       etaSeconds = (long) Math.ceil(remaining / rate);
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/ConsistencyServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/ConsistencyServiceTest.java
@@ -2442,4 +2442,23 @@ public class ConsistencyServiceTest {
 
     assertTrue(count.isEmpty());
   }
+
+  @Test
+  public void testCountMatching_softFailsOnRuntimeException() {
+    when(mockEsSystemMetadataDAO.count(any(), any(BoolQueryBuilder.class), anyBoolean()))
+        .thenThrow(new RuntimeException("ES unavailable"));
+
+    OperationContext opContext = mock(OperationContext.class);
+    EntityRegistry registry = mock(EntityRegistry.class);
+    EntitySpec entitySpec = mock(EntitySpec.class);
+    when(opContext.getEntityRegistry()).thenReturn(registry);
+    when(registry.getEntitySpec("assertion")).thenReturn(entitySpec);
+    when(entitySpec.getKeyAspectName()).thenReturn("assertionKey");
+
+    Optional<Long> count =
+        consistencyService.countMatching(
+            opContext, CheckBatchRequest.builder().entityType("assertion").batchSize(100).build());
+
+    assertTrue(count.isEmpty());
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/ConsistencyServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/ConsistencyServiceTest.java
@@ -2397,4 +2397,49 @@ public class ConsistencyServiceTest {
                     i.getFixType() == ConsistencyFixType.HARD_DELETE
                         || i.getFixType() == ConsistencyFixType.DELETE_INDEX_DOCUMENTS));
   }
+
+  @Test
+  public void testCountMatching_returnsDaoCount() {
+    when(mockEsSystemMetadataDAO.count(any(), any(BoolQueryBuilder.class), anyBoolean()))
+        .thenReturn(Optional.of(42L));
+
+    OperationContext opContext = mock(OperationContext.class);
+    EntityRegistry registry = mock(EntityRegistry.class);
+    EntitySpec entitySpec = mock(EntitySpec.class);
+    when(opContext.getEntityRegistry()).thenReturn(registry);
+    when(registry.getEntitySpec("assertion")).thenReturn(entitySpec);
+    when(entitySpec.getKeyAspectName()).thenReturn("assertionKey");
+
+    Optional<Long> count =
+        consistencyService.countMatching(
+            opContext,
+            CheckBatchRequest.builder()
+                .entityType("assertion")
+                .filter(SystemMetadataFilter.builder().keyAspectOnly(true).build())
+                .batchSize(100)
+                .build());
+
+    assertTrue(count.isPresent());
+    assertEquals(count.get().longValue(), 42L);
+    verify(mockEsSystemMetadataDAO).count(eq(opContext), any(BoolQueryBuilder.class), eq(false));
+  }
+
+  @Test
+  public void testCountMatching_softFailsOnDaoEmpty() {
+    when(mockEsSystemMetadataDAO.count(any(), any(BoolQueryBuilder.class), anyBoolean()))
+        .thenReturn(Optional.empty());
+
+    OperationContext opContext = mock(OperationContext.class);
+    EntityRegistry registry = mock(EntityRegistry.class);
+    EntitySpec entitySpec = mock(EntitySpec.class);
+    when(opContext.getEntityRegistry()).thenReturn(registry);
+    when(registry.getEntitySpec("assertion")).thenReturn(entitySpec);
+    when(entitySpec.getKeyAspectName()).thenReturn("assertionKey");
+
+    Optional<Long> count =
+        consistencyService.countMatching(
+            opContext, CheckBatchRequest.builder().entityType("assertion").batchSize(100).build());
+
+    assertTrue(count.isEmpty());
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
@@ -187,20 +187,25 @@ public class ConsistencyScanRunnerTest {
                 .build());
 
     AtomicInteger batches = new AtomicInteger();
+    AtomicInteger onCompleteCalls = new AtomicInteger();
     Thread runnerThread =
         new Thread(
-            () ->
-                runner.run(
-                    opContext,
-                    ConsistencyScanRequest.builder()
-                        .entityType("dataset")
-                        .delayMs(60_000)
-                        .onBatch(
-                            r -> {
-                              batches.incrementAndGet();
-                              return BatchHandleResult.none();
-                            })
-                        .build()));
+            () -> {
+              ConsistencyScanResult result =
+                  runner.run(
+                      opContext,
+                      ConsistencyScanRequest.builder()
+                          .entityType("dataset")
+                          .delayMs(60_000)
+                          .onBatch(
+                              r -> {
+                                batches.incrementAndGet();
+                                return BatchHandleResult.none();
+                              })
+                          .onComplete(r -> onCompleteCalls.incrementAndGet())
+                          .build());
+              assertTrue(result.isCancelled());
+            });
     runnerThread.start();
     Thread.sleep(200);
     runnerThread.interrupt();
@@ -208,6 +213,7 @@ public class ConsistencyScanRunnerTest {
 
     assertFalse(runnerThread.isAlive());
     assertEquals(batches.get(), 1);
+    assertEquals(onCompleteCalls.get(), 0);
     verify(consistencyService, times(1)).checkBatch(eq(opContext), any(), isNull());
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -188,30 +189,30 @@ public class ConsistencyScanRunnerTest {
 
     AtomicInteger batches = new AtomicInteger();
     AtomicInteger onCompleteCalls = new AtomicInteger();
+    AtomicReference<ConsistencyScanResult> resultHolder = new AtomicReference<>();
     Thread runnerThread =
         new Thread(
-            () -> {
-              ConsistencyScanResult result =
-                  runner.run(
-                      opContext,
-                      ConsistencyScanRequest.builder()
-                          .entityType("dataset")
-                          .delayMs(60_000)
-                          .onBatch(
-                              r -> {
-                                batches.incrementAndGet();
-                                return BatchHandleResult.none();
-                              })
-                          .onComplete(r -> onCompleteCalls.incrementAndGet())
-                          .build());
-              assertTrue(result.isCancelled());
-            });
+            () ->
+                resultHolder.set(
+                    runner.run(
+                        opContext,
+                        ConsistencyScanRequest.builder()
+                            .entityType("dataset")
+                            .delayMs(60_000)
+                            .onBatch(
+                                r -> {
+                                  batches.incrementAndGet();
+                                  return BatchHandleResult.none();
+                                })
+                            .onComplete(r -> onCompleteCalls.incrementAndGet())
+                            .build())));
     runnerThread.start();
     Thread.sleep(200);
     runnerThread.interrupt();
     runnerThread.join(5000);
 
     assertFalse(runnerThread.isAlive());
+    assertTrue(resultHolder.get().isCancelled());
     assertEquals(batches.get(), 1);
     assertEquals(onCompleteCalls.get(), 0);
     verify(consistencyService, times(1)).checkBatch(eq(opContext), any(), isNull());
@@ -222,19 +223,23 @@ public class ConsistencyScanRunnerTest {
     when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
         .thenReturn(Optional.of(1000L));
     when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
-        .thenReturn(
-            CheckResult.builder()
-                .entitiesScanned(100)
-                .issuesFound(0)
-                .issues(List.of())
-                .scrollId("more")
-                .build());
+        .thenAnswer(
+            invocation -> {
+              CheckBatchRequest batchRequest = invocation.getArgument(1);
+              int scanned = batchRequest.getBatchSize();
+              return CheckResult.builder()
+                  .entitiesScanned(scanned)
+                  .issuesFound(0)
+                  .issues(List.of())
+                  .scrollId("more")
+                  .build();
+            });
 
     ConsistencyScanResult result =
         runner.run(
             opContext, ConsistencyScanRequest.builder().entityType("dataset").limit(150).build());
 
-    assertEquals(result.getEntitiesScanned(), 200); // two batches then stop (>= limit)
+    assertEquals(result.getEntitiesScanned(), 150);
     assertEquals(result.getTotalEstimate().longValue(), 150L); // min(count, limit)
     verify(consistencyService, times(2)).checkBatch(eq(opContext), any(), isNull());
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.*;
 
 import com.linkedin.metadata.aspect.consistency.ConsistencyService;
 import com.linkedin.metadata.aspect.consistency.check.CheckBatchRequest;
+import com.linkedin.metadata.aspect.consistency.check.CheckContext;
 import com.linkedin.metadata.aspect.consistency.check.CheckResult;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
@@ -116,6 +117,98 @@ public class ConsistencyScanRunnerTest {
     assertNull(starts.get(0).getTotalEstimate());
     assertNull(result.getTotalEstimate());
     assertEquals(result.getEntitiesScanned(), 50);
+  }
+
+  @Test
+  public void testOnStartUsesLimitedTotal() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(1000L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(100)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId(null)
+                .build());
+
+    List<ConsistencyScanStart> starts = new ArrayList<>();
+    runner.run(
+        opContext,
+        ConsistencyScanRequest.builder()
+            .entityType("dataset")
+            .limit(150)
+            .onStart(starts::add)
+            .build());
+
+    assertEquals(starts.size(), 1);
+    assertEquals(starts.get(0).getTotalEstimate().longValue(), 150L);
+  }
+
+  @Test
+  public void testSharedContext_clearsOrphanUrnsEachBatch() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(100L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), any()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(50)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId("more")
+                .build(),
+            CheckResult.builder()
+                .entitiesScanned(50)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId(null)
+                .build());
+
+    CheckContext ctx = mock(CheckContext.class);
+    runner.run(
+        opContext,
+        ConsistencyScanRequest.builder().entityType("dataset").checkContext(ctx).build());
+
+    verify(ctx, times(2)).clearOrphanUrns("dataset");
+    verify(consistencyService, times(2)).checkBatch(eq(opContext), any(), eq(ctx));
+  }
+
+  @Test
+  public void testDelayInterruptStopsScan() throws Exception {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(1000L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(100)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId("more")
+                .build());
+
+    AtomicInteger batches = new AtomicInteger();
+    Thread runnerThread =
+        new Thread(
+            () ->
+                runner.run(
+                    opContext,
+                    ConsistencyScanRequest.builder()
+                        .entityType("dataset")
+                        .delayMs(60_000)
+                        .onBatch(
+                            r -> {
+                              batches.incrementAndGet();
+                              return BatchHandleResult.none();
+                            })
+                        .build()));
+    runnerThread.start();
+    Thread.sleep(200);
+    runnerThread.interrupt();
+    runnerThread.join(5000);
+
+    assertFalse(runnerThread.isAlive());
+    assertEquals(batches.get(), 1);
+    verify(consistencyService, times(1)).checkBatch(eq(opContext), any(), isNull());
   }
 
   @Test
@@ -239,6 +332,8 @@ public class ConsistencyScanRunnerTest {
         runner.run(opContext, ConsistencyScanRequest.builder().entityType("dataset").build());
 
     assertEquals(result.getEntitiesScanned(), 0);
+    assertEquals(result.getTotalEstimate().longValue(), 0L);
+    assertTrue(result.getFinalProgress().isFinished());
     verify(consistencyService, times(1)).checkBatch(eq(opContext), any(), isNull());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/consistency/scan/ConsistencyScanRunnerTest.java
@@ -1,0 +1,244 @@
+package com.linkedin.metadata.aspect.consistency.scan;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.aspect.consistency.ConsistencyService;
+import com.linkedin.metadata.aspect.consistency.check.CheckBatchRequest;
+import com.linkedin.metadata.aspect.consistency.check.CheckResult;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ConsistencyScanRunnerTest {
+
+  @Mock private ConsistencyService consistencyService;
+  @Mock private OperationContext opContext;
+
+  private ConsistencyScanRunner runner;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    runner = new ConsistencyScanRunner(consistencyService);
+  }
+
+  @Test
+  public void testMultiBatchScan_checkpointsEveryBatch_progressThrottled() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(300L));
+
+    CheckResult batch1 =
+        CheckResult.builder()
+            .entitiesScanned(100)
+            .issuesFound(0)
+            .issues(List.of())
+            .scrollId("s1")
+            .build();
+    CheckResult batch2 =
+        CheckResult.builder()
+            .entitiesScanned(100)
+            .issuesFound(1)
+            .issues(List.of())
+            .scrollId("s2")
+            .build();
+    CheckResult batch3 =
+        CheckResult.builder()
+            .entitiesScanned(100)
+            .issuesFound(0)
+            .issues(List.of())
+            .scrollId(null)
+            .build();
+
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(batch1, batch2, batch3);
+
+    List<ConsistencyScanCheckpoint> checkpoints = new ArrayList<>();
+    AtomicInteger progressReports = new AtomicInteger();
+    AtomicInteger batches = new AtomicInteger();
+
+    ConsistencyScanResult result =
+        runner.run(
+            opContext,
+            ConsistencyScanRequest.builder()
+                .entityType("dataset")
+                .batchSize(100)
+                .progressLogIntervalMs(60_000)
+                .progressWarmupMs(60_000) // suppress progress during short test
+                .delayMs(0)
+                .onBatch(
+                    r -> {
+                      batches.incrementAndGet();
+                      return BatchHandleResult.none();
+                    })
+                .onCheckpoint(checkpoints::add)
+                .onProgress(s -> progressReports.incrementAndGet())
+                .build());
+
+    assertEquals(batches.get(), 3);
+    assertEquals(checkpoints.size(), 3);
+    assertEquals(result.getEntitiesScanned(), 300);
+    assertEquals(result.getTotalEstimate().longValue(), 300L);
+    // Warmup not elapsed → no progress callbacks
+    assertEquals(progressReports.get(), 0);
+    verify(consistencyService, times(1)).countMatching(eq(opContext), any());
+    verify(consistencyService, times(3)).checkBatch(eq(opContext), any(), isNull());
+  }
+
+  @Test
+  public void testCountEmpty_rateOnlyNoTotal() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.empty());
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(50)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId(null)
+                .build());
+
+    List<ConsistencyScanStart> starts = new ArrayList<>();
+    ConsistencyScanResult result =
+        runner.run(
+            opContext,
+            ConsistencyScanRequest.builder().entityType("dataset").onStart(starts::add).build());
+
+    assertEquals(starts.size(), 1);
+    assertFalse(starts.get(0).isEtaEnabled());
+    assertNull(starts.get(0).getTotalEstimate());
+    assertNull(result.getTotalEstimate());
+    assertEquals(result.getEntitiesScanned(), 50);
+  }
+
+  @Test
+  public void testLimitStopsScan() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(1000L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(100)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId("more")
+                .build());
+
+    ConsistencyScanResult result =
+        runner.run(
+            opContext, ConsistencyScanRequest.builder().entityType("dataset").limit(150).build());
+
+    assertEquals(result.getEntitiesScanned(), 200); // two batches then stop (>= limit)
+    assertEquals(result.getTotalEstimate().longValue(), 150L); // min(count, limit)
+    verify(consistencyService, times(2)).checkBatch(eq(opContext), any(), isNull());
+  }
+
+  @Test
+  public void testOnBatchAccumulatesFixCounts() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(100L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(100)
+                .issuesFound(2)
+                .issues(List.of())
+                .scrollId(null)
+                .build());
+
+    ConsistencyScanResult result =
+        runner.run(
+            opContext,
+            ConsistencyScanRequest.builder()
+                .entityType("dataset")
+                .onBatch(r -> BatchHandleResult.of(1, 1))
+                .build());
+
+    assertEquals(result.getIssuesFixed(), 1);
+    assertEquals(result.getIssuesFailed(), 1);
+    assertEquals(result.getIssuesFound(), 2);
+  }
+
+  @Test
+  public void testEntityEtaIneligible_ignoresCount() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(500L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(
+            CheckResult.builder()
+                .entitiesScanned(10)
+                .issuesFound(0)
+                .issues(List.of())
+                .scrollId(null)
+                .build());
+
+    List<ConsistencyScanStart> starts = new ArrayList<>();
+    ConsistencyScanResult result =
+        runner.run(
+            opContext,
+            ConsistencyScanRequest.builder()
+                .entityType("dataset")
+                .entityEtaEligible(false)
+                .onStart(starts::add)
+                .build());
+
+    assertFalse(starts.get(0).isEtaEnabled());
+    assertNull(result.getTotalEstimate());
+  }
+
+  @Test
+  public void testShouldStopHaltsEarly() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(1000L));
+
+    AtomicInteger calls = new AtomicInteger();
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenAnswer(
+            inv -> {
+              calls.incrementAndGet();
+              return CheckResult.builder()
+                  .entitiesScanned(100)
+                  .issuesFound(0)
+                  .issues(List.of())
+                  .scrollId("more")
+                  .build();
+            });
+
+    AtomicInteger batches = new AtomicInteger();
+    runner.run(
+        opContext,
+        ConsistencyScanRequest.builder()
+            .entityType("dataset")
+            .shouldStop(() -> batches.get() >= 1)
+            .onBatch(
+                r -> {
+                  batches.incrementAndGet();
+                  return BatchHandleResult.none();
+                })
+            .build());
+
+    // shouldStop checked at loop start: first iteration runs, second sees stop
+    assertEquals(batches.get(), 1);
+  }
+
+  @Test
+  public void testEmptyFirstBatch() {
+    when(consistencyService.countMatching(eq(opContext), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(0L));
+    when(consistencyService.checkBatch(eq(opContext), any(CheckBatchRequest.class), isNull()))
+        .thenReturn(CheckResult.empty());
+
+    ConsistencyScanResult result =
+        runner.run(opContext, ConsistencyScanRequest.builder().entityType("dataset").build());
+
+    assertEquals(result.getEntitiesScanned(), 0);
+    verify(consistencyService, times(1)).checkBatch(eq(opContext), any(), isNull());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -967,6 +967,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "systemUpdate.entityConsistency.dryRun",
           "systemUpdate.entityConsistency.entityTypes",
           "systemUpdate.entityConsistency.gracePeriodSeconds",
+          "systemUpdate.entityConsistency.progressLogIntervalMs",
+          "systemUpdate.entityConsistency.progressWarmupMs",
           "systemUpdate.entityConsistency.systemMetadataFilterConfig.aspectFilters",
           "systemUpdate.entityConsistency.systemMetadataFilterConfig.entityTypes",
           "systemUpdate.entityConsistency.systemMetadataFilterConfig.gePitEpochMs",

--- a/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
@@ -19,7 +19,7 @@ public class ProgressTrackerTest {
         ProgressTracker.builder()
             .label("test")
             .reportIntervalMs(60_000)
-            .warmupMs(0)
+            .warmupMs(0L)
             .clock(clock)
             .build();
 
@@ -43,7 +43,7 @@ public class ProgressTrackerTest {
             .label("scan")
             .total(1000L)
             .reportIntervalMs(60_000)
-            .warmupMs(0)
+            .warmupMs(0L)
             .clock(clock)
             .build();
 
@@ -65,7 +65,7 @@ public class ProgressTrackerTest {
   public void testPercentCappedAt99UntilFinished() {
     MutableClock clock = new MutableClock(1_000_000L);
     ProgressTracker tracker =
-        ProgressTracker.builder().label("scan").total(100L).warmupMs(0).clock(clock).build();
+        ProgressTracker.builder().label("scan").total(100L).warmupMs(0L).clock(clock).build();
 
     tracker.record(99);
     clock.advance(1000);
@@ -85,7 +85,7 @@ public class ProgressTrackerTest {
         ProgressTracker.builder()
             .label("scan")
             .total(1000L)
-            .warmupMs(30_000)
+            .warmupMs(30_000L)
             .reportIntervalMs(60_000)
             .clock(clock)
             .build();
@@ -113,7 +113,7 @@ public class ProgressTrackerTest {
         ProgressTracker.builder()
             .label("scan")
             .total(10_000L)
-            .warmupMs(0)
+            .warmupMs(0L)
             .reportIntervalMs(60_000)
             .clock(clock)
             .build();
@@ -137,14 +137,14 @@ public class ProgressTrackerTest {
   }
 
   @Test
-  public void testResumeInitialProcessed() {
+  public void testResumeInitialProcessed_rateUsesCurrentRunOnly() {
     MutableClock clock = new MutableClock(1_000_000L);
     ProgressTracker tracker =
         ProgressTracker.builder()
             .label("scan")
             .total(1000L)
             .initialProcessed(400)
-            .warmupMs(0)
+            .warmupMs(0L)
             .clock(clock)
             .build();
 
@@ -153,6 +153,42 @@ public class ProgressTrackerTest {
     assertEquals(tracker.getProcessed(), 500);
     ProgressSnapshot snap = tracker.snapshot();
     assertEquals(snap.getPercentComplete().intValue(), 50);
+    assertEquals(snap.getRatePerSecond(), 10.0, 0.01);
+    assertEquals(snap.getEtaSeconds().longValue(), 50L);
+  }
+
+  @Test
+  public void testZeroTotal_markedFinished() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder().label("scan").total(0L).warmupMs(0L).clock(clock).build();
+
+    ProgressSnapshot snap = tracker.snapshot();
+    assertEquals(snap.getTotal().longValue(), 0L);
+    assertTrue(snap.isFinished());
+    assertEquals(snap.getPercentComplete().intValue(), 100);
+    assertNull(snap.getEtaSeconds());
+  }
+
+  @Test
+  public void testBuilderDefaultWarmup() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(1000L)
+            .reportIntervalMs(60_000L)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(10_000);
+
+    assertNull(tracker.snapshot().getEtaSeconds());
+    assertFalse(tracker.maybeReport(s -> {}));
+
+    clock.advance(25_000);
+    assertNotNull(tracker.snapshot().getEtaSeconds());
   }
 
   @Test
@@ -162,7 +198,7 @@ public class ProgressTrackerTest {
         ProgressTracker.builder()
             .label("scan")
             .total(100L)
-            .warmupMs(0)
+            .warmupMs(0L)
             .reportIntervalMs(60_000)
             .clock(clock)
             .build();
@@ -186,7 +222,7 @@ public class ProgressTrackerTest {
   public void testEtaHumanOnLongRemaining() {
     MutableClock clock = new MutableClock(1_000_000L);
     ProgressTracker tracker =
-        ProgressTracker.builder().label("scan").total(100_000L).warmupMs(0).clock(clock).build();
+        ProgressTracker.builder().label("scan").total(100_000L).warmupMs(0L).clock(clock).build();
 
     tracker.record(100);
     clock.advance(10_000); // 10/sec → ~9990s remaining ≈ 2h 46m

--- a/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
@@ -1,0 +1,230 @@
+package com.linkedin.metadata.utils.progress;
+
+import static org.testng.Assert.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.testng.annotations.Test;
+
+public class ProgressTrackerTest {
+
+  @Test
+  public void testSnapshotWithoutTotal_noEtaOrPercent() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("test")
+            .reportIntervalMs(60_000)
+            .warmupMs(0)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(10_000);
+
+    ProgressSnapshot snap = tracker.snapshot();
+    assertEquals(snap.getProcessed(), 100);
+    assertNull(snap.getTotal());
+    assertNull(snap.getPercentComplete());
+    assertNull(snap.getEtaSeconds());
+    assertTrue(snap.getMessage().contains("100 processed"));
+    assertFalse(snap.getMessage().contains("ETA"));
+  }
+
+  @Test
+  public void testSnapshotWithTotal_computesPercentAndEta() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(1000L)
+            .reportIntervalMs(60_000)
+            .warmupMs(0)
+            .clock(clock)
+            .build();
+
+    tracker.record(250);
+    clock.advance(10_000); // 25/sec
+
+    ProgressSnapshot snap = tracker.snapshot();
+    assertEquals(snap.getProcessed(), 250);
+    assertEquals(snap.getTotal().longValue(), 1000L);
+    assertEquals(snap.getPercentComplete().intValue(), 25);
+    assertNotNull(snap.getEtaSeconds());
+    assertEquals(snap.getEtaSeconds().longValue(), 30L); // 750 remaining / 25/sec
+    assertEquals(snap.getEtaHuman(), "30s");
+    assertTrue(snap.getMessage().contains("250/1000"));
+    assertTrue(snap.getMessage().contains("est. ETA 30s"));
+  }
+
+  @Test
+  public void testPercentCappedAt99UntilFinished() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder().label("scan").total(100L).warmupMs(0).clock(clock).build();
+
+    tracker.record(99);
+    clock.advance(1000);
+    assertEquals(tracker.snapshot().getPercentComplete().intValue(), 99);
+
+    tracker.record(1);
+    ProgressSnapshot done = tracker.snapshot();
+    assertTrue(done.isFinished());
+    assertEquals(done.getPercentComplete().intValue(), 100);
+    assertNull(done.getEtaSeconds());
+  }
+
+  @Test
+  public void testWarmupSuppressesEtaAndFirstReport() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(1000L)
+            .warmupMs(30_000)
+            .reportIntervalMs(60_000)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(10_000); // still in warmup
+
+    ProgressSnapshot duringWarmup = tracker.snapshot();
+    assertNull(duringWarmup.getEtaSeconds());
+
+    List<ProgressSnapshot> reports = new ArrayList<>();
+    assertFalse(tracker.maybeReport(reports::add));
+    assertTrue(reports.isEmpty());
+
+    clock.advance(25_000); // past warmup
+    assertTrue(tracker.maybeReport(reports::add));
+    assertEquals(reports.size(), 1);
+    assertNotNull(reports.get(0).getEtaSeconds());
+  }
+
+  @Test
+  public void testThrottleSuppressesRapidReports() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(10_000L)
+            .warmupMs(0)
+            .reportIntervalMs(60_000)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(1000);
+
+    AtomicReference<Integer> count = new AtomicReference<>(0);
+    assertTrue(tracker.maybeReport(s -> count.updateAndGet(c -> c + 1)));
+    assertEquals(count.get().intValue(), 1);
+
+    clock.advance(30_000);
+    tracker.record(100);
+    assertFalse(tracker.maybeReport(s -> count.updateAndGet(c -> c + 1)));
+    assertEquals(count.get().intValue(), 1);
+
+    clock.advance(30_000);
+    tracker.record(100);
+    assertTrue(tracker.maybeReport(s -> count.updateAndGet(c -> c + 1)));
+    assertEquals(count.get().intValue(), 2);
+  }
+
+  @Test
+  public void testResumeInitialProcessed() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(1000L)
+            .initialProcessed(400)
+            .warmupMs(0)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(10_000);
+    assertEquals(tracker.getProcessed(), 500);
+    ProgressSnapshot snap = tracker.snapshot();
+    assertEquals(snap.getPercentComplete().intValue(), 50);
+  }
+
+  @Test
+  public void testForceReportBypassesThrottle() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(100L)
+            .warmupMs(0)
+            .reportIntervalMs(60_000)
+            .clock(clock)
+            .build();
+
+    tracker.record(10);
+    clock.advance(1000);
+    List<ProgressSnapshot> reports = new ArrayList<>();
+    tracker.forceReport(reports::add);
+    tracker.forceReport(reports::add);
+    assertEquals(reports.size(), 2);
+  }
+
+  @Test
+  public void testFormatDuration() {
+    assertEquals(ProgressTracker.formatDuration(45), "45s");
+    assertEquals(ProgressTracker.formatDuration(125), "2m 5s");
+    assertEquals(ProgressTracker.formatDuration(3725), "1h 2m");
+  }
+
+  @Test
+  public void testEtaHumanOnLongRemaining() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder().label("scan").total(100_000L).warmupMs(0).clock(clock).build();
+
+    tracker.record(100);
+    clock.advance(10_000); // 10/sec → ~9990s remaining ≈ 2h 46m
+    ProgressSnapshot snap = tracker.snapshot();
+    assertEquals(snap.getEtaHuman(), "2h 46m");
+    assertTrue(snap.getMessage().contains("est. ETA 2h 46m"));
+  }
+
+  /** Simple mutable clock for deterministic tests. */
+  private static final class MutableClock extends Clock {
+    private long millis;
+
+    MutableClock(long millis) {
+      this.millis = millis;
+    }
+
+    void advance(long deltaMs) {
+      millis += deltaMs;
+    }
+
+    @Override
+    public ZoneOffset getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(java.time.ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return Instant.ofEpochMilli(millis);
+    }
+
+    @Override
+    public long millis() {
+      return millis;
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/utils/progress/ProgressTrackerTest.java
@@ -212,6 +212,36 @@ public class ProgressTrackerTest {
   }
 
   @Test
+  public void testNegativeTotal_treatedAsUnknown() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder().label("scan").total(-5L).warmupMs(0L).clock(clock).build();
+
+    ProgressSnapshot snap = tracker.snapshot();
+    assertNull(snap.getTotal());
+    assertNull(snap.getPercentComplete());
+    assertFalse(snap.isFinished());
+  }
+
+  @Test
+  public void testNegativeWarmupUsesDefault() {
+    MutableClock clock = new MutableClock(1_000_000L);
+    ProgressTracker tracker =
+        ProgressTracker.builder()
+            .label("scan")
+            .total(1000L)
+            .warmupMs(-1L)
+            .reportIntervalMs(60_000L)
+            .clock(clock)
+            .build();
+
+    tracker.record(100);
+    clock.advance(10_000);
+    assertNull(tracker.snapshot().getEtaSeconds());
+    assertFalse(tracker.maybeReport(s -> {}));
+  }
+
+  @Test
   public void testFormatDuration() {
     assertEquals(ProgressTracker.formatDuration(45), "45s");
     assertEquals(ProgressTracker.formatDuration(125), "2m 5s");

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityConsistencyConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityConsistencyConfiguration.java
@@ -55,6 +55,18 @@ public class EntityConsistencyConfiguration {
   private int limit;
 
   /**
+   * Minimum interval between progress/ETA INFO log lines during a long entity-type scan (ms).
+   * Default 60000. Checkpoints remain silent every batch.
+   */
+  private long progressLogIntervalMs = 60_000L;
+
+  /**
+   * Warmup before the first time-based ETA is logged (ms). Default 30000 so early rate estimates
+   * are not noisy.
+   */
+  private long progressWarmupMs = 30_000L;
+
+  /**
    * Job-level entity types for default (non-orphan) checks. If empty or null, uses entity types
    * that have registered default checks.
    *

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1536,6 +1536,9 @@ systemUpdate:
     delayMs: ${SYSTEM_UPDATE_ENTITY_CONSISTENCY_DELAY_MS:1000}
     gracePeriodSeconds: ${SYSTEM_UPDATE_ENTITY_CONSISTENCY_GRACE_PERIOD_SECONDS:14400}  # 4 hours - exclude recently modified entities to avoid eventual consistency false positives
     limit: ${SYSTEM_UPDATE_ENTITY_CONSISTENCY_LIMIT:0}
+    # Min ms between progress/ETA INFO lines per entity type (checkpoints stay silent every batch)
+    progressLogIntervalMs: ${SYSTEM_UPDATE_ENTITY_CONSISTENCY_PROGRESS_LOG_INTERVAL_MS:60000}
+    progressWarmupMs: ${SYSTEM_UPDATE_ENTITY_CONSISTENCY_PROGRESS_WARMUP_MS:30000}
     entityTypes: []  # Job-level override of entity types for default checks. Empty = types with registered default checks.
     checkIds: []  # Check IDs to run. Empty = all default checks for the entity types.
     reprocess:

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/ConsistencyController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/ConsistencyController.java
@@ -314,18 +314,24 @@ public class ConsistencyController {
           buildFilterWithGracePeriod(
               checkRequest.getFilter(), checkRequest.getGracePeriodSeconds());
 
-      CheckResult result =
-          consistencyService.checkBatch(
-              opContext,
-              CheckBatchRequest.builder()
-                  .entityType(checkRequest.getEntityType())
-                  .checkIds(checkRequest.getCheckIds())
-                  .batchSize(checkRequest.getBatchSize())
-                  .scrollId(checkRequest.getScrollId())
-                  .filter(filterConfig)
-                  .build());
+      CheckBatchRequest batchRequest =
+          CheckBatchRequest.builder()
+              .entityType(checkRequest.getEntityType())
+              .checkIds(checkRequest.getCheckIds())
+              .batchSize(checkRequest.getBatchSize())
+              .scrollId(checkRequest.getScrollId())
+              .filter(filterConfig)
+              .build();
 
-      return ResponseEntity.ok(ConsistencyCheckResult.from(result));
+      Long totalEstimate = null;
+      if (checkRequest.getScrollId() == null) {
+        Optional<Long> counted = consistencyService.countMatching(opContext, batchRequest);
+        totalEstimate = counted != null ? counted.orElse(null) : null;
+      }
+
+      CheckResult result = consistencyService.checkBatch(opContext, batchRequest);
+
+      return ResponseEntity.ok(ConsistencyCheckResult.from(result, totalEstimate));
     } catch (IllegalArgumentException e) {
       log.warn("Invalid check request: {}", e.getMessage());
       return ResponseEntity.badRequest().build();
@@ -475,17 +481,23 @@ public class ConsistencyController {
       SystemMetadataFilter filterConfig =
           buildFilterWithGracePeriod(fixRequest.getFilter(), fixRequest.getGracePeriodSeconds());
 
+      CheckBatchRequest batchRequest =
+          CheckBatchRequest.builder()
+              .entityType(fixRequest.getEntityType())
+              .checkIds(fixRequest.getCheckIds())
+              .batchSize(fixRequest.getBatchSize())
+              .scrollId(fixRequest.getScrollId())
+              .filter(filterConfig)
+              .build();
+
+      Long totalEstimate = null;
+      if (fixRequest.getScrollId() == null) {
+        Optional<Long> counted = consistencyService.countMatching(opContext, batchRequest);
+        totalEstimate = counted != null ? counted.orElse(null) : null;
+      }
+
       // Run checks
-      CheckResult checkResult =
-          consistencyService.checkBatch(
-              opContext,
-              CheckBatchRequest.builder()
-                  .entityType(fixRequest.getEntityType())
-                  .checkIds(fixRequest.getCheckIds())
-                  .batchSize(fixRequest.getBatchSize())
-                  .scrollId(fixRequest.getScrollId())
-                  .filter(filterConfig)
-                  .build());
+      CheckResult checkResult = consistencyService.checkBatch(opContext, batchRequest);
 
       // Fix any issues found
       ConsistencyFixResult fixResult =
@@ -493,7 +505,7 @@ public class ConsistencyController {
 
       return ResponseEntity.ok(
           io.datahubproject.openapi.operations.consistency.models.ConsistencyFixResult.from(
-              checkResult, fixResult));
+              checkResult, fixResult, totalEstimate));
     } catch (IllegalArgumentException e) {
       log.warn("Invalid fix request: {}", e.getMessage());
       return ResponseEntity.badRequest().build();

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyCheckResult.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyCheckResult.java
@@ -18,11 +18,18 @@ public class ConsistencyCheckResult {
 
   /** Creates a ConsistencyCheckResult from a service-layer CheckResult. */
   public static ConsistencyCheckResult from(@Nonnull CheckResult result) {
+    return from(result, null);
+  }
+
+  /** Creates a ConsistencyCheckResult with an optional total estimate from countMatching. */
+  public static ConsistencyCheckResult from(
+      @Nonnull CheckResult result, @Nullable Long totalEstimate) {
     return ConsistencyCheckResult.builder()
         .entitiesScanned(result.getEntitiesScanned())
         .issuesFound(result.getIssuesFound())
         .issues(ConsistencyIssue.from(result.getIssues()))
         .scrollId(result.getScrollId())
+        .totalEstimate(totalEstimate)
         .build();
   }
 
@@ -41,4 +48,12 @@ public class ConsistencyCheckResult {
           "Scroll ID for pagination. Null if no more results. Pass to next request to continue.")
   @Nullable
   private String scrollId;
+
+  @Schema(
+      description =
+          "Estimated matching system-metadata documents for this request filter. "
+              + "Populated on the first page (scrollId null) when a count is available. "
+              + "With keyAspectOnly, approximates unique entities.")
+  @Nullable
+  private Long totalEstimate;
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyCheckResult.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyCheckResult.java
@@ -52,8 +52,8 @@ public class ConsistencyCheckResult {
   @Schema(
       description =
           "Estimated matching system-metadata documents for this request filter. "
-              + "Populated on the first page (scrollId null) when a count is available. "
-              + "With keyAspectOnly, approximates unique entities.")
+              + "Populated on the first request page (when no scroll ID is supplied) when a count "
+              + "is available. With keyAspectOnly, approximates unique entities.")
   @Nullable
   private Long totalEstimate;
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyFixResult.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyFixResult.java
@@ -26,6 +26,13 @@ public class ConsistencyFixResult {
   public static ConsistencyFixResult from(
       @Nonnull CheckResult checkResult,
       @Nonnull com.linkedin.metadata.aspect.consistency.fix.ConsistencyFixResult fixResult) {
+    return from(checkResult, fixResult, null);
+  }
+
+  public static ConsistencyFixResult from(
+      @Nonnull CheckResult checkResult,
+      @Nonnull com.linkedin.metadata.aspect.consistency.fix.ConsistencyFixResult fixResult,
+      @Nullable Long totalEstimate) {
     return io.datahubproject.openapi.operations.consistency.models.ConsistencyFixResult.builder()
         .entitiesScanned(checkResult.getEntitiesScanned())
         .issuesFound(checkResult.getIssuesFound())
@@ -35,6 +42,7 @@ public class ConsistencyFixResult {
         .entitiesFixed(fixResult.getEntitiesFixed())
         .entitiesFailed(fixResult.getEntitiesFailed())
         .fixDetails(FixDetail.from(fixResult.getFixDetails()))
+        .totalEstimate(totalEstimate)
         .build();
   }
 
@@ -65,4 +73,11 @@ public class ConsistencyFixResult {
   @Schema(description = "Details of each fix operation")
   @Nonnull
   private List<FixDetail> fixDetails;
+
+  @Schema(
+      description =
+          "Estimated matching system-metadata documents for this request filter. "
+              + "Populated on the first page (scrollId null) when a count is available.")
+  @Nullable
+  private Long totalEstimate;
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyFixResult.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/consistency/models/ConsistencyFixResult.java
@@ -77,7 +77,8 @@ public class ConsistencyFixResult {
   @Schema(
       description =
           "Estimated matching system-metadata documents for this request filter. "
-              + "Populated on the first page (scrollId null) when a count is available.")
+              + "Populated on the first request page (when no scroll ID is supplied) when a count "
+              + "is available.")
   @Nullable
   private Long totalEstimate;
 }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/consistency/ConsistencyControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/consistency/ConsistencyControllerTest.java
@@ -331,6 +331,9 @@ public class ConsistencyControllerTest extends AbstractTestNGSpringContextTests 
     when(mockConsistencyService.checkBatch(
             any(OperationContext.class), any(CheckBatchRequest.class)))
         .thenReturn(checkResult);
+    when(mockConsistencyService.countMatching(
+            any(OperationContext.class), any(CheckBatchRequest.class)))
+        .thenReturn(Optional.of(500L));
 
     ConsistencyCheckRequest request = new ConsistencyCheckRequest();
     request.setEntityType("assertion");
@@ -346,7 +349,39 @@ public class ConsistencyControllerTest extends AbstractTestNGSpringContextTests 
         .andExpect(MockMvcResultMatchers.jsonPath("$.entitiesScanned").value(10))
         .andExpect(MockMvcResultMatchers.jsonPath("$.issuesFound").value(2))
         .andExpect(MockMvcResultMatchers.jsonPath("$.scrollId").value("scroll123"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.totalEstimate").value(500))
         .andExpect(MockMvcResultMatchers.jsonPath("$.issues[0].entityUrn").exists());
+  }
+
+  @Test
+  public void testBatchCheckSkipsCountOnResumeScroll() throws Exception {
+    CheckResult checkResult =
+        CheckResult.builder()
+            .entitiesScanned(10)
+            .issuesFound(0)
+            .issues(List.of())
+            .scrollId("next")
+            .build();
+
+    when(mockConsistencyService.checkBatch(
+            any(OperationContext.class), any(CheckBatchRequest.class)))
+        .thenReturn(checkResult);
+
+    ConsistencyCheckRequest request = new ConsistencyCheckRequest();
+    request.setEntityType("assertion");
+    request.setScrollId("resume-token");
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/operations/consistency/check")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.totalEstimate").doesNotExist());
+
+    verify(mockConsistencyService, never())
+        .countMatching(any(OperationContext.class), any(CheckBatchRequest.class));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds reusable `ProgressTracker` and `ConsistencyScanRunner` so long-running entity-consistency upgrade scans can report rate and human-readable ETA (~1 INFO line/min after warmup) without per-batch log spam.
- Wires `FixEntityConsistencyStep` onto the runner with configurable `progressLogIntervalMs` / `progressWarmupMs`.
- Exposes additive `totalEstimate` (matching entity/doc count) on OpenAPI consistency check/fix responses for the first page.

## Test plan
- [x] `:metadata-io` unit tests for `ProgressTracker`, `ConsistencyScanRunner`, `ConsistencyService`
- [x] `:datahub-upgrade` `FixEntityConsistencyStepTest`
- [x] `:metadata-service:openapi-servlet` `ConsistencyControllerTest`
- [x] Spotless apply on touched modules
- [ ] Local system-update: confirm start + throttled mid-run ETA lines for a multi-minute entity-consistency scan


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ETA-based, throttled progress to entity-consistency scans and exposes a total estimate on first-page OpenAPI responses. Previously we logged per batch without ETA and always marked success; now we log rate and human-readable ETA after warmup, persist silent checkpoints, cap batches to respect limits, and keep IN_PROGRESS with Action.ABORT when a scan is interrupted.

- Reusable utilities in `metadata-io`: `ProgressTracker`, `ConsistencyScanRunner`, and `ConsistencyService.countMatching` backed by `ESSystemMetadataDAO.count`; soft-fails on ES errors, logs failures, caps totals by limit (including zero), and only enables entity ETA when key-aspect-only is true.
- `FixEntityConsistencyStep` uses the runner: preserves batch delay/limit, caps batch size to honor limits, stops on interrupt and returns IN_PROGRESS/ABORT, clears per-batch orphan URNs, silently checkpoints scroll/counters/last ETA, and records totalEstimate in the final state.
- OpenAPI `/consistency/check` and `/consistency/fix` include totalEstimate on the first page only; resume pages skip counting.
- Configuration: progressLogIntervalMs and progressWarmupMs (defaults 60000/30000) via env vars SYSTEM_UPDATE_ENTITY_CONSISTENCY_PROGRESS_LOG_INTERVAL_MS and SYSTEM_UPDATE_ENTITY_CONSISTENCY_PROGRESS_WARMUP_MS. No migrations required.

<sup>Written for commit 29e1d2046acd07f166606e35804e2850ab9fd2dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

