### PR TITLE
fix(executor): mask everything that reaches the execution report

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/default_executor.py
+++ b/metadata-ingestion/src/datahub/executor/execution/default_executor.py
@@ -28,6 +28,7 @@ from datahub.executor.request.execution_request import ExecutionRequest
 from datahub.executor.request.signal_request import SignalRequest
 from datahub.executor.result.execution_result import ExecutionResult, Type
 from datahub.executor.secret.secret_store_registry import SecretStoreRegistry
+from datahub.masking.bootstrap import shutdown_secret_masking
 from datahub.secret.secret_store import SecretStore, SecretStoreConfig
 
 logger = logging.getLogger(__name__)
@@ -166,6 +167,16 @@ class DefaultExecutor(Executor):
             execution_result.set_result_type(Type.CANCELLED)
             return execution_result
         finally:
+            # Releases the hold taken when the recipe was resolved. Here rather than
+            # in the task, so it also covers report lines written by the except blocks
+            # above, and paths that never reach the task at all.
+            try:
+                shutdown_secret_masking(owner=execution_id)
+            except Exception:
+                logger.warning(
+                    f"Failed to release secret masking for {execution_id}",
+                    exc_info=True,
+                )
             if task_event_loop:
                 task_event_loop.close()
             if execution_id in self.task_futures:

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
@@ -48,8 +48,7 @@ from datahub.executor.execution.sub_process_task_common import (
     resolve_wrapper_script,
 )
 from datahub.executor.execution.task import Task, TaskError
-from datahub.masking.bootstrap import shutdown_secret_masking
-from datahub.masking.masking_filter import SecretMaskingFilter
+from datahub.masking.masking_filter import SecretMaskingFilter, mask_secrets
 from datahub.masking.secret_registry import SecretRegistry
 
 logger = logging.getLogger(__name__)
@@ -448,6 +447,7 @@ class SubProcessIngestionTask(Task):
     ) -> None:
         """Monitor subprocess execution with async tasks for output reading and progress reporting."""
         most_recent_log_ts: Optional[datetime] = None
+        progress_masking_filter = SecretMaskingFilter(SecretRegistry.get_instance())
 
         async def _read_output_lines() -> None:
             nonlocal most_recent_log_ts
@@ -509,8 +509,12 @@ class SubProcessIngestionTask(Task):
                     if most_recent_log_ts is None:
                         report = "No logs yet"
                     else:
