### PR TITLE
feat(ui): make deprecation date input editable

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/DatePicker/constants.ts
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/constants.ts
@@ -1,4 +1,5 @@
 export enum DatePickerVariant {
     Default = 'DEFAULT',
+    EditableInput = 'EDITABLE_INPUT',
     DateSwitcher = 'DATE_SWITCHER',
 }

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/hooks/useVariantProps.ts
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/hooks/useVariantProps.ts
@@ -3,12 +3,15 @@ import { useMemo } from 'react';
 import { DatePickerVariant } from '@components/components/DatePicker/constants';
 import { VariantProps } from '@components/components/DatePicker/types';
 import { CommonVariantProps, DateSwitcherVariantProps } from '@components/components/DatePicker/variants';
+import { EditableInputVariantProps } from '@components/components/DatePicker/variants/editableInput/props';
 
 export default function useVariantProps(variant: DatePickerVariant | undefined): VariantProps {
     return useMemo(() => {
         switch (variant) {
             case DatePickerVariant.DateSwitcher:
                 return DateSwitcherVariantProps;
+            case DatePickerVariant.EditableInput:
+                return EditableInputVariantProps;
             default:
                 return CommonVariantProps;
         }

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/components.tsx
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/components.tsx
@@ -3,9 +3,9 @@ import { Calendar } from '@phosphor-icons/react/dist/csr/Calendar';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ExtendedInputRenderProps } from '@components/components/DatePicker/types';
+import { DefaultDatePickerInputProps } from '@components/components/DatePicker/variants/common/types';
 
-export function DefaultDatePickerInput({ datePickerProps, ...props }: ExtendedInputRenderProps) {
+export function DefaultDatePickerInput({ datePickerProps, ...props }: DefaultDatePickerInputProps) {
     const { t } = useTranslation('alchemy');
     const { disabled } = datePickerProps;
     return (
@@ -16,7 +16,6 @@ export function DefaultDatePickerInput({ datePickerProps, ...props }: ExtendedIn
             isDisabled={disabled}
             placeholder={props.placeholder || t('datePicker.placeholder')}
             icon={{ icon: Calendar }}
-            isReadOnly
             style={{
                 cursor: disabled ? 'not-allowed' : 'pointer',
                 ...props.style,

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/props.tsx
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/props.tsx
@@ -6,7 +6,7 @@ import { DefaultDatePickerInput } from '@components/components/DatePicker/varian
 
 export const CommonVariantProps: VariantProps = {
     panelRender: (panel) => <StyledCalendarWrapper>{panel}</StyledCalendarWrapper>,
-    inputRender: (props) => <DefaultDatePickerInput {...props} />,
+    inputRender: (props) => <DefaultDatePickerInput isReadOnly {...props} />,
     bordered: false,
     allowClear: false,
     format: 'll',

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/common/types.ts
@@ -1,0 +1,5 @@
+import { ExtendedInputRenderProps } from '@components/components/DatePicker/types';
+
+export type DefaultDatePickerInputProps = {
+    isReadOnly?: boolean;
+} & ExtendedInputRenderProps;

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/editableInput/props.tsx
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/editableInput/props.tsx
@@ -6,5 +6,9 @@ import { CommonVariantProps } from '@components/components/DatePicker/variants/c
 
 export const EditableInputVariantProps: VariantProps = {
     ...CommonVariantProps,
+    // Only the first entry drives display; the rest are parse-only fallbacks so pasted dates are
+    // accepted. Keep them unambiguous — dayjs parses non-strictly and takes the first format that
+    // yields a valid date, so e.g. MM/DD and DD/MM together would silently misread 12/01/2026.
+    format: ['ll', 'YYYY-MM-DD', 'YYYY/MM/DD'],
     inputRender: (props) => <DefaultDatePickerInput {...props} />,
 };

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/editableInput/props.tsx
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/editableInput/props.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { VariantProps } from '@components/components/DatePicker/types';
+import { DefaultDatePickerInput } from '@components/components/DatePicker/variants/common/components';
+import { CommonVariantProps } from '@components/components/DatePicker/variants/common/props';
+
+export const EditableInputVariantProps: VariantProps = {
+    ...CommonVariantProps,
+    inputRender: (props) => <DefaultDatePickerInput {...props} />,
+};

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
@@ -1,4 +1,4 @@
-import { Button, DatePicker, Loader, Modal, SimpleSelect, TextArea, toast } from '@components';
+import { Button, DatePicker, DatePickerVariant, Loader, Modal, SimpleSelect, TextArea, toast } from '@components';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
@@ -175,6 +175,7 @@ export const UpdateDeprecationModal = ({
                     placeholder={t('deprecation.decommissionDateLabel')}
                     value={decommissionTime}
                     onChange={(v) => setDecommissionTime(v)}
+                    variant={DatePickerVariant.EditableInput}
                 />
 
                 {isReplacementModalVisible && !isDeprecatingFields && (


### PR DESCRIPTION
This PR allows editing and pasting in deprecation date input

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the deprecation date input in Update Deprecation modal editable. It was read-only; now users can type or paste a date, while calendar selection still works.

- New DatePicker variant adds editable input capability.
- The default DatePicker stays read-only; other fields are unaffected unless they opt into the new variant.
- Typed or pasted dates accept the locale format plus ISO (`YYYY-MM-DD`, `YYYY/MM/DD`).

<sup>Written for commit 148d858d7d8fc52db62b9fbbe2ad8c7c78f91992. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

