### PR TITLE
fix(actions): handle SIGTERM so container stops shut down cleanly

### DIFF
--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -110,6 +110,13 @@ def run(ctx: Any, config: List[str], debug: bool) -> None:
     else:
         logging.getLogger().setLevel(logging.INFO)
 
+    # Registered before any of the work below, which loads configs and constructs event
+    # sources (network I/O against Kafka, the schema registry, or GMS). With `exec` in the
+    # entrypoint this process is PID 1, and the kernel discards signals that PID 1 has no
+    # handler for -- so a stop arriving during startup would not terminate the process at
+    # all, and the runtime could only end it with SIGKILL once the grace period expired.
+    _register_shutdown_handlers()
+
     pipelines: List[Pipeline] = []
     logger.debug("Creating Actions Pipelines...")
 
@@ -172,8 +179,6 @@ def run(ctx: Any, config: List[str], debug: bool) -> None:
 
     logger.debug("Starting Actions Pipelines")
 
-    _register_shutdown_handlers()
-
     # Start each pipeline
     for p in pipelines:
         pipeline_manager.start_pipeline(p.name, p)
@@ -194,7 +199,14 @@ def version() -> None:
 # Handle shutdown signal (ctrl-c, or a container runtime stopping the process).
 def handle_shutdown(signum: int, frame: Any) -> None:
     logger.info("Stopping all running Action Pipelines...")
-    pipeline_manager.stop_all()
+    try:
+        pipeline_manager.stop_all()
+    except Exception:
+        # Raising out of a signal handler would kill the process with a traceback and an
+        # incidental exit code. Exit non-zero deliberately instead: a pipeline that failed
+        # to stop may not have flushed its consumer offsets, so this is not a clean stop.
+        logger.exception("Failed to stop all Action Pipelines cleanly")
+        sys.exit(1)
     # A completed graceful shutdown is a success, not a failure, to the container runtime.
     sys.exit(0)
 

--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -172,6 +172,8 @@ def run(ctx: Any, config: List[str], debug: bool) -> None:
 
     logger.debug("Starting Actions Pipelines")
 
+    _register_shutdown_handlers()
+
     # Start each pipeline
     for p in pipelines:
         pipeline_manager.start_pipeline(p.name, p)
@@ -189,11 +191,20 @@ def version() -> None:
     click.echo(f"Python version: {sys.version}")
 
 
-# Handle shutdown signal. (ctrl-c)
+# Handle shutdown signal (ctrl-c, or a container runtime stopping the process).
 def handle_shutdown(signum: int, frame: Any) -> None:
     logger.info("Stopping all running Action Pipelines...")
     pipeline_manager.stop_all()
-    sys.exit(1)
+    # A completed graceful shutdown is a success, not a failure, to the container runtime.
+    sys.exit(0)
 
 
-signal.signal(signal.SIGINT, handle_shutdown)
+def _register_shutdown_handlers() -> None:
+    # Registered here rather than at module import time: this module is imported
+    # unconditionally by the `datahub` CLI, so import-time registration would install
+    # these handlers on every `datahub` invocation -- including ingestion subprocesses,
+    # which are themselves cancelled with SIGTERM -- not just `datahub actions run`.
+    signal.signal(signal.SIGINT, handle_shutdown)
+    # Container runtimes stop with SIGTERM; it must reach the same stop_all() path,
+    # which is what closes the event source and flushes consumer offsets.
+    signal.signal(signal.SIGTERM, handle_shutdown)

--- a/datahub-actions/src/datahub_actions/pipeline/pipeline_manager.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline_manager.py
@@ -97,7 +97,8 @@ class PipelineManager:
                     # Reporting is best-effort; a pipeline that never reached mark_start()
                     # has no stats to print, and that must not look like a stop failure.
                     logger.warning(
-                        f"Could not print run summary for pipeline {name}", exc_info=True
+                        f"Could not print run summary for pipeline {name}",
+                        exc_info=True,
                     )
                 del self.pipeline_registry[name]
             except Exception as e:

