### PR TITLE
refactor(ingest/kafka): consolidate Stream Catalog indexing into CatalogIndex

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/catalog_index.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/catalog_index.py
@@ -1,0 +1,85 @@
+from typing import Generic, List, Optional, Type, TypeVar
+
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.source.confluent.client import ConfluentStreamCatalogClient
+from datahub.ingestion.source.confluent.config import ConfluentStreamCatalogConfig
+from datahub.ingestion.source.confluent.models import (
+    CatalogEntityType,
+    NameIndex,
+    index_by_name,
+)
+
+CatalogReportType = TypeVar("CatalogReportType", bound=SourceReport)
+
+
+class CatalogIndex(Generic[CatalogEntityType, CatalogReportType]):
+    """Lazy, name-indexed view over one Confluent Stream Catalog entity type.
+
+    Every catalog-backed source repeats the same boilerplate: fetch a single entity
+    type once, remember whether the read was complete, index it by name (reporting
+    empty and duplicate names), and close the client. That lives here so each source
+    only supplies its entity type, query, and any entity-specific behaviour.
+
+    Subclasses pass the query/root key/model/label to `__init__` and may override
+    `_filter` (narrow the fetched entities), `_warn_ambiguous` (duplicate-name
+    wording) and `_record_indexed` (bump the source's report counter).
+    """
+
+    def __init__(
+        self,
+        config: ConfluentStreamCatalogConfig,
+        report: CatalogReportType,
+        *,
+        query: str,
+        root_key: str,
+        model: Type[CatalogEntityType],
+        entity_label: str,
+        client: Optional[ConfluentStreamCatalogClient] = None,
+    ) -> None:
+        self.config = config
+        self.report = report
+        self.client = client or ConfluentStreamCatalogClient(config, report)
+        self._query = query
+        self._root_key = root_key
+        self._model = model
+        self._entity_label = entity_label
+        self._index: Optional[NameIndex[CatalogEntityType]] = None
+        self._complete = True
+
+    def is_complete(self) -> bool:
+        self._ensure_indexed()
+        return self._complete
+
+    def close(self) -> None:
+        self.client.close()
+
+    def _get(self, name: str) -> Optional[CatalogEntityType]:
+        return self._ensure_indexed().get(name)
+
+    def _ensure_indexed(self) -> NameIndex[CatalogEntityType]:
+        if self._index is None:
+            result = self.client.fetch_entities(
+                self._query, self._root_key, self._model
+            )
+            self._complete = result.complete
+            entities = self._filter(list(result.entities))
+            index = index_by_name(entities)
+            index.report_issues(self.report, self._entity_label)
+            for name, candidates in index.ambiguous.items():
+                self._warn_ambiguous(name, candidates)
+            self._record_indexed(len(index.by_name))
+            self._index = index
+        return self._index
+
+    def _filter(self, entities: List[CatalogEntityType]) -> List[CatalogEntityType]:
+        return entities
+
+    def _warn_ambiguous(self, name: str, candidates: List[CatalogEntityType]) -> None:
+        self.report.warning(
+            message="Skipping Stream Catalog metadata for a name that the catalog "
+            "reports more than once in this environment.",
+            context=f"entity={self._entity_label}, name={name}",
+        )
+
+    def _record_indexed(self, count: int) -> None:
+        pass

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/confluent_catalog.py
@@ -1,14 +1,10 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import Field
 
+from datahub.ingestion.source.confluent.catalog_index import CatalogIndex
 from datahub.ingestion.source.confluent.client import ConfluentStreamCatalogClient
