### PR TITLE
fix(ingest/documents): stop checkpoint poisoning by failed documents

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -641,8 +641,14 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             # A batch fallback above aborted systemically and already reported a
             # specific failure. Falling back again would replay a full
             # enumeration + hydration storm against GMS for the same outcome.
+            # Do not acknowledge events we did not finish processing.
+            event_consumer.suppress_offset_commits = True
             raise
         except Exception as e:
+            # An exception escaping the loop (e.g. the max-document limit abort)
+            # leaves events unprocessed with no failure counted per document —
+            # committing offsets would drop them, so hold the window here too.
+            event_consumer.suppress_offset_commits = True
             # Catch any errors during event processing and fall back to batch mode
             error_msg = str(e)
             logger.error(

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -19,7 +19,7 @@ from dataclasses import field
 from datetime import datetime
 from itertools import islice
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, cast
+from typing import Any, Dict, Generator, Iterable, Optional, cast
 
 from datahub.configuration.common import GraphError, OperationalError
 from datahub.ingestion.api.common import PipelineContext
@@ -396,10 +396,12 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     continue
 
             # Process document and yield workunits
-            yield from self._process_document_with_throttle(doc)
+            processed_ok = yield from self._process_document_with_throttle(doc)
 
-            # Update state after successful processing (we own this document now).
-            if self.config.incremental.enabled:
+            # Update state only when processing did not fail. Recording the hash for a
+            # failed document would make every later run skip it as "unchanged" even
+            # though no semanticContent was ever written for it.
+            if self.config.incremental.enabled and processed_ok:
                 self._update_document_state(doc["urn"], doc.get("text", ""))
 
     def _bootstrap_event_mode_offsets(self, consumer_id: str) -> None:
@@ -548,10 +550,10 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         self.report.report_document_fetched()
 
         # Process document and yield work units
-        yield from self._process_document_with_throttle(doc)
+        processed_ok = yield from self._process_document_with_throttle(doc)
 
-        # Update state (we own this document now).
-        if self.config.incremental.enabled:
+        # Update state only when processing did not fail (see _process_batch_mode).
+        if self.config.incremental.enabled and processed_ok:
             self._update_document_state(entity_urn, text)
 
     def _process_event_mode(self) -> Iterable[MetadataWorkUnit]:
@@ -610,6 +612,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         try:
             # Track if we've processed any events
             events_processed = False
+            failures_before = self.report.num_documents_failed
 
             # Process events
             # consume_events() already yields parsed MCL dicts with entityUrn, aspectName, etc.
@@ -619,6 +622,11 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     self.lock.heartbeat()
                 events_processed = True
                 yield from self._process_single_event(event)
+                # A failed document gets no state hash, but consuming its event would
+                # still acknowledge it — with no later event, it would never be
+                # retried. Hold the offsets so the window is re-polled next run.
+                if self.report.num_documents_failed > failures_before:
+                    event_consumer.suppress_offset_commits = True
 
             # If no events were processed and no lookback window, fall back to batch
             if not events_processed and not self.config.event_mode.lookback_days:
@@ -1483,19 +1491,43 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
 
     def _process_document_with_throttle(
         self, doc: dict[str, Any]
-    ) -> Iterable[MetadataWorkUnit]:
-        """Process one document and throttle only when it produced work units."""
+    ) -> Generator[MetadataWorkUnit, None, bool]:
+        """Process one document and throttle only when it produced work units.
+
+        Returns False when processing failed, so callers must not record
+        incremental state for the document (it should be retried next run).
+        """
         indexed = False
-        for wu in self._process_single_document(doc):
-            indexed = True
-            yield wu
+        gen = self._process_single_document(doc)
+        try:
+            while True:
+                try:
+                    wu = next(gen)
+                except StopIteration as stop:
+                    # _process_single_document returns False on a swallowed failure;
+                    # any other return (True, or None from a plain iterator) is ok.
+                    processed_ok = stop.value is not False
+                    break
+                indexed = True
+                yield wu
+        finally:
+            # Deterministic cleanup if our own generator is closed early. Plain
+            # iterators (test mocks) have no close().
+            close = getattr(gen, "close", None)
+            if close is not None:
+                close()
         if indexed:
             self._throttle_after_indexing()
