### PR TITLE
test(ingestion): fix flaky matrix-source read-fails test

### DIFF
--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSourceTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/ingestion/PollingIngestionCliVersionMatrixSourceTest.java
@@ -73,12 +73,15 @@ public class PollingIngestionCliVersionMatrixSourceTest {
     // it)
     // and leave the last-fetched timestamp untouched — in-flight resolutions never see a flap.
     StubReader reader = new StubReader(MATRIX_JSON);
-    reader.failNextWith(new RuntimeException("storage unavailable"));
 
     PollingIngestionCliVersionMatrixSource source = newSource(reader);
     source.shutdown(); // stop the scheduler so its startup tick can't consume a stubbed result
     source.refresh(); // good load
     long stampAfterGoodLoad = source.getLastFetchedAtMillis();
+
+    // Arm the failure only after the good load has landed: if the scheduler's startup tick still
+    // raced ahead of shutdown() above, it can only have consumed a good read, never this one.
+    reader.failNextWith(new RuntimeException("storage unavailable"));
     source.refresh(); // read throws — must retain
 
     assertEquals(


### PR DESCRIPTION
## Summary
- `PollingIngestionCliVersionMatrixSourceTest.retainsLastKnownMatrixWhenReadFails` intermittently failed in OSS CI (~3.9% of runs).
- Root cause: the stub's `failNextWith(...)` was armed before the source was constructed. The background scheduler's `delay=0` startup tick could race ahead of `shutdown()` and consume the failing read before the test's own good-load `refresh()` ran, inverting the intended success/failure sequence and flaking the `getLastFetchedAtMillis()` assertion.
- Fix: arm `failNextWith` only after the good-load `refresh()` has completed, so a stray scheduler tick can only ever consume a good read.

## Test plan
- [ ] CI run confirms `PollingIngestionCliVersionMatrixSourceTest` passes reliably (could not build locally in this environment due to an unrelated JDK 17/25 toolchain mismatch in the checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
