### PR TITLE
fix(ingest/redshift): warn on catalog race errors

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/exception.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/exception.py
@@ -57,6 +57,12 @@ def report_redshift_failure(
                 message="Failed to extract metadata due to insufficient permissions.",
                 exc=e,
             )
+    elif "could not open relation with oid" in error_message:
+        report.warning(
+            title="Transient catalog error",
+            message="Failed to extract some metadata because a referenced relation was concurrently dropped or recreated on the Redshift cluster (e.g. by a CTAS-and-swap ETL job). This is usually a transient catalog-race condition and may resolve on the next scheduled run.",
+            exc=e,
+        )
     else:
         report.failure(
             title="Failed to extract some metadata",

--- a/metadata-ingestion/tests/unit/redshift/test_redshift_exception.py
+++ b/metadata-ingestion/tests/unit/redshift/test_redshift_exception.py
@@ -1,0 +1,61 @@
+import redshift_connector
+
+from datahub.ingestion.source.redshift.exception import report_redshift_failure
+from datahub.ingestion.source.redshift.report import RedshiftReport
+
+
+def _programming_error(message: str) -> redshift_connector.error.ProgrammingError:
+    # redshift_connector wraps the server response in a dict keyed by the
+    # single-letter Postgres protocol field codes; "M" is the human-readable
+    # message, matching the shape seen in real driver exceptions.
+    return redshift_connector.error.ProgrammingError(
+        {"S": "ERROR", "C": "XX000", "M": message}
+    )
+
+
+def test_permission_denied_svv_table_info_reported_as_failure() -> None:
+    report = RedshiftReport()
+    e = _programming_error("permission denied for relation svv_table_info")
+
+    report_redshift_failure(report, e)
+
+    assert len(report.failures) == 1
+    assert len(report.warnings) == 0
+    assert report.failures[0].title == "Permission denied"
+
+
+def test_could_not_open_relation_with_oid_reported_as_warning() -> None:
+    """A concurrent catalog change (e.g. an ETL job dropping/recreating a table
+    mid-extraction) surfaces as 'could not open relation with OID <n>'. This is
+    a transient Redshift/Postgres catalog-race condition, not a hard failure
+    that should be surfaced the same way as a real permissions or connectivity
+    problem, so it must land in warnings, not failures."""
+    report = RedshiftReport()
+    e = _programming_error("could not open relation with OID 12345")
+
+    report_redshift_failure(report, e)
+
+    assert len(report.warnings) == 1
+    assert len(report.failures) == 0
+    assert report.warnings[0].title == "Transient catalog error"
+
+
+def test_could_not_open_relation_with_oid_matched_case_insensitively() -> None:
+    report = RedshiftReport()
+    e = _programming_error("Could Not Open Relation With OID 999")
+
+    report_redshift_failure(report, e)
+
+    assert len(report.warnings) == 1
+    assert len(report.failures) == 0
+
+
+def test_generic_redshift_error_reported_as_failure() -> None:
+    report = RedshiftReport()
+    e = _programming_error("connection to server was lost")
+
+    report_redshift_failure(report, e)
+
+    assert len(report.failures) == 1
+    assert len(report.warnings) == 0
+    assert report.failures[0].title == "Failed to extract some metadata"


### PR DESCRIPTION
A live ingestion source intermittently failed with "could not open
relation with OID <n>" on roughly 1-in-7 scheduled runs. This happens
when a relation referenced mid-extraction is concurrently dropped and
recreated elsewhere on the cluster (e.g. a CTAS-then-swap ETL job) - a
transient Postgres/Redshift catalog-race condition, not a credentials
or permissions problem.

Previously this fell into the generic "Failed to extract some
metadata" failure branch, indistinguishable from a genuine hard error
and offering the operator no indication that the run would likely
succeed if simply retried on the next schedule. Classify it separately
and report it as a warning instead, so a transient race no longer
reads as an unexplained ingestion failure.

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns on transient Redshift catalog race errors ("could not open relation with OID <n>") instead of marking runs as generic failures. Previously these surfaced as "Failed to extract some metadata"; now they appear as "Transient catalog error" so operators can distinguish transient races and rely on retries.

- Detection uses a case-insensitive match on "could not open relation with oid".
- Keeps permission-denied and other errors as failures; adds unit tests for both paths.

<sup>Written for commit dd36d14a7d72d0555117adc9ef0e972ae35cb46c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

