### PR TITLE
refactor(ingest/kafka): hoist catalog include_tags/business_metadata to shared base

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent/config.py
@@ -41,6 +41,15 @@ class ConfluentStreamCatalogConfig(ConfigModel):
         default=DEFAULT_TIMEOUT_SECONDS,
         description="Timeout in seconds for each Stream Catalog GraphQL request.",
     )
+    include_tags: bool = Field(
+        default=True,
+        description="Emit Confluent Cloud tags from the Stream Catalog as DataHub tags.",
+    )
+    include_business_metadata: bool = Field(
+        default=True,
+        description="Emit Confluent Cloud business metadata attributes from the Stream "
+        "Catalog as DataHub custom properties.",
+    )
 
     @model_validator(mode="after")
     def validate_catalog_settings(self) -> "ConfluentStreamCatalogConfig":

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka/kafka_config.py
@@ -208,15 +208,6 @@ class KafkaConfluentCatalogConfig(ConfluentStreamCatalogConfig):
         "behind this Schema Registry holds more than one Kafka cluster, since the catalog "
         "covers the whole environment and topic names can repeat across clusters.",
     )
-    include_tags: bool = Field(
-        default=True,
-        description="Emit Confluent Cloud tags on topics as DataHub tags.",
-    )
-    include_business_metadata: bool = Field(
-        default=True,
-        description="Emit Confluent Cloud business metadata attributes on topics as DataHub "
-        "custom properties.",
-    )
     include_lineage: bool = Field(
         default=False,
         description="Emit topic-to-topic lineage from Stream Catalog replication metadata "

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/common.py
@@ -184,15 +184,6 @@ class ConfluentCatalogConfig(ConfluentStreamCatalogConfig):
         "the column-level lineage that comes with it, with a `connector -> topic` edge only. "
         "Sink connectors are unaffected.",
     )
-    include_tags: bool = Field(
-        default=True,
-        description="Emit Confluent Cloud tags on connectors as DataHub tags.",
-    )
-    include_business_metadata: bool = Field(
-        default=True,
-        description="Emit Confluent Cloud business metadata attributes on connectors as DataHub "
-        "custom properties.",
-    )
 
     @model_validator(mode="after")
     def validate_catalog_connection(self) -> "ConfluentCatalogConfig":


### PR DESCRIPTION
## Summary

Part 5 of a stack (base: the Flink SQL lineage PR). Small config-cleanliness refactor.

Both the kafka (`KafkaConfluentCatalogConfig`) and kafka-connect (`ConfluentCatalogConfig`) Stream Catalog configs redeclared identical `include_tags` / `include_business_metadata` flags. This moves them onto the shared `ConfluentStreamCatalogConfig` base so the two sources inherit one definition.

Each source keeps its own `include_lineage`, which is deliberately **not** shared — it means different things per source (mirror-topic lineage in kafka vs connector lineage in kafka-connect).

## Stack

1. #19425 — Stream Catalog mirror / cluster-link lineage
2. #19431 — consolidate Stream Catalog indexing into `CatalogIndex`
3. #19432 — kafka-connect S3 + managed Postgres source lineage
4. #19433 — Confluent Cloud Flink SQL topic lineage
5. **This PR** — hoist catalog `include_tags`/`include_business_metadata` to shared base

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Behaviour-preserving (fields inherited unchanged)
- [x] No breaking changes