### PR TITLE
fix(dataProduct): batch unset side effect graph queries for large membership writes

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidator.java
@@ -86,13 +86,20 @@ public class DataProductMembershipAuthorizationValidator
         extractProposedProductDomainsAspects(batchItems);
     List<AspectValidationException> failures = new ArrayList<>();
 
+    Set<Urn> productsNeedingDomains = new HashSet<>(changedAssetsByProduct.keySet());
+    productsNeedingDomains.addAll(nameChangeProducts);
+    Map<Urn, Map<String, Aspect>> persistedProductDomainsAspects =
+        productsNeedingDomains.isEmpty()
+            ? Map.of()
+            : aspectRetriever.getLatestAspectObjects(
+                operationContext, productsNeedingDomains, Set.of(DOMAINS_ASPECT_NAME));
+
     if (!membershipChanges.isEmpty()) {
       Set<Urn> unauthorizedMembership =
           EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-              operationContext,
               session,
-              aspectRetriever,
               changedAssetsByProduct,
+              persistedProductDomainsAspects,
               proposedProductDomainsAspects);
 
       for (BatchItem item : membershipChanges) {
@@ -109,10 +116,9 @@ public class DataProductMembershipAuthorizationValidator
     if (!nameChangeProducts.isEmpty()) {
       Set<Urn> unauthorizedRenames =
           EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
-              operationContext,
               session,
-              aspectRetriever,
               nameChangeProducts,
+              persistedProductDomainsAspects,
               proposedProductDomainsAspects);
 
       for (BatchItem item : items) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtils.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.query.QuerySubject;
 import com.linkedin.query.QuerySubjects;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -208,12 +209,37 @@ public final class EntityAspectAuthorizationUtils {
         proposedProductDomainsAspects);
   }
 
