### PR TITLE
ci: add is_community_contribution flag to PostHog CI metrics

### DIFF
--- a/.github/scripts/collect_workflow_metrics.py
+++ b/.github/scripts/collect_workflow_metrics.py
@@ -86,7 +86,7 @@ def main() -> int:
         collected_at=collected_at.isoformat(),
         repository=args.repo,
         workflow=WorkflowMetrics.from_api(
-            run_data, int(args.run_id), args.attempt, rerun_type
+            run_data, int(args.run_id), args.attempt, rerun_type, args.repo
         ),
         jobs=[JobMetrics.from_api(j) for j in attempt_jobs],
     )

--- a/.github/scripts/test/test_workflow_metrics.py
+++ b/.github/scripts/test/test_workflow_metrics.py
@@ -46,6 +46,7 @@ def test_workflow_metrics_base_branch_from_pull_request():
                     "base": {"ref": "main"},
                 }
             ],
+            "head_repository": {"full_name": "org/repo"},
             "head_branch": "feature/foo",
             "head_sha": "abc123",
             "conclusion": "success",
@@ -56,9 +57,11 @@ def test_workflow_metrics_base_branch_from_pull_request():
         run_id=99,
         attempt=1,
         rerun_type="initial",
+        repository="org/repo",
     )
     assert metrics.base_branch == "main"
     assert metrics.pull_request_number == 42
+    assert metrics.is_community_contribution is False
 
 
 def test_workflow_metrics_base_branch_from_pull_request_target():
@@ -76,6 +79,7 @@ def test_workflow_metrics_base_branch_from_pull_request_target():
                     "base": {"ref": "main"},
                 }
             ],
+            "head_repository": {"full_name": "org/repo"},
             "head_branch": "feature/foo",
             "head_sha": "abc123",
             "conclusion": "success",
@@ -86,8 +90,10 @@ def test_workflow_metrics_base_branch_from_pull_request_target():
         run_id=99,
         attempt=1,
         rerun_type="initial",
+        repository="org/repo",
     )
     assert metrics.base_branch == "main"
+    assert metrics.is_community_contribution is False
 
 
 def test_workflow_metrics_base_branch_absent_without_pull_request():
@@ -99,6 +105,7 @@ def test_workflow_metrics_base_branch_absent_without_pull_request():
             "actor": {"login": "alice"},
             "triggering_actor": {"login": "alice"},
             "pull_requests": [],
+            "head_repository": {"full_name": "org/repo"},
             "head_branch": "main",
             "head_sha": "abc123",
             "conclusion": "success",
@@ -109,9 +116,11 @@ def test_workflow_metrics_base_branch_absent_without_pull_request():
         run_id=99,
         attempt=1,
         rerun_type="initial",
+        repository="org/repo",
     )
     assert metrics.base_branch is None
     assert metrics.pull_request_number is None
+    assert metrics.is_community_contribution is False
 
 
 def test_workflow_metrics_base_branch_ignored_for_non_pull_request_event():
@@ -130,6 +139,7 @@ def test_workflow_metrics_base_branch_ignored_for_non_pull_request_event():
                     "base": {"ref": "main"},
                 }
             ],
+            "head_repository": {"full_name": "contributor/repo"},
             "head_branch": "feature/foo",
             "head_sha": "abc123",
             "conclusion": "success",
@@ -140,6 +150,70 @@ def test_workflow_metrics_base_branch_ignored_for_non_pull_request_event():
         run_id=99,
         attempt=1,
         rerun_type="initial",
+        repository="org/repo",
     )
     assert metrics.base_branch is None
     assert metrics.pull_request_number == 42
