### PR TITLE
fix(executor): tell a failed CLI probe apart from a missing flag

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/wrapper_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/wrapper_common.py
@@ -5,6 +5,7 @@ long-lived executor process. They handle venv activation, secret masking
 registration, envelope parsing, and datahub capability detection.
 """
 
+import enum
 import json
 import os
 import re
@@ -100,21 +101,48 @@ def register_secrets_for_masking(secrets: dict[str, str]) -> None:
         )
 
 
-def check_cli_flag_support(datahub_binary: Path, flag: str) -> bool:
-    """Check if the datahub CLI supports a given flag on `ingest run`."""
+class FlagSupport(enum.Enum):
+    """Outcome of probing the CLI for a flag.
+
+    PROBE_FAILED is distinct from UNSUPPORTED on purpose: a CLI that cannot answer
+    is broken, not old, and callers that would otherwise degrade gracefully need to
+    tell those apart. Collapsing them is how a broken venv gets reported as an old
+    CLI version.
+    """
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    PROBE_FAILED = "probe_failed"
+
+
+def check_cli_flag_support(datahub_binary: Path, flag: str) -> FlagSupport:
+    """Check whether the datahub CLI supports a given flag on `ingest run`."""
     try:
         result = subprocess.run(
             [str(datahub_binary), "ingest", "run", "--help"],
             capture_output=True,
             text=True,
         )
-        return flag in result.stdout
     except Exception as e:
         print(
             f"Warning: Failed to check --{flag} support: {e}",
             file=sys.stderr,
         )
-        return False
+        return FlagSupport.PROBE_FAILED
+
+    if result.returncode != 0:
+        print(
+            f"Warning: could not determine --{flag} support: "
+            f"`datahub ingest run --help` exited {result.returncode}. "
+            f"This is a CLI failure, not a missing feature. "
+            f"stderr: {result.stderr.strip()[:2000]}",
+            file=sys.stderr,
+        )
+        return FlagSupport.PROBE_FAILED
+
+    if flag in result.stdout:
+        return FlagSupport.SUPPORTED
+    return FlagSupport.UNSUPPORTED
 
 
 def _resolve_element(element: Any, secrets: dict[str, str], pattern: re.Pattern) -> Any:  # type: ignore[type-arg]

--- a/metadata-ingestion/src/datahub/executor/wrappers/run_ingest.py
+++ b/metadata-ingestion/src/datahub/executor/wrappers/run_ingest.py
@@ -24,6 +24,7 @@ import sys
 from pathlib import Path
 
 from datahub.executor.execution.wrapper_common import (
+    FlagSupport,
     activate_venv,
     build_datahub_stdin,
     check_cli_flag_support,
@@ -53,15 +54,15 @@ def main():
     setup_memory_limit()
     register_secrets_for_masking(secrets)
 
-    has_report_to = check_cli_flag_support(venv_datahub, "report-to")
-    if has_report_to:
+    report_to_support = check_cli_flag_support(venv_datahub, "report-to")
+    if report_to_support is FlagSupport.SUPPORTED:
         print(
             "This version of datahub supports report-to functionality", file=sys.stderr
         )
         report_path = Path(report_out_file)
         if report_path.exists():
             report_path.unlink()
-    else:
+    elif report_to_support is FlagSupport.UNSUPPORTED:
         print(
             "Warning: This version of datahub does not support --report-to",
             file=sys.stderr,
@@ -73,7 +74,7 @@ def main():
     if debug_mode.lower() == "true":
         cmd.append("--debug")
     cmd.extend(["ingest", "run", "-c", "-"])
-    if has_report_to:
+    if report_to_support is FlagSupport.SUPPORTED:
         cmd.extend(["--report-to", report_out_file])
 
     sys.exit(run_datahub_subprocess(cmd, datahub_stdin))

--- a/metadata-ingestion/src/datahub/executor/wrappers/run_test_connection.py
+++ b/metadata-ingestion/src/datahub/executor/wrappers/run_test_connection.py
@@ -25,6 +25,7 @@ import sys
 from pathlib import Path
 
 from datahub.executor.execution.wrapper_common import (
+    FlagSupport,
     activate_venv,
     build_datahub_stdin,
     check_cli_flag_support,
@@ -34,6 +35,21 @@ from datahub.executor.execution.wrapper_common import (
     setup_memory_limit,
     validate_venv,
 )
+
+
+def create_probe_failure_report(report_out_file: str) -> None:
+    """Create a report for a CLI that could not answer the capability probe."""
+    report = {
+        "internal_failure": True,
+        "internal_failure_reason": (
+            "The datahub CLI in this environment failed to run, so the connection was "
+            "never tested. This is an environment problem rather than a recipe problem "
+            "-- see the execution logs for the CLI's own error."
+        ),
+    }
+
+    with open(report_out_file, "w") as f:
+        json.dump(report, f, indent=2)
 
 
 def create_unsupported_report(report_out_file: str) -> None:
@@ -73,8 +89,11 @@ def main():
     setup_memory_limit()
     register_secrets_for_masking(secrets)
 
-    has_test_connection = check_cli_flag_support(venv_datahub, "test-source-connection")
-    if not has_test_connection:
+    support = check_cli_flag_support(venv_datahub, "test-source-connection")
+    if support is FlagSupport.PROBE_FAILED:
+        create_probe_failure_report(report_out_file)
+        sys.exit(1)
+    if support is FlagSupport.UNSUPPORTED:
         create_unsupported_report(report_out_file)
         sys.exit(0)
 

--- a/metadata-ingestion/tests/unit/executor/wrappers/test_wrapper_common.py
+++ b/metadata-ingestion/tests/unit/executor/wrappers/test_wrapper_common.py
@@ -17,7 +17,7 @@ import pytest
 import yaml
 
 from datahub.executor.execution import wrapper_common
-from datahub.executor.wrappers import run_ingest
+from datahub.executor.wrappers import run_ingest, run_test_connection
 
 
 class TestParseBoolEnv:
@@ -183,7 +183,11 @@ class TestWrapperStdinContent:
         with (
             patch.object(sys, "argv", ["wrapper", str(tmp_path / "venv")]),
             patch.object(sys, "stdin", io.StringIO(envelope)),
-            patch.object(run_ingest, "check_cli_flag_support", return_value=True),
+            patch.object(
+                run_ingest,
+                "check_cli_flag_support",
+                return_value=wrapper_common.FlagSupport.SUPPORTED,
+            ),
             patch.object(run_ingest, "register_secrets_for_masking"),
             patch(
                 "datahub.executor.execution.wrapper_common.subprocess.Popen",
@@ -204,3 +208,155 @@ class TestWrapperStdinContent:
         # from whatever `datahub` happens to be on PATH.
         cmd = mock_popen.call_args[0][0]
         assert cmd[0] == str(venv_dir / "datahub")
+
+
+class TestCliFlagProbe:
+    """The probe reports a failure, an absent flag and a present flag separately."""
+
+    def _script(self, tmp_path: Path, name: str, body: str) -> Path:
+        path = tmp_path / name
+        path.write_text(f"#!/bin/sh\n{body}\n")
+        path.chmod(0o755)
+        return path
+
+    def test_a_failing_probe_surfaces_its_own_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        broken = self._script(
+            tmp_path,
+            "broken",
+            "echo 'ImportError: no module named snowflake' >&2\nexit 1",
+        )
+
+        assert (
+            wrapper_common.check_cli_flag_support(broken, "some-flag")
+            is wrapper_common.FlagSupport.PROBE_FAILED
+        )
+        assert "ImportError: no module named snowflake" in capsys.readouterr().err
+
+    def test_a_genuinely_missing_flag_is_reported_silently(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        old_cli = self._script(
+            tmp_path, "old", "echo 'Usage: datahub ingest run'\nexit 0"
+        )
+
+        assert (
+            wrapper_common.check_cli_flag_support(old_cli, "some-flag")
+            is wrapper_common.FlagSupport.UNSUPPORTED
+        )
+        assert capsys.readouterr().err == ""
+
+    def test_a_supported_flag_is_reported_as_supported(self, tmp_path: Path) -> None:
+        new_cli = self._script(
+            tmp_path, "new", "echo 'Usage: datahub ingest run --some-flag'\nexit 0"
+        )
+
+        assert (
+            wrapper_common.check_cli_flag_support(new_cli, "some-flag")
+            is wrapper_common.FlagSupport.SUPPORTED
+        )
+
+
+class TestIngestProbeOutcome:
+    """Ingestion passes --report-to only when the probe confirmed support."""
+
+    def _cmd_for_probe(
+        self, outcome: wrapper_common.FlagSupport, tmp_path: Path
+    ) -> list[str]:
+        envelope = json.dumps(
+            {
+                "__recipe_yaml__": yaml.dump({"source": {"type": "test"}}),
+                "__secrets__": {},
+                "__report_out_file__": str(tmp_path / "report.json"),
+                "__debug_mode__": "false",
+            }
+        )
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = iter([])
+        mock_process.wait.return_value = 0
+
+        venv_dir = tmp_path / "venv" / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "python").touch()
+        (venv_dir / "datahub").touch()
+
+        with (
+            patch.object(sys, "argv", ["wrapper", str(tmp_path / "venv")]),
+            patch.object(sys, "stdin", io.StringIO(envelope)),
+            patch.object(run_ingest, "check_cli_flag_support", return_value=outcome),
+            patch.object(run_ingest, "register_secrets_for_masking"),
+            patch(
+                "datahub.executor.execution.wrapper_common.subprocess.Popen",
+                return_value=mock_process,
+            ) as mock_popen,
+            pytest.raises(SystemExit),
+        ):
+            run_ingest.main()
+
+        return list(mock_popen.call_args[0][0])
+
+    def test_a_failed_probe_does_not_pass_the_flag(self, tmp_path: Path) -> None:
+        cmd = self._cmd_for_probe(wrapper_common.FlagSupport.PROBE_FAILED, tmp_path)
+
+        assert "--report-to" not in cmd
+
+    def test_a_supported_flag_is_passed(self, tmp_path: Path) -> None:
+        cmd = self._cmd_for_probe(wrapper_common.FlagSupport.SUPPORTED, tmp_path)
+
+        assert "--report-to" in cmd
+
+
+class TestTestConnectionProbeOutcome:
+    """Test connection exits nonzero for a failed probe, zero for an old CLI."""
+
+    def _run_with_probe(
+        self, outcome: wrapper_common.FlagSupport, tmp_path: Path
+    ) -> tuple[int, dict]:
+        report_out = tmp_path / "connection_report.json"
+        envelope = json.dumps(
+            {
+                "__recipe_yaml__": yaml.dump({"source": {"type": "test"}}),
+                "__secrets__": {},
+                "__report_out_file__": str(report_out),
+            }
+        )
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").touch()
+        (venv_bin / "datahub").touch()
+
+        with (
+            patch.object(sys, "argv", ["wrapper", str(tmp_path / "venv")]),
+            patch.object(sys, "stdin", io.StringIO(envelope)),
+            patch.object(
+                run_test_connection, "check_cli_flag_support", return_value=outcome
+            ),
+            patch.object(run_test_connection, "register_secrets_for_masking"),
+            pytest.raises(SystemExit) as exit_info,
+        ):
+            run_test_connection.main()
+
+        code = exit_info.value.code
+        assert isinstance(code, int)
+        return code, json.loads(report_out.read_text())
+
+    def test_a_broken_cli_exits_nonzero(self, tmp_path: Path) -> None:
+        code, report = self._run_with_probe(
+            wrapper_common.FlagSupport.PROBE_FAILED, tmp_path
+        )
+
+        assert code != 0
+        assert report["internal_failure"] is True
+        # The old-version wording belongs to the other report.
+        assert "old version" not in report["internal_failure_reason"]
+
+    def test_an_old_cli_still_exits_cleanly(self, tmp_path: Path) -> None:
+        code, report = self._run_with_probe(
+            wrapper_common.FlagSupport.UNSUPPORTED, tmp_path
+        )
+
+        assert code == 0
+        assert report["internal_failure"] is True
+        assert "old version" in report["internal_failure_reason"]


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes.

## What was wrong

The wrapper decides what the CLI can do by running `ingest run --help` and looking for a flag in the output. Three outcomes collapsed into a single `False`: the flag is genuinely absent, the binary would not launch, or the CLI ran and crashed. The probe also ignored `returncode` entirely and only grepped stdout — so a CLI that ran and failed was indistinguishable from an old one, and silently, since `subprocess.run` itself had succeeded.

For **test connection** that meant a broken venv exited 0 — reported as a successful run — carrying a report that blamed an old CLI version, while the real `ImportError` went only to the logs. `validate_venv` checks that `bin/datahub` exists, never that it runs, and cached venvs are reused, so the false success repeated on every attempt until someone cleared the cache. Anyone debugging it was sent after the wrong problem.

## What changed

`check_cli_flag_support` now checks the exit code, surfaces the CLI's own stderr, and returns a three-state `FlagSupport`.

- **Test connection** exits nonzero when the probe could not answer, with a report saying the environment is broken, and still exits 0 for a genuinely old CLI.
- **Ingestion** is unchanged in behaviour: it degrades to the legacy reporting path as before, and the run then fails with the CLI's own error.

An enum rather than `Optional[bool]` deliberately: `if not has_flag` is what collapsed these cases in the first place, and a bool carrying a third value invites the same slip.

**No timeout is added to the probe, and that is deliberate.** One existed before; cold starts on import-heavy venvs outran it, which switched runs to a legacy reporting path and made scheduled runs vanish from the ingestion UI. `test_slow_help_probe_does_not_fall_back_to_cli_mode` guards it.

> **Note for anyone syncing this elsewhere:** `wrapper_common` and `run_test_connection` must move together. Every enum member is truthy, so a partial pickup would hand an old CLI the flag it cannot support.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — probe outcomes, plus the ingest and test-connection behaviour for each
- [x] Behaviour change is intentional and scoped to test connection (nonzero exit on a broken venv, where it previously reported success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test connection so a broken CLI environment exits nonzero and reports an environment problem, instead of exiting 0 and blaming an old CLI version.

- The capability probe now checks the exit code, surfaces the CLI's stderr, and returns a three-state `FlagSupport` enum instead of a bool.
- Ingestion behavior is unchanged: a failed probe degrades to the legacy reporting path as before.

**Rollout notes**
- `wrapper_common` and `run_test_connection` must move together when syncing; every enum member is truthy, so a partial pickup would pass an unsupported flag.
- No timeout is added to the probe, deliberately: a prior timeout misreported cold starts and made scheduled runs vanish from the ingestion UI.

<sup>Written for commit ad4ac88fff903352ba7426fb1d4f8334b99f9959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

