### PR TITLE
fix(ingest): serialize workunit processor report values in as_obj

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/workunit_processor.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/workunit_processor.py
@@ -1,8 +1,9 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Generic, Iterable, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Generic, Iterable, Optional, Type, TypeVar, cast
 
+from datahub.ingestion.api.report import Report
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.utilities.type_annotations import get_class_from_annotation
 
@@ -24,15 +25,14 @@ _ReportT = TypeVar("_ReportT", bound="WorkunitProcessorReport")
 
 
 @dataclass
-class WorkunitProcessorReport:
-    """Base report class for workunit processor metrics."""
+class WorkunitProcessorReport(Report):
+    """Base report class for workunit processor metrics.
 
-    def as_obj(self) -> Dict[str, object]:
-        return {
-            key: value
-            for key, value in self.__dict__.items()
-            if not key.startswith("_")
-        }
+    Inherits Report.as_obj, which runs values through to_pure_python_obj so the
+    report stays JSON-serializable. The run summary reporter json.dumps the whole
+    source report, processor reports included, so a field value that is not a JSON
+    primitive would drop the execution-request result for the entire run.
+    """
 
 
 @dataclass

--- a/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
@@ -21,6 +21,15 @@ def test_as_obj_serializes_non_primitive_field_values() -> None:
     ]
 
 
+@dataclass
+class _ReportWithPrivateField(WorkunitProcessorReport):
+    _cache: str = "internal"
+
+
+def test_as_obj_skips_private_fields() -> None:
+    assert _ReportWithPrivateField().as_obj() == {}
+
+
 def test_no_processor_report_declares_a_platform_field() -> None:
     # Report.__post_init__ assigns self.platform, so a subclass field of that name
     # would be silently reset to None at construction.

--- a/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
@@ -1,8 +1,6 @@
-import dataclasses
 import json
 from dataclasses import dataclass, field
 
-import datahub.ingestion.workunit_processors  # noqa: F401  # registers every processor report
 from datahub.ingestion.api.workunit_processor import WorkunitProcessorReport
 from datahub.utilities.lossy_collections import LossySet
 
@@ -28,10 +26,3 @@ class _ReportWithPrivateField(WorkunitProcessorReport):
 
 def test_as_obj_skips_private_fields() -> None:
     assert _ReportWithPrivateField().as_obj() == {}
-
-
-def test_no_processor_report_declares_a_platform_field() -> None:
-    # Report.__post_init__ assigns self.platform, so a subclass field of that name
-    # would be silently reset to None at construction.
-    for report_class in WorkunitProcessorReport.__subclasses__():
-        assert "platform" not in {f.name for f in dataclasses.fields(report_class)}

--- a/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
@@ -9,8 +9,6 @@ from datahub.utilities.lossy_collections import LossySet
 
 @dataclass
 class _ReportWithNonPrimitiveField(WorkunitProcessorReport):
-    # No processor report holds a non-primitive value today, so this stands in for
-    # the next one that does.
     sample: LossySet[str] = field(default_factory=LossySet)
 
 

--- a/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
+++ b/metadata-ingestion/tests/unit/workunit_processors/test_workunit_processor_report.py
@@ -1,0 +1,30 @@
+import dataclasses
+import json
+from dataclasses import dataclass, field
+
+import datahub.ingestion.workunit_processors  # noqa: F401  # registers every processor report
+from datahub.ingestion.api.workunit_processor import WorkunitProcessorReport
+from datahub.utilities.lossy_collections import LossySet
+
+
+@dataclass
+class _ReportWithNonPrimitiveField(WorkunitProcessorReport):
+    # No processor report holds a non-primitive value today, so this stands in for
+    # the next one that does.
+    sample: LossySet[str] = field(default_factory=LossySet)
+
+
+def test_as_obj_serializes_non_primitive_field_values() -> None:
+    report = _ReportWithNonPrimitiveField()
+    report.sample.add("urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)")
+
+    assert json.loads(json.dumps(report.as_obj()))["sample"] == [
+        "urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)"
+    ]
+
+
+def test_no_processor_report_declares_a_platform_field() -> None:
+    # Report.__post_init__ assigns self.platform, so a subclass field of that name
+    # would be silently reset to None at construction.
+    for report_class in WorkunitProcessorReport.__subclasses__():
+        assert "platform" not in {f.name for f in dataclasses.fields(report_class)}


### PR DESCRIPTION
`WorkunitProcessorReport.as_obj()` returned `__dict__` values raw instead of routing them through `Report.to_pure_python_obj`. Any field value that `json.dumps` rejects therefore raised `TypeError`, so the execution-request result was never emitted — ingestion completed and wrote its metadata, but the report was silently lost.

The base class now inherits `Report` rather than re-implementing `as_obj`.

### Output change

- `Report.as_obj` skips None values, so `AutoStatusAspectProcessorReport.status_patch_mode` (`Optional[bool]`, unset by default) is now absent rather than `null`. `False` is still emitted.
- `unresolved_refs_sample` (a `LossyList`) now goes through `LossyList.as_obj`, which appends `... sampled of N total elements` when the sample is truncated. Raw serialization skipped that marker.

### Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)