### PR TITLE
fix(search): scope query filter rewriters to their declared search types

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/BaseQueryFilterRewriter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/BaseQueryFilterRewriter.java
@@ -273,8 +273,12 @@ public abstract class BaseQueryFilterRewriter implements QueryFilterRewriter {
 
     Set<Urn> nextUrns = new HashSet<>();
 
-    Supplier<Boolean> earlyExitCriteria =
-        () -> (queryUrns.size() + visitedUrns.size() + nextUrns.size()) >= limit;
+    // Mark visited before scrolling: the budget below has to count each urn once, and the current
+    // frontier is already part of the expanded set. Counting queryUrns separately charged them
+    // twice, which cost a multi-urn filter its whole expansion budget.
+    visitedUrns.addAll(queryUrns);
+
+    Supplier<Boolean> earlyExitCriteria = () -> (visitedUrns.size() + nextUrns.size()) >= limit;
 
     Function<RelatedEntitiesScrollResult, Boolean> consumer =
         result -> {
@@ -304,14 +308,17 @@ public abstract class BaseQueryFilterRewriter implements QueryFilterRewriter {
         null,
         null);
 
-    // mark visited
-    visitedUrns.addAll(queryUrns);
-
     if (cascade != null && !nextUrns.isEmpty()) {
       cascade.recordEntitiesProcessed(nextUrns.size());
     }
     if (earlyExitCriteria.get()) {
       visitedUrns.addAll(nextUrns);
+      log.warn(
+          "{} truncated filter expansion for {} at limit {}; the filter is incomplete and results "
+              + "may be missing. Raise the expansion limit for this rewriter if this is expected.",
+          getClass().getSimpleName(),
+          getRewriterFieldNames(),
+          limit);
     } else if (!nextUrns.isEmpty()) {
       // next hop
       scrollGraph(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/QueryFilterRewriter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/QueryFilterRewriter.java
@@ -28,8 +28,12 @@ public interface QueryFilterRewriter {
 
   default boolean isQueryTimeEnabled(
       @Nonnull QueryFilterRewriterSearchType rewriteSearchType, @Nullable SearchFlags searchFlags) {
-    return getRewriterSearchTypes().contains(rewriteSearchType) && searchFlags == null
-        || searchFlags.isRewriteQuery() == null
-        || Boolean.TRUE.equals(searchFlags.isRewriteQuery());
+    // The parentheses are load-bearing: `&&` binds tighter than `||`, so without them the
+    // search-type check is discarded whenever rewriteQuery is unset or true, and a null
+    // SearchFlags dereferences.
+    return getRewriterSearchTypes().contains(rewriteSearchType)
+        && (searchFlags == null
+            || searchFlags.isRewriteQuery() == null
+            || Boolean.TRUE.equals(searchFlags.isRewriteQuery()));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/QueryFilterRewriterContext.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/QueryFilterRewriterContext.java
@@ -37,7 +37,13 @@ public class QueryFilterRewriterContext {
         if (isTimeseries) {
           this.searchType = TIMESERIES;
         } else if (this.searchFlags != null) {
-          this.searchType = this.searchFlags.isFulltext() ? FULLTEXT_SEARCH : STRUCTURED_SEARCH;
+          // `fulltext` is an optional boolean with no PDL default, and SearchContext's own default
+          // flags leave it unset, so unboxing it directly throws. Unset reads as not fulltext, the
+          // same reading SearchRequestHandler applies.
+          this.searchType =
+              Boolean.TRUE.equals(this.searchFlags.isFulltext())
+                  ? FULLTEXT_SEARCH
+                  : STRUCTURED_SEARCH;
         } else {
           this.searchType = AUTOCOMPLETE;
         }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
@@ -5,21 +5,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.search.elasticsearch.query.filter.BaseQueryFilterRewriter;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterContext;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterSearchType;
 import io.datahubproject.metadata.context.OperationContext;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.testng.annotations.Test;
 
 public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewriter> {
+
+  static final Set<Condition> HIERARCHY_CONDITIONS =
+      Set.of(Condition.ANCESTORS_INCL, Condition.DESCENDANTS_INCL, Condition.RELATED_INCL);
 
   abstract OperationContext getOpContext();
 
@@ -80,17 +87,24 @@ public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewri
   }
 
   /**
-   * A hierarchy rewriter must expand only for the explicit hierarchical conditions and leave
-   * EQUAL/IEQUAL alone. A catch-all {@code default:} in the condition switch instead gives every
-   * equality filter hierarchy semantics -- for container filters that means matching the parent's
-   * other children, so a container's contents list its siblings and itself.
+   * A hierarchy rewriter must expand only for the three explicit hierarchical conditions and leave
+   * every other condition alone. A catch-all {@code default:} in the condition switch instead gives
+   * them all hierarchy semantics -- for container filters that means matching the parent's other
+   * children, so a container's contents list its siblings and itself.
+   *
+   * <p>The sweep is over {@link Condition#values()} rather than a hand-picked pair so that a
+   * condition added later has to be classified deliberately instead of inheriting whatever the
+   * switch happens to do with it.
    */
   @Test
-  public void testEqualityConditionsNotExpanded() {
+  public void testNonHierarchyConditionsNotExpanded() {
     BaseQueryFilterRewriter test = getTestRewriter();
     GraphRetriever graphRetriever = getOpContext().getRetrieverContext().getGraphRetriever();
 
-    for (Condition condition : List.of(Condition.EQUAL, Condition.IEQUAL)) {
+    for (Condition condition : Condition.values()) {
+      if (HIERARCHY_CONDITIONS.contains(condition)) {
+        continue;
+      }
       TermsQueryBuilder testQuery =
           QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue());
 
@@ -109,6 +123,81 @@ public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewri
 
     // An unstubbed retriever expands to nothing, so the equality assertion alone would pass even
     // when the rewriter traverses. Assert no traversal was attempted at all.
+    verify(graphRetriever, never())
+        .scrollRelatedEntities(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * A rewriter declares the search types it applies to, and anything outside that set must be left
+   * alone. Because {@code &&} binds tighter than {@code ||}, an unparenthesised search-type check
+   * in the enablement gate is discarded whenever query rewriting is not explicitly disabled -- the
+   * rewriter then runs on search types it never opted into, and throws outright when the request
+   * carries no search flags at all.
+   */
+  @Test
+  public void testUnsupportedSearchTypeNotRewritten() {
+    BaseQueryFilterRewriter test = getTestRewriter();
+    GraphRetriever graphRetriever = getOpContext().getRetrieverContext().getGraphRetriever();
+
+    Set<QueryFilterRewriterSearchType> unsupportedSearchTypes =
+        Arrays.stream(QueryFilterRewriterSearchType.values())
+            .filter(searchType -> !test.getRewriterSearchTypes().contains(searchType))
+            .collect(Collectors.toSet());
+    assertFalse(
+        unsupportedSearchTypes.isEmpty(),
+        "Expected the rewriter to opt out of at least one search type, otherwise this proves nothing");
+
+    // Both flag shapes matter: absent flags is the case that throws rather than over-expanding.
+    for (SearchFlags searchFlags : Arrays.asList(new SearchFlags(), null)) {
+      for (QueryFilterRewriterSearchType searchType : unsupportedSearchTypes) {
+        TermsQueryBuilder testQuery =
+            QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue());
+
+        assertEquals(
+            test.rewrite(
+                getOpContext(),
+                QueryFilterRewriterContext.builder()
+                    .condition(getTargetCondition())
+                    .searchType(searchType)
+                    .searchFlags(searchFlags)
+                    .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                    .build(false),
+                testQuery),
+            QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()),
+            String.format("Expected no rewrite for unsupported search type %s", searchType));
+      }
+    }
+
+    verify(graphRetriever, never())
+        .scrollRelatedEntities(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * {@code rewriteQuery=false} is the caller's kill switch, and it has to keep working for a search
+   * type the rewriter does support.
+   */
+  @Test
+  public void testRewriteQueryDisabledIsRespected() {
+    BaseQueryFilterRewriter test = getTestRewriter();
+    GraphRetriever graphRetriever = getOpContext().getRetrieverContext().getGraphRetriever();
+
+    TermsQueryBuilder testQuery = QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue());
+
+    assertEquals(
+        test.rewrite(
+            getOpContext(),
+            QueryFilterRewriterContext.builder()
+                .condition(getTargetCondition())
+                .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                .searchFlags(new SearchFlags().setRewriteQuery(false))
+                .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                .build(false),
+            testQuery),
+        QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()),
+        "Expected no rewrite when rewriteQuery is disabled");
+
     verify(graphRetriever, never())
         .scrollRelatedEntities(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any());

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/ContainerExpansionRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/ContainerExpansionRewriterTest.java
@@ -471,4 +471,199 @@ public class ContainerExpansionRewriterTest
         .scrollRelatedEntities(
             any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any());
   }
+
+  /**
+   * `limit` caps the size of the expanded filter. The early-exit budget counted the current
+   * frontier twice -- once as the urns being queried and once as already-visited -- so a filter
+   * carrying several urns lost that much of its budget, and one carrying at least half the limit in
+   * roots barely expanded at all. Batched container filters do carry many urns.
+   */
+  @Test
+  public void testExpansionHonorsConfiguredLimit() {
+    final int limit = 10;
+    ContainerExpansionRewriter test =
+        ContainerExpansionRewriter.builder()
+            .config(
+                new QueryFilterRewriterConfiguration.ExpansionRewriterConfiguration(true, 1, limit))
+            .build();
+
+    List<String> roots =
+        List.of("urn:li:container:root0", "urn:li:container:root1", "urn:li:container:root2");
+
+    // One ancestor per page, always another page available: the limit is the only thing that stops
+    // the walk.
+    when(mockGraphRetriever.scrollRelatedEntities(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING)),
+            any(),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenAnswer(
+            invocation -> {
+              String scrollId = invocation.getArgument(7);
+              int page = scrollId == null ? 0 : Integer.parseInt(scrollId);
+              return new RelatedEntitiesScrollResult(
+                  100,
+                  1,
+                  String.valueOf(page + 1),
+                  List.of(
+                      new RelatedEntities(
+                          "IsPartOf",
+                          roots.get(0),
+                          "urn:li:container:ancestor" + page,
+                          RelationshipDirection.OUTGOING,
+                          null)));
+            });
+
+    TermsQueryBuilder rewritten =
+        test.rewrite(
+            opContext,
+            QueryFilterRewriterContext.builder()
+                .condition(Condition.ANCESTORS_INCL)
+                .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                .build(false),
+            QueryBuilders.termsQuery(FIELD_NAME, roots));
+
+    assertEquals(
+        rewritten.values().size(),
+        limit,
+        "Expected the expanded filter to use the whole configured limit, counting each urn once");
+  }
+
+  /**
+   * RELATED_INCL has two implementations: an entity-graph-cache read that expands each direction
+   * from the roots, and a graph traversal that walks descendants and then ancestors of that
+   * expanded set. For the same hierarchy they have to produce the same filter, otherwise results
+   * depend on whether the cache happens to be warm.
+   */
+  @Test
+  public void testRelatedInclCacheAndTraversalAgree() {
+    ContainerExpansionRewriter test = getTestRewriter();
+    // Expanded values come back sorted.
+    TermsQueryBuilder expected =
+        QueryBuilders.termsQuery(FIELD_NAME, childUrn, parentUrn, grandParentUrn);
+
+    // Traversal: descendants of the root, then ancestors of the root plus those descendants.
+    when(mockGraphRetriever.scrollRelatedEntities(
+            eq(Set.of(CONTAINER_ENTITY_NAME)),
+            eq(
+                QueryUtils.newDisjunctiveFilter(
+                    buildCriterion("urn", Condition.EQUAL, List.of(parentUrn)))),
+            eq(Set.of(CONTAINER_ENTITY_NAME)),
+            eq(EMPTY_FILTER),
+            eq(Set.of("IsPartOf")),
+            eq(newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(Edge.EDGE_SORT_CRITERION),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                1,
+                1,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        "IsPartOf", childUrn, parentUrn, RelationshipDirection.INCOMING, null))));
+    when(mockGraphRetriever.scrollRelatedEntities(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING)),
+            any(),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                1,
+                1,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        "IsPartOf",
+                        parentUrn,
+                        grandParentUrn,
+                        RelationshipDirection.OUTGOING,
+                        null))));
+
+    TermsQueryBuilder viaTraversal =
+        test.rewrite(
+            opContext,
+            QueryFilterRewriterContext.builder()
+                .condition(Condition.RELATED_INCL)
+                .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                .build(false),
+            QueryBuilders.termsQuery(FIELD_NAME, parentUrn));
+
+    assertEquals(viaTraversal, expected, "Expected the traversal to walk both directions");
+
+    // Cache: each direction expanded from the roots, then unioned.
+    EntityGraphCache entityGraphCache = mock(EntityGraphCache.class);
+    EntityGraphBinding binding =
+        EntityGraphBinding.builder().graphId("container").source(GraphSnapshotSource.GRAPH).build();
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.CONTAINER))
+        .thenReturn(Optional.of(binding));
+    when(entityGraphCache.expand(
+            eq("container"),
+            eq(GraphSnapshotSource.GRAPH),
+            eq(TraversalDirection.REVERSE),
+            eq(Set.of(parentUrn)),
+            anyInt(),
+            eq(EntityGraphCache.USE_DEFINITION_MAX_DEPTH),
+            eq(ReadMode.CACHED)))
+        .thenReturn(GraphReadResult.fromVertices(Set.of(parentUrn, childUrn)));
+    when(entityGraphCache.expand(
+            eq("container"),
+            eq(GraphSnapshotSource.GRAPH),
+            eq(TraversalDirection.FORWARD),
+            eq(Set.of(parentUrn)),
+            anyInt(),
+            eq(EntityGraphCache.USE_DEFINITION_MAX_DEPTH),
+            eq(ReadMode.CACHED)))
+        .thenReturn(GraphReadResult.fromVertices(Set.of(parentUrn, grandParentUrn)));
+
+    EntityRegistry entityRegistry = new TestEntityRegistry();
+    CachingAspectRetriever cachingAspectRetriever = mock(CachingAspectRetriever.class);
+    when(cachingAspectRetriever.getEntityRegistry()).thenReturn(entityRegistry);
+    OperationContext cacheOpContext =
+        opContext.toBuilder()
+            .retrieverContext(
+                io.datahubproject.metadata.context.RetrieverContext.builder()
+                    .aspectRetriever(cachingAspectRetriever)
+                    .cachingAspectRetriever(
+                        TestOperationContexts.emptyActiveUsersAspectRetriever(() -> entityRegistry))
+                    .graphRetriever(mockGraphRetriever)
+                    .searchRetriever(SearchRetriever.EMPTY)
+                    .entityGraphCache(entityGraphCache)
+                    .build())
+            .build(opContext.getSessionAuthentication(), false);
+
+    TermsQueryBuilder viaCache =
+        test.rewrite(
+            cacheOpContext,
+            QueryFilterRewriterContext.builder()
+                .condition(Condition.RELATED_INCL)
+                .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                .build(false),
+            QueryBuilders.termsQuery(FIELD_NAME, parentUrn));
+
+    assertEquals(
+        viaCache,
+        viaTraversal,
+        "Expected the cached and traversed RELATED_INCL expansions to produce the same filter");
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -26,16 +27,22 @@ import com.linkedin.metadata.models.annotation.SearchableAnnotation;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
+import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterContext;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SearchContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.CreatePitRequest;
 import org.opensearch.core.rest.RestStatus;
@@ -157,6 +164,45 @@ public class ESUtilsTest {
                 Map.of(
                     STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
                     new Aspect(structPropUnderscoresAndDotsDefinitionV1.data()))));
+  }
+
+  /**
+   * Every hierarchical condition has to reach the rewrite chain carrying its own condition -- that
+   * is the seam the rewriters' condition switch keys off, and the single arm in {@code
+   * getQueryBuilderFromCriterionForSingleField} has to serve all three. Every other {@code
+   * ESUtilsTest} case passes {@link QueryFilterRewriteChain#EMPTY} or a bare mock, so the seam was
+   * untested in either direction.
+   */
+  @Test
+  public void testRewriteChainReceivesTheCriterionCondition() {
+    QueryFilterRewriteChain chain = mock(QueryFilterRewriteChain.class);
+    when(chain.rewrite(any(), any(), any())).thenAnswer(invocation -> invocation.getArgument(2));
+
+    OperationContext opContext = mock(OperationContext.class);
+    // EMPTY carries SearchContext's own default flags, which leave `fulltext` unset -- the shape
+    // that used to blow up deriving a search type on the way into the chain.
+    when(opContext.getSearchContext()).thenReturn(SearchContext.EMPTY);
+
+    List<Condition> conditions =
+        List.of(Condition.ANCESTORS_INCL, Condition.DESCENDANTS_INCL, Condition.RELATED_INCL);
+    for (Condition condition : conditions) {
+      ESUtils.getQueryBuilderFromCriterion(
+          buildCriterion("container", condition, "urn:li:container:foo"),
+          false,
+          new HashMap<>(),
+          opContext,
+          chain);
+    }
+
+    ArgumentCaptor<QueryFilterRewriterContext> contexts =
+        ArgumentCaptor.forClass(QueryFilterRewriterContext.class);
+    verify(chain, Mockito.times(conditions.size())).rewrite(any(), contexts.capture(), any());
+    assertEquals(
+        contexts.getAllValues().stream()
+            .map(QueryFilterRewriterContext::getCondition)
+            .collect(Collectors.toList()),
+        conditions,
+        "Expected each condition to reach the rewrite chain unchanged");
   }
 
   @Test


### PR DESCRIPTION
## What this code does, and why it needed fixing

When you filter a search by a container — a database, a schema, a folder — or by a domain, the filter you send is not always the filter the search index should receive. Asking for "everything under this database" has to become "everything whose container is this database, *or* any schema inside it". The **query filter rewriters** in `metadata-io` do that widening: before a query reaches the index, they take the urns in your filter, walk the metadata graph to find their descendants or ancestors, and hand the index the full set of urns the filter should really match. Container, domain and document hierarchies each have one.

Widening is only correct when it is asked for, and only up to the configured size. Three things in this step were getting that wrong. The rewriters each declare which kinds of query they apply to, but a misplaced pair of parentheses meant that declaration was thrown away, so every rewriter ran on query types it had explicitly opted out of — and threw a null-pointer exception on some of them. The graph walk stopped earlier than its configured limit and said nothing about it, so a filter could come back missing part of the hierarchy and look exactly like a complete one. And picking which kind of query a filter belongs to unboxed an optional flag that is normally unset, which throws.

All three date back to the rewriter chain's original commit (#11279, Sep 2024), and they survived two years for the same reason: every existing test drove the rewriters directly using the single search type and the two conditions that happen to work, so the combinations that actually run in production were the untested ones. This PR fixes all three and widens the shared rewriter tests to derive their cases from what each rewriter declares, rather than from a hand-picked list.

## 1. The enablement gate discarded its own search-type check

`QueryFilterRewriter.isQueryTimeEnabled` read:

```java
return getRewriterSearchTypes().contains(rewriteSearchType) && searchFlags == null
    || searchFlags.isRewriteQuery() == null
    || Boolean.TRUE.equals(searchFlags.isRewriteQuery());
```

`&&` binds tighter than `||`, so this is `(contains && flags == null) || flags.isRewriteQuery() == null || TRUE.equals(...)`. Two defects:

1. **The search-type allowlist is dead.** Whenever search flags are present and `rewriteQuery` is unset or true — the normal case — the second clause short-circuits to `true` and `getRewriterSearchTypes()` never matters. Every rewriter has been running on search types it declared out of scope.
2. **NPE on absent search flags.** With `searchFlags == null` and a search type outside the rewriter's set, clause one is `false` and clause two dereferences the null. `QueryFilterRewriterContext` declares the field `@Nullable`.

Adding the parentheses restores *in scope for this search type* **and** *rewriting not disabled*. `rewriteQuery=false` keeps working.

**Behavior change, deliberately scoped to one search type.** `QueryFilterRewriterContext.build(boolean)` only ever produces `TIMESERIES`, `FULLTEXT_SEARCH`, `STRUCTURED_SEARCH` or `AUTOCOMPLETE`, and all three rewriters declare the last three. So the only search type this newly excludes is `TIMESERIES` — which every rewriter already excludes on purpose, and where the rewriter field names (`container`, `domains`, `documents`) do not exist on timeseries documents anyway. `PREDICATE` is declared on the enum but never constructed anywhere in this repo, so it is unaffected either way.

## 2. The expansion budget charged the current frontier twice

`scrollGraph`'s early exit was `queryUrns.size() + visitedUrns.size() + nextUrns.size() >= limit`. At the first hop `visitedUrns` is seeded from `queryUrns` by `expandTerms`, so the roots were counted twice and the walk stopped that much early. The effective budget was `limit - roots`, not `limit`: a filter carrying half the limit in roots barely expanded at all, and batched container filters do carry many urns.

Marking the frontier visited *before* scrolling makes the budget count each urn once. It also keeps the current frontier out of `nextUrns`, so a hop can no longer re-queue urns it has already walked.

**Truncation was silent.** No log, no metric, no flag on the result, so a filter that dropped part of the hierarchy was indistinguishable from a complete one. Added a warn naming the rewriter, its fields and the limit, so the operator can see it and raise `SEARCH_SERVICE_FILTER_*_EXPANSION_LIMIT` if it is expected.

## 3. Deriving the search type unboxed an unset optional flag

`QueryFilterRewriterContextBuilder.build(boolean)` chose between `FULLTEXT_SEARCH` and `STRUCTURED_SEARCH` with `this.searchFlags.isFulltext() ? ... : ...`. `fulltext` is `optional boolean` in `SearchFlags.pdl` with no default, and `SearchContext`'s own `buildDefaultSearchFlags()` is `new SearchFlags().setSkipCache(false)` — so any `SearchContext` built without explicit flags hands back a `SearchFlags` whose `isFulltext()` is `null`, and the ternary unboxes it. Every hierarchical-condition filter evaluated on such a context throws:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of
"com.linkedin.metadata.query.SearchFlags.isFulltext()" is null
  at QueryFilterRewriterContext$QueryFilterRewriterContextBuilder.build(QueryFilterRewriterContext.java:40)
  at ESUtils.getQueryBuilderFromCriterionForSingleField(ESUtils.java:985)
```

`Boolean.TRUE.equals(...)` reads unset as not-fulltext, which is what `SearchRequestHandler` already does with the same flag two files over (`getQuery(opContext, input, Boolean.TRUE.equals(searchFlags.isFulltext()))`).

## Coverage

- **`testUnsupportedSearchTypeNotRewritten`** (`BaseQueryFilterRewriterTest`) — derives the undeclared search types from `getRewriterSearchTypes()` instead of hardcoding them, asserts the query comes back unchanged for both flag shapes, and asserts no graph traversal was attempted. It also asserts the undeclared set is non-empty, so a rewriter that later declares every search type fails loudly rather than turning the test into a no-op.
- **`testRewriteQueryDisabledIsRespected`** — pins the `rewriteQuery=false` kill switch, the escape hatch an operator reaches for when expansion misbehaves in production. Green before and after; it guards the rewritten boolean.
- **`testNonHierarchyConditionsNotExpanded`** — the existing guard swept a hardcoded `EQUAL, IEQUAL` pair; it now sweeps `Condition.values()` and skips only the three hierarchical ones, so a condition added later has to be classified deliberately instead of inheriting whatever the switch happens to do with it.
- **`testExpansionHonorsConfiguredLimit`** (`ContainerExpansionRewriterTest`) — asserts the expanded filter uses the whole configured limit.
- **`testRelatedInclCacheAndTraversalAgree`** — `RELATED_INCL` has two implementations: an entity-graph-cache read that expands each direction from the roots, and a traversal that walks descendants then ancestors of that expanded set. This asserts they produce the same filter, so results cannot depend on whether the cache happens to be warm. Neither `RELATED_INCL` nor the equivalence had any coverage.
- **`testRewriteChainReceivesTheCriterionCondition`** (`ESUtilsTest`) — pins that each hierarchical condition reaches the rewrite chain carrying the criterion's own condition. That seam is what the rewriters' condition switch keys off, and every existing `ESUtilsTest` case passes `QueryFilterRewriteChain.EMPTY` or a bare mock, so it was untested in either direction. It drives a `SearchContext` carrying the default flags, so it is also the guard for #3 — it is the test that produced the stack trace above.

The three rewriter guards live on the shared base test class, so container, domain and document inherit them and any rewriter added later is covered the day it is written.

## Verification

```
./gradlew :metadata-io:test \
  --tests 'com.linkedin.metadata.search.query.filter.*' \
  --tests 'com.linkedin.metadata.search.query.request.*' \
  --tests 'com.linkedin.metadata.search.utils.ESUtilsTest' \
  --tests 'com.linkedin.metadata.timeseries.search.TimeseriesAspectServiceUnitTest' \
  --rerun-tasks
```

**278 passing, 0 failures, 0 skips.** `--rerun-tasks` throughout; a cached pass proves nothing here. `TimeseriesAspectServiceUnitTest` is in the set deliberately -- `TIMESERIES` is the one search type fix #1 newly excludes.

Red verified for each fix, by reverting that file to `origin/master` and re-running:

- **Gate, null flags** -> `NullPointerException: Cannot invoke "SearchFlags.isRewriteQuery()" because "searchFlags" is null` at `QueryFilterRewriter.java:32`, in all three rewriter test classes.
- **Gate, present-but-unset flags** -> with the null case temporarily guarded so the NPE could not mask it: `NeverWantedButInvoked: graphRetriever.scrollRelatedEntities(...)`. The rewriter walked the graph for a search type it never declared. That second run is why the test asserts no traversal rather than only comparing queries: an unstubbed retriever expands to nothing, so a query comparison passes while the rewriter is still traversing.
- **Expansion budget** -> `expected [10] but found [7]` with three root urns and a limit of ten, exactly the predicted `limit - roots`.
- **Search-type derivation** -> the `NullPointerException` on `SearchFlags.isFulltext()` quoted in #3 above.

## Checklist

- [x] PR conforms to the Contributing Guideline, particularly PR Title Format
- [x] Tests added, red verified before green
- [ ] Docs — none needed
- [ ] Updating DataHub — not a breaking change; this restores declared behavior rather than changing a documented contract

## Notes

- Flagged, not changed: `QueryFilterRewriterContextBuilder.build(boolean)` unboxes `searchFlags.isFulltext()` without a null check, so a `SearchFlags` that reaches it with `fulltext` unset throws rather than falling back to a search type. In practice flags normally arrive after `SearchContext.withFlagDefaults`, so this is latent, not live — but it is the same shape as the gate NPE above and belongs to whoever decides what an unset `fulltext` should mean.
- Flagged, not changed: the `RELATED_INCL` cache path gives each traversal direction its own `limit` while the traversal path caps the union at `limit`, so a warm cache can return a larger set than a cold one for the same query. The new equivalence test pins the under-limit case; deciding what `limit` should mean across both paths is a separate call.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope query filter rewriters to their declared search types and fix two bugs in expansion and search-type derivation. Previously, rewriters ran on unsupported types, some requests threw, and expansion stopped early without warning.

- Gate: Fix `isQueryTimeEnabled` in `QueryFilterRewriter` to honor declared search types and `rewriteQuery=false`. New behavior excludes only `TIMESERIES`, which rewriters already opt out of.
- Expansion: Count the current frontier once by marking it visited before scrolling in `BaseQueryFilterRewriter`. Expansion now uses the full limit and logs a warn when truncated, naming the rewriter, fields, and limit.
- Search type derivation: In `QueryFilterRewriterContext`, treat unset `SearchFlags.fulltext` as not fulltext to avoid NPEs.
- Tests: Broaden shared tests to derive cases from `getRewriterSearchTypes()` and `Condition.values()`. Add coverage for unsupported types, the `rewriteQuery=false` kill switch, limit honoring, `RELATED_INCL` cache vs traversal equivalence, and that the rewrite chain receives the criterion’s condition.

**Rollout**
- No migrations. Monitor new warn logs for truncated expansions; raise `SEARCH_SERVICE_FILTER_*_EXPANSION_LIMIT` if expected.

<sup>Written for commit 4de02af211b775f1790399c5e219f6e9f9aa0203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

