### PR TITLE
fix(ingestion/looker): don't soft-delete dashboards that failed to fetch

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -143,6 +143,7 @@ class LookerAPI:
                 total=self.config.max_retries,
                 backoff_factor=1,
                 status_forcelist=[429, 500, 502, 503, 504],
+                allowed_methods=["GET", "POST"],
             )
             adapter = HTTPAdapter(
                 max_retries=retries,

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -27,6 +27,7 @@ from looker_sdk.sdk.api40.models import (
 )
 from pydantic import BaseModel, Field
 from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import ConfigurationError, TransparentSecretStr
@@ -135,8 +136,16 @@ class LookerAPI:
             self.client.transport, looker_requests_transport.RequestsTransport
         ):
             pool_size = self.config.max_threads + 10
+            # A plain int for max_retries only retries connection-level
+            # errors (urllib3), not HTTP responses like 429/5xx that the
+            # Looker SDK turns into SDKError - those need status_forcelist.
+            retries = Retry(
+                total=self.config.max_retries,
+                backoff_factor=1,
+                status_forcelist=[429, 500, 502, 503, 504],
+            )
             adapter = HTTPAdapter(
-                max_retries=self.config.max_retries,
+                max_retries=retries,
                 pool_connections=pool_size,
                 pool_maxsize=pool_size,
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1280,13 +1280,11 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             # causes it to be soft-deleted even though it still exists.
             self.reporter.failure(
                 title="Failed to fetch dashboard from the Looker API",
-                message="Error occurred while attempting to loading dashboard from Looker API. Skipping.",
+                message="Error occurred while attempting to load dashboard from Looker API. Skipping.",
                 context=f"Dashboard ID: {dashboard_id}",
                 exc=e,
                 log=False,
             )
-            return None
-
     def _create_empty_result(
         self, dashboard_id: str, start_time: datetime.datetime
     ) -> DashboardProcessingResult:

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1273,12 +1273,16 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 fields=fields,
             )
         except (SDKError, DeserializeError) as e:
-            self.reporter.warning(
+            # Reported as a failure (not a warning) so that
+            # StaleEntityRemovalHandler.gen_removed_entity_workunits skips
+            # soft-deletion for this run: an entity we failed to fetch was
+            # never "seen," and treating that the same as "genuinely gone"
+            # causes it to be soft-deleted even though it still exists.
+            self.reporter.failure(
                 title="Failed to fetch dashboard from the Looker API",
                 message="Error occurred while attempting to loading dashboard from Looker API. Skipping.",
                 context=f"Dashboard ID: {dashboard_id}",
                 exc=e,
-                log=False,
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1283,6 +1283,7 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 message="Error occurred while attempting to loading dashboard from Looker API. Skipping.",
                 context=f"Dashboard ID: {dashboard_id}",
                 exc=e,
+                log=False,
             )
             return None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1285,6 +1285,8 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
                 exc=e,
                 log=False,
             )
+            return None
+
     def _create_empty_result(
         self, dashboard_id: str, start_time: datetime.datetime
     ) -> DashboardProcessingResult:

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -115,4 +115,5 @@ def test_http_adapter_pool_size_matches_max_threads():
     retries = kwargs["max_retries"]
     assert retries.total == config.max_retries
     assert retries.status_forcelist == [429, 500, 502, 503, 504]
+    assert "POST" in retries.allowed_methods
     assert mock_session.mount.call_count == 2

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -108,9 +108,11 @@ def test_http_adapter_pool_size_matches_max_threads():
     ):
         LookerAPI(config=config)
 
-    mock_adapter_cls.assert_called_once_with(
-        max_retries=config.max_retries,
-        pool_connections=30,
-        pool_maxsize=30,
-    )
+    assert mock_adapter_cls.call_count == 1
+    _, kwargs = mock_adapter_cls.call_args
+    assert kwargs["pool_connections"] == 30
+    assert kwargs["pool_maxsize"] == 30
+    retries = kwargs["max_retries"]
+    assert retries.total == config.max_retries
+    assert retries.status_forcelist == [429, 500, 502, 503, 504]
     assert mock_session.mount.call_count == 2

--- a/metadata-ingestion/tests/unit/looker/test_looker_source.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_source.py
@@ -1,0 +1,27 @@
+from unittest import mock
+
+from looker_sdk.error import SDKError
+
+from datahub.ingestion.source.looker.looker_common import LookerDashboardSourceReport
+from datahub.ingestion.source.looker.looker_source import LookerDashboardSource
+
+
+def test_fetch_dashboard_from_api_reports_failure_not_warning():
+    """A fetch error must be a report.failure(), not a warning().
+
+    StaleEntityRemovalHandler.gen_removed_entity_workunits only skips
+    soft-deletion when report.failures is non-empty: a dashboard that fails
+    to fetch was never "seen" this run, and if that's reported as a mere
+    warning, stale-entity removal still soft-deletes it even though it
+    still exists in Looker.
+    """
+    source = object.__new__(LookerDashboardSource)
+    source.looker_api = mock.MagicMock()
+    source.looker_api.dashboard.side_effect = SDKError("boom")
+    source.reporter = LookerDashboardSourceReport()
+
+    result = source._fetch_dashboard_from_api(dashboard_id="1", fields=["id"])
+
+    assert result is None
+    assert len(source.reporter.failures) == 1
+    assert len(source.reporter.warnings) == 0


### PR DESCRIPTION
## Summary
- A per-dashboard Looker API fetch error (e.g. transient rate-limiting or a timeout) was reported as a `warning`, so `StaleEntityRemovalHandler` treated the dashboard as genuinely gone and soft-deleted it even though it still exists in Looker. Reporting it as a `failure` routes into the handler's existing check that skips soft-deletion when the source had a failure.
- The Looker API's HTTP retry adapter was configured with a plain retry count, which only retries connection-level errors, not HTTP error responses (429/5xx) that the Looker SDK raises as `SDKError`. Switched to a `urllib3.Retry` with `status_forcelist` so those are actually retried, reducing how often the fetch fails in the first place.

## Test plan
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/looker/test_looker_source.py` — new test asserting fetch errors report a `failure`, not a `warning`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/looker/test_looker_lib_wrapper.py` — updated retry-adapter test
- [x] `./gradlew :metadata-ingestion:lintFix`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents soft-deleting Looker dashboards when a per-dashboard fetch fails and reduces noise from transient errors. Previously these were warnings and dashboards were treated as removed; now they are failures (without logging), stale-entity removal skips deletion, and transient 429/5xx responses are retried.

- `_fetch_dashboard_from_api` reports fetch errors via `reporter.failure(..., log=False)` so failures block soft-deletion without ERROR logs; restores explicit `return None` after failure.
- Configures `requests.adapters.HTTPAdapter` with `urllib3.Retry` (`status_forcelist=[429, 500, 502, 503, 504]`, `backoff_factor=1`, `allowed_methods=["GET", "POST"]`); pool sizing remains tied to `max_threads`.
- Adds a unit test asserting failure reporting (not warning) and updates retry configuration tests.

<sup>Written for commit 43af1efb81c0b899c501b4913a9c6e27faa4a8a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

