### PR TITLE
fix(incidents): authorize field incidents against the parent entity

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtils.java
@@ -19,9 +19,12 @@ import com.linkedin.incident.IncidentInfo;
 import com.linkedin.incident.IncidentStage;
 import com.linkedin.incident.IncidentState;
 import com.linkedin.incident.IncidentStatus;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.service.IncidentInfoPatch;
 import com.linkedin.metadata.service.IncidentInfoUpsert;
+import com.linkedin.metadata.utils.SchemaFieldUtils;
+import com.linkedin.util.Pair;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -45,6 +48,32 @@ public class IncidentUtils {
         .toList();
   }
 
+  /**
+   * Resolves the URN that an incident edit is authorized against.
+   *
+   * <p>For a schemaField this is the parent entity encoded in the field URN, not the field itself.
+   * There is no schemaField resource type in {@link PoliciesConfig}, so a dataset-scoped policy
+   * never matches a field URN and only platform admins would pass the check. Authorizing on the
+   * parent matches how the field page already reads its permissions, and it matches column edits,
+   * where EDIT_DATASET_COL_* is a dataset privilege rather than a field-entity one.
+   *
+   * <p>The parent is usually a dataset, but GraphQL allows dashboard and chart parents too, so the
+   * parent is read from the URN rather than assumed. A field URN that does not parse falls back to
+   * itself, which preserves the previous behaviour instead of failing open.
+   *
+   * <p>This applies to the incident edit check only. View restrictions and EDIT_DATASET_COL_* are
+   * unaffected.
+   */
+  @Nonnull
+  public static Urn getIncidentAuthorizationUrn(@Nonnull final Urn resourceUrn) {
+    if (!Constants.SCHEMA_FIELD_ENTITY_NAME.equals(resourceUrn.getEntityType())) {
+      return resourceUrn;
+    }
+    return SchemaFieldUtils.parseSchemaFieldUrn(resourceUrn)
+        .map(Pair::getFirst)
+        .orElse(resourceUrn);
+  }
+
   public static boolean isAuthorizedToEditIncidentForResource(
       final Urn resourceUrn, final QueryContext context) {
     final DisjunctivePrivilegeGroup orPrivilegeGroups =
@@ -54,8 +83,9 @@ public class IncidentUtils {
                 new ConjunctivePrivilegeGroup(
                     ImmutableList.of(PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType()))));
 
+    final Urn authorizationUrn = getIncidentAuthorizationUrn(resourceUrn);
     return AuthorizationUtils.isAuthorized(
-        context, resourceUrn.getEntityType(), resourceUrn.toString(), orPrivilegeGroups);
+        context, authorizationUrn.getEntityType(), authorizationUrn.toString(), orPrivilegeGroups);
   }
 
   @Nullable

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolver.java
@@ -1,21 +1,16 @@
 package com.linkedin.datahub.graphql.resolvers.incident;
 
-import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.ALL_PRIVILEGES_GROUP;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.incident.IncidentUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
-import com.datahub.authorization.ConjunctivePrivilegeGroup;
-import com.datahub.authorization.DisjunctivePrivilegeGroup;
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
@@ -28,7 +23,6 @@ import com.linkedin.incident.IncidentSource;
 import com.linkedin.incident.IncidentSourceType;
 import com.linkedin.incident.IncidentType;
 import com.linkedin.metadata.aspect.validation.CreateIfNotExistsValidator;
