### PR TITLE
feat(ingest/kafka-connect): add S3 and managed Postgres source lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -130,11 +130,12 @@ MYSQL_CDC_SOURCE_V2_CLOUD: Final[str] = "MySqlCdcSourceV2"
 MYSQL_SINK_CLOUD: Final[str] = "MySqlSink"
 S3_SOURCE_CLOUD: Final[str] = "S3Source"
 
-# Cloud JDBC source connector classes
+# Cloud CDC source classes routed to DebeziumSourceConnector.
+# PostgresSource is a managed JDBC source (topic.prefix + table), not CDC, so it
+# is not listed here — see ConnectorRegistry._get_source_connector.
 CLOUD_JDBC_SOURCE_CLASSES: Final[List[str]] = [
     POSTGRES_CDC_SOURCE_CLOUD,
     POSTGRES_CDC_SOURCE_V2_CLOUD,
-    POSTGRES_SOURCE_CLOUD,
     MYSQL_SOURCE_CLOUD,
     MYSQL_CDC_SOURCE_CLOUD,
     MYSQL_CDC_SOURCE_V2_CLOUD,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -120,6 +120,7 @@ DEBEZIUM_CONNECTORS_WITH_2_LEVEL_CONTAINER: Final[set] = {
 # - https://docs.confluent.io/cloud/current/connectors/cc-snowflake-source.html
 POSTGRES_CDC_SOURCE_CLOUD: Final[str] = "PostgresCdcSource"
 POSTGRES_CDC_SOURCE_V2_CLOUD: Final[str] = "PostgresCdcSourceV2"
+POSTGRES_SOURCE_CLOUD: Final[str] = "PostgresSource"
 POSTGRES_SINK_CLOUD: Final[str] = "PostgresSink"
 SNOWFLAKE_SINK_CLOUD: Final[str] = "SnowflakeSink"
 SNOWFLAKE_SOURCE_CLOUD: Final[str] = "SnowflakeSource"
@@ -127,11 +128,13 @@ MYSQL_SOURCE_CLOUD: Final[str] = "MySqlSource"
 MYSQL_CDC_SOURCE_CLOUD: Final[str] = "MySqlCdcSource"
 MYSQL_CDC_SOURCE_V2_CLOUD: Final[str] = "MySqlCdcSourceV2"
 MYSQL_SINK_CLOUD: Final[str] = "MySqlSink"
+S3_SOURCE_CLOUD: Final[str] = "S3Source"
 
 # Cloud JDBC source connector classes
 CLOUD_JDBC_SOURCE_CLASSES: Final[List[str]] = [
     POSTGRES_CDC_SOURCE_CLOUD,
     POSTGRES_CDC_SOURCE_V2_CLOUD,
+    POSTGRES_SOURCE_CLOUD,
     MYSQL_SOURCE_CLOUD,
     MYSQL_CDC_SOURCE_CLOUD,
     MYSQL_CDC_SOURCE_V2_CLOUD,

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/config_constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/config_constants.py
@@ -6,7 +6,7 @@ modules (common.py, transform_plugins.py, etc.) without creating circular depend
 """
 
 import logging
-from typing import Dict, Final, List
+from typing import Dict, Final, FrozenSet, List
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,9 @@ class ConnectorConfigKeys:
     TOPICS_DIR: Final[str] = "topics.dir"
     AWS_ACCESS_KEY_ID: Final[str] = "aws.access.key.id"
     AWS_SECRET_ACCESS_KEY: Final[str] = "aws.secret.access.key"
+    AWS_SESSION_TOKEN: Final[str] = "aws.session.token"
     S3_SSE_CUSTOMER_KEY: Final[str] = "s3.sse.customer.key"
+    S3_SSE_CUSTOMER_KEY_MD5: Final[str] = "s3.sse.customer.key.md5"
     S3_PROXY_PASSWORD: Final[str] = "s3.proxy.password"
 
     # MongoDB configuration
@@ -86,6 +88,18 @@ class ConnectorConfigKeys:
     VALUE_CONVERTER_BASIC_AUTH_USER_INFO: Final[str] = (
         "value.converter.basic.auth.user.info"
     )
+
+
+S3_SENSITIVE_CONFIG_KEYS: Final[FrozenSet[str]] = frozenset(
+    {
+        ConnectorConfigKeys.AWS_ACCESS_KEY_ID,
+        ConnectorConfigKeys.AWS_SECRET_ACCESS_KEY,
+        ConnectorConfigKeys.AWS_SESSION_TOKEN,
+        ConnectorConfigKeys.S3_SSE_CUSTOMER_KEY,
+        ConnectorConfigKeys.S3_SSE_CUSTOMER_KEY_MD5,
+        ConnectorConfigKeys.S3_PROXY_PASSWORD,
+    }
+)
 
 
 def parse_comma_separated_list(value: str) -> List[str]:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
@@ -12,6 +12,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KAFKA,
     MYSQL_SINK_CLOUD,
     POSTGRES_SINK_CLOUD,
+    S3_SOURCE_CLOUD,
     SINK,
     SNOWFLAKE_SINK_CLOUD,
     SNOWFLAKE_SOURCE_CLOUD,
@@ -169,7 +170,9 @@ class ConnectorRegistry:
             DEBEZIUM_SOURCE_CONNECTOR_PREFIX,
             JDBC_SOURCE_CONNECTOR_CLASS,
             MONGO_SOURCE_CONNECTOR_CLASS,
+            S3_SOURCE_CONNECTOR_CLASS,
             ConfluentJDBCSourceConnector,
+            ConfluentS3SourceConnector,
             DebeziumSourceConnector,
             MongoSourceConnector,
             SnowflakeSourceConnector,
@@ -181,7 +184,10 @@ class ConnectorRegistry:
         # Snowflake Source connector (Confluent Cloud managed)
         elif connector_class_value == SNOWFLAKE_SOURCE_CLOUD:
             return SnowflakeSourceConnector(manifest, config, report)
-        # Cloud CDC connectors (use Debezium-style naming)
+        # S3 source connectors (self-hosted and Confluent Cloud managed)
+        elif connector_class_value in (S3_SOURCE_CONNECTOR_CLASS, S3_SOURCE_CLOUD):
+            return ConfluentS3SourceConnector(manifest, config, report)
+        # Cloud CDC/JDBC source connectors (use Debezium-style naming)
         elif (
             connector_class_value in CLOUD_JDBC_SOURCE_CLASSES
             or connector_class_value.startswith(DEBEZIUM_SOURCE_CONNECTOR_PREFIX)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/connector_registry.py
@@ -12,6 +12,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KAFKA,
     MYSQL_SINK_CLOUD,
     POSTGRES_SINK_CLOUD,
+    POSTGRES_SOURCE_CLOUD,
     S3_SOURCE_CLOUD,
     SINK,
     SNOWFLAKE_SINK_CLOUD,
@@ -178,16 +179,41 @@ class ConnectorRegistry:
             SnowflakeSourceConnector,
         )
 
-        # Traditional JDBC source connector
-        if connector_class_value == JDBC_SOURCE_CONNECTOR_CLASS:
+        # Traditional JDBC source connector, plus Confluent Cloud managed
+        # PostgresSource (non-CDC). Managed JDBC topics are {topic.prefix}{table};
+        # the Debezium path would emit {server}.{schema}.{table} instead.
+        if connector_class_value in (
+            JDBC_SOURCE_CONNECTOR_CLASS,
+            POSTGRES_SOURCE_CLOUD,
+        ):
             return ConfluentJDBCSourceConnector(manifest, config, report)
         # Snowflake Source connector (Confluent Cloud managed)
         elif connector_class_value == SNOWFLAKE_SOURCE_CLOUD:
             return SnowflakeSourceConnector(manifest, config, report)
-        # S3 source connectors (self-hosted and Confluent Cloud managed)
+        # S3 source connectors (self-hosted and Confluent Cloud managed).
+        # Explicit generic_connectors mappings win over class-name auto-detection,
+        # matching the sink path.
         elif connector_class_value in (S3_SOURCE_CONNECTOR_CLASS, S3_SOURCE_CLOUD):
+            generic = ConnectorRegistry._generic_connector_for_name(
+                manifest, config, report
+            )
+            if generic is not None:
+                if (
+                    generic.generic_config.target_dataset
+                    or generic.generic_config.target_platform
+                ):
+                    report.warning(
+                        message=(
+                            "generic_connectors entry includes target_dataset/"
+                            "target_platform, which is sink-direction; ignoring it "
+                            "for this source so lineage is not inverted"
+                        ),
+                        context=manifest.name,
+                    )
+                else:
+                    return generic
             return ConfluentS3SourceConnector(manifest, config, report)
-        # Cloud CDC/JDBC source connectors (use Debezium-style naming)
+        # Cloud CDC source connectors (use Debezium-style naming)
         elif (
             connector_class_value in CLOUD_JDBC_SOURCE_CLASSES
             or connector_class_value.startswith(DEBEZIUM_SOURCE_CONNECTOR_PREFIX)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/kafka_connect.py
@@ -45,6 +45,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     CLOUD_JDBC_SOURCE_CLASSES,
     CONNECTOR_CLASS,
     KAFKA,
+    POSTGRES_SOURCE_CLOUD,
     SINK,
     SOURCE,
     ConnectorManifest,
@@ -1062,6 +1063,7 @@ class KafkaConnectSource(StatefulIngestionSourceBase):
                 "JdbcSourceConnector" in connector_class
                 or connector_class.startswith("io.debezium.connector")
                 or connector_class in CLOUD_JDBC_SOURCE_CLASSES
+                or connector_class == POSTGRES_SOURCE_CLOUD
             )
             and lineage.source_dataset
             and config.connect_to_platform_map

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/sink_connectors.py
@@ -18,6 +18,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     validate_jdbc_url,
 )
 from datahub.ingestion.source.kafka_connect.config_constants import (
+    S3_SENSITIVE_CONFIG_KEYS,
     ConnectorConfigKeys,
     parse_comma_separated_list,
     parse_topic_to_table_map,
@@ -84,19 +85,11 @@ class ConfluentS3SinkConnector(BaseConnector):
         return self._get_topics_from_sink_config()
 
     def extract_flow_property_bag(self) -> Dict[str, str]:
-        # Mask/Remove properties that may reveal credentials
-        flow_property_bag: Dict[str, str] = {
+        return {
             k: v
             for k, v in self.connector_manifest.config.items()
-            if k
-            not in [
-                "aws.access.key.id",
-                "aws.secret.access.key",
-                "s3.sse.customer.key",
-                "s3.proxy.password",
-            ]
+            if k not in S3_SENSITIVE_CONFIG_KEYS
         }
-        return flow_property_bag
 
     def extract_lineages(self) -> List[KafkaConnectLineage]:
         try:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -527,8 +527,8 @@ class ConfluentJDBCSourceConnector(BaseConnector):
             f"database: {parser.database_name}"
         )
 
-        # Early return if no topics
-        if not self.connector_manifest.topic_names:
+        # Cloud JDBC sources leave topic_names empty; lineage uses cluster topics.
+        if not self.available_topics():
             return []
 
         # Handle query-based connectors early (can't determine source tables from custom queries)

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -24,6 +24,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     KNOWN_TOPIC_ROUTING_TRANSFORMS,
     MYSQL_CDC_SOURCE_V2_CLOUD,
     POSTGRES_CDC_SOURCE_V2_CLOUD,
+    POSTGRES_SOURCE_CLOUD,
     REGEXROUTER_TRANSFORM,
     SNOWFLAKE_SOURCE_CLOUD,
     BaseConnector,
@@ -36,6 +37,9 @@ from datahub.ingestion.source.kafka_connect.common import (
     remove_prefix,
     unquote,
     validate_jdbc_url,
+)
+from datahub.ingestion.source.kafka_connect.config_constants import (
+    S3_SENSITIVE_CONFIG_KEYS,
 )
 from datahub.ingestion.source.kafka_connect.pattern_matchers import (
     JavaRegexMatcher,
@@ -247,8 +251,8 @@ class JdbcParserFactory:
 
 @dataclass
 class ConfluentJDBCSourceConnector(BaseConnector):
-    # Traditional io.confluent.connect.jdbc.JdbcSourceConnector only — Cloud
-    # Postgres/MySQL CDC classes dispatch to DebeziumSourceConnector instead.
+    # Self-hosted JdbcSourceConnector and Confluent Cloud PostgresSource (non-CDC).
+    # Cloud Postgres/MySQL CDC classes still dispatch to DebeziumSourceConnector.
     needs_cluster_topics: ClassVar[bool] = True
 
     # Use imported constants from connector_constants module
@@ -555,7 +559,10 @@ class ConfluentJDBCSourceConnector(BaseConnector):
         connector_class = self.connector_manifest.config.get(CONNECTOR_CLASS, "")
 
         # Determine environment type
-        is_cloud_environment = connector_class in CLOUD_JDBC_SOURCE_CLASSES
+        is_cloud_environment = (
+            connector_class in CLOUD_JDBC_SOURCE_CLASSES
+            or connector_class == POSTGRES_SOURCE_CLOUD
+        )
 
         if is_cloud_environment:
             return self._extract_lineages_cloud_environment(parser)
@@ -3557,17 +3564,10 @@ class ConfluentS3SourceConnector(BaseConnector):
         return self._produced_topics()
 
     def extract_flow_property_bag(self) -> Dict[str, str]:
-        # Mask/Remove properties that may reveal credentials
         return {
             k: v
             for k, v in self.connector_manifest.config.items()
-            if k
-            not in [
-                "aws.access.key.id",
-                "aws.secret.access.key",
-                "s3.sse.customer.key",
-                "s3.proxy.password",
-            ]
+            if k not in S3_SENSITIVE_CONFIG_KEYS
         }
 
     def extract_lineages(self) -> List[KafkaConnectLineage]:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -3498,10 +3498,129 @@ class ConfigDrivenSourceConnector(BaseConnector):
         return lineages
 
 
+@dataclass
+class ConfluentS3SourceConnector(BaseConnector):
+    # Inverse of ConfluentS3SinkConnector: reads objects written under
+    # `{bucket}/{topics.dir}/{topic}/...` and produces them back to `{topic}`.
+    @dataclass
+    class S3SourceParser:
+        source_platform: str
+        bucket: str
+        topics_dir: str
+        topics: Iterable[str]
+
+    def _get_parser(
+        self, connector_manifest: ConnectorManifest
+    ) -> "ConfluentS3SourceConnector.S3SourceParser":
+        # https://docs.confluent.io/cloud/current/connectors/cc-s3-source.html#configuration-properties
+        bucket: Optional[str] = connector_manifest.config.get("s3.bucket.name")
+        if not bucket:
+            raise ValueError(
+                "Could not find 's3.bucket.name' in connector configuration"
+            )
+
+        topics_dir: str = connector_manifest.config.get("topics.dir", "topics")
+
+        return self.S3SourceParser(
+            source_platform="s3",
+            bucket=bucket,
+            topics_dir=topics_dir,
+            topics=self._produced_topics(),
+        )
+
+    def _produced_topics(self) -> List[str]:
+        # Prefer the topics the connector config pins explicitly. The managed
+        # S3Source routes objects to topics via `topic.regex.list`
+        # ("<topic1>:<regex1>,<topic2>:<regex2>"); the left side of each pair is
+        # the produced topic. Self-hosted variants use the single `topic` field.
+        # Fall back to the connector's own reported topics (never the whole
+        # cluster list) so a source can't fabricate lineage for unrelated topics.
+        config = self.connector_manifest.config
+
+        topic_regex_list = config.get("topic.regex.list", "")
+        if topic_regex_list:
+            topics = [
+                pair.split(":", 1)[0].strip()
+                for pair in parse_comma_separated_list(topic_regex_list)
+                if pair.split(":", 1)[0].strip()
+            ]
+            if topics:
+                return list(dict.fromkeys(topics))
+
+        topic = config.get("topic", "") or config.get("kafka.topic", "")
+        if topic:
+            return [topic.strip()]
+
+        return list(self.connector_manifest.topic_names)
+
+    def get_topics_from_config(self) -> List[str]:
+        return self._produced_topics()
+
+    def extract_flow_property_bag(self) -> Dict[str, str]:
+        # Mask/Remove properties that may reveal credentials
+        return {
+            k: v
+            for k, v in self.connector_manifest.config.items()
+            if k
+            not in [
+                "aws.access.key.id",
+                "aws.secret.access.key",
+                "s3.sse.customer.key",
+                "s3.proxy.password",
+            ]
+        }
+
+    def extract_lineages(self) -> List[KafkaConnectLineage]:
+        try:
+            parser = self._get_parser(self.connector_manifest)
+
+            topics = list(parser.topics)
+            if not topics:
+                self.report.warning(
+                    message="No topics found for S3 source connector; cannot build "
+                    "S3 -> topic lineage. Set 'topic.regex.list' (or 'topic') so the "
+                    "produced topics are known.",
+                    context=self.connector_manifest.name,
+                )
+                return []
+
+            lineages: List[KafkaConnectLineage] = []
+            for topic in topics:
+                source_dataset = f"{parser.bucket}/{parser.topics_dir}/{topic}"
+                lineages.append(
+                    KafkaConnectLineage(
+                        source_dataset=source_dataset,
+                        source_platform=parser.source_platform,
+                        target_dataset=topic,
+                        target_platform=KAFKA,
+                    )
+                )
+            return lineages
+        except ValueError as e:
+            self.report.warning(
+                message="Configuration error in S3 source connector",
+                context=self.connector_manifest.name,
+                exc=e,
+            )
+        except Exception as e:
+            self.report.warning(
+                message="Unexpected error resolving lineage for S3 source connector",
+                context=self.connector_manifest.name,
+                exc=e,
+            )
+        return []
+
+    def get_platform(self) -> str:
+        return "s3"
+
+
 JDBC_SOURCE_CONNECTOR_CLASS: Final[str] = (
     "io.confluent.connect.jdbc.JdbcSourceConnector"
 )
 DEBEZIUM_SOURCE_CONNECTOR_PREFIX: Final[str] = "io.debezium.connector"
 MONGO_SOURCE_CONNECTOR_CLASS: Final[str] = (
     "com.mongodb.kafka.connect.MongoSourceConnector"
+)
+S3_SOURCE_CONNECTOR_CLASS: Final[str] = (
+    "io.confluent.connect.s3.source.S3SourceConnector"
 )

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -593,7 +593,7 @@ class ConfluentJDBCSourceConnector(BaseConnector):
         This method implements a hybrid approach that properly handles transforms while
         working within Cloud environment constraints.
         """
-        all_topics = self.available_topics()
+        all_topics = self._topics_for_this_connector(self.available_topics())
 
         # If we have topics and transforms, try the transform-aware approach
         if all_topics and parser.transforms:
@@ -613,6 +613,20 @@ class ConfluentJDBCSourceConnector(BaseConnector):
         else:
             # Use available topics directly if no better strategy
             return self._create_direct_lineages_from_topics(all_topics, parser)
+
+    def _topics_for_this_connector(self, cluster_topics: List[str]) -> List[str]:
+        # Cloud connectors often leave topic_names empty. Prefer {topic.prefix}{table}
+        # (or other config-derived names) intersected with the cluster list so we
+        # do not emit lineage for every topic on the cluster.
+        expected = self.get_topics_from_config()
+        if expected:
+            expected_set = set(expected)
+            scoped = [topic for topic in cluster_topics if topic in expected_set]
+            if scoped:
+                return scoped
+        if self.connector_manifest.topic_names:
+            return list(self.connector_manifest.topic_names)
+        return cluster_topics
 
     def _has_one_to_one_topic_mapping(self, topics: Optional[List[str]] = None) -> bool:
         """Check if connector has clear 1:1 table to topic mapping from config."""
@@ -906,6 +920,8 @@ class ConfluentJDBCSourceConnector(BaseConnector):
         )
 
         for topic in available_topics:
+            if parser.topic_prefix and not topic.startswith(parser.topic_prefix):
+                continue
             # Remove prefix to get source table name
             source_table = self._extract_source_table_from_topic(
                 topic, parser.topic_prefix

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
@@ -1220,7 +1220,7 @@ class TestConfluentCloudConnectors:
 
         lineages = connector.extract_lineages()
 
-        assert any(lineage.target_dataset == "pg-users" for lineage in lineages)
+        assert [lineage.target_dataset for lineage in lineages] == ["pg-users"]
 
     def test_get_job_id_prefixes_managed_postgres_source(self) -> None:
         lineage = KafkaConnectLineage(

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect.py
@@ -17,6 +17,7 @@ from datahub.ingestion.source.kafka_connect.common import (
     get_dataset_name,
     has_three_level_hierarchy,
 )
+from datahub.ingestion.source.kafka_connect.kafka_connect import KafkaConnectSource
 from datahub.ingestion.source.kafka_connect.sink_connectors import (
     BigQuerySinkConnector,
     ClickHouseSinkConnector,
@@ -1197,6 +1198,51 @@ class TestConfluentCloudConnectors:
         assert any(t.schema == "public" and t.table == "users" for t in table_names)
         # Check for TableId with schema='public' and table='orders'
         assert any(t.schema == "public" and t.table == "orders" for t in table_names)
+
+    def test_cloud_managed_postgres_source_uses_cluster_topics(self) -> None:
+        connector_config: Dict[str, str] = {
+            "connector.class": "PostgresSource",
+            "connection.url": "jdbc:postgresql://db.example:5432/testdb",
+            "table.whitelist": "users",
+            "topic.prefix": "pg-",
+        }
+        manifest = ConnectorManifest(
+            name="pg-src",
+            type="source",
+            config=connector_config,
+            tasks=[],
+            topic_names=[],
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        report: Mock = Mock(spec=KafkaConnectSourceReport)
+        connector = ConfluentJDBCSourceConnector(manifest, config, report)
+        connector.all_cluster_topics = ["pg-users", "unrelated"]
+
+        lineages = connector.extract_lineages()
+
+        assert any(lineage.target_dataset == "pg-users" for lineage in lineages)
+
+    def test_get_job_id_prefixes_managed_postgres_source(self) -> None:
+        lineage = KafkaConnectLineage(
+            source_dataset="public.users",
+            source_platform="postgres",
+            target_dataset="pg-users",
+            target_platform="kafka",
+        )
+        connector = ConnectorManifest(
+            name="pg-src",
+            type="source",
+            config={"connector.class": "PostgresSource"},
+            tasks=[],
+            topic_names=[],
+            lineages=[lineage],
+        )
+        config: Mock = create_mock_kafka_connect_config()
+        config.connect_to_platform_map = {"pg-src": {"postgres": "prod-pg"}}
+
+        job_id = KafkaConnectSource.get_job_id(None, lineage, connector, config)  # type: ignore[arg-type]
+
+        assert job_id == "prod-pg.public.users"
 
     def test_cloud_postgres_source_connector(self) -> None:
         """Test Confluent Cloud PostgreSQL CDC source connector."""

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
@@ -9,6 +9,8 @@ from datahub.ingestion.source.kafka_connect.common import (
     MYSQL_SINK_CLOUD,
     POSTGRES_CDC_SOURCE_CLOUD,
     POSTGRES_SINK_CLOUD,
+    POSTGRES_SOURCE_CLOUD,
+    S3_SOURCE_CLOUD,
     SINK,
     SNOWFLAKE_SINK_CLOUD,
     SNOWFLAKE_SOURCE_CLOUD,
@@ -37,7 +39,9 @@ from datahub.ingestion.source.kafka_connect.sink_connectors import (
 from datahub.ingestion.source.kafka_connect.source_connectors import (
     JDBC_SOURCE_CONNECTOR_CLASS,
     MONGO_SOURCE_CONNECTOR_CLASS,
+    S3_SOURCE_CONNECTOR_CLASS,
     ConfluentJDBCSourceConnector,
+    ConfluentS3SourceConnector,
     DebeziumSourceConnector,
     MongoSourceConnector,
     SnowflakeSourceConnector,
@@ -118,6 +122,53 @@ class TestConnectorRegistrySourceConnectors:
         assert connector is not None
         assert isinstance(connector, DebeziumSourceConnector)
         assert connector.get_platform() == "postgres"
+
+    def test_postgres_source_cloud_connector(self) -> None:
+        """Test routing for the Confluent Cloud managed (non-CDC) Postgres source.
+
+        PostgresSource is symmetric with the existing MySqlSource: both are
+        managed JDBC source connectors that share the Debezium-style topic
+        naming path, so both route to DebeziumSourceConnector.
+        """
+        manifest = create_manifest(SOURCE, POSTGRES_SOURCE_CLOUD)
+        config = create_mock_config()
+        report = create_mock_report()
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert connector is not None
+        assert isinstance(connector, DebeziumSourceConnector)
+        assert connector.get_platform() == "postgres"
+
+    def test_s3_source_cloud_connector(self) -> None:
+        """Test routing for the Confluent Cloud managed S3 source connector."""
+        manifest = create_manifest(SOURCE, S3_SOURCE_CLOUD)
+        config = create_mock_config()
+        report = create_mock_report()
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert connector is not None
+        assert isinstance(connector, ConfluentS3SourceConnector)
+        assert connector.get_platform() == "s3"
+
+    def test_s3_source_self_hosted_connector(self) -> None:
+        """Test routing for the self-hosted S3 source connector."""
+        manifest = create_manifest(SOURCE, S3_SOURCE_CONNECTOR_CLASS)
+        config = create_mock_config()
+        report = create_mock_report()
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert connector is not None
+        assert isinstance(connector, ConfluentS3SourceConnector)
+        assert connector.get_platform() == "s3"
 
     def test_debezium_connector_with_prefix(self) -> None:
         """Test routing for Debezium connector with standard prefix."""

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
@@ -170,9 +170,7 @@ class TestConnectorRegistrySourceConnectors:
         assert connector.get_platform() == "s3"
 
     def test_generic_source_overrides_s3_class(self) -> None:
-        manifest = create_manifest(
-            SOURCE, S3_SOURCE_CLOUD, name="my-s3-source"
-        )
+        manifest = create_manifest(SOURCE, S3_SOURCE_CLOUD, name="my-s3-source")
         generic_config = GenericConnectorConfig(
             connector_name="my-s3-source",
             source_platform="s3",

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_connector_registry.py
@@ -126,9 +126,8 @@ class TestConnectorRegistrySourceConnectors:
     def test_postgres_source_cloud_connector(self) -> None:
         """Test routing for the Confluent Cloud managed (non-CDC) Postgres source.
 
-        PostgresSource is symmetric with the existing MySqlSource: both are
-        managed JDBC source connectors that share the Debezium-style topic
-        naming path, so both route to DebeziumSourceConnector.
+        PostgresSource is a managed JDBC source: topics are {topic.prefix}{table},
+        so it routes to ConfluentJDBCSourceConnector rather than Debezium.
         """
         manifest = create_manifest(SOURCE, POSTGRES_SOURCE_CLOUD)
         config = create_mock_config()
@@ -139,8 +138,8 @@ class TestConnectorRegistrySourceConnectors:
         )
 
         assert connector is not None
-        assert isinstance(connector, DebeziumSourceConnector)
-        assert connector.get_platform() == "postgres"
+        assert isinstance(connector, ConfluentJDBCSourceConnector)
+        assert connector.get_platform() == "unknown"
 
     def test_s3_source_cloud_connector(self) -> None:
         """Test routing for the Confluent Cloud managed S3 source connector."""
@@ -169,6 +168,27 @@ class TestConnectorRegistrySourceConnectors:
         assert connector is not None
         assert isinstance(connector, ConfluentS3SourceConnector)
         assert connector.get_platform() == "s3"
+
+    def test_generic_source_overrides_s3_class(self) -> None:
+        manifest = create_manifest(
+            SOURCE, S3_SOURCE_CLOUD, name="my-s3-source"
+        )
+        generic_config = GenericConnectorConfig(
+            connector_name="my-s3-source",
+            source_platform="s3",
+            source_dataset="my-bucket/custom-prefix",
+        )
+        config = create_mock_config()
+        config.generic_connectors = [generic_config]
+        report = create_mock_report()
+
+        connector = ConnectorRegistry.get_connector_for_manifest(
+            manifest, config, report
+        )
+
+        assert connector is not None
+        assert isinstance(connector, _GenericConnector)
+        assert connector.generic_config == generic_config
 
     def test_debezium_connector_with_prefix(self) -> None:
         """Test routing for Debezium connector with standard prefix."""

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_s3_source.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_s3_source.py
@@ -108,6 +108,10 @@ def test_flow_property_bag_masks_credentials() -> None:
             "s3.bucket.name": "my-bucket",
             "aws.access.key.id": "AKIA",
             "aws.secret.access.key": "secret",
+            "aws.session.token": "session",
+            "s3.sse.customer.key": "sse-key",
+            "s3.sse.customer.key.md5": "md5",
+            "s3.proxy.password": "proxy-pw",
         }
     )
 
@@ -115,4 +119,8 @@ def test_flow_property_bag_masks_credentials() -> None:
 
     assert "aws.access.key.id" not in bag
     assert "aws.secret.access.key" not in bag
+    assert "aws.session.token" not in bag
+    assert "s3.sse.customer.key" not in bag
+    assert "s3.sse.customer.key.md5" not in bag
+    assert "s3.proxy.password" not in bag
     assert bag["s3.bucket.name"] == "my-bucket"

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_s3_source.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_s3_source.py
@@ -1,0 +1,118 @@
+"""Tests for the S3 source connector (S3 objects -> Kafka topics)."""
+
+from typing import Dict, List, Optional
+from unittest.mock import Mock
+
+from datahub.ingestion.source.kafka_connect.common import (
+    SOURCE,
+    ConnectorManifest,
+    KafkaConnectSourceConfig,
+    KafkaConnectSourceReport,
+)
+from datahub.ingestion.source.kafka_connect.source_connectors import (
+    ConfluentS3SourceConnector,
+)
+
+
+def _connector(
+    config: Dict[str, str],
+    topic_names: Optional[List[str]] = None,
+) -> ConfluentS3SourceConnector:
+    manifest = ConnectorManifest(
+        name="s3-source",
+        type=SOURCE,
+        config={"connector.class": "S3Source", **config},
+        tasks=[],
+        topic_names=topic_names or [],
+    )
+    return ConfluentS3SourceConnector(
+        manifest,
+        Mock(spec=KafkaConnectSourceConfig),
+        Mock(spec=KafkaConnectSourceReport),
+    )
+
+
+def test_lineage_from_topic_regex_list() -> None:
+    connector = _connector(
+        {
+            "s3.bucket.name": "my-bucket",
+            "topic.regex.list": "orders:.*orders.*,payments:.*payments.*",
+        }
+    )
+
+    lineages = connector.extract_lineages()
+
+    edges = {(lineage.source_dataset, lineage.target_dataset) for lineage in lineages}
+    assert edges == {
+        ("my-bucket/topics/orders", "orders"),
+        ("my-bucket/topics/payments", "payments"),
+    }
+    assert all(lineage.source_platform == "s3" for lineage in lineages)
+    assert all(lineage.target_platform == "kafka" for lineage in lineages)
+
+
+def test_topics_dir_override() -> None:
+    connector = _connector(
+        {
+            "s3.bucket.name": "my-bucket",
+            "topics.dir": "exports",
+            "topic.regex.list": "orders:.*",
+        }
+    )
+
+    lineages = connector.extract_lineages()
+
+    assert len(lineages) == 1
+    assert lineages[0].source_dataset == "my-bucket/exports/orders"
+
+
+def test_single_topic_field() -> None:
+    connector = _connector({"s3.bucket.name": "my-bucket", "topic": "events"})
+
+    topics = connector.get_topics_from_config()
+
+    assert topics == ["events"]
+
+
+def test_falls_back_to_reported_topics_not_cluster() -> None:
+    # No topic config -> use the connector's own reported topics only, so a
+    # source can't fabricate lineage for unrelated cluster topics.
+    connector = _connector(
+        {"s3.bucket.name": "my-bucket"}, topic_names=["produced-topic"]
+    )
+
+    lineages = connector.extract_lineages()
+
+    assert len(lineages) == 1
+    assert lineages[0].source_dataset == "my-bucket/topics/produced-topic"
+    assert lineages[0].target_dataset == "produced-topic"
+
+
+def test_missing_bucket_warns_and_returns_empty() -> None:
+    connector = _connector({"topic.regex.list": "orders:.*"})
+
+    assert connector.extract_lineages() == []
+    connector.report.warning.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_no_topics_warns_and_returns_empty() -> None:
+    connector = _connector({"s3.bucket.name": "my-bucket"})
+
+    assert connector.extract_lineages() == []
+    connector.report.warning.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_flow_property_bag_masks_credentials() -> None:
+    connector = _connector(
+        {
+            "s3.bucket.name": "my-bucket",
+            "aws.access.key.id": "AKIA",
+            "aws.secret.access.key": "secret",
+        }
+    )
+
+    bag = connector.extract_flow_property_bag()
+
+    assert "aws.access.key.id" not in bag
+    assert "aws.secret.access.key" not in bag
+    assert bag["s3.bucket.name"] == "my-bucket"


### PR DESCRIPTION
## Summary

Part 3 of a stack (base: the `CatalogIndex` refactor PR). Adds two source-connector lineage paths to the `kafka-connect` source.

- **S3 source**: new `ConfluentS3SourceConnector` (inverse of the existing `ConfluentS3SinkConnector`) routes the Confluent Cloud managed `S3Source` and the self-hosted `io.confluent.connect.s3.source.S3SourceConnector`, mapping `{bucket}/{topics.dir}/{topic}` objects back to their produced topics. Produced topics come from `topic.regex.list` / `topic`, falling back to the connector's own reported topics only (never the whole cluster list).
- **Managed Postgres source**: `PostgresSource` is routed through the JDBC handler (managed JDBC topic naming `{topic.prefix}{table}`). When the connector reports no topics, lineage is scoped to those config-derived names (intersected with the cluster list) rather than every topic on the cluster.

## Stack

1. #19425 — Stream Catalog mirror / cluster-link lineage
2. #19431 — consolidate Stream Catalog indexing into `CatalogIndex`
3. **This PR** — kafka-connect S3 + managed Postgres source lineage
4. #19433 — Confluent Cloud Flink SQL topic lineage
5. #19434 — hoist catalog `include_tags`/`include_business_metadata` to shared base

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated (S3 source lineage + connector-registry routing + Cloud JDBC topic scoping)
- [ ] Docs to follow
- [x] No breaking changes

## Notes
- The S3/Postgres source handlers are exercised by unit tests here; a live run against a Confluent Cloud tenant (needs a Cloud API key) is still pending for end-to-end validation of the produced edges.