### PR TITLE
fix(executor): stop logging requirement contents into the execution report

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -60,9 +60,10 @@ def _expand_pip_req(req: str) -> str:
 
 _DEFAULT_MAX_LOG_LINES = 2000
 _DEFAULT_MAX_BYTES_PER_LINE = 2**12  # 4kb
-# Kafka has a 1mb limit on the size of a data packet.
-# Doing 90% of that so we have some buffer for other things.
-_DEFAULT_MAX_LOG_SIZE_BYTES = int(0.9 * 2**18)  # 90% of 1mb
+# Bounds the output captured on a SubprocessRunner failure, i.e. what gets attached to
+# CalledProcessError when a venv-setup command fails. Not the cap on ingestion logs:
+# those go through LogHolder.get_lines() and SubProcessTaskUtil.MAX_LOG_SIZE_BYTES.
+_DEFAULT_MAX_LOG_SIZE_BYTES = int(0.9 * 2**18)  # ~230kb
 
 VENV_VERSION_LATEST = "latest"
 VENV_VERSION_BUNDLED = "bundled"
@@ -547,10 +548,19 @@ async def setup_venv(
     if venv_config.requirements_file is not None:
         # Case 2: the caller supplied its own requirements file, so install from it
         # verbatim rather than composing an acryl-datahub requirement line.
-        runner._logs.append(
-            f"Installing requirements from: {venv_config.requirements_file}\n"
+        # Contents are not logged: a caller-supplied requirements file may carry index
+        # credentials, and these logs reach the execution report.
+        req_line_count = len(
+            [
+                line
+                for line in venv_config.requirements_file.read_text().splitlines()
+                if line.strip() and not line.lstrip().startswith("#")
+            ]
         )
-        await runner.execute(["cat", str(venv_config.requirements_file)])
+        runner._logs.append(
+            f"Installing {req_line_count} requirement(s) from: "
+            f"{venv_config.requirements_file}\n"
+        )
         install_cmd = [
             _find_uv(),
             "pip",
@@ -613,8 +623,15 @@ async def setup_venv(
     if venv_config.requirements_file is None and expanded_pip_reqs:
         extra_req_file = venv_loc / "extra-requirements.txt"
         extra_req_file.write_text("\n".join(expanded_pip_reqs))
-        runner._logs.append(f"Installing extra requirements from: {extra_req_file}\n")
-        await runner.execute(["cat", str(extra_req_file)])
+        # Log the requirement lines as configured, not the expanded file: ${VAR}
+        # templates are commonly index-URL credentials, and expanded values reach the
+        # execution report, which is readable with Manage Ingestion alone.
+        runner._logs.append(
+            f"Installing {len(expanded_pip_reqs)} extra requirement(s) from: "
+            f"{extra_req_file}\n"
+        )
+        for req in venv_config.extra_pip_requirements:
+            runner._logs.append(f"  {req}\n")
         await runner.execute(
             [_find_uv(), "pip", "install", "-r", str(extra_req_file)],
             env=venv_env,

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Iterator
 from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -1405,3 +1406,67 @@ def test_get_stable_venv_name_stable_when_env_var_unchanged(
         ],
     )
     assert config.get_stable_venv_name() == config.get_stable_venv_name()
+
+
+class TestRequirementLoggingDoesNotLeakCredentials:
+    """The requirement lines setup_venv logs are as configured, never expanded."""
+
+    @pytest.fixture
+    def recording_runner(self) -> Iterator[tuple[SubprocessRunner, LogHolder]]:
+        """A runner whose `uv venv` creates the venv but installs are no-ops."""
+        logs = LogHolder()
+        runner = SubprocessRunner(logs=logs)
+
+        async def fake_execute(cmd: list, *_args: object, **_kwargs: object) -> None:
+            if len(cmd) > 1 and cmd[1] == "venv":
+                loc = Path(cmd[-1])
+                (loc / "bin").mkdir(parents=True, exist_ok=True)
+                (loc / "bin" / "python").touch()
+            return None
+
+        with (
+            patch.object(runner, "execute", AsyncMock(side_effect=fake_execute)),
+            patch("datahub.executor.execution.runner._find_uv", return_value="uv"),
+        ):
+            yield runner, logs
+
+    async def test_extra_requirements_are_logged_unexpanded(
+        self,
+        recording_runner: tuple[SubprocessRunner, LogHolder],
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("PYPI_TOKEN", "SUPERSECRET_TOKEN_abc123")
+        runner, logs = recording_runner
+        config = VenvConfig(
+            version="1.0.0",
+            main_plugin="demo-data",
+            extra_pip_requirements=[
+                "--extra-index-url https://user:${PYPI_TOKEN}@pypi.acme.com/simple",
+            ],
+        )
+
+        await setup_venv(config, runner, tmp_path)
+
+        text = "".join(logs.get_lines())
+        assert "SUPERSECRET_TOKEN_abc123" not in text
+        # The configured line is still logged, placeholder intact.
+        assert "https://user:${PYPI_TOKEN}@pypi.acme.com/simple" in text
+
+    async def test_a_supplied_requirements_file_is_summarised_not_dumped(
+        self, recording_runner: tuple[SubprocessRunner, LogHolder], tmp_path: Path
+    ) -> None:
+        runner, logs = recording_runner
+        req = tmp_path / "requirements.txt"
+        req.write_text(
+            "# comment\n\n--extra-index-url https://u:SUPERSECRET_basic@idx/simple\nacme==1.0\n"
+        )
+        config = VenvConfig(
+            version="1.0.0", main_plugin="demo-data", requirements_file=req
+        )
+
+        await setup_venv(config, runner, tmp_path)
+
+        text = "".join(logs.get_lines())
+        assert "SUPERSECRET_basic" not in text
+        assert "2 requirement(s)" in text  # blanks and comments not counted


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes.

## What was wrong

`setup_venv` ran `cat` on the requirements files it was about to install and appended the output to the runner's logs, which become part of the execution report. The report is readable with the **Manage Ingestion** privilege alone, so a credential in a requirement line was exposed to a wider audience than the secret store it came from.

Two paths, both leaking:

- A **caller-supplied requirements file** was `cat`'d verbatim. Such files commonly carry `--index-url` or `--extra-index-url` with credentials embedded in the host.
- **Composed `extra_pip_requirements`** were `cat`'d *after* `${VAR}` expansion, so the logged text held the resolved secret values rather than the templates.

## What changed

Neither is `cat`'d any more.

- The supplied-file path logs a count of non-comment lines instead.
- The composed path logs the requirement lines **as configured** — templates unexpanded — which keeps the diagnostic value of seeing what was asked for without publishing what it resolved to.

Also corrects the comment on `_DEFAULT_MAX_LOG_SIZE_BYTES`, which described a Kafka packet limit it has nothing to do with: it bounds the output attached to `CalledProcessError` when a venv-setup command fails, not the ingestion log cap.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — both paths asserted to log counts/templates and not file contents
- [x] No breaking change (log text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `setup_venv` from logging requirement file contents into the execution report, which was exposing credentials to anyone with Manage Ingestion privilege.

**Bug Fixes**
- Caller-supplied requirements files are now logged as a count of non-comment lines instead of being `cat`'d verbatim.
- Composed `extra_pip_requirements` are logged as configured (templates unexpanded) rather than after `${VAR}` expansion.
- Corrects the `_DEFAULT_MAX_LOG_SIZE_BYTES` comment, which incorrectly referenced a Kafka packet limit; it bounds output attached to `CalledProcessError` on venv-setup failure.

<sup>Written for commit 6f06d6fc82867594b9739d617aee2c2edc512214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