+    assert metrics.is_community_contribution is False
+
+
+def test_workflow_metrics_community_contribution_from_fork_pr():
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "pull_request",
+            "actor": {"login": "contributor"},
+            "triggering_actor": {"login": "contributor"},
+            "pull_requests": [
+                {
+                    "number": 99,
+                    "url": "https://api.github.com/repos/org/repo/pulls/99",
+                    "base": {"ref": "main"},
+                }
+            ],
+            "head_repository": {"full_name": "contributor/repo"},
+            "head_branch": "fix-typo",
+            "head_sha": "def456",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=100,
+        attempt=1,
+        rerun_type="initial",
+        repository="org/repo",
+    )
+    assert metrics.is_community_contribution is True
+
+
+def test_workflow_metrics_community_contribution_from_fork_pr_target():
+    metrics = WorkflowMetrics.from_api(
+        {
+            "workflow_id": 1,
+            "name": "lint",
+            "event": "pull_request_target",
+            "actor": {"login": "contributor"},
+            "triggering_actor": {"login": "contributor"},
+            "pull_requests": [
+                {
+                    "number": 99,
+                    "url": "https://api.github.com/repos/org/repo/pulls/99",
+                    "base": {"ref": "main"},
+                }
+            ],
+            "head_repository": {"full_name": "contributor/repo"},
+            "head_branch": "fix-typo",
+            "head_sha": "def456",
+            "conclusion": "success",
+            "created_at": "2026-01-01T00:00:00Z",
+            "run_started_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        run_id=100,
+        attempt=1,
+        rerun_type="initial",
+        repository="org/repo",
+    )
+    assert metrics.is_community_contribution is True

--- a/.github/scripts/utils/github/workflow_metrics.py
+++ b/.github/scripts/utils/github/workflow_metrics.py
@@ -107,12 +107,27 @@ class WorkflowMetrics:
     base_branch: str | None
     head_branch: str | None
     head_sha: str | None
+    is_community_contribution: bool
     conclusion: str | None
     created_at: str | None
     started_at: str | None
     completed_at: str | None
     duration_seconds: int | None
     attempt: AttemptInfo
+
+    @staticmethod
+    def _is_community_contribution(
+        trigger_event: str | None, data: dict[str, Any], repository: str
+    ) -> bool:
+        """True for PR runs whose head repo differs from the workflow repo (fork PRs).
+
+        Mirrors IS_FORK in docker-unified.yml:
+        event is a PR trigger and head.repo.full_name != github.repository.
+        """
+        if trigger_event not in _PR_TRIGGER_EVENTS:
+            return False
+        head_repo = (data.get("head_repository") or {}).get("full_name")
+        return head_repo is not None and head_repo != repository
 
     @classmethod
     def from_api(
@@ -121,6 +136,7 @@ class WorkflowMetrics:
         run_id: int,
         attempt: int,
         rerun_type: str,
+        repository: str,
     ) -> "WorkflowMetrics":
         run_started = parse_dt(data.get("run_started_at"))
         run_completed = parse_dt(data.get("updated_at"))
@@ -146,6 +162,9 @@ class WorkflowMetrics:
             base_branch=base_branch,
             head_branch=data.get("head_branch"),
             head_sha=data.get("head_sha"),
+            is_community_contribution=cls._is_community_contribution(
+                trigger_event, data, repository
+            ),
             conclusion=data.get("conclusion"),
             created_at=data.get("created_at"),
             started_at=data.get("run_started_at"),

--- a/.github/scripts/utils/posthog/ci_reporter.py
+++ b/.github/scripts/utils/posthog/ci_reporter.py
@@ -70,6 +70,7 @@ class PostHogCIReporter:
             "base_branch": w.get("base_branch"),
             "head_branch": w.get("head_branch"),
             "head_sha": w.get("head_sha"),
+            "is_community_contribution": w.get("is_community_contribution", False),
             "conclusion": w.get("conclusion"),
             "created_at": parse_dt(w.get("created_at")),
             "started_at": parse_dt(w.get("started_at")),


### PR DESCRIPTION
## Summary
- Add `is_community_contribution` to PostHog CI workflow props, true when a PR run's `head_repository` differs from the workflow repo (fork PRs), matching the `IS_FORK` logic used in docker-unified.yml
- Derive the flag during metrics collection and include it on `ci_workflow_run_completed` (and shared step/job props)

## Test plan
- [x] Unit tests in `.github/scripts/test/test_workflow_metrics.py` cover same-repo PR, fork PR, `pull_request_target`, and non-PR events
- [ ] Confirm a fork PR workflow run publishes `is_community_contribution: true` in PostHog
- [ ] Confirm an internal PR / push run publishes `is_community_contribution: false`


Made with [Cursor](https://cursor.com)