### PR TITLE
fix(executor): coerce non-string extra_env_vars values

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
@@ -246,7 +246,7 @@ class SubProcessRecipeTaskArgs(PermissiveConfigModel):
 
     extra_pip_requirements: list[str] = []
     extra_pip_plugins: list[str] = []
-    extra_env_vars: dict = {}
+    extra_env_vars: dict[str, str] = {}
 
     @pydantic.field_validator(
         "extra_pip_requirements", "extra_pip_plugins", mode="before"
@@ -263,8 +263,20 @@ class SubProcessRecipeTaskArgs(PermissiveConfigModel):
     def parse_json_dict_field(cls, v: Any) -> dict:
         if isinstance(v, str):
             # Handle corner case where UI passes an empty string
-            return {} if v == "" else json.loads(v)
-        return v
+            v = {} if v == "" else json.loads(v)
+        if not isinstance(v, dict):
+            return v
+        coerced = {}
+        for key, value in v.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                coerced[key] = str(value).lower()
+            elif isinstance(value, (int, float)):
+                coerced[key] = str(value)
+            else:
+                coerced[key] = value
+        return coerced
 
     def get_venv_name(self, plugin: str) -> str:
         """Generate venv name, consistent with VenvConfig.get_stable_venv_name().

--- a/metadata-ingestion/tests/unit/executor/test_sub_process_task_common.py
+++ b/metadata-ingestion/tests/unit/executor/test_sub_process_task_common.py
@@ -476,3 +476,43 @@ class TestGetCombinedEnvVars:
         assert combined_env.get("TEST_VAR1") == "user_override1"
         assert combined_env.get("TEST_VAR2") == "user_override2"
         assert combined_env.get("NEW_VAR") == "new_value"
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(8080, "8080"), (True, "true"), (False, "false"), (1.5, "1.5")],
+        ids=["int", "true", "false", "float"],
+    )
+    def test_non_string_scalars_are_coerced(self, value: object, expected: str) -> None:
+        """Coerces ints and floats to strings, and bools to lowercase strings."""
+        args = SubProcessRecipeTaskArgs(
+            recipe='{"source": {"type": "test"}}',
+            version="0.12.0",
+            extra_env_vars={"VAR": value},
+        )
+
+        assert args.get_combined_env_vars().get("VAR") == expected
+
+    def test_none_values_are_dropped_rather_than_passed_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drops keys whose value is None, rather than passing None through."""
+        monkeypatch.delenv("VAR", raising=False)
+
+        args = SubProcessRecipeTaskArgs(
+            recipe='{"source": {"type": "test"}}',
+            version="0.12.0",
+            extra_env_vars={"VAR": None},
+        )
+
+        assert "VAR" not in args.get_combined_env_vars()
+
+    def test_container_values_are_rejected_naming_the_key(self) -> None:
+        """Rejects a container value during validation, naming the key."""
+        with pytest.raises(ValidationError) as exc_info:
+            SubProcessRecipeTaskArgs(
+                recipe='{"source": {"type": "test"}}',
+                version="0.12.0",
+                extra_env_vars={"NESTED": {"a": 1}},
+            )
+
+        assert "NESTED" in str(exc_info.value)


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes.

## What was wrong

`extra_env_vars` was typed as a bare `dict` and passed straight into the subprocess environment. `os.environ` rejects non-string values, so a recipe setting a numeric or boolean env var — `{"PORT": 8080}` or `{"DEBUG": true}`, both of which JSON round-trip from the UI as their native types — failed at spawn time with a `TypeError` from deep inside the process launch, nowhere near the recipe field that caused it.

## What changed

Scalars are coerced at validation:

- ints and floats stringified
- bools lowercased to `"true"` / `"false"`, so they read as the shell conventions rather than Python's `"True"`
- `None` drops the key entirely instead of passing `None` through, matching how an unset variable behaves

Typing the field `dict[str, str]` also makes pydantic reject container values outright, naming the offending key, rather than letting a dict or list through to fail unattributably at spawn time.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — coercion per scalar type, `None` dropping, and container rejection
- [x] No breaking change (previously these inputs crashed the spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `extra_env_vars` so numeric, boolean, and `None` values are handled at validation instead of crashing the subprocess spawn with a cryptic `TypeError` from deep in the process launch.

- Coerces ints and floats to strings, and lowercases bools to `"true"`/`"false"` to match shell conventions.
- Drops `None` values entirely instead of passing them through.
- Typing the field as `dict[str, str]` lets pydantic reject dict/list values during validation, naming the offending key.

<sup>Written for commit 00307f8e804a9574bcb8c29ea5ea0033a780babf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

