### PR TITLE
docs(managed-datahub): release notes for v2.1.4

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,48 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.4
+
+This release rolls up hotfixes on top of v2.1.3. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+25-Aug-2026
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
+#### Product
+
+- **Home page performance** — home widgets (You Own and discovery cards) use a leaner search-result card query, so cards no longer hydrate unused structured properties, ownership, tags, glossary terms, and dataset stats.
+- **Get Support button** — support-widget requests no longer attach Sentry tracing headers to third-party origins, restoring the Zendesk popup.
+- **GitHub Context Document sync-back** — re-import reuses existing document identity instead of minting duplicate URNs and soft-deleting the originals. Nesting under folder and file parents, file→folder conversion, path-collision handling, and the sync-back pull-request lifecycle (stack edits on an open PR; reopen a closed unmerged PR) are hardened. New recipe options: `sync_back.include_unpublished` (default `false`) and `sync_back.max_files_per_commit` (default `100`).
+
+#### AI / Ask DataHub
+
+- **MCP `list_schema_fields`** — coerces string `keywords` arguments that MCP clients commonly send (a bare keyword or a JSON-encoded array), so the tool no longer fails validation while keeping an array-shaped schema for clients that require it.
+
+#### Platform
+
+- **External OAuth → real DataHub user (opt-in)** — set `EXTERNAL_OAUTH_MAP_TO_CORPUSER=true` so a bearer token from a trusted external issuer signs in as the existing DataHub user named by `EXTERNAL_OAUTH_USER_ID_CLAIM`, instead of a `__oauth_<issuer>_<subject>` service account. Off by default; never creates users. `EXTERNAL_OAUTH_CORPUSER_CLAIM_REGEX` / `EXTERNAL_OAUTH_CORPUSER_TEMPLATE` now apply on this path as well. JWKS responses are cached per URI for five minutes.
+- **Completed pre-v1.0.0 system-update backfills default-disabled** — long-finished backfill steps (`GenerateAssertionEntityField`, `GenerateAssertionFieldPath`, `BackfillBrowsePathsV2`, `BackfillDataProcessInstances`, `BackfillDatasetLineageIndexFields`) now default to `enabled=false` so upgrades skip unnecessary work on mature instances.
+- **Entity graph cache** — search snapshots fetch indexed graph fields (for example `parentDomain`) needed to resolve FULL graphs, and null / blank relationship endpoints are skipped instead of failing cache builds.
+
+#### Bug Fixes
+
+- Fixed container contents listing (and other `EQUAL` / `IEQUAL` container filters) incorrectly expanding to the parent container and its siblings.
+- Fixed structured-property string mapping failing when a URN-typed value could not be resolved; unresolved URNs are now skipped.
+- Fixed entity-graph cache snapshots throwing when a stored relationship endpoint was null or unparsable.
+
+#### Environment Variables
+
+- **[datahub-gms] `EXTERNAL_OAUTH_MAP_TO_CORPUSER` (default `false`, opt-in).** When on, a bearer token from a trusted external issuer signs in as the **existing DataHub user** named by `EXTERNAL_OAUTH_USER_ID_CLAIM`. When off, the token signs in as a `__oauth_<issuer>_<subject>` service account. The user must already exist; unmatched claims are rejected. Only enable when users cannot set the claim themselves and `EXTERNAL_OAUTH_ALLOWED_AUDIENCES` limits which clients can obtain a token for DataHub. Prefer a single trusted issuer — GMS warns at startup if more than one issuer is configured with this setting on.
+
 ### v2.1.3
 
 This release rolls up hotfixes on top of v2.1.2. There are no breaking changes or deprecations.


### PR DESCRIPTION
DataHub Cloud v2.1.4 release notes.

See the added `### v2.1.4` section under `docs/managed-datahub/release-notes/v_2_1_0.md`.

## Test plan
- [ ] `### v2.1.4` appears at the top of the Release Changelog (above v2.1.3)
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions filled in before marking ready

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v2.1.4 section to the DataHub Cloud v2.1.x release notes and places it above v2.1.3. It documents a hotfix rollup with no breaking changes, recommended versions, and an opt-in env var for external OAuth mapping.

**Migration**
- Enable `EXTERNAL_OAUTH_MAP_TO_CORPUSER` only if you want external OAuth tokens to map to existing users; it defaults to off.

<sup>Written for commit 1c167954034605d1f43415bcbc00b699ebb061a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

