### PR TITLE
fix(openapi): redact unauthorized lineage scroll endpoints as restricted

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
@@ -193,10 +193,13 @@ public final class ScrollUtils {
 
     // Label each edge with its upstream/downstream endpoints, then drop edges running the wrong
     // way relative to the anchor urns (a no-op when direction or urns are absent).
+    Map<Urn, Urn> restrictCache = new HashMap<>();
+    Function<Urn, Urn> cachedRestrict =
+        cachedRestrictFunction(opContext, restrictedService, restrictCache);
     List<LineageRelationship> lineage =
         toLineageRelationships(result.getEntities(), lineageRegistry).stream()
             .filter(edge -> keepByLineageDirection(edge, urns, direction))
-            .map(edge -> restrictUnauthorizedLineageEndpoints(opContext, restrictedService, edge))
+            .map(edge -> restrictUnauthorizedLineageEndpoints(cachedRestrict, edge))
             .collect(Collectors.toList());
 
     return ResponseEntity.ok(
@@ -241,25 +244,28 @@ public final class ScrollUtils {
     }
   }
 
+  private static Function<Urn, Urn> cachedRestrictFunction(
+      OperationContext opContext, RestrictedService restrictedService, Map<Urn, Urn> cache) {
+    return urn ->
+        cache.computeIfAbsent(
+            urn,
+            key -> {
+              if (AuthUtil.isAPIAuthorizedUrns(opContext, RELATIONSHIP, READ, List.of(key))) {
+                return key;
+              }
+              return restrictedService.encryptRestrictedUrn(key);
+            });
+  }
+
   /**
-   * Replaces endpoints the caller cannot {@link ApiOperation#READ} via {@link
-   * ApiGroup#RELATIONSHIP} with encrypted {@code urn:li:restricted:…} placeholders — same contract
-   * as GraphQL lineage and Rest.li {@code scrollAcrossLineage}.
+   * Replaces endpoints the caller cannot {@link
+   * com.linkedin.metadata.authorization.ApiOperation#READ} via {@link
+   * com.linkedin.metadata.authorization.ApiGroup#RELATIONSHIP} with encrypted {@code
+   * urn:li:restricted:…} placeholders — same contract as GraphQL lineage and Rest.li {@code
+   * scrollAcrossLineage}.
    */
   static LineageRelationship restrictUnauthorizedLineageEndpoints(
-      OperationContext opContext, RestrictedService restrictedService, LineageRelationship edge) {
-    Map<Urn, Urn> cache = new HashMap<>();
-    Function<Urn, Urn> cachedRestrict =
-        urn ->
-            cache.computeIfAbsent(
-                urn,
-                key -> {
-                  if (AuthUtil.isAPIAuthorizedUrns(opContext, RELATIONSHIP, READ, List.of(key))) {
-                    return key;
-                  }
-                  return restrictedService.encryptRestrictedUrn(key);
-                });
-
+      Function<Urn, Urn> cachedRestrict, LineageRelationship edge) {
     Urn upstream = cachedRestrict.apply(UrnUtils.getUrn(edge.getUpstream()));
     Urn downstream = cachedRestrict.apply(UrnUtils.getUrn(edge.getDownstream()));
     Urn source = cachedRestrict.apply(UrnUtils.getUrn(edge.getSource().getUrn()));

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/ScrollUtils.java
@@ -27,6 +27,7 @@ import com.linkedin.metadata.utils.CriterionUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.metadata.context.usage.UsageOperation;
+import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.openapi.exception.UnauthorizedException;
 import io.datahubproject.openapi.models.GenericScrollResult;
 import io.datahubproject.openapi.v2.models.GenericRelationship;
@@ -34,9 +35,12 @@ import io.datahubproject.openapi.v3.models.LineageRelationship;
 import io.datahubproject.openapi.v3.models.ScrollRelationshipsRequestBody;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -144,6 +148,7 @@ public final class ScrollUtils {
   public static ResponseEntity<GenericScrollResult<LineageRelationship>> doScrollLineage(
       OperationContext systemOperationContext,
       AuthorizerChain authorizationChain,
+      RestrictedService restrictedService,
       GraphService graphService,
       HttpServletRequest request,
       String operationName,
@@ -191,16 +196,8 @@ public final class ScrollUtils {
     List<LineageRelationship> lineage =
         toLineageRelationships(result.getEntities(), lineageRegistry).stream()
             .filter(edge -> keepByLineageDirection(edge, urns, direction))
+            .map(edge -> restrictUnauthorizedLineageEndpoints(opContext, restrictedService, edge))
             .collect(Collectors.toList());
-
-    Set<Urn> resultUrns =
-        lineage.stream()
-            .flatMap(
-                edge ->
-                    Stream.of(
-                        UrnUtils.getUrn(edge.getUpstream()), UrnUtils.getUrn(edge.getDownstream())))
-            .collect(Collectors.toSet());
-    checkAuthorizedOnUrns(opContext, resultUrns);
 
     return ResponseEntity.ok(
         GenericScrollResult.<LineageRelationship>builder()
@@ -244,10 +241,38 @@ public final class ScrollUtils {
     }
   }
 
-  private static void checkAuthorizedOnUrns(OperationContext opContext, Set<Urn> urns) {
-    if (!AuthUtil.isAPIAuthorizedUrns(opContext, RELATIONSHIP, READ, urns)) {
-      throw unauthorized();
-    }
+  /**
+   * Replaces endpoints the caller cannot {@link ApiOperation#READ} via {@link
+   * ApiGroup#RELATIONSHIP} with encrypted {@code urn:li:restricted:…} placeholders — same contract
+   * as GraphQL lineage and Rest.li {@code scrollAcrossLineage}.
+   */
+  static LineageRelationship restrictUnauthorizedLineageEndpoints(
+      OperationContext opContext, RestrictedService restrictedService, LineageRelationship edge) {
+    Map<Urn, Urn> cache = new HashMap<>();
+    Function<Urn, Urn> cachedRestrict =
+        urn ->
+            cache.computeIfAbsent(
+                urn,
+                key -> {
+                  if (AuthUtil.isAPIAuthorizedUrns(opContext, RELATIONSHIP, READ, List.of(key))) {
+                    return key;
+                  }
+                  return restrictedService.encryptRestrictedUrn(key);
+                });
+
+    Urn upstream = cachedRestrict.apply(UrnUtils.getUrn(edge.getUpstream()));
+    Urn downstream = cachedRestrict.apply(UrnUtils.getUrn(edge.getDownstream()));
+    Urn source = cachedRestrict.apply(UrnUtils.getUrn(edge.getSource().getUrn()));
+    Urn destination = cachedRestrict.apply(UrnUtils.getUrn(edge.getDestination().getUrn()));
+
+    return LineageRelationship.builder()
+        .relationshipType(edge.getRelationshipType())
+        .source(GenericRelationship.GenericNode.fromUrn(source))
+        .destination(GenericRelationship.GenericNode.fromUrn(destination))
+        .upstream(upstream.toString())
+        .downstream(downstream.toString())
+        .properties(edge.getProperties())
+        .build();
   }
 
   private static UnauthorizedException unauthorized() {

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/LineageController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/LineageController.java
@@ -5,6 +5,7 @@ import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.LineageDirection;
 import com.linkedin.metadata.models.registry.LineageRegistry;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.openapi.controller.ScrollUtils;
 import io.datahubproject.openapi.models.GenericScrollResult;
 import io.datahubproject.openapi.v3.models.LineageRelationship;
@@ -35,6 +36,7 @@ public class LineageController {
 
   @Autowired private GraphService graphService;
   @Autowired private AuthorizerChain authorizationChain;
+  @Autowired private RestrictedService restrictedService;
 
   @Qualifier("systemOperationContext")
   @Autowired
@@ -80,6 +82,7 @@ public class LineageController {
     return ScrollUtils.doScrollLineage(
         systemOperationContext,
         authorizationChain,
+        restrictedService,
         graphService,
         request,
         "scrollLineage",

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/LineageControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/LineageControllerTest.java
@@ -13,6 +13,7 @@ import com.datahub.authorization.AuthUtil;
 import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizerChain;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
@@ -28,6 +29,7 @@ import com.linkedin.metadata.query.filter.RelationshipDirection;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.usage.UsageOperation;
+import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
 import io.datahubproject.openapi.config.SpringWebConfig;
 import io.datahubproject.openapi.config.TracingInterceptor;
@@ -131,6 +133,18 @@ public class LineageControllerTest extends AbstractTestNGSpringContextTests {
       AuthenticationContext.setAuthentication(authentication);
 
       return authorizerChain;
+    }
+
+    @Bean
+    public RestrictedService restrictedService() {
+      RestrictedService restrictedService = mock(RestrictedService.class);
+      when(restrictedService.encryptRestrictedUrn(any()))
+          .thenAnswer(
+              invocation -> {
+                Urn urn = invocation.getArgument(0);
+                return new Urn("restricted", "redacted-" + urn.getEntityType());
+              });
+      return restrictedService;
     }
   }
 
@@ -410,7 +424,7 @@ public class LineageControllerTest extends AbstractTestNGSpringContextTests {
   }
 
   @Test
-  public void testScrollLineageUnauthorizedOnResultsReturnsForbidden() throws Exception {
+  public void testScrollLineageUnauthorizedOnResultsReturnsRestrictedUrns() throws Exception {
     stubLineageRegistry(
         "dataset", "Consumes", RelationshipDirection.OUTGOING, RelationshipDirection.INCOMING);
     stubScrollRelatedEntities(
@@ -439,7 +453,11 @@ public class LineageControllerTest extends AbstractTestNGSpringContextTests {
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                   .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isForbidden());
+          .andExpect(status().is2xxSuccessful())
+          .andExpect(jsonPath("$.results.length()").value(2))
+          .andExpect(jsonPath("$.results[0].upstream").value("urn:li:restricted:redacted-dataset"))
+          .andExpect(
+              jsonPath("$.results[0].downstream").value("urn:li:restricted:redacted-dataset"));
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the authorization gap between OpenAPI lineage scroll and the existing Rest.li (`scrollAcrossLineage`) and GraphQL lineage APIs.

Previously, OpenAPI returned 403 for the entire scroll page when any result endpoint was unauthorized. Rest.li and GraphQL instead redact individual endpoints the caller cannot READ via RELATIONSHIP into `urn:li:restricted:…` placeholders while still returning a successful response. This change brings OpenAPI in line with that contract.

- OpenAPI lineage scroll now encrypts unauthorized upstream, downstream, source, and destination URNs via `RestrictedService` per lineage edge.
- Updates `LineageControllerTest` to expect restricted URNs on unauthorized endpoints rather than a forbidden response.

## Test plan

- [x] `./gradlew spotlessApply`
- [x] `./gradlew :metadata-service:openapi-servlet:test --tests io.datahubproject.openapi.v3.controller.LineageControllerTest` (10 passing)

## Related

https://github.com/datahub-project/datahub/pull/19428