### PR TITLE
fix(openlineage): resolve Iceberg table symlink identity

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/src/test/java/datahub/spark/OpenLineageEventToDatahubTest.java
+++ b/metadata-integration/java/acryl-spark-lineage/src/test/java/datahub/spark/OpenLineageEventToDatahubTest.java
@@ -214,6 +214,49 @@ public class OpenLineageEventToDatahubTest {
   }
 
   @Test
+  public void testSparkConfigConnectionResolvesIcebergTableIdentity() {
+    String catalogNamespace = "https://catalog.example/api/catalog";
+    Config datahubConfig =
+        ConfigFactory.parseString(
+            "metadata.dataset.connections {\n"
+                + "  \"https://catalog.example/api/catalog\" { platformInstance = \"iceberg_prod\", env = \"PROD\" }\n"
+                + "}");
+    DatahubOpenlineageConfig conf =
+        SparkConfigParser.sparkConfigToDatahubOpenlineageConf(datahubConfig, new SparkAppContext());
+    OpenLineage openLineage = new OpenLineage(URI.create("https://test"));
+    OpenLineage.CatalogDatasetFacet catalog =
+        openLineage
+            .newCatalogDatasetFacetBuilder()
+            .framework("iceberg")
+            .type("rest")
+            .name("catalog")
+            .metadataUri(catalogNamespace)
+            .warehouseUri("s3://warehouse-bucket")
+            .build();
+    OpenLineage.SymlinksDatasetFacet symlinks =
+        openLineage.newSymlinksDatasetFacet(
+            List.of(
+                openLineage.newSymlinksDatasetFacetIdentifiers(
+                    catalogNamespace, "my_db.events", "TABLE")));
+    OpenLineage.InputDataset dataset =
+        openLineage
+            .newInputDatasetBuilder()
+            .namespace("s3://warehouse-bucket")
+            .name("catalog/db/table")
+            .facets(
+                openLineage.newDatasetFacetsBuilder().catalog(catalog).symlinks(symlinks).build())
+            .build();
+
+    Optional<DatasetUrn> urn =
+        OpenLineageToDataHub.convertOpenlineageDatasetToDatasetUrn(dataset, conf);
+
+    assertTrue(urn.isPresent());
+    assertEquals(
+        "urn:li:dataset:(urn:li:dataPlatform:iceberg,iceberg_prod.my_db.events,PROD)",
+        urn.get().toString());
+  }
+
+  @Test
   public void testGenerateUrnFromStreamingDescriptionGCSWithPathSpec()
       throws InstantiationException, IllegalArgumentException, URISyntaxException {
     Config datahubConfig =

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -139,39 +139,32 @@ public class OpenLineageToDataHub {
     if (dataset.getFacets() != null
         && dataset.getFacets().getSymlinks() != null
         && !mappingConfig.isDisableSymlinkResolution()) {
-      String connectionKey = null;
       Optional<DatasetUrn> originalUrn =
           getDatasetUrnFromOlDataset(namespace, datasetName, null, mappingConfig);
-      for (OpenLineage.SymlinksDatasetFacetIdentifiers symlink :
-          dataset.getFacets().getSymlinks().getIdentifiers()) {
-        if ("TABLE".equals(symlink.getType())) {
-          // Before OpenLineage 0.17.1 the namespace started with "aws:glue:" and after that it was
-          // changed to :arn:aws:glue:"
-          if (symlink.getNamespace().startsWith("aws:glue:")
-              || symlink.getNamespace().startsWith("arn:aws:glue:")) {
-            namespace = "glue";
-          } else {
-            namespace = mappingConfig.getHivePlatformAlias();
-          }
-          if (symlink.getName().startsWith(TABLE_PREFIX)) {
-            datasetName = symlink.getName().replaceFirst(TABLE_PREFIX, "").replace("/", ".");
-          } else {
-            datasetName = symlink.getName();
-          }
-          // Derive the connection-instance map key from the symlink's own namespace before it is
-          // flattened above (e.g. the Glue ARN, which "glue" alone can't recover). toConnectionKey
-          // dispatches on the namespace protocol — it is not Glue-specific.
-          connectionKey = toConnectionKey(symlink.getNamespace());
+      Optional<OpenLineage.SymlinksDatasetFacetIdentifiers> tableSymlink =
+          getUsableTableSymlink(dataset.getFacets().getSymlinks());
+      if (tableSymlink.isPresent()) {
+        OpenLineage.SymlinksDatasetFacetIdentifiers symlink = tableSymlink.get();
+        namespace =
+            resolveTableSymlinkPlatform(
+                symlink.getNamespace(), dataset.getFacets().getCatalog(), mappingConfig);
+        if (symlink.getName().startsWith(TABLE_PREFIX)) {
+          datasetName = symlink.getName().replaceFirst(TABLE_PREFIX, "").replace("/", ".");
+        } else {
+          datasetName = symlink.getName();
         }
+        String connectionKey = toConnectionKey(symlink.getNamespace());
+        Optional<DatasetUrn> symlinkedUrn =
+            getDatasetUrnFromOlDataset(namespace, datasetName, connectionKey, mappingConfig);
+        if (symlinkedUrn.isPresent() && originalUrn.isPresent()) {
+          mappingConfig
+              .getUrnAliases()
+              .put(originalUrn.get().toString(), symlinkedUrn.get().toString());
+        }
+        datahubUrn = symlinkedUrn;
+      } else {
+        datahubUrn = originalUrn;
       }
-      Optional<DatasetUrn> symlinkedUrn =
-          getDatasetUrnFromOlDataset(namespace, datasetName, connectionKey, mappingConfig);
-      if (symlinkedUrn.isPresent() && originalUrn.isPresent()) {
-        mappingConfig
-            .getUrnAliases()
-            .put(originalUrn.get().toString(), symlinkedUrn.get().toString());
-      }
-      datahubUrn = symlinkedUrn;
     } else {
       datahubUrn = getDatasetUrnFromOlDataset(namespace, datasetName, null, mappingConfig);
     }
@@ -193,6 +186,37 @@ public class OpenLineageToDataHub {
     }
 
     return datahubUrn;
+  }
+
+  private static Optional<OpenLineage.SymlinksDatasetFacetIdentifiers> getUsableTableSymlink(
+      OpenLineage.SymlinksDatasetFacet symlinks) {
+    if (symlinks.getIdentifiers() == null) {
+      return Optional.empty();
+    }
+    return symlinks.getIdentifiers().stream()
+        .filter(
+            symlink ->
+                symlink != null
+                    && "TABLE".equals(symlink.getType())
+                    && symlink.getName() != null
+                    && !symlink.getName().isBlank())
+        .reduce((first, second) -> second);
+  }
+
+  private static String resolveTableSymlinkPlatform(
+      String symlinkNamespace,
+      OpenLineage.CatalogDatasetFacet catalog,
+      DatahubOpenlineageConfig mappingConfig) {
+    // Before OpenLineage 0.17.1 the Glue namespace omitted the "arn:" prefix.
+    if (symlinkNamespace != null
+        && (symlinkNamespace.startsWith("aws:glue:")
+            || symlinkNamespace.startsWith("arn:aws:glue:"))) {
+      return "glue";
+    }
+    if (catalog != null && "iceberg".equalsIgnoreCase(catalog.getFramework())) {
+      return "iceberg";
+    }
+    return mappingConfig.getHivePlatformAlias();
   }
 
   private static Optional<DatasetUrn> getDatasetUrnFromOlDataset(

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -148,11 +148,7 @@ public class OpenLineageToDataHub {
         namespace =
             resolveTableSymlinkPlatform(
                 symlink.getNamespace(), dataset.getFacets().getCatalog(), mappingConfig);
-        if (symlink.getName().startsWith(TABLE_PREFIX)) {
-          datasetName = symlink.getName().replaceFirst(TABLE_PREFIX, "").replace("/", ".");
-        } else {
-          datasetName = symlink.getName();
-        }
+        datasetName = normalizeTableSymlinkName(symlink.getName());
         String connectionKey = toConnectionKey(symlink.getNamespace());
         Optional<DatasetUrn> symlinkedUrn =
             getDatasetUrnFromOlDataset(namespace, datasetName, connectionKey, mappingConfig);
@@ -199,8 +195,15 @@ public class OpenLineageToDataHub {
                 symlink != null
                     && "TABLE".equals(symlink.getType())
                     && symlink.getName() != null
-                    && !symlink.getName().isBlank())
+                    && !normalizeTableSymlinkName(symlink.getName()).isBlank())
         .reduce((first, second) -> second);
+  }
+
+  private static String normalizeTableSymlinkName(String symlinkName) {
+    if (symlinkName.startsWith(TABLE_PREFIX)) {
+      return symlinkName.substring(TABLE_PREFIX.length()).replace("/", ".");
+    }
+    return symlinkName;
   }
 
   private static String resolveTableSymlinkPlatform(

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDatasetIdentityTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDatasetIdentityTest.java
@@ -1,0 +1,201 @@
+package io.datahubproject.openlineage;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.FabricType;
+import com.linkedin.common.urn.DatasetUrn;
+import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
+import io.datahubproject.openlineage.converter.OpenLineageToDataHub;
+import io.datahubproject.openlineage.dataset.ConnectionInstanceDetail;
+import io.datahubproject.openlineage.dataset.DatahubJob;
+import io.openlineage.client.OpenLineage;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+public class OpenLineageDatasetIdentityTest {
+  private static final String CATALOG_NAMESPACE = "https://catalog.example/api/catalog";
+  private final OpenLineage openLineage =
+      new OpenLineage(URI.create("https://github.com/OpenLineage/OpenLineage/spark"));
+
+  @Test
+  public void testIcebergCatalogSelectsIcebergPlatformCaseInsensitively() {
+    OpenLineage.InputDataset dataset =
+        tableDataset("IcEbErG", "rest", CATALOG_NAMESPACE, "table/Analytics/Events");
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder()
+            .fabricType(FabricType.PROD)
+            .lowerCaseDatasetUrns(true)
+            .build();
+
+    assertEquals(
+        convert(dataset, config),
+        "urn:li:dataset:(urn:li:dataPlatform:iceberg,analytics.events,PROD)");
+  }
+
+  @Test
+  public void testIcebergCatalogPreservesConnectionInstanceAndEnvironment() {
+    OpenLineage.InputDataset dataset =
+        tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "my_db.events");
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder()
+            .fabricType(FabricType.QA)
+            .connectionInstanceMap(
+                Map.of(
+                    CATALOG_NAMESPACE,
+                    ConnectionInstanceDetail.builder()
+                        .platformInstance(Optional.of("iceberg_prod"))
+                        .env(Optional.of(FabricType.PROD))
+                        .build()))
+            .build();
+
+    assertEquals(
+        convert(dataset, config),
+        "urn:li:dataset:(urn:li:dataPlatform:iceberg,iceberg_prod.my_db.events,PROD)");
+  }
+
+  @Test
+  public void testHiveRestAndGlueSymlinkPlatformsRemainUnchanged() {
+    OpenLineage.InputDataset hive =
+        tableDataset(null, null, "hive://metastore.example:9083", "my_db.events");
+    OpenLineage.InputDataset restCatalog =
+        tableDataset(null, "rest", CATALOG_NAMESPACE, "my_db.events");
+    OpenLineage.InputDataset glueCatalog =
+        tableDataset("iceberg", "glue", "arn:aws:glue:us-east-1:111122223333", "my_db.events");
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder().fabricType(FabricType.PROD).build();
+
+    assertEquals(
+        convert(hive, config), "urn:li:dataset:(urn:li:dataPlatform:hive,my_db.events,PROD)");
+    assertEquals(
+        convert(restCatalog, config),
+        "urn:li:dataset:(urn:li:dataPlatform:hive,my_db.events,PROD)");
+    assertEquals(
+        convert(glueCatalog, config),
+        "urn:li:dataset:(urn:li:dataPlatform:glue,my_db.events,PROD)");
+  }
+
+  @Test
+  public void testMissingLogicalNameKeepsPhysicalIdentity() {
+    OpenLineage.InputDataset dataset = tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "  ");
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder().fabricType(FabricType.PROD).build();
+
+    assertEquals(
+        convert(dataset, config),
+        "urn:li:dataset:(urn:li:dataPlatform:s3,warehouse-bucket/catalog/db/table,PROD)");
+  }
+
+  @Test
+  public void testMixedPlatformJobKeepsIndependentDatasetIdentities() throws Exception {
+    OpenLineage.InputDataset iceberg =
+        tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "my_db.events");
+    OpenLineage.InputDataset postgres =
+        openLineage
+            .newInputDatasetBuilder()
+            .namespace("postgres://database.example:5432")
+            .name("my_db.public.users")
+            .build();
+    OpenLineage.RunEvent event =
+        openLineage
+            .newRunEventBuilder()
+            .eventTime(ZonedDateTime.parse("2026-01-01T00:00:00Z"))
+            .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+            .run(
+                openLineage
+                    .newRunBuilder()
+                    .runId(UUID.randomUUID())
+                    .facets(openLineage.newRunFacetsBuilder().build())
+                    .build())
+            .job(
+                openLineage
+                    .newJobBuilder()
+                    .namespace("spark")
+                    .name("mixed-platform-job")
+                    .facets(openLineage.newJobFacetsBuilder().build())
+                    .build())
+            .inputs(List.of(iceberg, postgres))
+            .outputs(Collections.emptyList())
+            .build();
+
+    DatahubJob job =
+        OpenLineageToDataHub.convertRunEventToJob(
+            event,
+            DatahubOpenlineageConfig.builder()
+                .fabricType(FabricType.PROD)
+                .orchestrator("spark")
+                .build());
+    Set<String> inputUrns =
+        job.getInSet().stream()
+            .map(datahubDataset -> datahubDataset.getUrn().toString())
+            .collect(Collectors.toSet());
+
+    assertEquals(
+        inputUrns,
+        Set.of(
+            "urn:li:dataset:(urn:li:dataPlatform:iceberg,my_db.events,PROD)",
+            "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.public.users,PROD)"));
+  }
+
+  @Test
+  public void testPhysicalIdentityContinuesToResolveThroughIcebergAlias() {
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder().fabricType(FabricType.PROD).build();
+    OpenLineage.InputDataset logical =
+        tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "my_db.events");
+
+    String logicalUrn = convert(logical, config);
+    OpenLineage.InputDataset physical =
+        openLineage
+            .newInputDatasetBuilder()
+            .namespace("s3://warehouse-bucket")
+            .name("catalog/db/table")
+            .build();
+
+    assertEquals(convert(physical, config), logicalUrn);
+  }
+
+  private OpenLineage.InputDataset tableDataset(
+      String framework, String type, String symlinkNamespace, String symlinkName) {
+    OpenLineage.SymlinksDatasetFacet symlinks =
+        openLineage.newSymlinksDatasetFacet(
+            List.of(
+                openLineage.newSymlinksDatasetFacetIdentifiers(
+                    symlinkNamespace, symlinkName, "TABLE")));
+    OpenLineage.DatasetFacetsBuilder facets =
+        openLineage.newDatasetFacetsBuilder().symlinks(symlinks);
+    if (framework != null || type != null) {
+      facets.catalog(
+          openLineage
+              .newCatalogDatasetFacetBuilder()
+              .framework(framework)
+              .type(type)
+              .name("catalog")
+              .metadataUri(CATALOG_NAMESPACE)
+              .warehouseUri("s3://warehouse-bucket")
+              .build());
+    }
+    return openLineage
+        .newInputDatasetBuilder()
+        .namespace("s3://warehouse-bucket")
+        .name("catalog/db/table")
+        .facets(facets.build())
+        .build();
+  }
+
+  private static String convert(
+      OpenLineage.Dataset dataset, DatahubOpenlineageConfig mappingConfig) {
+    Optional<DatasetUrn> urn =
+        OpenLineageToDataHub.convertOpenlineageDatasetToDatasetUrn(dataset, mappingConfig);
+    assertTrue(urn.isPresent());
+    return urn.get().toString();
+  }
+}

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDatasetIdentityTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDatasetIdentityTest.java
@@ -85,12 +85,17 @@ public class OpenLineageDatasetIdentityTest {
 
   @Test
   public void testMissingLogicalNameKeepsPhysicalIdentity() {
-    OpenLineage.InputDataset dataset = tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "  ");
+    OpenLineage.InputDataset blankName = tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "  ");
+    OpenLineage.InputDataset prefixOnlyName =
+        tableDataset("iceberg", "rest", CATALOG_NAMESPACE, "table/");
     DatahubOpenlineageConfig config =
         DatahubOpenlineageConfig.builder().fabricType(FabricType.PROD).build();
 
     assertEquals(
-        convert(dataset, config),
+        convert(blankName, config),
+        "urn:li:dataset:(urn:li:dataPlatform:s3,warehouse-bucket/catalog/db/table,PROD)");
+    assertEquals(
+        convert(prefixOnlyName, config),
         "urn:li:dataset:(urn:li:dataPlatform:s3,warehouse-bucket/catalog/db/table,PROD)");
   }
 


