### PR TITLE
docs(hive): add Kerberos + Remote Executor setup guidance

### DIFF
--- a/metadata-ingestion/docs/sources/hive-metastore/hive-metastore_post.md
+++ b/metadata-ingestion/docs/sources/hive-metastore/hive-metastore_post.md
@@ -104,6 +104,97 @@ If your Hive Metastore is configured with `hadoop.rpc.protection` set to `integr
 - **Kerberos ticket required**: Must have valid ticket before running (not embedded in config)
 - **HMS version compatibility**: Tested with HMS 2.x and 3.x
 
+##### Kerberos with Remote Executor
+
+When running Hive Metastore ingestion on a **DataHub Cloud Remote Executor**, `kinit` is not run
+automatically. The executor Docker image ships Kerberos client tools (`krb5`, `kinit`, `klist`,
+`cyrus-sasl-mit`), but you must supply a keytab and configure an init container to obtain a ticket
+before ingestion starts.
+
+> **Note**: The executor's `extraSidecars` field is defined in `values.yaml` but is not rendered in
+> any executor deployment template. Do not attempt sidecar-based ticket renewal — use the init
+> container approach below.
+
+**Step 1 — Create Kubernetes resources:**
+
+```bash
+# Secret for the keytab
+kubectl create secret generic executor-krb5-keytab \
+  --from-file=user.keytab=/path/to/user.keytab \
+  --namespace <executor-namespace>
+
+# ConfigMap for krb5.conf
+kubectl create configmap executor-krb5-config \
+  --from-file=krb5.conf=/etc/krb5.conf \
+  --namespace <executor-namespace>
+```
+
+**Step 2 — Helm values override:**
+
+```yaml
+extraVolumes:
+  - name: krb5-keytab
+    secret:
+      secretName: executor-krb5-keytab
+      defaultMode: 0400
+  - name: krb5-config
+    configMap:
+      name: executor-krb5-config
+  - name: krb5-ccache
+    emptyDir: {}
+
+extraInitContainers:
+  - name: kerberos-init
+    image: <your-executor-image>
+    command: ["/bin/bash", "-c"]
+    args:
+      - |
+        kinit -kt /etc/kerberos/keytab/user.keytab user@YOUR.REALM
+        klist # Fail fast if kinit failed
+    env:
+      - name: KRB5CCNAME
+        value: FILE:/tmp/krb5cc/krb5cc_default
+      - name: KRB5_CONFIG
+        value: /etc/kerberos/krb5.conf
+    volumeMounts:
+      - name: krb5-keytab
+        mountPath: /etc/kerberos/keytab
+        readOnly: true
+      - name: krb5-config
+        mountPath: /etc/kerberos/krb5.conf
+        subPath: krb5.conf
+        readOnly: true
+      - name: krb5-ccache
+        mountPath: /tmp/krb5cc
+
+extraVolumeMounts:
+  - name: krb5-ccache
+    mountPath: /tmp/krb5cc
+
+extraEnvs:
+  - name: KRB5CCNAME
+    value: FILE:/tmp/krb5cc/krb5cc_default
+  - name: KRB5_CONFIG
+    value: /etc/kerberos/krb5.conf
+```
+
+**Step 3 — Ingestion recipe:**
+
+```yaml
+source:
+  type: hive-metastore
+  config:
+    connection_type: thrift
+    host_port: hms.company.com:9083
+    use_kerberos: true
+    kerberos_service_name: hive
+    kerberos_qop: auth # or auth-int / auth-conf to match hadoop.rpc.protection
+```
+
+**TGT lifetime**: Kerberos TGTs typically expire after 10 hours, which is sufficient for most
+ingestion runs. For long-running ingestions, coordinate with your KDC administrator to issue a
+renewable ticket or extend the maximum ticket lifetime.
+
 #### Storage Lineage
 
 The Hive Metastore connector supports the same storage lineage features as the Hive connector, with enhanced performance due to direct database access.
@@ -461,3 +552,24 @@ Same as the Hive connector:
 - Check database query performance (may need indexes on metastore tables)
 - Ensure low latency network connection to metastore database
 - Consider disabling column lineage if not needed
+
+#### Kerberos Ticket Not Found (Remote Executor)
+
+**Problem**: Ingestion fails with `GSS initiate failed`, `No Kerberos credentials available`, or
+`TTransportException` when using Thrift + Kerberos on a Remote Executor.
+
+**Solutions**:
+
+- **Check init container logs**: `kubectl logs <pod> -c kerberos-init` — look for `kinit` errors
+  such as bad keytab path, wrong principal, or KDC unreachable.
+- **Verify `KRB5CCNAME`**: Both the init container and the main executor container must set
+  `KRB5CCNAME=FILE:/tmp/krb5cc/krb5cc_default` (paths must match exactly).
+- **Verify emptyDir mounts**: Confirm the `krb5-ccache` volume is mounted at the same `mountPath`
+  in both `extraInitContainers.volumeMounts` and `extraVolumeMounts`.
+- **Verify keytab secret**: Run `kubectl get secret executor-krb5-keytab -o yaml` and confirm the
+  `user.keytab` key is present.
+- **Run `klist`**: Add `klist` as the last command in the init container `args` — it exits non-zero
+  if the ticket cache is empty, causing the pod to fail fast rather than silently.
+- **Check `kerberos_qop`**: Ensure the `kerberos_qop` value in your recipe matches
+  `hadoop.rpc.protection` on the HMS server (see the QOP table in the Thrift with Kerberos section
+  above).

--- a/metadata-ingestion/docs/sources/hive/hive_post.md
+++ b/metadata-ingestion/docs/sources/hive/hive_post.md
@@ -148,6 +148,11 @@ Module behavior is constrained by source APIs, permissions, and metadata exposed
 - **No Proxy Support**: Direct connection to HiveServer2 required
 - **Token-Based Auth**: Not natively supported (use Kerberos or basic auth)
 - **Multi-Factor Authentication**: Not supported
+- **Remote Executor Kerberos**: `extraSidecars` is defined in the executor `values.yaml` but is not
+  rendered in any executor deployment template — sidecar-based ticket renewal is not available. Use
+  an `extraInitContainers` entry instead (see the Kerberos with Remote Executor section in
+  Prerequisites above). For ingestions that run longer than the TGT lifetime (typically 10 hours),
+  coordinate with your KDC administrator to issue a renewable ticket.
 
 ### Troubleshooting
 
@@ -159,3 +164,17 @@ Module behavior is constrained by source APIs, permissions, and metadata exposed
    - Hive is case-insensitive by default
    - DataHub automatically lowercases URNs for consistency
 4. **View Lineage Parsing**: Complex views using non-standard SQL may not have complete lineage extracted.
+
+5. **Kerberos Ticket Not Found (Remote Executor)**: If ingestion fails with `GSS initiate failed` or
+   `No Kerberos credentials available`, diagnose with these steps:
+
+   - **Check init container logs**: `kubectl logs <pod> -c kerberos-init` — look for `kinit` errors
+     such as bad keytab path, wrong principal, or KDC unreachable.
+   - **Verify `KRB5CCNAME`**: Both the init container and the main executor container must set
+     `KRB5CCNAME=FILE:/tmp/krb5cc/krb5cc_default` (paths must match exactly).
+   - **Verify emptyDir mounts**: Confirm the `krb5-ccache` volume is mounted at the same `mountPath`
+     in both `extraInitContainers.volumeMounts` and `extraVolumeMounts`.
+   - **Verify keytab secret**: Run `kubectl get secret executor-krb5-keytab -o yaml` and confirm the
+     `user.keytab` key is present.
+   - **Run `klist`**: Add `klist` as the last command in the init container `args` — it exits
+     non-zero if the ticket cache is empty, causing the pod to fail fast rather than silently.

--- a/metadata-ingestion/docs/sources/hive/hive_pre.md
+++ b/metadata-ingestion/docs/sources/hive/hive_pre.md
@@ -106,7 +106,8 @@ source:
 
 - Valid Kerberos ticket (use `kinit` before running ingestion)
 - Kerberos configuration file (`/etc/krb5.conf` or specified via `KRB5_CONFIG` environment variable)
-- PyKerberos or requests-kerberos package installed
+- `kerberos` package installed (`pip install kerberos`). Note: this is not included in the
+  `hive` plugin by default — add it via `extra_pip_requirements` or install it separately.
 
 ##### TLS/SSL Connection
 

--- a/metadata-ingestion/docs/sources/hive/hive_pre.md
+++ b/metadata-ingestion/docs/sources/hive/hive_pre.md
@@ -109,6 +109,97 @@ source:
 - `kerberos` package installed (`pip install kerberos`). Note: this is not included in the
   `hive` plugin by default — add it via `extra_pip_requirements` or install it separately.
 
+##### Kerberos with Remote Executor
+
+When running Hive ingestion on a **DataHub Cloud Remote Executor**, `kinit` is not run
+automatically. The executor Docker image ships Kerberos client tools (`krb5`, `kinit`, `klist`,
+`cyrus-sasl-mit`), but you must supply a keytab and configure an init container to obtain a ticket
+before ingestion starts.
+
+> **Note**: The executor's `extraSidecars` field is defined in `values.yaml` but is not rendered in
+> any executor deployment template. Do not attempt sidecar-based ticket renewal — use the init
+> container approach below.
+
+**Step 1 — Create Kubernetes resources:**
+
+```bash
+# Secret for the keytab
+kubectl create secret generic executor-krb5-keytab \
+  --from-file=user.keytab=/path/to/user.keytab \
+  --namespace <executor-namespace>
+
+# ConfigMap for krb5.conf
+kubectl create configmap executor-krb5-config \
+  --from-file=krb5.conf=/etc/krb5.conf \
+  --namespace <executor-namespace>
+```
+
+**Step 2 — Helm values override:**
+
+```yaml
+extraVolumes:
+  - name: krb5-keytab
+    secret:
+      secretName: executor-krb5-keytab
+      defaultMode: 0400
+  - name: krb5-config
+    configMap:
+      name: executor-krb5-config
+  - name: krb5-ccache
+    emptyDir: {}
+
+extraInitContainers:
+  - name: kerberos-init
+    image: <your-executor-image>
+    command: ["/bin/bash", "-c"]
+    args:
+      - |
+        kinit -kt /etc/kerberos/keytab/user.keytab user@YOUR.REALM
+        klist # Fail fast if kinit failed
+    env:
+      - name: KRB5CCNAME
+        value: FILE:/tmp/krb5cc/krb5cc_default
+      - name: KRB5_CONFIG
+        value: /etc/kerberos/krb5.conf
+    volumeMounts:
+      - name: krb5-keytab
+        mountPath: /etc/kerberos/keytab
+        readOnly: true
+      - name: krb5-config
+        mountPath: /etc/kerberos/krb5.conf
+        subPath: krb5.conf
+        readOnly: true
+      - name: krb5-ccache
+        mountPath: /tmp/krb5cc
+
+extraVolumeMounts:
+  - name: krb5-ccache
+    mountPath: /tmp/krb5cc
+
+extraEnvs:
+  - name: KRB5CCNAME
+    value: FILE:/tmp/krb5cc/krb5cc_default
+  - name: KRB5_CONFIG
+    value: /etc/kerberos/krb5.conf
+```
+
+**Step 3 — Ingestion recipe:**
+
+```yaml
+source:
+  type: hive
+  config:
+    host_port: hive.company.com:10000
+    options:
+      connect_args:
+        auth: KERBEROS
+        kerberos_service_name: hive
+```
+
+**TGT lifetime**: Kerberos TGTs typically expire after 10 hours, which is sufficient for most
+ingestion runs. For long-running ingestions, coordinate with your KDC administrator to issue a
+renewable ticket or extend the maximum ticket lifetime.
+
 ##### TLS/SSL Connection
 
 For secure connections over HTTPS:


### PR DESCRIPTION
## Summary

Closes a documentation gap for configuring Kerberos authentication when running Hive / Hive Metastore ingestion on a **DataHub Cloud Remote Executor**, where none of the existing Kerberos guidance applies: it all assumes a self-managed CLI host where a ticket is already sitting in the default cache before `datahub ingest` runs.

- **`hive_pre.md`** — adds a "Kerberos with Remote Executor" section under Prerequisites: Kubernetes Secret/ConfigMap setup, a Helm values override using `extraVolumes`/`extraInitContainers`/`extraVolumeMounts`/`extraEnvs`, and a matching ingestion recipe using `connect_args.auth: KERBEROS`.
- **`hive_post.md`** — adds a bullet to Authentication Limitations noting `extraSidecars` is defined in `values.yaml` but never rendered in any executor deployment template (so sidecar-based ticket renewal silently does nothing); adds a troubleshooting entry for "Kerberos Ticket Not Found (Remote Executor)" with concrete diagnostic steps.
- **`hive-metastore_post.md`** — adds the same "Kerberos with Remote Executor" section under Thrift Mode Limitations, with a Thrift-specific recipe (`use_kerberos: true`, `kerberos_service_name`, `kerberos_qop`) and the matching troubleshooting section.

**Key technical points documented:**
- `extraSidecars` exists in the executor Helm chart's `values.yaml` but isn't wired into any deployment template — a sidecar running a background `kinit`/renewal loop is a natural instinct here and it does not work.
- An `emptyDir` volume plus a `KRB5CCNAME` env var set identically on both the init container (runs `kinit`) and the main executor container is what actually shares the credential cache between them.
- Kerberos TGTs are typically valid ~10 hours; long-running ingestion needs a renewable ticket coordinated with the KDC administrator.

## Test plan

- [x] `./gradlew :datahub-web-react:mdPrettierCheck` — passes clean
- [x] Docs-only change, no code logic touched


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kerberos setup guidance for Hive and Hive Metastore ingestion on DataHub Cloud Remote Executors, which previously had no supported path because the existing docs assumed a self-managed CLI host with a ticket already sitting in the default cache.

- Documents a Helm values override (`extraVolumes`, `extraInitContainers`, `extraVolumeMounts`, `extraEnvs`) that runs `kinit` into a shared `emptyDir` ticket cache, with `KRB5CCNAME` set identically on the init and main containers.
- Warns that `extraSidecars` is defined in `values.yaml` but never rendered in executor deployment templates, so sidecar-based ticket renewal silently does nothing.
- Adds troubleshooting steps for `GSS initiate failed` and `No Kerberos credentials available` failures on Remote Executors and notes the ~10 hour TGT lifetime.
- Covers both Hive (`connect_args.auth: KERBEROS`) and Hive Metastore Thrift (`use_kerberos`, `kerberos_service_name`, `kerberos_qop`) recipes.
- Docs-only change; no code logic touched.

<sup>Written for commit 6d6331480304f50d125e2ae81da570662204f90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

