### PR TITLE
fix(bigquery): decode JSON escape sequences in BigQuery object descriptions

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_helper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_helper.py
@@ -1,5 +1,27 @@
+import json
 import re
 from typing import Dict, Optional
+
+
+def unquote_and_decode_escape_seq(
+    string: str,
+    leading_quote: str = '"',
+    trailing_quote: Optional[str] = None,
+) -> str:
+    """
+    Unquotes a double-quoted string and decodes its escape sequences via JSON, falling
+    back to unquote_and_decode_unicode_escape_seq for anything that isn't valid JSON.
+    """
+    if leading_quote == '"' and (trailing_quote or leading_quote) == '"':
+        try:
+            decoded = json.loads(string)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(decoded, str):
+                return decoded
+
+    return unquote_and_decode_unicode_escape_seq(string, leading_quote, trailing_quote)
 
 
 def unquote_and_decode_unicode_escape_seq(

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -31,7 +31,7 @@ from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
 from datahub.ingestion.source.bigquery_v2.bigquery_config import BigQueryV2Config
 from datahub.ingestion.source.bigquery_v2.bigquery_data_reader import BigQueryDataReader
 from datahub.ingestion.source.bigquery_v2.bigquery_helper import (
-    unquote_and_decode_unicode_escape_seq,
+    unquote_and_decode_escape_seq,
 )
 from datahub.ingestion.source.bigquery_v2.bigquery_platform_resource_helper import (
     BigQueryLabel,
@@ -1151,9 +1151,7 @@ class BigQuerySchemaGenerator:
         dataset_properties = DatasetProperties(
             name=datahub_dataset_name.get_table_display_name(),
             description=(
-                unquote_and_decode_unicode_escape_seq(table.comment)
-                if table.comment
-                else ""
+                unquote_and_decode_escape_seq(table.comment) if table.comment else ""
             ),
             qualifiedName=str(datahub_dataset_name),
             created=(

--- a/metadata-ingestion/tests/unit/bigquery/test_bigquery_helper.py
+++ b/metadata-ingestion/tests/unit/bigquery/test_bigquery_helper.py
@@ -1,0 +1,87 @@
+import pytest
+
+from datahub.ingestion.source.bigquery_v2.bigquery_helper import (
+    unquote_and_decode_escape_seq,
+    unquote_and_decode_unicode_escape_seq,
+)
+
+
+@pytest.mark.parametrize(
+    "string, expected",
+    [
+        ('"line one\\nline two\\ttabbed"', "line one\nline two\ttabbed"),
+        ('"a \\"quoted\\" word"', 'a "quoted" word'),
+        ('"a backslash: \\\\"', "a backslash: \\"),
+        ('"caf\\u00e9"', "café"),
+        ('"\\ud83d\\ude00"', "\U0001f600"),  # surrogate pair (astral plane)
+    ],
+)
+def test_unquote_and_decode_escape_seq(string: str, expected: str) -> None:
+    assert unquote_and_decode_escape_seq(string) == expected
+
+
+def test_unquote_and_decode_escape_seq_falls_back_on_invalid_json() -> None:
+    # \a is valid GoogleSQL but not valid JSON
+    assert unquote_and_decode_escape_seq('"\\a"') == "\\a"
+
+
+def test_unquote_and_decode_escape_seq_falls_back_for_non_double_quotes() -> None:
+    assert unquote_and_decode_escape_seq("'caf\\u00e9'", leading_quote="'") == "café"
+
+
+def test_unquote_and_decode_unicode_escape_seq():
+    # Test with a string that starts and ends with quotes and has Unicode escape sequences
+    input_string = '"Hello \\u003cWorld\\u003e"'
+    expected_output = "Hello <World>"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with a string that does not start and end with quotes
+    input_string = "Hello \\u003cWorld\\u003e"
+    expected_output = "Hello <World>"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with an empty string
+    input_string = ""
+    expected_output = ""
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with a string that does not have Unicode escape sequences
+    input_string = "No escape sequences here"
+    expected_output = "No escape sequences here"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with a string that starts and ends with quotes but does not have escape sequences
+    input_string = '"No escape sequences here"'
+    expected_output = "No escape sequences here"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with invalid Unicode escape sequences
+    input_string = '"No escape \\u123 sequences here"'
+    expected_output = "No escape \\u123 sequences here"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with a string that has multiple Unicode escape sequences
+    input_string = '"Hello \\u003cWorld\\u003e \\u003cAgain\\u003e \\u003cAgain\\u003e \\u003cAgain\\u003e"'
+    expected_output = "Hello <World> <Again> <Again> <Again>"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with a string that has a Unicode escape sequence at the beginning
+    input_string = '"Hello \\utest"'
+    expected_output = "Hello \\utest"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output
+
+    # Test with special characters
+    input_string = (
+        '"Hello \\u003cWorld\\u003e \\u003cçãâÁÁà|{}()[].,/;\\+=--_*&%$#@!?\\u003e"'
+    )
+    expected_output = "Hello <World> <çãâÁÁà|{}()[].,/;\\+=--_*&%$#@!?>"
+    result = unquote_and_decode_unicode_escape_seq(input_string)
+    assert result == expected_output

--- a/metadata-ingestion/tests/unit/bigquery/test_bigqueryv2_usage_source.py
+++ b/metadata-ingestion/tests/unit/bigquery/test_bigqueryv2_usage_source.py
@@ -7,9 +7,6 @@ from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
     BigQueryTableRef,
 )
 from datahub.ingestion.source.bigquery_v2.bigquery_config import BigQueryV2Config
-from datahub.ingestion.source.bigquery_v2.bigquery_helper import (
-    unquote_and_decode_unicode_escape_seq,
-)
 from datahub.ingestion.source.bigquery_v2.bigquery_report import BigQueryV2Report
 from datahub.ingestion.source.bigquery_v2.common import BigQueryIdentifierBuilder
 from datahub.ingestion.source.bigquery_v2.usage import BigQueryUsageExtractor
@@ -138,61 +135,3 @@ def test_bigquery_table_sanitasitation():
     assert table_identifier.dataset == "dataset-4567"
     assert table_identifier.table == "foo_2016*"
     assert table_identifier.get_table_display_name() == "foo"
-
-
-def test_unquote_and_decode_unicode_escape_seq():
-    # Test with a string that starts and ends with quotes and has Unicode escape sequences
-    input_string = '"Hello \\u003cWorld\\u003e"'
-    expected_output = "Hello <World>"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with a string that does not start and end with quotes
-    input_string = "Hello \\u003cWorld\\u003e"
-    expected_output = "Hello <World>"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with an empty string
-    input_string = ""
-    expected_output = ""
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with a string that does not have Unicode escape sequences
-    input_string = "No escape sequences here"
-    expected_output = "No escape sequences here"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with a string that starts and ends with quotes but does not have escape sequences
-    input_string = '"No escape sequences here"'
-    expected_output = "No escape sequences here"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with invalid Unicode escape sequences
-    input_string = '"No escape \\u123 sequences here"'
-    expected_output = "No escape \\u123 sequences here"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with a string that has multiple Unicode escape sequences
-    input_string = '"Hello \\u003cWorld\\u003e \\u003cAgain\\u003e \\u003cAgain\\u003e \\u003cAgain\\u003e"'
-    expected_output = "Hello <World> <Again> <Again> <Again>"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with a string that has a Unicode escape sequence at the beginning
-    input_string = '"Hello \\utest"'
-    expected_output = "Hello \\utest"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output
-
-    # Test with special characters
-    input_string = (
-        '"Hello \\u003cWorld\\u003e \\u003cçãâÁÁà|{}()[].,/;\\+=--_*&%$#@!?\\u003e"'
-    )
-    expected_output = "Hello <World> <çãâÁÁà|{}()[].,/;\\+=--_*&%$#@!?>"
-    result = unquote_and_decode_unicode_escape_seq(input_string)
-    assert result == expected_output


### PR DESCRIPTION
## Summary

BigQuery's `INFORMATION_SCHEMA.TABLE_OPTIONS.OPTION_VALUE` returns descriptions as DDL-quoted strings with JSON-style escaping (`\n`, `\t`, `\\`, `\uXXXX`), but `unquote_and_decode_unicode_escape_seq` only decodes `\uXXXX`. So:

```sql
OPTIONS (description = "Daily active users.\nSource: events pipeline.")
```

renders in DataHub as the literal `Daily active users.\nSource: events pipeline.` instead of expected two lines.

## Fix

Adds `unquote_and_decode_escape_seq`, decoding via `json.loads` and falling back to the existing decoder for anything not valid JSON (non-`"` quoting, or GoogleSQL-only escapes like `\a`/`\v`/octal/hex). Updated the one call site in `bigquery_schema_gen.py` (shared by tables/views/snapshots). `unquote_and_decode_unicode_escape_seq` is unchanged.

## Known limitation

GoogleSQL-only escapes (`\a`, `\b`, `\f`, `\v`, octal, hex) still aren't decoded - rare in real descriptions, and hand-rolling GoogleSQL's full escape grammar risks mis-decoding legit content for little benefit. Falls back to prior (unchanged) behavior, so no regressions.

## Testing

Added `tests/unit/bigquery/test_bigquery_helper.py` (didn't exist before), consolidating the existing `unquote_and_decode_unicode_escape_seq` test (moved out of `test_bigqueryv2_usage_source.py`) plus new parametrized cases.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR title format)
- [ ] Links to related issues — n/a
- [x] Tests added/updated
- [ ] Docs updated — n/a
- [ ] Updating DataHub entry — n/a, non-breaking