+        return processed_ok
 
     def _process_single_document(
         self, doc: dict[str, Any]
-    ) -> Iterable[MetadataWorkUnit]:
-        """Process a single document: partition text → chunk → embed → emit SemanticContent."""
+    ) -> Generator[MetadataWorkUnit, None, bool]:
+        """Process a single document: partition text → chunk → embed → emit SemanticContent.
+
+        Returns False when processing failed (the failure is swallowed and
+        reported); returns True on success or a legitimate skip.
+        """
         try:
             document_urn = doc["urn"]
             text = doc.get("text", "")
@@ -1506,7 +1538,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"Skipping document {document_urn} (text too short: {len(text)} chars)"
                 )
                 self.report.report_document_skipped_empty()
-                return
+                return True
 
             # Partition text as markdown into unstructured elements
             logger.debug(f"Partitioning text for document {document_urn}")
@@ -1517,7 +1549,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"No elements created from text for document {document_urn}"
                 )
                 self.report.report_document_skipped()
-                return
+                return True
 
             # Delegate chunking + embedding + SemanticContent emission to chunking_source.
             # DocumentChunkingSource enforces max_documents and raises RuntimeError when exceeded.
@@ -1539,6 +1571,8 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                 context=doc.get("urn", "unknown"),
                 exc=e,
             )
+            return False
+        return True
 
     def get_report(self) -> SourceReport:
         # Forward stats from the chunking sub-component into our report

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -18,7 +18,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Optional
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
@@ -272,9 +272,9 @@ class DocumentChunkingSource(Source):
             logger.warning(f"No elements provided for document {document_urn}")
             return
 
-        # Chunk the elements. A chunking failure must raise (not return []) so the
-        # calling source does not record the document as successfully processed.
-        chunks = self._chunk_elements(elements, raise_on_error=True)
+        # Chunk the elements. A chunking failure raises so the calling source
+        # does not record the document as successfully processed.
+        chunks = self._chunk_elements(elements)
         if not chunks:
             logger.warning(f"No chunks created for document {document_urn}")
             return
@@ -442,6 +442,9 @@ class DocumentChunkingSource(Source):
                     error_msg = f"Failed to process MCL event for {document_urn}: {e}"
                     logger.error(error_msg, exc_info=True)
                     self.report.report_error(error_msg)
+                    # The failed document produced no semanticContent; committing the
+                    # offset would acknowledge its event and it would never be retried.
+                    event_consumer.suppress_offset_commits = True
 
         finally:
             event_consumer.close()
@@ -460,10 +463,11 @@ class DocumentChunkingSource(Source):
                     continue
 
             # Process document and yield any workunits (SemanticContent aspects)
-            yield from self._process_single_document(doc)
+            processed_ok = yield from self._process_single_document(doc)
 
-            # Update state after successful processing
-            if self.config.incremental_mode:
+            # Update state only when processing did not fail — recording the hash
+            # for a failed document would skip it as "unchanged" forever.
+            if self.config.incremental_mode and processed_ok is not False:
                 self._update_document_state(doc)
 
         # Save state file after processing all documents
@@ -568,25 +572,31 @@ class DocumentChunkingSource(Source):
 
     def _process_single_document(
         self, doc: dict[str, Any]
-    ) -> Iterable[MetadataWorkUnit]:
-        """Process a single document: extract elements, chunk, embed, emit SemanticContent."""
+    ) -> Generator[MetadataWorkUnit, None, bool]:
+        """Process a single document: extract elements, chunk, embed, emit SemanticContent.
+
+        Returns False when processing failed (failure swallowed and reported), so
+        the caller must not record incremental state; True on success or a
+        legitimate skip.
+        """
         try:
             # Extract unstructured elements
             elements = self._extract_elements(doc)
             if not elements:
                 logger.warning(f"No elements found for document {doc['urn']}")
                 self.report.report_document_skipped()
-                return
+                return True
 
             # Chunk the elements
             chunks = self._chunk_elements(elements)
             if not chunks:
                 logger.warning(f"No chunks created for document {doc['urn']}")
                 self.report.report_document_skipped()