+  /**
+   * Like {@link #filterUnauthorizedToManageDataProductMembership(OperationFingerprint,
+   * AuthorizationSession, AspectRetriever, Map, Map)} but uses caller-supplied persisted {@code
+   * domains} aspects (avoids a redundant read when membership and rename checks share one fetch).
+   */
+  @Nonnull
+  public static Set<Urn> filterUnauthorizedToManageDataProductMembership(
+      @Nonnull AuthorizationSession session,
+      @Nonnull Map<Urn, Set<Urn>> changedAssetsByProduct,
+      @Nonnull Map<Urn, Map<String, Aspect>> persistedProductDomainsAspects,
+      @Nonnull Map<Urn, Aspect> proposedProductDomainsAspects) {
+    if (changedAssetsByProduct.isEmpty()) {
+      return Set.of();
+    }
+
+    Map<Urn, Boolean> assetAuthCache = new HashMap<>();
+    return filterUnauthorizedToManageDataProductMembership(
+        session,
+        changedAssetsByProduct,
+        persistedProductDomainsAspects,
+        proposedProductDomainsAspects,
+        assetAuthCache);
+  }
+
   @Nonnull
   private static Set<Urn> filterUnauthorizedToManageDataProductMembership(
       @Nonnull AuthorizationSession session,
       @Nonnull Map<Urn, Set<Urn>> changedAssetsByProduct,
       @Nonnull Map<Urn, Map<String, Aspect>> persistedProductDomainsAspects,
-      @Nonnull Map<Urn, Aspect> proposedProductDomainsAspects) {
+      @Nonnull Map<Urn, Aspect> proposedProductDomainsAspects,
+      @Nonnull Map<Urn, Boolean> assetAuthCache) {
     Set<Urn> unauthorized = new HashSet<>();
     for (Map.Entry<Urn, Set<Urn>> entry : changedAssetsByProduct.entrySet()) {
       Urn dataProductUrn = entry.getKey();
@@ -228,7 +254,8 @@ public final class EntityAspectAuthorizationUtils {
       }
       Set<Urn> productDomainUrns = resolveUniqueDomainUrns(productDomainsAspect);
 
-      if (!isAuthorizedToChangeDataProductMembership(session, productDomainUrns, changedAssets)) {
+      if (!isAuthorizedToChangeDataProductMembership(
+          session, productDomainUrns, changedAssets, assetAuthCache)) {
         unauthorized.add(dataProductUrn);
       }
     }
@@ -271,6 +298,27 @@ public final class EntityAspectAuthorizationUtils {
             new HashSet<>(dataProductUrnsWithNameChange),
             Set.of(DOMAINS_ASPECT_NAME));
 
+    return filterUnauthorizedToRenameDataProduct(
+        session,
+        dataProductUrnsWithNameChange,
+        persistedProductDomainsAspects,
+        proposedProductDomainsAspects);
+  }
+
+  /**
+   * Like {@link #filterUnauthorizedToRenameDataProduct(OperationFingerprint, AuthorizationSession,
+   * AspectRetriever, Set, Map)} but uses caller-supplied persisted {@code domains} aspects.
+   */
+  @Nonnull
+  public static Set<Urn> filterUnauthorizedToRenameDataProduct(
+      @Nonnull AuthorizationSession session,
+      @Nonnull Set<Urn> dataProductUrnsWithNameChange,
+      @Nonnull Map<Urn, Map<String, Aspect>> persistedProductDomainsAspects,
+      @Nonnull Map<Urn, Aspect> proposedProductDomainsAspects) {
+    if (dataProductUrnsWithNameChange.isEmpty()) {
+      return Set.of();
+    }
+
     Set<Urn> unauthorized = new HashSet<>();
     for (Urn dataProductUrn : dataProductUrnsWithNameChange) {
       Aspect productDomainsAspect = proposedProductDomainsAspects.get(dataProductUrn);
@@ -307,19 +355,29 @@ public final class EntityAspectAuthorizationUtils {
       @Nonnull AuthorizationSession session,
       @Nonnull Set<Urn> productDomainUrns,
       @Nonnull Set<Urn> changedAssetUrns) {
+    return isAuthorizedToChangeDataProductMembership(
+        session, productDomainUrns, changedAssetUrns, new HashMap<>());
+  }
+
+  static boolean isAuthorizedToChangeDataProductMembership(
+      @Nonnull AuthorizationSession session,
+      @Nonnull Set<Urn> productDomainUrns,
+      @Nonnull Set<Urn> changedAssetUrns,
+      @Nonnull Map<Urn, Boolean> assetAuthCache) {
     if (changedAssetUrns.isEmpty()) {
       return false;
     }
 
-    boolean productSide =
-        !productDomainUrns.isEmpty()
-            && isAuthorizedToManageDataProductsOnAnyDomain(session, productDomainUrns);
+    if (!productDomainUrns.isEmpty()
+        && isAuthorizedToManageDataProductsOnAnyDomain(session, productDomainUrns)) {
+      return true;
+    }
 
-    boolean assetSide =
-        changedAssetUrns.stream()
-            .allMatch(asset -> isAuthorizedToEditDataProductMembershipOnAsset(session, asset));
-
-    return productSide || assetSide;
+    return changedAssetUrns.stream()
+        .allMatch(
+            asset ->
+                assetAuthCache.computeIfAbsent(
+                    asset, key -> isAuthorizedToEditDataProductMembershipOnAsset(session, key)));
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
@@ -26,11 +26,12 @@ import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.utils.CriterionUtils;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,6 +58,10 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
 
   /** Max asset URNs per graph scroll when batching unset lookups. */
   static final int GRAPH_SCROLL_CHUNK_SIZE = 100;
+
+  /** Stable sort for graph scroll pagination within a batched asset chunk. */
+  static final List<SortCriterion> GRAPH_SCROLL_SORT =
+      List.of(new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING));
 
   @Nonnull private AspectPluginConfig config;
 
@@ -215,7 +220,7 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
               EMPTY_FILTER,
               Set.of("DataProductContains"),
               QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-              Collections.emptyList(),
+              GRAPH_SCROLL_SORT,
               scrollId,
               GRAPH_SCROLL_CHUNK_SIZE,
               null,

--- a/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
@@ -5,11 +5,12 @@ import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAM
 import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
 
 import com.datahub.context.OperationFingerprint;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.dataproduct.DataProductAssociation;
 import com.linkedin.dataproduct.DataProductAssociationArray;
 import com.linkedin.dataproduct.DataProductProperties;
-import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.GraphRetriever;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
 import com.linkedin.metadata.aspect.batch.MCLItem;
@@ -23,12 +24,15 @@ import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
 import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
 import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.utils.QueryUtils;
+import com.linkedin.metadata.utils.CriterionUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +54,10 @@ import lombok.extern.slf4j.Slf4j;
 @Setter
 @Accessors(chain = true)
 public class DataProductUnsetSideEffect extends MCPSideEffect {
+
+  /** Max asset URNs per graph scroll when batching unset lookups. */
+  static final int GRAPH_SCROLL_CHUNK_SIZE = 100;
+
   @Nonnull private AspectPluginConfig config;
 
   @Override
@@ -85,25 +93,45 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
       DataProductProperties previousDataProductProperties =
           mclItem.getPreviousAspect(DataProductProperties.class);
 
-      if (!ChangeType.UPSERT.equals(mclItem.getChangeType())
-          || previousDataProductProperties == null) {
-        // CREATE/CREATE_ENTITY/RESTATE
+      if (previousDataProductProperties == null) {
         return generateUnsetMCPs(mclItem, newDataProductAssociationArray, retrieverContext);
-      } else {
-        // UPSERT with previous
-        DataProductAssociationArray oldDataProductAssociationArray =
-            Optional.ofNullable(previousDataProductProperties.getAssets())
-                .orElse(new DataProductAssociationArray());
-
-        DataProductAssociationArray additions =
-            newDataProductAssociationArray.stream()
-                .filter(association -> !oldDataProductAssociationArray.contains(association))
-                .collect(Collectors.toCollection(DataProductAssociationArray::new));
-
-        return generateUnsetMCPs(mclItem, additions, retrieverContext);
       }
+
+      DataProductAssociationArray additions =
+          computeAssetAdditions(previousDataProductProperties, newDataProductAssociationArray);
+      return generateUnsetMCPs(mclItem, additions, retrieverContext);
     }
     return Stream.empty();
+  }
+
+  @Nonnull
+  static DataProductAssociationArray computeAssetAdditions(
+      @Nonnull DataProductProperties previousDataProductProperties,
+      @Nonnull DataProductAssociationArray newDataProductAssociationArray) {
+    Set<String> previousDestinationUrns =
+        extractDestinationUrns(
+            Optional.ofNullable(previousDataProductProperties.getAssets())
+                .orElse(new DataProductAssociationArray()));
+
+    return newDataProductAssociationArray.stream()
+        .filter(
+            association ->
+                association.hasDestinationUrn()
+                    && !previousDestinationUrns.contains(
+                        association.getDestinationUrn().toString()))
+        .collect(Collectors.toCollection(DataProductAssociationArray::new));
+  }
+
+  @Nonnull
+  private static Set<String> extractDestinationUrns(
+      @Nonnull DataProductAssociationArray associations) {
+    Set<String> urns = new HashSet<>();
+    for (DataProductAssociation association : associations) {
+      if (association.hasDestinationUrn()) {
+        urns.add(association.getDestinationUrn().toString());
+      }
+    }
+    return urns;
   }
 
   private static Stream<MCPItem> generateUnsetMCPs(
@@ -113,37 +141,26 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
     List<MCPItem> mcpItems = new ArrayList<>();
     Map<String, List<GenericJsonPatch.PatchOp>> patchOpMap = new HashMap<>();
 
-    for (DataProductAssociation dataProductAssociation : dataProductAssociations) {
-      RelatedEntitiesScrollResult result =
-          retrieverContext
-              .getGraphRetriever()
-              .scrollRelatedEntities(
-                  null,
-                  QueryUtils.newFilter(
-                      "urn", dataProductAssociation.getDestinationUrn().toString()),
-                  null,
-                  EMPTY_FILTER,
-                  Set.of("DataProductContains"),
-                  QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-                  Collections.emptyList(),
-                  null,
-                  10, // Should only ever be one, if ever greater than ten will decrease over time
-                  // to become consistent
-                  null,
-                  null);
-      if (!result.getEntities().isEmpty()) {
-        for (RelatedEntities entity : result.getEntities()) {
-          if (!dataProductItem.getUrn().equals(UrnUtils.getUrn(entity.getSourceUrn()))) {
-            GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
-            patchOp.setOp(PatchOperationType.REMOVE.getValue());
-            patchOp.setPath(String.format("/assets/%s", entity.getDestinationUrn()));
-            patchOpMap
-                .computeIfAbsent(entity.getSourceUrn(), urn -> new ArrayList<>())
-                .add(patchOp);
-          }
-        }
+    List<String> destinationUrns = new ArrayList<>();
+    for (DataProductAssociation association : dataProductAssociations) {
+      if (association.hasDestinationUrn()) {
+        destinationUrns.add(association.getDestinationUrn().toString());
       }
     }
+
+    if (destinationUrns.isEmpty()) {
+      return Stream.empty();
+    }
+
+    GraphRetriever graphRetriever = retrieverContext.getGraphRetriever();
+    for (int offset = 0; offset < destinationUrns.size(); offset += GRAPH_SCROLL_CHUNK_SIZE) {
+      List<String> chunk =
+          destinationUrns.subList(
+              offset, Math.min(offset + GRAPH_SCROLL_CHUNK_SIZE, destinationUrns.size()));
+      scrollRelatedDataProductsForAssets(
+          graphRetriever, chunk, dataProductItem.getUrn(), patchOpMap);
+    }
+
     for (String urn : patchOpMap.keySet()) {
       EntitySpec entitySpec =
           retrieverContext
@@ -175,5 +192,50 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
     }
 
     return mcpItems.stream();
+  }
+
+  private static void scrollRelatedDataProductsForAssets(
+      @Nonnull GraphRetriever graphRetriever,
+      @Nonnull List<String> assetDestinationUrns,
+      @Nonnull Urn currentDataProductUrn,
+      @Nonnull Map<String, List<GenericJsonPatch.PatchOp>> patchOpMap) {
+    if (assetDestinationUrns.isEmpty()) {
+      return;
+    }
+
+    String scrollId = null;
+    boolean hasMore = true;
+    while (hasMore) {
+      RelatedEntitiesScrollResult result =
+          graphRetriever.scrollRelatedEntities(
+              null,
+              QueryUtils.newFilter(
+                  CriterionUtils.buildCriterion("urn", Condition.EQUAL, assetDestinationUrns)),
+              null,
+              EMPTY_FILTER,
+              Set.of("DataProductContains"),
+              QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
+              Collections.emptyList(),
+              scrollId,
+              GRAPH_SCROLL_CHUNK_SIZE,
+              null,
+              null);
+
+      if (result.getEntities().isEmpty()) {
+        break;
+      }
+
+      for (RelatedEntities entity : result.getEntities()) {
+        if (!currentDataProductUrn.equals(UrnUtils.getUrn(entity.getSourceUrn()))) {
+          GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+          patchOp.setOp(PatchOperationType.REMOVE.getValue());
+          patchOp.setPath(String.format("/assets/%s", entity.getDestinationUrn()));
+          patchOpMap.computeIfAbsent(entity.getSourceUrn(), urn -> new ArrayList<>()).add(patchOp);
+        }
+      }
+
+      scrollId = result.getScrollId();
+      hasMore = scrollId != null && !scrollId.isEmpty();
+    }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffect.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
 import com.linkedin.metadata.aspect.batch.MCLItem;
 import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
@@ -26,8 +27,6 @@ import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
-import com.linkedin.metadata.query.filter.SortCriterion;
-import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.utils.CriterionUtils;
 import java.util.ArrayList;
@@ -58,10 +57,6 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
 
   /** Max asset URNs per graph scroll when batching unset lookups. */
   static final int GRAPH_SCROLL_CHUNK_SIZE = 100;
-
-  /** Stable sort for graph scroll pagination within a batched asset chunk. */
-  static final List<SortCriterion> GRAPH_SCROLL_SORT =
-      List.of(new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING));
 
   @Nonnull private AspectPluginConfig config;
 
@@ -220,7 +215,7 @@ public class DataProductUnsetSideEffect extends MCPSideEffect {
               EMPTY_FILTER,
               Set.of("DataProductContains"),
               QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-              GRAPH_SCROLL_SORT,
+              Edge.EDGE_SORT_CRITERION,
               scrollId,
               GRAPH_SCROLL_CHUNK_SIZE,
               null,

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DataProductMembershipAuthorizationValidatorTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.aspect.validation;
 
 import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.DOMAINS_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -81,11 +82,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                    any(),
-                    eq(mockAuthSession),
-                    eq(mockAspectRetriever),
-                    any(Map.class),
-                    any(Map.class)))
+                    eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of(DATA_PRODUCT_URN));
 
     TestMCP item = upsertItem(proposed);
@@ -103,11 +100,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                    any(),
-                    eq(mockAuthSession),
-                    eq(mockAspectRetriever),
-                    any(Map.class),
-                    any(Map.class)))
+                    eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of());
 
     TestMCP item = upsertItem(proposed);
