### PR TITLE
fix(i18n): slim the parity PR comment to per-locale counts

### DIFF
--- a/datahub-web-react/scripts/check-i18n-parity.mjs
+++ b/datahub-web-react/scripts/check-i18n-parity.mjs
@@ -86,6 +86,12 @@ function sumByType(findings, type) {
     return findings.filter((f) => f.type === type).reduce((n, f) => n + f.count, 0);
 }
 
+// Distinct namespace files with drift. Not findings.length — one file can emit a missing, a stale
+// and a placeholder finding, which would count it three times.
+function filesAffected(findings) {
+    return new Set(findings.map((f) => f.file)).size;
+}
+
 // Newlines in a workflow-command message must be encoded so the whole annotation stays on one line.
 function encodeAnnotation(message) {
     return message.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
@@ -113,7 +119,7 @@ function buildSummaryMarkdown(perLocale, total, { detail = true } = {}) {
     lines.push('| Locale | Missing keys | Stale keys | Placeholder | Files |', '| --- | --- | --- | --- | --- |');
     for (const { lang, findings } of perLocale) {
         lines.push(
-            `| ${lang} | ${sumByType(findings, 'missing')} | ${sumByType(findings, 'stale')} | ${sumByType(findings, 'placeholder')} | ${findings.length} |`,
+            `| ${lang} | ${sumByType(findings, 'missing')} | ${sumByType(findings, 'stale')} | ${sumByType(findings, 'placeholder')} | ${filesAffected(findings)} |`,
         );
     }
     lines.push('');
@@ -177,6 +183,7 @@ for (const lang of languages) {
     for (const f of extraFiles) {
         findings.push({
             type: 'stale',
+            file: f,
             count: Object.keys(loadFlat(path.join(langDir, f))).length,
             message: `${f} — file does not exist in "${BASE_LANG}" (stale, should be deleted)`,
         });
@@ -190,6 +197,7 @@ for (const lang of languages) {
         if (!existsSync(otherPath)) {
             findings.push({
                 type: 'missing',
+                file: nsFile,
                 count: enKeys.length,
                 message: `${nsFile} — file missing entirely (${enKeys.length} untranslated key(s))`,
             });
@@ -208,6 +216,7 @@ for (const lang of languages) {
         if (missingGroups.length > 0) {
             findings.push({
                 type: 'missing',
+                file: nsFile,
                 count: missingGroups.length,
                 message: `${nsFile} — ${missingGroups.length} missing key(s):\n${missingGroups.map((k) => `      - ${k}`).join('\n')}`,
             });
@@ -216,6 +225,7 @@ for (const lang of languages) {
         if (extraGroups.length > 0) {
             findings.push({
                 type: 'stale',
+                file: nsFile,
                 count: extraGroups.length,
                 message: `${nsFile} — ${extraGroups.length} extra/stale key(s):\n${extraGroups.map((k) => `      - ${k}`).join('\n')}`,
             });
@@ -239,6 +249,7 @@ for (const lang of languages) {
         if (mismatches.length > 0) {
             findings.push({
                 type: 'placeholder',
+                file: nsFile,
                 count: mismatches.length,
                 message: `${nsFile} — ${mismatches.length} placeholder mismatch(es):\n${mismatches.join('\n')}`,
             });

--- a/datahub-web-react/scripts/check-i18n-parity.mjs
+++ b/datahub-web-react/scripts/check-i18n-parity.mjs
@@ -81,8 +81,9 @@ function jsonFilesIn(dir) {
     return readdirSync(dir).filter((f) => f.endsWith('.json') && statSync(path.join(dir, f)).isFile());
 }
 
-function countByType(findings, type) {
-    return findings.filter((f) => f.type === type).length;
+// Total keys affected by findings of one type (findings are per-namespace-file, each covering N keys).
+function sumByType(findings, type) {
+    return findings.filter((f) => f.type === type).reduce((n, f) => n + f.count, 0);
 }
 
 // Newlines in a workflow-command message must be encoded so the whole annotation stays on one line.
@@ -102,23 +103,37 @@ function emitGithubAnnotations(perLocale) {
     }
 }
 
-// Build the markdown report shared by the job summary and the sticky PR comment.
-function buildSummaryMarkdown(perLocale, total) {
+// Build the markdown report. `detail` controls whether the per-locale key dumps are included: the
+// job summary gets them, the sticky PR comment does not (the full dump runs to ~140KB and drowns
+// the PR conversation — reproduce it locally with the command in the footer instead).
+function buildSummaryMarkdown(perLocale, total, { detail = true } = {}) {
     const lines = ['## i18n locale parity', ''];
     const status = total === 0 ? '✅ in sync' : enforce ? '❌ failed' : '⚠️ drift detected (warn-only)';
     lines.push(`**Status:** ${status} — ${total} issue(s) across ${perLocale.length} locale(s)`, '');
-    lines.push('| Locale | Missing | Stale | Placeholder |', '| --- | --- | --- | --- |');
+    lines.push('| Locale | Missing keys | Stale keys | Placeholder | Files |', '| --- | --- | --- | --- | --- |');
     for (const { lang, findings } of perLocale) {
         lines.push(
-            `| ${lang} | ${countByType(findings, 'missing')} | ${countByType(findings, 'stale')} | ${countByType(findings, 'placeholder')} |`,
+            `| ${lang} | ${sumByType(findings, 'missing')} | ${sumByType(findings, 'stale')} | ${sumByType(findings, 'placeholder')} | ${findings.length} |`,
         );
     }
     lines.push('');
 
-    for (const { lang, findings } of perLocale) {
-        if (findings.length === 0) continue;
-        const detail = findings.map((f) => `${ICON} ${f.message}`).join('\n');
-        lines.push(`<details><summary>${lang}</summary>`, '', '```', detail, '```', '', '</details>', '');
+    if (detail) {
+        for (const { lang, findings } of perLocale) {
+            if (findings.length === 0) continue;
+            const body = findings.map((f) => `${ICON} ${f.message}`).join('\n');
+            lines.push(`<details><summary>${lang}</summary>`, '', '```', body, '```', '', '</details>', '');
+        }
+    } else if (total > 0) {
+        lines.push(
+            'Per-key detail is in the **job summary** of the `datahub-web-react-lint` run, or reproduce locally:',
+            '',
+            '```bash',
+            './gradlew :datahub-web-react:yarnI18nParityCheck        # all locales',
+            'cd datahub-web-react && yarn check-i18n-parity --lang de  # one locale',
+            '```',
+            '',
+        );
     }
     return lines.join('\n');
 }
@@ -126,14 +141,16 @@ function buildSummaryMarkdown(perLocale, total) {
 // Render the report to the job summary page (visible on the run page without opening logs) and,
 // when there are findings, to a file the workflow turns into a sticky PR comment.
 function writeReports(perLocale, total) {
-    const markdown = buildSummaryMarkdown(perLocale, total);
     if (process.env.GITHUB_STEP_SUMMARY) {
-        appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+        appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${buildSummaryMarkdown(perLocale, total)}\n`);
     }
     // Only emit the comment file when there's something to report — absence signals "in sync" to
     // the workflow so it doesn't open a noisy comment on every PR.
     if (process.env.I18N_PARITY_SUMMARY_FILE && total > 0) {
-        appendFileSync(process.env.I18N_PARITY_SUMMARY_FILE, `${markdown}\n`);
+        appendFileSync(
+            process.env.I18N_PARITY_SUMMARY_FILE,
+            `${buildSummaryMarkdown(perLocale, total, { detail: false })}\n`,
+        );
     }
 }
 
@@ -160,6 +177,7 @@ for (const lang of languages) {
     for (const f of extraFiles) {
         findings.push({
             type: 'stale',
+            count: Object.keys(loadFlat(path.join(langDir, f))).length,
             message: `${f} — file does not exist in "${BASE_LANG}" (stale, should be deleted)`,
         });
     }
@@ -172,6 +190,7 @@ for (const lang of languages) {
         if (!existsSync(otherPath)) {
             findings.push({
                 type: 'missing',
+                count: enKeys.length,
                 message: `${nsFile} — file missing entirely (${enKeys.length} untranslated key(s))`,
             });
             continue;
@@ -189,6 +208,7 @@ for (const lang of languages) {
         if (missingGroups.length > 0) {
             findings.push({
                 type: 'missing',
+                count: missingGroups.length,
                 message: `${nsFile} — ${missingGroups.length} missing key(s):\n${missingGroups.map((k) => `      - ${k}`).join('\n')}`,
             });
         }
@@ -196,6 +216,7 @@ for (const lang of languages) {
         if (extraGroups.length > 0) {
             findings.push({
                 type: 'stale',
+                count: extraGroups.length,
                 message: `${nsFile} — ${extraGroups.length} extra/stale key(s):\n${extraGroups.map((k) => `      - ${k}`).join('\n')}`,
             });
         }
@@ -218,6 +239,7 @@ for (const lang of languages) {
         if (mismatches.length > 0) {
             findings.push({
                 type: 'placeholder',
+                count: mismatches.length,
                 message: `${nsFile} — ${mismatches.length} placeholder mismatch(es):\n${mismatches.join('\n')}`,
             });
         }


### PR DESCRIPTION
## Problem

The sticky i18n parity comment posted on every PR dumps every drifting key for every locale. On
current `master` that is **~55 KB of markdown** in the conversation — ten collapsed `<details>`
blocks holding roughly 1,400 key names — which buries the actual signal and pushes real review
discussion off the screen. (It is worse downstream, where more locales have drifted: ~145 KB.)

The comment already opens with a per-locale summary table. Everything after it is detail that
belongs somewhere you opt into, not in the conversation thread.

## Change

`datahub-web-react/scripts/check-i18n-parity.mjs` — `buildSummaryMarkdown` now takes a `detail`
flag:

- **Sticky PR comment** (`detail: false`): summary table + a repro command. **~55 KB → ~0.7 KB.**
- **Job summary** of the `datahub-web-react-lint` run (`detail: true`): unchanged, keeps the full
  per-key dump (well under the 1 MB step-summary cap).

The table's counts also change meaning. They were counts of *findings* — one per namespace file — so
`de | 11` read as "11 missing keys" when it actually meant "11 files have missing keys". They are now
**key** counts, with the file count kept as its own column. Rendered against current `master`:

| Locale | Missing keys | Stale keys | Placeholder | Files |
| --- | --- | --- | --- | --- |
| de | 140 | 0 | 0 | 11 |
| es | 140 | 0 | 0 | 11 |
| fi | 170 | 2 | 0 | 13 |
| fr | 153 | 0 | 0 | 13 |
| hu | 153 | 0 | 0 | 13 |
| it | 153 | 0 | 0 | 13 |
| ja | 8 | 0 | 0 | 1 |
| nb | 153 | 0 | 0 | 13 |
| pt-BR | 153 | 0 | 0 | 13 |
| sv | 153 | 0 | 0 | 13 |

followed by:

> Per-key detail is in the **job summary** of the `datahub-web-react-lint` run, or reproduce locally:
>
> ```bash
> ./gradlew :datahub-web-react:yarnI18nParityCheck        # all locales
> cd datahub-web-react && yarn check-i18n-parity --lang de  # one locale
> ```

## Not changed

- **Enforcement mode** stays `warn`. With ~1,400 missing keys across 10 locales, `fail` would block
  every PR.
- **Per-locale GitHub annotations** still carry the full key list. They render on the checks page
  rather than in the conversation, so they are not the noise this fixes — though they are capped at
  4096 chars each and silently truncate today.
- **Console output** for local runs is untouched.

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated — n/a; verified by running the script locally and diffing both rendered
      report surfaces (comment file and job summary file)
- [x] Docs added/updated — n/a
- [x] Breaking changes — none; CI-reporting only, no behavior change to the check itself
