### PR TITLE
fix(search): prevent structured-property text-mapping poisoning and surface ES shard failures

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
@@ -5,8 +5,10 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryConte
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.getSearchEntityNames;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.EntityType;
@@ -113,7 +115,9 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
                     ? input.getSearchFlags().getIncludeStructuredPropertyFacets()
                     : false;
             List<String> structuredPropertyFacets =
-                shouldIncludeStructuredPropertyFacets ? getStructuredPropertyFacets(context) : null;
+                shouldIncludeStructuredPropertyFacets
+                    ? getStructuredPropertyFacets(context, finalEntities)
+                    : Collections.emptyList();
 
             // Execute search and remove default filter fields from aggregations
             SearchResult searchResult =
@@ -152,9 +156,16 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
         "get");
   }
 
-  private List<String> getStructuredPropertyFacets(final QueryContext context) {
+  private List<String> getStructuredPropertyFacets(
+      final QueryContext context, final List<String> searchedEntityNames) {
     try {
-      SearchFlags searchFlags = new SearchFlags().setSkipCache(true);
+      // Fetch each property's entityTypes so facets can be scoped to the searched entity types —
+      // aggregating an unrelated property across every searched index risks querying indexes where
+      // the field was never mapped.
+      SearchFlags searchFlags =
+          new SearchFlags()
+              .setSkipCache(true)
+              .setFetchExtraFields(new StringArray(STRUCTURED_PROPERTY_ENTITY_TYPES_FIELD));
       SearchResult result =
           _entityClient.searchAcrossEntities(
               context.getOperationContext().withSearchFlags(flags -> searchFlags),
@@ -164,7 +175,16 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
               0,
               100,
               Collections.emptyList());
+      final ObjectMapper objectMapper = context.getOperationContext().getObjectMapper();
       return result.getEntities().stream()
+          .filter(
+              entity ->
+                  structuredPropertyAppliesToEntityTypes(
+                      objectMapper,
+                      entity.getExtraFields() == null
+                          ? null
+                          : entity.getExtraFields().get(STRUCTURED_PROPERTY_ENTITY_TYPES_FIELD),
+                      searchedEntityNames))
           .map(entity -> String.format("structuredProperties.%s", entity.getEntity().getId()))
           .collect(Collectors.toList());
     } catch (Exception e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.search;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -16,6 +18,7 @@ import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.datahub.graphql.types.mappers.UrnScrollResultsMapper;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.models.StructuredPropertyUtils;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -32,6 +35,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -47,6 +51,10 @@ public class SearchUtils {
   private SearchUtils() {}
 
   private static final int DEFAULT_SEARCH_COUNT = 10;
+
+  /** Search-document field on structured properties listing the entity type URNs they apply to. */
+  public static final String STRUCTURED_PROPERTY_ENTITY_TYPES_FIELD = "entityTypes";
+
   private static final int DEFAULT_SCROLL_COUNT = 10;
   private static final String DEFAULT_SCROLL_KEEP_ALIVE = "5m";
 
@@ -532,5 +540,56 @@ public class SearchUtils {
         },
         className,
         "searchAcrossEntities");
+  }
+
+  /**
+   * Doc-level, fail-open check of whether a structured property applies to any of the searched
+   * entity types. {@code entityTypesJson} is the JSON-stringified {@code entityTypes} field from
+   * the structured property's search document: a list of entity type URNs such as {@code
+   * urn:li:entityType:datahub.dataset}. A property is kept when the searched entity list is empty,
+   * when entityTypes is missing/empty/unparseable (fail open: an extra facet for an unrelated type
+   * is harmless, a missing facet is not), or when at least one of its entity types matches a
+   * searched entity name.
+   */
+  public static boolean structuredPropertyAppliesToEntityTypes(
+      @Nonnull final ObjectMapper objectMapper,
+      @Nullable final String entityTypesJson,
+      @Nonnull final List<String> searchedEntityNames) {
+    if (searchedEntityNames.isEmpty() || entityTypesJson == null) {
+      return true;
+    }
+    final List<String> entityTypeUrns;
+    try {
+      entityTypeUrns = objectMapper.readValue(entityTypesJson, new TypeReference<>() {});
+    } catch (Exception e) {
+      log.warn(
+          "Failed to parse structured property entityTypes {}; keeping facet", entityTypesJson, e);
+      return true;
+    }
+    if (entityTypeUrns == null || entityTypeUrns.isEmpty()) {
+      return true;
+    }
+    final Set<String> searchedNames =
+        searchedEntityNames.stream()
+            .map(name -> name.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+    // Entity type URNs come in both the modern urn:li:entityType:datahub.dataset and the legacy
+    // urn:li:entityType:dataset forms. Reuse the canonical parser (same helper the mapping side
+    // uses) so both resolve; null/unparseable entries are kept (fail open).
+    return entityTypeUrns.stream()
+        .anyMatch(
+            typeUrn -> {
+              if (typeUrn == null) {
+                return true;
+              }
+              final String entityName;
+              try {
+                entityName = StructuredPropertyUtils.getEntityTypeId(UrnUtils.getUrn(typeUrn));
+              } catch (Exception e) {
+                return true;
+              }
+              return entityName == null
+                  || searchedNames.contains(entityName.toLowerCase(Locale.ROOT));
+            });
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/semantic/SemanticSearchAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/semantic/SemanticSearchAcrossEntitiesResolver.java
@@ -10,8 +10,10 @@ package com.linkedin.datahub.graphql.resolvers.semantic;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
@@ -119,7 +121,7 @@ public class SemanticSearchAcrossEntitiesResolver
                     : false;
             List<String> structuredPropertyFacets =
                 shouldIncludeStructuredPropertyFacets
-                    ? getStructuredPropertyFacets(context)
+                    ? getStructuredPropertyFacets(context, finalEntities)
                     : Collections.emptyList();
 
             return UrnSearchResultsMapper.map(
@@ -158,9 +160,16 @@ public class SemanticSearchAcrossEntitiesResolver
         "get");
   }
 
-  private List<String> getStructuredPropertyFacets(final QueryContext context) {
+  private List<String> getStructuredPropertyFacets(
+      final QueryContext context, final List<String> searchedEntityNames) {
     try {
-      SearchFlags searchFlags = new SearchFlags().setSkipCache(true);
+      // Fetch each property's entityTypes so facets can be scoped to the searched entity types —
+      // aggregating an unrelated property across every searched index risks querying indexes where
+      // the field was never mapped.
+      SearchFlags searchFlags =
+          new SearchFlags()
+              .setSkipCache(true)
+              .setFetchExtraFields(new StringArray(STRUCTURED_PROPERTY_ENTITY_TYPES_FIELD));
       SearchResult result =
           _entityClient.searchAcrossEntities(
               context.getOperationContext().withSearchFlags(flags -> searchFlags),
@@ -171,7 +180,16 @@ public class SemanticSearchAcrossEntitiesResolver
               1000,
               null,
               null);
+      final ObjectMapper objectMapper = context.getOperationContext().getObjectMapper();
       return result.getEntities().stream()
+          .filter(
+              entity ->
+                  structuredPropertyAppliesToEntityTypes(
+                      objectMapper,
+                      entity.getExtraFields() == null
+                          ? null
+                          : entity.getExtraFields().get(STRUCTURED_PROPERTY_ENTITY_TYPES_FIELD),
+                      searchedEntityNames))
           .map(entity -> entity.getEntity().toString())
           .collect(Collectors.toList());
     } catch (Exception e) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
@@ -6,6 +6,7 @@ import static com.linkedin.metadata.config.search.EntityTypeListConfig.parseCsv;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 
 import com.google.common.collect.ImmutableList;
@@ -13,6 +14,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AndFilterInput;
 import com.linkedin.datahub.graphql.generated.EntityType;
@@ -31,6 +33,7 @@ import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
@@ -42,7 +45,9 @@ import com.linkedin.view.DataHubViewType;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -670,7 +675,7 @@ public class SearchAcrossEntitiesResolverTest {
                 Mockito.eq(start),
                 Mockito.eq(limit),
                 Mockito.eq(Collections.emptyList()),
-                Mockito.eq(null)))
+                Mockito.eq(Collections.emptyList())))
         .thenReturn(result);
     return client;
   }
@@ -696,11 +701,108 @@ public class SearchAcrossEntitiesResolverTest {
             Mockito.eq(start),
             Mockito.eq(limit),
             Mockito.eq(Collections.emptyList()),
-            Mockito.eq(null));
+            Mockito.eq(Collections.emptyList()));
   }
 
   private static void verifyMockViewService(ViewService mockService, Urn viewUrn) {
     Mockito.verify(mockService, Mockito.times(1)).getViewInfo(any(), Mockito.eq(viewUrn));
+  }
+
+  @Test
+  public static void testStructuredPropertyFacetsScopedToSearchedEntityTypes() throws Exception {
+    // Given: three enabled structured properties — one scoped to datasets, one scoped to glossary
+    // terms, and one with no entityTypes in its search document.
+    SearchEntity datasetOnlySp =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:structuredProperty:datasetOnly"))
+            .setExtraFields(
+                new StringMap(Map.of("entityTypes", "[\"urn:li:entityType:datahub.dataset\"]")));
+    SearchEntity termScopedSp =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:structuredProperty:termScoped"))
+            .setExtraFields(
+                new StringMap(
+                    Map.of("entityTypes", "[\"urn:li:entityType:datahub.glossaryTerm\"]")));
+    SearchEntity noTypesSp =
+        new SearchEntity().setEntity(UrnUtils.getUrn("urn:li:structuredProperty:noTypes"));
+    SearchResult spFetchResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray(datasetOnlySp, termScopedSp, noTypesSp))
+            .setFrom(0)
+            .setPageSize(100)
+            .setNumEntities(3)
+            .setMetadata(new SearchResultMetadata());
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    // Structured property fetch (7-arg overload used by getStructuredPropertyFacets)
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                anyList(),
+                Mockito.eq("*"),
+                any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                Mockito.eq(Collections.emptyList())))
+        .thenReturn(spFetchResult);
+    // Main search call
+    SearchResult emptyResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setFrom(0)
+            .setPageSize(10)
+            .setNumEntities(0)
+            .setMetadata(new SearchResultMetadata());
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(),
+                anyList(),
+                Mockito.anyString(),
+                any(),
+                Mockito.anyInt(),
+                Mockito.anyInt(),
+                anyList(),
+                anyList()))
+        .thenReturn(emptyResult);
+
+    ViewService mockService = Mockito.mock(ViewService.class);
+    final SearchAcrossEntitiesResolver resolver =
+        new SearchAcrossEntitiesResolver(mockClient, mockService);
+
+    // When: searching only glossary terms with structured property facets enabled
+    final SearchAcrossEntitiesInput testInput = new SearchAcrossEntitiesInput();
+    testInput.setTypes(ImmutableList.of(EntityType.GLOSSARY_TERM));
+    testInput.setQuery("");
+    testInput.setStart(0);
+    testInput.setCount(10);
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setIncludeStructuredPropertyFacets(true);
+    testInput.setSearchFlags(searchFlags);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).join();
+
+    // Then: the dataset-scoped property is excluded; the matching and the entityTypes-less
+    // (fail-open) properties are kept.
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> facetsCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockClient, Mockito.times(1))
+        .searchAcrossEntities(
+            any(),
+            anyList(),
+            Mockito.anyString(),
+            any(),
+            Mockito.anyInt(),
+            Mockito.anyInt(),
+            anyList(),
+            facetsCaptor.capture());
+    Assert.assertEquals(
+        facetsCaptor.getValue(),
+        ImmutableList.of("structuredProperties.termScoped", "structuredProperties.noTypes"));
   }
 
   private SearchAcrossEntitiesResolverTest() {}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtilsTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.search;
 
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.metadata.Constants;
@@ -254,6 +255,61 @@ public class SearchUtilsTest {
     Assert.assertEquals(empty.getCount(), Integer.valueOf(25));
     Assert.assertEquals(empty.getTotal(), Integer.valueOf(0));
     Assert.assertTrue(empty.getSearchResults().isEmpty());
+  }
+
+  @Test
+  public static void testStructuredPropertyAppliesToEntityTypes() {
+    ObjectMapper mapper = new ObjectMapper();
+    List<String> searched = ImmutableList.of("glossaryTerm");
+
+    // Excluded: property scoped to a different entity type
+    Assert.assertFalse(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:datahub.dataset\"]", searched));
+
+    // Kept: matching entity type (case-insensitive against the searched names)
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:datahub.glossaryTerm\"]", searched));
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:datahub.GLOSSARYTERM\"]", searched));
+
+    // Kept: any one of multiple types matching is enough
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper,
+            "[\"urn:li:entityType:datahub.dataset\",\"urn:li:entityType:datahub.glossaryTerm\"]",
+            searched));
+
+    // Kept: empty searched entity list means all types
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:datahub.dataset\"]", ImmutableList.of()));
+
+    // Legacy entity-type URN form (no datahub. prefix) resolves the same way, so an in-scope
+    // property is still kept and an out-of-scope one still excluded.
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:glossaryTerm\"]", searched));
+    Assert.assertFalse(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(
+            mapper, "[\"urn:li:entityType:dataset\"]", searched));
+  }
+
+  @Test
+  public static void testStructuredPropertyAppliesToEntityTypesFailsOpen() {
+    ObjectMapper mapper = new ObjectMapper();
+    List<String> searched = ImmutableList.of("glossaryTerm");
+
+    // Missing, empty, or unparseable entityTypes keep the property
+    Assert.assertTrue(SearchUtils.structuredPropertyAppliesToEntityTypes(mapper, null, searched));
+    Assert.assertTrue(SearchUtils.structuredPropertyAppliesToEntityTypes(mapper, "[]", searched));
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(mapper, "not json", searched));
+    // A malformed (null) entry is kept rather than silently dropped
+    Assert.assertTrue(
+        SearchUtils.structuredPropertyAppliesToEntityTypes(mapper, "[null]", searched));
   }
 
   private SearchUtilsTest() {}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/semantic/SemanticSearchAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/semantic/SemanticSearchAcrossEntitiesResolverTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertTrue;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
