### PR TITLE
fix(executor): stop a SIGTERM during the spawn from orphaning the CLI

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/wrapper_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/wrapper_common.py
@@ -178,6 +178,7 @@ def run_datahub_subprocess(cmd: list[str], stdin_data: str) -> int:
     masking_filter = SecretMaskingFilter(secret_registry=registry)
 
     process: Optional[subprocess.Popen] = None
+    deferred_signum: Optional[int] = None
 
     def _reap_and_exit(signum: int, _frame: Any) -> None:
         # Our process group got a termination signal -- stop and REAP the datahub
@@ -188,7 +189,14 @@ def run_datahub_subprocess(cmd: list[str], stdin_data: str) -> int:
         # this wrapper outright and the child it just spawned is never reaped.
         # `process` is still None for the part of that window before Popen returns,
         # hence the guard.
-        if process is not None and process.poll() is None:
+        nonlocal deferred_signum
+        if process is None:
+            # Signalled between the spawn and the assignment below: the child exists
+            # but is not reachable yet. Exiting here orphans it, so record the signal
+            # and let the replay after the assignment do the reaping.
+            deferred_signum = signum
+            return
+        if process.poll() is None:
             process.terminate()
             try:
                 process.wait(timeout=30)
@@ -199,15 +207,22 @@ def run_datahub_subprocess(cmd: list[str], stdin_data: str) -> int:
 
     signal.signal(signal.SIGTERM, _reap_and_exit)
 
-    process = subprocess.Popen(
-        cmd,
-        env=os.environ.copy(),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    )
+    try:
+        process = subprocess.Popen(
+            cmd,
+            env=os.environ.copy(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except Exception:
+        if deferred_signum is not None:
+            sys.exit(128 + deferred_signum)
+        raise
+    if deferred_signum is not None:
+        _reap_and_exit(deferred_signum, None)
 
     try:
         assert process.stdin is not None

--- a/metadata-ingestion/tests/unit/executor/wrappers/test_wrapper_common.py
+++ b/metadata-ingestion/tests/unit/executor/wrappers/test_wrapper_common.py
@@ -86,6 +86,61 @@ class TestSetupMemoryLimit:
             wrapper_common.setup_memory_limit()
 
 
+class TestSigtermDuringSpawn:
+    """SIGTERM arriving after the handler is installed but before Popen returns."""
+
+    @pytest.fixture(autouse=True)
+    def restore_sigterm(self):
+        previous = signal.getsignal(signal.SIGTERM)
+        yield
+        signal.signal(signal.SIGTERM, previous)
+
+    def _child(self) -> MagicMock:
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        proc.stdout = iter([])
+        proc.poll.return_value = None  # still running when the handler looks
+        proc.wait.return_value = 0
+        return proc
+
+    def test_the_child_is_terminated_rather_than_orphaned(self) -> None:
+        proc = self._child()
+
+        def fake_popen(*_args: Any, **_kwargs: Any) -> MagicMock:
+            signal.raise_signal(signal.SIGTERM)  # `process` is still None here
+            return proc
+
+        with (
+            patch(
+                "datahub.executor.execution.wrapper_common.subprocess.Popen",
+                side_effect=fake_popen,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            wrapper_common.run_datahub_subprocess(["/bin/true"], "recipe: {}")
+
+        proc.terminate.assert_called_once()
+        assert exc_info.value.code == 128 + signal.SIGTERM
+
+    def test_a_signal_is_not_dropped_when_the_spawn_itself_fails(self) -> None:
+        """Exits with the signal's code when Popen itself raises."""
+
+        def failing_popen(*_args: Any, **_kwargs: Any) -> MagicMock:
+            signal.raise_signal(signal.SIGTERM)
+            raise FileNotFoundError("no such binary")
+
+        with (
+            patch(
+                "datahub.executor.execution.wrapper_common.subprocess.Popen",
+                side_effect=failing_popen,
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            wrapper_common.run_datahub_subprocess(["/nonexistent"], "recipe: {}")
+
+        assert exc_info.value.code == 128 + signal.SIGTERM
+
+
 class TestWrapperStdinContent:
     """Tests for what the wrapper pipes to `datahub ingest -c -` stdin.
 


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes.

## What was wrong

`run_datahub_subprocess` installs its SIGTERM handler *before* `Popen`, deliberately: registering it afterwards leaves a window where the default disposition applies, and a signal landing there kills the wrapper outright while the child it just spawned is never reaped.

But `process` stays unbound until `Popen` returns. For the part of that window after the fork and before the assignment, the handler found `None`, concluded there was nothing to kill, and exited — leaving the child running with no parent waiting on it.

Reproduced by raising SIGTERM from inside `Popen.__init__` once the child exists: the child was left behind.

## What changed

The handler now records a signal that arrives too early and returns; the signal is replayed once `process` is bound. The spawn is also wrapped, because on that path the replay is unreachable and the recorded signal would be dropped silently — the wrapper would go on to raise the `Popen` error instead of exiting for the signal it was sent.

**Why not `pthread_sigmask`,** which is the obvious approach: `fork` inherits the signal mask and `exec` preserves it, so the CLI would have started life with SIGTERM blocked and cancellation would have degraded to waiting out the SIGKILL escalation.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — `TestSigtermDuringSpawn` covers both the orphan case and the failing-spawn case
- [x] No breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a SIGTERM that arrives during subprocess spawn from orphaning the CLI child process. The handler previously saw `process` as `None` and exited without reaping the child; now it records the signal and reaps after `Popen` returns, and the spawn failure path also exits with the signal's code.

**Bug Fixes**
- Records SIGTERM that arrives before `process` is bound and replays it after assignment.
- Wraps `Popen` so a recorded signal is not dropped if spawn itself fails.
- Adds tests covering both the orphan case and the failing-spawn case.

<sup>Written for commit 6ee3b18dc059819338ba47a38c3e54fd81cad9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