--- a/datahub-actions/src/datahub_actions/pipeline/pipeline_manager.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline_manager.py
@@ -62,9 +62,16 @@ class PipelineManager:
         logger.debug(f"Attempting to start pipeline with name {name}...")
         if name not in self.pipeline_registry:
             thread = Thread(target=run_pipeline, args=([pipeline]))
-            thread.start()
+            # Register before starting: a shutdown signal arriving between these two
+            # statements must still find the pipeline, or its worker runs on unstopped
+            # (and, being non-daemon, blocks interpreter exit until SIGKILL).
             spec = PipelineSpec(name, pipeline, thread)
             self.pipeline_registry[name] = spec
+            try:
+                thread.start()
+            except Exception:
+                del self.pipeline_registry[name]
+                raise
             logger.debug(f"Started pipeline with name {name}.")
         else:
             raise Exception(f"Pipeline with name {name} is already running.")
@@ -77,11 +84,21 @@ class PipelineManager:
             try:
                 pipeline_spec = self.pipeline_registry[name]
                 pipeline_spec.pipeline.stop()
-                pipeline_spec.thread.join()  # Wait for the pipeline thread to terminate.
+                if pipeline_spec.thread.ident is not None:
+                    # Skipped when the pipeline was registered but its thread had not
+                    # started yet: join() on an unstarted thread raises RuntimeError.
+                    pipeline_spec.thread.join()  # Wait for the pipeline thread to terminate.
                 logger.info(f"Actions Pipeline with name '{name}' has been stopped.")
-                pipeline_spec.pipeline.stats().pretty_print_summary(
-                    name
-                )  # Print the pipeline's statistics.
+                try:
+                    pipeline_spec.pipeline.stats().pretty_print_summary(
+                        name
+                    )  # Print the pipeline's statistics.
+                except Exception:
+                    # Reporting is best-effort; a pipeline that never reached mark_start()
+                    # has no stats to print, and that must not look like a stop failure.
+                    logger.warning(
+                        f"Could not print run summary for pipeline {name}", exc_info=True
+                    )
                 del self.pipeline_registry[name]
             except Exception as e:
                 # Failed to stop a pipeline - this is a critical issue, we should avoid starting another action of the same type

--- a/datahub-actions/tests/unit/cli/test_actions.py
+++ b/datahub-actions/tests/unit/cli/test_actions.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import signal
 import tempfile
 from contextlib import contextmanager
 from typing import Generator
@@ -8,7 +9,11 @@ from unittest.mock import Mock
 import pytest
 from click.testing import CliRunner
 
-from datahub_actions.cli.actions import actions, pipeline_config_to_pipeline
+from datahub_actions.cli.actions import (
+    actions,
+    handle_shutdown,
+    pipeline_config_to_pipeline,
+)
 from datahub_actions.pipeline.pipeline import Pipeline
 from datahub_actions.pipeline.pipeline_manager import PipelineManager
 
@@ -448,3 +453,45 @@ def test_type_annotations() -> None:
     # These assertions serve as runtime checks
     assert isinstance(runner, CliRunner)
     assert isinstance(config_dict, dict)
+
+
+def test_run_registers_sigterm_handler(
+    temp_config_file: str,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_pipeline: Mock,
+    mock_pipeline_manager: Mock,
+) -> None:
+    """Container runtimes stop with SIGTERM, but only SIGINT was registered, so a
+    container stop killed the process without running the stop_all() path that
+    flushes consumer offsets. Asserts on `run` rather than on the registration
+    helper, so dropping the call from `run` fails the test."""
+
+    def mock_create_pipeline(config: dict) -> Pipeline:
+        return mock_pipeline
+
+    def mock_sleep(seconds: int) -> None:
+        raise KeyboardInterrupt()
+
+    previous_sigint = signal.getsignal(signal.SIGINT)
+    previous_sigterm = signal.getsignal(signal.SIGTERM)
+    try:
+        with (
+            local_monkeypatch(
+                monkeypatch,
+                "datahub_actions.pipeline.pipeline.Pipeline.create",
+                mock_create_pipeline,
+            ),
+            local_monkeypatch(monkeypatch, "time.sleep", mock_sleep),
+            local_monkeypatch(
+                monkeypatch,
+                "datahub_actions.cli.actions.pipeline_manager",
+                mock_pipeline_manager,
+            ),
+        ):
+            CliRunner().invoke(actions, ["run", "-c", temp_config_file])
+
+        assert signal.getsignal(signal.SIGTERM) is handle_shutdown
+        assert signal.getsignal(signal.SIGINT) is handle_shutdown
+    finally:
+        signal.signal(signal.SIGINT, previous_sigint)
+        signal.signal(signal.SIGTERM, previous_sigterm)