@@ -128,7 +121,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
-                    any(), any(), any(), any(Set.class), any(Map.class)))
+                    eq(mockAuthSession), any(Set.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of());
 
     TestMCP item = upsertItem(proposed);
@@ -137,11 +130,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
     authUtilsMockedStatic.verify(
         () ->
             EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
-                any(),
-                eq(mockAuthSession),
-                eq(mockAspectRetriever),
-                eq(Set.of(DATA_PRODUCT_URN)),
-                any(Map.class)));
+                eq(mockAuthSession), eq(Set.of(DATA_PRODUCT_URN)), any(Map.class), any(Map.class)));
   }
 
   @Test
@@ -156,7 +145,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
-                    any(), any(), any(), any(Set.class), any(Map.class)))
+                    eq(mockAuthSession), any(Set.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of(DATA_PRODUCT_URN));
 
     TestMCP item = upsertItem(proposed);
@@ -175,7 +164,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                    any(), any(), any(), any(Map.class), any(Map.class)))
+                    eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of());
 
     TestMCP item = upsertItem(proposed);
@@ -184,11 +173,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
     authUtilsMockedStatic.verify(
         () ->
             EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                any(),
-                eq(mockAuthSession),
-                eq(mockAspectRetriever),
-                any(Map.class),
-                any(Map.class)));
+                eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)));
   }
 
   @Test