### PR DESCRIPTION
## Summary

- Resolve non-Glue TABLE symlinks as DataHub `iceberg` datasets when the OpenLineage catalog facet declares `framework=iceberg`.
- Preserve the symlink namespace for per-connection platform-instance and environment mapping while keeping existing Hive, Glue, lowercasing, and physical-to-logical alias behavior.
- Fall back to the physical dataset identity when a TABLE symlink does not provide a usable logical name.

## Testing

- `./gradlew :metadata-integration:java:openlineage-converter:test` (28 passing)
- `./gradlew :metadata-integration:java:acryl-spark-lineage:test --tests datahub.spark.OpenLineageEventToDatahubTest` (46 passing)
- `./gradlew spotlessApply`
- `git diff --check origin/master...HEAD`

## Checklist

- [x] PR title follows the DataHub contributing convention.
- [x] Regression tests cover Iceberg REST catalogs, Hive, Glue, mixed-platform jobs, connection mapping, malformed symlinks, lowercasing, and aliases.
- [x] No documentation or upgrade note is required because this corrects dataset identity without changing configuration or introducing a breaking change.

## AI assistance

This change was developed with OpenAI Codex assistance and reviewed and validated by the author.

Closes #19421

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves non-Glue TABLE symlinks as DataHub `iceberg` datasets when the OpenLineage catalog facet declares `framework=iceberg`; previously they resolved as Hive. Rejects empty normalized TABLE symlink names (e.g., "table/") so we fall back to the physical dataset identity instead of producing bad URNs.

- Handle `catalog.framework` case-insensitively when selecting `iceberg`.
- Preserve platform-instance and environment mapping from the symlink namespace.
- Add fallback to the physical dataset only when the TABLE symlink name is blank after removing the `table/` prefix.
- Keep existing Glue/Hive behavior and physical-to-logical aliasing unchanged.

<sup>Written for commit 7cb2b18a341a5e0396010929c06594ca0e01d7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