--- a/datahub-actions/tests/unit/pipeline/test_shutdown_path.py
+++ b/datahub-actions/tests/unit/pipeline/test_shutdown_path.py
@@ -7,8 +7,8 @@ pins down current behaviour so a later change that bounds the shutdown path has
 a baseline to change against; none of them assert desirable behaviour.
 """
 
-from typing import Any, Optional
-from unittest.mock import MagicMock
+from typing import Any, List, Optional
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -114,23 +114,46 @@ def test_pipeline_registry_is_shared_across_manager_instances(tmp_path: Any) -> 
     assert "shared" in second.pipeline_registry
 
 
-def test_stop_all_fails_for_a_registered_but_not_yet_started_pipeline(
-    tmp_path: Any,
-) -> None:
-    """A pipeline registered before its thread reaches `mark_start()` breaks stop_all().
+def test_stop_pipeline_survives_a_pipeline_that_never_started(tmp_path: Any) -> None:
+    """A pipeline registered before its worker reached `mark_start()` must still stop.
 
-    `start_pipeline` starts the worker and registers the spec, while `run()` sets
-    `started_at` as its first statement. SIGTERM landing in between leaves
-    `stop_pipeline` calling `stats().pretty_print_summary()` on stats that have no
-    `started_at`; the AttributeError is re-raised as a stop failure, which by the
-    test above abandons every remaining pipeline.
+    `start_pipeline` registers the spec before starting the thread, and `run()` sets
+    `started_at` as its first statement, so a shutdown can land while stats are still
+    empty. Printing the run summary is best-effort: it must not escalate into a stop
+    failure, which would abandon every remaining pipeline.
     """
     manager = PipelineManager()
     pipeline = _pipeline("unstarted", tmp_path)
     pipeline.stop = MagicMock()  # type: ignore[method-assign]
-    manager.pipeline_registry["unstarted"] = PipelineSpec(
-        "unstarted", pipeline, MagicMock()
-    )
+    thread = MagicMock()
+    thread.ident = None  # never started
+    manager.pipeline_registry["unstarted"] = PipelineSpec("unstarted", pipeline, thread)
 
-    with pytest.raises(Exception, match="Caught exception while attempting to stop"):
-        manager.stop_pipeline("unstarted")
+    manager.stop_pipeline("unstarted")
+
+    pipeline.stop.assert_called_once()
+    thread.join.assert_not_called()  # join() on an unstarted thread raises
+    assert "unstarted" not in manager.pipeline_registry
+
+
+def test_start_pipeline_registers_before_starting_the_worker(tmp_path: Any) -> None:
+    """The worker must be reachable by stop_all() the instant it can be running.
+
+    If the thread were started first, a shutdown signal arriving in the gap would not
+    find the pipeline, so nothing would stop it -- and being non-daemon it would then
+    block interpreter exit until the runtime gave up and sent SIGKILL.
+    """
+    manager = PipelineManager()
+    pipeline = _pipeline("ordered", tmp_path)
+    registered_when_started: List[bool] = []
+
+    def fake_start() -> None:
+        registered_when_started.append("ordered" in manager.pipeline_registry)
+
+    with patch("datahub_actions.pipeline.pipeline_manager.Thread") as thread_cls:
+        thread_cls.return_value.start.side_effect = fake_start
+        manager.start_pipeline("ordered", pipeline)
+
+    assert registered_when_started == [True], (
+        "pipeline was not in the registry at the moment its worker started"
+    )