-import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.key.IncidentKey;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -75,7 +69,7 @@ public class RaiseIncidentResolver implements DataFetcher<CompletableFuture<Stri
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           for (Urn urn : resourceUrns) {
-            if (!isAuthorizedToCreateIncidentForResource(urn, context)) {
+            if (!IncidentUtils.isAuthorizedToEditIncidentForResource(urn, context)) {
               throw new AuthorizationException(
                   "Unauthorized to perform this action. Please contact your DataHub administrator.");
             }
@@ -193,18 +187,5 @@ public class RaiseIncidentResolver implements DataFetcher<CompletableFuture<Stri
         SetMode.IGNORE_NULL);
     result.setStatus(IncidentUtils.mapIncidentStatus(input.getStatus(), actorStamp));
     return result;
-  }
-
-  private boolean isAuthorizedToCreateIncidentForResource(
-      final Urn resourceUrn, final QueryContext context) {
-    final DisjunctivePrivilegeGroup orPrivilegeGroups =
-        new DisjunctivePrivilegeGroup(
-            ImmutableList.of(
-                ALL_PRIVILEGES_GROUP,
-                new ConjunctivePrivilegeGroup(
-                    ImmutableList.of(PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType()))));
-
-    return AuthorizationUtils.isAuthorized(
-        context, resourceUrn.getEntityType(), resourceUrn.toString(), orPrivilegeGroups);
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentStatusResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentStatusResolver.java
@@ -1,18 +1,13 @@
 package com.linkedin.datahub.graphql.resolvers.incident;
 
-import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.ALL_PRIVILEGES_GROUP;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
-import com.datahub.authorization.ConjunctivePrivilegeGroup;
-import com.datahub.authorization.DisjunctivePrivilegeGroup;
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
@@ -23,7 +18,6 @@ import com.linkedin.incident.IncidentInfo;
 import com.linkedin.incident.IncidentStage;
 import com.linkedin.incident.IncidentState;
 import com.linkedin.incident.IncidentStatus;
-import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.EntityUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -63,7 +57,7 @@ public class UpdateIncidentStatusResolver implements DataFetcher<CompletableFutu
             // Check whether the actor has permission to edit the incident
             // Currently only supporting a single entity. TODO: Support multiple incident entities.
             final Urn resourceUrn = info.getEntities().get(0);
-            if (isAuthorizedToUpdateIncident(resourceUrn, context)) {
+            if (IncidentUtils.isAuthorizedToEditIncidentForResource(resourceUrn, context)) {
               info.setStatus(
                   new IncidentStatus()
                       .setState(IncidentState.valueOf(input.getState().name()))
@@ -97,16 +91,5 @@ public class UpdateIncidentStatusResolver implements DataFetcher<CompletableFutu
         },
         this.getClass().getSimpleName(),
         "get");
-  }
-
-  private boolean isAuthorizedToUpdateIncident(final Urn resourceUrn, final QueryContext context) {
-    final DisjunctivePrivilegeGroup orPrivilegeGroups =
-        new DisjunctivePrivilegeGroup(
-            ImmutableList.of(
-                ALL_PRIVILEGES_GROUP,
-                new ConjunctivePrivilegeGroup(
-                    ImmutableList.of(PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType()))));
-    return AuthorizationUtils.isAuthorized(
-        context, resourceUrn.getEntityType(), resourceUrn.toString(), orPrivilegeGroups);
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -186,11 +186,10 @@ public class TestUtils {
     when(mockContext.getActorUrn()).thenReturn(actorUrn);
     when(mockContext.getAuthorizer()).thenReturn(mockAuthorizer);
     when(mockContext.getAuthentication()).thenReturn(authentication);
-    when(mockContext.getOperationContext())
-        .thenReturn(
-            withDefaultSearchEntityTypes(
-                TestOperationContexts.userContextNoSearchAuthorization(
-                    mockAuthorizer, authentication)));
+    OperationContext operationContext =
+        withDefaultSearchEntityTypes(
+            TestOperationContexts.userContextNoSearchAuthorization(mockAuthorizer, authentication));
+    when(mockContext.getOperationContext()).thenReturn(operationContext);
     return mockContext;
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -153,6 +153,47 @@ public class TestUtils {
         .build(operationContext.getSessionActorContext(), false);
   }
 
+  /**
+   * Returns a context that allows a single privilege on a single resource URN and denies everything
+   * else. Lets a test assert which URN a check was actually made against, rather than only whether
+   * it passed.
+   */
+  public static QueryContext getMockAllowContextForResource(
+      @Nonnull final String actorUrn,
+      @Nonnull final String privilege,
+      @Nonnull final Urn allowedResourceUrn) {
+    Authorizer mockAuthorizer = mock(Authorizer.class);
+    when(mockAuthorizer.authorize(any(AuthorizationRequest.class)))
+        .thenAnswer(
+            args -> {
+              AuthorizationRequest request = args.getArgument(0);
+              boolean allowed =
+                  privilege.equals(request.getPrivilege())
+                      && request
+                          .getResourceSpec()
+                          .map(spec -> allowedResourceUrn.toString().equals(spec.getEntity()))
+                          .orElse(false);
+              return new AuthorizationResult(
+                  request,
+                  allowed ? AuthorizationResult.Type.ALLOW : AuthorizationResult.Type.DENY,
+                  "");
+            });
+
+    Authentication authentication =
+        new Authentication(new Actor(ActorType.USER, UrnUtils.getUrn(actorUrn).getId()), "creds");
+
+    QueryContext mockContext = mock(QueryContext.class);
+    when(mockContext.getActorUrn()).thenReturn(actorUrn);
+    when(mockContext.getAuthorizer()).thenReturn(mockAuthorizer);
+    when(mockContext.getAuthentication()).thenReturn(authentication);
+    when(mockContext.getOperationContext())
+        .thenReturn(
+            withDefaultSearchEntityTypes(
+                TestOperationContexts.userContextNoSearchAuthorization(
+                    mockAuthorizer, authentication)));
+    return mockContext;
+  }
+
   public static QueryContext getMockDenyContext() {
     return getMockDenyContext("urn:li:corpuser:test");
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtilsTest.java
@@ -1,16 +1,20 @@
 package com.linkedin.datahub.graphql.resolvers.incident;
 
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContextForResource;
 import static org.testng.Assert.*;
 
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.IncidentPriority;
 import com.linkedin.datahub.graphql.generated.IncidentStatusInput;
 import com.linkedin.incident.IncidentAssigneeArray;
 import com.linkedin.incident.IncidentStage;
 import com.linkedin.incident.IncidentState;
 import com.linkedin.incident.IncidentStatus;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.utils.SchemaFieldUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +23,15 @@ import org.testng.annotations.Test;
 public class IncidentUtilsTest {
 
   private static final Urn TEST_USER_URN = UrnUtils.getUrn("urn:li:corpuser:test");
+  private static final Urn TEST_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleTable,PROD)");
+  private static final Urn TEST_OTHER_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,OtherTable,PROD)");
+  private static final Urn TEST_CHART_URN = UrnUtils.getUrn("urn:li:chart:(looker,baz)");
+  private static final Urn TEST_SCHEMA_FIELD_URN =
+      SchemaFieldUtils.generateSchemaFieldUrn(TEST_DATASET_URN, "user_id");
+  private static final String EDIT_INCIDENTS =
+      PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType();
 
   @Test
   public void testMapIncidentPriorityWithNull() {
@@ -102,5 +115,58 @@ public class IncidentUtilsTest {
     assertEquals(status.getState(), IncidentState.RESOLVED);
     assertEquals(status.getStage(), IncidentStage.INVESTIGATION);
     assertEquals(status.getMessage(), "Issue resolved");
+  }
+
+  @Test
+  public void testGetIncidentAuthorizationUrnRemapsSchemaFieldToParent() {
+    assertEquals(
+        IncidentUtils.getIncidentAuthorizationUrn(TEST_SCHEMA_FIELD_URN), TEST_DATASET_URN);
+  }
+
+  @Test
+  public void testGetIncidentAuthorizationUrnLeavesOtherEntitiesAlone() {
+    assertEquals(IncidentUtils.getIncidentAuthorizationUrn(TEST_DATASET_URN), TEST_DATASET_URN);
+    assertEquals(IncidentUtils.getIncidentAuthorizationUrn(TEST_CHART_URN), TEST_CHART_URN);
+  }
+
+  @Test
+  public void testGetIncidentAuthorizationUrnFallsBackWhenFieldUrnDoesNotParse() {
+    // A schemaField URN missing its field path cannot yield a parent, so the check stays on the
+    // URN it was given rather than failing open.
+    Urn malformed = UrnUtils.getUrn("urn:li:schemaField:notAFieldUrn");
+    assertEquals(IncidentUtils.getIncidentAuthorizationUrn(malformed), malformed);
+  }
+
+  @Test
+  public void testEditIncidentOnSchemaFieldAllowedByParentDatasetPolicy() {
+    QueryContext context =
+        getMockAllowContextForResource(TEST_USER_URN.toString(), EDIT_INCIDENTS, TEST_DATASET_URN);
+    assertTrue(IncidentUtils.isAuthorizedToEditIncidentForResource(TEST_SCHEMA_FIELD_URN, context));
+  }
+
+  @Test
+  public void testEditIncidentOnSchemaFieldDeniedWhenParentPolicyDoesNotMatch() {
+    QueryContext context =
+        getMockAllowContextForResource(
+            TEST_USER_URN.toString(), EDIT_INCIDENTS, TEST_OTHER_DATASET_URN);
+    assertFalse(
+        IncidentUtils.isAuthorizedToEditIncidentForResource(TEST_SCHEMA_FIELD_URN, context));
+  }
+
+  @Test
+  public void testEditIncidentOnSchemaFieldUsesNonDatasetParent() {
+    Urn chartFieldUrn = SchemaFieldUtils.generateSchemaFieldUrn(TEST_CHART_URN, "user_id");
+    QueryContext context =
+        getMockAllowContextForResource(TEST_USER_URN.toString(), EDIT_INCIDENTS, TEST_CHART_URN);
+    assertTrue(IncidentUtils.isAuthorizedToEditIncidentForResource(chartFieldUrn, context));
+  }
+
+  @Test
+  public void testEditIncidentOnOtherEntitiesIsUnchanged() {
+    QueryContext context =
+        getMockAllowContextForResource(TEST_USER_URN.toString(), EDIT_INCIDENTS, TEST_DATASET_URN);
+    assertTrue(IncidentUtils.isAuthorizedToEditIncidentForResource(TEST_DATASET_URN, context));
+    // The remap is scoped to schemaField: a dataset policy still does not reach other entities.
+    assertFalse(IncidentUtils.isAuthorizedToEditIncidentForResource(TEST_CHART_URN, context));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.incident;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContextForResource;
 import static com.linkedin.metadata.Constants.INCIDENT_INFO_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 
@@ -10,6 +11,7 @@ import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.IncidentPriority;
@@ -26,9 +28,11 @@ import com.linkedin.incident.IncidentState;
 import com.linkedin.incident.IncidentStatus;
 import com.linkedin.incident.IncidentType;
 import com.linkedin.metadata.aspect.validation.CreateIfNotExistsValidator;
+import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.key.IncidentKey;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.SchemaFieldUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
@@ -43,6 +47,10 @@ import org.testng.annotations.Test;
 public class RaiseIncidentResolverTest {
 
   private static final Urn TEST_INCIDENT_URN = UrnUtils.getUrn("urn:li:incident:TEST");
+  private static final Urn TEST_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleTable,PROD)");
+  private static final Urn TEST_SCHEMA_FIELD_URN =
+      SchemaFieldUtils.generateSchemaFieldUrn(TEST_DATASET_URN, "user_id");
 
   @Test
   public void testGetSuccessAllFields() throws Exception {
@@ -402,5 +410,61 @@ public class RaiseIncidentResolverTest {
 
     Assert.assertEquals(proposalCaptor.getValue().getChangeType(), ChangeType.UPSERT);
     Assert.assertFalse(proposalCaptor.getValue().hasHeaders());
+  }
+
+  @Test
+  public void testRaiseOnSchemaFieldAllowedByParentDatasetPolicy() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    // The actor holds EDIT_ENTITY_INCIDENTS on the parent dataset only. No policy can name the
+    // field itself, so this is the realistic grant for someone raising a column incident.
+    QueryContext mockContext =
+        getMockAllowContextForResource(
+            "urn:li:corpuser:test",
+            PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType(),
+            TEST_DATASET_URN);
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.OPERATIONAL);
+    testInput.setResourceUrn(TEST_SCHEMA_FIELD_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+    Assert.assertEquals(resolver.get(mockEnv).get(), TEST_INCIDENT_URN.toString());
+  }
+
+  @Test
+  public void testRaiseOnSchemaFieldDeniedWhenParentPolicyDoesNotMatch() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    QueryContext mockContext =
+        getMockAllowContextForResource(
+            "urn:li:corpuser:test",
+            PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType(),
+            UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,OtherTable,PROD)"));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.OPERATIONAL);
+    testInput.setResourceUrn(TEST_SCHEMA_FIELD_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+    try {
+      resolver.get(mockEnv).get();
+      Assert.fail("Expected exception was not thrown");
+    } catch (ExecutionException e) {
+      Assert.assertTrue(e.getCause() instanceof AuthorizationException);
+    }
+    Mockito.verifyNoInteractions(mockClient);
   }
 }


### PR DESCRIPTION
Part 1 of the two PRs agreed with @AdrianMachado on #19322: auth first with tests, then gates 5-6.

## The problem

Incident edits on a `schemaField` are authorized against the field URN itself.
`IncidentUtils.isAuthorizedToEditIncidentForResource` calls
`AuthorizationUtils.isAuthorized(context, resourceUrn.getEntityType(), ...)`, so for a field URN it
asks for `EDIT_ENTITY_INCIDENTS` on a `schemaField` resource. There is no `schemaField` resource
type in `PoliciesConfig`, so a dataset-scoped policy never matches it and only platform admins pass.

Wire an Incidents tab onto the field page without fixing this and the tab renders, the count is
correct, and Raise Incident is greyed out for everyone who is not an admin. That is worse than no
tab, so this lands first.

## The change

`IncidentUtils.getIncidentAuthorizationUrn` resolves the URN an incident edit is authorized
against. For a `schemaField` that is the parent encoded in the field URN; everything else passes
through unchanged.

The parent is read via `SchemaFieldUtils.parseSchemaFieldUrn` rather than assumed to be a dataset,
since GraphQL already allows dashboard and chart parents. A field URN that does not parse falls
back to itself, which preserves today's behaviour instead of failing open.

This matches what the frontend already assumes: `schemaField.graphql` fetches
`parent { ... on Dataset { privileges { ...entityPrivileges } } }` today, so the backend now agrees
with the UI. It also matches column edits, where `EDIT_DATASET_COL_*` is a dataset privilege rather
than a field-entity one. No `SCHEMA_FIELD_PRIVILEGES` are introduced.

## Why two resolvers you did not mention are in this diff

The remap belongs in `IncidentUtils` so raise and update-status share it. They did not share it.
`RaiseIncidentResolver.isAuthorizedToCreateIncidentForResource` and
`UpdateIncidentStatusResolver.isAuthorizedToUpdateIncident` were private, byte-identical copies of
the same check. Fixing only `IncidentUtils` would have left Raise Incident and Resolve authorizing
on the field while the button that enables them authorized on the parent. Both now delegate, so
there is one check and the button and the mutation cannot drift apart.

## Scope

Incident edit only. View restrictions and `EDIT_DATASET_COL_*` are untouched, and no field-level
incident privileges are added.

## Tests

`TestUtils.getMockAllowContextForResource` allows one privilege on one resource URN and denies
everything else, so these assert which URN the check was made against, not just whether it passed.

- `IncidentUtilsTest`: parent remap, passthrough for other entity types, fallback for an
  unparseable field URN, allowed via the parent dataset policy, denied when the policy names a
  different dataset, and a non-dataset (chart) parent.
- `RaiseIncidentResolverTest`: raising an incident on a field succeeds under a dataset-only policy
  and is rejected when the policy names a different dataset, which covers the mutation path rather
  than only the helper.

## One gap I have not closed

`UpdateIncidentStatusResolver` has no test class in this repo. This PR changes it, so the resolve
path is now covered by inspection only, while the raise path has real tests. I did not add one
here because it would mean standing up a new test class for a resolver this PR only refactors, and
that felt like scope I should ask about rather than assume. Happy to add
`UpdateIncidentStatusResolverTest` in this PR or as a follow-up if you would like it.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Links to related issues: #19322
- [x] Tests added
- [ ] Docs: none needed, no user-facing surface changes yet. #18685 covers the supported-types docs.
- [ ] Breaking changes: none


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize incident edits on `schemaField` entities against the parent entity so dataset-scoped `EDIT_ENTITY_INCIDENTS` policies apply. Previously we checked the field URN, which never matched any policy and effectively required platform admin.

- Centralizes authorization in IncidentUtils.getIncidentAuthorizationUrn and isAuthorizedToEditIncidentForResource; `RaiseIncidentResolver` and `UpdateIncidentStatusResolver` now delegate instead of duplicating checks.
- Reads the parent from the field URN via SchemaFieldUtils; supports dataset, dashboard, and chart parents. If the field URN does not parse, falls back to the original URN (no fail-open).
- Scope: incident edits only. View restrictions and `EDIT_DATASET_COL_*` stay unchanged; no `schemaField` privilege added.
- Tests cover the remap and the raise path; `UpdateIncidentStatusResolver` lacks a dedicated test class.

<sup>Written for commit 8a6ae71127388a00b887227e2195ca6588eee01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

