### PR TITLE
fix(docker): add grpcio to chainguard-ci no-build packages

### DIFF
--- a/docker/snippets/uv/profiles/chainguard-ci.toml
+++ b/docker/snippets/uv/profiles/chainguard-ci.toml
@@ -27,6 +27,7 @@ index-strategy = "unsafe-best-match"
 # Force wheels for packages known to hit that path
 no-build-package = [
     "beautifulsoup4",
+    "grpcio",
     "orjson",
     "pydantic",
     "pypdf",


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

## Summary
- Add `grpcio` to `no-build-package` in the Chainguard CI uv profile so remediations that are sdist-only do not force a source build during CI image builds.

## Test plan
- [ ] Confirm Chainguard CI Docker/Python dependency resolution prefers a wheel for `grpcio` (no source build fallback)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grpcio` to the Chainguard CI `uv` profile’s no-build list to prevent source builds during CI Docker image builds. Previously CI could compile `grpcio` from an sdist; now it requires a wheel, which speeds builds and avoids compiler/toolchain deps. If no wheel is available for the target platform, the build will fail instead of compiling.

<sup>Written for commit b9a56e76c3b2cdc108f6526aae2392a7a34c5150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