--- a/datahub-actions/tests/unit/pipeline/test_shutdown_path.py
+++ b/datahub-actions/tests/unit/pipeline/test_shutdown_path.py
@@ -1,0 +1,136 @@
+"""Characterization tests for the graceful-shutdown path.
+
+SIGTERM handling (see `datahub_actions.cli.actions._register_shutdown_handlers`)
+makes this path reachable in a container for the first time, so the behaviours
+below now run on every container stop instead of effectively never. Each test
+pins down current behaviour so a later change that bounds the shutdown path has
+a baseline to change against; none of them assert desirable behaviour.
+"""
+
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from datahub_actions.pipeline.pipeline import Pipeline, PipelineException
+from datahub_actions.pipeline.pipeline_manager import PipelineManager, PipelineSpec
+
+
+def _pipeline(name: str = "test_pipeline", tmp_path: Optional[Any] = None) -> Pipeline:
+    return Pipeline(
+        name=name,
+        source=MagicMock(),
+        filters=[],
+        transforms=[],
+        action=MagicMock(),
+        retry_count=0,
+        failure_mode=None,
+        failed_events_dir=str(tmp_path) if tmp_path is not None else None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry() -> Any:
+    # pipeline_registry is declared on the class, not the instance, so state
+    # leaks between PipelineManager instances and therefore between tests.
+    PipelineManager.pipeline_registry.clear()
+    yield
+    PipelineManager.pipeline_registry.clear()
+
+
+def test_stop_closes_failed_events_fd_before_the_worker_is_joined(
+    tmp_path: Any,
+) -> None:
+    """`stop()` closes the failed-events file while the worker thread is still live.
+
+    `Pipeline.stop()` runs on the signal-handler thread and closes
+    `_failed_events_fd` before `PipelineManager.stop_pipeline()` joins the worker.
+    A failed event arriving in that window cannot be recorded, and
+    `_append_failed_event_to_file` converts the closed-file error into a
+    PipelineException -- destroying the event it exists to preserve.
+    """
+    pipeline = _pipeline(tmp_path=tmp_path)
+    pipeline.stop()
+
+    event = MagicMock()
+    event.as_json.return_value = '{"eventType": "test"}'
+
+    with pytest.raises(PipelineException, match="Failed to log failed event to file"):
+        pipeline._append_failed_event_to_file(event)
+
+
+def test_stop_all_abandons_remaining_pipelines_when_one_fails_to_stop(
+    tmp_path: Any,
+) -> None:
+    """`stop_all()` re-raises on the first failure, so later pipelines never stop.
+
+    Because the exception escapes, `handle_shutdown` also never reaches
+    `sys.exit(0)`: the process exits non-zero on an unhandled exception and the
+    surviving pipelines are left un-stopped, so their sources are never closed.
+    """
+    manager = PipelineManager()
+
+    failing = _pipeline("failing", tmp_path)
+    failing.stop = MagicMock(side_effect=Exception("stop failed"))  # type: ignore[method-assign]
+    surviving = _pipeline("surviving", tmp_path)
+    surviving.stop = MagicMock()  # type: ignore[method-assign]
+
+    for name, pipeline in (("failing", failing), ("surviving", surviving)):
+        manager.pipeline_registry[name] = PipelineSpec(name, pipeline, MagicMock())
+
+    with pytest.raises(Exception, match="Caught exception while attempting to stop"):
+        manager.stop_all()
+
+    surviving.stop.assert_not_called()
+    assert "surviving" in manager.pipeline_registry
+
+
+def test_stop_pipeline_joins_the_worker_thread_without_a_timeout(tmp_path: Any) -> None:
+    """`stop_pipeline()` joins with no timeout, so shutdown is unbounded.
+
+    A worker that does not wind down keeps the process alive until the container
+    runtime's grace period expires and SIGKILL lands -- at which point no offset
+    is committed, which is the failure the SIGTERM handler set out to avoid.
+    """
+    manager = PipelineManager()
+    pipeline = _pipeline("hanging", tmp_path)
+    pipeline.stop = MagicMock()  # type: ignore[method-assign]
+    pipeline._stats.mark_start()  # isolate the join from the stats path below
+    thread = MagicMock()
+    manager.pipeline_registry["hanging"] = PipelineSpec("hanging", pipeline, thread)
+
+    manager.stop_pipeline("hanging")
+
+    # No positional or keyword timeout: join() blocks forever by contract.
+    thread.join.assert_called_once_with()
+
+
+def test_pipeline_registry_is_shared_across_manager_instances(tmp_path: Any) -> None:
+    """`pipeline_registry` is a class attribute, so instances share one dict."""
+    first, second = PipelineManager(), PipelineManager()
+    pipeline = _pipeline("shared", tmp_path)
+    first.pipeline_registry["shared"] = PipelineSpec("shared", pipeline, MagicMock())
+
+    assert "shared" in second.pipeline_registry
+
+
+def test_stop_all_fails_for_a_registered_but_not_yet_started_pipeline(
+    tmp_path: Any,
+) -> None:
+    """A pipeline registered before its thread reaches `mark_start()` breaks stop_all().
+
+    `start_pipeline` starts the worker and registers the spec, while `run()` sets
+    `started_at` as its first statement. SIGTERM landing in between leaves
+    `stop_pipeline` calling `stats().pretty_print_summary()` on stats that have no
+    `started_at`; the AttributeError is re-raised as a stop failure, which by the
+    test above abandons every remaining pipeline.
+    """
+    manager = PipelineManager()
+    pipeline = _pipeline("unstarted", tmp_path)
+    pipeline.stop = MagicMock()  # type: ignore[method-assign]
+    manager.pipeline_registry["unstarted"] = PipelineSpec(
+        "unstarted", pipeline, MagicMock()
+    )
+
+    with pytest.raises(Exception, match="Caught exception while attempting to stop"):
+        manager.stop_pipeline("unstarted")

--- a/docker/datahub-actions/start.sh
+++ b/docker/datahub-actions/start.sh
@@ -97,7 +97,7 @@ else
 fi
 
 if [ "$MONITORING_ENABLED" = true ]; then
-    datahub-actions --enable-monitoring --monitoring-port "$MONITORING_PORT" actions $config_files
+    exec datahub-actions --enable-monitoring --monitoring-port "$MONITORING_PORT" actions $config_files
 else
-    datahub-actions actions $config_files
+    exec datahub-actions actions $config_files
 fi

--- a/smoke-test/tests/actions/test_actions_shutdown.py
+++ b/smoke-test/tests/actions/test_actions_shutdown.py
@@ -31,24 +31,46 @@ pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)
 # instead.
 
 
