### PR TITLE
docs(managed-datahub): release notes for v2.2.0

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -827,6 +827,7 @@ module.exports = {
     },
     {
       "DataHub Cloud Release History": [
+        "docs/managed-datahub/release-notes/v_2_2_0",
         "docs/managed-datahub/release-notes/v_2_1_0",
         "docs/managed-datahub/release-notes/v_2_0_0",
         "docs/managed-datahub/release-notes/v_1_1_0",

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -1175,6 +1175,7 @@ See [Monitoring — API usage aggregation metrics](../advanced/monitoring.md#api
 | `GRAPHQL_METRICS_FIELD_LEVEL_PATH_ENABLED`      | `false`                                                    | Include field path in GraphQL metrics            | GMS        |
 | `GRAPHQL_METRICS_FIELD_LEVEL_PATHS`             | ``                                                         | GraphQL field-level paths                        | GMS        |
 | `GRAPHQL_METRICS_TRIVIAL_DATA_FETCHERS_ENABLED` | `false`                                                    | Include trivial data fetchers in GraphQL metrics | GMS        |
+| `GRAPHQL_ASPECT_OPTIMIZATION_ENABLED`           | `true`                                                     | Load only aspects the query selection needs      | GMS        |
 
 ### Chrome Extension Configuration
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -107,6 +107,12 @@ Requirements:
 
 - **(Metadata Model / Data Products)** `dataProductProperties` now includes an optional `parentDataProduct` URN so Data Products can nest in a parent-child taxonomy (mirroring Domains' `parentDomain`). The field is additive; existing Data Products are unchanged (null parent). No migration or reindex is required. Free-text search may match child products on the parent URN string, the same way `parentDomain` already behaves.
 
+- #18987 **(GMS / GraphQL)** GraphQL entity hydration now fetches only the aspects a query's selection set requires (schema-driven aspect mapping), instead of each entity loader's full default aspect set. Reduces primary-store reads on search cards, entity profiles, and browse. **Action:** none; set `GRAPHQL_ASPECT_OPTIMIZATION_ENABLED=false` to revert to legacy full-aspect hydration if a specific query or page regresses.
+
+### Environment Variables
+
+- `GRAPHQL_ASPECT_OPTIMIZATION_ENABLED` (default `true`) — Schema-driven GraphQL aspect fetching. See Other Notable Changes above and [Environment Variables](../deploy/environment-vars.md).
+
 ## v1.7.0
 
 Requirements:

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -125,6 +125,7 @@ TBD
 - **Slack and Teams status queries** — `slackIntegrationStatus` and `teamsIntegrationStatus` GraphQL queries are the single source of truth for connected state and health.
 - **Grafana dashboard deprecation** — `/admin/dashboard` operational proxy scheduled for tombstone in 2.2 and removal in 2.3; controlled by `GRAFANA_DASHBOARD_MODE`.
 - **Corp user siblings (opt-in)** — `CORP_USER_SIBLINGS_ENABLED` de-duplicates corp users that share an email with different casing.
+- **Schema-driven GraphQL aspect fetching** — GMS analyzes each GraphQL selection set and loads only the aspects those fields require, instead of each entity type's full default aspect bundle, reducing primary-store reads on search cards, entity profiles, and browse. Enabled by default on GMS (`GRAPHQL_ASPECT_OPTIMIZATION_ENABLED=true`); set to `false` to revert to legacy full-aspect hydration if a specific query or page regresses after upgrade.
 
 #### Ingestion
 

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -1,5 +1,5 @@
 ---
-description: "DataHub Cloud v2.2.0 release notes — SPARQL and relationship-graph discovery, Evals 2.0, Ask DataHub on-demand skills, Context Hub proposals for Domains and Data Products, LookML semantic models, Search V3 foundations, and expanded governance and ingestion improvements."
+description: "DataHub Cloud v2.2.0 release notes — Agents Private Beta, Agentic Ingestion Configuration, one-click Slack app install, Data Discovery & Ontology (relationship traversal, SPARQL endpoint, Ontology Explorer), Data Product Marketplace with hierarchical Data Products, Domain and Data Product proposals, Semantic Model container lineage, improved volume assertion anomaly detection, and expanded ingestion coverage."
 ---
 
 # v2.2.0
@@ -10,211 +10,161 @@ description: "DataHub Cloud v2.2.0 release notes — SPARQL and relationship-gra
 
 #### Release Availability Date
 
-TBD
+2-Sep-2026
 
 #### Recommended Versions
 
-- **CLI/SDK**: TBD
-- **Remote Executor**: TBD
+- **CLI/SDK**: 1.7.0.5
+- **Remote Executor**: v2.2.0-cloud, v2.1.5-cloud, v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud
 - **On-Prem Versions**:
   - **Helm**: TBD
-  - **API Gateway**: TBD
-  - **Actions**: TBD
+  - **API Gateway**: v0.7.3
 
-#### New Feature Highlights
+#### Release Highlights
 
-- **SPARQL query engine** — opt-in SPARQL endpoint (`/openapi/v3/sparql`, gated by `SPARQL_API_ENABLED`) with view-based access control on results, plus RDF ontology export of the relationship graph for programmatic discovery of native and custom relationship types.
-- **Relationship-graph MCP tools** — `get_metadata_graph` and `get_relationships` expose the relationship vocabulary and let agents walk the graph without hard-coding type names; gated by `RELATIONSHIP_GRAPH_TOOLS_ENABLED` and GMS 2.2.0+.
-- **Evals 2.0** — the Evals page lists every eval in the instance (not just the Context Hub suite), adds METADATA vs SQL types, per-run runner attribution, advisory validation while authoring, a dedicated create page with Try with Ask DataHub, and expanded run-history and details views.
-- **Ask DataHub on-demand skills** — the planner is replaced by Claude-Code-style skills loaded via a `Skill` tool, reducing latency while preserving task-specific guidance; controlled by `CHATBOT_SKILLS_ENABLED`.
-- **Domain and Data Product proposals** — stewards can propose creating Domains and Data Products through the existing accept/reject workflow, with a new `PROPOSE_CREATE_DOMAIN` privilege and steward UI.
-- **LookML semantic models** — declared LookML explores, measures, and dimensions generate semantic-model drafts in the shared IR, so Looker investments carry into Context Platform without mining query logs alone.
-- **Ontology Explorer rework** — large term graphs load via a capped initial view with search, filter, and expand exploration instead of rendering the full graph upfront.
-- **Agent owners** — AI agent entities can be assigned as owners on assets in the UI and GraphQL APIs.
-- **Japanese locale (Beta)** — Japanese translations can be enabled when internationalization is turned on for the instance.
-- **Search V3 write-path hardening** — consolidated V3 entity indices, baseline backfill semantics, transient-failure redelivery, and startup guards before enabling V3 keyword reads lay the foundation for the next-generation search index.
+DataHub Cloud v2.2.0 is packed with exciting updates, including:
 
-- All changes in https://github.com/datahub-project/datahub/releases/tag/TBD
-  - Note Breaking Changes: [https://datahubproject.io/docs/how/updating-datahub/](https://datahubproject.io/docs/how/updating-datahub/)
+- **Agents (Private Beta)** — Build purpose-built AI assistants for every data persona, publish them to Ask DataHub chat in one click, and schedule tasks that automatically enrich documentation, tags, and ownership, so your catalog stays current without the manual upkeep. Learn more [here](https://docs.datahub.com/docs/features/feature-guides/agents).
+- **Agentic Ingestion Configuration** — Root-causes failed runs by reading the connector's actual code. Grounds every answer in the exact configuration schema for your connector. Finds your ingestion source's recent runs automatically. Routes connector questions to the right specialist automatically. Version-aware diagnosis — knows the exact CLI version a run used.
+- **One-Click Slack App Install** — App Config & Refresh Tokens are no longer required to install the DataHub Slack App. Simply click 'Connect to Slack' on the Integrations > Slack page to install. Existing installations using App Config, Refresh, and Bot tokens will continue to be supported.
+- **Data Discovery & Ontology** — DataHub supports more complex querying of its metadata graph, with new relationship traversal and SPARQL query endpoints. New MCP tools let agents walk the metadata graph without hard-coding relationship types. And the new Ontology Explorer supports viewing how your glossary terms relate to each other. The basic APIs and explorer will be available in 2.2.1, while the SPARQL engine and custom relationships are in private beta; talk to your DataHub representative to enable them.
 
-#### Breaking Changes
+#### Notable Breaking Changes
 
-- **MCP server: the `?token=` query parameter no longer works.** Send the access token in `Authorization: Bearer <token>` only. Clients that cannot set headers can use `mcp-remote` with `--header "Authorization: Bearer <token>"`. See [MCP → Connecting & Authenticating](https://docs.datahub.com/docs/features/feature-guides/mcp#connecting--authenticating).
-- **Search V2.5 enabled by default** — instances not already on V2.5 adopt it after upgrade. Set `SEARCH_VERSION_V2_5_ENABLED=false` on GMS and system-update to roll back temporarily.
-- **Dataset semantic search no longer implicit** — default `ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES=document` no longer bridges datasets; set `document,dataset` explicitly to keep dataset semantic search.
-- **Semantic-anchor `output_dir` removed** — remove from recipes; use executor-provided `INGESTION_ARTIFACT_DIR`.
-- **`getSecretValues` requires system authentication** — human users and PATs with `MANAGE_SECRETS` can no longer decrypt secrets via GraphQL; migrate executor, actions, and integrations-service callers to system credentials.
-- **Executor coordinator env flags** — `DATAHUB_EXECUTOR_MONITORS_ENABLED` and `DATAHUB_EXECUTOR_TASKS_ENABLED` are hard opt-outs. Use `DATAHUB_EXECUTOR_INGESTION_PIPELINE_ENABLED` to disable the actions pipeline.
-- **Agent env-flag gating writes `Status.lifecycleStage`** — disabled SYSTEM agents are ARCHIVED instead of returning null on direct fetch.
-- **Lineage scroll API contract** — `POST /openapi/v3/lineage/scroll` takes a single `urns` list and `direction` of `UPSTREAM`/`DOWNSTREAM`.
-- **Subscriptions inherit notification defaults** — omitting `notificationSettings` uses the actor's current defaults at delivery time; send `sinkTypes: []` explicitly for no-sink subscriptions.
-- **MCP `search` tool** — `search_strategy` argument removed; all deployments get the same tool with sort support.
-- **GMS search indexing startup guard** — GMS/MAE refuse to start when consuming MCLs with both UI indexing paths disabled ([datahub-project/datahub#19295](https://github.com/datahub-project/datahub/pull/19295)). Leave `PRE_PROCESS_HOOKS_UI_ENABLED=true` or set `PRE_PROCESS_HOOKS_REPROCESS_ENABLED=true`.
-- **Access token create-time expiry policy** — never-expiring token creation disabled by default; set `ACCESS_TOKEN_ALLOW_NO_EXPIRY=true` to restore.
-- **OpenAPI v2 entity APIs deprecated** — plan migration to `/openapi/v3/entity` and `/openapi/v3/relationship`.
-- **Great Expectations SQL profiler removed** — remove `profiling.method` and the `profiling-ge` extra from recipes.
-- **Kafka Connect SQL Server / Oracle URN shape changes** — see Ingestion connector improvements; set `schema.name` when warnings appear.
-- **`opensearch-py` 3.x required** for `acryl-datahub[elasticsearch]` — pin `>=3.0.0,<4.0.0` if you manage the client directly.
-- **Semantic model `semanticModelInfo.datasets` deprecated** — re-ingest semantic models so `metricUpstreams` is populated; metric-to-dataset lineage is missing until the next ingest run.
-- **Policy name search gap until reindex** — run `RestoreIndices` for `dataHubPolicyInfo` after upgrade (see Product).
-- **Semantic anchors must be regenerated** after deployment so complete bodies and embeddings use the new `semanticText` + `contents.text` format.
-- **APAC Bedrock cross-region prefix** — Sonnet 4.5+ models require `au` or `jp` prefix, not legacy `apac`, for APAC deployments.
-- **Observe: New anomaly detection assertions must now collect 14 days of history** before alerting; existing predictions are preserved during temporary retraining-data shortages. This gives the assertion more time to detect daily and weekly patterns and avoid noisy false alarms.
+Full technical remediation lives in [Updating DataHub](../../how/updating-datahub.md). Source-specific breaking changes appear inline under [Metadata Ingestion](#metadata-ingestion).
 
-#### Deprecations
+- **MCP server: `?token=` query parameter removed to encourage best practices.** Send the access token in `Authorization: Bearer <token>` only. Clients that cannot set headers can use `mcp-remote` with `--header "Authorization: Bearer <token>"`. See [MCP → Connecting & Authenticating](https://docs.datahub.com/docs/features/feature-guides/mcp#connecting--authenticating).
+- **`getSecretValues` now requires system authentication.** Human users and PATs with `MANAGE_SECRETS` can no longer decrypt secrets via GraphQL; migrate executor, actions, and integrations-service callers to system credentials.
+- **Never-expiring access tokens disabled by default.** Set `ACCESS_TOKEN_ALLOW_NO_EXPIRY=true` to restore. Existing tokens are unaffected.
+- **Great Expectations SQL profiler removed.** Remove `profiling.method` and the `profiling-ge` extra from recipes; SQLAlchemy is now the only SQL profiler.
+- **`semanticModelInfo.datasets` deprecated.** After upgrade, this field no longer writes graph or search edges, and GraphQL `SemanticModelInfo.datasets` returns empty. Metric-to-dataset lineage is missing until you re-ingest. **Action:** Re-ingest Semantic Models so `metricUpstreams` is populated. If you use Snowflake Semantic Views, run `datahub migrate snowflake-semantic-views` first. Customers who do not use Semantic Models can ignore this.
+- **Lineage scroll API contract changed.** `POST /openapi/v3/lineage/scroll` now takes a single `urns` list and `direction` of `UPSTREAM` / `DOWNSTREAM`.
+- **Subscriptions inherit notification defaults.** Omitting `notificationSettings` uses the actor's current defaults at delivery time; send `sinkTypes: []` explicitly for no-sink subscriptions.
+- **APAC Bedrock cross-region prefix.** Sonnet 4.5+ models require the `au` or `jp` prefix, not legacy `apac`, for APAC deployments.
+- **Observe: Anomaly detection assertions require 14 days of history** before alerting; existing predictions are preserved during temporary retraining-data shortages. This gives the assertion more time to detect daily and weekly patterns and avoid noisy false alarms.
+- **OpenAPI v2 entity APIs deprecated.** Plan migration to `/openapi/v3/entity` and `/openapi/v3/relationship`.
+- You can no longer, through the UI, create legacy propagation automations (Tag Propagation, Glossary Term Propagation, and Column Documentation Propagation). These are replaced by the new Lineage Propagation automation. You can still run and edit pre-existing automations via the UI, and create legacy ones via API.
 
-- **Grafana operational dashboard** — `/admin/dashboard` tombstoned in 2.2, disabled in 2.3, deleted in 2.4. Operational signals move to public APIs and Observe.
-- **OpenAPI v2 entity and relationship APIs** — deprecated in favor of v3; timeseries, platform ingest, and timeline v2 endpoints are not affected by this deprecation.
-- **`semanticModelInfo.datasets`** — stop populating; use member-side `semanticModelProperties.semanticModel` and `metricUpstreams` instead.
-- **`ENABLE_BEDROCK_OPTIMIZED_LATENCY` removed** — was a no-op for current model families while inflating cost estimates.
-- **`hideChatBetaLabel` removed** — Ask DataHub is GA; remove the env var if set.
+#### User Experience
 
-#### Product
+This release includes significant improvements to the user interface and user experience.
 
-- **Ontology Explorer** — initial graph capped at 30 nodes with relationship-count-sorted seed search, batched hydration, search/filter/expand exploration, and loading states that avoid full-graph redraws on large ontologies.
-- **Evals UI** — eval creation moved to `/context/evals/create`; Try with Ask DataHub seeds the chat sidebar with the draft question routed to the eval-runner agent; domain column and filters on the evals table; multiple accepted answers supported in the UI.
-- **Proposals** — `CREATE_DOMAIN` and `CREATE_DATA_PRODUCT` action-request types with steward inbox rendering; `PROPOSE_CREATE_DOMAIN` platform privilege granted to default roles matching glossary propose privileges.
-- **Compliance forms** — new `APPLICATION` prompt type lets forms require setting an Application on an asset, parallel to the existing Domain prompt.
-- **Manage Entity Forms privilege** — new `MANAGE_ENTITY_FORMS` platform privilege lets authorized users complete compliance forms on any asset without being an assignee or owner; granted to Admin and Root User by default.
-- **Agent, Service, and Repository catalog** — `agentTool` and `agentSkill` entities join `aiAgent`; new `service` and `repository` entity types catalog REST/MCP services and source repos with lineage edges. Purely additive.
-- **Logical Models UI** — `LOGICAL_MODELS_ENABLED` now defaults on; create, link, column-edit, and physical-child mapping from the UI; new Create Logical Models platform privilege on Admin by default.
-- **Policy name search** — policy display names index under the standard `name` field for Search V2.5 ranking. **Existing policies need a one-time `RestoreIndices` scoped to `dataHubPolicyInfo` before name search works again** — until then, policy-name search returns nothing.
-- **Observe: Assertion notification emails** — refreshed layout; footer labels renamed (`Alert ID`, `Assertion URN`, `Dataset URN`). Please update email-integration regexes that matched the old footer for deduplication.
-- **Observe: Greatly improved volume assertion anomaly detection accuracy and reliability** — predictions now better align with sub-daily seasonality, remain more stable over time, and use more practical sensitivity bounds to avoid false positives.
+##### Data Product Marketplace & Hierarchical Data Products
+
+DataHub v2.2.0 introduces a dedicated Data Products experience for managing **Data Products** and first-class support for **parent–child taxonomies**. Together, these changes make it easier to model and discover data products.
+
+Both capabilities are enabled by default after upgrade.
+
+- **Dedicated browse experience** at `/dataProducts` with a left-nav **Data Products** entry (Govern section).
+- **Hierarchical sidebar** to expand/collapse root and child Data Products, with infinite scroll, Domain filter, and in-sidebar autocomplete search.
+
+##### Domain and Data Product proposals
+
+Stewards can now propose creating Domains and Data Products through the existing accept/reject workflow, with a new `Propose Create Domain` platform privilege and steward inbox rendering. This matches the glossary-term propose flow that shipped earlier and gives governance leads an audit trail for structural additions to the catalog.
+
+##### Ontology Explorer
+
+Explore your business glossary's relationships with the new Ontology Explorer. Similar to the lineage graph, the explorer lets you visualize how your glossary terms relate to one another, via built-in and custom relationships. Supports search, filtering by relationship type, and expanding to see further related glossary terms. Available globally in 2.2.1, via the navigation sidebar and on the new Relationships tab of the glossary term entity page.
+
+##### Semantic Model container lineage
+
+Semantic Models now render as grouping containers in the lineage explorer rather than as intermediate hops on the lineage path. Datasets and metrics belonging to a model appear inside a bounding box (similar to Data Products), while metric lineage flows directly through the logical datasets a metric reads from: **Metric → Semantic Model Dataset → Physical Dataset**.
+
+**Note:** Existing semantic-model metadata may need a re-ingest or migration run so metric lineage is populated in the new shape. See **Notable Breaking Changes** above.
+
+##### Volume assertion accuracy
+
+Greatly improved anomaly detection reliability. Predictions align better with sub-daily seasonality, remain more stable over time, and use practical sensitivity bounds to avoid false positives.
+
+##### Other Improvements
+
 - **Slack bot service-account mappings** — map a Slack `bot_id` to a corp user so automated `@DataHub` mentions from approved bots are answered instead of refused.
-- **Workflow form requests** — `createActionWorkflowFormRequest` accepts an optional caller-supplied `id` for stable action-request URNs.
-- **Support OAuth login** — support staff can authenticate via the support OIDC provider with ticket-bound, one-hour tokens (no refresh tokens).
-- **Customizable notification emails** — `NOTIFICATION_LOGO_URL` and `NOTIFICATION_FOOTER_TEXT` customize SMTP notification branding.
-- **Glossary Term AI throttling** — opt-in caps on concurrent term-classification pipelines and per-run/per-minute batch sizes prevent integrations-service overload when many automations run together.
-
-#### AI / Ask DataHub
-
-- **On-demand skills** — Ask DataHub loads task guidance via a `Skill` tool instead of a separate planner LLM; `CHATBOT_PLANNING_ENABLED` removed. Disable with `CHATBOT_SKILLS_ENABLED=false`.
-- **Mermaid in chat** — Ask DataHub renders mermaid code blocks as diagrams.
-- **Human-in-the-loop tool approval** — mutating metadata tools on the web UI pause for explicit Approve/Reject before applying (`DATAHUB_AI_TOOL_APPROVAL_ENABLED`, default on). Slack, Teams, and MCP unchanged.
-- **`respond_to_user` removed** — answers finalize as plain end-of-turn text; entity links rewrite to canonical frontend URLs in history; follow-up suggestions arrive on a deferred stream event (`CHAT_SUGGESTIONS_ENABLED`, default on).
-- **LLM provider defaults** — `DATAHUB_LLM_PROVIDER` sets the default provider across use cases when per-use-case `*_MODEL` vars are unset; auto-detects Vertex vs Bedrock from environment. BYOK Anthropic defaults to Claude Sonnet 5; OpenAI BYOK defaults to GPT-5.6 with Responses API reasoning summaries.
-- **AI cost and credit estimates** — LLM calls carry `cost_estimate_usd` and `credits_used_estimate`; conversations accumulate totals; tune USD-to-credit ratio with `GENAI_CREDITS_PER_USD`.
-- **Custom agent billing separation** — custom agents bill under `ai_module=agent` and no longer consume Ask DataHub message credits; core Ask DataHub, Ingestion Troubleshooter, and Observability agent remain on Ask DataHub billing.
-- **MCP tool consolidation** — `register_feedback` and `note_sql_anchor_observation` replaced by `note_metadata_observation`, which can raise ANNOTATE proposals on context docs or POST_ATTACHMENT_PROPOSAL when no target doc exists.
-- **External MCP plugin validation** — connecting a plugin verifies it exposes tools; zero-tool servers fail connect with actionable guidance; chat disables empty plugins without dropping stored credentials.
-- **Semantic search improvements** — minScore relevance floor on native kNN; soft-delete and DRAFT filtering on kNN path; bridge-document handling fixes; optional SearchFlag to include non-global documents in agent keyword search.
-- **Semantic anchors** — Looker declared models fold into the existing source; Glossary Term evidence in anchor generation; external anchor generation wired into the ingestion source; folder identity stabilized by source key.
-- **Looker semantic views** — generate semantic models from declared LookML in the query-grouping pipeline.
-- **Eval advisory validation** — create/edit dialogs and Validate action surface missing assets, conflicting conditions, and SQL/table reference problems before runs fail silently.
-- **Agent task turn budget** — integrations service accepts executor turn budgets up to 500 (was 100); LangGraph recursion limit scales with budget.
-- **Azure OpenAI BYOK disabled** — Azure OpenAI selection fails closed as unstable until deployment-name and api-version contracts are remediated.
-
-#### Platform
-
-- **SPARQL API** — SELECT / ASK / CONSTRUCT with content negotiation; view authorization on results when enabled; opt-in via `SPARQL_API_ENABLED` (default off).
-- **Relationship schema export** — `GET /openapi/v3/relationship/schema` returns the relationship graph as RDF (Turtle default, JSON-LD, N-Triples, RDF/XML).
-- **Search V2.5 default** — `SEARCH_VERSION_V2_5_ENABLED` defaults on for Cloud; set `false` on GMS and system-update to roll back temporarily.
-- **Search V3** — entity-index V3 write path, baseline LoadIndices semantics, retryable indexing exceptions, semantic-search startup version check, and read guards before enabling V3 keyword reads. See [Updating DataHub](../../how/updating-datahub.md) for the ordered migration steps.
-- **Structured-property search ranking (opt-in)** — `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED` (default off) lets properties with `useAsRankFeature` drive recall and ranking; requires mapping rollout and `RestoreIndices` backfill for existing assets.
-- **Domain-scoped entity create for writers** — domain-separated writers can create entities with proposed domains in-batch without a separate unscoped create policy ([datahub-project/datahub#18944](https://github.com/datahub-project/datahub/pull/18944)).
-- **OpenAPI create authorization** — OpenAPI entity create paths authorize each URN with existence-aware Create vs Edit checks ([datahub-project/datahub#18944](https://github.com/datahub-project/datahub/pull/18944)).
-- **Access token expiry policy** — never-expiring token creation disabled by default; finite durations configured via `ACCESS_TOKEN_ALLOWED_DURATIONS`. Existing tokens unaffected.
-- **GMS auth helpers restricted** — `/auth/signUp`, password reset, SSO settings, and related helpers require system client credentials; frontend flows unchanged.
-- **OAuth DCR idle reclamation** — anonymous DCR clients reclaimed before the cap is hit (`OAUTH2_DCR_EVICT_*` settings), preventing MCP sign-in outages when the registration cap is reached.
-- **External OAuth user mapping (opt-in)** — `EXTERNAL_OAUTH_MAP_TO_CORPUSER` maps external bearer tokens to existing corp users instead of synthetic service accounts.
-- **Optional optimistic locking** — `OPTIMISTIC_LOCKING_ENABLED` (default off) uses CAS on aspect writes instead of `SELECT FOR UPDATE`.
-- **VIEW_SYSTEM_STATUS privilege** — read messaging consumer lag, transport, and registered consumers without full system-operations access.
-- **Parent Data Products** — `dataProductProperties.parentDataProduct` supports nested data-product taxonomies.
-- **Elasticsearch operations** — system-update sees in-flight `_reindex` tasks on Elasticsearch 8; incremental ZDU Phase 1 validates against launch-time doc counts; LoadIndices fails loud on bulk errors.
-- **Slack and Teams status queries** — `slackIntegrationStatus` and `teamsIntegrationStatus` GraphQL queries are the single source of truth for connected state and health.
-- **Grafana dashboard deprecation** — `/admin/dashboard` operational proxy scheduled for tombstone in 2.2 and removal in 2.3; controlled by `GRAFANA_DASHBOARD_MODE`.
-- **Corp user siblings (opt-in)** — `CORP_USER_SIBLINGS_ENABLED` de-duplicates corp users that share an email with different casing.
-- **Schema-driven GraphQL aspect fetching** — GMS analyzes each GraphQL selection set and loads only the aspects those fields require, instead of each entity type's full default aspect bundle, reducing primary-store reads on search cards, entity profiles, and browse. Enabled by default on GMS (`GRAPHQL_ASPECT_OPTIMIZATION_ENABLED=true`); set to `false` to revert to legacy full-aspect hydration if a specific query or page regresses after upgrade.
-
-#### Ingestion
-
-**New ingestion sources:**
-
-- **S3 and GCS CLI version matrix sources** — ingestion sources backed by object-store version matrices ([datahub-project/datahub#18202](https://github.com/datahub-project/datahub/pull/18202)).
-
-**Connector improvements:**
-
-- **Kafka / Kafka Connect** — Confluent Cloud Stream Catalog metadata support ([datahub-project/datahub#18764](https://github.com/datahub-project/datahub/pull/18764)).
-- **Glue** — cross-account platform instances and Lake Formation resource-link lineage ([datahub-project/datahub#17963](https://github.com/datahub-project/datahub/pull/17963)).
-- **Power BI** — Elasticsearch ODBC sources resolve to the `elasticsearch` platform ([datahub-project/datahub#18716](https://github.com/datahub-project/datahub/pull/18716)).
-- **ODCS** — contracts from S3, GCS, HTTP, and Git; UI form for the source ([datahub-project/datahub#18477](https://github.com/datahub-project/datahub/pull/18477), [datahub-project/datahub#18474](https://github.com/datahub-project/datahub/pull/18474)).
-- **Snowflake** — semantic views preserve logical-table casing; new opt-in `preserve_column_case` for quoted mixed-case columns; profile field paths align with schema paths.
-- **Snowflake / Oracle SQL profiling** — case-colliding quoted columns no longer silently dropped during reflection; warnings when statistics cannot attach to distinct fields.
-- **Document sources** — `min_text_length` defaults to `0` for `datahub_documents`, Notion, and Confluence so short documents embed by default ([datahub-project/datahub#19103](https://github.com/datahub-project/datahub/pull/19103)).
-- **Elasticsearch source** — uses `opensearch-py` and supports both Elasticsearch and OpenSearch clusters.
-- **Kafka Connect** — SQL Server treated as three-level (`database.schema.table`); Oracle JDBC sink URNs emit `schema.table`; see Breaking Changes if URNs change.
-- **SQL profiling** — legacy Great Expectations SQL profiler removed; SQLAlchemy is the only SQL profiler. New `profiling.profiling_isolation_level` for long-running profile transactions on MySQL/Postgres ([datahub-project/datahub#18690](https://github.com/datahub-project/datahub/pull/18690)).
-
-**Ingestion infrastructure:**
-
-- **Semantic-anchor `output_dir` removed** — artifacts go to `INGESTION_ARTIFACT_DIR` (set automatically on executor runs). Remove `output_dir` from recipes.
-- **Bridge-backed semantic search** — hidden bridge documents for datasets, charts, dashboards, glossary terms, and data products in the document semantic index.
-- **`semanticText` aspect** — document embedding-source override moved to standalone aspect; GraphQL surface unchanged.
-- **CLI** — `datahub check get-kafka-consumer-offsets` supports newer response formats and `-o json` ([datahub-project/datahub#19247](https://github.com/datahub-project/datahub/pull/19247)).
-- **Periodic analytics sources** — hourly usage roll-up and daily billing-sync system sources bootstrapped inert by default.
-
-**Executor:**
-
-- **Ingestion log GC (opt-in)** — `DATAHUB_EXECUTOR_LOG_GC_ENABLED` deletes aged per-execution log directories with retention and size-cap tunables (default off).
-- **Inference routing split** — `DATAHUB_USE_INFERENCE_V2` selects V2 trainer; `DATAHUB_USE_OBSERVE_MODELS` gates observe-models import only.
-- **Custom SQL assertions** — optional stored-procedure `CALL` support via `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` (default off).
-- **CDE Steward** — synced field assertions created INACTIVE for review before evaluation; fitness scores renamed to compliance facts; term-scoped domain-wide rediscovery tool removed.
-- **Observe: Skip freshness assertion queries until due** — Freshness Anomaly detection was polling warehouses' for updates too frequently (minimum once per hour). Queries are now delayed until the next predicted update, with more frequent polling after staleness is detected.
-
-#### Security / Dependencies
-
-- **Stored XSS fixes** in GraphQL/UI paths ([datahub-project/datahub#19298](https://github.com/datahub-project/datahub/pull/19298), [datahub-project/datahub#19299](https://github.com/datahub-project/datahub/pull/19299), [datahub-project/datahub#19300](https://github.com/datahub-project/datahub/pull/19300)).
-- **DuckDB analytics SQL injection hardened** — read-only sandbox, sqlglot allowlist parser, and `canViewForms` authorization on Forms analytics.
-- **Logback**: bumped to **1.5.38** for CVE-2026-9828 and CVE-2026-10532.
-- **Apache Log4j**: bumped to **2.25.5** for CVE-2026-49844.
-- **Apache Parquet**: bumped to **1.18.0** (shaded Jackson refresh for CVE-2026-54512/54513).
-- **libthrift**: bumped to **0.23.0** for CVE-2026-43869.
-
-#### Bug Fixes
-
+- **Support OAuth login** — support staff can authenticate via the support OIDC provider with ticket-bound one-hour tokens (no refresh tokens).
+- **Japanese i18n locale (Beta)** — Japanese translations can be enabled when internationalization is turned on for the instance (`I18N_ENABLED=true`).
+- **Parent Data Products** — nested data-product taxonomies via `dataProductProperties.parentDataProduct`.
+- **Glossary Term AI throttling** — opt-in caps on concurrent term-classification pipelines and per-run / per-minute batch sizes prevent integrations-service overload when many automations run together.
+- **AI agent ownership** — AI agent entities can be assigned as owners on assets in the UI and GraphQL APIs.
 - Fixed lineage graphs for view-restricted users rendering Restricted nodes instead of failing when neighbors are unviewable.
-- Fixed MCP clients sending chunked `initialize` POSTs failing the handshake with HTTP 400.
-- Fixed Ask DataHub send button hidden on smaller screens.
-- Fixed eval run Sources panel showing zero citations when runs referenced deleted or restricted assets.
-- Fixed smart assertion freshness/volume schedules dropped on GraphQL upsert or monitor re-apply.
 - Fixed container filter expansion on equality conditions breaking search filters.
-- Fixed custom SQL assertion float conditions for Observe monitors.
-- Fixed GitHub document sync-back identity, nesting, and folder conversion.
-- Fixed entity graph cache dropping relationship endpoints when indexed fields were missing.
-- Fixed OpenSearch 3.x API compatibility for keyword-only arguments in Cloud deployments.
-- Fixed ingestion sources page type filter ([datahub-project/datahub#19264](https://github.com/datahub-project/datahub/pull/19264)).
-- Fixed issue where assertion backfill jobs would get stuck forever.
-- Assertions created by Monitoring Rules no longer error at midnight.
-- The UI for Custom SQL Assertions now correctly display floats for conditions.
+- Fixed Custom SQL Assertion UI now correctly displays floats in condition inputs.
+- Fixed Ask DataHub send button hidden on smaller screens.
+- **Observe**
+  - Skip freshness assertion queries until due — Freshness Anomaly detection was polling warehouses for updates too frequently (minimum once per hour). Queries are now delayed until the next predicted update, with more frequent polling after staleness is detected.
+  - Assertion notification emails have a refreshed layout. Footer labels renamed to `Alert ID`, `Assertion URN`, and `Dataset URN`. **If you match on the old footer for deduplication in your email integrations (e.g. PagerDuty), update your regexes.**
+  - Fixed issue where assertion backfill jobs would get stuck forever.
+  - Assertions created by Monitoring Rules no longer error at midnight.
+  - The UI for Custom SQL Assertions now correctly display floats for conditions.
 
-## Known Issues
+#### Metadata Ingestion
 
-- **Policy name search after upgrade** — existing policies are invisible to name search until a scoped `RestoreIndices` backfill completes (see Product).
+We're continuously improving our integrations to add new capabilities and squash bugs.
+
+##### New Sources
+
+- **S3 and GCS CLI version matrix sources** — ingestion sources backed by object-store version matrices for CLI release tracking ([datahub-project/datahub#18202](https://github.com/datahub-project/datahub/pull/18202)).
+- **Alias Aspect creation on GMS side** for new ingestion and backfill for older entries (needed as a prerequisite for the URN Casing feature) ([datahub-project/datahub#18679](https://github.com/datahub-project/datahub/pull/18679), [datahub-project/datahub#19138](https://github.com/datahub-project/datahub/pull/19138), [datahub-project/datahub#18639](https://github.com/datahub-project/datahub/pull/18639)).
+
+##### Existing Sources
+
+- **Kafka / Kafka Connect:**
+  - Confluent Cloud Stream Catalog metadata support ([datahub-project/datahub#18764](https://github.com/datahub-project/datahub/pull/18764)).
+  - Kafka Connect: SQL Server treated as three-level (`database.schema.table`); Oracle JDBC sink URNs emit `schema.table`. **See source-specific breaking changes below.**
+- **Glue:** Cross-account platform instances and Lake Formation resource-link lineage ([datahub-project/datahub#17963](https://github.com/datahub-project/datahub/pull/17963)).
+- **Power BI:** Elasticsearch ODBC sources resolve to the `elasticsearch` platform ([datahub-project/datahub#18716](https://github.com/datahub-project/datahub/pull/18716)).
+- **ODCS:** Import contracts from S3, GCS, HTTP, and Git, plus a UI form for the source ([datahub-project/datahub#18477](https://github.com/datahub-project/datahub/pull/18477), [datahub-project/datahub#18474](https://github.com/datahub-project/datahub/pull/18474)).
+- **Snowflake:**
+  - Semantic views preserve logical-table casing.
+  - New opt-in `preserve_column_case` for quoted mixed-case columns.
+  - Profile field paths align with schema paths.
+- **Snowflake / Oracle SQL profiling:** Case-colliding quoted columns no longer silently dropped during reflection; warnings surface when statistics cannot attach to distinct fields.
+- **Elasticsearch source:** Uses `opensearch-py` and supports both Elasticsearch and OpenSearch clusters.
+- **Document sources:** `min_text_length` now defaults to `0` for `datahub_documents`, Notion, and Confluence so short documents embed by default ([datahub-project/datahub#19103](https://github.com/datahub-project/datahub/pull/19103)).
+- **Ingestion log GC (opt-in)** — `DATAHUB_EXECUTOR_LOG_GC_ENABLED` deletes aged per-execution log directories with retention and size-cap tunables (default off). See [Remote Executor best practices](https://docs.datahub.com/docs/managed-datahub/remote-executor/best-practices#storage).
+- **Executor:**
+  - Stop per-run uv cache duplication of acryl-datahub.
+  - Fix cancelled zombie processes bug.
+
+##### Source-specific breaking changes
+
+- **Kafka Connect** — SQL Server / Oracle URN shape changes. Set `schema.name` when warnings appear.
+- **Semantic-anchor `output_dir` removed** — remove from recipes and rely on the executor-provided `INGESTION_ARTIFACT_DIR`.
+- **Snowflake:**
+  - New opt-in `preserve_column_case` for quoted mixed-case columns.
+- **Remote executor** defaults to use hardlinking for uv cache. For read-only filesystems, see [best practices](https://docs.datahub.com/docs/managed-datahub/remote-executor/best-practices#read-only-root-filesystem).
+
+#### API, SDK, and MCP
+
+##### MCP Tools and Skills
+
+- New tools: **`get_metadata_graph`** and **`get_relationships`** — expose the relationship vocabulary and let agents walk the metadata graph without hard-coding type names. Disabled by default in Private Beta.
+- **Ask DataHub Skill loader** — on-demand skill loading via a `Skill` search tool replaces the planner LLM. Currently only supports built-in skills, but will evolve to support user-customizable skills in future versions.
+- **External MCP plugin validation** — connecting an AI plugin verifies it exposes tools; zero-tool servers fail connect with actionable guidance; chat disables empty plugins without dropping previously stored credentials.
+- **Bug Fix:** Fixed MCP clients sending chunked `initialize` POSTs failing the handshake with HTTP 400.
+
+##### GraphQL & OpenAPI
+
+- **Relationship schema export** — `GET /openapi/v3/relationship/schema` returns the relationship graph as RDF (Turtle default, JSON-LD, N-Triples, RDF/XML).
+- **Structured-property search ranking (opt-in)** — properties marked `useAsRankFeature` drive recall and ranking. Requires mapping rollout and `RestoreIndices` backfill for existing assets. Enable with `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED=true`.
+- **Domain-scoped entity create for writers** — domain-separated writers can create entities with proposed domains in-batch without a separate unscoped create policy ([datahub-project/datahub#18944](https://github.com/datahub-project/datahub/pull/18944)).
+- **`VIEW_SYSTEM_STATUS` privilege** — read messaging consumer lag, transport, and registered consumers without full system-operations access.
+
+##### Deprecations
+
+- **Grafana operational dashboard (`/admin/dashboard`)** — tombstoned in 2.2, disabled in 2.3, removed in 2.4. Operational signals move to public APIs and Observe. Controlled by `GRAFANA_DASHBOARD_MODE`.
+- **OpenAPI v2 entity and relationship APIs** — deprecated in favor of v3. Timeseries, platform ingest, and timeline v2 endpoints are unaffected.
+- **`semanticModelInfo.datasets`** — stop populating. Use `semanticModelProperties.semanticModel` and `metricUpstreams` instead.
+- **`ENABLE_BEDROCK_OPTIMIZED_LATENCY`** — removed. Was a no-op for current model families while inflating cost estimates.
+- **`hideChatBetaLabel`** — removed. Ask DataHub is GA; remove the env var if set.
+
+#### Security Notes
+
+- Bumped **Logback** to 1.5.38 (CVE-2026-9828, CVE-2026-10532), **Log4j** to 2.25.5 (CVE-2026-49844), **Parquet** to 1.18.0 (CVE-2026-54512, CVE-2026-54513), and **libthrift** to 0.23.0 (CVE-2026-43869). No client action required beyond a standard upgrade.
+- **Stored XSS fixes** in GraphQL / UI paths ([datahub-project/datahub#19298](https://github.com/datahub-project/datahub/pull/19298), [datahub-project/datahub#19299](https://github.com/datahub-project/datahub/pull/19299), [datahub-project/datahub#19300](https://github.com/datahub-project/datahub/pull/19300)).
+- **DuckDB analytics SQL injection hardened** — read-only sandbox, sqlglot allowlist parser, and `canViewForms` authorization on Forms analytics.
+
+#### Known Issues
+
+- **Policy name search after upgrade** — existing policies are invisible to name search until a scoped `RestoreIndices` backfill for `dataHubPolicyInfo` completes.
 - **OpenSearch 2.x bridge semantic search** — do not enable semantic search on OpenSearch 2.x builds containing the pre-fix bridge kNN filter regression; hold until a build containing the fix ships, or run Elasticsearch 8.
-- **Elasticsearch mapping repair** — indices with dynamically inferred `text` fields where `keyword` was expected require a one-time reindex with `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX=true` on system-update; see [Updating DataHub](../../how/updating-datahub.md).
-- **Tableau + Snowflake `preserve_column_case`** — Tableau column-level lineage may not match until Tableau resolves ingested Snowflake casing; ingest Snowflake before Tableau when enabling the option.
-
-#### Environment Variables
-
-- `SPARQL_API_ENABLED` (default `false`): gates the SPARQL query endpoint.
-- `RELATIONSHIP_GRAPH_TOOLS_ENABLED` (default `true`): kill switch for `get_metadata_graph` and `get_relationships` MCP tools.
-- `CHATBOT_SKILLS_ENABLED` (default `true`): gates Ask DataHub on-demand skills; replaces removed planner flag.
-- `DATAHUB_LLM_PROVIDER`: default LLM provider when per-use-case `*_MODEL` vars are unset; auto-detects Vertex vs Bedrock.
-- `GENAI_CREDITS_PER_USD` (default `1`): credits per estimated USD of LLM spend for billing telemetry.
-- `DATAHUB_AI_TOOL_APPROVAL_ENABLED` (default `true`): human-in-the-loop approval for mutating chat tools on the web UI.
-- `CHAT_SUGGESTIONS_ENABLED` (default `true`): gates deferred follow-up suggestion generation.
-- `EXTERNAL_OAUTH_MAP_TO_CORPUSER` (default `false`): map external OAuth tokens to existing corp users (opt-in).
-- `OAUTH2_DCR_EVICT_IDLE_DAYS` / `OAUTH2_DCR_EVICT_THRESHOLD_PERCENT` / `OAUTH2_DCR_EVICT_BATCH_SIZE`: idle anonymous DCR client reclamation before the registration cap.
-- `ACCESS_TOKEN_ALLOW_NO_EXPIRY` / `ACCESS_TOKEN_ALLOWED_DURATIONS`: access-token create-time expiry policy.
-- `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED` (default `false`): structured-property rank features in search.
-- `OPTIMISTIC_LOCKING_ENABLED` (default `false`): CAS-based aspect writes instead of row locks.
-- `ELASTICSEARCH_ENTITY_INDEX_V3_WRITE_ENABLED` / `SEARCH_V3_KEYWORD_READ_ENABLED`: Search V3 write and read gates — set on GMS, system-update, and standalone MAE per migration runbook.
-- `DATAHUB_USE_INFERENCE_V2` / `DATAHUB_USE_OBSERVE_MODELS`: smart-assertion trainer selection and observe-models import gate.
-- `DATAHUB_EXECUTOR_LOG_GC_ENABLED` (default `false`): opt-in ingestion-log garbage collection on executors.
-- `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` (default `false`): allow `CALL` in custom SQL assertions.
-- `NOTIFICATION_LOGO_URL` / `NOTIFICATION_FOOTER_TEXT`: SMTP notification branding.
-- `GRAFANA_DASHBOARD_MODE` / related vars: Grafana dashboard deprecation schedule.
-- `SHOW_CONTEXT_HUB`: gates Context Hub UI (evals, proposals inbox, context settings).
-- `I18N_ENABLED`: gates translation features including Japanese Beta.
-- `SMART_FRESHNESS_QUERY_GATING_ENABLED` (default: `true`): Kill-switches the change to freshness assertion evaluation in the `datahub-executor`
+- **Elasticsearch mapping repair** — indices with dynamically inferred `text` fields where `keyword` was expected require a one-time reindex with `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX=true` on system-update. See [Updating DataHub](../../how/updating-datahub.md).
+- **Tableau + Snowflake `preserve_column_case`** — Tableau column-level lineage may not match until Tableau resolves ingested Snowflake casing. Ingest Snowflake before Tableau when enabling the option.

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -1,0 +1,215 @@
+---
+description: "DataHub Cloud v2.2.0 release notes — SPARQL and relationship-graph discovery, Evals 2.0, Ask DataHub on-demand skills, Context Hub proposals for Domains and Data Products, LookML semantic models, Search V3 foundations, and expanded governance and ingestion improvements."
+---
+
+# v2.2.0
+
+## Release Changelog
+
+### v2.2.0rc1
+
+#### Release Availability Date
+
+TBD
+
+#### Recommended Versions
+
+- **CLI/SDK**: TBD
+- **Remote Executor**: TBD
+- **On-Prem Versions**:
+  - **Helm**: TBD
+  - **API Gateway**: TBD
+  - **Actions**: TBD
+
+#### New Feature Highlights
+
+- **SPARQL query engine** — opt-in SPARQL endpoint (`/openapi/v3/sparql`, gated by `SPARQL_API_ENABLED`) with view-based access control on results, plus RDF ontology export of the relationship graph for programmatic discovery of native and custom relationship types.
+- **Relationship-graph MCP tools** — `get_metadata_graph` and `get_relationships` expose the relationship vocabulary and let agents walk the graph without hard-coding type names; gated by `RELATIONSHIP_GRAPH_TOOLS_ENABLED` and GMS 2.2.0+.
+- **Evals 2.0** — the Evals page lists every eval in the instance (not just the Context Hub suite), adds METADATA vs SQL types, per-run runner attribution, advisory validation while authoring, a dedicated create page with Try with Ask DataHub, and expanded run-history and details views.
+- **Ask DataHub on-demand skills** — the planner is replaced by Claude-Code-style skills loaded via a `Skill` tool, reducing latency while preserving task-specific guidance; controlled by `CHATBOT_SKILLS_ENABLED`.
+- **Domain and Data Product proposals** — stewards can propose creating Domains and Data Products through the existing accept/reject workflow, with a new `PROPOSE_CREATE_DOMAIN` privilege and steward UI.
+- **LookML semantic models** — declared LookML explores, measures, and dimensions generate semantic-model drafts in the shared IR, so Looker investments carry into Context Platform without mining query logs alone.
+- **Ontology Explorer rework** — large term graphs load via a capped initial view with search, filter, and expand exploration instead of rendering the full graph upfront.
+- **Agent owners** — AI agent entities can be assigned as owners on assets in the UI and GraphQL APIs.
+- **Japanese locale (Beta)** — Japanese translations can be enabled when internationalization is turned on for the instance.
+- **Search V3 write-path hardening** — consolidated V3 entity indices, baseline backfill semantics, transient-failure redelivery, and startup guards before enabling V3 keyword reads lay the foundation for the next-generation search index.
+
+- All changes in https://github.com/datahub-project/datahub/releases/tag/TBD
+  - Note Breaking Changes: [https://datahubproject.io/docs/how/updating-datahub/](https://datahubproject.io/docs/how/updating-datahub/)
+
+#### Breaking Changes
+
+- **MCP server: the `?token=` query parameter no longer works.** Send the access token in `Authorization: Bearer <token>` only. Clients that cannot set headers can use `mcp-remote` with `--header "Authorization: Bearer <token>"`. See [MCP → Connecting & Authenticating](https://docs.datahub.com/docs/features/feature-guides/mcp#connecting--authenticating).
+- **Search V2.5 enabled by default** — instances not already on V2.5 adopt it after upgrade. Set `SEARCH_VERSION_V2_5_ENABLED=false` on GMS and system-update to roll back temporarily.
+- **Dataset semantic search no longer implicit** — default `ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES=document` no longer bridges datasets; set `document,dataset` explicitly to keep dataset semantic search.
+- **Semantic-anchor `output_dir` removed** — remove from recipes; use executor-provided `INGESTION_ARTIFACT_DIR`.
+- **`getSecretValues` requires system authentication** — human users and PATs with `MANAGE_SECRETS` can no longer decrypt secrets via GraphQL; migrate executor, actions, and integrations-service callers to system credentials.
+- **Smart-assertion inference routing** — set `DATAHUB_USE_INFERENCE_V2=true` alongside `DATAHUB_USE_OBSERVE_MODELS=true` to keep V2 training; `DATAHUB_USE_OBSERVE_MODELS` alone no longer selects V2.
+- **Executor coordinator env flags** — `DATAHUB_EXECUTOR_MONITORS_ENABLED` and `DATAHUB_EXECUTOR_TASKS_ENABLED` are hard opt-outs. Use `DATAHUB_EXECUTOR_INGESTION_PIPELINE_ENABLED` to disable the actions pipeline.
+- **Agent env-flag gating writes `Status.lifecycleStage`** — disabled SYSTEM agents are ARCHIVED instead of returning null on direct fetch.
+- **Lineage scroll API contract** — `POST /openapi/v3/lineage/scroll` takes a single `urns` list and `direction` of `UPSTREAM`/`DOWNSTREAM`.
+- **Subscriptions inherit notification defaults** — omitting `notificationSettings` uses the actor's current defaults at delivery time; send `sinkTypes: []` explicitly for no-sink subscriptions.
+- **MCP `search` tool** — `search_strategy` argument removed; all deployments get the same tool with sort support.
+- **GMS search indexing startup guard** — GMS/MAE refuse to start when consuming MCLs with both UI indexing paths disabled ([datahub-project/datahub#19295](https://github.com/datahub-project/datahub/pull/19295)). Leave `PRE_PROCESS_HOOKS_UI_ENABLED=true` or set `PRE_PROCESS_HOOKS_REPROCESS_ENABLED=true`.
+- **Access token create-time expiry policy** — never-expiring token creation disabled by default; set `ACCESS_TOKEN_ALLOW_NO_EXPIRY=true` to restore.
+- **OpenAPI v2 entity APIs deprecated** — plan migration to `/openapi/v3/entity` and `/openapi/v3/relationship`.
+- **Great Expectations SQL profiler removed** — remove `profiling.method` and the `profiling-ge` extra from recipes.
+- **Kafka Connect SQL Server / Oracle URN shape changes** — see Ingestion connector improvements; set `schema.name` when warnings appear.
+- **`opensearch-py` 3.x required** for `acryl-datahub[elasticsearch]` — pin `>=3.0.0,<4.0.0` if you manage the client directly.
+- **Semantic model `semanticModelInfo.datasets` deprecated** — re-ingest semantic models so `metricUpstreams` is populated; metric-to-dataset lineage is missing until the next ingest run.
+- **Policy name search gap until reindex** — run `RestoreIndices` for `dataHubPolicyInfo` after upgrade (see Product).
+- **Assertion email footer label changes** — update external alert regexes (see Product).
+- **Semantic anchors must be regenerated** after deployment so complete bodies and embeddings use the new `semanticText` + `contents.text` format.
+- **APAC Bedrock cross-region prefix** — Sonnet 4.5+ models require `au` or `jp` prefix, not legacy `apac`, for APAC deployments.
+
+#### Deprecations
+
+- **Grafana operational dashboard** — `/admin/dashboard` tombstoned in 2.2, disabled in 2.3, deleted in 2.4. Operational signals move to public APIs and Observe.
+- **OpenAPI v2 entity and relationship APIs** — deprecated in favor of v3; timeseries, platform ingest, and timeline v2 endpoints are not affected by this deprecation.
+- **`semanticModelInfo.datasets`** — stop populating; use member-side `semanticModelProperties.semanticModel` and `metricUpstreams` instead.
+- **`ENABLE_BEDROCK_OPTIMIZED_LATENCY` removed** — was a no-op for current model families while inflating cost estimates.
+- **`hideChatBetaLabel` removed** — Ask DataHub is GA; remove the env var if set.
+
+#### Product
+
+- **Ontology Explorer** — initial graph capped at 30 nodes with relationship-count-sorted seed search, batched hydration, search/filter/expand exploration, and loading states that avoid full-graph redraws on large ontologies.
+- **Evals UI** — eval creation moved to `/context/evals/create`; Try with Ask DataHub seeds the chat sidebar with the draft question routed to the eval-runner agent; domain column and filters on the evals table; multiple accepted answers supported in the UI.
+- **Proposals** — `CREATE_DOMAIN` and `CREATE_DATA_PRODUCT` action-request types with steward inbox rendering; `PROPOSE_CREATE_DOMAIN` platform privilege granted to default roles matching glossary propose privileges.
+- **Compliance forms** — new `APPLICATION` prompt type lets forms require setting an Application on an asset, parallel to the existing Domain prompt.
+- **Manage Entity Forms privilege** — new `MANAGE_ENTITY_FORMS` platform privilege lets authorized users complete compliance forms on any asset without being an assignee or owner; granted to Admin and Root User by default.
+- **Agent, Service, and Repository catalog** — `agentTool` and `agentSkill` entities join `aiAgent`; new `service` and `repository` entity types catalog REST/MCP services and source repos with lineage edges. Purely additive.
+- **Logical Models UI** — `LOGICAL_MODELS_ENABLED` now defaults on; create, link, column-edit, and physical-child mapping from the UI; new Create Logical Models platform privilege on Admin by default.
+- **Policy name search** — policy display names index under the standard `name` field for Search V2.5 ranking. **Existing policies need a one-time `RestoreIndices` scoped to `dataHubPolicyInfo` before name search works again** — until then, policy-name search returns nothing.
+- **Assertion notification emails** — refreshed layout; footer labels renamed (`Alert ID`, `Assertion URN`, `Dataset URN`) and `Alert ID` is now the bare run id. Update PagerDuty or email-integration regexes that matched the old footer.
+- **Slack bot service-account mappings** — map a Slack `bot_id` to a corp user so automated `@DataHub` mentions from approved bots are answered instead of refused.
+- **Workflow form requests** — `createActionWorkflowFormRequest` accepts an optional caller-supplied `id` for stable action-request URNs.
+- **Support OAuth login** — support staff can authenticate via the support OIDC provider with ticket-bound, one-hour tokens (no refresh tokens).
+- **Customizable notification emails** — `NOTIFICATION_LOGO_URL` and `NOTIFICATION_FOOTER_TEXT` customize SMTP notification branding.
+- **Glossary Term AI throttling** — opt-in caps on concurrent term-classification pipelines and per-run/per-minute batch sizes prevent integrations-service overload when many automations run together.
+
+#### AI / Ask DataHub
+
+- **On-demand skills** — Ask DataHub loads task guidance via a `Skill` tool instead of a separate planner LLM; `CHATBOT_PLANNING_ENABLED` removed. Disable with `CHATBOT_SKILLS_ENABLED=false`.
+- **Mermaid in chat** — Ask DataHub renders mermaid code blocks as diagrams.
+- **Human-in-the-loop tool approval** — mutating metadata tools on the web UI pause for explicit Approve/Reject before applying (`DATAHUB_AI_TOOL_APPROVAL_ENABLED`, default on). Slack, Teams, and MCP unchanged.
+- **`respond_to_user` removed** — answers finalize as plain end-of-turn text; entity links rewrite to canonical frontend URLs in history; follow-up suggestions arrive on a deferred stream event (`CHAT_SUGGESTIONS_ENABLED`, default on).
+- **LLM provider defaults** — `DATAHUB_LLM_PROVIDER` sets the default provider across use cases when per-use-case `*_MODEL` vars are unset; auto-detects Vertex vs Bedrock from environment. BYOK Anthropic defaults to Claude Sonnet 5; OpenAI BYOK defaults to GPT-5.6 with Responses API reasoning summaries.
+- **AI cost and credit estimates** — LLM calls carry `cost_estimate_usd` and `credits_used_estimate`; conversations accumulate totals; tune USD-to-credit ratio with `GENAI_CREDITS_PER_USD`.
+- **Custom agent billing separation** — custom agents bill under `ai_module=agent` and no longer consume Ask DataHub message credits; core Ask DataHub, Ingestion Troubleshooter, and Observability agent remain on Ask DataHub billing.
+- **MCP tool consolidation** — `register_feedback` and `note_sql_anchor_observation` replaced by `note_metadata_observation`, which can raise ANNOTATE proposals on context docs or POST_ATTACHMENT_PROPOSAL when no target doc exists.
+- **External MCP plugin validation** — connecting a plugin verifies it exposes tools; zero-tool servers fail connect with actionable guidance; chat disables empty plugins without dropping stored credentials.
+- **Semantic search improvements** — minScore relevance floor on native kNN; soft-delete and DRAFT filtering on kNN path; bridge-document handling fixes; optional SearchFlag to include non-global documents in agent keyword search.
+- **Semantic anchors** — Looker declared models fold into the existing source; Glossary Term evidence in anchor generation; external anchor generation wired into the ingestion source; folder identity stabilized by source key.
+- **Looker semantic views** — generate semantic models from declared LookML in the query-grouping pipeline.
+- **Eval advisory validation** — create/edit dialogs and Validate action surface missing assets, conflicting conditions, and SQL/table reference problems before runs fail silently.
+- **Agent task turn budget** — integrations service accepts executor turn budgets up to 500 (was 100); LangGraph recursion limit scales with budget.
+- **Azure OpenAI BYOK disabled** — Azure OpenAI selection fails closed as unstable until deployment-name and api-version contracts are remediated.
+
+#### Platform
+
+- **SPARQL API** — SELECT / ASK / CONSTRUCT with content negotiation; view authorization on results when enabled; opt-in via `SPARQL_API_ENABLED` (default off).
+- **Relationship schema export** — `GET /openapi/v3/relationship/schema` returns the relationship graph as RDF (Turtle default, JSON-LD, N-Triples, RDF/XML).
+- **Search V2.5 default** — `SEARCH_VERSION_V2_5_ENABLED` defaults on for Cloud; set `false` on GMS and system-update to roll back temporarily.
+- **Search V3** — entity-index V3 write path, baseline LoadIndices semantics, retryable indexing exceptions, semantic-search startup version check, and read guards before enabling V3 keyword reads. See [Updating DataHub](../../how/updating-datahub.md) for the ordered migration steps.
+- **Structured-property search ranking (opt-in)** — `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED` (default off) lets properties with `useAsRankFeature` drive recall and ranking; requires mapping rollout and `RestoreIndices` backfill for existing assets.
+- **Domain-scoped entity create for writers** — domain-separated writers can create entities with proposed domains in-batch without a separate unscoped create policy ([datahub-project/datahub#18944](https://github.com/datahub-project/datahub/pull/18944)).
+- **OpenAPI create authorization** — OpenAPI entity create paths authorize each URN with existence-aware Create vs Edit checks ([datahub-project/datahub#18944](https://github.com/datahub-project/datahub/pull/18944)).
+- **Access token expiry policy** — never-expiring token creation disabled by default; finite durations configured via `ACCESS_TOKEN_ALLOWED_DURATIONS`. Existing tokens unaffected.
+- **GMS auth helpers restricted** — `/auth/signUp`, password reset, SSO settings, and related helpers require system client credentials; frontend flows unchanged.
+- **OAuth DCR idle reclamation** — anonymous DCR clients reclaimed before the cap is hit (`OAUTH2_DCR_EVICT_*` settings), preventing MCP sign-in outages when the registration cap is reached.
+- **External OAuth user mapping (opt-in)** — `EXTERNAL_OAUTH_MAP_TO_CORPUSER` maps external bearer tokens to existing corp users instead of synthetic service accounts.
+- **Optional optimistic locking** — `OPTIMISTIC_LOCKING_ENABLED` (default off) uses CAS on aspect writes instead of `SELECT FOR UPDATE`.
+- **VIEW_SYSTEM_STATUS privilege** — read messaging consumer lag, transport, and registered consumers without full system-operations access.
+- **Parent Data Products** — `dataProductProperties.parentDataProduct` supports nested data-product taxonomies.
+- **Elasticsearch operations** — system-update sees in-flight `_reindex` tasks on Elasticsearch 8; incremental ZDU Phase 1 validates against launch-time doc counts; LoadIndices fails loud on bulk errors.
+- **Slack and Teams status queries** — `slackIntegrationStatus` and `teamsIntegrationStatus` GraphQL queries are the single source of truth for connected state and health.
+- **Grafana dashboard deprecation** — `/admin/dashboard` operational proxy scheduled for tombstone in 2.2 and removal in 2.3; controlled by `GRAFANA_DASHBOARD_MODE`.
+- **Corp user siblings (opt-in)** — `CORP_USER_SIBLINGS_ENABLED` de-duplicates corp users that share an email with different casing.
+
+#### Ingestion
+
+**New ingestion sources:**
+
+- **S3 and GCS CLI version matrix sources** — ingestion sources backed by object-store version matrices ([datahub-project/datahub#18202](https://github.com/datahub-project/datahub/pull/18202)).
+
+**Connector improvements:**
+
+- **Kafka / Kafka Connect** — Confluent Cloud Stream Catalog metadata support ([datahub-project/datahub#18764](https://github.com/datahub-project/datahub/pull/18764)).
+- **Glue** — cross-account platform instances and Lake Formation resource-link lineage ([datahub-project/datahub#17963](https://github.com/datahub-project/datahub/pull/17963)).
+- **Power BI** — Elasticsearch ODBC sources resolve to the `elasticsearch` platform ([datahub-project/datahub#18716](https://github.com/datahub-project/datahub/pull/18716)).
+- **ODCS** — contracts from S3, GCS, HTTP, and Git; UI form for the source ([datahub-project/datahub#18477](https://github.com/datahub-project/datahub/pull/18477), [datahub-project/datahub#18474](https://github.com/datahub-project/datahub/pull/18474)).
+- **Snowflake** — semantic views preserve logical-table casing; new opt-in `preserve_column_case` for quoted mixed-case columns; profile field paths align with schema paths.
+- **Snowflake / Oracle SQL profiling** — case-colliding quoted columns no longer silently dropped during reflection; warnings when statistics cannot attach to distinct fields.
+- **Document sources** — `min_text_length` defaults to `0` for `datahub_documents`, Notion, and Confluence so short documents embed by default ([datahub-project/datahub#19103](https://github.com/datahub-project/datahub/pull/19103)).
+- **Elasticsearch source** — uses `opensearch-py` and supports both Elasticsearch and OpenSearch clusters.
+- **Kafka Connect** — SQL Server treated as three-level (`database.schema.table`); Oracle JDBC sink URNs emit `schema.table`; see Breaking Changes if URNs change.
+- **SQL profiling** — legacy Great Expectations SQL profiler removed; SQLAlchemy is the only SQL profiler. New `profiling.profiling_isolation_level` for long-running profile transactions on MySQL/Postgres ([datahub-project/datahub#18690](https://github.com/datahub-project/datahub/pull/18690)).
+
+**Ingestion infrastructure:**
+
+- **Semantic-anchor `output_dir` removed** — artifacts go to `INGESTION_ARTIFACT_DIR` (set automatically on executor runs). Remove `output_dir` from recipes.
+- **Bridge-backed semantic search** — hidden bridge documents for datasets, charts, dashboards, glossary terms, and data products in the document semantic index.
+- **`semanticText` aspect** — document embedding-source override moved to standalone aspect; GraphQL surface unchanged.
+- **CLI** — `datahub check get-kafka-consumer-offsets` supports newer response formats and `-o json` ([datahub-project/datahub#19247](https://github.com/datahub-project/datahub/pull/19247)).
+- **Periodic analytics sources** — hourly usage roll-up and daily billing-sync system sources bootstrapped inert by default.
+
+**Executor:**
+
+- **Ingestion log GC (opt-in)** — `DATAHUB_EXECUTOR_LOG_GC_ENABLED` deletes aged per-execution log directories with retention and size-cap tunables (default off).
+- **Smart assertions** — record `INIT` during exclusion windows instead of false anomalies; delta-space bounds gated by `DATAHUB_EXECUTOR_ENABLE_DELTA_BOUNDS` (default off).
+- **Inference routing split** — `DATAHUB_USE_INFERENCE_V2` selects V2 trainer; `DATAHUB_USE_OBSERVE_MODELS` gates observe-models import only.
+- **Custom SQL assertions** — optional stored-procedure `CALL` support via `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` (default off).
+- **CDE Steward** — synced field assertions created INACTIVE for review before evaluation; fitness scores renamed to compliance facts; term-scoped domain-wide rediscovery tool removed.
+
+#### Security / Dependencies
+
+- **Stored XSS fixes** in GraphQL/UI paths ([datahub-project/datahub#19298](https://github.com/datahub-project/datahub/pull/19298), [datahub-project/datahub#19299](https://github.com/datahub-project/datahub/pull/19299), [datahub-project/datahub#19300](https://github.com/datahub-project/datahub/pull/19300)).
+- **DuckDB analytics SQL injection hardened** — read-only sandbox, sqlglot allowlist parser, and `canViewForms` authorization on Forms analytics.
+- **Logback**: bumped to **1.5.38** for CVE-2026-9828 and CVE-2026-10532.
+- **Apache Log4j**: bumped to **2.25.5** for CVE-2026-49844.
+- **Apache Parquet**: bumped to **1.18.0** (shaded Jackson refresh for CVE-2026-54512/54513).
+- **libthrift**: bumped to **0.23.0** for CVE-2026-43869.
+
+#### Bug Fixes
+
+- Fixed lineage graphs for view-restricted users rendering Restricted nodes instead of failing when neighbors are unviewable.
+- Fixed MCP clients sending chunked `initialize` POSTs failing the handshake with HTTP 400.
+- Fixed Ask DataHub send button hidden on smaller screens.
+- Fixed eval run Sources panel showing zero citations when runs referenced deleted or restricted assets.
+- Fixed smart assertion freshness/volume schedules dropped on GraphQL upsert or monitor re-apply.
+- Fixed container filter expansion on equality conditions breaking search filters.
+- Fixed custom SQL assertion float conditions for Observe monitors.
+- Fixed GitHub document sync-back identity, nesting, and folder conversion.
+- Fixed entity graph cache dropping relationship endpoints when indexed fields were missing.
+- Fixed OpenSearch 3.x API compatibility for keyword-only arguments in Cloud deployments.
+- Fixed ingestion sources page type filter ([datahub-project/datahub#19264](https://github.com/datahub-project/datahub/pull/19264)).
+
+## Known Issues
+
+- **Policy name search after upgrade** — existing policies are invisible to name search until a scoped `RestoreIndices` backfill completes (see Product).
+- **OpenSearch 2.x bridge semantic search** — do not enable semantic search on OpenSearch 2.x builds containing the pre-fix bridge kNN filter regression; hold until a build containing the fix ships, or run Elasticsearch 8.
+- **Elasticsearch mapping repair** — indices with dynamically inferred `text` fields where `keyword` was expected require a one-time reindex with `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX=true` on system-update; see [Updating DataHub](../../how/updating-datahub.md).
+- **Tableau + Snowflake `preserve_column_case`** — Tableau column-level lineage may not match until Tableau resolves ingested Snowflake casing; ingest Snowflake before Tableau when enabling the option.
+
+#### Environment Variables
+
+- `SPARQL_API_ENABLED` (default `false`): gates the SPARQL query endpoint.
+- `RELATIONSHIP_GRAPH_TOOLS_ENABLED` (default `true`): kill switch for `get_metadata_graph` and `get_relationships` MCP tools.
+- `CHATBOT_SKILLS_ENABLED` (default `true`): gates Ask DataHub on-demand skills; replaces removed planner flag.
+- `DATAHUB_LLM_PROVIDER`: default LLM provider when per-use-case `*_MODEL` vars are unset; auto-detects Vertex vs Bedrock.
+- `GENAI_CREDITS_PER_USD` (default `1`): credits per estimated USD of LLM spend for billing telemetry.
+- `DATAHUB_AI_TOOL_APPROVAL_ENABLED` (default `true`): human-in-the-loop approval for mutating chat tools on the web UI.
+- `CHAT_SUGGESTIONS_ENABLED` (default `true`): gates deferred follow-up suggestion generation.
+- `EXTERNAL_OAUTH_MAP_TO_CORPUSER` (default `false`): map external OAuth tokens to existing corp users (opt-in).
+- `OAUTH2_DCR_EVICT_IDLE_DAYS` / `OAUTH2_DCR_EVICT_THRESHOLD_PERCENT` / `OAUTH2_DCR_EVICT_BATCH_SIZE`: idle anonymous DCR client reclamation before the registration cap.
+- `ACCESS_TOKEN_ALLOW_NO_EXPIRY` / `ACCESS_TOKEN_ALLOWED_DURATIONS`: access-token create-time expiry policy.
+- `SEARCH_STRUCTURED_PROPERTY_RANK_FEATURES_ENABLED` (default `false`): structured-property rank features in search.
+- `OPTIMISTIC_LOCKING_ENABLED` (default `false`): CAS-based aspect writes instead of row locks.
+- `ELASTICSEARCH_ENTITY_INDEX_V3_WRITE_ENABLED` / `SEARCH_V3_KEYWORD_READ_ENABLED`: Search V3 write and read gates — set on GMS, system-update, and standalone MAE per migration runbook.
+- `DATAHUB_USE_INFERENCE_V2` / `DATAHUB_USE_OBSERVE_MODELS`: smart-assertion trainer selection and observe-models import gate.
+- `DATAHUB_EXECUTOR_LOG_GC_ENABLED` (default `false`): opt-in ingestion-log garbage collection on executors.
+- `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` (default `false`): allow `CALL` in custom SQL assertions.
+- `NOTIFICATION_LOGO_URL` / `NOTIFICATION_FOOTER_TEXT`: SMTP notification branding.
+- `GRAFANA_DASHBOARD_MODE` / related vars: Grafana dashboard deprecation schedule.
+- `SHOW_CONTEXT_HUB`: gates Context Hub UI (evals, proposals inbox, context settings).
+- `I18N_ENABLED`: gates translation features including Japanese Beta.

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -10,14 +10,14 @@ description: "DataHub Cloud v2.2.0 release notes — Agents Private Beta, Agenti
 
 #### Release Availability Date
 
-2-Sep-2026
+3-Sep-2026
 
 #### Recommended Versions
 
 - **CLI/SDK**: 1.7.0.5
 - **Remote Executor**: v2.2.0-cloud, v2.1.5-cloud, v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud
 - **On-Prem Versions**:
-  - **Helm**: TBD
+  - **Helm**: 2.0.30
   - **API Gateway**: v0.7.3
 
 #### Release Highlights

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -6,7 +6,7 @@ description: "DataHub Cloud v2.2.0 release notes — SPARQL and relationship-gra
 
 ## Release Changelog
 
-### v2.2.0rc1
+### v2.2.0
 
 #### Release Availability Date
 

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -44,7 +44,6 @@ TBD
 - **Dataset semantic search no longer implicit** — default `ELASTICSEARCH_SEMANTIC_SEARCH_ENTITIES=document` no longer bridges datasets; set `document,dataset` explicitly to keep dataset semantic search.
 - **Semantic-anchor `output_dir` removed** — remove from recipes; use executor-provided `INGESTION_ARTIFACT_DIR`.
 - **`getSecretValues` requires system authentication** — human users and PATs with `MANAGE_SECRETS` can no longer decrypt secrets via GraphQL; migrate executor, actions, and integrations-service callers to system credentials.
-- **Smart-assertion inference routing** — set `DATAHUB_USE_INFERENCE_V2=true` alongside `DATAHUB_USE_OBSERVE_MODELS=true` to keep V2 training; `DATAHUB_USE_OBSERVE_MODELS` alone no longer selects V2.
 - **Executor coordinator env flags** — `DATAHUB_EXECUTOR_MONITORS_ENABLED` and `DATAHUB_EXECUTOR_TASKS_ENABLED` are hard opt-outs. Use `DATAHUB_EXECUTOR_INGESTION_PIPELINE_ENABLED` to disable the actions pipeline.
 - **Agent env-flag gating writes `Status.lifecycleStage`** — disabled SYSTEM agents are ARCHIVED instead of returning null on direct fetch.
 - **Lineage scroll API contract** — `POST /openapi/v3/lineage/scroll` takes a single `urns` list and `direction` of `UPSTREAM`/`DOWNSTREAM`.
@@ -58,9 +57,9 @@ TBD
 - **`opensearch-py` 3.x required** for `acryl-datahub[elasticsearch]` — pin `>=3.0.0,<4.0.0` if you manage the client directly.
 - **Semantic model `semanticModelInfo.datasets` deprecated** — re-ingest semantic models so `metricUpstreams` is populated; metric-to-dataset lineage is missing until the next ingest run.
 - **Policy name search gap until reindex** — run `RestoreIndices` for `dataHubPolicyInfo` after upgrade (see Product).
-- **Assertion email footer label changes** — update external alert regexes (see Product).
 - **Semantic anchors must be regenerated** after deployment so complete bodies and embeddings use the new `semanticText` + `contents.text` format.
 - **APAC Bedrock cross-region prefix** — Sonnet 4.5+ models require `au` or `jp` prefix, not legacy `apac`, for APAC deployments.
+- **Observe: New anomaly detection assertions must now collect 14 days of history** before alerting; existing predictions are preserved during temporary retraining-data shortages. This gives the assertion more time to detect daily and weekly patterns and avoid noisy false alarms.
 
 #### Deprecations
 
@@ -80,7 +79,8 @@ TBD
 - **Agent, Service, and Repository catalog** — `agentTool` and `agentSkill` entities join `aiAgent`; new `service` and `repository` entity types catalog REST/MCP services and source repos with lineage edges. Purely additive.
 - **Logical Models UI** — `LOGICAL_MODELS_ENABLED` now defaults on; create, link, column-edit, and physical-child mapping from the UI; new Create Logical Models platform privilege on Admin by default.
 - **Policy name search** — policy display names index under the standard `name` field for Search V2.5 ranking. **Existing policies need a one-time `RestoreIndices` scoped to `dataHubPolicyInfo` before name search works again** — until then, policy-name search returns nothing.
-- **Assertion notification emails** — refreshed layout; footer labels renamed (`Alert ID`, `Assertion URN`, `Dataset URN`) and `Alert ID` is now the bare run id. Update PagerDuty or email-integration regexes that matched the old footer.
+- **Observe: Assertion notification emails** — refreshed layout; footer labels renamed (`Alert ID`, `Assertion URN`, `Dataset URN`). Please update email-integration regexes that matched the old footer for deduplication.
+- **Observe: Greatly improved volume assertion anomaly detection accuracy and reliability** — predictions now better align with sub-daily seasonality, remain more stable over time, and use more practical sensitivity bounds to avoid false positives.
 - **Slack bot service-account mappings** — map a Slack `bot_id` to a corp user so automated `@DataHub` mentions from approved bots are answered instead of refused.
 - **Workflow form requests** — `createActionWorkflowFormRequest` accepts an optional caller-supplied `id` for stable action-request URNs.
 - **Support OAuth login** — support staff can authenticate via the support OIDC provider with ticket-bound, one-hour tokens (no refresh tokens).
@@ -156,10 +156,10 @@ TBD
 **Executor:**
 
 - **Ingestion log GC (opt-in)** — `DATAHUB_EXECUTOR_LOG_GC_ENABLED` deletes aged per-execution log directories with retention and size-cap tunables (default off).
-- **Smart assertions** — record `INIT` during exclusion windows instead of false anomalies; delta-space bounds gated by `DATAHUB_EXECUTOR_ENABLE_DELTA_BOUNDS` (default off).
 - **Inference routing split** — `DATAHUB_USE_INFERENCE_V2` selects V2 trainer; `DATAHUB_USE_OBSERVE_MODELS` gates observe-models import only.
 - **Custom SQL assertions** — optional stored-procedure `CALL` support via `DATAHUB_EXECUTOR_ALLOW_CALL_STATEMENTS` (default off).
 - **CDE Steward** — synced field assertions created INACTIVE for review before evaluation; fitness scores renamed to compliance facts; term-scoped domain-wide rediscovery tool removed.
+- **Observe: Skip freshness assertion queries until due** — Freshness Anomaly detection was polling warehouses' for updates too frequently (minimum once per hour). Queries are now delayed until the next predicted update, with more frequent polling after staleness is detected.
 
 #### Security / Dependencies
 
@@ -183,6 +183,9 @@ TBD
 - Fixed entity graph cache dropping relationship endpoints when indexed fields were missing.
 - Fixed OpenSearch 3.x API compatibility for keyword-only arguments in Cloud deployments.
 - Fixed ingestion sources page type filter ([datahub-project/datahub#19264](https://github.com/datahub-project/datahub/pull/19264)).
+- Fixed issue where assertion backfill jobs would get stuck forever.
+- Assertions created by Monitoring Rules no longer error at midnight.
+- The UI for Custom SQL Assertions now correctly display floats for conditions.
 
 ## Known Issues
 
@@ -213,3 +216,4 @@ TBD
 - `GRAFANA_DASHBOARD_MODE` / related vars: Grafana dashboard deprecation schedule.
 - `SHOW_CONTEXT_HUB`: gates Context Hub UI (evals, proposals inbox, context settings).
 - `I18N_ENABLED`: gates translation features including Japanese Beta.
+- `SMART_FRESHNESS_QUERY_GATING_ENABLED` (default: `true`): Kill-switches the change to freshness assertion evaluation in the `datahub-executor`


### PR DESCRIPTION
## Summary
- Add DataHub Cloud v2.2.0rc1 release notes at `docs/managed-datahub/release-notes/v_2_2_0.md`
- Prepend the sidebar entry under DataHub Cloud Release History
- Synthesized from `v2.1.3-cloud..v2.2.0rc1-cloud` fork range and staging `## Next` docs

## Test plan
- [ ] Sidebar entry appears under DataHub Cloud Release History as the first item
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date, Recommended Versions, and OSS release tag link filled in before marking ready


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes DataHub Cloud v2.2.0rc1 release notes and puts them first in the Cloud Release History so users see the latest release first. It also documents schema-driven GraphQL aspect fetching and its rollback option.

- Covers release highlights, breaking changes, ingestion and API updates, security notes, known issues, and recommended versions including Helm 2.0.30.
- Adds `GRAPHQL_ASPECT_OPTIMIZATION_ENABLED`, enabled by default; set it to `false` to restore full-aspect hydration.
- Before merge, add the OSS release tag link and verify the sidebar and `markdown_format` checks.

<sup>Written for commit d0328a00b73d27da9fe2fbf9eacd76a3f4be13c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

