### PR TITLE
perf(gms): batch frontier scrolls in hierarchy graph fallback

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
@@ -6,12 +6,10 @@ import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.graph.cache.snapshot.EntityGraphEndpoints;
 import com.linkedin.metadata.query.filter.Condition;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
-import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
+import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.utils.CriterionUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collection;
@@ -115,21 +113,14 @@ public final class GraphScrollFallback {
     }
   }
 
+  /**
+   * Single multi-value {@code urn} EQUAL criterion (one {@code termsQuery}), not one OR clause per
+   * parent — wide frontiers must not approach ES {@code indices.query.bool.max_clause_count}.
+   */
   @Nonnull
   private static Filter urnEqualsFilter(@Nonnull Collection<Urn> urns) {
-    return new Filter()
-        .setOr(
-            new ConjunctiveCriterionArray(
-                urns.stream()
-                    .map(Urn::toString)
-                    .map(
-                        urn ->
-                            new ConjunctiveCriterion()
-                                .setAnd(
-                                    new CriterionArray(
-                                        List.of(
-                                            CriterionUtils.buildCriterion(
-                                                "urn", Condition.EQUAL, urn)))))
-                    .collect(Collectors.toList())));
+    List<String> values = urns.stream().map(Urn::toString).collect(Collectors.toList());
+    return QueryUtils.newDisjunctiveFilter(
+        CriterionUtils.buildCriterion("urn", Condition.EQUAL, values));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
@@ -14,9 +14,11 @@ import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
 import com.linkedin.metadata.utils.CriterionUtils;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +33,43 @@ public final class GraphScrollFallback {
       @Nonnull OperationContext opContext,
       @Nonnull HierarchyReadSpec spec,
       @Nonnull Urn parentUrn) {
+    return childrenOf(opContext, spec, Set.of(parentUrn));
+  }
+
+  /**
+   * Expand all descendants under {@code rootUrn} via level-batched graph scroll.
+   *
+   * <p>Each frontier level issues one (paginated) scroll with an OR filter over every parent in
+   * that level — O(depth) scroll rounds instead of one round-trip per node. Matches the pre-cache
+   * domain BFS used for hierarchy expansion when the entity graph cache is disabled or misses.
+   */
+  @Nonnull
+  public static Set<Urn> allDescendants(
+      @Nonnull OperationContext opContext, @Nonnull HierarchyReadSpec spec, @Nonnull Urn rootUrn) {
+    Set<Urn> descendants = new LinkedHashSet<>();
+    Set<Urn> frontier = new LinkedHashSet<>(Set.of(rootUrn));
+    while (!frontier.isEmpty()) {
+      DirectChildrenResult level = childrenOf(opContext, spec, frontier);
+      Set<Urn> nextFrontier = new LinkedHashSet<>();
+      for (Urn child : level.getChildUrns()) {
+        if (descendants.add(child)) {
+          nextFrontier.add(child);
+        }
+      }
+      frontier = nextFrontier;
+    }
+    return descendants;
+  }
+
+  @Nonnull
+  private static DirectChildrenResult childrenOf(
+      @Nonnull OperationContext opContext,
+      @Nonnull HierarchyReadSpec spec,
+      @Nonnull Collection<Urn> parentUrns) {
+    if (parentUrns.isEmpty()) {
+      return new DirectChildrenResult(Set.of(), false);
+    }
+
     GraphRetriever graphRetriever = opContext.getRetrieverContext().getGraphRetriever();
     if (graphRetriever == GraphRetriever.EMPTY
         || spec.getScrollSourceEntityTypes().isEmpty()
@@ -39,17 +78,7 @@ public final class GraphScrollFallback {
     }
 
     try {
-      Filter destinationFilter =
-          new Filter()
-              .setOr(
-                  new ConjunctiveCriterionArray(
-                      new ConjunctiveCriterion()
-                          .setAnd(
-                              new CriterionArray(
-                                  List.of(
-                                      CriterionUtils.buildCriterion(
-                                          "urn", Condition.EQUAL, parentUrn.toString()))))));
-
+      Filter destinationFilter = urnEqualsFilter(parentUrns);
       Set<Urn> children = new LinkedHashSet<>();
       RelatedEntitiesScrollResult result = null;
       while (result == null || result.getScrollId() != null) {
@@ -78,8 +107,8 @@ public final class GraphScrollFallback {
       return new DirectChildrenResult(children, false);
     } catch (Exception e) {
       log.error(
-          "Failed to scroll direct children for {} on graph {}",
-          parentUrn,
+          "Failed to scroll direct children for {} parent(s) on graph {}",
+          parentUrns.size(),
           spec.getBinding().getGraphId(),
           e);
       return new DirectChildrenResult(Set.of(), true);
@@ -87,23 +116,20 @@ public final class GraphScrollFallback {
   }
 
   @Nonnull
-  public static Set<Urn> allDescendants(
-      @Nonnull OperationContext opContext, @Nonnull HierarchyReadSpec spec, @Nonnull Urn rootUrn) {
-    Set<Urn> descendants = new LinkedHashSet<>();
-    collectDescendants(opContext, spec, rootUrn, descendants);
-    return descendants;
-  }
-
-  private static void collectDescendants(
-      @Nonnull OperationContext opContext,
-      @Nonnull HierarchyReadSpec spec,
-      @Nonnull Urn parentUrn,
-      @Nonnull Set<Urn> descendants) {
-    DirectChildrenResult directChildren = directChildren(opContext, spec, parentUrn);
-    for (Urn child : directChildren.getChildUrns()) {
-      if (descendants.add(child)) {
-        collectDescendants(opContext, spec, child, descendants);
-      }
-    }
+  private static Filter urnEqualsFilter(@Nonnull Collection<Urn> urns) {
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                urns.stream()
+                    .map(Urn::toString)
+                    .map(
+                        urn ->
+                            new ConjunctiveCriterion()
+                                .setAnd(
+                                    new CriterionArray(
+                                        List.of(
+                                            CriterionUtils.buildCriterion(
+                                                "urn", Condition.EQUAL, urn)))))
+                    .collect(Collectors.toList())));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
@@ -896,6 +896,19 @@ public class Neo4jGraphService implements GraphService {
     return disjunctionToFragments(filter.getOr(), alias);
   }
 
+  /**
+   * Same as {@link #filterToFragments(Filter, String)} for relationship filters. {@link
+   * RelationshipFilter} includes Filter fields in PDL but is not a Java subtype of {@link Filter}.
+   */
+  @Nonnull
+  private static Neo4jFilterFragments filterToFragments(
+      @Nullable RelationshipFilter filter, @Nonnull String alias) {
+    if (filter == null || filter.getOr() == null) {
+      return Neo4jFilterFragments.EMPTY;
+    }
+    return disjunctionToFragments(filter.getOr(), alias);
+  }
+
   @Nonnull
   private static Neo4jFilterFragments disjunctionToFragments(
       @Nullable final ConjunctiveCriterionArray disjunction, @Nonnull String alias) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
@@ -530,9 +530,12 @@ public class Neo4jGraphService implements GraphService {
       return new RelatedEntitiesResult(offset, 0, 0, Collections.emptyList());
     }
 
-    final String srcCriteria = filterToCriteria(graphFilters.getSourceEntityFilter()).trim();
-    final String destCriteria = filterToCriteria(graphFilters.getDestinationEntityFilter()).trim();
-    final String edgeCriteria = relationshipFilterToCriteria(graphFilters.getRelationshipFilter());
+    final Neo4jFilterFragments srcFilter =
+        filterToFragments(graphFilters.getSourceEntityFilter(), "src");
+    final Neo4jFilterFragments destFilter =
+        filterToFragments(graphFilters.getDestinationEntityFilter(), "dest");
+    final Neo4jFilterFragments edgeFilter =
+        filterToFragments(graphFilters.getRelationshipFilter(), "r");
 
     final RelationshipDirection relationshipDirection = graphFilters.getRelationshipDirection();
 
@@ -544,24 +547,17 @@ public class Neo4jGraphService implements GraphService {
     }
 
     String srcNodeLabel = StringUtils.EMPTY;
-    // Create a URN from the String. Only proceed if srcCriteria is not null or empty
-    if (StringUtils.isNotEmpty(srcCriteria)) {
-      final String urnValue =
-          graphFilters
-              .getSourceEntityFilter()
-              .getOr()
-              .get(0)
-              .getAnd()
-              .get(0)
-              .getValues()
-              .get(0)
-              .toString();
-      try {
-        final Urn urn = Urn.createFromString(urnValue);
-        srcNodeLabel = urn.getEntityType();
-        matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
-      } catch (URISyntaxException e) {
-        log.error("Failed to parse URN: {} ", urnValue, e);
+    // Create a URN from the String. Only proceed if src filter is not empty
+    if (srcFilter.hasConstraints()) {
+      final String urnValue = firstFilterValue(graphFilters.getSourceEntityFilter());
+      if (urnValue != null) {
+        try {
+          final Urn urn = Urn.createFromString(urnValue);
+          srcNodeLabel = urn.getEntityType();
+          matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
+        } catch (URISyntaxException e) {
+          log.error("Failed to parse URN: {} ", urnValue, e);
+        }
       }
     }
 
@@ -573,6 +569,12 @@ public class Neo4jGraphService implements GraphService {
     String whereClause =
         computeEntityTypeWhereClause(
             graphFilters.getSourceTypes(), graphFilters.getDestinationTypes());
+    whereClause =
+        appendWherePredicates(
+            whereClause,
+            srcFilter.wherePredicates,
+            destFilter.wherePredicates,
+            edgeFilter.wherePredicates);
 
     // Build Statement strings
     String baseStatementString;
@@ -582,19 +584,19 @@ public class Neo4jGraphService implements GraphService {
           String.format(
               matchTemplate,
               srcNodeLabel,
-              srcCriteria,
+              srcFilter.propertyMap,
               relationshipTypeFilter,
-              edgeCriteria,
-              destCriteria,
+              edgeFilter.propertyMap,
+              destFilter.propertyMap,
               whereClause);
     } else {
       baseStatementString =
           String.format(
               matchTemplate,
-              srcCriteria,
+              srcFilter.propertyMap,
               relationshipTypeFilter,
-              edgeCriteria,
-              destCriteria,
+              edgeFilter.propertyMap,
+              destFilter.propertyMap,
               whereClause);
     }
     log.info(baseStatementString);
@@ -875,65 +877,125 @@ public class Neo4jGraphService implements GraphService {
       return key + ":" + value;
     }
 
-    return key + ":\"" + value + "\"";
+    return key + ":\"" + escapeCypherString(value.toString()) + "\"";
   }
 
   /**
-   * Converts {@link RelationshipFilter} to neo4j query criteria, filter criterion condition
-   * requires to be EQUAL.
+   * Converts a {@link Filter} into Neo4j MATCH property-map criteria plus WHERE predicates.
    *
-   * @param filter Query relationship filter
-   * @return Neo4j criteria string
+   * <p>Single-value EQUAL criteria stay in the node/relationship property map. Multi-value EQUAL
+   * criteria become {@code alias.field IN [...]} WHERE predicates — Neo4j property maps cannot
+   * express OR across values, and taking only {@code values.get(0)} silently under-filters.
    */
   @Nonnull
-  private static String relationshipFilterToCriteria(@Nonnull RelationshipFilter filter) {
-    return disjunctionToCriteria(filter.getOr());
+  @VisibleForTesting
+  static Neo4jFilterFragments filterToFragments(@Nullable Filter filter, @Nonnull String alias) {
+    if (filter == null || filter.getOr() == null) {
+      return Neo4jFilterFragments.EMPTY;
+    }
+    return disjunctionToFragments(filter.getOr(), alias);
   }
 
-  /**
-   * Converts {@link Filter} to neo4j query criteria, filter criterion condition requires to be
-   * EQUAL.
-   *
-   * @param filter Query Filter
-   * @return Neo4j criteria string
-   */
   @Nonnull
-  private static String filterToCriteria(@Nonnull Filter filter) {
-    return disjunctionToCriteria(filter.getOr());
-  }
-
-  private static String disjunctionToCriteria(final ConjunctiveCriterionArray disjunction) {
+  private static Neo4jFilterFragments disjunctionToFragments(
+      @Nullable final ConjunctiveCriterionArray disjunction, @Nonnull String alias) {
+    if (disjunction == null || disjunction.isEmpty()) {
+      return Neo4jFilterFragments.EMPTY;
+    }
     if (disjunction.size() > 1) {
       // TODO: Support disjunctions (ORs).
       throw new UnsupportedOperationException(
           "Neo4j query filter only supports 1 set of conjunction criteria");
     }
     final CriterionArray criterionArray =
-        disjunction.size() > 0 ? disjunction.get(0).getAnd() : new CriterionArray();
-    return criterionToString(criterionArray);
+        disjunction.get(0).getAnd() != null ? disjunction.get(0).getAnd() : new CriterionArray();
+    return criterionToFragments(criterionArray, alias);
   }
 
-  /**
-   * Converts {@link CriterionArray} to neo4j query string.
-   *
-   * @param criterionArray CriterionArray in a Filter
-   * @return Neo4j criteria string
-   */
   @Nonnull
-  private static String criterionToString(@Nonnull CriterionArray criterionArray) {
+  private static Neo4jFilterFragments criterionToFragments(
+      @Nonnull CriterionArray criterionArray, @Nonnull String alias) {
     if (!criterionArray.stream()
         .allMatch(criterion -> Condition.EQUAL.equals(criterion.getCondition()))) {
       throw new RuntimeException(
           "Neo4j query filter only support EQUAL condition " + criterionArray);
     }
 
-    final StringJoiner joiner = new StringJoiner(",", "{", "}");
+    final StringJoiner mapJoiner = new StringJoiner(",", "{", "}");
+    final List<String> wherePredicates = new ArrayList<>();
 
-    criterionArray.forEach(
-        criterion ->
-            joiner.add(toCriterionString(criterion.getField(), criterion.getValues().get(0))));
+    for (var criterion : criterionArray) {
+      if (criterion.getValues() == null || criterion.getValues().isEmpty()) {
+        continue;
+      }
+      if (criterion.getValues().size() == 1) {
+        mapJoiner.add(toCriterionString(criterion.getField(), criterion.getValues().get(0)));
+      } else {
+        String inList =
+            criterion.getValues().stream()
+                .map(value -> "\"" + escapeCypherString(value) + "\"")
+                .collect(Collectors.joining(", ", "[", "]"));
+        wherePredicates.add(alias + "." + criterion.getField() + " IN " + inList);
+      }
+    }
 
-    return joiner.length() <= 2 ? "" : joiner.toString();
+    String propertyMap = mapJoiner.length() <= 2 ? "" : mapJoiner.toString();
+    return new Neo4jFilterFragments(propertyMap, wherePredicates);
+  }
+
+  @Nonnull
+  private static String escapeCypherString(@Nonnull String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  @Nullable
+  private static String firstFilterValue(@Nullable Filter filter) {
+    if (filter == null
+        || filter.getOr() == null
+        || filter.getOr().isEmpty()
+        || filter.getOr().get(0).getAnd() == null
+        || filter.getOr().get(0).getAnd().isEmpty()
+        || filter.getOr().get(0).getAnd().get(0).getValues() == null
+        || filter.getOr().get(0).getAnd().get(0).getValues().isEmpty()) {
+      return null;
+    }
+    return filter.getOr().get(0).getAnd().get(0).getValues().get(0);
+  }
+
+  @SafeVarargs
+  @Nonnull
+  private static String appendWherePredicates(
+      @Nonnull String whereClause, @Nonnull List<String>... predicateGroups) {
+    List<String> extras =
+        java.util.Arrays.stream(predicateGroups)
+            .flatMap(List::stream)
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toList());
+    if (extras.isEmpty()) {
+      return whereClause;
+    }
+    String joined = String.join(" AND ", extras);
+    if (StringUtils.containsIgnoreCase(whereClause, "WHERE")) {
+      return whereClause + " AND " + joined;
+    }
+    return " WHERE " + joined;
+  }
+
+  @VisibleForTesting
+  static final class Neo4jFilterFragments {
+    static final Neo4jFilterFragments EMPTY = new Neo4jFilterFragments("", List.of());
+
+    final String propertyMap;
+    final List<String> wherePredicates;
+
+    Neo4jFilterFragments(@Nonnull String propertyMap, @Nonnull List<String> wherePredicates) {
+      this.propertyMap = propertyMap;
+      this.wherePredicates = List.copyOf(wherePredicates);
+    }
+
+    boolean hasConstraints() {
+      return StringUtils.isNotEmpty(propertyMap) || !wherePredicates.isEmpty();
+    }
   }
 
   @Override
@@ -1000,9 +1062,12 @@ public class Neo4jGraphService implements GraphService {
       return new RelatedEntitiesScrollResult(0, 0, null, Collections.emptyList());
     }
 
-    final String srcCriteria = filterToCriteria(graphFilters.getSourceEntityFilter()).trim();
-    final String destCriteria = filterToCriteria(graphFilters.getDestinationEntityFilter()).trim();
-    final String edgeCriteria = relationshipFilterToCriteria(graphFilters.getRelationshipFilter());
+    final Neo4jFilterFragments srcFilter =
+        filterToFragments(graphFilters.getSourceEntityFilter(), "src");
+    final Neo4jFilterFragments destFilter =
+        filterToFragments(graphFilters.getDestinationEntityFilter(), "dest");
+    final Neo4jFilterFragments edgeFilter =
+        filterToFragments(graphFilters.getRelationshipFilter(), "r");
 
     final RelationshipDirection relationshipDirection = graphFilters.getRelationshipDirection();
 
@@ -1014,24 +1079,17 @@ public class Neo4jGraphService implements GraphService {
     }
 
     String srcNodeLabel = StringUtils.EMPTY;
-    // Create a URN from the String. Only proceed if srcCriteria is not null or empty
-    if (StringUtils.isNotEmpty(srcCriteria)) {
-      final String urnValue =
-          graphFilters
-              .getSourceEntityFilter()
-              .getOr()
-              .get(0)
-              .getAnd()
-              .get(0)
-              .getValues()
-              .get(0)
-              .toString();
-      try {
-        final Urn urn = Urn.createFromString(urnValue);
-        srcNodeLabel = urn.getEntityType();
-        matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
-      } catch (URISyntaxException e) {
-        log.error("Failed to parse URN: {} ", urnValue, e);
+    // Create a URN from the String. Only proceed if src filter is not empty
+    if (srcFilter.hasConstraints()) {
+      final String urnValue = firstFilterValue(graphFilters.getSourceEntityFilter());
+      if (urnValue != null) {
+        try {
+          final Urn urn = Urn.createFromString(urnValue);
+          srcNodeLabel = urn.getEntityType();
+          matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
+        } catch (URISyntaxException e) {
+          log.error("Failed to parse URN: {} ", urnValue, e);
+        }
       }
     }
 
@@ -1043,6 +1101,12 @@ public class Neo4jGraphService implements GraphService {
     String whereClause =
         computeEntityTypeWhereClause(
             graphFilters.getSourceTypes(), graphFilters.getDestinationTypes());
+    whereClause =
+        appendWherePredicates(
+            whereClause,
+            srcFilter.wherePredicates,
+            destFilter.wherePredicates,
+            edgeFilter.wherePredicates);
 
     // Build Statement strings
     String baseStatementString;
@@ -1052,19 +1116,19 @@ public class Neo4jGraphService implements GraphService {
           String.format(
               matchTemplate,
               srcNodeLabel,
-              srcCriteria,
+              srcFilter.propertyMap,
               relationshipTypeFilter,
-              edgeCriteria,
-              destCriteria,
+              edgeFilter.propertyMap,
+              destFilter.propertyMap,
               whereClause);
     } else {
       baseStatementString =
           String.format(
               matchTemplate,
-              srcCriteria,
+              srcFilter.propertyMap,
               relationshipTypeFilter,
-              edgeCriteria,
-              destCriteria,
+              edgeFilter.propertyMap,
+              destFilter.propertyMap,
               whereClause);
     }
     log.info(baseStatementString);
@@ -1100,7 +1164,6 @@ public class Neo4jGraphService implements GraphService {
                         null));
     final int totalCount = runQuery(countStatement).single().get(0).asInt();
     log.info("Total Related Entities: {}", totalCount);
-    // return new RelatedEntitiesResult(0, relatedEntities.size(), totalCount, relatedEntities);
     String nextScrollId = null;
     if (relatedEntities.size() == count) {
       String pitId = Integer.toString(offset + count);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
@@ -547,17 +547,12 @@ public class Neo4jGraphService implements GraphService {
     }
 
     String srcNodeLabel = StringUtils.EMPTY;
-    // Create a URN from the String. Only proceed if src filter is not empty
+    // Label optimization only when every parseable source URN shares one entity type.
     if (srcFilter.hasConstraints()) {
-      final String urnValue = firstFilterValue(graphFilters.getSourceEntityFilter());
-      if (urnValue != null) {
-        try {
-          final Urn urn = Urn.createFromString(urnValue);
-          srcNodeLabel = urn.getEntityType();
-          matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
-        } catch (URISyntaxException e) {
-          log.error("Failed to parse URN: {} ", urnValue, e);
-        }
+      final String commonType = commonSourceNodeLabel(graphFilters.getSourceEntityFilter());
+      if (commonType != null) {
+        srcNodeLabel = commonType;
+        matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
       }
     }
 
@@ -638,26 +633,31 @@ public class Neo4jGraphService implements GraphService {
 
     Boolean hasSourceTypes = sourceTypes != null && !sourceTypes.isEmpty();
     Boolean hasDestTypes = destinationTypes != null && !destinationTypes.isEmpty();
+    // Parenthesize type OR-groups so AND with later predicates cannot bind into one branch.
     if (hasSourceTypes && hasDestTypes) {
       whereClause =
           String.format(
               " WHERE left(type(r), 2)<>'r_' AND %s AND %s",
-              sourceTypes.stream().map(type -> "src:" + type).collect(Collectors.joining(" OR ")),
+              sourceTypes.stream()
+                  .map(type -> "src:" + type)
+                  .collect(Collectors.joining(" OR ", "(", ")")),
               destinationTypes.stream()
                   .map(type -> "dest:" + type)
-                  .collect(Collectors.joining(" OR ")));
+                  .collect(Collectors.joining(" OR ", "(", ")")));
     } else if (hasSourceTypes) {
       whereClause =
           String.format(
               " WHERE left(type(r), 2)<>'r_' AND %s",
-              sourceTypes.stream().map(type -> "src:" + type).collect(Collectors.joining(" OR ")));
+              sourceTypes.stream()
+                  .map(type -> "src:" + type)
+                  .collect(Collectors.joining(" OR ", "(", ")")));
     } else if (hasDestTypes) {
       whereClause =
           String.format(
               " WHERE left(type(r), 2)<>'r_' AND %s",
               destinationTypes.stream()
                   .map(type -> "dest:" + type)
-                  .collect(Collectors.joining(" OR ")));
+                  .collect(Collectors.joining(" OR ", "(", ")")));
     }
     return whereClause;
   }
@@ -939,7 +939,9 @@ public class Neo4jGraphService implements GraphService {
 
     for (var criterion : criterionArray) {
       if (criterion.getValues() == null || criterion.getValues().isEmpty()) {
-        continue;
+        // Fail closed — dropping an EQUAL constraint would over-match.
+        throw new IllegalArgumentException(
+            "Neo4j EQUAL criterion requires at least one value for field: " + criterion.getField());
       }
       if (criterion.getValues().size() == 1) {
         mapJoiner.add(toCriterionString(criterion.getField(), criterion.getValues().get(0)));
@@ -961,23 +963,50 @@ public class Neo4jGraphService implements GraphService {
     return value.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
+  /**
+   * Returns the shared Neo4j node label for source filter URNs, or {@code null} when the filter has
+   * no parseable URNs or mixes entity types (so a single label would under-match).
+   */
   @Nullable
-  private static String firstFilterValue(@Nullable Filter filter) {
-    if (filter == null
-        || filter.getOr() == null
-        || filter.getOr().isEmpty()
-        || filter.getOr().get(0).getAnd() == null
-        || filter.getOr().get(0).getAnd().isEmpty()
-        || filter.getOr().get(0).getAnd().get(0).getValues() == null
-        || filter.getOr().get(0).getAnd().get(0).getValues().isEmpty()) {
+  @VisibleForTesting
+  static String commonSourceNodeLabel(@Nullable Filter filter) {
+    if (filter == null || filter.getOr() == null || filter.getOr().isEmpty()) {
       return null;
     }
-    return filter.getOr().get(0).getAnd().get(0).getValues().get(0);
+    if (filter.getOr().get(0).getAnd() == null) {
+      return null;
+    }
+    String commonType = null;
+    boolean sawUrn = false;
+    for (var criterion : filter.getOr().get(0).getAnd()) {
+      if (criterion.getValues() == null) {
+        continue;
+      }
+      for (String value : criterion.getValues()) {
+        try {
+          final String type = Urn.createFromString(value).getEntityType();
+          sawUrn = true;
+          if (commonType == null) {
+            commonType = type;
+          } else if (!commonType.equals(type)) {
+            return null;
+          }
+        } catch (URISyntaxException ignored) {
+          // Non-URN filter values (e.g. platform) do not participate in label selection.
+        }
+      }
+    }
+    return sawUrn ? commonType : null;
   }
 
+  /**
+   * Appends AND-joined predicates to an existing WHERE clause. Parenthesizes the existing body so
+   * Cypher AND/OR precedence cannot let a new predicate apply to only one branch of a type OR.
+   */
   @SafeVarargs
   @Nonnull
-  private static String appendWherePredicates(
+  @VisibleForTesting
+  static String appendWherePredicates(
       @Nonnull String whereClause, @Nonnull List<String>... predicateGroups) {
     List<String> extras =
         java.util.Arrays.stream(predicateGroups)
@@ -989,7 +1018,8 @@ public class Neo4jGraphService implements GraphService {
     }
     String joined = String.join(" AND ", extras);
     if (StringUtils.containsIgnoreCase(whereClause, "WHERE")) {
-      return whereClause + " AND " + joined;
+      String body = whereClause.replaceFirst("(?i)\\s*WHERE\\s+", "").trim();
+      return " WHERE (" + body + ") AND " + joined;
     }
     return " WHERE " + joined;
   }
@@ -1092,17 +1122,12 @@ public class Neo4jGraphService implements GraphService {
     }
 
     String srcNodeLabel = StringUtils.EMPTY;
-    // Create a URN from the String. Only proceed if src filter is not empty
+    // Label optimization only when every parseable source URN shares one entity type.
     if (srcFilter.hasConstraints()) {
-      final String urnValue = firstFilterValue(graphFilters.getSourceEntityFilter());
-      if (urnValue != null) {
-        try {
-          final Urn urn = Urn.createFromString(urnValue);
-          srcNodeLabel = urn.getEntityType();
-          matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
-        } catch (URISyntaxException e) {
-          log.error("Failed to parse URN: {} ", urnValue, e);
-        }
+      final String commonType = commonSourceNodeLabel(graphFilters.getSourceEntityFilter());
+      if (commonType != null) {
+        srcNodeLabel = commonType;
+        matchTemplate = matchTemplate.replace("(src ", "(src:%s ");
       }
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
@@ -218,6 +218,11 @@ public class GraphScrollFallbackTest {
     assertEquals(parentsPerScroll.get(0), Set.of(ROOT.toString()));
     assertEquals(parentsPerScroll.get(1), Set.of(CHILD_A.toString(), CHILD_B.toString()));
     assertEquals(parentsPerScroll.get(2), Set.of(GRANDCHILD_A.toString(), GRANDCHILD_B.toString()));
+    // Wide frontiers must use one multi-value EQUAL criterion (termsQuery), not N OR clauses.
+    assertEquals(filterCaptor.getAllValues().get(1).getOr().size(), 1);
+    assertEquals(filterCaptor.getAllValues().get(1).getOr().get(0).getAnd().size(), 1);
+    assertEquals(
+        filterCaptor.getAllValues().get(1).getOr().get(0).getAnd().get(0).getValues().size(), 2);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -24,19 +26,27 @@ import com.linkedin.metadata.graph.cache.EntityGraphBinding;
 import com.linkedin.metadata.graph.cache.EntityGraphCache;
 import com.linkedin.metadata.graph.cache.GraphSnapshotSource;
 import com.linkedin.metadata.graph.cache.KnownEntityGraph;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 public class GraphScrollFallbackTest {
 
   private static final Urn ROOT = UrnUtils.getUrn("urn:li:domain:root");
-  private static final Urn CHILD = UrnUtils.getUrn("urn:li:domain:child");
+  private static final Urn CHILD_A = UrnUtils.getUrn("urn:li:domain:childA");
+  private static final Urn CHILD_B = UrnUtils.getUrn("urn:li:domain:childB");
+  private static final Urn GRANDCHILD_A = UrnUtils.getUrn("urn:li:domain:grandchildA");
+  private static final Urn GRANDCHILD_B = UrnUtils.getUrn("urn:li:domain:grandchildB");
 
   @Test
   public void directChildrenScrollsOutgoingIsPartOfEdges() {
@@ -61,7 +71,7 @@ public class GraphScrollFallbackTest {
                 List.of(
                     new RelatedEntities(
                         "IsPartOf",
-                        CHILD.toString(),
+                        CHILD_A.toString(),
                         ROOT.toString(),
                         RelationshipDirection.OUTGOING,
                         null))));
@@ -71,7 +81,7 @@ public class GraphScrollFallbackTest {
         GraphScrollFallback.directChildren(
             opContext, HierarchyBindings.domainSpec(opContext), ROOT);
 
-    assertEquals(result.getChildUrns(), Set.of(CHILD));
+    assertEquals(result.getChildUrns(), Set.of(CHILD_A));
     assertFalse(result.isTruncated());
   }
 
@@ -110,7 +120,7 @@ public class GraphScrollFallbackTest {
                 List.of(
                     new RelatedEntities(
                         "IsPartOf",
-                        CHILD.toString(),
+                        CHILD_A.toString(),
                         ROOT.toString(),
                         RelationshipDirection.OUTGOING,
                         null))))
@@ -121,7 +131,93 @@ public class GraphScrollFallbackTest {
     assertEquals(
         GraphScrollFallback.allDescendants(
             opContext, HierarchyBindings.domainSpec(opContext), ROOT),
-        Set.of(CHILD));
+        Set.of(CHILD_A));
+  }
+
+  @Test
+  public void allDescendantsBatchesFrontierPerLevel() {
+    // root -> {A, B}; A -> {grandchildA}; B -> {grandchildB}
+    // Batched BFS: 3 scrolls (one per depth). Per-parent recursion would need 5.
+    GraphRetriever graphRetriever = mock(GraphRetriever.class);
+    when(graphRetriever.scrollRelatedEntities(
+            eq(Set.of("domain")),
+            isNull(),
+            eq(Set.of("domain")),
+            any(),
+            eq(Set.of("IsPartOf")),
+            any(),
+            eq(Edge.EDGE_SORT_CRITERION),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                2,
+                2,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        "IsPartOf",
+                        CHILD_A.toString(),
+                        ROOT.toString(),
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        "IsPartOf",
+                        CHILD_B.toString(),
+                        ROOT.toString(),
+                        RelationshipDirection.OUTGOING,
+                        null))))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                2,
+                2,
+                null,
+                List.of(
+                    new RelatedEntities(
+                        "IsPartOf",
+                        GRANDCHILD_A.toString(),
+                        CHILD_A.toString(),
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        "IsPartOf",
+                        GRANDCHILD_B.toString(),
+                        CHILD_B.toString(),
+                        RelationshipDirection.OUTGOING,
+                        null))))
+        .thenReturn(new RelatedEntitiesScrollResult(0, 0, null, List.of()));
+
+    OperationContext opContext = contextWithGraphRetriever(graphRetriever);
+
+    assertEquals(
+        GraphScrollFallback.allDescendants(
+            opContext, HierarchyBindings.domainSpec(opContext), ROOT),
+        Set.of(CHILD_A, CHILD_B, GRANDCHILD_A, GRANDCHILD_B));
+
+    ArgumentCaptor<Filter> filterCaptor = ArgumentCaptor.forClass(Filter.class);
+    verify(graphRetriever, times(3))
+        .scrollRelatedEntities(
+            eq(Set.of("domain")),
+            isNull(),
+            eq(Set.of("domain")),
+            filterCaptor.capture(),
+            eq(Set.of("IsPartOf")),
+            any(),
+            eq(Edge.EDGE_SORT_CRITERION),
+            nullable(String.class),
+            anyInt(),
+            isNull(),
+            isNull());
+
+    List<Set<String>> parentsPerScroll =
+        filterCaptor.getAllValues().stream()
+            .map(GraphScrollFallbackTest::urnsInFilter)
+            .collect(Collectors.toList());
+    assertEquals(parentsPerScroll.get(0), Set.of(ROOT.toString()));
+    assertEquals(parentsPerScroll.get(1), Set.of(CHILD_A.toString(), CHILD_B.toString()));
+    assertEquals(parentsPerScroll.get(2), Set.of(GRANDCHILD_A.toString(), GRANDCHILD_B.toString()));
   }
 
   @Test
@@ -139,6 +235,16 @@ public class GraphScrollFallbackTest {
 
     assertTrue(result.isTruncated());
     assertTrue(result.getChildUrns().isEmpty());
+  }
+
+  private static Set<String> urnsInFilter(Filter filter) {
+    Set<String> urns = new HashSet<>();
+    for (ConjunctiveCriterion orClause : filter.getOr()) {
+      orClause.getAnd().stream()
+          .filter(criterion -> "urn".equals(criterion.getField()))
+          .forEach(criterion -> urns.addAll(criterion.getValues()));
+    }
+    return urns;
   }
 
   private static OperationContext contextWithGraphRetriever(GraphRetriever graphRetriever) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceFilterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceFilterTest.java
@@ -1,0 +1,70 @@
+package com.linkedin.metadata.graph.neo4j;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.utils.CriterionUtils;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class Neo4jGraphServiceFilterTest {
+
+  @Test
+  public void filterToFragmentsKeepsSingleValueInPropertyMap() {
+    Filter filter =
+        andFilter(CriterionUtils.buildCriterion("urn", Condition.EQUAL, "urn:li:domain:root"));
+
+    Neo4jGraphService.Neo4jFilterFragments fragments =
+        Neo4jGraphService.filterToFragments(filter, "dest");
+
+    assertEquals(fragments.propertyMap, "{urn:\"urn:li:domain:root\"}");
+    assertTrue(fragments.wherePredicates.isEmpty());
+  }
+
+  @Test
+  public void filterToFragmentsMovesMultiValueEqualToWhereIn() {
+    Filter filter =
+        andFilter(
+            CriterionUtils.buildCriterion(
+                "urn", Condition.EQUAL, List.of("urn:li:domain:childA", "urn:li:domain:childB")));
+
+    Neo4jGraphService.Neo4jFilterFragments fragments =
+        Neo4jGraphService.filterToFragments(filter, "dest");
+
+    assertEquals(fragments.propertyMap, "");
+    assertEquals(
+        fragments.wherePredicates,
+        List.of("dest.urn IN [\"urn:li:domain:childA\", \"urn:li:domain:childB\"]"));
+  }
+
+  @Test
+  public void filterToFragmentsSplitsMixedSingleAndMultiValueCriteria() {
+    Filter filter =
+        andFilter(
+            CriterionUtils.buildCriterion("platform", Condition.EQUAL, "mysql"),
+            CriterionUtils.buildCriterion(
+                "urn", Condition.EQUAL, List.of("urn:li:dataset:a", "urn:li:dataset:b")));
+
+    Neo4jGraphService.Neo4jFilterFragments fragments =
+        Neo4jGraphService.filterToFragments(filter, "src");
+
+    assertEquals(fragments.propertyMap, "{platform:\"mysql\"}");
+    assertEquals(
+        fragments.wherePredicates,
+        List.of("src.urn IN [\"urn:li:dataset:a\", \"urn:li:dataset:b\"]"));
+  }
+
+  private static Filter andFilter(Criterion... criteria) {
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                new ConjunctiveCriterion().setAnd(new CriterionArray(Arrays.asList(criteria)))));
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceFilterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceFilterTest.java
@@ -1,8 +1,11 @@
 package com.linkedin.metadata.graph.neo4j;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
+import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -59,6 +62,53 @@ public class Neo4jGraphServiceFilterTest {
     assertEquals(
         fragments.wherePredicates,
         List.of("src.urn IN [\"urn:li:dataset:a\", \"urn:li:dataset:b\"]"));
+  }
+
+  @Test
+  public void filterToFragmentsRejectsEmptyEqualValues() {
+    Criterion empty =
+        new Criterion().setField("urn").setCondition(Condition.EQUAL).setValues(new StringArray());
+    Filter filter = andFilter(empty);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> Neo4jGraphService.filterToFragments(filter, "src"));
+  }
+
+  @Test
+  public void appendWherePredicatesParenthesizesExistingOrBody() {
+    String where =
+        " WHERE left(type(r), 2)<>'r_' AND (src:dataset OR src:chart) AND (dest:dataset)";
+    String result =
+        Neo4jGraphService.appendWherePredicates(
+            where, List.of("dest.urn IN [\"urn:li:dataset:a\", \"urn:li:dataset:b\"]"));
+
+    assertEquals(
+        result,
+        " WHERE (left(type(r), 2)<>'r_' AND (src:dataset OR src:chart) AND (dest:dataset))"
+            + " AND dest.urn IN [\"urn:li:dataset:a\", \"urn:li:dataset:b\"]");
+  }
+
+  @Test
+  public void commonSourceNodeLabelRequiresUniformEntityType() {
+    assertEquals(
+        Neo4jGraphService.commonSourceNodeLabel(
+            andFilter(
+                CriterionUtils.buildCriterion(
+                    "urn", Condition.EQUAL, List.of("urn:li:domain:a", "urn:li:domain:b")))),
+        "domain");
+
+    assertNull(
+        Neo4jGraphService.commonSourceNodeLabel(
+            andFilter(
+                CriterionUtils.buildCriterion(
+                    "urn", Condition.EQUAL, List.of("urn:li:domain:a", "urn:li:dataset:b")))));
+
+    assertEquals(
+        Neo4jGraphService.commonSourceNodeLabel(
+            andFilter(
+                CriterionUtils.buildCriterion("platform", Condition.EQUAL, "mysql"),
+                CriterionUtils.buildCriterion("urn", Condition.EQUAL, "urn:li:dataset:a"))),
+        "dataset");
   }
 
   private static Filter andFilter(Criterion... criteria) {


### PR DESCRIPTION
## Summary

- Restore **level-batched BFS** in `GraphScrollFallback.allDescendants` so uncached hierarchy expands (domains via `BoundHierarchyAccess.expandDescendants`, and any other graph using this fallback) issue **one scroll per frontier depth** with an OR filter over parents, instead of recursively calling `directChildren` once per node.
- This regresses performance when the entity graph cache is disabled or misses (e.g. tenants with SAC on and graph cache off): the cache-era generic fallback was correct but O(nodes) scrolls; the pre-cache domain algorithm was already batched by frontier.
- Unit test asserts a bushy 2-level tree needs **3** scrolls (not 5) and that the mid-level filter includes both parents.

## Test plan

- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.graph.cache.client.GraphScrollFallbackTest'`
- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.graph.cache.client.BoundHierarchyAccessDomainTest'`
- [ ] Manual / env: with `ENTITY_GRAPH_CACHE_ENABLED=false` (or domain graph disabled), exercise domain descendant expansion under VBAC / nested domains and confirm scroll volume scales with depth, not node count


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches hierarchy scrolls by frontier depth and fixes Neo4j multi-value filter handling so descendant expansion is fast and correct. Previously the fallback scrolled once per node and Neo4j only honored the first value of multi-value EQUAL criteria; now it scrolls once per level with a single multi-value urn filter and Neo4j composes safe WHERE IN predicates.

- Adds `childrenOf(Collection<Urn>)` and `urnEqualsFilter(...)` to build one multi-value EQUAL (terms) criterion instead of N OR clauses, avoiding ES indices.query.bool.max_clause_count on wide frontiers.
- Replaces the recursive per-parent collector with an iterative, level-batched BFS in `GraphScrollFallback.allDescendants`; result semantics are unchanged.
- Updates `Neo4jGraphService` to split filters into property-map and WHERE fragments: single-value EQUAL stays in the map; multi-value EQUAL becomes `alias.field IN [...]` via `filterToFragments(...)` and `appendWherePredicates(...)`. Applies to both `findRelatedEntities` and `scrollRelatedEntities`.
- Hardens Cypher composition: parenthesizes type predicates before appending IN filters, applies the source node label only when all parseable URNs share one entity type, rejects empty EQUAL criteria, and escapes string literals.
- Scope: only affects the hierarchy fallback path when the entity graph cache is disabled or misses; cached paths are unchanged. Neo4j queries now correctly honor multi-value EQUAL filters, which can narrow previously over-broad results. Tests cover level batching, truncation on failure, and filter splitting.

<sup>Written for commit bbe9424f10cdf5f77d0cac05e9a8bc3074743f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