@@ -691,6 +692,86 @@ public class SemanticSearchAcrossEntitiesResolverTest {
             eq(0),
             eq(10),
             anyList()); // Should include structured property URNs as facets
+  }
+
+  @Test
+  public void testStructuredPropertyFacetsScopedToSearchedEntityTypes() throws Exception {
+    // Given: dataset-only search with structured property facets enabled
+    SearchAcrossEntitiesInput input = new SearchAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DATASET));
+    input.setQuery("test");
+    input.setStart(0);
+    input.setCount(10);
+    SearchFlags flags = new SearchFlags();
+    flags.setIncludeStructuredPropertyFacets(true);
+    input.setSearchFlags(flags);
+    when(mockEnvironment.getArgument("input")).thenReturn(input);
+
+    // Two properties: one scoped to glossary terms only, one scoped to datasets
+    SearchEntity termScopedSp =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:structuredProperty:termScoped"))
+            .setExtraFields(
+                new StringMap(
+                    java.util.Map.of(
+                        "entityTypes", "[\"urn:li:entityType:datahub.glossaryTerm\"]")));
+    SearchEntity datasetScopedSp =
+        new SearchEntity()
+            .setEntity(UrnUtils.getUrn("urn:li:structuredProperty:datasetScoped"))
+            .setExtraFields(
+                new StringMap(
+                    java.util.Map.of("entityTypes", "[\"urn:li:entityType:datahub.dataset\"]")));
+    SearchResult structuredPropResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray(termScopedSp, datasetScopedSp))
+            .setFrom(0)
+            .setPageSize(1000)
+            .setNumEntities(2)
+            .setMetadata(new SearchResultMetadata());
+    when(mockEntityClient.searchAcrossEntities(
+            any(OperationContext.class),
+            anyList(),
+            anyString(),
+            any(),
+            anyInt(),
+            anyInt(),
+            any(),
+            any()))
+        .thenReturn(structuredPropResult);
+
+    SearchResult mockSearchResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setFrom(0)
+            .setPageSize(10)
+            .setNumEntities(0)
+            .setMetadata(new SearchResultMetadata());
+    when(mockSemanticSearchService.semanticSearchAcrossEntities(
+            any(OperationContext.class),
+            anyList(),
+            anyString(),
+            any(),
+            anyList(),
+            anyInt(),
+            anyInt(),
+            anyList()))
+        .thenReturn(mockSearchResult);
+
+    // When
+    resolver.get(mockEnvironment).get();
+
+    // Then: only the dataset-scoped property survives as a facet; the glossary-term-only
+    // property is filtered out.
+    verify(mockSemanticSearchService, times(1))
+        .semanticSearchAcrossEntities(
+            any(OperationContext.class),
+            anyList(),
+            eq("test"),
+            any(),
+            anyList(),
+            eq(0),
+            eq(10),
+            eq(Collections.singletonList("urn:li:structuredProperty:datasetScoped")));
   }
 
   @Test

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.search.elasticsearch.query.request;
 import static com.linkedin.metadata.search.utils.ESUtils.NAME_SUGGESTION;
 import static com.linkedin.metadata.search.utils.ESUtils.applyDefaultSearchFilters;
 