@@ -201,11 +186,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
         .when(
             () ->
                 EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                    any(),
-                    eq(mockAuthSession),
-                    eq(mockAspectRetriever),
-                    any(Map.class),
-                    any(Map.class)))
+                    eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)))
         .thenReturn(Set.of());
 
     TestMCP item = upsertItem(proposed);
@@ -214,11 +195,7 @@ public class DataProductMembershipAuthorizationValidatorTest {
     authUtilsMockedStatic.verify(
         () ->
             EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
-                any(),
-                eq(mockAuthSession),
-                eq(mockAspectRetriever),
-                any(Map.class),
-                any(Map.class)));
+                eq(mockAuthSession), any(Map.class), any(Map.class), any(Map.class)));
   }
 
   private void mockCurrentProperties(DataProductProperties current) {
@@ -226,6 +203,9 @@ public class DataProductMembershipAuthorizationValidatorTest {
     when(mockAspectRetriever.getLatestAspectObjects(
             any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))))
         .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of(DATA_PRODUCT_PROPERTIES_ASPECT_NAME, aspect)));
+    when(mockAspectRetriever.getLatestAspectObjects(
+            any(), eq(Set.of(DATA_PRODUCT_URN)), eq(Set.of(DOMAINS_ASPECT_NAME))))
+        .thenReturn(Map.of(DATA_PRODUCT_URN, Map.of()));
   }
 
   private static DataProductProperties propertiesWithAssets(Urn assetUrn) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/EntityAspectAuthorizationUtilsTest.java
@@ -885,4 +885,94 @@ public class EntityAspectAuthorizationUtilsTest {
 
     Assert.assertEquals(viewable, Set.of(QUERY_URN));
   }