-                return
+                return True
 
             # Generate embeddings (only if configured)
             embeddings = []
+            embed_failed = False
             if self.embedding_model:
                 try:
                     embeddings = self._generate_embeddings(chunks)
@@ -601,6 +611,7 @@ class DocumentChunkingSource(Source):
                         exc=e,
                         log=False,
                     )
+                    embed_failed = True
             else:
                 logger.debug(
                     f"Skipping embedding generation for {doc['urn']} - no embedding provider configured"
@@ -612,11 +623,15 @@ class DocumentChunkingSource(Source):
 
             self.report.report_document_processed(len(chunks))
             self.report.report_embeddings_generated(len(embeddings))
+            # A failed embedding means no semanticContent was written — the caller
+            # must not record the document as done, so it is retried next run.
+            return not embed_failed
 
         except Exception as e:
             error_msg = f"Failed to process document {doc.get('urn', 'unknown')}: {e}"
             logger.error(error_msg, exc_info=True)
             self.report.report_error(error_msg)
+            return False
 
     def _fetch_documents(self) -> list[dict[str, Any]]:
         """Fetch documents from DataHub using GraphQL."""
@@ -727,16 +742,13 @@ class DocumentChunkingSource(Source):
             logger.error(f"Failed to parse elements JSON for {doc['urn']}: {e}")
             return []
 
-    def _chunk_elements(
-        self, elements: list[dict[str, Any]], raise_on_error: bool = False
-    ) -> list[dict[str, Any]]:
+    def _chunk_elements(self, elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Chunk elements using Unstructured's chunking strategies.
 
-        With raise_on_error=False (standalone-source path) a chunking failure is
-        logged and returns [], which is indistinguishable from "nothing to chunk".
-        Inline callers that record per-document incremental state must pass
-        raise_on_error=True so a failure propagates instead of being mistaken for
-        a successfully-processed empty document.
+        A chunking failure raises instead of returning [] — an empty result is
+        indistinguishable from "nothing to chunk", and callers that record
+        per-document incremental state would mark the document as successfully
+        processed. Both callers handle the exception per document.
         """
         try:
             from unstructured.chunking.basic import chunk_elements as basic_chunk
@@ -769,9 +781,7 @@ class DocumentChunkingSource(Source):
 
         except Exception as e:
             logger.error(f"Failed to chunk elements: {e}", exc_info=True)
-            if raise_on_error:
-                raise
-            return []
+            raise
 
     def _generate_embeddings(self, chunks: list[dict[str, Any]]) -> list[list[float]]:
         """Generate embeddings via the configured provider."""

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -436,7 +436,12 @@ class DocumentChunkingSource(Source):
                         "custom_properties": custom_props,
                     }
                     self.report.report_document_fetched()
-                    yield from self._process_single_document(doc)
+                    processed_ok = yield from self._process_single_document(doc)
+                    if processed_ok is False:
+                        # The document produced no semanticContent; committing the
+                        # offset would acknowledge its event and it would never be
+                        # retried.
+                        event_consumer.suppress_offset_commits = True
 
                 except Exception as e:
                     error_msg = f"Failed to process MCL event for {document_urn}: {e}"
@@ -739,8 +744,10 @@ class DocumentChunkingSource(Source):
             logger.debug(f"Extracted {len(elements)} elements from {doc['urn']}")
             return elements
         except json.JSONDecodeError as e:
+            # Raise instead of returning [] — an empty result reads as a legitimately
+            # empty document and the caller would record its hash as processed.
             logger.error(f"Failed to parse elements JSON for {doc['urn']}: {e}")
-            return []
+            raise
 
     def _chunk_elements(self, elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Chunk elements using Unstructured's chunking strategies.

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -272,8 +272,9 @@ class DocumentChunkingSource(Source):
             logger.warning(f"No elements provided for document {document_urn}")
             return
 
-        # Chunk the elements
-        chunks = self._chunk_elements(elements)
+        # Chunk the elements. A chunking failure must raise (not return []) so the
+        # calling source does not record the document as successfully processed.
+        chunks = self._chunk_elements(elements, raise_on_error=True)
         if not chunks:
             logger.warning(f"No chunks created for document {document_urn}")
             return
@@ -726,8 +727,17 @@ class DocumentChunkingSource(Source):
             logger.error(f"Failed to parse elements JSON for {doc['urn']}: {e}")
             return []
 
-    def _chunk_elements(self, elements: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Chunk elements using Unstructured's chunking strategies."""
+    def _chunk_elements(
+        self, elements: list[dict[str, Any]], raise_on_error: bool = False
+    ) -> list[dict[str, Any]]:
+        """Chunk elements using Unstructured's chunking strategies.
+
+        With raise_on_error=False (standalone-source path) a chunking failure is
+        logged and returns [], which is indistinguishable from "nothing to chunk".
+        Inline callers that record per-document incremental state must pass
+        raise_on_error=True so a failure propagates instead of being mistaken for
+        a successfully-processed empty document.
+        """
         try:
             from unstructured.chunking.basic import chunk_elements as basic_chunk
             from unstructured.chunking.title import chunk_by_title
@@ -759,6 +769,8 @@ class DocumentChunkingSource(Source):
 
         except Exception as e:
             logger.error(f"Failed to chunk elements: {e}", exc_info=True)
+            if raise_on_error:
+                raise
             return []
 
     def _generate_embeddings(self, chunks: list[dict[str, Any]]) -> list[list[float]]:

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/event_consumer.py
@@ -49,6 +49,11 @@ class DocumentEventConsumer:
         self.poll_limit = poll_limit
         self.state_handler = state_handler
         self.aspect_names = tuple(aspect_names)
+        # When True, offsets are NOT committed on exit/close. Set by the driving
+        # source when a document in the polled window failed to process, so the
+        # window is re-polled and the document retried on the next run instead of
+        # its event being acknowledged and lost.
+        self.suppress_offset_commits = False
 
         # Base URL for events API
         self.base_url = f"{graph.config.server}/openapi"
@@ -336,18 +341,27 @@ class DocumentEventConsumer:
                     continue
 
         # Commit all offsets before exiting
-        for topic in self.topics:
-            offset_id = self.offset_ids.get(topic)
-            if offset_id:
-                self._save_offset(topic, offset_id)
+        self._commit_offsets()
 
         logger.info(
             f"Event consumption complete. Total events processed: {total_events_processed}"
         )
 
-    def close(self) -> None:
-        """Close the consumer and commit offsets."""
+    def _commit_offsets(self) -> None:
+        if self.suppress_offset_commits:
+            # ponytail: re-polls the whole window next run; a permanently failing
+            # document stalls offset advance (loud per-run warnings) — upgrade to a
+            # per-document retry queue if that ever bites.
+            logger.warning(
+                "Offset commit suppressed because a document in this window failed "
+                "to process; the window will be re-polled next run."
+            )
+            return
         for topic in self.topics:
             offset_id = self.offset_ids.get(topic)
             if offset_id:
                 self._save_offset(topic, offset_id)
+
+    def close(self) -> None:
+        """Close the consumer and commit offsets."""
+        self._commit_offsets()

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -1201,3 +1201,27 @@ def test_batch_success_recorded_in_state(pipeline_context, chunking_config):
         list(source._process_batch())
 
     assert doc["urn"] in source.document_state
+
+
+def test_malformed_elements_json_not_recorded_in_state(
+    pipeline_context, chunking_config
+):
+    """Malformed unstructured_elements JSON is a failure, not an empty document —
+    the hash must not be recorded."""
+    with patch("datahub.ingestion.source.unstructured.chunking_source.DataHubGraph"):
+        source = DocumentChunkingSource(
+            ctx=pipeline_context, config=chunking_config, standalone=True, graph=None
+        )
+    source.config.incremental_mode = True
+
+    doc = {
+        "urn": "urn:li:document:(test,doc1,PROD)",
+        "custom_properties": {"unstructured_elements": "{not valid json"},
+    }
+    with (
+        patch.object(source, "_fetch_documents", return_value=[doc]),
+        patch.object(source, "_save_state"),
+    ):
+        list(source._process_batch())
+
+    assert doc["urn"] not in source.document_state

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -1123,3 +1123,81 @@ def test_semantic_content_workunit_is_not_primary_source(pipeline_context):
     )
     semantic_wu = next(wu for wu in workunits if "semanticContent" in wu.id)
     assert semantic_wu.is_primary_source is False
+
+
+def test_batch_failed_document_not_recorded_in_state(pipeline_context, chunking_config):
+    """A document whose processing fails (chunker crash) must not get its hash
+    recorded in incremental state, or every later run skips it as unchanged."""
+    with patch("datahub.ingestion.source.unstructured.chunking_source.DataHubGraph"):
+        source = DocumentChunkingSource(
+            ctx=pipeline_context, config=chunking_config, standalone=True, graph=None
+        )
+    source.config.incremental_mode = True
+
+    doc = {
+        "urn": "urn:li:document:(test,doc1,PROD)",
+        "custom_properties": {
+            "unstructured_elements": '[{"type": "Title", "text": "Test Title"}]'
+        },
+    }
+    with (
+        patch.object(source, "_fetch_documents", return_value=[doc]),
+        patch.object(source, "_save_state"),
+        patch.object(
+            source, "_chunk_elements", side_effect=RuntimeError("chunker crashed")
+        ),
+    ):
+        list(source._process_batch())
+
+    assert doc["urn"] not in source.document_state
+
+
+def test_batch_embed_failure_not_recorded_in_state(pipeline_context, chunking_config):
+    """An embedding failure means no semanticContent was written — the document
+    must be retried next run, not recorded as done."""
+    with patch("datahub.ingestion.source.unstructured.chunking_source.DataHubGraph"):
+        source = DocumentChunkingSource(
+            ctx=pipeline_context, config=chunking_config, standalone=True, graph=None
+        )
+    source.config.incremental_mode = True
+
+    doc = {
+        "urn": "urn:li:document:(test,doc1,PROD)",
+        "custom_properties": {
+            "unstructured_elements": '[{"type": "Title", "text": "Test Title"}]'
+        },
+    }
+    with (
+        patch.object(source, "_fetch_documents", return_value=[doc]),
+        patch.object(source, "_save_state"),
+        patch.object(
+            source, "_generate_embeddings", side_effect=Exception("provider down")
+        ),
+    ):
+        list(source._process_batch())
+
+    assert doc["urn"] not in source.document_state
+
+
+def test_batch_success_recorded_in_state(pipeline_context, chunking_config):
+    """Successful processing still records incremental state."""
+    with patch("datahub.ingestion.source.unstructured.chunking_source.DataHubGraph"):
+        source = DocumentChunkingSource(
+            ctx=pipeline_context, config=chunking_config, standalone=True, graph=None
+        )
+    source.config.incremental_mode = True
+
+    doc = {
+        "urn": "urn:li:document:(test,doc1,PROD)",
+        "custom_properties": {
+            "unstructured_elements": '[{"type": "Title", "text": "Test Title"}]'
+        },
+    }
+    with (
+        patch.object(source, "_fetch_documents", return_value=[doc]),
+        patch.object(source, "_save_state"),
+        patch.object(source, "_generate_embeddings", return_value=[[0.1] * 4]),
+    ):
+        list(source._process_batch())
+
+    assert doc["urn"] in source.document_state

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -1043,6 +1043,37 @@ class TestStateStorage:
 
                 assert consumer.suppress_offset_commits is True
 
+    def test_event_exception_suppresses_offset_commit(self, ctx, config, mock_graph):
+        """An exception escaping the event loop (e.g. the max-document limit
+        abort) leaves events unprocessed with no per-document failure counted —
+        offsets must still be held so those events are not acknowledged."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.config.event_mode.enabled = True
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_event_offset.return_value = "offset-1"
+
+            with (
+                patch(
+                    "datahub.ingestion.source.datahub_documents.datahub_documents_source.DocumentEventConsumer"
+                ) as mock_consumer_cls,
+                patch.object(
+                    source,
+                    "_process_single_event",
+                    side_effect=RuntimeError("Document limit of 100000 reached"),
+                ),
+                patch.object(source, "_process_batch_mode", return_value=iter([])),
+            ):
+                consumer = mock_consumer_cls.return_value
+                consumer.consume_events.return_value = iter([{"entityUrn": "urn:x"}])
+                consumer.suppress_offset_commits = False
+
+                list(source._process_event_mode())
+
+                assert consumer.suppress_offset_commits is True
+
     def test_event_success_commits_offsets(self, ctx, config, mock_graph):
         """Successful event processing must not suppress offset commits."""
         with mock_graph:

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -907,6 +907,166 @@ class TestStateStorage:
                 assert calls[0][0][1] == hash1
                 assert calls[1][0][1] == hash2
 
+    def test_failed_document_not_recorded_in_state(self, ctx, config, mock_graph):
+        """A document whose processing fails must NOT get its hash recorded,
+        otherwise every later run skips it as "unchanged" even though no
+        semanticContent was ever written for it."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_document_hash.return_value = None
+            mock_state_handler.update_document_state = Mock()
+
+            mock_docs = [
+                {"urn": "urn:li:document:failing", "text": "Some document content"},
+            ]
+            with (
+                patch.object(
+                    source, "_fetch_documents_graphql", return_value=mock_docs
+                ),
+                patch.object(
+                    source.text_partitioner, "partition_text", return_value=[Mock()]
+                ),
+                patch.object(
+                    source.chunking_source,
+                    "process_elements_inline",
+                    side_effect=RuntimeError("embedding provider unavailable"),
+                ),
+            ):
+                workunits = list(source._process_batch_mode())
+
+                assert workunits == []
+                mock_state_handler.update_document_state.assert_not_called()
+
+    def test_partial_emission_then_failure_not_recorded(self, ctx, config, mock_graph):
+        """A failure after some work units were already emitted must also skip
+        the state update, so the document is fully reprocessed next run."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_document_hash.return_value = None
+            mock_state_handler.update_document_state = Mock()
+
+            def _yield_then_fail(document_urn, elements):
+                yield Mock()
+                raise RuntimeError("embedding provider unavailable")
+
+            mock_docs = [
+                {"urn": "urn:li:document:failing", "text": "Some document content"},
+            ]
+            with (
+                patch.object(
+                    source, "_fetch_documents_graphql", return_value=mock_docs
+                ),
+                patch.object(
+                    source.text_partitioner, "partition_text", return_value=[Mock()]
+                ),
+                patch.object(
+                    source.chunking_source,
+                    "process_elements_inline",
+                    side_effect=_yield_then_fail,
+                ),
+            ):
+                workunits = list(source._process_batch_mode())
+
+                # The pre-failure work unit is still emitted, but the document
+                # is not marked as done.
+                assert len(workunits) == 1
+                mock_state_handler.update_document_state.assert_not_called()
+
+    def test_chunking_failure_not_recorded_in_state(self, ctx, config, mock_graph):
+        """A crash inside the chunker itself (below process_elements_inline) must
+        propagate as a failure, not read as a successfully-processed empty
+        document that gets its hash recorded."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_document_hash.return_value = None
+            mock_state_handler.update_document_state = Mock()
+
+            mock_docs = [
+                {"urn": "urn:li:document:failing", "text": "Some document content"},
+            ]
+            with (
+                patch.object(
+                    source, "_fetch_documents_graphql", return_value=mock_docs
+                ),
+                patch.object(
+                    source.text_partitioner,
+                    "partition_text",
+                    return_value=[{"type": "NarrativeText", "text": "content"}],
+                ),
+                patch(
+                    "unstructured.staging.base.elements_from_dicts",
+                    side_effect=RuntimeError("chunker crashed"),
+                ),
+            ):
+                workunits = list(source._process_batch_mode())
+
+                assert workunits == []
+                assert source.report.num_documents_failed == 1
+                mock_state_handler.update_document_state.assert_not_called()
+
+    def test_event_failure_suppresses_offset_commit(self, ctx, config, mock_graph):
+        """A document that fails during event-mode processing must hold the offset
+        commit: its hash is not recorded, so acknowledging its event anyway would
+        mean it is never retried."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.config.event_mode.enabled = True
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_event_offset.return_value = "offset-1"
+
+            def _fail_event(event):
+                source.report.report_document_failed()
+                return iter([])
+
+            with (
+                patch(
+                    "datahub.ingestion.source.datahub_documents.datahub_documents_source.DocumentEventConsumer"
+                ) as mock_consumer_cls,
+                patch.object(source, "_process_single_event", side_effect=_fail_event),
+            ):
+                consumer = mock_consumer_cls.return_value
+                consumer.consume_events.return_value = iter([{"entityUrn": "urn:x"}])
+                consumer.suppress_offset_commits = False
+
+                list(source._process_event_mode())
+
+                assert consumer.suppress_offset_commits is True
+
+    def test_event_success_commits_offsets(self, ctx, config, mock_graph):
+        """Successful event processing must not suppress offset commits."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.config.event_mode.enabled = True
+
+            mock_state_handler = patch.object(source, "state_handler").start()
+            mock_state_handler.is_checkpointing_enabled.return_value = True
+            mock_state_handler.get_event_offset.return_value = "offset-1"
+
+            with (
+                patch(
+                    "datahub.ingestion.source.datahub_documents.datahub_documents_source.DocumentEventConsumer"
+                ) as mock_consumer_cls,
+                patch.object(source, "_process_single_event", return_value=iter([])),
+            ):
+                consumer = mock_consumer_cls.return_value
+                consumer.consume_events.return_value = iter([{"entityUrn": "urn:x"}])
+                consumer.suppress_offset_commits = False
+
+                list(source._process_event_mode())
+
+                assert consumer.suppress_offset_commits is False
+
     def test_fallback_stores_document_hashes(self, ctx, config, mock_graph):
         """Test that fallback to batch mode stores document hashes."""
         with mock_graph:
@@ -2452,6 +2612,36 @@ class TestMaxDocumentsLimit:
                 list(source._process_batch_mode())
 
             assert source.chunking_source.report.num_documents_processed == 2
+
+
+class TestOffsetCommitSuppression:
+    """Offsets must not be committed when a document in the window failed."""
+
+    @staticmethod
+    def _consumer(state_handler):
+        consumer = DocumentEventConsumer(
+            graph=Mock(),
+            consumer_id="test-consumer",
+            topics=["MetadataChangeLog_Versioned_v1"],
+            state_handler=state_handler,
+        )
+        consumer.offset_ids["MetadataChangeLog_Versioned_v1"] = "offset-42"
+        return consumer
+
+    def test_close_commits_offsets_by_default(self):
+        state_handler = Mock()
+        consumer = self._consumer(state_handler)
+        consumer.close()
+        state_handler.update_event_offset.assert_called_once_with(
+            "MetadataChangeLog_Versioned_v1", "offset-42"
+        )
+
+    def test_close_skips_commit_when_suppressed(self):
+        state_handler = Mock()
+        consumer = self._consumer(state_handler)
+        consumer.suppress_offset_commits = True
+        consumer.close()
+        state_handler.update_event_offset.assert_not_called()
 
 
 class TestGetCurrentOffset:


### PR DESCRIPTION
## Summary

`datahub-documents` recorded a document's content hash in the stateful-ingestion checkpoint even when processing that document failed, so every later run skipped it as "unchanged" although no `semanticContent` was ever written. One transient failure (embedding error, chunker crash) permanently excluded a document from semantic search until a force reprocess. Observed live: ~1000 documents stuck missing or stale while every run reported SUCCESS with all documents skipped-unchanged.

## Fix

Closes the three paths that acknowledged a failed document:

- `_process_single_document` returns False on a swallowed failure; both call sites (batch and event) record state only on success. Partial emission then failure counts as failed.
- `process_elements_inline` calls `_chunk_elements(raise_on_error=True)` so a chunker crash propagates; the standalone path stays lenient.
- Event mode suppresses offset commits when a document in the polled window failed, so the window is re-polled next run.

Tests: 162 documents-source + 132 chunking/notion/confluence unit tests pass.