+import com.datahub.util.exception.ESQueryException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -64,6 +66,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.text.Text;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -434,6 +437,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
       Filter filter,
       int from,
       @Nullable Integer size) {
+    handleShardFailures(opContext, searchResponse);
     int totalCount = (int) searchResponse.getHits().getTotalHits().value;
     Collection<SearchEntity> resultList = getRestrictedResults(opContext, searchResponse);
     SearchResultMetadata searchResultMetadata =
@@ -455,6 +459,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
       @Nullable String keepAlive,
       @Nullable Integer size,
       boolean supportsPointInTime) {
+    handleShardFailures(opContext, searchResponse);
     int totalCount = (int) searchResponse.getHits().getTotalHits().value;
     size = ConfigUtils.applyLimit(searchServiceConfig, size);
 
@@ -518,6 +523,70 @@ public class SearchRequestHandler extends BaseRequestHandler {
       scrollResult.setScrollId(nextScrollId);
     }
     return scrollResult;
+  }
+
+  /**
+   * Surfaces per-shard failures that Elasticsearch reports inside an HTTP 200 response. Without
+   * this check, hits from failing shards are silently dropped and entities simply vanish from
+   * results. Deterministic failures (query/mapping bugs that fail on every retry, e.g. a terms
+   * aggregation on a dynamically-mapped text field) throw so callers see a loud error; transient
+   * failures (circuit breakers, timeouts, rejected executions on a busy cluster) keep the partial
+   * result and are surfaced via log + metric only.
+   */
+  @VisibleForTesting
+  void handleShardFailures(
+      @Nonnull OperationContext opContext, @Nonnull SearchResponse searchResponse) {
+    ShardSearchFailure[] shardFailures = searchResponse.getShardFailures();
+    if (shardFailures == null || shardFailures.length == 0) {
+      return;
+    }
+    for (ShardSearchFailure failure : shardFailures) {
+      if (isDeterministicShardFailure(failure)) {
+        throw new ESQueryException(
+            String.format(
+                "Search response had %d/%d failed shards with a deterministic query failure: %s",
+                shardFailures.length, searchResponse.getTotalShards(), shardFailureReason(failure)),
+            failure.getCause());
+      }
+    }
+    log.warn(
+        "Search response had {}/{} failed shards (transient). First failure: {}",
+        shardFailures.length,
+        searchResponse.getTotalShards(),
+        shardFailureReason(shardFailures[0]));
+    opContext
+        .getMetricUtils()
+        .ifPresent(
+            metricUtils ->
+                metricUtils.increment(
+                    SearchRequestHandler.class, "transientShardFailures", shardFailures.length));
+  }
+
+  private static boolean isDeterministicShardFailure(@Nonnull ShardSearchFailure failure) {
+    String reason = shardFailureReason(failure).toLowerCase(Locale.ROOT);
+    // Covers both the REST-parsed form ("type=illegal_argument_exception") and the local/transport
+    // form (the cause's class name), plus the specific fielddata error Lucene emits when a terms
+    // aggregation hits a dynamically-mapped text field.
+    // NOTE: the ES8 client shim rebuilds shard failures from the reason message alone and drops the
+    // exception type, so on ES8 a non-fielddata illegal_argument error lacks the type token and
+    // falls through to the transient path (no regression vs pre-change — the text-fielddata symptom
+    // that causes the SP poisoning still matches on every backend). Carrying the type through the
+    // shim is a follow-up.
+    return reason.contains("illegal_argument_exception")
+        || reason.contains("illegalargumentexception")
+        || reason.contains("text fields are not optimised");
+  }
+
+  private static String shardFailureReason(@Nonnull ShardSearchFailure failure) {
+    StringBuilder reason = new StringBuilder();
+    if (failure.reason() != null) {
+      reason.append(failure.reason());
+    }
+    Throwable cause = failure.getCause();
+    if (cause != null) {
+      reason.append(' ').append(cause);
+    }
+    return reason.toString();
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 import com.datahub.context.OperationFingerprint;
+import com.datahub.util.exception.ESQueryException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -67,8 +68,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.lucene.search.TotalHits;
+import org.opensearch.OpenSearchException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ExistsQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
@@ -1821,5 +1824,135 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
                 10)
             .source()
             .query();