-from datahub.ingestion.source.confluent.models import (
-    CatalogEntity,
-    CatalogModel,
-    NameIndex,
-    index_by_name,
-)
+from datahub.ingestion.source.confluent.models import CatalogEntity, CatalogModel
 from datahub.ingestion.source.kafka.confluent_catalog_constants import (
     TOPIC_CATALOG_QUERY,
     TOPIC_ROOT_KEY,
@@ -38,60 +34,50 @@ class CatalogKafkaTopic(CatalogEntity):
         return self.external_source_topic_name or None
 
 
-class KafkaTopicCatalog:
+class KafkaTopicCatalog(CatalogIndex[CatalogKafkaTopic, KafkaSourceReport]):
     def __init__(
         self,
         config: KafkaConfluentCatalogConfig,
         report: KafkaSourceReport,
         client: Optional[ConfluentStreamCatalogClient] = None,
     ) -> None:
-        self.config = config
-        self.report = report
-        self.client = client or ConfluentStreamCatalogClient(config, report)
-        self._topics: Optional[NameIndex[CatalogKafkaTopic]] = None
-        self._complete = True
+        super().__init__(
+            config,
+            report,
+            query=TOPIC_CATALOG_QUERY,
+            root_key=TOPIC_ROOT_KEY,
+            model=CatalogKafkaTopic,
+            entity_label="topic",
+            client=client,
+        )
+        self._cluster_id = config.cluster_id
 
     def get_topic(self, topic_name: str) -> Optional[CatalogKafkaTopic]:
-        if self._topics is None:
-            self._topics = self._fetch_topics()
-        return self._topics.get(topic_name)
+        return self._get(topic_name)
 
-    def is_complete(self) -> bool:
-        if self._topics is None:
-            self._topics = self._fetch_topics()
-        return self._complete
-
-    def _fetch_topics(self) -> NameIndex[CatalogKafkaTopic]:
-        result = self.client.fetch_entities(
-            TOPIC_CATALOG_QUERY, TOPIC_ROOT_KEY, CatalogKafkaTopic
-        )
-        self._complete = result.complete
-        topics = result.entities
-        if self.config.cluster_id:
-            in_cluster = [
-                topic for topic in topics if topic.cluster_id == self.config.cluster_id
-            ]
-            if topics and not in_cluster:
-                # Wrong / unset logical_cluster_id otherwise looks like "0 topics indexed".
-                self.report.warning(
-                    message="No Stream Catalog topic carries the configured Kafka cluster id, so no "
-                    "catalog metadata will be applied. Check `confluent_catalog.cluster_id`.",
-                    context=f"cluster_id={self.config.cluster_id}, topics_in_catalog={len(topics)}, "
-                    f"cluster_ids_seen={sorted({str(topic.cluster_id) for topic in topics})}",
-                )
-            topics = in_cluster
-
-        index = index_by_name(topics)
-        index.report_issues(self.report, "topic")
-        for name, candidates in index.ambiguous.items():
+    def _filter(self, entities: List[CatalogKafkaTopic]) -> List[CatalogKafkaTopic]:
+        if not self._cluster_id:
+            return entities
+        in_cluster = [
+            topic for topic in entities if topic.cluster_id == self._cluster_id
+        ]
+        if entities and not in_cluster:
+            # Wrong / unset logical_cluster_id otherwise looks like "0 topics indexed".
             self.report.warning(
-                message="Skipping Stream Catalog metadata for a topic name that exists in "
-                "more than one Kafka cluster in this environment. Set "
-                "`confluent_catalog.cluster_id` to pick the right cluster.",
-                context=f"topic={name}, clusters={sorted(str(c.cluster_id) for c in candidates)}",
+                message="No Stream Catalog topic carries the configured Kafka cluster id, so no "
+                "catalog metadata will be applied. Check `confluent_catalog.cluster_id`.",
+                context=f"cluster_id={self._cluster_id}, topics_in_catalog={len(entities)}, "
+                f"cluster_ids_seen={sorted({str(topic.cluster_id) for topic in entities})}",
             )
-        self.report.catalog_topics_indexed = len(index.by_name)
-        return index
+        return in_cluster
 
-    def close(self) -> None:
-        self.client.close()
+    def _warn_ambiguous(self, name: str, candidates: List[CatalogKafkaTopic]) -> None:
+        self.report.warning(
+            message="Skipping Stream Catalog metadata for a topic name that exists in "
+            "more than one Kafka cluster in this environment. Set "
+            "`confluent_catalog.cluster_id` to pick the right cluster.",
+            context=f"topic={name}, clusters={sorted(str(c.cluster_id) for c in candidates)}",
+        )
+
+    def _record_indexed(self, count: int) -> None:
+        self.report.catalog_topics_indexed = count

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/confluent_catalog.py
@@ -2,12 +2,12 @@ from typing import List, Optional
 
 from pydantic import Field
 
+from datahub.ingestion.source.confluent.catalog_index import CatalogIndex
 from datahub.ingestion.source.confluent.client import ConfluentStreamCatalogClient
 from datahub.ingestion.source.confluent.models import (
     CatalogEntity,
     NameIndex,
     NullAsEmptyList,
-    index_by_name,
 )
 from datahub.ingestion.source.kafka_connect.common import (
     ConfluentCatalogConfig,
@@ -26,44 +26,35 @@ class CatalogConnector(CatalogEntity):
         return list(dict.fromkeys(topic.name for topic in self.topics if topic.name))
 
 
-class ConnectorCatalog:
+class ConnectorCatalog(CatalogIndex[CatalogConnector, KafkaConnectSourceReport]):
     def __init__(
         self,
         config: ConfluentCatalogConfig,
         report: KafkaConnectSourceReport,
         client: Optional[ConfluentStreamCatalogClient] = None,
     ) -> None:
-        self.config = config
-        self.report = report
-        self.client = client or ConfluentStreamCatalogClient(config, report)
-        self._connectors: Optional[NameIndex[CatalogConnector]] = None
-        self._complete = True
-
-    def is_complete(self) -> bool:
-        self.get_connectors()
-        return self._complete
+        super().__init__(
+            config,
+            report,
+            query=CONNECTOR_CATALOG_QUERY,
+            root_key=CONNECTOR_ROOT_KEY,
+            model=CatalogConnector,
+            entity_label="connector",
+            client=client,
+        )
 
     def get_connectors(self) -> NameIndex[CatalogConnector]:
-        if self._connectors is None:
-            result = self.client.fetch_entities(
-                CONNECTOR_CATALOG_QUERY, CONNECTOR_ROOT_KEY, CatalogConnector
-            )
-            self._complete = result.complete
-            connectors = result.entities
-            index = index_by_name(connectors)
-            index.report_issues(self.report, "connector")
-            for name in index.ambiguous:
-                self.report.warning(
-                    message="Skipping Stream Catalog metadata for a connector name that the "
-                    "catalog reports more than once in this environment.",
-                    context=f"connector={name}",
-                )
-            self._connectors = index
-            self.report.catalog_connectors_indexed = len(index.by_name)
-        return self._connectors
+        return self._ensure_indexed()
 
     def get_connector(self, connector_name: str) -> Optional[CatalogConnector]:
-        return self.get_connectors().get(connector_name)
+        return self._get(connector_name)
 
-    def close(self) -> None:
-        self.client.close()
+    def _warn_ambiguous(self, name: str, candidates: List[CatalogConnector]) -> None:
+        self.report.warning(
+            message="Skipping Stream Catalog metadata for a connector name that the "
+            "catalog reports more than once in this environment.",
+            context=f"connector={name}",
+        )
+
+    def _record_indexed(self, count: int) -> None:
+        self.report.catalog_connectors_indexed = count


### PR DESCRIPTION
## Summary

Part 2 of a stack (base: #19425). Shared/framework refactor, no behaviour change.

`KafkaTopicCatalog` (kafka) and `ConnectorCatalog` (kafka-connect) shared near-identical boilerplate — lazy fetch, completeness flag, index-by-name + issue reporting, and client close. This consolidates that into a generic `CatalogIndex` in the shared `confluent/` package, leaving each source with only its entity type, its GraphQL query, and any entity-specific filtering (kafka additionally filters by `cluster_id`).

- New `confluent/catalog_index.py`.
- `kafka/confluent_catalog.py` and `kafka_connect/confluent_catalog.py` reduced to their source-specific parts.
- No functional change; existing catalog unit tests cover both sources.

## Stack

1. #19425 — Stream Catalog mirror / cluster-link lineage
2. **This PR** — consolidate Stream Catalog indexing into `CatalogIndex`
3. #19432 — kafka-connect S3 + managed Postgres source lineage
4. #19433 — Confluent Cloud Flink SQL topic lineage
5. #19434 — hoist catalog `include_tags`/`include_business_metadata` to shared base

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Behaviour-preserving refactor (covered by existing catalog tests)
- [x] No breaking changes