+# A wedged daemon or container must fail this test, not hang the whole smoke phase.
+DOCKER_TIMEOUT_SEC = 30
+
+
 def _docker(*args: str, check: bool = True) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["docker", *args], capture_output=True, text=True, check=check
-    )
+    try:
+        return subprocess.run(
+            ["docker", *args],
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=DOCKER_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"`docker {' '.join(args)}` did not return within {DOCKER_TIMEOUT_SEC}s"
+        )
 
 
-def _infer_actions_container() -> str:
-    completed = subprocess.run(
-        "docker ps --format '{{.Names}}' | grep actions",
-        capture_output=True,
-        shell=True,
-        text=True,
-        check=False,
+def _actions_container() -> str:
+    """Resolve the actions container by its compose service label.
+
+    Matching on the container name would also select anything else whose name merely
+    contains "actions"; the compose service label is set only by the stack itself.
+    """
+    result = _docker(
+        "ps", "--format", '{{.Label "com.docker.compose.service"}}\t{{.Names}}'
     )
-    lines = str(completed.stdout).splitlines()
-    if not lines:
+    names = [
+        line.split("\t", 1)[1]
+        for line in result.stdout.splitlines()
+        if "\t" in line and line.split("\t", 1)[0].startswith("datahub-actions")
+    ]
+    if not names:
         pytest.skip("No datahub-actions container running in this environment")
-    return lines[0]
+    assert len(names) == 1, (
+        f"expected exactly one datahub-actions container, found {names}; "
+        "refusing to guess which one to inspect"
+    )
+    return names[0]
 
 
 @pytest.mark.integration
@@ -60,7 +82,7 @@ def test_actions_entrypoint_execs_so_python_is_pid_1() -> None:
     running stop_all(). Reads /proc/1/cmdline rather than shelling out to ps, which is not
     present in the slim image.
     """
-    container = _infer_actions_container()
+    container = _actions_container()
 
     # /proc/1/cmdline is NUL-separated; tr makes it greppable.
     result = _docker(

--- a/smoke-test/tests/actions/test_actions_shutdown.py
+++ b/smoke-test/tests/actions/test_actions_shutdown.py
@@ -1,0 +1,83 @@
+import logging
+import subprocess
+
+import pytest
+
+from tests.utilities.domains import Domain
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+
+# ==============================================
+# ACTIONS CONTAINER SHUTDOWN TESTS
+# ==============================================
+# Consumer offsets are flushed by EventSource.close(), reached only through
+# pipeline_manager.stop_all() on the shutdown-signal path. Two things must hold for a
+# container stop to get there:
+#
+#   1. the entrypoint must `exec` the CLI so python is PID 1 and receives the SIGTERM a
+#      container runtime sends -- bash as PID 1 swallows it, and
+#   2. `datahub actions run` must register a SIGTERM handler, not just SIGINT.
+#
+# (2) is covered by a unit test (tests/unit/cli/test_actions.py::
+# test_run_registers_sigterm_handler). (1) cannot be: it lives in a shell script, so it
+# needs a real container to observe, which is what this test does.
+#
+# The end-to-end consequence -- the durable consumer offset advancing across a stop -- is
+# deliberately not asserted here. It needs a pipeline with its own consumer group and live
+# event traffic; running that alongside the shared actions container would join its
+# consumer groups and disturb the doc-propagation tests. It is verified out-of-band
+# instead.
+
+
+def _docker(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", *args], capture_output=True, text=True, check=check
+    )
+
+
+def _infer_actions_container() -> str:
+    completed = subprocess.run(
+        "docker ps --format '{{.Names}}' | grep actions",
+        capture_output=True,
+        shell=True,
+        text=True,
+        check=False,
+    )
+    lines = str(completed.stdout).splitlines()
+    if not lines:
+        pytest.skip("No datahub-actions container running in this environment")
+    return lines[0]
+
+
+@pytest.mark.integration
+def test_actions_entrypoint_execs_so_python_is_pid_1() -> None:
+    """PID 1 must be the python process, otherwise SIGTERM never reaches the handler.
+
+    Without `exec` in docker/datahub-actions/start.sh, bash stays PID 1 and the CLI runs
+    as its child; a container stop then kills the process group without any pipeline ever
+    running stop_all(). Reads /proc/1/cmdline rather than shelling out to ps, which is not
+    present in the slim image.
+    """
+    container = _infer_actions_container()
+
+    # /proc/1/cmdline is NUL-separated; tr makes it greppable.
+    result = _docker(
+        "exec", container, "sh", "-c", "tr '\\0' ' ' < /proc/1/cmdline", check=False
+    )
+    assert result.returncode == 0, f"could not read /proc/1/cmdline: {result.stderr}"
+    pid1 = result.stdout.strip()
+    logger.info(f"actions container {container} PID 1: {pid1!r}")
+
+    # Deliberately not matching bare "datahub": the broken cmdline is
+    # "/bin/bash /start_datahub_actions.sh", which contains it. "python" and the
+    # hyphenated console-script name appear only when the CLI itself is PID 1.
+    assert "python" in pid1 or "datahub-actions" in pid1, (
+        f"PID 1 in the actions container is {pid1!r}, expected the datahub-actions "
+        "python process. A bash PID 1 means start.sh lost its `exec` and SIGTERM "
+        "will not reach the shutdown handler."
+    )
+    assert "bash" not in pid1, (
+        f"PID 1 is bash ({pid1!r}); start.sh must `exec` the CLI so it becomes PID 1."
+    )


### PR DESCRIPTION
## Problem

`datahub-actions` never saw `SIGTERM`:

- only `SIGINT` was registered on `handle_shutdown`, and
- `docker/datahub-actions/start.sh` launched the CLI as a bash child without `exec`, so bash stayed PID 1 and never forwarded the `SIGTERM` a container runtime sends on stop.

So every container stop (`docker stop`, pod eviction, rolling restart) killed the process outright, and `pipeline_manager.stop_all()` — with it `Pipeline.stop()` and `EventSource.close()` — never ran.

**Offset-commit durability on shutdown differs by source, and for one of them the cost is unbounded.**

- **DataHub Cloud (REST) source** — commits in exactly one place. `ack()` only pops an in-memory dict in `AckManager`, and `safe_to_ack_offsets` advances in memory; the single production call to `commit_offsets()` → `offsets_store.store_offset_id()` lives inside `close()` (`datahub_cloud_event_source.py:292`), whose only caller is `Pipeline.stop()`. Since the CLI never reaches that path on `SIGTERM` today, the durable offset never advances for the life of the deployment: every restart resumes from whatever `load_offset_id()` returns. The replay window is unbounded, and once the un-acked span ages past the events topic's server-side retention it stops being replay and becomes silent loss.
- **Kafka source** — commits continuously, so the exposure is bounded. Default `async_commit_enabled: true` stores offsets per acked event and lets librdkafka auto-commit every `auto.commit.interval.ms` (10s); with `false`, `ack()` commits synchronously per event. A `SIGKILL` costs ≤10s of re-delivered progress, plus a `session.timeout.ms` rebalance stall on sibling pods because the consumer never leaves the group.
- **pgqueue source** — acks per event against the queue, so shutdown timing does not affect durability.

Being killed also skips the pipeline's own teardown in every case (failed-event file handle, lag monitor, run stats).

This PR makes the graceful path reachable for all three.

## Change

- Register `SIGTERM` alongside `SIGINT`, at the top of `run()` rather than at module import time (see note below).
- `exec` the Python process in the entrypoint so it becomes PID 1 and receives the signal.
- Exit `0` after a shutdown that completed its work — a graceful stop is not a failure to the container runtime — and `1`, deliberately, if `stop_all()` itself failed.
- Register each pipeline before starting its worker, so a stop can always find it.

### The PID 1 window

`exec` has a consequence worth stating: **the kernel discards signals that PID 1 has no handler installed for.** Verified directly — a PID-1 process with no `SIGTERM` handler slept straight through `docker stop` and could only be ended by `SIGKILL` at the grace expiry. So registering the handlers *after* `Pipeline.create()` would leave the whole startup phase — which does network I/O against Kafka, the schema registry, or GMS — unable to respond to a stop at all. They are installed before any of that work now; a `SIGTERM` during pipeline creation exits `0` immediately.

Two adjacent gaps closed for the same reason, since `exec` is what makes them reachable:

- `start_pipeline()` started the worker thread *before* inserting it into `pipeline_registry`. A shutdown in that gap found no pipeline to stop, and the non-daemon thread then blocked interpreter exit until `SIGKILL`. It now registers first (rolling back if `start()` raises), and `stop_pipeline()` skips `join()` on a thread that never started, where `join()` would raise `RuntimeError`.
- `stop_pipeline()` treated printing the run summary as load-bearing, so a pipeline that had not reached `mark_start()` yet failed to stop — which, per the known limitation below, abandons every pipeline after it. Reporting is best-effort now.

### Why registration moved out of module scope

`metadata-ingestion` imports this CLI module unconditionally, so registering at import time installed the actions shutdown handler for *every* `datahub` command in any environment where the actions package is present — including ingestion subprocesses, which are themselves cancelled with `SIGTERM`. Registration now happens inside the command that actually runs pipelines, via `_register_shutdown_handlers()`.

## Tests

`datahub-actions/tests/unit` — 209/209 passing. `smoke-test/tests/actions/test_actions_shutdown.py` — 1 passed against a running quickstartDebug stack.

**Unit** — `tests/unit/cli/test_actions.py::test_run_registers_sigterm_handler` drives
`actions run` and asserts both handlers are installed on the way through, rather than
calling the registration helper directly, so deleting the
`_register_shutdown_handlers()` call from `run()` fails it. Checked in both directions:
red against the unpatched module, and red again with the call removed from `run()`.
Previous handlers are restored in a `finally` block so no global signal state leaks into
the rest of the session.

**Smoke** — `smoke-test/tests/actions/test_actions_shutdown.py` asserts PID 1 in the
running actions container is the python process. It resolves that container by its
`com.docker.compose.service` label rather than a name substring, fails if the match is
not unique, and bounds every docker call with a timeout so a wedged daemon fails the test
instead of stalling the smoke phase. The `exec` half of this fix lives in a
shell script, so no unit test can cover it and nothing observed it before: losing the
`exec` would silently restore the old behaviour with every other test still green.
Verified in both directions against a container built from this branch — passes on the
patched entrypoint (`PID 1 = .../python3 .../datahub-actions actions`), fails on the
pre-patch one (`PID 1 = /bin/bash /start_datahub_actions.sh`).

The offset-advance end-to-end is deliberately **not** in the smoke suite. It needs a
pipeline with its own consumer group plus live event traffic, and running that beside the
shared actions container would join its consumer groups and disturb the doc-propagation
tests; a version that dodges that by cloning the shared container inherits the same
configs and therefore the same groups. It is verified out-of-band instead, below.

## Verified end-to-end

Ran against a live DataHub Cloud instance using an image built from this branch
(`:datahub-actions:docker`), with a `datahub-cloud` source and a throwaway
consumer id, generating events by toggling tags on a scratch dataset.

**Container signal delivery** (real `start.sh`, stub `datahub-actions` reporting its own pid):

| entrypoint | pid of python | SIGTERM delivered | `docker stop` | exit |
| --- | --- | --- | --- | --- |
| with `exec` (this PR) | **1** | **yes** | 0s | **0** |
| without `exec` (before) | 13 | **no** | 3s (21s at `--time 20`) | **137** (SIGKILL) |

**Durable offset across a stop** (REST source, `PlatformResource` holding `EventConsumerState`):

| phase | `docker stop` (SIGTERM) | `docker kill -s KILL` |
| --- | --- | --- |
| before start | `null` | `null` |
| while consuming | `null` (5 batches) | `null` (**365 batches**) |
| after stop | **`offset_id` set, `timestamp` written** | **`null` — unchanged** |
| exit code | 0 (returned in 1s) | 137 |
| shutdown log | `Stopping all running…` → `Stored offset id …` → `has been stopped` | none |

The `null`-while-consuming reading is the direct evidence for the problem
statement: nothing commits during normal operation, so the 365 batches the
SIGKILLed consumer had already processed would all be redelivered on restart.
The SIGTERM run committed on the way out; the SIGKILL run did not.

## Known limitation — pre-existing, deliberately out of scope

`PipelineManager.stop_all()` → `stop_pipeline()` joins each pipeline thread with **no timeout**, and `Pipeline.stop()` closes the source from the signal-handler thread while the pipeline thread may still be inside its poll (the confluent-kafka `Consumer` is not thread-safe). If a pipeline does not wind down within the runtime's grace period (`docker stop` 10s, Kubernetes `terminationGracePeriodSeconds` 30s), `SIGKILL` still lands and the commit is still lost. That matters most for the REST source, where the entire offset commit is one write at shutdown rather than a continuous stream. This PR makes the shutdown path reachable rather than dead; bounding it is a separate change.

`tests/unit/pipeline/test_shutdown_path.py` characterizes that path as it
behaves today, so the follow-up has a baseline. It also pins two further issues
found while testing: `stop_pipeline()` breaks on a pipeline registered before its
worker reaches `mark_start()` (a real race in the window this handler opens), and
`PipelineManager.pipeline_registry` is a class attribute shared across instances.

Also deliberately excluded: any change to offset-commit timing, ack semantics, or
retry defaults. Separately noted, not changed here:
`DataHubEventsSourceConfig.consumer_id` is documented as "Used to store offset for
the consumer" but is never read — the offset key is derived from the pipeline name.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Docs — no user-facing surface change
- [ ] Updating DataHub entry — not a breaking change. One behaviour note for anyone scripting against it: a ctrl-c/`SIGTERM` shutdown that completes now exits `0` instead of `1`.