+  }
+
+  private SearchRequestHandler shardFailureTestHandler() {
+    return SearchRequestHandler.getBuilder(
+        operationContext,
+        TestEntitySpecBuilder.getSpec(),
+        testQueryConfig,
+        null,
+        QueryFilterRewriteChain.EMPTY,
+        TEST_SEARCH_SERVICE_CONFIG);
+  }
+
+  @Test
+  public void testExtractResultThrowsOnDeterministicShardFailure() {
+    // A terms aggregation on a dynamically-mapped text field fails per shard with
+    // illegal_argument_exception while the response is still HTTP 200 — the hits from failing
+    // shards were previously dropped silently.
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    when(mockResponse.getShardFailures())
+        .thenReturn(
+            new ShardSearchFailure[] {
+              new ShardSearchFailure(
+                  new OpenSearchException(
+                      "OpenSearch exception [type=illegal_argument_exception, reason=Text fields"
+                          + " are not optimised for operations that require per-document field"
+                          + " data]"))
+            });
+    when(mockResponse.getTotalShards()).thenReturn(4);
+
+    expectThrows(
+        ESQueryException.class,
+        () -> shardFailureTestHandler().extractResult(operationContext, mockResponse, null, 0, 10));
+  }
+
+  @Test
+  public void testExtractScrollResultThrowsOnDeterministicShardFailureCause() {
+    // Same classification when the failure carries the raw cause instead of a parsed reason.
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    when(mockResponse.getShardFailures())
+        .thenReturn(
+            new ShardSearchFailure[] {
+              new ShardSearchFailure(
+                  new IllegalArgumentException(
+                      "Text fields are not optimised for operations that require per-document"
+                          + " field data"))
+            });
+    when(mockResponse.getTotalShards()).thenReturn(2);
+
+    expectThrows(
+        ESQueryException.class,
+        () ->
+            shardFailureTestHandler()
+                .extractScrollResult(operationContext, mockResponse, null, "5m", 10, true));
+  }
+
+  @Test
+  public void testExtractResultThrowsOnFielddataFailureWithoutTypeToken() {
+    // The ES8 client shim rebuilds shard failures from the reason message only, dropping the
+    // exception type. The text-fielddata symptom — the structured-property poisoning case — must
+    // still classify as deterministic on the reason substring alone, with no illegal_argument type
+    // token or IllegalArgumentException cause present.
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    when(mockResponse.getShardFailures())
+        .thenReturn(
+            new ShardSearchFailure[] {
+              new ShardSearchFailure(
+                  new OpenSearchException(
+                      "Text fields are not optimised for operations that require per-document field"
+                          + " data like aggregations and sorting"))
+            });
+    when(mockResponse.getTotalShards()).thenReturn(3);
+
+    expectThrows(
+        ESQueryException.class,
+        () -> shardFailureTestHandler().extractResult(operationContext, mockResponse, null, 0, 10));
+  }
+
+  @Test
+  public void testExtractResultToleratesTransientShardFailure() {
+    // Transient failures on a busy cluster (circuit breaker, timeout, rejected execution) must not
+    // fail the request — partial results are returned and the failure is only logged/counted.
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    SearchHits mockHits = mock(SearchHits.class);
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(new TotalHits(5L, TotalHits.Relation.EQUAL_TO));
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(mockResponse.getAggregations()).thenReturn(null);
+    when(mockResponse.getSuggest()).thenReturn(null);
+    when(mockResponse.getShardFailures())
+        .thenReturn(
+            new ShardSearchFailure[] {
+              new ShardSearchFailure(
+                  new OpenSearchException(
+                      "OpenSearch exception [type=circuit_breaking_exception, reason=[parent] Data"
+                          + " too large]"))
+            });
+    when(mockResponse.getTotalShards()).thenReturn(4);
+
+    SearchResult result =
+        shardFailureTestHandler().extractResult(operationContext, mockResponse, null, 0, 10);
+
+    assertEquals(result.getNumEntities().intValue(), 5);
+    assertEquals(result.getEntities().size(), 0);
+  }
+
+  @Test
+  public void testExtractScrollResultToleratesTransientShardFailure() {
+    SearchResponse mockResponse = mock(SearchResponse.class);
+    SearchHits mockHits = mock(SearchHits.class);
+    when(mockResponse.getHits()).thenReturn(mockHits);
+    when(mockHits.getTotalHits()).thenReturn(new TotalHits(5L, TotalHits.Relation.EQUAL_TO));
+    when(mockHits.getHits()).thenReturn(new SearchHit[0]);
+    when(mockResponse.getAggregations()).thenReturn(null);
+    when(mockResponse.getSuggest()).thenReturn(null);
+    when(mockResponse.getShardFailures())
+        .thenReturn(
+            new ShardSearchFailure[] {
+              new ShardSearchFailure(
+                  new OpenSearchException(
+                      "OpenSearch exception [type=search_phase_execution_exception,"
+                          + " reason=Partial shards failure (timed out)]"))
+            });
+    when(mockResponse.getTotalShards()).thenReturn(4);
+
+    ScrollResult result =
+        shardFailureTestHandler()
+            .extractScrollResult(operationContext, mockResponse, null, "5m", 10, true);
+
+    assertEquals(result.getNumEntities().intValue(), 5);
+    assertEquals(result.getEntities().size(), 0);
   }
 }


### PR DESCRIPTION
## Summary

Structured-property (SP) values dynamically mapped as `text` throw a per-shard `illegal_argument_exception` on terms aggregations. In multi-index `searchAcrossEntities`, Elasticsearch returns HTTP 200 with the failing shards' hits dropped, so entities carrying such SPs silently vanish from search results.

Fixes #19047 (root cause tracked in #18842).

## Changes

1. **Surface ES shard failures** in `SearchRequestHandler`: deterministic failures (illegal_argument / text fielddata) throw `ESQueryException`; transient ones log a warning and increment a metric.
2. **Scope SP facets to the searched entity types** in the search resolvers; fail-open when `entityTypes` is absent.

A mapping-level fix (`dynamic:false` on the SP container) was explored and dropped: OSS indexes SPs dynamic-by-design with no per-property mapping update on the target index, so it left SP values unindexed and broke SP search. Deferred to a follow-up.