-                        report = SubProcessTaskUtil._format_log_lines(
-                            shared_logs.get_lines()
+                        report = mask_secrets(
+                            SubProcessTaskUtil._format_log_lines(
+                                shared_logs.get_lines()
+                            ),
+                            "progress report",
+                            progress_masking_filter,
                         )
                         current_time = datetime.now(tz=timezone.utc)
                         if most_recent_log_ts < current_time - timedelta(minutes=2):
@@ -599,16 +603,9 @@ class SubProcessIngestionTask(Task):
             try:
                 with open(report_out_file) as structured_report_fp:
                     report_content = structured_report_fp.read()
-                try:
-                    registry = SecretRegistry.get_instance()
-                    if registry and registry.get_count() > 0:
-                        report_content = SecretMaskingFilter(registry).mask_text(
-                            report_content
-                        )
-                except Exception:
-                    # Better to have the report than to fail completely.
-                    logger.warning("Failed to mask structured report, using original")
-                ctx.get_report().set_structured_report(report_content)
+                ctx.get_report().set_structured_report(
+                    mask_secrets(report_content, "structured report")
+                )
             except Exception:
                 logger.exception(
                     "Failed to process structured report from %s", report_out_file
@@ -616,17 +613,15 @@ class SubProcessIngestionTask(Task):
 
         try:
             ctx.get_report().set_logs(
-                SubProcessTaskUtil._format_log_lines(shared_logs.get_lines())
+                mask_secrets(
+                    SubProcessTaskUtil._format_log_lines(shared_logs.get_lines()),
+                    "logs",
+                )
             )
         except Exception:
             logger.exception("Failed to set logs on execution report")
 
         SubProcessTaskUtil._remove_directory(exec_out_dir)
-
-        try:
-            shutdown_secret_masking()
-        except Exception as e:
-            logger.warning(f"Failed to shutdown secret masking: {e}")
 
         if cancelled:
             ctx.get_report().report_info("Ingestion task was cancelled")

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
@@ -188,7 +188,7 @@ class SubProcessTaskUtil:
         # Set up secret masking in the executor process (for masking logs/reports)
         if secrets_to_resolve:
             try:
-                initialize_secret_masking(force=True)
+                initialize_secret_masking(force=True, owner=execution_ctx.exec_id)
                 registry = SecretRegistry.get_instance()
                 for secret_name in secrets_to_resolve:
                     secret_value = secret_values_dict.get(secret_name)

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -38,7 +38,6 @@ from datahub.executor.execution.sub_process_task_common import (
     resolve_wrapper_script,
 )
 from datahub.executor.execution.task import Task, TaskError
-from datahub.masking.bootstrap import shutdown_secret_masking
 from datahub.masking.masking_filter import SecretMaskingFilter
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -208,12 +207,6 @@ class SubProcessTestConnectionTask(Task):
 
             # Cleanup execution directory
             SubProcessTaskUtil._remove_directory(exec_out_dir)
-
-            # Shutdown DataHub masking framework
-            try:
-                shutdown_secret_masking()
-            except Exception as e:
-                logger.warning(f"Failed to shutdown secret masking: {e}")
 
         if return_code != 0:
             # Failed

--- a/metadata-ingestion/src/datahub/executor/report/execution_report.py
+++ b/metadata-ingestion/src/datahub/executor/report/execution_report.py
@@ -17,11 +17,12 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from datahub.ingestion.api.report import Report
+from datahub.masking.masking_filter import mask_secrets
 
 
 def format_report_line(line_type: str, message: str) -> str:
     utc_time = datetime.datetime.utcnow()
-    return f"{utc_time} {line_type}: {message}"
+    return f"{utc_time} {line_type}: {mask_secrets(message, 'report line')}"
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/masking/bootstrap.py
+++ b/metadata-ingestion/src/datahub/masking/bootstrap.py
@@ -17,7 +17,7 @@ import logging
 import sys
 import threading
 import traceback
-from typing import Optional
+from typing import Optional, Set
 
 from datahub.masking.logging_utils import get_masking_safe_logger
 from datahub.masking.masking_filter import (
@@ -34,6 +34,58 @@ _bootstrap_completed = False
 _bootstrap_error: Optional[Exception] = None
 _original_excepthook = None  # Track original exception hook for restoration
 _bootstrap_lock = threading.Lock()  # Thread safety for concurrent initialization
+
+# Owner used by callers that own the whole process (the CLI, the wrapper subprocess)
+# and never tear masking back down.
+PROCESS_OWNER = "process"
+
+
+class MaskingLifecycle:
+    """Tracks which executions still need masking installed.
+
+    Masking state is process-wide -- one filter on the root logger, one stdout
+    wrapper, one shared registry -- but the executor runs several ingestions in one
+    process, a thread each. Teardown waits for the last holder to leave.
+
+    Holders are tracked by identity rather than counted.
+    """
+
+    _instance: Optional["MaskingLifecycle"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._holders: Set[str] = set()
+
+    @classmethod
+    def get_instance(cls) -> "MaskingLifecycle":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        with cls._instance_lock:
+            cls._instance = None
+
+    def acquire(self, owner: str) -> None:
+        with self._lock:
+            self._holders.add(owner)
+
+    def release(self, owner: str) -> bool:
+        """Drop `owner`'s hold. True once nothing holds masking any more.
+
+        Not exactly-once: simultaneous releases can all see an empty set. Teardown is
+        serialized under the bootstrap lock and is idempotent.
+        """
+        with self._lock:
+            self._holders.discard(owner)
+            return not self._holders
+
+    def holders(self) -> Set[str]:
+        with self._lock:
+            return set(self._holders)
 
 
 def is_bootstrapped() -> bool:
@@ -83,6 +135,7 @@ def _install_exception_hook(registry: SecretRegistry) -> None:
 def initialize_secret_masking(
     max_message_size: int = 5000,
     force: bool = False,
+    owner: str = PROCESS_OWNER,
 ) -> None:
     """
     Initialize secret masking infrastructure (logging filter + exception hook).
@@ -104,6 +157,9 @@ def initialize_secret_masking(
 
     # Thread-safe initialization: acquire lock for entire operation
     with _bootstrap_lock:
+        # Teardown takes this same lock, so it cannot interleave with installation.
+        MaskingLifecycle.get_instance().acquire(owner)
+
         # Prevent double initialization
         if _bootstrap_completed and not force:
             logger.debug("Secret masking already initialized")
@@ -161,30 +217,38 @@ def initialize_secret_masking(
             # Don't raise - graceful degradation
 
 
-def shutdown_secret_masking() -> None:
-    """Shutdown secret masking system."""
+def shutdown_secret_masking(owner: str = PROCESS_OWNER) -> None:
+    """Release `owner`'s hold, tearing masking down once it is the last one."""
     global _bootstrap_completed, _bootstrap_error, _original_excepthook
 
-    try:
-        uninstall_masking_filter()
+    with _bootstrap_lock:
+        if not MaskingLifecycle.get_instance().release(owner):
+            logger.debug(
+                "Secret masking still held by "
+                f"{sorted(MaskingLifecycle.get_instance().holders())}; deferring shutdown"
+            )
+            return
 
-        # Restore original exception hook
-        if _original_excepthook is not None:
-            sys.excepthook = _original_excepthook
-            _original_excepthook = None
+        try:
+            uninstall_masking_filter()
 
-        # Clear registry
-        registry = SecretRegistry.get_instance()
-        registry.clear()
+            # Restore original exception hook
+            if _original_excepthook is not None:
+                sys.excepthook = _original_excepthook
+                _original_excepthook = None
 
-        # Reset masking-safe loggers to restore normal logging
-        from datahub.masking.logging_utils import reset_masking_safe_loggers
+            # Clear registry
+            registry = SecretRegistry.get_instance()
+            registry.clear()
 
-        reset_masking_safe_loggers()
+            # Reset masking-safe loggers to restore normal logging
+            from datahub.masking.logging_utils import reset_masking_safe_loggers
 
-        _bootstrap_completed = False
-        _bootstrap_error = None
+            reset_masking_safe_loggers()
 
-        logger.info("Secret masking shutdown completed")
-    except Exception as e:
-        logger.error(f"Error during secret masking shutdown: {e}")
+            _bootstrap_completed = False
+            _bootstrap_error = None
+
+            logger.info("Secret masking shutdown completed")
+        except Exception as e:
+            logger.error(f"Error during secret masking shutdown: {e}")

--- a/metadata-ingestion/src/datahub/masking/masking_filter.py
+++ b/metadata-ingestion/src/datahub/masking/masking_filter.py
@@ -492,6 +492,36 @@ def _update_existing_handlers() -> None:
         logger.debug(f"Updated {updated_count} logging handlers to use wrapped streams")
 
 
+def mask_secrets(
+    text: str, context: str, masking_filter: Optional["SecretMaskingFilter"] = None
+) -> str:
+    """Redact registered secrets from text bound for the execution report.
+
+    For text that never passes through the installed filter -- report lines captured
+    for the summary, log buffers filled by direct appends -- so it cannot rely on the
+    filter still being installed when the text is finally published.
+
+    Pass `masking_filter` to reuse one across repeated calls: a filter caches its
+    compiled pattern per registry version, so a fresh one rebuilds it every call. A
+    reused filter also keeps its failure state, so repeated failures trip its circuit
+    breaker -- reports then carry a fixed redaction marker rather than leaking.
+
+    Returns the text unmasked if masking cannot be attempted at all.
+    """
+    try:
+        if masking_filter is not None:
+            return masking_filter.mask_text(text)
+        registry = SecretRegistry.get_instance()
+        if registry.get_count() == 0:
+            return text
+        return SecretMaskingFilter(registry).mask_text(text)
+    except Exception:
+        logger.warning(
+            "Failed to mask secrets in %s; publishing text unmasked", context
+        )
+    return text
+
+
 def install_masking_filter(
     secret_registry: Optional[SecretRegistry] = None,
     max_message_size: int = 5000,

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
@@ -53,10 +53,8 @@ _SETUP_VENV = "datahub.executor.execution.sub_process_ingestion_task.setup_venv"
 
 @pytest.fixture(autouse=True)
 def reset_secret_registry() -> Iterator[None]:
-    # SecretRegistry is a process-wide singleton and _handle_subprocess_completion
-    # both reads it (to mask the structured report) and clears it via
-    # shutdown_secret_masking(). Reset around every test so these tests neither
-    # inherit nor leak registered secrets under --random-order.
+    # SecretRegistry is a process-wide singleton. Reset around every test so these
+    # tests neither inherit nor leak registered secrets under --random-order.
     SecretRegistry.reset_instance()
     yield
     SecretRegistry.reset_instance()
@@ -749,6 +747,33 @@ class TestSubProcessIngestionTaskCompletion:
         ][0]
         assert secret_value not in published
 
+    def test_logs_are_masked_when_secrets_are_registered(
+        self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
+    ) -> None:
+        """Masks registered secrets in the logs published at completion."""
+        secret_value = "s3cr3t-p4ssw0rd"
+        SecretRegistry.get_instance().register_secret("DB_PASSWORD", secret_value)
+
+        logs = LogHolder()
+        logs.append(f"error: Failed to fetch https://u:{secret_value}@idx/simple\n")
+
+        mock_process = Mock()
+        mock_process.returncode = 0
+
+        with patch("os.path.exists", return_value=False), patch(_REMOVE_DIRECTORY):
+            ingestion_task._handle_subprocess_completion(
+                mock_process,
+                mock_execution_context,
+                "/tmp/report.json",
+                "/tmp/artifacts",
+                {"pipeline_name": "test-pipeline"},
+                "/tmp/exec",
+                logs,
+            )
+
+        published = mock_execution_context.get_report().set_logs.call_args[0][0]
+        assert secret_value not in published
+
     def test_handle_subprocess_completion_failure_exit_code(
         self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
     ) -> None:
@@ -874,11 +899,6 @@ class TestSubProcessIngestionTaskCompletion:
             patch("builtins.open", side_effect=OSError(errno.EIO, "I/O error")),
             # set_logs fails.
             patch(_FORMAT_LOG_LINES, side_effect=RuntimeError("format boom")),
-            # Secret-masking shutdown fails.
-            patch(
-                "datahub.executor.execution.sub_process_ingestion_task.shutdown_secret_masking",
-                side_effect=Exception("masking boom"),
-            ),
             # _remove_directory is internally guarded; stub it out.
             patch(_REMOVE_DIRECTORY),
         ):
@@ -1076,6 +1096,61 @@ class TestSubProcessIngestionTaskProgressReporting:
                 ),
                 timeout=5.0,
             )
+
+    async def test_progress_reports_are_masked_when_secrets_are_registered(
+        self,
+        ingestion_task: SubProcessIngestionTask,
+        mock_execution_context: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Masks registered secrets in the progress reports sent during the run."""
+        secret_value = "s3cr3t-p4ssw0rd"
+        SecretRegistry.get_instance().register_secret("DB_PASSWORD", secret_value)
+
+        mock_process = AsyncMock()
+        mock_process.returncode = None
+        mock_process.stdout = AsyncMock()
+
+        progress_callback = Mock()
+        mock_execution_context.request.progress_callback = progress_callback
+
+        line_emitted = False
+
+        async def mock_readuntil(delimiter: bytes) -> bytes:
+            nonlocal line_emitted
+            if not line_emitted:
+                line_emitted = True
+                return f"connecting with {secret_value}\n".encode()
+            return b""
+
+        async def mock_wait() -> None:
+            await asyncio.sleep(0.05)
+            mock_process.returncode = 0
+
+        mock_process.stdout.readuntil = mock_readuntil
+        mock_process.wait = mock_wait
+
+        stdout_lines = LogHolder()
+        mock_log_file = Mock()
+
+        monkeypatch.setattr(ingestion_task.config, "heartbeat_time_seconds", 0.02)
+
+        with patch("sys.stdout"):
+            await asyncio.wait_for(
+                ingestion_task._monitor_subprocess(
+                    mock_process,
+                    "test-exec-id",
+                    mock_execution_context,
+                    stdout_lines,
+                    mock_log_file,
+                ),
+                timeout=5.0,
+            )
+
+        reported = " ".join(call[0][0] for call in progress_callback.call_args_list)
+        assert secret_value not in reported
+        # The marker also shows the line reached the report at all.
+        assert "***REDACTED:DB_PASSWORD***" in reported
 
 
 class TestSubProcessIngestionTaskClose:

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -137,9 +137,6 @@ async def test_execute_success(
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
         ) as _mock_remove_dir,
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
-        ),
     ):
         # Setup mocks: _resolve_recipe now returns (recipe, secret_values)
         mock_resolve.return_value = (
@@ -257,9 +254,6 @@ async def test_execute_failure_raises(
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
         ) as _mock_remove_dir,
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
-        ),
     ):
         # Setup mocks: _resolve_recipe now returns (recipe, secret_values)
         mock_resolve.return_value = ({"source": {"type": "demo-data"}}, {})
@@ -342,9 +336,6 @@ async def test_cancellation_terminates_the_subprocess(
         patch("os.path.exists", return_value=False),
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
-        ),
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
         ),
     ):
         mock_resolve.return_value = ({"source": {"type": "demo-data"}}, {})

--- a/metadata-ingestion/tests/unit/test_bootstrap.py
+++ b/metadata-ingestion/tests/unit/test_bootstrap.py
@@ -8,6 +8,8 @@ automatically at point-of-read (config expansion, Pydantic validation).
 
 from unittest.mock import patch
 
+import pytest
+
 
 class TestBootstrapErrorHandling:
     """Test bootstrap initialization error handling."""
@@ -433,3 +435,82 @@ class TestExceptionHookOptimization:
 
         finally:
             shutdown_secret_masking()
+
+
+class TestConcurrentExecutionTeardown:
+    """Masking outlives the first execution to finish, and is torn down by the last."""
+
+    @pytest.fixture(autouse=True)
+    def clean_masking_state(self):
+        """Resets the process-wide masking state around each test."""
+        from datahub.masking.bootstrap import MaskingLifecycle
+        from datahub.masking.secret_registry import SecretRegistry
+
+        MaskingLifecycle.reset_instance()
+        SecretRegistry.reset_instance()
+        yield
+        MaskingLifecycle.reset_instance()
+        SecretRegistry.reset_instance()
+
+    def _register(self, name: str, value: str) -> None:
+        from datahub.masking.secret_registry import SecretRegistry
+
+        SecretRegistry.get_instance().register_secret(name, value)
+
+    def _filter_installed(self) -> bool:
+        import logging
+
+        from datahub.masking.masking_filter import SecretMaskingFilter
+
+        return any(
+            isinstance(f, SecretMaskingFilter) for f in logging.getLogger().filters
+        )
+
+    def test_masking_survives_until_the_last_execution_finishes(self) -> None:
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+        from datahub.masking.masking_filter import SecretMaskingFilter
+        from datahub.masking.secret_registry import SecretRegistry
+
+        initialize_secret_masking(force=True, owner="exec-long")
+        try:
+            self._register("PW_LONG", "long-run-secret")
+            initialize_secret_masking(force=True, owner="exec-short")
+            self._register("PW_SHORT", "short-run-secret")
+
+            # The short run finishes first.
+            shutdown_secret_masking(owner="exec-short")
+
+            # The long run is still reporting, so its secret stays masked...
+            masked = SecretMaskingFilter(SecretRegistry.get_instance()).mask_text(
+                "connecting with long-run-secret"
+            )
+            assert "long-run-secret" not in masked
+            # ...and the installed filter is still in place.
+            assert self._filter_installed()
+        finally:
+            shutdown_secret_masking(owner="exec-long")
+
+        assert SecretRegistry.get_instance().get_count() == 0
+        assert not self._filter_installed()
+
+    def test_a_run_with_no_secrets_does_not_tear_down_a_run_that_has_them(self) -> None:
+        """A run with no secrets never initializes, but still calls shutdown."""
+        from datahub.masking.bootstrap import (
+            initialize_secret_masking,
+            shutdown_secret_masking,
+        )
+        from datahub.masking.secret_registry import SecretRegistry
+
+        initialize_secret_masking(force=True, owner="exec-with-secrets")
+        try:
+            self._register("PW", "still-needed")
+
+            shutdown_secret_masking(owner="exec-no-secrets")
+
+            assert SecretRegistry.get_instance().get_count() == 1
+            assert self._filter_installed()
+        finally:
+            shutdown_secret_masking(owner="exec-with-secrets")

--- a/metadata-ingestion/tests/unit/test_masking_filter.py
+++ b/metadata-ingestion/tests/unit/test_masking_filter.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 
@@ -22,6 +23,7 @@ from datahub.masking.masking_filter import (
     SecretMaskingFilter,
     StreamMaskingWrapper,
     install_masking_filter,
+    mask_secrets,
     uninstall_masking_filter,
 )
 from datahub.masking.secret_registry import SecretRegistry
@@ -1177,3 +1179,39 @@ class TestThreadSafetyConcurrent:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestMaskSecretsHelper:
+    """`mask_secrets` masks report lines, log buffers and the structured report."""
+
+    @pytest.fixture(autouse=True)
+    def empty_singleton(self):
+        SecretRegistry.reset_instance()
+        yield
+        SecretRegistry.reset_instance()
+
+    def test_a_supplied_filter_is_used_even_when_the_singleton_is_empty(self) -> None:
+        """Masks from the supplied filter's registry while the singleton is empty."""
+        own_registry = SecretRegistry()
+        own_registry.register_secret("OTHER_PW", "other-secret-value")
+        assert SecretRegistry.get_instance().get_count() == 0
+
+        masked = mask_secrets(
+            "connecting with other-secret-value",
+            "test",
+            SecretMaskingFilter(own_registry),
+        )
+
+        assert masked == "connecting with ***REDACTED:OTHER_PW***"
+
+    def test_the_report_survives_a_masking_failure(self) -> None:
+        """Returns the text unchanged when the registry lookup raises."""
+        with patch.object(
+            SecretRegistry, "get_instance", side_effect=RuntimeError("registry gone")
+        ):
+            result = mask_secrets("connection failed after 3 retries", "test")
+
+        assert result == "connection failed after 3 retries"
+
+    def test_text_is_returned_unchanged_when_nothing_is_registered(self) -> None:
+        assert mask_secrets("nothing to hide here", "test") == "nothing to hide here"


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes. This one carries all the secret-masking changes.

## What was wrong

Secret masking was installed per execution but only ever applied to the final structured report, and it was torn down process-wide by whichever execution finished first. Four gaps in the same mechanism:

1. **Run logs went out unmasked.** Only `set_structured_report` passed through the filter; `set_logs` did not, so a secret the CLI echoed to stdout reached the report verbatim.
2. **Progress reports went out unmasked.** The reports published every few seconds during a run bypassed masking entirely, so a secret was readable in the UI for the duration of the run even when the final report came out clean.
3. **Report lines were never masked.** `format_report_line` builds the `report_info` / `report_warning` summary from arbitrary strings, including exception text from failure paths.
4. **Teardown was unconditional.** The executor runs several ingestions in one process, a thread each, but `shutdown_secret_masking` uninstalled the filter, restored the exception hook and cleared the shared registry outright. The first execution to finish stripped masking from every execution still running — and cleared the registry they were masking against.

## What changed

Masking is now reference-held by execution id: `initialize_secret_masking` takes an `owner`, `shutdown_secret_masking` releases that owner, and teardown runs once the last holder leaves. The release moved into `DefaultExecutor`'s `finally` block so it also covers report lines written by the error paths and executions that never reach a task at all. Callers that own the whole process (the CLI, the wrapper subprocess) keep the previous behaviour under a default `PROCESS_OWNER`.

The masking itself is now a single `mask_secrets` helper rather than the same try/except repeated at each site. It takes an optional filter to reuse, for two reasons: a filter caches its compiled pattern per registry version, so a fresh one per call rebuilds it — which matters in the progress loop; and a reused filter keeps its failure state, so repeated failures trip its circuit breaker and the report carries a redaction marker instead of leaking.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — `test_bootstrap.py`, `test_masking_filter.py`, `test_subprocess_ingestion_task.py`
- [x] No breaking change (default `PROCESS_OWNER` preserves existing single-owner behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secret masking now covers everything that reaches the execution report, and masking teardown is reference-counted so it survives until the last execution finishes.

Old behavior: masking applied only to the final structured report, and the first execution to finish tore down masking for every running execution. Now: run logs, progress reports, and report lines are masked too, and masking is tied to an execution id — teardown happens only after the last holder releases, with the release in `DefaultExecutor`'s `finally` block so error paths are covered. Callers that own the whole process (CLI, wrapper subprocess) keep the previous single-owner behavior via a default `PROCESS_OWNER`.

- Adds a `mask_secrets` helper that consolidates the per-site masking logic.
- `initialize_secret_masking` and `shutdown_secret_masking` now take an owner to track holders and defer teardown until the last one leaves.
- `format_report_line` now masks report lines, which includes exception text from failure paths.

<sup>Written for commit 7ecbd9ca703d7188392f6f0358fcc6ca96ac9cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

