### PR TITLE
fix(structured-properties): clarify field-collision error for hard-deleted properties [PFP-5468]

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/PropertyDefinitionValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/PropertyDefinitionValidator.java
@@ -312,9 +312,15 @@ public class PropertyDefinitionValidator extends AspectPayloadValidator {
         AspectValidationException.forItem(
             item,
             String.format(
-                "Structured property Elasticsearch field '%s' collides with existing property"
-                    + " mapping. Qualified names that differ only by '.' vs '_' normalize to the"
-                    + " same field name (proposed qualifiedName='%s').",
+                "Structured property Elasticsearch field '%s' (from qualifiedName='%s') already"
+                    + " exists in the entity-index mapping. This is either a live collision with"
+                    + " another property whose qualified name normalizes to the same field ('.' and"
+                    + " '_' both normalize to '_'), or a residual mapping left by a hard-deleted"
+                    + " property with this field name (Elasticsearch cannot drop a field from a"
+                    + " mapping, so the field survives the delete). To resolve: choose a qualified"
+                    + " name that stays distinct after '.'->'_', or, when recreating a deleted"
+                    + " property, complete its assignment cleanup and reindex the entity indices"
+                    + " (via the SystemUpdate job) before recreating it.",
                 esField, newDefinition.getQualifiedName())));
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/PropertyDefinitionValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/PropertyDefinitionValidatorTest.java
@@ -591,12 +591,15 @@ public class PropertyDefinitionValidatorTest {
     when(mockStructuredPropertyMappingLookup.fieldExists(any(), eq("certification_status")))
         .thenReturn(true);
 
+    // PFP-5468: the collision is still rejected, and its message must surface both causes (live
+    // collision vs residual mapping from a hard-deleted property) plus the reindex recovery path.
     assertEquals(
         PropertyDefinitionValidator.validateDefinitionUpsertsProposed(
                 operationContext,
                 TestMCP.ofOneMCP(newUrn, newDefinition, entityRegistry),
                 mockRetrieverContext,
                 mockStructuredPropertyMappingLookup)
+            .filter(e -> e.getMessage().contains("residual") && e.getMessage().contains("reindex"))
             .count(),
         1);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/PropertyDefinitionValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/structuredproperties/validators/PropertyDefinitionValidatorTest.java
@@ -591,7 +591,7 @@ public class PropertyDefinitionValidatorTest {
     when(mockStructuredPropertyMappingLookup.fieldExists(any(), eq("certification_status")))
         .thenReturn(true);
 
-    // PFP-5468: the collision is still rejected, and its message must surface both causes (live
+    // The collision is still rejected; the message must surface both causes (live '.'/'_'
     // collision vs residual mapping from a hard-deleted property) plus the reindex recovery path.
     assertEquals(
         PropertyDefinitionValidator.validateDefinitionUpsertsProposed(


### PR DESCRIPTION
Deleting a structured property removes the entity but leaves its Elasticsearch field mapping in place (ES cannot drop a field from a mapping without a reindex). Redefining a property with the same `qualifiedName` afterwards is then rejected, and the error only mentioned the `.`-vs-`_` normalization case, so the residual-mapping cause and the recovery path were undiscoverable.

This rewrites the collision message in `PropertyDefinitionValidator` to name both causes (a live cross-property collision, or a residual mapping left by a hard-deleted property) and to state the recovery: choose a name that stays distinct after `.`->`_`, or complete assignment cleanup and reindex the entity indices before recreating the property. Behavior is unchanged; the write is still rejected.

Fixes #18974
