### PR TITLE
fix(executor): make Task an ABC so incomplete tasks are rejected

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/task.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from datahub.executor.common.config import ConfigModel
 from datahub.executor.context.execution_context import ExecutionContext
@@ -33,7 +33,7 @@ class TaskError(Exception):
     """An error occurred when executing a task"""
 
 
-class Task:
+class Task(ABC):
     @classmethod
     @abstractmethod
     def create(cls, config: dict, ctx: ExecutorContext) -> "Task":

--- a/metadata-ingestion/tests/unit/executor/test_task_registry.py
+++ b/metadata-ingestion/tests/unit/executor/test_task_registry.py
@@ -75,21 +75,3 @@ class TestRegistryResolvesRetiredPaths:
         registry.register_lazy("BOGUS", "acryl.executor.execution.nope.Nope")
         with pytest.raises(EnvironmentError):
             registry.get("BOGUS")
-
-
-class TestIncompleteTasksAreRejected:
-    """The registry rejects a Task subclass that is missing a required method."""
-
-    def test_a_subclass_missing_execute_is_rejected(self) -> None:
-        class MissingExecute(Task):
-            @classmethod
-            def create(cls, config: dict, ctx: object) -> "MissingExecute":  # type: ignore[override]
-                return cls()
-
-            def close(self) -> None:
-                pass
-
-        registry: TaskRegistry = TaskRegistry()
-        with pytest.raises(ValueError, match="abstract"):
-            # The abstract class is the subject of the test; mypy flags it here.
-            registry.register("RUN_INGEST", MissingExecute)  # type: ignore[type-abstract]

--- a/metadata-ingestion/tests/unit/executor/test_task_registry.py
+++ b/metadata-ingestion/tests/unit/executor/test_task_registry.py
@@ -75,3 +75,21 @@ class TestRegistryResolvesRetiredPaths:
         registry.register_lazy("BOGUS", "acryl.executor.execution.nope.Nope")
         with pytest.raises(EnvironmentError):
             registry.get("BOGUS")
+
+
+class TestIncompleteTasksAreRejected:
+    """The registry rejects a Task subclass that is missing a required method."""
+
+    def test_a_subclass_missing_execute_is_rejected(self) -> None:
+        class MissingExecute(Task):
+            @classmethod
+            def create(cls, config: dict, ctx: object) -> "MissingExecute":  # type: ignore[override]
+                return cls()
+
+            def close(self) -> None:
+                pass
+
+        registry: TaskRegistry = TaskRegistry()
+        with pytest.raises(ValueError, match="abstract"):
+            # The abstract class is the subject of the test; mypy flags it here.
+            registry.register("RUN_INGEST", MissingExecute)  # type: ignore[type-abstract]


### PR DESCRIPTION
Split out of #19435, which bundled six independent fixes.

## What was wrong

`Task` declared `create` / `execute` / `close` with `@abstractmethod` but did not inherit `ABC`, which makes the decorator inert — `abstractmethod` only blocks instantiation via `ABCMeta`.

A subclass missing `execute()` instantiated cleanly and failed later, at the point the executor called the method that was never implemented, surfacing as an `AttributeError` mid-execution rather than at registration.

## What changed

Inheriting `ABC` makes the omission a `TypeError` at construction — where the task is loaded from the registry, and where the failure names the missing methods.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added — `test_task_registry.py` asserts an incomplete subclass is rejected at construction
- [x] No breaking change (all in-tree `Task` subclasses implement the full interface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`Task` now inherits `ABC`, so subclasses that omit required methods are rejected with an abstract-class error at registration instead of surfacing as an `AttributeError` mid-execution.

- All in-tree `Task` subclasses implement the full interface, so no breaking change.

<sup>Written for commit fd7ef133e1833b20acfe579627c4faa9e07fe8dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

