### PR TITLE
docs(hive): fix incorrect Kerberos package name in prerequisites

### DIFF
--- a/metadata-ingestion/docs/sources/hive/hive_pre.md
+++ b/metadata-ingestion/docs/sources/hive/hive_pre.md
@@ -106,7 +106,8 @@ source:
 
 - Valid Kerberos ticket (use `kinit` before running ingestion)
 - Kerberos configuration file (`/etc/krb5.conf` or specified via `KRB5_CONFIG` environment variable)
-- PyKerberos or requests-kerberos package installed
+- `kerberos` package installed (`pip install kerberos`). Note: this is not included in the
+  `hive` plugin by default — add it via `extra_pip_requirements` or install it separately.
 
 ##### TLS/SSL Connection
 


### PR DESCRIPTION
## Summary

- Replaces the misleading "PyKerberos or requests-kerberos" prerequisite with the actual PyPI package name, `kerberos`
- `requests-kerberos` authenticates the `requests` HTTP library via SPNEGO and provides no `kerberos` importable module — it does nothing for Hive's Thrift/SASL layer, and would fail at runtime with `puresasl: kerberos module not installed, GSSAPI will be ignored` followed by `Could not start SASL: None of the mechanisms listed meet all required properties`
- "PyKerberos" is the upstream project name, not the exact PyPI distribution name a reader would type into `pip install`
- Notes that the `hive` extra does not bundle this dependency (only `hive-metastore` does), so installing `acryl-datahub[hive]` alone is not enough

## Test plan

- [x] Verified the failure mode directly: `pure-sasl`'s `client.py` emits exactly this warning/error when `kerberos` isn't importable, reproduced against a live Hive+Kerberos ingestion source configured with `auth: KERBEROS`
- [x] Confirmed via `metadata-ingestion/setup.py` that `hive-metastore`'s extras include `"kerberos>=1.3.0,<2.0.0"` while `hive`'s do not
- [x] Docs-only change, no code logic touched


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Hive prerequisites doc so readers install the correct Kerberos package. Previously the doc suggested `PyKerberos` or `requests-kerberos`, but neither provides the `kerberos` module that Hive's Thrift/SASL layer needs. The doc now points to the `kerberos` PyPI package and notes it isn't bundled with the `hive` extra — install it separately or via `extra_pip_requirements`.

<sup>Written for commit 9acbfbb75ea7a4015c54eef09c6a8d6c4c266743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