+
+  @Test
+  public void testFilterUnauthorizedToManageDataProductMembership_dedupsAssetAuthAcrossProducts() {
+    Urn otherProduct = UrnUtils.getUrn("urn:li:dataProduct:other-auth-test");
+    Urn sharedAsset = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,shared,PROD)");
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("dataset", sharedAsset.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
+            mockAuthSession,
+            Map.of(
+                DATA_PRODUCT_URN, Set.of(sharedAsset),
+                otherProduct, Set.of(sharedAsset)),
+            Map.of(),
+            Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+    authUtilMockedStatic.verify(
+        () ->
+            AuthUtil.isAuthorized(
+                eq(mockAuthSession),
+                any(DisjunctivePrivilegeGroup.class),
+                eq(new EntitySpec("dataset", sharedAsset.toString()))),
+        times(1));
+  }
+
+  @Test
+  public void testFilterUnauthorizedToManageDataProductMembership_productSideSkipsAssetAuth() {
+    Domains productDomains = new Domains();
+    productDomains.setDomains(new UrnArray(DOMAIN_A));
+    Aspect persistedDomains = new Aspect(productDomains.data());
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("domain", DOMAIN_A.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToManageDataProductMembership(
+            mockAuthSession,
+            Map.of(DATA_PRODUCT_URN, Set.of(ASSET_URN)),
+            Map.of(DATA_PRODUCT_URN, Map.of(DOMAINS_ASPECT_NAME, persistedDomains)),
+            Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+    authUtilMockedStatic.verify(
+        () ->
+            AuthUtil.isAuthorized(
+                eq(mockAuthSession),
+                any(DisjunctivePrivilegeGroup.class),
+                eq(new EntitySpec("dataset", ASSET_URN.toString()))),
+        times(0));
+  }
+
+  @Test
+  public void testFilterUnauthorizedToRenameDataProduct_usesPreloadedPersistedDomains() {
+    Domains productDomains = new Domains();
+    productDomains.setDomains(new UrnArray(DOMAIN_A));
+    Aspect persistedDomains = new Aspect(productDomains.data());
+
+    authUtilMockedStatic
+        .when(
+            () ->
+                AuthUtil.isAuthorized(
+                    eq(mockAuthSession),
+                    any(DisjunctivePrivilegeGroup.class),
+                    eq(new EntitySpec("domain", DOMAIN_A.toString()))))
+        .thenReturn(true);
+
+    Set<Urn> unauthorized =
+        EntityAspectAuthorizationUtils.filterUnauthorizedToRenameDataProduct(
+            mockAuthSession,
+            Set.of(DATA_PRODUCT_URN),
+            Map.of(DATA_PRODUCT_URN, Map.of(DOMAINS_ASPECT_NAME, persistedDomains)),
+            Map.of());
+
+    Assert.assertTrue(unauthorized.isEmpty());
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
@@ -3,15 +3,23 @@ package com.linkedin.metadata.dataproducts.sideeffects;
 import static com.linkedin.metadata.Constants.DATA_PRODUCT_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATA_PRODUCT_PROPERTIES_ASPECT_NAME;
 import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.context.OperationFingerprint;
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.dataproduct.DataProductAssociation;
 import com.linkedin.dataproduct.DataProductAssociationArray;
 import com.linkedin.dataproduct.DataProductProperties;
@@ -31,17 +39,24 @@ import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.entity.ebean.batch.MCLItemImpl;
 import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.test.metadata.aspect.TestEntityRegistry;
 import io.datahubproject.metadata.context.RetrieverContext;
 import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -77,66 +92,17 @@ public class DataProductUnsetSideEffectTest {
           .build();
 
   private CachingAspectRetriever mockAspectRetriever;
+  private GraphRetriever graphRetriever;
   private RetrieverContext retrieverContext;
+  private final Map<String, Urn> existingProductByAsset = new HashMap<>();
 
   @BeforeMethod
   public void setup() {
     mockAspectRetriever = mock(CachingAspectRetriever.class);
     when(mockAspectRetriever.getEntityRegistry()).thenReturn(TEST_REGISTRY);
-    GraphRetriever graphRetriever = mock(GraphRetriever.class);
-    RelatedEntities relatedEntities =
-        new RelatedEntities(
-            "DataProductContains",
-            TEST_PRODUCT_URN.toString(),
-            DATASET_URN_1.toString(),
-            RelationshipDirection.INCOMING,
-            null);
-
-    List<RelatedEntities> relatedEntitiesList = new ArrayList<>();
-    relatedEntitiesList.add(relatedEntities);
-    RelatedEntitiesScrollResult relatedEntitiesScrollResult =
-        new RelatedEntitiesScrollResult(1, 10, null, relatedEntitiesList);
-    when(graphRetriever.scrollRelatedEntities(
-            eq(null),
-            eq(QueryUtils.newFilter("urn", DATASET_URN_1.toString())),
-            eq(null),
-            eq(EMPTY_FILTER),
-            eq(ImmutableSet.of("DataProductContains")),
-            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(Collections.emptyList()),
-            eq(null),
-            eq(10), // Should only ever be one, if ever greater than ten will decrease over time to
-            // become consistent
-            eq(null),
-            eq(null)))
-        .thenReturn(relatedEntitiesScrollResult);
-
-    RelatedEntities relatedEntities2 =
-        new RelatedEntities(
-            "DataProductContains",
-            TEST_PRODUCT_URN_2.toString(),
-            DATASET_URN_2.toString(),
-            RelationshipDirection.INCOMING,
-            null);
-
-    List<RelatedEntities> relatedEntitiesList2 = new ArrayList<>();
-    relatedEntitiesList2.add(relatedEntities2);
-    RelatedEntitiesScrollResult relatedEntitiesScrollResult2 =
-        new RelatedEntitiesScrollResult(1, 10, null, relatedEntitiesList2);
-    when(graphRetriever.scrollRelatedEntities(
-            eq(null),
-            eq(QueryUtils.newFilter("urn", DATASET_URN_2.toString())),
-            eq(null),
-            eq(EMPTY_FILTER),
-            eq(ImmutableSet.of("DataProductContains")),
-            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(Collections.emptyList()),
-            eq(null),
-            eq(10), // Should only ever be one, if ever greater than ten will decrease over time to
-            // become consistent
-            eq(null),
-            eq(null)))
-        .thenReturn(relatedEntitiesScrollResult2);
+    graphRetriever = mock(GraphRetriever.class);
+    existingProductByAsset.clear();
+    stubBatchGraphScroll();
     retrieverContext =
         RetrieverContext.builder()
             .searchRetriever(mock(SearchRetriever.class))
@@ -145,8 +111,72 @@ public class DataProductUnsetSideEffectTest {
             .build();
   }
 
+  private void registerAssetInProduct(Urn assetUrn, Urn dataProductUrn) {
+    existingProductByAsset.put(assetUrn.toString(), dataProductUrn);
+  }
+
+  private void stubBatchGraphScroll() {
+    when(graphRetriever.scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(Collections.emptyList()),
+            any(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull()))
+        .thenAnswer(
+            invocation -> {
+              Set<String> requestedUrns = extractUrnFilterValues(invocation.getArgument(1));
+              List<RelatedEntities> entities = new ArrayList<>();
+              for (Map.Entry<String, Urn> entry : existingProductByAsset.entrySet()) {
+                if (requestedUrns.isEmpty() || requestedUrns.contains(entry.getKey())) {
+                  entities.add(
+                      new RelatedEntities(
+                          "DataProductContains",
+                          entry.getValue().toString(),
+                          entry.getKey(),
+                          RelationshipDirection.INCOMING,
+                          null));
+                }
+              }
+              return new RelatedEntitiesScrollResult(
+                  entities.size(),
+                  DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE,
+                  null,
+                  entities);
+            });
+  }
+
+  private MCLItemImpl buildMclItem(ChangeItemImpl changeItem, RecordTemplate previousAspect) {
+    return MCLItemImpl.builder()
+        .build(changeItem, previousAspect, null, retrieverContext.getAspectRetriever());
+  }
+
+  private static Set<String> extractUrnFilterValues(Filter filter) {
+    Set<String> urns = new HashSet<>();
+    if (filter == null || filter.getOr() == null) {
+      return urns;
+    }
+    for (ConjunctiveCriterion conjunction : filter.getOr()) {
+      if (conjunction.getAnd() == null) {
+        continue;
+      }
+      for (Criterion criterion : conjunction.getAnd()) {
+        if ("urn".equals(criterion.getField()) && criterion.getValues() != null) {
+          urns.addAll(criterion.getValues());
+        }
+      }
+    }
+    return urns;
+  }
+
   @Test
   public void testDPAlreadySetToSame() {
+    registerAssetInProduct(DATASET_URN_1, TEST_PRODUCT_URN);
     DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);
 
@@ -186,6 +216,7 @@ public class DataProductUnsetSideEffectTest {
 
   @Test
   public void testDPRemoveOld() {
+    registerAssetInProduct(DATASET_URN_2, TEST_PRODUCT_URN_2);
     DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);
 
@@ -256,48 +287,15 @@ public class DataProductUnsetSideEffectTest {
     DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);
 
-    // Create 100 dataset URNs and set up their existing relationships
     List<Urn> datasetUrns = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
       Urn datasetUrn =
           UrnUtils.getUrn(
               String.format("urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_%d,PROD)", i));
       datasetUrns.add(datasetUrn);
-
-      // Mock the existing relationship for each dataset with the old data product
-      RelatedEntities relatedEntities =
-          new RelatedEntities(
-              "DataProductContains",
-              TEST_PRODUCT_URN_2.toString(), // Old data product
-              datasetUrn.toString(),
-              RelationshipDirection.INCOMING,
-              null);
-
-      List<RelatedEntities> relatedEntitiesList = new ArrayList<>();
-      relatedEntitiesList.add(relatedEntities);
-      RelatedEntitiesScrollResult relatedEntitiesScrollResult =
-          new RelatedEntitiesScrollResult(1, 10, null, relatedEntitiesList);
-
-      when(retrieverContext
-              .getGraphRetriever()
-              .scrollRelatedEntities(
-                  eq(null),
-                  eq(QueryUtils.newFilter("urn", datasetUrn.toString())),
-                  eq(null),
-                  eq(EMPTY_FILTER),
-                  eq(ImmutableSet.of("DataProductContains")),
-                  eq(
-                      QueryUtils.newRelationshipFilter(
-                          EMPTY_FILTER, RelationshipDirection.INCOMING)),
-                  eq(Collections.emptyList()),
-                  eq(null),
-                  eq(10),
-                  eq(null),
-                  eq(null)))
-          .thenReturn(relatedEntitiesScrollResult);
+      registerAssetInProduct(datasetUrn, TEST_PRODUCT_URN_2);
     }
 
-    // Create data product properties with all 100 assets
     DataProductProperties dataProductProperties = new DataProductProperties();
     DataProductAssociationArray dataProductAssociations = new DataProductAssociationArray();
     for (Urn datasetUrn : datasetUrns) {
@@ -307,10 +305,9 @@ public class DataProductUnsetSideEffectTest {
     }
     dataProductProperties.setAssets(dataProductAssociations);
 
-    // Run test
     ChangeItemImpl dataProductPropertiesChangeItem =
         ChangeItemImpl.builder()
-            .urn(TEST_PRODUCT_URN) // New data product
+            .urn(TEST_PRODUCT_URN)
             .aspectName(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
             .changeType(ChangeType.UPSERT)
             .entitySpec(TEST_REGISTRY.getEntitySpec(DATA_PRODUCT_ENTITY_NAME))
@@ -335,30 +332,134 @@ public class DataProductUnsetSideEffectTest {
                 retrieverContext)
             .toList();
 
-    // Verify test
     assertEquals(testOutput.size(), 1, "Expected one patch to remove assets from old data product");
+    verify(graphRetriever, atMost(1))
+        .scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(Collections.emptyList()),
+            any(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull());
 
     MCPItem patchItem = testOutput.get(0);
     assertEquals(
         patchItem.getUrn(), TEST_PRODUCT_URN_2, "Patch should target the old data product");
     assertEquals(patchItem.getAspectName(), DATA_PRODUCT_PROPERTIES_ASPECT_NAME);
 
-    // Verify the patch contains remove operations for all 100 assets
     JsonArray patchArray = ((PatchItemImpl) patchItem).getPatch().toJsonArray();
     assertEquals(patchArray.size(), 100, "Should have 100 remove operations");
+  }
 
-    // Verify each remove operation
-    for (int i = 0; i < 100; i++) {
-      JsonObject op = patchArray.getJsonObject(i);
-      assertEquals(op.getString("op"), PatchOperationType.REMOVE.getValue());
-      assertEquals(
-          op.getString("path"),
-          String.format("/assets/urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_%d,PROD)", i));
-    }
+  @Test
+  public void testUpsertWithOnlyAuditStampChangeSkipsGraphScroll() {
+    DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    DataProductProperties previousProperties = new DataProductProperties();
+    DataProductAssociation previousAssociation = new DataProductAssociation();
+    previousAssociation.setDestinationUrn(DATASET_URN_1);
+    previousAssociation.setCreated(
+        new AuditStamp().setTime(1L).setActor(UrnUtils.getUrn("urn:li:corpuser:old")));
+    DataProductAssociationArray previousAssociations = new DataProductAssociationArray();
+    previousAssociations.add(previousAssociation);
+    previousProperties.setAssets(previousAssociations);
+
+    DataProductProperties newProperties = new DataProductProperties();
+    DataProductAssociation newAssociation = new DataProductAssociation();
+    newAssociation.setDestinationUrn(DATASET_URN_1);
+    newAssociation.setCreated(
+        new AuditStamp().setTime(2L).setActor(UrnUtils.getUrn("urn:li:corpuser:new")));
+    DataProductAssociationArray newAssociations = new DataProductAssociationArray();
+    newAssociations.add(newAssociation);
+    newProperties.setAssets(newAssociations);
+
+    SystemAspect prevData = mock(SystemAspect.class);
+    when(prevData.getRecordTemplate()).thenReturn(previousProperties);
+
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(TEST_PRODUCT_URN)
+            .aspectName(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
+            .changeType(ChangeType.UPSERT)
+            .entitySpec(TEST_REGISTRY.getEntitySpec(DATA_PRODUCT_ENTITY_NAME))
+            .aspectSpec(
+                TEST_REGISTRY
+                    .getEntitySpec(DATA_PRODUCT_ENTITY_NAME)
+                    .getAspectSpec(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(newProperties)
+            .previousSystemAspect(prevData)
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    List<MCPItem> output =
+        test.postMCPSideEffect(
+                OperationFingerprint.EMPTY,
+                List.of(buildMclItem(changeItem, previousProperties)),
+                retrieverContext)
+            .toList();
+
+    assertTrue(output.isEmpty(), "Unchanged destination URNs should not trigger graph scroll");
+    verify(graphRetriever, never())
+        .scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(Collections.emptyList()),
+            any(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull());
+  }
+
+  @Test
+  public void testRestateWithPreviousUsesDeltaOnly() {
+    registerAssetInProduct(DATASET_URN_2, TEST_PRODUCT_URN_2);
+    DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    DataProductProperties previousProperties = getTestDataProductProperties(DATASET_URN_1);
+    DataProductProperties newProperties = new DataProductProperties();
+    DataProductAssociationArray newAssociations = new DataProductAssociationArray();
+    DataProductAssociation existing = new DataProductAssociation();
+    existing.setDestinationUrn(DATASET_URN_1);
+    DataProductAssociation added = new DataProductAssociation();
+    added.setDestinationUrn(DATASET_URN_2);
+    newAssociations.add(existing);
+    newAssociations.add(added);
+    newProperties.setAssets(newAssociations);
+
+    MCLItemImpl mclItem =
+        MCLItemImpl.builder()
+            .metadataChangeLog(
+                new MetadataChangeLog()
+                    .setEntityUrn(TEST_PRODUCT_URN)
+                    .setEntityType(DATA_PRODUCT_ENTITY_NAME)
+                    .setChangeType(ChangeType.RESTATE)
+                    .setAspectName(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
+                    .setAspect(GenericRecordUtils.serializeAspect(newProperties))
+                    .setPreviousAspectValue(GenericRecordUtils.serializeAspect(previousProperties))
+                    .setCreated(AuditStampUtils.createDefaultAuditStamp()))
+            .build(retrieverContext.getAspectRetriever());
+
+    List<MCPItem> output =
+        test.postMCPSideEffect(OperationFingerprint.EMPTY, List.of(mclItem), retrieverContext)
+            .toList();
+
+    assertEquals(output.size(), 1, "Only the newly added asset should trigger unset");
   }
 
   @Test
   public void testUpsertWithPreviousAspect() {
+    registerAssetInProduct(DATASET_URN_2, TEST_PRODUCT_URN_2);
     DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);
 
@@ -403,13 +504,7 @@ public class DataProductUnsetSideEffectTest {
     List<MCPItem> testOutput =
         test.postMCPSideEffect(
                 OperationFingerprint.EMPTY,
-                List.of(
-                    MCLItemImpl.builder()
-                        .build(
-                            dataProductPropertiesChangeItem,
-                            null,
-                            null,
-                            retrieverContext.getAspectRetriever())),
+                List.of(buildMclItem(dataProductPropertiesChangeItem, previousProperties)),
                 retrieverContext)
             .toList();
 
@@ -432,7 +527,7 @@ public class DataProductUnsetSideEffectTest {
     sameProperties.setAssets(sameAssociations);
 
     SystemAspect prevSameData = mock(SystemAspect.class);
-    when(prevData.getRecordTemplate()).thenReturn(sameProperties);
+    when(prevSameData.getRecordTemplate()).thenReturn(sameProperties);
 
     ChangeItemImpl noChangeItem =
         ChangeItemImpl.builder()
@@ -452,9 +547,7 @@ public class DataProductUnsetSideEffectTest {
     List<MCPItem> noChangeOutput =
         test.postMCPSideEffect(
                 OperationFingerprint.EMPTY,
-                List.of(
-                    MCLItemImpl.builder()
-                        .build(noChangeItem, null, null, retrieverContext.getAspectRetriever())),
+                List.of(buildMclItem(noChangeItem, sameProperties)),
                 retrieverContext)
             .toList();
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
@@ -30,6 +30,7 @@ import com.linkedin.metadata.aspect.CachingAspectRetriever;
 import com.linkedin.metadata.aspect.GraphRetriever;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
@@ -127,7 +128,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -345,7 +346,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -419,7 +420,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -457,7 +458,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             isNull(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -476,7 +477,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             eq("page-2"),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -517,7 +518,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -581,7 +582,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq(Edge.EDGE_SORT_CRITERION),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),

--- a/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dataproducts/sideeffects/DataProductUnsetSideEffectTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -51,7 +53,6 @@ import com.linkedin.test.metadata.aspect.TestEntityRegistry;
 import io.datahubproject.metadata.context.RetrieverContext;
 import jakarta.json.JsonArray;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -70,6 +71,9 @@ public class DataProductUnsetSideEffectTest {
 
   private static final Urn TEST_PRODUCT_URN_2 =
       UrnUtils.getUrn("urn:li:dataProduct:someOtherDataProductId");
+
+  private static final Urn TEST_PRODUCT_URN_3 =
+      UrnUtils.getUrn("urn:li:dataProduct:thirdDataProductId");
 
   private static final Urn DATASET_URN_1 =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)");
@@ -123,7 +127,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(Collections.emptyList()),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -341,7 +345,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(Collections.emptyList()),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -354,6 +358,170 @@ public class DataProductUnsetSideEffectTest {
 
     JsonArray patchArray = ((PatchItemImpl) patchItem).getPatch().toJsonArray();
     assertEquals(patchArray.size(), 100, "Should have 100 remove operations");
+  }
+
+  @Test
+  public void testBulkAssetMoveUsesMultipleChunks() {
+    DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    List<Urn> datasetUrns = new ArrayList<>();
+    for (int i = 0; i < 150; i++) {
+      Urn datasetUrn =
+          UrnUtils.getUrn(
+              String.format("urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_%d,PROD)", i));
+      datasetUrns.add(datasetUrn);
+      registerAssetInProduct(datasetUrn, TEST_PRODUCT_URN_2);
+    }
+
+    DataProductProperties dataProductProperties = new DataProductProperties();
+    DataProductAssociationArray dataProductAssociations = new DataProductAssociationArray();
+    for (Urn datasetUrn : datasetUrns) {
+      DataProductAssociation association = new DataProductAssociation();
+      association.setDestinationUrn(datasetUrn);
+      dataProductAssociations.add(association);
+    }
+    dataProductProperties.setAssets(dataProductAssociations);
+
+    ChangeItemImpl dataProductPropertiesChangeItem =
+        ChangeItemImpl.builder()
+            .urn(TEST_PRODUCT_URN)
+            .aspectName(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
+            .changeType(ChangeType.UPSERT)
+            .entitySpec(TEST_REGISTRY.getEntitySpec(DATA_PRODUCT_ENTITY_NAME))
+            .aspectSpec(
+                TEST_REGISTRY
+                    .getEntitySpec(DATA_PRODUCT_ENTITY_NAME)
+                    .getAspectSpec(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(dataProductProperties)
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    List<MCPItem> testOutput =
+        test.postMCPSideEffect(
+                OperationFingerprint.EMPTY,
+                List.of(
+                    MCLItemImpl.builder()
+                        .build(
+                            dataProductPropertiesChangeItem,
+                            null,
+                            null,
+                            retrieverContext.getAspectRetriever())),
+                retrieverContext)
+            .toList();
+
+    assertEquals(testOutput.size(), 1, "Expected one patch to remove assets from old data product");
+    verify(graphRetriever, times(2))
+        .scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            any(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull());
+
+    JsonArray patchArray = ((PatchItemImpl) testOutput.get(0)).getPatch().toJsonArray();
+    assertEquals(patchArray.size(), 150, "Should have 150 remove operations");
+  }
+
+  @Test
+  public void testGraphScrollPaginatesUntilScrollIdExhausted() {
+    reset(graphRetriever);
+    DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    RelatedEntities firstPage =
+        new RelatedEntities(
+            "DataProductContains",
+            TEST_PRODUCT_URN_2.toString(),
+            DATASET_URN_2.toString(),
+            RelationshipDirection.INCOMING,
+            null);
+    RelatedEntities secondPage =
+        new RelatedEntities(
+            "DataProductContains",
+            TEST_PRODUCT_URN_3.toString(),
+            DATASET_URN_2.toString(),
+            RelationshipDirection.INCOMING,
+            null);
+
+    when(graphRetriever.scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            isNull(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                1,
+                DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE,
+                "page-2",
+                List.of(firstPage)));
+
+    when(graphRetriever.scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            eq("page-2"),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull()))
+        .thenReturn(
+            new RelatedEntitiesScrollResult(
+                1, DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE, null, List.of(secondPage)));
+
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(TEST_PRODUCT_URN)
+            .aspectName(DATA_PRODUCT_PROPERTIES_ASPECT_NAME)
+            .changeType(ChangeType.UPSERT)
+            .entitySpec(TEST_REGISTRY.getEntitySpec(DATA_PRODUCT_ENTITY_NAME))
+            .aspectSpec(
+                TEST_REGISTRY
+                    .getEntitySpec(DATA_PRODUCT_ENTITY_NAME)
+                    .getAspectSpec(DATA_PRODUCT_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(getTestDataProductProperties(DATASET_URN_2))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    List<MCPItem> output =
+        test.postMCPSideEffect(
+                OperationFingerprint.EMPTY,
+                List.of(
+                    MCLItemImpl.builder()
+                        .build(changeItem, null, null, retrieverContext.getAspectRetriever())),
+                retrieverContext)
+            .toList();
+
+    assertEquals(output.size(), 2, "Both paginated graph pages should produce unset patches");
+    verify(graphRetriever, times(2))
+        .scrollRelatedEntities(
+            isNull(),
+            any(),
+            isNull(),
+            eq(EMPTY_FILTER),
+            eq(ImmutableSet.of("DataProductContains")),
+            eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
+            any(),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
+            isNull(),
+            isNull());
   }
 
   @Test
@@ -413,7 +581,7 @@ public class DataProductUnsetSideEffectTest {
             eq(EMPTY_FILTER),
             eq(ImmutableSet.of("DataProductContains")),
             eq(QueryUtils.newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING)),
-            eq(Collections.emptyList()),
+            eq(DataProductUnsetSideEffect.GRAPH_SCROLL_SORT),
             any(),
             eq(DataProductUnsetSideEffect.GRAPH_SCROLL_CHUNK_SIZE),
             isNull(),
@@ -422,6 +590,7 @@ public class DataProductUnsetSideEffectTest {
 
   @Test
   public void testRestateWithPreviousUsesDeltaOnly() {
+    registerAssetInProduct(DATASET_URN_1, TEST_PRODUCT_URN_3);
     registerAssetInProduct(DATASET_URN_2, TEST_PRODUCT_URN_2);
     DataProductUnsetSideEffect test = new DataProductUnsetSideEffect();
     test.setConfig(TEST_PLUGIN_CONFIG);
@@ -455,6 +624,7 @@ public class DataProductUnsetSideEffectTest {
             .toList();
 
     assertEquals(output.size(), 1, "Only the newly added asset should trigger unset");
+    assertEquals(output.get(0).getUrn(), TEST_PRODUCT_URN_2);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes `dataProductProperties` ingest timeouts on large membership writes after GMS by addressing two contributors:

- **Primary:** `DataProductUnsetSideEffect` compared full Pegasus `Edge` records when detecting asset additions, so re-ingest with unchanged URNs but new audit stamps treated every asset as new and ran N sequential graph scrolls. This change compares by destination URN only, uses delta whenever previous aspect is present (including RESTATE), and batches graph scrolls in chunks of 100.
- **Secondary:** `DataProductMembershipAuthorizationValidator` overhead reduced via per-URN auth dedup across products in a batch and a single consolidated `domains` aspect read. **Authorization semantics are unchanged** — same allow/deny outcomes; only structural dedup and IO consolidation.

Remote executor ingestion uses a service-account token and is **not** system auth; the membership validator continues to run for that path.

Related: [PFP-5830](https://linear.app/acryl-data/issue/PFP-5830/dataproductproperties-ingestion-times-out-after-gms-21x-upgrade-due-to)

## Test plan

- [x] `./gradlew :metadata-io:test --tests DataProductUnsetSideEffectTest`
- [x] `./gradlew :metadata-io:test --tests EntityAspectAuthorizationUtilsTest`
- [x] `./gradlew :metadata-io:test --tests DataProductMembershipAuthorizationValidatorTest`
- [x] `./gradlew spotlessApply`


Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `dataProductProperties` ingest timeouts on large membership writes (PFP-5830) after GMS by comparing assets by destination URN only and batching graph scrolls in chunks of 100; previously every re-ingest ran N sequential scrolls. Also reduces authorization overhead via per-URN auth dedup and a single consolidated `domains` aspect read, with no change to allow/deny outcomes.

**Changes**
- `DataProductUnsetSideEffect` computes asset additions as a URN delta and scrolls related data products in batches of 100, paginating with `Edge.EDGE_SORT_CRITERION` so `scrollId` resumes stably when a chunk returns more than one edge per asset.
- `EntityAspectAuthorizationUtils` deduplicates per-asset authorization checks and shares one `domains` fetch across membership and rename checks.
- The membership validator still runs for remote executor ingestion (service-account token path).

<sup>Written for commit 6860068b7249b36474a74470c847388920926bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



