### PR TITLE
fix(lineage): bound scrollAcrossLineage traversal to prevent GMS OOM

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
@@ -1684,14 +1684,7 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
       return false; // fully covered, or unlimited budget
     }
     if (!allowPartialResults) {
-      log.error(
-          "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-          sliceId,
-          maxRelations);
-      throw new IllegalStateException(
-          String.format(
-              "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-              sliceId, maxRelations));
+      throw rejectMaxRelationsExceeded(sliceId, maxRelations);
     }
     // Shared budget ran out mid-page: keep only what we reserved, drop the over-limit tail so the
     // combined retained relationships never exceed maxRelations.
@@ -1700,6 +1693,60 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
         "Shared maxRelations budget exhausted during slice {}, stopping. Results will be marked as partial.",
         sliceId);
     return true;
+  }
+
+  /**
+   * Guard to run before a slice fetches a page: when the shared per-hop budget is already exhausted
+   * (by this or any other slice), reject in strict mode — reaching the cap is an error, matching
+   * the pre-shared-budget per-slice behavior — or tell the caller to stop with partial results.
+   * Also avoids wasteful post-exhaustion fetches, including pages whose hits would all be dropped
+   * as already visited.
+   */
+  static boolean stopSliceIfSharedBudgetExhausted(
+      @Nullable AtomicInteger sharedRemaining,
+      int maxRelations,
+      int sliceId,
+      boolean allowPartialResults) {
+    if (sharedRemaining == null || sharedRemaining.get() > 0) {
+      return false;
+    }
+    if (!allowPartialResults) {
+      throw rejectMaxRelationsExceeded(sliceId, maxRelations);
+    }
+    log.warn(
+        "Shared maxRelations budget exhausted before slice {} fetch, stopping. Results will be marked as partial.",
+        sliceId);
+    return true;
+  }
+
+  /**
+   * Mark a hop's fetch result partial when its shared relationship budget ended exhausted: the hop
+   * was truncated at the shared maxRelations capacity, which the outer unique-entity limit check
+   * can miss when cross-slice duplicates merge to fewer unique entities than relationships were
+   * retained. Only applies with partial results allowed; in strict mode a slice rejects instead.
+   */
+  static LineageSliceFetchResult markPartialIfSharedBudgetExhausted(
+      LineageSliceFetchResult fetch,
+      @Nullable AtomicInteger sharedRemaining,
+      boolean allowPartialResults) {
+    if (!allowPartialResults
+        || fetch.isPartial()
+        || sharedRemaining == null
+        || sharedRemaining.get() > 0) {
+      return fetch;
+    }
+    return new LineageSliceFetchResult(fetch.getLineageRelationships(), true);
+  }
+
+  private static IllegalStateException rejectMaxRelationsExceeded(int sliceId, int maxRelations) {
+    log.error(
+        "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+        sliceId,
+        maxRelations);
+    return new IllegalStateException(
+        String.format(
+            "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+            sliceId, maxRelations));
   }
 
   protected void cancelAndDrainSliceFutures(

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
@@ -1631,28 +1631,75 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
   }
 
   /**
-   * The next page size for a slice: the smaller of the configured page size and the budget still
-   * shared across the hop's slices, so a fetch near the limit does not pull a full page past it.
-   * Returns {@code defaultPageSize} unchanged when the budget is unlimited ({@code null}).
+   * Atomically reserve up to {@code want} units from the budget shared across a hop's slices, to be
+   * claimed BEFORE fetching a page. Because the reservation is atomic, the reservations held by all
+   * slices at once can never exceed the budget, so the combined retained relationships stay within
+   * {@code maxRelations} even under concurrent slices (a plain read-then-deduct would let two
+   * slices observe the same remaining and overshoot). Returns the amount reserved (0..want); 0
+   * means the budget is exhausted. A {@code null} budget (unlimited) reserves the full {@code
+   * want}.
    */
-  static int nextSharedPageSize(@Nullable AtomicInteger sharedRemaining, int defaultPageSize) {
-    if (sharedRemaining == null) {
-      return defaultPageSize;
+  static int reserveSharedBudget(@Nullable AtomicInteger sharedRemaining, int want) {
+    if (want <= 0) {
+      return 0;
     }
-    return Math.min(defaultPageSize, Math.max(1, sharedRemaining.get()));
+    if (sharedRemaining == null) {
+      return want;
+    }
+    while (true) {
+      int current = sharedRemaining.get();
+      if (current <= 0) {
+        return 0;
+      }
+      int grant = Math.min(current, want);
+      if (sharedRemaining.compareAndSet(current, current - grant)) {
+        return grant;
+      }
+    }
   }
 
   /**
-   * Deduct the relationships a slice just added from the shared budget and report whether the
-   * budget is now exhausted (so the slice must stop). A {@code null} budget (unlimited) never
-   * exhausts.
+   * Bound a slice's retained relationships to its atomic share of the hop's shared budget. The
+   * slice materializes a page, appends it to {@code sliceRelationships}, then calls this to keep
+   * only what it can reserve, dropping any tail past the limit. Reserving the ACTUAL retained count
+   * after the fetch (rather than a full page before it) keeps the relationships retained across all
+   * slices within {@code maxRelations} without letting the first slice speculatively grab the whole
+   * budget and starve its siblings, and the atomic reservation avoids the read-then-deduct
+   * overshoot a plain deduct would allow. Returns {@code true} when the shared budget is exhausted
+   * so the caller stops; throws when the limit is hit and partial results are disallowed.
    */
-  static boolean deductSharedBudgetAndCheckExhausted(
-      @Nullable AtomicInteger sharedRemaining, int added) {
-    if (sharedRemaining == null) {
-      return false;
+  boolean reserveOrTruncateToSharedBudget(
+      List<LineageRelationship> sliceRelationships,
+      int before,
+      @Nullable AtomicInteger sharedRemaining,
+      int maxRelations,
+      int sliceId,
+      boolean allowPartialResults) {
+    int added = sliceRelationships.size() - before;
+    if (added <= 0) {
+      return false; // nothing new retained this batch (all dropped as visited/duplicate)
     }
-    return sharedRemaining.addAndGet(-Math.max(0, added)) <= 0;
+    int reserved = reserveSharedBudget(sharedRemaining, added);
+    if (reserved >= added) {
+      return false; // fully covered, or unlimited budget
+    }
+    if (!allowPartialResults) {
+      log.error(
+          "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+          sliceId,
+          maxRelations);
+      throw new IllegalStateException(
+          String.format(
+              "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+              sliceId, maxRelations));
+    }
+    // Shared budget ran out mid-page: keep only what we reserved, drop the over-limit tail so the
+    // combined retained relationships never exceed maxRelations.
+    sliceRelationships.subList(before + reserved, sliceRelationships.size()).clear();
+    log.warn(
+        "Shared maxRelations budget exhausted during slice {}, stopping. Results will be marked as partial.",
+        sliceId);
+    return true;
   }
 
   protected void cancelAndDrainSliceFutures(

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -1617,6 +1618,43 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
    * (see {@code elasticsearch.search.graph.sliceFutureDrainTimeoutSeconds}) is a bounded join on
    * those stages, not a reliable wait for in-flight HTTP to finish.
    */
+  /**
+   * A hop's relationship budget shared across its parallel slices. Each slice draws from this
+   * single counter instead of independently self-capping to the full remaining {@code
+   * maxRelations}; that per-slice independence made the per-hop transient peak {@code slices *
+   * maxRelations} relationships in memory, which could exhaust the GMS heap. {@code null} means
+   * unlimited ({@code maxRelations <= 0}), which never caps.
+   */
+  @Nullable
+  static AtomicInteger newSharedRelationshipBudget(int maxRelations) {
+    return maxRelations > 0 ? new AtomicInteger(maxRelations) : null;
+  }
+
+  /**
+   * The next page size for a slice: the smaller of the configured page size and the budget still
+   * shared across the hop's slices, so a fetch near the limit does not pull a full page past it.
+   * Returns {@code defaultPageSize} unchanged when the budget is unlimited ({@code null}).
+   */
+  static int nextSharedPageSize(@Nullable AtomicInteger sharedRemaining, int defaultPageSize) {
+    if (sharedRemaining == null) {
+      return defaultPageSize;
+    }
+    return Math.min(defaultPageSize, Math.max(1, sharedRemaining.get()));
+  }
+
+  /**
+   * Deduct the relationships a slice just added from the shared budget and report whether the
+   * budget is now exhausted (so the slice must stop). A {@code null} budget (unlimited) never
+   * exhausts.
+   */
+  static boolean deductSharedBudgetAndCheckExhausted(
+      @Nullable AtomicInteger sharedRemaining, int added) {
+    if (sharedRemaining == null) {
+      return false;
+    }
+    return sharedRemaining.addAndGet(-Math.max(0, added)) <= 0;
+  }
+
   protected void cancelAndDrainSliceFutures(
       List<CompletableFuture<List<LineageRelationship>>> sliceFutures) {
     if (sliceFutures.isEmpty()) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
@@ -104,8 +104,13 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
         sliceFutures.add(sliceFuture);
       }
 
-      // Reuse the existing slice coordination logic
-      return processSliceFutures(sliceFutures, remainingTime, allowPartialResults);
+      // Reuse the existing slice coordination logic. If the shared budget ended exhausted, the hop
+      // was truncated at maxRelations — report partial explicitly, since the outer unique-entity
+      // limit check can miss it when cross-slice duplicates merge away.
+      return markPartialIfSharedBudgetExhausted(
+          processSliceFutures(sliceFutures, remainingTime, allowPartialResults),
+          sharedRemaining,
+          allowPartialResults);
     } finally {
       // Match PIT DAO: cancel(true) only interrupts; bounded wait so slices can clear scroll.
       cancelAndDrainSliceFutures(sliceFutures);
@@ -146,6 +151,12 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
     try {
       if (System.currentTimeMillis() >= deadline) {
         log.warn("Slice {} timed out before initial scroll search", sliceId);
+        return sliceRelationships;
+      }
+
+      // Other slices may have exhausted the shared budget before this slice starts.
+      if (stopSliceIfSharedBudgetExhausted(
+          sharedRemaining, maxRelations, sliceId, allowPartialResults)) {
         return sliceRelationships;
       }
 
@@ -215,10 +226,10 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
         }
 
         // Stop before the next scroll once the shared per-hop budget is exhausted (consumed by this
-        // or another slice). Retention is already bounded by the reservation below; this avoids
-        // wasteful post-exhaustion fetches (including all-visited pages). The outer hop loop
-        // enforces the total maxRelations limit and the partial/strict-reject decision.
-        if (sharedRemaining != null && sharedRemaining.get() <= 0) {
+        // or another slice): strict mode rejects, partial mode stops and searchWithSlices marks the
+        // hop partial. Retention is already bounded by the reservation below.
+        if (stopSliceIfSharedBudgetExhausted(
+            sharedRemaining, maxRelations, sliceId, allowPartialResults)) {
           break;
         }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.ClearScrollRequest;
@@ -73,6 +75,8 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
 
     // Create slice-based search requests
     List<CompletableFuture<List<LineageRelationship>>> sliceFutures = new ArrayList<>();
+    // One budget shared across all slices of this hop (see GraphQueryBaseDAO); null == unlimited.
+    final AtomicInteger sharedRemaining = newSharedRelationshipBudget(maxRelations);
     try {
       for (int sliceId = 0; sliceId < slices; sliceId++) {
         final int currentSliceId = sliceId;
@@ -89,6 +93,7 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
                       remainingHops,
                       existingPaths,
                       maxRelations,
+                      sharedRemaining,
                       defaultPageSize,
                       currentSliceId,
                       slices,
@@ -125,6 +130,7 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
       int remainingHops,
       ThreadSafePathStore existingPaths,
       int maxRelations,
+      @Nullable AtomicInteger sharedRemaining, // budget shared across this hop's slices; null=∞
       int defaultPageSize,
       int sliceId,
       int totalSlices,
@@ -147,7 +153,7 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
       SearchRequest searchRequest = new SearchRequest();
       SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
       searchSourceBuilder.query(query);
-      searchSourceBuilder.size(defaultPageSize);
+      searchSourceBuilder.size(nextSharedPageSize(sharedRemaining, defaultPageSize));
 
       // Add sorting for consistent results
       ESUtils.buildSortOrder(searchSourceBuilder, Edge.EDGE_SORT_CRITERION, List.of(), false);
@@ -174,6 +180,7 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
       }
 
       // Process initial results
+      int beforeInitial = sliceRelationships.size();
       processSearchResponse(
           response,
           sliceRelationships,
@@ -184,10 +191,29 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
           numHops,
           remainingHops,
           existingPaths);
+      // Deduct the initial page from the hop's shared budget before scrolling further.
+      if (deductSharedBudgetAndCheckExhausted(
+          sharedRemaining, sliceRelationships.size() - beforeInitial)) {
+        if (allowPartialResults) {
+          log.warn(
+              "Shared maxRelations budget exhausted during slice {} initial search, stopping. Results will be marked as partial.",
+              sliceId);
+          return sliceRelationships;
+        } else {
+          log.error(
+              "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+              sliceId,
+              maxRelations);
+          throw new IllegalStateException(
+              String.format(
+                  "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
+                  sliceId, maxRelations));
+        }
+      }
 
-      // Continue scrolling until we reach the limit or no more results
-      // If maxRelations is -1 or 0, treat as unlimited (only bound by time)
-      while (maxRelations <= 0 || sliceRelationships.size() < maxRelations) {
+      // Continue scrolling until the shared budget is exhausted or no more results.
+      // If maxRelations is -1 or 0, treat as unlimited (only bound by time).
+      while (maxRelations <= 0 || sharedRemaining.get() > 0) {
         if (System.currentTimeMillis() >= deadline) {
           log.warn("Slice {} timed out, stopping scroll search", sliceId);
           break;
@@ -222,6 +248,7 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
         }
 
         // Process scroll results
+        int beforeScroll = sliceRelationships.size();
         processSearchResponse(
             response,
             sliceRelationships,
@@ -233,11 +260,12 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
             remainingHops,
             existingPaths);
 
-        // Safety check to prevent exceeding the limit (skip if unlimited, i.e., -1 or 0)
-        if (maxRelations > 0 && sliceRelationships.size() >= maxRelations) {
+        // Deduct from the hop's shared budget; stop when it (not this slice alone) is exhausted.
+        if (deductSharedBudgetAndCheckExhausted(
+            sharedRemaining, sliceRelationships.size() - beforeScroll)) {
           if (allowPartialResults) {
             log.warn(
-                "Slice {} reached maxRelations limit, stopping scroll search. Results will be marked as partial.",
+                "Shared maxRelations budget exhausted during slice {}, stopping scroll search. Results will be marked as partial.",
                 sliceId);
             break;
           } else {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
@@ -153,7 +153,11 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
       SearchRequest searchRequest = new SearchRequest();
       SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
       searchSourceBuilder.query(query);
-      searchSourceBuilder.size(nextSharedPageSize(sharedRemaining, defaultPageSize));
+      // Scroll cannot change page size after the initial request, so fix it up front (capped to
+      // maxRelations so a small limit does not over-fetch). Retention is bounded per batch below.
+      int scrollBatchSize =
+          maxRelations > 0 ? Math.min(defaultPageSize, maxRelations) : defaultPageSize;
+      searchSourceBuilder.size(scrollBatchSize);
 
       // Add sorting for consistent results
       ESUtils.buildSortOrder(searchSourceBuilder, Edge.EDGE_SORT_CRITERION, List.of(), false);
@@ -191,29 +195,20 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
           numHops,
           remainingHops,
           existingPaths);
-      // Deduct the initial page from the hop's shared budget before scrolling further.
-      if (deductSharedBudgetAndCheckExhausted(
-          sharedRemaining, sliceRelationships.size() - beforeInitial)) {
-        if (allowPartialResults) {
-          log.warn(
-              "Shared maxRelations budget exhausted during slice {} initial search, stopping. Results will be marked as partial.",
-              sliceId);
-          return sliceRelationships;
-        } else {
-          log.error(
-              "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-              sliceId,
-              maxRelations);
-          throw new IllegalStateException(
-              String.format(
-                  "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-                  sliceId, maxRelations));
-        }
+      // Bound retained relationships to this slice's atomic share of the hop's shared budget.
+      if (reserveOrTruncateToSharedBudget(
+          sliceRelationships,
+          beforeInitial,
+          sharedRemaining,
+          maxRelations,
+          sliceId,
+          allowPartialResults)) {
+        return sliceRelationships; // shared budget exhausted; partial results
       }
 
-      // Continue scrolling until the shared budget is exhausted or no more results.
-      // If maxRelations is -1 or 0, treat as unlimited (only bound by time).
-      while (maxRelations <= 0 || sharedRemaining.get() > 0) {
+      // Continue scrolling until the shared budget is exhausted (checked per batch below) or no
+      // more results. If maxRelations is -1 or 0 the budget is unlimited (only bound by time).
+      while (true) {
         if (System.currentTimeMillis() >= deadline) {
           log.warn("Slice {} timed out, stopping scroll search", sliceId);
           break;
@@ -260,24 +255,15 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
             remainingHops,
             existingPaths);
 
-        // Deduct from the hop's shared budget; stop when it (not this slice alone) is exhausted.
-        if (deductSharedBudgetAndCheckExhausted(
-            sharedRemaining, sliceRelationships.size() - beforeScroll)) {
-          if (allowPartialResults) {
-            log.warn(
-                "Shared maxRelations budget exhausted during slice {}, stopping scroll search. Results will be marked as partial.",
-                sliceId);
-            break;
-          } else {
-            log.error(
-                "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-                sliceId,
-                maxRelations);
-            throw new IllegalStateException(
-                String.format(
-                    "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-                    sliceId, maxRelations));
-          }
+        // Bound retained relationships to this slice's atomic share of the hop's shared budget.
+        if (reserveOrTruncateToSharedBudget(
+            sliceRelationships,
+            beforeScroll,
+            sharedRemaining,
+            maxRelations,
+            sliceId,
+            allowPartialResults)) {
+          break; // shared budget exhausted; partial results
         }
       }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAO.java
@@ -214,6 +214,14 @@ public class GraphQueryElasticsearch7DAO extends GraphQueryBaseDAO {
           break;
         }
 
+        // Stop before the next scroll once the shared per-hop budget is exhausted (consumed by this
+        // or another slice). Retention is already bounded by the reservation below; this avoids
+        // wasteful post-exhaustion fetches (including all-visited pages). The outer hop loop
+        // enforces the total maxRelations limit and the partial/strict-reject decision.
+        if (sharedRemaining != null && sharedRemaining.get() <= 0) {
+          break;
+        }
+
         // Continue scroll
         SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
         scrollRequest.scroll(keepAlive); // Use configured keepAlive

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
@@ -231,6 +231,14 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
           break;
         }
 
+        // Stop before fetching once the shared per-hop budget is exhausted (consumed by this or
+        // another slice). Retention is already bounded by the reservation below; this avoids
+        // wasteful post-exhaustion fetches (including all-visited pages). The outer hop loop
+        // enforces the total maxRelations limit and the partial/strict-reject decision.
+        if (sharedRemaining != null && sharedRemaining.get() <= 0) {
+          break;
+        }
+
         // Build search request with PIT and slice configuration
         SearchRequest searchRequest = new SearchRequest();
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.search.SearchRequest;
@@ -134,6 +136,9 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
                   .getIndexName(opContext, INDEX_NAME));
       final String tempPitId = pitId;
 
+      // One budget shared across all slices of this hop (see GraphQueryBaseDAO); null == unlimited.
+      final AtomicInteger sharedRemaining = newSharedRelationshipBudget(maxRelations);
+
       for (int sliceId = 0; sliceId < slices; sliceId++) {
         final int currentSliceId = sliceId;
 
@@ -150,6 +155,7 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
                       remainingHops,
                       existingPaths,
                       maxRelations,
+                      sharedRemaining,
                       defaultPageSize,
                       currentSliceId,
                       slices,
@@ -191,6 +197,7 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
       int remainingHops,
       ThreadSafePathStore existingPaths,
       int maxRelations, // This is the REMAINING capacity, not the original total limit
+      @Nullable AtomicInteger sharedRemaining, // budget shared across this hop's slices; null=∞
       int defaultPageSize,
       int sliceId,
       int totalSlices,
@@ -205,8 +212,11 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
     long deadline = System.currentTimeMillis() + remainingTime;
 
     try {
-      // If maxRelations is -1 or 0, treat as unlimited (only bound by time)
-      while (maxRelations <= 0 || sliceRelationships.size() < maxRelations) {
+      // If maxRelations is -1 or 0, treat as unlimited (only bound by time). Otherwise stop when
+      // the
+      // budget shared across all slices of this hop is exhausted, not when this one slice alone
+      // reaches maxRelations (that per-slice cap made the peak slices * maxRelations).
+      while (maxRelations <= 0 || sharedRemaining.get() > 0) {
         // Check for thread interruption (from future.cancel(true))
         if (Thread.currentThread().isInterrupted()) {
           log.warn("Slice {} was interrupted, cleaning up PIT and stopping", sliceId);
@@ -223,7 +233,7 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
         SearchRequest searchRequest = new SearchRequest();
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(query);
-        searchSourceBuilder.size(defaultPageSize);
+        searchSourceBuilder.size(nextSharedPageSize(sharedRemaining, defaultPageSize));
 
         // Add sorting for consistent results and search_after using Edge sort fields
         ESUtils.buildSortOrder(searchSourceBuilder, Edge.EDGE_SORT_CRITERION, List.of(), false);
@@ -276,11 +286,11 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
 
         sliceRelationships.addAll(pageRelationships);
 
-        // Safety check to prevent exceeding the limit (skip if unlimited, i.e., -1 or 0)
-        if (maxRelations > 0 && sliceRelationships.size() >= maxRelations) {
+        // Deduct from the hop's shared budget and stop when it (not this slice alone) is exhausted.
+        if (deductSharedBudgetAndCheckExhausted(sharedRemaining, pageRelationships.size())) {
           if (allowPartialResults) {
             log.warn(
-                "Slice {} reached maxRelations limit, stopping PIT search. Results will be marked as partial.",
+                "Shared maxRelations budget exhausted during slice {}, stopping PIT search. Results will be marked as partial.",
                 sliceId);
             break;
           } else {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
@@ -212,11 +212,13 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
     long deadline = System.currentTimeMillis() + remainingTime;
 
     try {
-      // If maxRelations is -1 or 0, treat as unlimited (only bound by time). Otherwise stop when
-      // the
-      // budget shared across all slices of this hop is exhausted, not when this one slice alone
-      // reaches maxRelations (that per-slice cap made the peak slices * maxRelations).
-      while (maxRelations <= 0 || sharedRemaining.get() > 0) {
+      // Fixed page size (capped to maxRelations so a small limit does not over-fetch). Retention is
+      // bounded per page below by reserving the ACTUAL retained count from the budget shared across
+      // this hop's slices and truncating any tail past it, so the slices can never collectively
+      // retain more than maxRelations. Reserving a full page BEFORE fetching would instead let the
+      // first slice speculatively grab the whole budget and starve its siblings.
+      int pageSize = maxRelations > 0 ? Math.min(defaultPageSize, maxRelations) : defaultPageSize;
+      while (true) {
         // Check for thread interruption (from future.cancel(true))
         if (Thread.currentThread().isInterrupted()) {
           log.warn("Slice {} was interrupted, cleaning up PIT and stopping", sliceId);
@@ -233,7 +235,7 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
         SearchRequest searchRequest = new SearchRequest();
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(query);
-        searchSourceBuilder.size(nextSharedPageSize(sharedRemaining, defaultPageSize));
+        searchSourceBuilder.size(pageSize);
 
         // Add sorting for consistent results and search_after using Edge sort fields
         ESUtils.buildSortOrder(searchSourceBuilder, Edge.EDGE_SORT_CRITERION, List.of(), false);
@@ -284,25 +286,18 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
                 existingPaths,
                 false); // exploreMultiplePaths - not needed for impact lineage
 
+        int before = sliceRelationships.size();
         sliceRelationships.addAll(pageRelationships);
 
-        // Deduct from the hop's shared budget and stop when it (not this slice alone) is exhausted.
-        if (deductSharedBudgetAndCheckExhausted(sharedRemaining, pageRelationships.size())) {
-          if (allowPartialResults) {
-            log.warn(
-                "Shared maxRelations budget exhausted during slice {}, stopping PIT search. Results will be marked as partial.",
-                sliceId);
-            break;
-          } else {
-            log.error(
-                "Slice {} exceeded maxRelations limit of {}. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-                sliceId,
-                maxRelations);
-            throw new IllegalStateException(
-                String.format(
-                    "Slice %d exceeded maxRelations limit of %d. Consider reducing maxHops or increasing the maxRelations limit, or set partialResults to true to return partial results.",
-                    sliceId, maxRelations));
-          }
+        // Bound retained relationships to this slice's atomic share of the hop's shared budget.
+        if (reserveOrTruncateToSharedBudget(
+            sliceRelationships,
+            before,
+            sharedRemaining,
+            maxRelations,
+            sliceId,
+            allowPartialResults)) {
+          break; // shared budget exhausted; partial results
         }
 
         // Get search_after for next page

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAO.java
@@ -169,8 +169,13 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
         sliceFutures.add(sliceFuture);
       }
 
-      // Reuse the common slice coordination logic
-      return processSliceFutures(sliceFutures, remainingTime, allowPartialResults);
+      // Reuse the common slice coordination logic. If the shared budget ended exhausted, the hop
+      // was truncated at maxRelations — report partial explicitly, since the outer unique-entity
+      // limit check can miss it when cross-slice duplicates merge away.
+      return markPartialIfSharedBudgetExhausted(
+          processSliceFutures(sliceFutures, remainingTime, allowPartialResults),
+          sharedRemaining,
+          allowPartialResults);
     } finally {
       // Cancel any still-running slice futures, then wait (bounded, see GraphQueryConstants) before
       // deleting the shared PIT. cancel(true) only sends an interrupt — without waiting, slices
@@ -232,10 +237,10 @@ public class GraphQueryPITDAO extends GraphQueryBaseDAO {
         }
 
         // Stop before fetching once the shared per-hop budget is exhausted (consumed by this or
-        // another slice). Retention is already bounded by the reservation below; this avoids
-        // wasteful post-exhaustion fetches (including all-visited pages). The outer hop loop
-        // enforces the total maxRelations limit and the partial/strict-reject decision.
-        if (sharedRemaining != null && sharedRemaining.get() <= 0) {
+        // another slice): strict mode rejects, partial mode stops and searchWithSlices marks the
+        // hop partial. Retention is already bounded by the reservation below.
+        if (stopSliceIfSharedBudgetExhausted(
+            sharedRemaining, maxRelations, sliceId, allowPartialResults)) {
           break;
         }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -138,7 +138,9 @@ public class LineageSearchService {
    * @param direction Direction of the relationship
    * @param entities list of entities to search (If empty, searches across all entities)
    * @param input the search input text
-   * @param maxHops the maximum number of hops away to search for. If null, defaults to 1000
+   * @param maxHops the maximum number of hops away to search for. If null, defaults to the
+   *     configured per-mode maximum (impact.maxHops for impact analysis; lineageMaxHops for
+   *     visualization), and any larger value is clamped to it
    * @param inputFilters the request map with fields and values as filters to be applied to search
    *     hits
    * @param sortCriteria list of {@link SortCriterion} to be applied to search results
@@ -953,7 +955,9 @@ public class LineageSearchService {
    * @param direction Direction of the relationship
    * @param entities list of entities to search (If empty, searches across all entities)
    * @param input the search input text
-   * @param maxHops the maximum number of hops away to search for. If null, defaults to 1000
+   * @param maxHops the maximum number of hops away to search for. If null, defaults to the
+   *     configured per-mode maximum (impact.maxHops for impact analysis; lineageMaxHops for
+   *     visualization), and any larger value is clamped to it
    * @param inputFilters the request map with fields and values as filters to be applied to search
    *     hits
    * @param sortCriteria list of {@link SortCriterion} to be applied to search results
@@ -981,6 +985,12 @@ public class LineageSearchService {
             metricUtils, "scrollAcrossLineage", sourceUrn, -1, "datahub.lineage")) {
       rejectUnsupportedScrollFlags(opContext.getSearchContext().getLineageFlags());
 
+      // Clamp hops the same way searchAcrossLineage does (see applyMaxHopsLimit), before building
+      // the cache key. The scroll path previously defaulted to 1000 without clamping, letting a
+      // caller-supplied maxHops drive an unbounded deep traversal; clamping before the key also
+      // keeps scroll and search cache entries aligned for the same logical request.
+      maxHops = applyMaxHopsLimit(opContext.getSearchContext().getLineageFlags(), maxHops);
+
       // Cache multihop result for faster performance
       final EntityLineageResultCacheKey cacheKey =
           new EntityLineageResultCacheKey(
@@ -997,11 +1007,6 @@ public class LineageSearchService {
               : null;
       EntityLineageResult lineageResult;
       if (cachedLineageResult == null) {
-        // Clamp hops the same way searchAcrossLineage does (see applyMaxHopsLimit). The scroll path
-        // previously defaulted to 1000 without clamping, so a caller-supplied maxHops could drive
-        // an
-        // unbounded deep traversal.
-        maxHops = applyMaxHopsLimit(opContext.getSearchContext().getLineageFlags(), maxHops);
         lineageResult = getLineageResult(opContext, sourceUrn, direction, maxHops);
         if (enableCache(opContext.getSearchContext().getSearchFlags())) {
           cache.put(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -997,7 +997,11 @@ public class LineageSearchService {
               : null;
       EntityLineageResult lineageResult;
       if (cachedLineageResult == null) {
-        maxHops = maxHops != null ? maxHops : 1000;
+        // Clamp hops the same way searchAcrossLineage does (see applyMaxHopsLimit). The scroll path
+        // previously defaulted to 1000 without clamping, so a caller-supplied maxHops could drive
+        // an
+        // unbounded deep traversal.
+        maxHops = applyMaxHopsLimit(opContext.getSearchContext().getLineageFlags(), maxHops);
         lineageResult = getLineageResult(opContext, sourceUrn, direction, maxHops);
         if (enableCache(opContext.getSearchContext().getSearchFlags())) {
           cache.put(

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
@@ -1,0 +1,78 @@
+package com.linkedin.metadata.graph.elastic;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the per-hop shared relationship budget helpers on {@link GraphQueryBaseDAO}. These
+ * bound lineage traversal memory: without a shared budget each parallel slice self-capped to the
+ * full remaining maxRelations, so the transient per-hop peak was {@code slices * maxRelations}.
+ */
+public class SharedRelationshipBudgetTest {
+
+  @Test
+  public void testNewSharedBudgetUnlimitedSentinelIsNull() {
+    assertNull(GraphQueryBaseDAO.newSharedRelationshipBudget(0));
+    assertNull(GraphQueryBaseDAO.newSharedRelationshipBudget(-1));
+  }
+
+  @Test
+  public void testNewSharedBudgetSeedsCounter() {
+    AtomicInteger budget = GraphQueryBaseDAO.newSharedRelationshipBudget(40000);
+    assertEquals(budget.get(), 40000);
+  }
+
+  @Test
+  public void testNextPageSizeUnlimitedKeepsDefault() {
+    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(null, 5000), 5000);
+  }
+
+  @Test
+  public void testNextPageSizeCapsToRemaining() {
+    // Plenty of budget: full page. Near the limit: shrink so a fetch cannot overshoot by a page.
+    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(40000), 5000), 5000);
+    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(10), 5000), 10);
+    // Never returns 0 (a zero-size page would spin without progress).
+    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(0), 5000), 1);
+  }
+
+  @Test
+  public void testDeductUnlimitedNeverExhausts() {
+    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(null, 1_000_000));
+  }
+
+  @Test
+  public void testDeductWithinBudget() {
+    AtomicInteger budget = new AtomicInteger(10);
+    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 4));
+    assertEquals(budget.get(), 6);
+  }
+
+  @Test
+  public void testDeductToExactlyZeroExhausts() {
+    AtomicInteger budget = new AtomicInteger(6);
+    assertTrue(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 6));
+    assertEquals(budget.get(), 0);
+  }
+
+  @Test
+  public void testDeductBeyondBudgetExhausts() {
+    AtomicInteger budget = new AtomicInteger(3);
+    // A page larger than the remaining budget drives it negative and reports exhaustion, so the
+    // slice that consumed the last of the shared budget is the one that stops.
+    assertTrue(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 5));
+    assertTrue(budget.get() <= 0);
+  }
+
+  @Test
+  public void testNegativeAddedTreatedAsZero() {
+    AtomicInteger budget = new AtomicInteger(4);
+    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, -3));
+    assertEquals(budget.get(), 4);
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
@@ -1,7 +1,10 @@
 package com.linkedin.metadata.graph.elastic;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,5 +85,48 @@ public class SharedRelationshipBudgetTest {
     }
     assertEquals(totalReserved.get(), maxRelations);
     assertEquals(budget.get(), 0);
+  }
+
+  @Test
+  public void testStopSliceGuardStrictRejectsWhenExhausted() {
+    // Reaching the cap in strict mode is an error, even at an exact page boundary where no
+    // partial grant ever happened — matching the pre-shared-budget per-slice behavior.
+    assertFalse(GraphQueryBaseDAO.stopSliceIfSharedBudgetExhausted(null, 100, 0, false));
+    assertFalse(
+        GraphQueryBaseDAO.stopSliceIfSharedBudgetExhausted(new AtomicInteger(1), 100, 0, false));
+    try {
+      GraphQueryBaseDAO.stopSliceIfSharedBudgetExhausted(new AtomicInteger(0), 100, 0, false);
+      fail("Strict mode must reject when the shared budget is exhausted");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("maxRelations limit"));
+    }
+  }
+
+  @Test
+  public void testStopSliceGuardPartialStopsWhenExhausted() {
+    assertTrue(
+        GraphQueryBaseDAO.stopSliceIfSharedBudgetExhausted(new AtomicInteger(0), 100, 0, true));
+    assertFalse(
+        GraphQueryBaseDAO.stopSliceIfSharedBudgetExhausted(new AtomicInteger(5), 100, 0, true));
+  }
+
+  @Test
+  public void testMarkPartialWhenBudgetExhausted() {
+    // An exhausted budget means the hop was truncated at maxRelations; the fetch must be reported
+    // partial directly, because the outer unique-entity limit check can miss the truncation when
+    // cross-slice duplicates merge to fewer unique entities than relationships were retained.
+    LineageSliceFetchResult fetch = new LineageSliceFetchResult(List.of(), false);
+    assertTrue(
+        GraphQueryBaseDAO.markPartialIfSharedBudgetExhausted(fetch, new AtomicInteger(0), true)
+            .isPartial());
+    // Budget remaining, unlimited, or strict mode (a slice rejects instead): unchanged.
+    assertFalse(
+        GraphQueryBaseDAO.markPartialIfSharedBudgetExhausted(fetch, new AtomicInteger(3), true)
+            .isPartial());
+    assertFalse(
+        GraphQueryBaseDAO.markPartialIfSharedBudgetExhausted(fetch, null, true).isPartial());
+    assertFalse(
+        GraphQueryBaseDAO.markPartialIfSharedBudgetExhausted(fetch, new AtomicInteger(0), false)
+            .isPartial());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/SharedRelationshipBudgetTest.java
@@ -1,17 +1,23 @@
 package com.linkedin.metadata.graph.elastic;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.testng.annotations.Test;
 
 /**
  * Unit tests for the per-hop shared relationship budget helpers on {@link GraphQueryBaseDAO}. These
  * bound lineage traversal memory: without a shared budget each parallel slice self-capped to the
- * full remaining maxRelations, so the transient per-hop peak was {@code slices * maxRelations}.
+ * full remaining maxRelations, so the transient per-hop peak was {@code slices * maxRelations}. The
+ * atomic reserve/return primitives replace a racy read-then-deduct so concurrent slices can never
+ * collectively retain more than maxRelations.
  */
 public class SharedRelationshipBudgetTest {
 
@@ -28,51 +34,53 @@ public class SharedRelationshipBudgetTest {
   }
 
   @Test
-  public void testNextPageSizeUnlimitedKeepsDefault() {
-    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(null, 5000), 5000);
+  public void testReserveUnlimitedGrantsFullWant() {
+    // A null budget means unlimited: reserve the full requested amount, never capping.
+    assertEquals(GraphQueryBaseDAO.reserveSharedBudget(null, 500), 500);
+    // A non-positive want reserves nothing.
+    assertEquals(GraphQueryBaseDAO.reserveSharedBudget(new AtomicInteger(10), 0), 0);
   }
 
   @Test
-  public void testNextPageSizeCapsToRemaining() {
-    // Plenty of budget: full page. Near the limit: shrink so a fetch cannot overshoot by a page.
-    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(40000), 5000), 5000);
-    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(10), 5000), 10);
-    // Never returns 0 (a zero-size page would spin without progress).
-    assertEquals(GraphQueryBaseDAO.nextSharedPageSize(new AtomicInteger(0), 5000), 1);
+  public void testReserveGrantsUpToRemainingThenExhausts() {
+    AtomicInteger b = new AtomicInteger(10);
+    assertEquals(GraphQueryBaseDAO.reserveSharedBudget(b, 4), 4);
+    assertEquals(b.get(), 6);
+    assertEquals(GraphQueryBaseDAO.reserveSharedBudget(b, 100), 6); // capped to remaining
+    assertEquals(b.get(), 0);
+    assertEquals(GraphQueryBaseDAO.reserveSharedBudget(b, 5), 0); // exhausted
   }
 
   @Test
-  public void testDeductUnlimitedNeverExhausts() {
-    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(null, 1_000_000));
-  }
-
-  @Test
-  public void testDeductWithinBudget() {
-    AtomicInteger budget = new AtomicInteger(10);
-    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 4));
-    assertEquals(budget.get(), 6);
-  }
-
-  @Test
-  public void testDeductToExactlyZeroExhausts() {
-    AtomicInteger budget = new AtomicInteger(6);
-    assertTrue(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 6));
+  public void testReserveNeverOverGrantsUnderConcurrency() throws Exception {
+    // The core invariant behind the fix: N parallel slices reserving from one shared budget can
+    // never collectively reserve more than maxRelations (no read-then-deduct overshoot), and the
+    // atomic reservation loses no capacity either — the total handed out equals the budget exactly.
+    int maxRelations = 40_000;
+    int page = 137; // odd page size to exercise the remainder near exhaustion
+    int slices = 8;
+    AtomicInteger budget = new AtomicInteger(maxRelations);
+    AtomicInteger totalReserved = new AtomicInteger(0);
+    ExecutorService pool = Executors.newFixedThreadPool(slices);
+    try {
+      List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < slices; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  int grant;
+                  while ((grant = GraphQueryBaseDAO.reserveSharedBudget(budget, page)) > 0) {
+                    totalReserved.addAndGet(grant);
+                  }
+                }));
+      }
+      for (Future<?> f : futures) {
+        f.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+    assertEquals(totalReserved.get(), maxRelations);
     assertEquals(budget.get(), 0);
-  }
-
-  @Test
-  public void testDeductBeyondBudgetExhausts() {
-    AtomicInteger budget = new AtomicInteger(3);
-    // A page larger than the remaining budget drives it negative and reports exhaustion, so the
-    // slice that consumed the last of the shared budget is the one that stops.
-    assertTrue(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, 5));
-    assertTrue(budget.get() <= 0);
-  }
-
-  @Test
-  public void testNegativeAddedTreatedAsZero() {
-    AtomicInteger budget = new AtomicInteger(4);
-    assertFalse(GraphQueryBaseDAO.deductSharedBudgetAndCheckExhausted(budget, -3));
-    assertEquals(budget.get(), 4);
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
@@ -654,9 +654,10 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
             eq(TEST_URN),
             eq(DOWNSTREAM_FILTERS),
             maxHopsCaptor.capture());
-    // Integer.MAX_VALUE must have been clamped down to the finite configured impact hop limit.
-    assertTrue(maxHopsCaptor.getValue() > 0);
-    assertTrue(maxHopsCaptor.getValue() < Integer.MAX_VALUE);
+    // Integer.MAX_VALUE must have been clamped down to the exact configured impact hop limit.
+    assertEquals(
+        maxHopsCaptor.getValue().intValue(),
+        getElasticSearchConfiguration().getSearch().getGraph().getImpact().getMaxHops());
     clearCache(false);
   }
 
@@ -697,9 +698,10 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
             eq(TEST_URN),
             eq(DOWNSTREAM_FILTERS),
             maxHopsCaptor.capture());
-    // null must have resolved to the finite configured impact hop limit, not passed through.
-    assertTrue(maxHopsCaptor.getValue() > 0);
-    assertTrue(maxHopsCaptor.getValue() < Integer.MAX_VALUE);
+    // null must resolve to the exact configured impact hop limit, not pass through.
+    assertEquals(
+        maxHopsCaptor.getValue().intValue(),
+        getElasticSearchConfiguration().getSearch().getGraph().getImpact().getMaxHops());
     clearCache(false);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
@@ -617,6 +617,50 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
   }
 
   @Test
+  public void testScrollAcrossLineageClampsExcessiveMaxHops() throws Exception {
+    // scrollAcrossLineage must clamp a caller-supplied maxHops the same way searchAcrossLineage
+    // does. Previously the scroll path defaulted to 1000 without clamping, so a caller could
+    // request an unbounded deep traversal.
+    when(graphService.getImpactLineage(
+            eq(getOperationContext().withSearchFlags(f -> f.setSkipCache(true))),
+            eq(TEST_URN),
+            eq(DOWNSTREAM_FILTERS),
+            anyInt()))
+        .thenReturn(mockResult(Collections.emptyList()));
+
+    lineageSearchService.scrollAcrossLineage(
+        getOperationContext()
+            .withSearchFlags(flags -> flags.setSkipCache(true))
+            .withLineageFlags(
+                flags ->
+                    flags
+                        .setStartTimeMillis(null, SetMode.REMOVE_IF_NULL)
+                        .setEndTimeMillis(null, SetMode.REMOVE_IF_NULL)),
+        TEST_URN,
+        LineageDirection.DOWNSTREAM,
+        ImmutableList.of(),
+        TEST1,
+        Integer.MAX_VALUE,
+        null,
+        null,
+        null,
+        "5m",
+        10);
+
+    ArgumentCaptor<Integer> maxHopsCaptor = ArgumentCaptor.forClass(Integer.class);
+    Mockito.verify(graphService)
+        .getImpactLineage(
+            eq(getOperationContext().withSearchFlags(f -> f.setSkipCache(true))),
+            eq(TEST_URN),
+            eq(DOWNSTREAM_FILTERS),
+            maxHopsCaptor.capture());
+    // Integer.MAX_VALUE must have been clamped down to the finite configured impact hop limit.
+    assertTrue(maxHopsCaptor.getValue() > 0);
+    assertTrue(maxHopsCaptor.getValue() < Integer.MAX_VALUE);
+    clearCache(false);
+  }
+
+  @Test
   public void testLightningSearchService() throws Exception {
     // Mostly this test ensures the code path is exercised
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageServiceTestBase.java
@@ -661,6 +661,49 @@ public abstract class LineageServiceTestBase extends AbstractTestNGSpringContext
   }
 
   @Test
+  public void testScrollAcrossLineageDefaultsNullMaxHopsToConfiguredLimit() throws Exception {
+    // A null maxHops must resolve to the finite configured impact hop limit, not pass through as an
+    // unbounded (or null) deep traversal.
+    when(graphService.getImpactLineage(
+            eq(getOperationContext().withSearchFlags(f -> f.setSkipCache(true))),
+            eq(TEST_URN),
+            eq(DOWNSTREAM_FILTERS),
+            anyInt()))
+        .thenReturn(mockResult(Collections.emptyList()));
+
+    lineageSearchService.scrollAcrossLineage(
+        getOperationContext()
+            .withSearchFlags(flags -> flags.setSkipCache(true))
+            .withLineageFlags(
+                flags ->
+                    flags
+                        .setStartTimeMillis(null, SetMode.REMOVE_IF_NULL)
+                        .setEndTimeMillis(null, SetMode.REMOVE_IF_NULL)),
+        TEST_URN,
+        LineageDirection.DOWNSTREAM,
+        ImmutableList.of(),
+        TEST1,
+        null,
+        null,
+        null,
+        null,
+        "5m",
+        10);
+
+    ArgumentCaptor<Integer> maxHopsCaptor = ArgumentCaptor.forClass(Integer.class);
+    Mockito.verify(graphService)
+        .getImpactLineage(
+            eq(getOperationContext().withSearchFlags(f -> f.setSkipCache(true))),
+            eq(TEST_URN),
+            eq(DOWNSTREAM_FILTERS),
+            maxHopsCaptor.capture());
+    // null must have resolved to the finite configured impact hop limit, not passed through.
+    assertTrue(maxHopsCaptor.getValue() > 0);
+    assertTrue(maxHopsCaptor.getValue() < Integer.MAX_VALUE);
+    clearCache(false);
+  }
+
+  @Test
   public void testLightningSearchService() throws Exception {
     // Mostly this test ensures the code path is exercised
 


### PR DESCRIPTION
## Summary

`scrollAcrossLineage` can exhaust the GMS heap on large lineage graphs. This bounds the traversal at the shared service layer so all callers (GraphQL, OpenAPI, Rest.li) are protected.

## Root cause

Two independent gaps on the multi-hop lineage scroll path:

1. **Hops were never clamped.** `searchAcrossLineage` clamps `maxHops` via `applyMaxHopsLimit`, but `scrollAcrossLineage` defaulted a null `maxHops` to 1000 and otherwise passed the caller value straight through, allowing an unbounded deep traversal.
2. **The relationship budget was per-slice, not per-hop.** `impact.maxRelations` was enforced independently inside each parallel slice, so the transient in-memory peak for a single hop was `slices * maxRelations` relationships (and their materialized paths), not `maxRelations`.

## Fix

1. `scrollAcrossLineage` now calls `applyMaxHopsLimit` **before building the lineage cache key**, matching `searchAcrossLineage`. Clamping before the key means both fresh and cached results are bounded (a cached over-limit result can no longer bypass the limit during the cache lifetime), and scroll/search entries for the same logical request key consistently. Impact-mode default is unchanged (a null `maxHops` still resolves to `impact.maxHops`); visualization-mode scroll now respects `lineageMaxHops` like search does.
2. A single relationship budget is shared across a hop's parallel slices via an **atomic reservation** on `GraphQueryBaseDAO`, threaded through both the PIT and Elasticsearch-7 slice implementations. Each slice reserves its **actual retained count after fetching** and drops any tail past the limit, so the relationships retained across all slices never exceed `maxRelations` — an exact bound, not an overshoot, and with no read-then-deduct race (concurrent slices can no longer observe the same remaining value and both proceed). Reserving after the fetch (rather than a full page before it) also prevents the first slice from speculatively claiming the whole budget and starving its siblings. Existing behavior at the limit is preserved: with `partialResults` enabled the slice keeps results up to the limit and marks them partial; otherwise it rejects.

Default `impact.maxRelations` (40000) and `impact.maxHops` are unchanged, so the memory bound is a safety ceiling, not a behavior change for well-sized graphs.

## Tests

- Unit tests for the shared-budget primitives, including a concurrency test proving N parallel slices never collectively over-reserve the budget.
- Existing PIT / Elasticsearch-7 slice and partial-results tests continue to pass under the new reservation.
- `scrollAcrossLineage` clamp tests for both an excessive `maxHops` and a null `maxHops` (resolves to the configured limit).

### Checklist
- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Tests added for the new behavior
