### PR TITLE
fix(restli-client): send only the current batch in batchIngestProposals

### DIFF
--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -1150,8 +1150,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
                             final AspectsDoIngestProposalBatchRequestBuilder requestBuilder =
                                 ASPECTS_REQUEST_BUILDERS
                                     .actionIngestProposalBatch()
-                                    .proposalsParam(
-                                        new MetadataChangeProposalArray(metadataChangeProposals))
+                                    .proposalsParam(new MetadataChangeProposalArray(batch))
                                     .asyncParam(String.valueOf(async));
                             String result =
                                 sendClientRequest(requestBuilder, opContext).getEntity();

--- a/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
+++ b/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
@@ -18,6 +18,7 @@ import com.datahub.authentication.Authentication;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.linkedin.aspect.GetTimeseriesAspectValuesResponse;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.RequiredFieldNotPresentException;
@@ -245,6 +246,47 @@ public class BaseClientTest {
 
     // Verify all URNs were returned
     assertEquals(result.size(), 15);
+  }
+
+  @Test
+  public void testBatchIngestProposalsSendsPartitionNotFullCollection()
+      throws RemoteInvocationException {
+    // Regression: proposalsParam must use the partition, not the full input collection.
+    // Sending N on every request of size B multiplies work by ceil(N/B).
+    final int total = 15;
+    final int batchSize = 5;
+    List<MetadataChangeProposal> mcps = createTestMCPs(total);
+
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    when(mockRestliClient.sendRequest(requestCaptor.capture())).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(batchSize)
+                .batchIngestConcurrency(3)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+
+    assertEquals(result.size(), total);
+    List<ActionRequest> requests = requestCaptor.getAllValues();
+    assertEquals(requests.size(), total / batchSize);
+    for (ActionRequest request : requests) {
+      DataList proposals = request.getInputRecord().data().getDataList("proposals");
+      assertEquals(
+          proposals.size(),
+          batchSize,
+          "Each ingest request must carry only its partition size, not the full input");
+    }
   }
 
   @Test

--- a/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
+++ b/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
@@ -67,6 +67,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -260,6 +261,10 @@ public class BaseClientTest {
   /**
    * Regression helper: proposalsParam must use the partition, not the full input collection.
    * Sending N on every request of size B multiplies work by ceil(N/B).
+   *
+   * <p>Batch sizes are compared as a sorted multiset — not in capture order — because
+   * batchIngestConcurrency &gt; 1 submits partitions concurrently and ArgumentCaptor order follows
+   * thread scheduling.
    */
   private void assertBatchIngestSendsPartitionsOnly(int total, int batchSize)
       throws RemoteInvocationException {
@@ -291,19 +296,26 @@ public class BaseClientTest {
     int expectedBatches = (total + batchSize - 1) / batchSize;
     assertEquals(requests.size(), expectedBatches);
 
-    int remaining = total;
+    List<Integer> expectedSizes = new ArrayList<>();
+    for (int remaining = total; remaining > 0; remaining -= batchSize) {
+      expectedSizes.add(Math.min(batchSize, remaining));
+    }
+    Collections.sort(expectedSizes);
+
+    List<Integer> actualSizes = new ArrayList<>();
     for (ActionRequest request : requests) {
       // ActionRequest only exposes the Rest.li input as a DataMap; the field name matches
       // AspectsDoIngestProposalBatchRequestBuilder.proposalsParam (generated Rest.li schema).
       DataList proposals = request.getInputRecord().data().getDataList("proposals");
-      int expectedSize = Math.min(batchSize, remaining);
-      assertEquals(
-          proposals.size(),
-          expectedSize,
-          "Each ingest request must carry only its partition, not the full input");
-      remaining -= proposals.size();
+      int size = proposals.size();
+      assertTrue(size > 0 && size <= batchSize, "partition size out of range: " + size);
+      if (total > batchSize) {
+        assertTrue(size < total, "request must not send the full input collection");
+      }
+      actualSizes.add(size);
     }
-    assertEquals(remaining, 0);
+    Collections.sort(actualSizes);
+    assertEquals(actualSizes, expectedSizes);
   }
 
   @Test

--- a/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
+++ b/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
@@ -2,6 +2,7 @@ package com.linkedin.common.client;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -251,10 +252,18 @@ public class BaseClientTest {
   @Test
   public void testBatchIngestProposalsSendsPartitionNotFullCollection()
       throws RemoteInvocationException {
-    // Regression: proposalsParam must use the partition, not the full input collection.
-    // Sending N on every request of size B multiplies work by ceil(N/B).
-    final int total = 15;
-    final int batchSize = 5;
+    // Evenly divisible and remainder cases — remainder catches off-by-one in partition sizing.
+    assertBatchIngestSendsPartitionsOnly(15, 5);
+    assertBatchIngestSendsPartitionsOnly(13, 5);
+  }
+
+  /**
+   * Regression helper: proposalsParam must use the partition, not the full input collection.
+   * Sending N on every request of size B multiplies work by ceil(N/B).
+   */
+  private void assertBatchIngestSendsPartitionsOnly(int total, int batchSize)
+      throws RemoteInvocationException {
+    reset(mockRestliClient);
     List<MetadataChangeProposal> mcps = createTestMCPs(total);
 
     ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
@@ -279,14 +288,22 @@ public class BaseClientTest {
 
     assertEquals(result.size(), total);
     List<ActionRequest> requests = requestCaptor.getAllValues();
-    assertEquals(requests.size(), total / batchSize);
+    int expectedBatches = (total + batchSize - 1) / batchSize;
+    assertEquals(requests.size(), expectedBatches);
+
+    int remaining = total;
     for (ActionRequest request : requests) {
+      // ActionRequest only exposes the Rest.li input as a DataMap; the field name matches
+      // AspectsDoIngestProposalBatchRequestBuilder.proposalsParam (generated Rest.li schema).
       DataList proposals = request.getInputRecord().data().getDataList("proposals");
+      int expectedSize = Math.min(batchSize, remaining);
       assertEquals(
           proposals.size(),
-          batchSize,
-          "Each ingest request must carry only its partition size, not the full input");
+          expectedSize,
+          "Each ingest request must carry only its partition, not the full input");
+      remaining -= proposals.size();
     }
+    assertEquals(remaining, 0);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `RestliEntityClient.batchIngestProposals` partitioned the input correctly but passed the **full** `metadataChangeProposals` collection into every Rest.li request instead of the partition (`batch`).
- With N proposals and batch size B this issued `ceil(N/B)` requests each carrying all N — amplification grows as batch size shrinks.
- Fix: use `batch` in `proposalsParam`. Add a regression test that asserts each captured request's `proposals` size equals B, not N.

## Why it mattered

- Return URNs and debug logs used `batch`, so callers and logs looked correct; ingest is idempotent, so data still converged while paying redundant GMS/DB work.
- GMS usually uses the Java entity client (correct path). Rest.li callers — including future node pods that must use `SystemRestliEntityClient` — hit this bug.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `RestliEntityClient.batchIngestProposals` to send only the current batch of proposals per request, eliminating request amplification and unnecessary GMS/DB work. Previously each of ceil(N/B) requests carried all N proposals; now each request carries only its partition.

- Adds tests that validate partition sizes across divisible and remainder cases.
- Makes tests order‑agnostic to avoid flakiness under concurrent batching.
- No API changes; reduces load for Rest.li clients including `SystemRestliEntityClient`.

<sup>Written for commit 61dc3f7b9a2d3af8e7100e90f5e3118f3febca90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

