### PR TITLE
feat(ingest/microstrategy): ingest project schema as Semantic Model

### DIFF
--- a/metadata-ingestion/docs/sources/microstrategy/microstrategy_post.md
+++ b/metadata-ingestion/docs/sources/microstrategy/microstrategy_post.md
@@ -55,6 +55,17 @@ When `extract_metric_expressions: true`, the connector fetches accessible metric
 
 When `extract_model_lineage: true`, the connector probes modeling table APIs needed for logical table and physical source warehouse lineage. Missing privileges are reported as warnings and counters; the connector continues with dashboard, dataset, metric, and source warehouse metadata.
 
+#### Semantic Model
+
+Set `emit_semantic_model_entities: true` to additionally emit each project's schema as a first-class `semanticModel` entity, separate from the dashboard/report datasets described above. Attributes and Facts are project-wide MicroStrategy schema objects reusable across every report and cube in a project, so the project — not any one report — is the unit of a semantic model:
+
+- One `semanticModel` entity per project.
+- One logical dataset (subtype `Semantic Model Dataset`) per MicroStrategy logical table, with attributes emitted as `Dimension`-annotated fields and facts as `Measure`-annotated fields. Each logical dataset carries coarse upstream lineage to its physical warehouse table when a warehouse context is resolved for the project.
+- One `metric` entity per project metric (Base, Derived/Compound, and Consolidated), with lineage resolved from the metric's own expression: a Base metric's `metricUpstreams` point at the logical dataset(s) backing the facts/attributes it reads; a Derived/Compound metric's `metricRelationships.derivedFrom` points at the `metric` entities it is computed from; a Consolidated metric resolves its consolidation's attribute references (one extra API call per distinct consolidation, cached across metrics that share one) and sets `metricUpstreams` from those.
+- Relationships between logical datasets, derived from MicroStrategy's attribute hierarchy API: an attribute shared across more than one logical table triggers a lookup of that attribute's parent/child relationships, and a `semanticModelRelationship` is emitted when the two ends resolve to different tables (a hierarchy encoded entirely within one lookup table's columns has nothing to join, so no relationship is emitted for that case).
+
+This is additive: it does not change the dashboard/report/dataset emission described elsewhere on this page, and is disabled by default. It requires `extract_model_lineage` access to the MicroStrategy modeling APIs (the same access `extract_model_lineage` already needs) and a DataHub server that registers `semanticModel`/`metric` (Cloud >= 2.1.0, or OSS with `METRICS_ENABLED=true`).
+
 #### Metric and Attribute Tags
 
 MicroStrategy metrics and attributes are emitted as schema fields on the dashboard dataset/cube. The connector attaches canonical DataHub tags to the fields:

--- a/metadata-ingestion/docs/sources/microstrategy/microstrategy_recipe.yml
+++ b/metadata-ingestion/docs/sources/microstrategy/microstrategy_recipe.yml
@@ -35,6 +35,13 @@ source:
     extract_metric_expressions: true
     extract_model_lineage: true
 
+    # Additionally emit each project's schema as a first-class semanticModel
+    # (one logical dataset per MicroStrategy logical table, one metric entity
+    # per project metric with lineage). Additive; existing dashboard/report
+    # datasets are unaffected. Requires a server that registers those entities
+    # (Cloud >= 2.1.0, or OSS with METRICS_ENABLED=true).
+    # emit_semantic_model_entities: true
+
     # Optional coarse table-level lineage from MicroStrategy SQL-view APIs.
     # Keep disabled unless you want dataset -> warehouse table edges without
     # field-level metric / attribute / fact lineage.

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/client.py
@@ -22,6 +22,7 @@ from datahub.ingestion.source.microstrategy.constants import (
     MSTR_LOGIN_MODE_GUEST,
     MSTR_LOGIN_MODE_STANDARD,
     MSTR_OBJECT_TYPE_DASHBOARD,
+    MSTR_OBJECT_TYPE_METRIC,
     MSTR_OBJECT_TYPE_REPORT,
 )
 from datahub.ingestion.source.microstrategy.models import (
@@ -205,6 +206,12 @@ class MicroStrategyClient:
             project_id, MSTR_OBJECT_TYPE_REPORT, "report search"
         )
 
+    def search_metrics(self, project_id: str) -> Iterable[MicroStrategyObject]:
+        """Project-wide metric catalog, independent of any specific report/cube."""
+        yield from self._search_typed_objects(
+            project_id, MSTR_OBJECT_TYPE_METRIC, "metric search"
+        )
+
     def get_report_object(
         self,
         project_id: str,
@@ -286,6 +293,26 @@ class MicroStrategyClient:
             f"/api/model/metrics/{metric_id}",
             project_id=project_id,
             params={"showExpressionAs": "tokens"},
+        )
+
+    def get_attribute_relationships(
+        self, project_id: str, attribute_id: str
+    ) -> Dict[str, object]:
+        """Raw parent/child hierarchy JSON for one attribute, including the logical
+        table implementing each relationship; parsed by lineage.parse_attribute_relationships."""
+        return self._get_json(
+            f"/api/model/systemHierarchy/attributes/{attribute_id}/relationships",
+            project_id=project_id,
+        )
+
+    def get_consolidation_model(
+        self, project_id: str, consolidation_id: str
+    ) -> Dict[str, object]:
+        """Raw consolidation definition JSON; parsed by lineage.consolidation_attribute_ids
+        to resolve the attributes a consolidated metric ultimately reads from."""
+        return self._get_json(
+            f"/api/model/consolidations/{consolidation_id}",
+            project_id=project_id,
         )
 
     def get_model_document(

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/config.py
@@ -294,6 +294,20 @@ class MicroStrategyConfig(
             "metadata definition APIs."
         ),
     )
+    emit_semantic_model_entities: bool = Field(
+        default=False,
+        description=(
+            "If true, additionally emit one `semanticModel` entity per project "
+            "(logical datasets with subtype `Semantic Model Dataset`, one per "
+            "MicroStrategy logical table, plus a `metric` entity per project-wide "
+            "Base/Derived/Consolidated metric with lineage resolved from its "
+            "expression). This is additive: existing report/dashboard/dataset "
+            "emission is unaffected. Default is false. Requires a DataHub server "
+            "that registers semanticModel/metric (Cloud >= 2.1.0, or OSS with "
+            "`METRICS_ENABLED=true`) and `extract_model_lineage` access to the "
+            "MicroStrategy modeling APIs."
+        ),
+    )
     tag_measures_and_dimensions: bool = Field(
         default=True,
         description=(

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/constants.py
@@ -20,6 +20,10 @@ MSTR_OBJECT_TYPE_DASHBOARD = 55
 MSTR_OBJECT_TYPE_REPORT = 3
 # Documents share object type 55 with dossiers; the subtype distinguishes them.
 MSTR_OBJECT_SUBTYPE_DOCUMENT = "14081"
+# EnumDSSXMLObjectTypes: Metric, Consolidation. Used for project-wide metric
+# search and to recognize a consolidation-type expression token.
+MSTR_OBJECT_TYPE_METRIC = 7
+MSTR_OBJECT_TYPE_CONSOLIDATION = 47
 
 MEASURE_TAG_URN = "urn:li:tag:Measure"
 DIMENSION_TAG_URN = "urn:li:tag:Dimension"

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/lineage.py
@@ -687,6 +687,14 @@ def metric_metric_ids_from_model(model: Dict[str, object]) -> List[str]:
     return _expression_target_ids(model, "metric")
 
 
+def metric_attribute_ids_from_model(model: Dict[str, object]) -> List[str]:
+    return _expression_target_ids(model, "attribute")
+
+
+def metric_consolidation_ids_from_model(model: Dict[str, object]) -> List[str]:
+    return _expression_target_ids(model, "consolidation")
+
+
 def _expression_target_ids(model: Dict[str, object], subtype: str) -> List[str]:
     object_ids: Set[str] = set()
     for target in _expression_targets(model):
@@ -791,6 +799,73 @@ def _expression_targets(model: Dict[str, object]) -> List[Dict[str, object]]:
         if token.get("objectId") or token.get("id"):
             targets.append(token)
     return targets
+
+
+def consolidation_attribute_ids(consolidation_model: Dict[str, object]) -> List[str]:
+    """Attribute ids a consolidation's elements are built over.
+
+    Walks each element's expression tree generically (elements_object/
+    object_reference/operator nodes all nest arbitrarily) rather than
+    modeling the tree shape explicitly, matching _expression_targets' "be
+    liberal about where the reference lives" approach.
+    """
+    object_ids: Set[str] = set()
+
+    def visit(node: object) -> None:
+        if isinstance(node, dict):
+            attribute = node.get("attribute")
+            if isinstance(attribute, dict):
+                object_id = _object_id(attribute)
+                if object_id:
+                    object_ids.add(_normalize_object_id(object_id))
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    for element in _coerce_dicts(consolidation_model.get("elements")):
+        expression = element.get("expression")
+        if isinstance(expression, dict):
+            visit(expression.get("tree"))
+    return sorted(object_ids)
+
+
+@dataclass(frozen=True)
+class AttributeRelationship:
+    parent_attribute_id: str
+    child_attribute_id: str
+    relationship_table_id: Optional[str]
+    relationship_type: Optional[str]
+
+
+def parse_attribute_relationships(
+    response: Dict[str, object],
+) -> List[AttributeRelationship]:
+    relationships: List[AttributeRelationship] = []
+    for entry in _coerce_dicts(response.get("relationships")):
+        parent = entry.get("parent")
+        child = entry.get("child")
+        parent_id = _object_id(parent) if isinstance(parent, dict) else None
+        child_id = _object_id(child) if isinstance(child, dict) else None
+        if not parent_id or not child_id:
+            continue
+        table = entry.get("relationshipTable")
+        table_id = _object_id(table) if isinstance(table, dict) else None
+        relationship_type = entry.get("relationshipType")
+        relationships.append(
+            AttributeRelationship(
+                parent_attribute_id=_normalize_object_id(parent_id),
+                child_attribute_id=_normalize_object_id(child_id),
+                relationship_table_id=(
+                    _normalize_object_id(table_id) if table_id else None
+                ),
+                relationship_type=(
+                    str(relationship_type) if relationship_type else None
+                ),
+            )
+        )
+    return relationships
 
 
 def _form_name(form: Dict[str, object]) -> Optional[str]:
@@ -930,3 +1005,24 @@ def _created_table_leaf_names(statements: List[str]) -> Set[str]:
         if match:
             names.add(_leaf_identifier(match.group(1)))
     return names
+
+
+# Public reuse surface for other MicroStrategy modules (the semantic-model
+# mapper) that need the same object-id/table-name parsing this module already
+# does for warehouse lineage, without duplicating it.
+def object_id(value: object) -> Optional[str]:
+    return _object_id(value)
+
+
+def normalize_object_id(value: str) -> str:
+    return _normalize_object_id(value)
+
+
+def coerce_dicts(value: object) -> List[Dict[str, object]]:
+    return _coerce_dicts(value)
+
+
+def physical_table_name(
+    physical_table: Dict[str, object], context: WarehouseLineageContext
+) -> Optional[str]:
+    return _physical_table_name(physical_table, context)

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/microstrategy_semantic_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/microstrategy_semantic_model.py
@@ -1,0 +1,611 @@
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from datahub.emitter.mcp_builder import ContainerKey
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.microstrategy.client import (
+    MicroStrategyAPIError,
+    MicroStrategyClient,
+)
+from datahub.ingestion.source.microstrategy.config import MicroStrategyConfig
+from datahub.ingestion.source.microstrategy.constants import MICROSTRATEGY_PLATFORM
+from datahub.ingestion.source.microstrategy.lineage import (
+    AttributeRelationship,
+    MicroStrategyLineageExtractor,
+    WarehouseLineageContext,
+    coerce_dicts,
+    consolidation_attribute_ids,
+    metric_attribute_ids_from_model,
+    metric_consolidation_ids_from_model,
+    metric_fact_ids_from_model,
+    metric_metric_ids_from_model,
+    normalize_object_id,
+    object_id,
+    parse_attribute_relationships,
+    physical_table_name,
+)
+from datahub.ingestion.source.microstrategy.report import MicroStrategyReport
+from datahub.metadata.schema_classes import (
+    ContainerClass,
+    DialectClass,
+    ERModelRelationshipCardinalityClass,
+    SemanticFieldTypeClass,
+)
+from datahub.metadata.urns import MetricUrn, SemanticModelUrn
+from datahub.sdk.metric import DialectExpressionInput, Metric
+from datahub.sdk.semantic_model import (
+    SemanticFieldInput,
+    SemanticModel,
+    SemanticModelDataset,
+    SemanticModelRelationshipInput,
+)
+
+# MicroStrategy's attribute-relationship API states cardinality parent-to-child
+# (e.g. "one_to_many" == one parent value maps to many child values). The
+# SemanticModelRelationshipInput this module emits runs the other direction
+# (from=child table, to=parent table, matching a fact/child table joining up
+# to a dimension/parent table), so the cardinality is inverted at the call site.
+_PARENT_TO_CHILD_CARDINALITY: Dict[str, str] = {
+    "one_to_one": ERModelRelationshipCardinalityClass.ONE_ONE,
+    "one_to_many": ERModelRelationshipCardinalityClass.ONE_N,
+    "many_to_one": ERModelRelationshipCardinalityClass.N_ONE,
+    "many_to_many": ERModelRelationshipCardinalityClass.N_N,
+}
+_INVERT_CARDINALITY: Dict[str, str] = {
+    ERModelRelationshipCardinalityClass.ONE_ONE: ERModelRelationshipCardinalityClass.ONE_ONE,
+    ERModelRelationshipCardinalityClass.ONE_N: ERModelRelationshipCardinalityClass.N_ONE,
+    ERModelRelationshipCardinalityClass.N_ONE: ERModelRelationshipCardinalityClass.ONE_N,
+    ERModelRelationshipCardinalityClass.N_N: ERModelRelationshipCardinalityClass.N_N,
+}
+
+_SEMANTIC_MODEL_ID = "schema"
+
+
+@dataclass
+class _TableInfo:
+    alias: str
+    table_object_id: Optional[str]
+    warehouse_urn: Optional[str]
+    fields: Dict[str, SemanticFieldInput]  # normalized object id -> field
+
+
+def _optional_str(value: object) -> Optional[str]:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _dedupe_field_path(name: str, seen: Set[str]) -> str:
+    cleaned = name.strip() or "unknown"
+    if cleaned not in seen:
+        seen.add(cleaned)
+        return cleaned
+    suffix = 2
+    while f"{cleaned}_{suffix}" in seen:
+        suffix += 1
+    deduped = f"{cleaned}_{suffix}"
+    seen.add(deduped)
+    return deduped
+
+
+class MicroStrategySemanticModelMapper:
+    """Emits one SemanticModel per MicroStrategy project: Attributes and Facts
+    are project-wide schema objects reusable across many reports/cubes, so the
+    project (not any one report) is the natural unit of a semantic model --
+    unlike this connector's other, per-report DatasetObject/mapper.py path."""
+
+    def __init__(
+        self,
+        *,
+        config: MicroStrategyConfig,
+        report: MicroStrategyReport,
+        client: MicroStrategyClient,
+        lineage: MicroStrategyLineageExtractor,
+    ) -> None:
+        self.config = config
+        self.report = report
+        self.client = client
+        self.lineage = lineage
+
+    def emit(
+        self,
+        *,
+        project_id: str,
+        project_name: str,
+        model_tables: List[Dict[str, object]],
+        warehouse_context: Optional[WarehouseLineageContext],
+        project_container_key: ContainerKey,
+    ) -> Iterable[MetadataWorkUnit]:
+        model_urn = str(
+            SemanticModelUrn(
+                platform=MICROSTRATEGY_PLATFORM,
+                path=project_id,
+                id=_SEMANTIC_MODEL_ID,
+            )
+        )
+
+        tables, fact_table_aliases, attribute_table_aliases = self._build_table_index(
+            model_tables, warehouse_context
+        )
+        if not tables:
+            self.report.warning(
+                title="MicroStrategy Semantic Model Has No Usable Tables",
+                message=(
+                    "Skipping semantic-model emission for this project; no "
+                    "logical table exposed a usable attribute or fact."
+                ),
+                context=f"project_id={project_id}",
+            )
+            return
+
+        datasets, alias_to_dataset = self._logical_datasets(
+            project_id, model_urn, tables, project_container_key
+        )
+        relationships = self._relationships(project_id, tables, attribute_table_aliases)
+        metrics = list(
+            self._metrics(
+                project_id=project_id,
+                model_urn=model_urn,
+                fact_table_aliases=fact_table_aliases,
+                attribute_table_aliases=attribute_table_aliases,
+                alias_to_dataset=alias_to_dataset,
+            )
+        )
+
+        model = SemanticModel(
+            platform=MICROSTRATEGY_PLATFORM,
+            path=project_id,
+            id=_SEMANTIC_MODEL_ID,
+            platform_instance=self.config.platform_instance,
+            name=project_name,
+            datasets=datasets,
+            relationships=relationships or None,
+            extra_aspects=self._container_aspects(project_container_key),
+        )
+
+        yield from model.as_workunits()
+        for dataset in datasets:
+            yield from dataset.as_workunits()
+        for metric in metrics:
+            yield from metric.as_workunits()
+
+        self.report.report_semantic_model_emitted()
+        self.report.report_semantic_model_datasets_emitted(len(datasets))
+        self.report.report_semantic_model_metrics_emitted(len(metrics))
+        self.report.report_semantic_model_relationships_emitted(len(relationships))
+
+    def _container_aspects(
+        self, project_container_key: ContainerKey
+    ) -> List[ContainerClass]:
+        return [ContainerClass(container=project_container_key.as_urn())]
+
+    # ------------------------------------------------------------------
+    # Tables -> logical datasets
+    # ------------------------------------------------------------------
+
+    def _build_table_index(
+        self,
+        model_tables: List[Dict[str, object]],
+        warehouse_context: Optional[WarehouseLineageContext],
+    ) -> Tuple[List[_TableInfo], Dict[str, Set[str]], Dict[str, Set[str]]]:
+        tables: List[_TableInfo] = []
+        fact_table_aliases: Dict[str, Set[str]] = {}
+        attribute_table_aliases: Dict[str, Set[str]] = {}
+
+        for table in model_tables:
+            physical_table = table.get("physicalTable")
+            if not isinstance(physical_table, dict):
+                continue
+            alias = self._table_alias(physical_table, warehouse_context)
+            if not alias:
+                continue
+            table_object_id = object_id(physical_table.get("information"))
+            warehouse_urn = (
+                self.lineage.warehouse_dataset_urn(warehouse_context, alias)
+                if warehouse_context is not None
+                else None
+            )
+
+            fields: Dict[str, SemanticFieldInput] = {}
+            seen_field_paths: Set[str] = set()
+            for fact in coerce_dicts(table.get("facts")):
+                fact_id = object_id(fact.get("information"))
+                field = self._fact_field(fact)
+                if fact_id is None or field is None:
+                    continue
+                normalized = normalize_object_id(fact_id)
+                field.field_path = _dedupe_field_path(
+                    field.field_path, seen_field_paths
+                )
+                fields[normalized] = field
+                fact_table_aliases.setdefault(normalized, set()).add(alias)
+            for attribute in coerce_dicts(table.get("attributes")):
+                attribute_id = object_id(attribute.get("information"))
+                field = self._attribute_field(attribute)
+                if attribute_id is None or field is None:
+                    continue
+                normalized = normalize_object_id(attribute_id)
+                field.field_path = _dedupe_field_path(
+                    field.field_path, seen_field_paths
+                )
+                fields[normalized] = field
+                attribute_table_aliases.setdefault(normalized, set()).add(alias)
+
+            if not fields:
+                continue
+            tables.append(
+                _TableInfo(
+                    alias=alias,
+                    table_object_id=(
+                        normalize_object_id(table_object_id)
+                        if table_object_id
+                        else None
+                    ),
+                    warehouse_urn=warehouse_urn,
+                    fields=fields,
+                )
+            )
+
+        return tables, fact_table_aliases, attribute_table_aliases
+
+    @staticmethod
+    def _table_alias(
+        physical_table: Dict[str, object],
+        warehouse_context: Optional[WarehouseLineageContext],
+    ) -> Optional[str]:
+        if warehouse_context is not None:
+            qualified = physical_table_name(physical_table, warehouse_context)
+            if qualified:
+                return qualified
+        # No warehouse context (or it couldn't resolve a name) -- fall back to
+        # MicroStrategy's own logical table identity so tables still get a
+        # stable, reasonably-unique alias.
+        raw = physical_table.get("tableName")
+        if not isinstance(raw, str) or not raw:
+            information = physical_table.get("information")
+            if isinstance(information, dict):
+                raw = information.get("name")
+        if not isinstance(raw, str) or not raw:
+            return None
+        namespace = physical_table.get("namespace")
+        return f"{namespace}.{raw}" if isinstance(namespace, str) and namespace else raw
+
+    @staticmethod
+    def _fact_field(fact: Dict[str, object]) -> Optional[SemanticFieldInput]:
+        information = fact.get("information")
+        if not isinstance(information, dict):
+            return None
+        name = information.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        # A fact's own data type isn't part of /api/model/tables' response;
+        # it is a raw, pre-aggregation numeric value by definition (the
+        # aggregated business measure is the Metric layered on top).
+        return SemanticFieldInput(
+            field_path=name,
+            type="number",
+            semantic_type=SemanticFieldTypeClass.MEASURE,
+            description=_optional_str(information.get("description")),
+        )
+
+    @classmethod
+    def _attribute_field(
+        cls, attribute: Dict[str, object]
+    ) -> Optional[SemanticFieldInput]:
+        information = attribute.get("information")
+        if not isinstance(information, dict):
+            return None
+        name = information.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        return SemanticFieldInput(
+            field_path=name,
+            type="string",
+            semantic_type=SemanticFieldTypeClass.DIMENSION,
+            description=_optional_str(information.get("description")),
+            is_time_dimension=cls._is_temporal_attribute(attribute, name),
+        )
+
+    @staticmethod
+    def _is_temporal_attribute(attribute: Dict[str, object], name: str) -> bool:
+        # Best-effort: no single field reliably marks an attribute as a date/time
+        # dimension across MicroStrategy versions, so this checks form category
+        # first (more reliable when present) and falls back to a name-token
+        # heuristic, matching this connector's existing _is_temporal in mapper.py.
+        for form in coerce_dicts(attribute.get("forms")):
+            category = str(
+                form.get("baseFormCategory") or form.get("category") or ""
+            ).lower()
+            if any(token in category for token in ("date", "time")):
+                return True
+        lowered = name.lower()
+        return any(
+            token in lowered
+            for token in ("date", "time", "year", "quarter", "month", "day", "week")
+        )
+
+    def _logical_dataset_name(self, project_id: str, alias: str) -> str:
+        return f"{project_id}.{alias}"
+
+    def _logical_datasets(
+        self,
+        project_id: str,
+        model_urn: str,
+        tables: List[_TableInfo],
+        project_container_key: ContainerKey,
+    ) -> Tuple[List[SemanticModelDataset], Dict[str, SemanticModelDataset]]:
+        datasets: List[SemanticModelDataset] = []
+        alias_to_dataset: Dict[str, SemanticModelDataset] = {}
+        for table_info in tables:
+            dataset = SemanticModelDataset(
+                platform=MICROSTRATEGY_PLATFORM,
+                name=self._logical_dataset_name(project_id, table_info.alias),
+                semantic_model=model_urn,
+                alias=table_info.alias,
+                schema=list(table_info.fields.values()),
+                platform_instance=self.config.platform_instance,
+                env=self.config.env,
+                extra_aspects=self._container_aspects(project_container_key),
+            )
+            if table_info.warehouse_urn:
+                dataset.set_upstreams([table_info.warehouse_urn])
+            datasets.append(dataset)
+            alias_to_dataset[table_info.alias] = dataset
+        return datasets, alias_to_dataset
+
+    # ------------------------------------------------------------------
+    # Attribute hierarchy -> relationships
+    # ------------------------------------------------------------------
+
+    def _relationships(
+        self,
+        project_id: str,
+        tables: List[_TableInfo],
+        attribute_table_aliases: Dict[str, Set[str]],
+    ) -> List[SemanticModelRelationshipInput]:
+        table_alias_by_object_id = {
+            info.table_object_id: info.alias for info in tables if info.table_object_id
+        }
+        table_info_by_alias = {info.alias: info for info in tables}
+
+        # Fetching hierarchy relationships costs one API call per attribute --
+        # scope it to attributes actually shared across more than one table
+        # (the only case that can produce a cross-table relationship at all).
+        shared_attribute_ids = sorted(
+            attribute_id
+            for attribute_id, aliases in attribute_table_aliases.items()
+            if len(aliases) >= 2
+        )
+
+        relationships: List[SemanticModelRelationshipInput] = []
+        seen_pairs: Set[Tuple[str, str]] = set()
+        for attribute_id in shared_attribute_ids:
+            try:
+                response = self.client.get_attribute_relationships(
+                    project_id, attribute_id
+                )
+            except MicroStrategyAPIError as error:
+                self.report.report_semantic_model_attribute_relationship_api_failure()
+                self.report.warning(
+                    title="MicroStrategy Attribute Relationship Unavailable",
+                    message=(
+                        "Skipping this attribute's hierarchy relationships for "
+                        "the semantic model."
+                    ),
+                    context=f"project_id={project_id}, attribute_id={attribute_id}",
+                    exc=error,
+                )
+                continue
+
+            for relationship in parse_attribute_relationships(response):
+                pair = (
+                    relationship.parent_attribute_id,
+                    relationship.child_attribute_id,
+                )
+                if pair in seen_pairs:
+                    continue
+                built = self._relationship_input(
+                    project_id,
+                    relationship,
+                    table_alias_by_object_id,
+                    attribute_table_aliases,
+                    table_info_by_alias,
+                )
+                if built is None:
+                    continue
+                seen_pairs.add(pair)
+                relationships.append(built)
+        return relationships
+
+    def _relationship_input(
+        self,
+        project_id: str,
+        relationship: AttributeRelationship,
+        table_alias_by_object_id: Dict[str, str],
+        attribute_table_aliases: Dict[str, Set[str]],
+        table_info_by_alias: Dict[str, _TableInfo],
+    ) -> Optional[SemanticModelRelationshipInput]:
+        parent_aliases = attribute_table_aliases.get(
+            relationship.parent_attribute_id, set()
+        )
+        child_aliases = attribute_table_aliases.get(
+            relationship.child_attribute_id, set()
+        )
+        parent_alias = (
+            table_alias_by_object_id.get(relationship.relationship_table_id)
+            if relationship.relationship_table_id
+            else None
+        )
+        if parent_alias is None or parent_alias not in parent_aliases:
+            if len(parent_aliases) != 1:
+                return None
+            parent_alias = next(iter(parent_aliases))
+
+        # A relationship is only meaningful across two DIFFERENT logical
+        # datasets; a hierarchy encoded entirely within one lookup table's
+        # columns (the common case) has nothing to join.
+        candidate_child_aliases = sorted(child_aliases - {parent_alias})
+        if not candidate_child_aliases:
+            return None
+        if len(candidate_child_aliases) > 1:
+            self.report.warning(
+                title="Ambiguous MicroStrategy Attribute Relationship",
+                message=(
+                    "The child attribute appears on multiple other tables; "
+                    "using the first (sorted) as a best-effort choice."
+                ),
+                context=(
+                    f"project_id={project_id}, "
+                    f"child_attribute_id={relationship.child_attribute_id}, "
+                    f"candidates={candidate_child_aliases}"
+                ),
+            )
+        child_alias = candidate_child_aliases[0]
+
+        parent_field = table_info_by_alias[parent_alias].fields.get(
+            relationship.parent_attribute_id
+        )
+        child_field = table_info_by_alias[child_alias].fields.get(
+            relationship.child_attribute_id
+        )
+        if parent_field is None or child_field is None:
+            return None
+
+        cardinality = None
+        if relationship.relationship_type:
+            parent_to_child = _PARENT_TO_CHILD_CARDINALITY.get(
+                relationship.relationship_type.lower()
+            )
+            if parent_to_child is None:
+                self.report.warning(
+                    title="Unrecognized MicroStrategy Relationship Type",
+                    message="This relationship will be emitted without a cardinality.",
+                    context=(
+                        f"project_id={project_id}, "
+                        f"relationship_type={relationship.relationship_type}"
+                    ),
+                )
+            else:
+                cardinality = _INVERT_CARDINALITY[parent_to_child]
+
+        return SemanticModelRelationshipInput(
+            from_alias=child_alias,
+            from_columns=[child_field.field_path],
+            to_alias=parent_alias,
+            to_columns=[parent_field.field_path],
+            name=f"{child_alias}_to_{parent_alias}",
+            cardinality=cardinality,
+        )
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    def _metrics(
+        self,
+        *,
+        project_id: str,
+        model_urn: str,
+        fact_table_aliases: Dict[str, Set[str]],
+        attribute_table_aliases: Dict[str, Set[str]],
+        alias_to_dataset: Dict[str, SemanticModelDataset],
+    ) -> Iterable[Metric]:
+        consolidation_cache: Dict[str, List[str]] = {}
+        for metric_object in self.client.search_metrics(project_id):
+            metric_id = normalize_object_id(metric_object.id)
+            try:
+                model = self.client.get_metric_model(project_id, metric_object.id)
+            except MicroStrategyAPIError as error:
+                self.report.report_metric_expression_api_failure()
+                self.report.report_failed_metric_model(metric_object.id)
+                self.report.warning(
+                    title="MicroStrategy Metric Model Unavailable",
+                    message=(
+                        "Skipping this metric for the semantic model; its "
+                        "expression could not be fetched."
+                    ),
+                    context=f"project_id={project_id}, metric_id={metric_object.id}",
+                    exc=error,
+                )
+                continue
+
+            upstream_aliases: Set[str] = set()
+            for fact_id in metric_fact_ids_from_model(model):
+                upstream_aliases |= fact_table_aliases.get(fact_id, set())
+            for attribute_id in metric_attribute_ids_from_model(model):
+                upstream_aliases |= attribute_table_aliases.get(attribute_id, set())
+            for consolidation_id in metric_consolidation_ids_from_model(model):
+                for attribute_id in self._resolve_consolidation(
+                    project_id, consolidation_id, consolidation_cache
+                ):
+                    upstream_aliases |= attribute_table_aliases.get(attribute_id, set())
+
+            upstream_dataset_urns = sorted(
+                str(alias_to_dataset[alias].urn)
+                for alias in upstream_aliases
+                if alias in alias_to_dataset
+            )
+            derived_from = [
+                str(
+                    MetricUrn(
+                        platform=MICROSTRATEGY_PLATFORM,
+                        path=project_id,
+                        id=referenced_metric_id,
+                    )
+                )
+                for referenced_metric_id in metric_metric_ids_from_model(model)
+            ]
+
+            model_expression = model.get("expression")
+            expression_text = _optional_str(
+                model_expression.get("text")
+                if isinstance(model_expression, dict)
+                else None
+            )
+            expression = (
+                DialectExpressionInput(
+                    expression=expression_text, dialect=DialectClass.OTHER
+                )
+                if expression_text
+                else None
+            )
+
+            yield Metric(
+                platform=MICROSTRATEGY_PLATFORM,
+                path=project_id,
+                id=metric_id,
+                semantic_model=model_urn,
+                platform_instance=self.config.platform_instance,
+                name=metric_object.name,
+                description=metric_object.description,
+                expression=expression,
+                upstream_datasets=upstream_dataset_urns,
+                derived_from=derived_from,
+            )
+
+    def _resolve_consolidation(
+        self,
+        project_id: str,
+        consolidation_id: str,
+        cache: Dict[str, List[str]],
+    ) -> List[str]:
+        if consolidation_id in cache:
+            return cache[consolidation_id]
+        try:
+            model = self.client.get_consolidation_model(project_id, consolidation_id)
+        except MicroStrategyAPIError as error:
+            self.report.report_semantic_model_consolidation_api_failure()
+            self.report.warning(
+                title="MicroStrategy Consolidation Unavailable",
+                message=(
+                    "Skipping this consolidation's attribute lineage for the "
+                    "semantic model."
+                ),
+                context=f"project_id={project_id}, consolidation_id={consolidation_id}",
+                exc=error,
+            )
+            cache[consolidation_id] = []
+            return []
+        attribute_ids = consolidation_attribute_ids(model)
+        cache[consolidation_id] = attribute_ids
+        return attribute_ids

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/microstrategy_semantic_model.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/microstrategy_semantic_model.py
@@ -64,7 +64,7 @@ _SEMANTIC_MODEL_ID = "schema"
 @dataclass
 class _TableInfo:
     alias: str
-    table_object_id: Optional[str]
+    logical_table_id: Optional[str]
     warehouse_urn: Optional[str]
     fields: Dict[str, SemanticFieldInput]  # normalized object id -> field
 
@@ -196,12 +196,24 @@ class MicroStrategySemanticModelMapper:
             physical_table = table.get("physicalTable")
             if not isinstance(physical_table, dict):
                 continue
-            alias = self._table_alias(physical_table, warehouse_context)
-            if not alias:
+            physical_alias = self._table_alias(physical_table, warehouse_context)
+            if not physical_alias:
                 continue
-            table_object_id = object_id(physical_table.get("information"))
+            # The logical table (this `table` entry's own "information" block,
+            # distinct from physicalTable's) is what the attribute-hierarchy
+            # API's relationshipTable refers to, and it is what distinguishes
+            # two logical tables role-playing the same physical table (e.g.
+            # "Order Date"/"Ship Date" both mapping to one shared date-lookup
+            # table) -- the physical name alone can't tell them apart.
+            logical_information = table.get("information")
+            logical_table_id = (
+                object_id(logical_information)
+                if isinstance(logical_information, dict)
+                else None
+            )
+            alias = self._dataset_alias(logical_information, physical_alias)
             warehouse_urn = (
-                self.lineage.warehouse_dataset_urn(warehouse_context, alias)
+                self.lineage.warehouse_dataset_urn(warehouse_context, physical_alias)
                 if warehouse_context is not None
                 else None
             )
@@ -236,9 +248,9 @@ class MicroStrategySemanticModelMapper:
             tables.append(
                 _TableInfo(
                     alias=alias,
-                    table_object_id=(
-                        normalize_object_id(table_object_id)
-                        if table_object_id
+                    logical_table_id=(
+                        normalize_object_id(logical_table_id)
+                        if logical_table_id
                         else None
                     ),
                     warehouse_urn=warehouse_urn,
@@ -269,6 +281,23 @@ class MicroStrategySemanticModelMapper:
             return None
         namespace = physical_table.get("namespace")
         return f"{namespace}.{raw}" if isinstance(namespace, str) and namespace else raw
+
+    @staticmethod
+    def _dataset_alias(
+        logical_information: object,
+        physical_alias: str,
+    ) -> str:
+        # Prefer the logical table's own name as this dataset's identity: in
+        # the common (non-role-playing) case it matches the physical table
+        # name anyway, and when a physical table is role-played by more than
+        # one logical table, the logical names are what differ (e.g. "Order
+        # Date" vs "Ship Date" both backed by one date-lookup table) -- using
+        # the physical name here would collapse those into one dataset.
+        if isinstance(logical_information, dict):
+            name = logical_information.get("name")
+            if isinstance(name, str) and name:
+                return name
+        return physical_alias
 
     @staticmethod
     def _fact_field(fact: Dict[str, object]) -> Optional[SemanticFieldInput]:
@@ -363,8 +392,10 @@ class MicroStrategySemanticModelMapper:
         tables: List[_TableInfo],
         attribute_table_aliases: Dict[str, Set[str]],
     ) -> List[SemanticModelRelationshipInput]:
-        table_alias_by_object_id = {
-            info.table_object_id: info.alias for info in tables if info.table_object_id
+        table_alias_by_logical_id = {
+            info.logical_table_id: info.alias
+            for info in tables
+            if info.logical_table_id
         }
         table_info_by_alias = {info.alias: info for info in tables}
 
@@ -407,7 +438,7 @@ class MicroStrategySemanticModelMapper:
                 built = self._relationship_input(
                     project_id,
                     relationship,
-                    table_alias_by_object_id,
+                    table_alias_by_logical_id,
                     attribute_table_aliases,
                     table_info_by_alias,
                 )
@@ -421,7 +452,7 @@ class MicroStrategySemanticModelMapper:
         self,
         project_id: str,
         relationship: AttributeRelationship,
-        table_alias_by_object_id: Dict[str, str],
+        table_alias_by_logical_id: Dict[str, str],
         attribute_table_aliases: Dict[str, Set[str]],
         table_info_by_alias: Dict[str, _TableInfo],
     ) -> Optional[SemanticModelRelationshipInput]:
@@ -432,7 +463,7 @@ class MicroStrategySemanticModelMapper:
             relationship.child_attribute_id, set()
         )
         parent_alias = (
-            table_alias_by_object_id.get(relationship.relationship_table_id)
+            table_alias_by_logical_id.get(relationship.relationship_table_id)
             if relationship.relationship_table_id
             else None
         )
@@ -511,7 +542,26 @@ class MicroStrategySemanticModelMapper:
         alias_to_dataset: Dict[str, SemanticModelDataset],
     ) -> Iterable[Metric]:
         consolidation_cache: Dict[str, List[str]] = {}
-        for metric_object in self.client.search_metrics(project_id):
+        try:
+            metric_objects = list(self.client.search_metrics(project_id))
+        except MicroStrategyAPIError as error:
+            # Metric discovery is a separate API call from the tables fetch
+            # that already succeeded by the time this runs; losing it must
+            # not take the structural semantic-model entities (the model and
+            # its logical datasets, already built by the caller) down with
+            # it, so this degrades to "no metrics" rather than propagating.
+            self.report.report_semantic_model_metric_search_api_failure()
+            self.report.warning(
+                title="MicroStrategy Metric Search Unavailable",
+                message=(
+                    "Skipping metric emission for the semantic model; project "
+                    "metrics could not be enumerated."
+                ),
+                context=f"project_id={project_id}",
+                exc=error,
+            )
+            return
+        for metric_object in metric_objects:
             metric_id = normalize_object_id(metric_object.id)
             try:
                 model = self.client.get_metric_model(project_id, metric_object.id)

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/report.py
@@ -52,6 +52,12 @@ class MicroStrategyReport(StaleEntityRemovalSourceReport):
     sql_views_without_statement: int = 0
     reports_skipped_not_dashboard_linked: int = 0
     failed_metric_model_ids: LossyList[str] = field(default_factory=LossyList)
+    semantic_models_emitted: int = 0
+    semantic_model_datasets_emitted: int = 0
+    semantic_model_metrics_emitted: int = 0
+    semantic_model_relationships_emitted: int = 0
+    semantic_model_attribute_relationship_api_failures: int = 0
+    semantic_model_consolidation_api_failures: int = 0
 
     def report_project_scanned(self) -> None:
         self.projects_scanned += 1
@@ -174,3 +180,21 @@ class MicroStrategyReport(StaleEntityRemovalSourceReport):
 
     def report_failed_metric_model(self, metric_id: str) -> None:
         self.failed_metric_model_ids.append(metric_id)
+
+    def report_semantic_model_emitted(self) -> None:
+        self.semantic_models_emitted += 1
+
+    def report_semantic_model_datasets_emitted(self, count: int) -> None:
+        self.semantic_model_datasets_emitted += count
+
+    def report_semantic_model_metrics_emitted(self, count: int) -> None:
+        self.semantic_model_metrics_emitted += count
+
+    def report_semantic_model_relationships_emitted(self, count: int) -> None:
+        self.semantic_model_relationships_emitted += count
+
+    def report_semantic_model_attribute_relationship_api_failure(self) -> None:
+        self.semantic_model_attribute_relationship_api_failures += 1
+
+    def report_semantic_model_consolidation_api_failure(self) -> None:
+        self.semantic_model_consolidation_api_failures += 1

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/report.py
@@ -58,6 +58,7 @@ class MicroStrategyReport(StaleEntityRemovalSourceReport):
     semantic_model_relationships_emitted: int = 0
     semantic_model_attribute_relationship_api_failures: int = 0
     semantic_model_consolidation_api_failures: int = 0
+    semantic_model_metric_search_api_failures: int = 0
 
     def report_project_scanned(self) -> None:
         self.projects_scanned += 1
@@ -198,3 +199,6 @@ class MicroStrategyReport(StaleEntityRemovalSourceReport):
 
     def report_semantic_model_consolidation_api_failure(self) -> None:
         self.semantic_model_consolidation_api_failures += 1
+
+    def report_semantic_model_metric_search_api_failure(self) -> None:
+        self.semantic_model_metric_search_api_failures += 1

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/source.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Dict, Iterable, List, Optional, Sequence, Set
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set
 
 from pydantic import ValidationError
 
@@ -49,6 +49,9 @@ from datahub.ingestion.source.microstrategy.lineage import (
     warehouse_context_with_connection,
 )
 from datahub.ingestion.source.microstrategy.mapper import MicroStrategyMapper
+from datahub.ingestion.source.microstrategy.microstrategy_semantic_model import (
+    MicroStrategySemanticModelMapper,
+)
 from datahub.ingestion.source.microstrategy.models import (
     DashboardDefinition,
     DatasetObject,
@@ -287,6 +290,38 @@ class MicroStrategySource(StatefulIngestionSourceBase, TestableSource):
                 lineage_context,
                 linked_report_ids,
             )
+        if self.config.emit_semantic_model_entities:
+            yield from self._process_project_semantic_model(project, lineage_context)
+
+    def _process_project_semantic_model(
+        self,
+        project: Project,
+        lineage_context: "_LazyProjectLineage",
+    ) -> Iterable[MetadataWorkUnit]:
+        model_tables = lineage_context.model_tables
+        if not model_tables:
+            self.report.warning(
+                title="MicroStrategy Semantic Model Unavailable",
+                message=(
+                    "Skipping semantic-model emission for this project because no "
+                    "logical tables were returned by the model tables API."
+                ),
+                context=f"project_id={project.id}",
+            )
+            return
+        semantic_model_mapper = MicroStrategySemanticModelMapper(
+            config=self.config,
+            report=self.report,
+            client=self.client,
+            lineage=self.lineage,
+        )
+        yield from semantic_model_mapper.emit(
+            project_id=project.id,
+            project_name=project.name,
+            model_tables=model_tables,
+            warehouse_context=lineage_context.warehouse_context,
+            project_container_key=self.mapper.project_key(project.id),
+        )
 
     def _get_project_source_warehouses(self, project_id: str) -> List[Datasource]:
         if not self.config.extract_source_warehouses:
@@ -773,24 +808,17 @@ class MicroStrategySource(StatefulIngestionSourceBase, TestableSource):
             }
         )
 
-    def _get_project_model_lineage_index(
-        self,
-        project_id: str,
-        warehouse_context: Optional[WarehouseLineageContext],
-    ) -> Optional[ModelLineageIndex]:
-        if not self.config.extract_lineage or not self.config.extract_model_lineage:
-            return None
-        if warehouse_context is None:
-            self.report.warning(
-                title="MicroStrategy Model Lineage Unavailable",
-                message=(
-                    "Skipping logical table lineage because no supported source "
-                    "warehouse context was discovered for this project."
-                ),
-                context=f"project_id={project_id}",
-            )
-            return None
+    def _fetch_project_model_tables(
+        self, project_id: str
+    ) -> Optional[List[Dict[str, object]]]:
+        """Paginate /api/model/tables for a project.
 
+        Returns None on API failure (already reported/warned); an empty list is
+        a genuine "no model tables" result, distinct from a failed fetch.
+        Shared by the classic per-report model-lineage path and the
+        project-level semantic-model path, so it is fetched at most once per
+        project regardless of how many consumers need it.
+        """
         model_tables: List[Dict[str, object]] = []
         offset = 0
         while True:
@@ -848,6 +876,30 @@ class MicroStrategySource(StatefulIngestionSourceBase, TestableSource):
                 break
 
         self.report.report_model_tables_scanned(len(model_tables))
+        return model_tables
+
+    def _get_project_model_lineage_index(
+        self,
+        project_id: str,
+        warehouse_context: Optional[WarehouseLineageContext],
+        model_tables_provider: Callable[[], Optional[List[Dict[str, object]]]],
+    ) -> Optional[ModelLineageIndex]:
+        if not self.config.extract_lineage or not self.config.extract_model_lineage:
+            return None
+        if warehouse_context is None:
+            self.report.warning(
+                title="MicroStrategy Model Lineage Unavailable",
+                message=(
+                    "Skipping logical table lineage because no supported source "
+                    "warehouse context was discovered for this project."
+                ),
+                context=f"project_id={project_id}",
+            )
+            return None
+
+        # Deferred until here (not called unconditionally by the caller) so the
+        # fetch stays skipped when these flags are off, exactly as before.
+        model_tables = model_tables_provider()
         if not model_tables:
             return None
         return self.lineage.model_lineage_index_from_tables(
@@ -1355,6 +1407,8 @@ class _LazyProjectLineage:
         self._context_resolved = False
         self._index: Optional[ModelLineageIndex] = None
         self._index_resolved = False
+        self._model_tables: Optional[List[Dict[str, object]]] = None
+        self._model_tables_resolved = False
 
     @property
     def warehouse_context(self) -> Optional[WarehouseLineageContext]:
@@ -1371,12 +1425,29 @@ class _LazyProjectLineage:
         return self._context
 
     @property
+    def model_tables(self) -> Optional[List[Dict[str, object]]]:
+        """Raw /api/model/tables rows, fetched at most once per project.
+
+        Shared by model_lineage_index (below) and the semantic-model pass, so
+        toggling both on for the same run costs one fetch, not two.
+        """
+        if not self._model_tables_resolved:
+            try:
+                self._model_tables = self._source._fetch_project_model_tables(
+                    self._project_id
+                )
+            finally:
+                self._model_tables_resolved = True
+        return self._model_tables
+
+    @property
     def model_lineage_index(self) -> Optional[ModelLineageIndex]:
         if not self._index_resolved:
             try:
                 self._index = self._source._get_project_model_lineage_index(
                     self._project_id,
                     self.warehouse_context,
+                    lambda: self.model_tables,
                 )
             finally:
                 self._index_resolved = True

--- a/metadata-ingestion/src/datahub/ingestion/source/microstrategy/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/microstrategy/source.py
@@ -827,7 +827,7 @@ class MicroStrategySource(StatefulIngestionSourceBase, TestableSource):
                     project_id,
                     limit=self.config.page_size,
                     offset=offset,
-                    fields="physicalTable,attributes,facts",
+                    fields="information,physicalTable,attributes,facts",
                 )
             except MicroStrategyAPIError as error:
                 self.report.report_model_lineage_api_failure()

--- a/metadata-ingestion/tests/integration/microstrategy/test_microstrategy.py
+++ b/metadata-ingestion/tests/integration/microstrategy/test_microstrategy.py
@@ -262,7 +262,7 @@ def _model_tables(
     offset: int = 0,
     fields: str | None = None,
 ) -> ModelTablesResponse:
-    assert fields == "physicalTable,attributes,facts"
+    assert fields == "information,physicalTable,attributes,facts"
     if offset > 0:
         return ModelTablesResponse(tables=[], total=1)
     return ModelTablesResponse.model_validate(

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_client.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_client.py
@@ -178,6 +178,87 @@ def test_search_reports_uses_report_object_type(
     assert reports[0].id == "report-1"
 
 
+def test_search_metrics_uses_metric_object_type(monkeypatch: MonkeyPatch) -> None:
+    config = MicroStrategyConfig.model_validate(
+        {"base_url": "https://mstr.example.com/MicroStrategyLibrary"}
+    )
+    client = MicroStrategyClient(config, MicroStrategyReport())
+    captured_params: Optional[Dict[str, Any]] = None
+
+    def fake_get_json(
+        path: str,
+        project_id: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        nonlocal captured_params
+        captured_params = params
+        return {"result": [{"id": "metric-1", "name": "Revenue"}]}
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    metrics = list(client.search_metrics(project_id="project-1"))
+
+    assert captured_params is not None
+    assert captured_params["type"] == "7"
+    assert metrics[0].id == "metric-1"
+
+
+def test_get_attribute_relationships_calls_system_hierarchy_endpoint(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    config = MicroStrategyConfig.model_validate(
+        {"base_url": "https://mstr.example.com/MicroStrategyLibrary"}
+    )
+    client = MicroStrategyClient(config, MicroStrategyReport())
+    captured: Dict[str, Any] = {}
+
+    def fake_get_json(
+        path: str,
+        project_id: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        captured["path"] = path
+        captured["project_id"] = project_id
+        return {"relationships": []}
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    result = client.get_attribute_relationships("project-1", "ATTR1")
+
+    assert (
+        captured["path"] == "/api/model/systemHierarchy/attributes/ATTR1/relationships"
+    )
+    assert captured["project_id"] == "project-1"
+    assert result == {"relationships": []}
+
+
+def test_get_consolidation_model_calls_consolidations_endpoint(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    config = MicroStrategyConfig.model_validate(
+        {"base_url": "https://mstr.example.com/MicroStrategyLibrary"}
+    )
+    client = MicroStrategyClient(config, MicroStrategyReport())
+    captured: Dict[str, Any] = {}
+
+    def fake_get_json(
+        path: str,
+        project_id: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        captured["path"] = path
+        captured["project_id"] = project_id
+        return {"elements": []}
+
+    monkeypatch.setattr(client, "_get_json", fake_get_json)
+
+    result = client.get_consolidation_model("project-1", "CONSOL1")
+
+    assert captured["path"] == "/api/model/consolidations/CONSOL1"
+    assert captured["project_id"] == "project-1"
+    assert result == {"elements": []}
+
+
 def test_list_datasources_reads_datasource_management_response(
     monkeypatch: MonkeyPatch,
 ) -> None:

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_config.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_config.py
@@ -27,3 +27,22 @@ def test_password_auth_rejects_blank_username(username: str) -> None:
                 },
             }
         )
+
+
+def test_emit_semantic_model_entities_defaults_to_false() -> None:
+    config = MicroStrategyConfig.model_validate(
+        {"base_url": "https://mstr.example.com/MicroStrategyLibrary"}
+    )
+
+    assert config.emit_semantic_model_entities is False
+
+
+def test_emit_semantic_model_entities_can_be_enabled() -> None:
+    config = MicroStrategyConfig.model_validate(
+        {
+            "base_url": "https://mstr.example.com/MicroStrategyLibrary",
+            "emit_semantic_model_entities": True,
+        }
+    )
+
+    assert config.emit_semantic_model_entities is True

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_lineage.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_lineage.py
@@ -9,10 +9,14 @@ from datahub.ingestion.source.microstrategy.lineage import (
     MicroStrategyLineageExtractor,
     WarehouseLineageContext,
     bind_visualizations_by_derived_objects,
+    consolidation_attribute_ids,
     datahub_platform_for_source_type,
     extract_field_names_from_expression,
+    metric_attribute_ids_from_model,
+    metric_consolidation_ids_from_model,
     metric_fact_ids_from_model,
     metric_metric_ids_from_model,
+    parse_attribute_relationships,
     qualify_table_name,
     unique_derived_object_owners,
     warehouse_context_from_datasource,
@@ -623,6 +627,133 @@ def test_metric_metric_ids_from_model_accepts_nested_and_top_level_tokens() -> N
 
     assert metric_metric_ids_from_model(nested_model) == ["METRIC-2"]
     assert metric_metric_ids_from_model(top_level_model) == ["METRIC-2"]
+
+
+def test_metric_attribute_ids_from_model_accepts_nested_and_top_level_tokens() -> None:
+    nested_model: Dict[str, Any] = {
+        "expression": {
+            "tokens": [{"target": {"objectId": "attr-1", "subType": "attribute"}}]
+        }
+    }
+    top_level_model: Dict[str, Any] = {
+        "expression": {"tokens": [{"objectId": "attr-1", "subType": "attribute"}]}
+    }
+
+    assert metric_attribute_ids_from_model(nested_model) == ["ATTR-1"]
+    assert metric_attribute_ids_from_model(top_level_model) == ["ATTR-1"]
+
+
+def test_metric_consolidation_ids_from_model_accepts_nested_and_top_level_tokens() -> (
+    None
+):
+    nested_model: Dict[str, Any] = {
+        "expression": {
+            "tokens": [{"target": {"objectId": "consol-1", "subType": "consolidation"}}]
+        }
+    }
+    top_level_model: Dict[str, Any] = {
+        "expression": {"tokens": [{"objectId": "consol-1", "subType": "consolidation"}]}
+    }
+
+    assert metric_consolidation_ids_from_model(nested_model) == ["CONSOL-1"]
+    assert metric_consolidation_ids_from_model(top_level_model) == ["CONSOL-1"]
+
+
+def test_consolidation_attribute_ids_walks_element_expression_trees() -> None:
+    consolidation_model: Dict[str, Any] = {
+        "elements": [
+            {
+                "expression": {
+                    "tree": {
+                        "type": "elements_object",
+                        "elements": [
+                            {
+                                "attribute": {
+                                    "objectId": "attr-1",
+                                    "subType": "attribute",
+                                }
+                            }
+                        ],
+                    }
+                }
+            },
+            {
+                "expression": {
+                    "tree": {
+                        "type": "operator",
+                        "function": "plus",
+                        "left": {
+                            "type": "elements_object",
+                            "elements": [
+                                {
+                                    "attribute": {
+                                        "objectId": "attr-2",
+                                        "subType": "attribute",
+                                    }
+                                }
+                            ],
+                        },
+                        "right": {
+                            "type": "elements_object",
+                            "elements": [
+                                {
+                                    "attribute": {
+                                        "objectId": "attr-1",
+                                        "subType": "attribute",
+                                    }
+                                }
+                            ],
+                        },
+                    }
+                }
+            },
+        ]
+    }
+
+    assert consolidation_attribute_ids(consolidation_model) == ["ATTR-1", "ATTR-2"]
+
+
+def test_consolidation_attribute_ids_handles_missing_elements() -> None:
+    assert consolidation_attribute_ids({}) == []
+    assert consolidation_attribute_ids({"elements": "not-a-list"}) == []
+
+
+def test_parse_attribute_relationships_extracts_parent_child_and_table() -> None:
+    response: Dict[str, Any] = {
+        "relationships": [
+            {
+                "parent": {"objectId": "parent-1", "subType": "attribute"},
+                "child": {"objectId": "child-1", "subType": "attribute"},
+                "relationshipTable": {
+                    "objectId": "table-1",
+                    "subType": "logical_table",
+                    "name": "LU_MONTH",
+                },
+                "relationshipType": "one_to_many",
+            }
+        ]
+    }
+
+    relationships = parse_attribute_relationships(response)
+
+    assert len(relationships) == 1
+    relationship = relationships[0]
+    assert relationship.parent_attribute_id == "PARENT-1"
+    assert relationship.child_attribute_id == "CHILD-1"
+    assert relationship.relationship_table_id == "TABLE-1"
+    assert relationship.relationship_type == "one_to_many"
+
+
+def test_parse_attribute_relationships_skips_entries_missing_parent_or_child() -> None:
+    response: Dict[str, Any] = {
+        "relationships": [
+            {"child": {"objectId": "child-1"}},
+            {"parent": {"objectId": "parent-1"}},
+            "not-a-dict",
+        ]
+    }
+
+    assert parse_attribute_relationships(response) == []
 
 
 def test_physical_table_uses_context_database_over_mstr_namespace() -> None:

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_semantic_model.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_semantic_model.py
@@ -1,0 +1,560 @@
+from typing import Any, Dict, Iterator, List, Optional
+
+from datahub.emitter.mcp_builder import ContainerKey
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
+from datahub.ingestion.source.microstrategy.client import MicroStrategyAPIError
+from datahub.ingestion.source.microstrategy.config import MicroStrategyConfig
+from datahub.ingestion.source.microstrategy.lineage import MicroStrategyLineageExtractor
+from datahub.ingestion.source.microstrategy.microstrategy_semantic_model import (
+    MicroStrategySemanticModelMapper,
+)
+from datahub.ingestion.source.microstrategy.models import MicroStrategyObject
+from datahub.ingestion.source.microstrategy.report import MicroStrategyReport
+from datahub.metadata.schema_classes import (
+    ERModelRelationshipCardinalityClass,
+    MetricInfoClass,
+    MetricRelationshipsClass,
+    MetricUpstreamsClass,
+    SchemaMetadataClass,
+    SemanticFieldAnnotationClass,
+    SemanticFieldTypeClass,
+    SemanticModelInfoClass,
+    SemanticModelPropertiesClass,
+)
+from datahub.metadata.urns import SchemaFieldUrn
+
+
+class _ProjectKey(ContainerKey):
+    project_id: str
+
+
+class FakeSemanticModelClient:
+    def __init__(
+        self,
+        *,
+        metrics: Optional[List[MicroStrategyObject]] = None,
+        metric_models: Optional[Dict[str, Dict[str, Any]]] = None,
+        attribute_relationships: Optional[Dict[str, Dict[str, Any]]] = None,
+        consolidation_models: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> None:
+        self._metrics = metrics or []
+        self._metric_models = metric_models or {}
+        self._attribute_relationships = attribute_relationships or {}
+        self._consolidation_models = consolidation_models or {}
+        self.attribute_relationship_calls: List[str] = []
+        self.consolidation_calls: List[str] = []
+
+    def search_metrics(self, project_id: str) -> Iterator[MicroStrategyObject]:
+        return iter(self._metrics)
+
+    def get_metric_model(self, project_id: str, metric_id: str) -> Dict[str, Any]:
+        return self._metric_models.get(metric_id, {})
+
+    def get_attribute_relationships(
+        self, project_id: str, attribute_id: str
+    ) -> Dict[str, Any]:
+        self.attribute_relationship_calls.append(attribute_id)
+        if attribute_id in self._attribute_relationships:
+            return self._attribute_relationships[attribute_id]
+        raise MicroStrategyAPIError(f"no fixture for {attribute_id}")
+
+    def get_consolidation_model(
+        self, project_id: str, consolidation_id: str
+    ) -> Dict[str, Any]:
+        self.consolidation_calls.append(consolidation_id)
+        if consolidation_id in self._consolidation_models:
+            return self._consolidation_models[consolidation_id]
+        raise MicroStrategyAPIError(f"no fixture for {consolidation_id}")
+
+
+def _config(**overrides: object) -> MicroStrategyConfig:
+    base: Dict[str, object] = {
+        "base_url": "https://mstr.example.com/MicroStrategyLibrary",
+        "emit_semantic_model_entities": True,
+    }
+    base.update(overrides)
+    return MicroStrategyConfig.model_validate(base)
+
+
+def _mapper(
+    client: FakeSemanticModelClient, **config_overrides: object
+) -> MicroStrategySemanticModelMapper:
+    config = _config(**config_overrides)
+    report = MicroStrategyReport()
+    return MicroStrategySemanticModelMapper(
+        config=config,
+        report=report,
+        client=client,  # type: ignore[arg-type]
+        lineage=MicroStrategyLineageExtractor(config, report),
+    )
+
+
+def _project_container_key() -> ContainerKey:
+    return _ProjectKey(
+        platform="microstrategy",
+        instance=None,
+        env="PROD",
+        project_id="project-1",
+    )
+
+
+def _aspects_by_urn(wus: List[MetadataWorkUnit]) -> Dict[str, Dict[str, object]]:
+    out: Dict[str, Dict[str, object]] = {}
+    for wu in wus:
+        urn = wu.get_urn()
+        aspect = wu.metadata.aspect  # type: ignore[union-attr]
+        if aspect is None:
+            continue
+        out.setdefault(urn, {})[type(aspect).__name__] = aspect
+    return out
+
+
+def _attribute(
+    object_id: str, name: str, description: Optional[str] = None
+) -> Dict[str, Any]:
+    information: Dict[str, Any] = {"objectId": object_id, "name": name}
+    if description:
+        information["description"] = description
+    return {"information": information, "forms": []}
+
+
+def _fact(object_id: str, name: str) -> Dict[str, Any]:
+    return {"information": {"objectId": object_id, "name": name}}
+
+
+def _table(
+    table_name: str, attributes: List[Dict[str, Any]], facts: List[Dict[str, Any]]
+) -> Dict[str, Any]:
+    return {
+        "physicalTable": {
+            "tableName": table_name,
+            "information": {"objectId": f"TBL-{table_name}", "name": table_name},
+        },
+        "attributes": attributes,
+        "facts": facts,
+    }
+
+
+def test_table_becomes_semantic_model_dataset_with_dimension_and_measure_fields() -> (
+    None
+):
+    mapper = _mapper(FakeSemanticModelClient())
+    model_tables = [
+        _table(
+            "SALES",
+            attributes=[_attribute("ATTR1", "Region")],
+            facts=[_fact("FACT1", "Revenue")],
+        )
+    ]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:microstrategy,project-1,schema)"
+    )
+    assert model_urn in aspects
+    info = aspects[model_urn]["SemanticModelInfoClass"]
+    assert isinstance(info, SemanticModelInfoClass)
+    assert info.name == "Project One"
+
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.SALES,PROD)"
+    )
+    assert dataset_urn in aspects
+    assert aspects[dataset_urn]["SubTypesClass"].typeNames == [  # type: ignore[attr-defined]
+        DatasetSubTypes.SEMANTIC_MODEL_DATASET
+    ]
+    props = aspects[dataset_urn]["SemanticModelPropertiesClass"]
+    assert isinstance(props, SemanticModelPropertiesClass)
+    assert props.alias == "SALES"
+    assert props.semanticModel == model_urn
+
+    schema_meta = aspects[dataset_urn]["SchemaMetadataClass"]
+    assert isinstance(schema_meta, SchemaMetadataClass)
+    field_paths = {f.fieldPath for f in schema_meta.fields}
+    assert field_paths == {"Region", "Revenue"}
+
+    region_field_urn = SchemaFieldUrn(dataset_urn, "Region").urn()
+    revenue_field_urn = SchemaFieldUrn(dataset_urn, "Revenue").urn()
+    region_annotation = aspects[region_field_urn]["SemanticFieldAnnotationClass"]
+    revenue_annotation = aspects[revenue_field_urn]["SemanticFieldAnnotationClass"]
+    assert isinstance(region_annotation, SemanticFieldAnnotationClass)
+    assert isinstance(revenue_annotation, SemanticFieldAnnotationClass)
+    assert region_annotation.type == SemanticFieldTypeClass.DIMENSION
+    assert revenue_annotation.type == SemanticFieldTypeClass.MEASURE
+
+
+def test_table_with_no_usable_fields_is_skipped_with_warning() -> None:
+    mapper = _mapper(FakeSemanticModelClient())
+    model_tables = [_table("EMPTY", attributes=[], facts=[])]
+
+    workunits = list(
+        mapper.emit(
+            project_id="project-1",
+            project_name="Project One",
+            model_tables=model_tables,
+            warehouse_context=None,
+            project_container_key=_project_container_key(),
+        )
+    )
+
+    assert workunits == []
+    assert mapper.report.warnings
+
+
+def test_relationship_emitted_for_attribute_shared_across_two_tables() -> None:
+    client = FakeSemanticModelClient(
+        attribute_relationships={
+            "ATTR-SHARED": {
+                "relationships": [
+                    {
+                        "parent": {"objectId": "ATTR-SHARED", "subType": "attribute"},
+                        "child": {"objectId": "ATTR-CHILD", "subType": "attribute"},
+                        "relationshipTable": {
+                            "objectId": "TBL-PARENT",
+                            "subType": "logical_table",
+                        },
+                        "relationshipType": "one_to_many",
+                    }
+                ]
+            }
+        }
+    )
+    mapper = _mapper(client)
+    model_tables = [
+        _table(
+            "PARENT",
+            attributes=[_attribute("ATTR-SHARED", "Quarter")],
+            facts=[],
+        ),
+        _table(
+            "CHILD",
+            attributes=[
+                _attribute("ATTR-SHARED", "Quarter"),
+                _attribute("ATTR-CHILD", "Month"),
+            ],
+            facts=[],
+        ),
+    ]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:microstrategy,project-1,schema)"
+    )
+    info = aspects[model_urn]["SemanticModelInfoClass"]
+    assert isinstance(info, SemanticModelInfoClass)
+    assert info.relationships
+    relationship = info.relationships[0]
+    assert relationship.from_ == "CHILD"
+    assert relationship.to == "PARENT"
+    assert relationship.fromColumns == ["Month"]
+    assert relationship.toColumns == ["Quarter"]
+    # "one_to_many" parent->child is inverted for the child->parent edge this
+    # module emits, so it becomes many-to-one (N_ONE).
+    assert relationship.cardinality == ERModelRelationshipCardinalityClass.N_ONE
+    assert client.attribute_relationship_calls == ["ATTR-SHARED"]
+
+
+def test_attribute_on_single_table_never_triggers_relationship_fetch() -> None:
+    client = FakeSemanticModelClient()
+    mapper = _mapper(client)
+    model_tables = [
+        _table("ONLY", attributes=[_attribute("ATTR1", "Region")], facts=[])
+    ]
+
+    list(
+        mapper.emit(
+            project_id="project-1",
+            project_name="Project One",
+            model_tables=model_tables,
+            warehouse_context=None,
+            project_container_key=_project_container_key(),
+        )
+    )
+
+    assert client.attribute_relationship_calls == []
+
+
+def test_relationship_fetch_failure_warns_and_is_skipped() -> None:
+    client = FakeSemanticModelClient()  # no fixture -> raises MicroStrategyAPIError
+    mapper = _mapper(client)
+    model_tables = [
+        _table("A", attributes=[_attribute("ATTR-SHARED", "X")], facts=[]),
+        _table("B", attributes=[_attribute("ATTR-SHARED", "X")], facts=[]),
+    ]
+
+    workunits = list(
+        mapper.emit(
+            project_id="project-1",
+            project_name="Project One",
+            model_tables=model_tables,
+            warehouse_context=None,
+            project_container_key=_project_container_key(),
+        )
+    )
+
+    assert workunits  # datasets/model still emitted
+    assert mapper.report.semantic_model_attribute_relationship_api_failures == 1
+
+
+def test_unrecognized_relationship_type_warns_but_still_emits_relationship() -> None:
+    client = FakeSemanticModelClient(
+        attribute_relationships={
+            "ATTR-SHARED": {
+                "relationships": [
+                    {
+                        "parent": {"objectId": "ATTR-SHARED", "subType": "attribute"},
+                        "child": {"objectId": "ATTR-CHILD", "subType": "attribute"},
+                        "relationshipTable": {"objectId": "TBL-PARENT"},
+                        "relationshipType": "weird_type",
+                    }
+                ]
+            }
+        }
+    )
+    mapper = _mapper(client)
+    model_tables = [
+        _table("PARENT", attributes=[_attribute("ATTR-SHARED", "Quarter")], facts=[]),
+        _table(
+            "CHILD",
+            attributes=[
+                _attribute("ATTR-SHARED", "Quarter"),
+                _attribute("ATTR-CHILD", "Month"),
+            ],
+            facts=[],
+        ),
+    ]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:microstrategy,project-1,schema)"
+    )
+    info = aspects[model_urn]["SemanticModelInfoClass"]
+    assert isinstance(info, SemanticModelInfoClass)
+    assert info.relationships
+    assert info.relationships[0].cardinality is None
+    assert mapper.report.warnings
+
+
+def _metric_object(metric_id: str, name: str) -> MicroStrategyObject:
+    return MicroStrategyObject.model_validate({"id": metric_id, "name": name})
+
+
+def test_base_metric_gets_upstream_datasets_and_no_derived_from() -> None:
+    client = FakeSemanticModelClient(
+        metrics=[_metric_object("METRIC1", "Revenue Metric")],
+        metric_models={
+            "METRIC1": {
+                "expression": {
+                    "text": "Sum(Revenue)",
+                    "tokens": [{"objectId": "FACT1", "subType": "fact"}],
+                }
+            }
+        },
+    )
+    mapper = _mapper(client)
+    model_tables = [_table("SALES", attributes=[], facts=[_fact("FACT1", "Revenue")])]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    metric_urn = "urn:li:metric:(urn:li:dataPlatform:microstrategy,project-1,METRIC1)"
+    assert metric_urn in aspects
+    metric_info = aspects[metric_urn]["MetricInfoClass"]
+    assert isinstance(metric_info, MetricInfoClass)
+    assert metric_info.expression is not None
+    upstreams = aspects[metric_urn]["MetricUpstreamsClass"]
+    assert isinstance(upstreams, MetricUpstreamsClass)
+    assert upstreams.datasetUpstreams
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.SALES,PROD)"
+    )
+    assert upstreams.datasetUpstreams[0].destinationUrn == dataset_urn
+    relationships = aspects[metric_urn]["MetricRelationshipsClass"]
+    assert isinstance(relationships, MetricRelationshipsClass)
+    assert relationships.derivedFrom == []
+
+
+def test_derived_metric_gets_derived_from_referenced_metric() -> None:
+    client = FakeSemanticModelClient(
+        metrics=[
+            _metric_object("BASE1", "Base Metric"),
+            _metric_object("DERIVED1", "Derived Metric"),
+        ],
+        metric_models={
+            "BASE1": {
+                "expression": {
+                    "tokens": [{"objectId": "FACT1", "subType": "fact"}],
+                }
+            },
+            "DERIVED1": {
+                "expression": {
+                    "tokens": [{"objectId": "BASE1", "subType": "metric"}],
+                }
+            },
+        },
+    )
+    mapper = _mapper(client)
+    model_tables = [_table("SALES", attributes=[], facts=[_fact("FACT1", "Revenue")])]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    derived_urn = "urn:li:metric:(urn:li:dataPlatform:microstrategy,project-1,DERIVED1)"
+    base_urn = "urn:li:metric:(urn:li:dataPlatform:microstrategy,project-1,BASE1)"
+    relationships = aspects[derived_urn]["MetricRelationshipsClass"]
+    assert isinstance(relationships, MetricRelationshipsClass)
+    assert [d.destinationUrn for d in relationships.derivedFrom] == [base_urn]
+
+
+def test_consolidated_metric_resolves_upstream_through_consolidation_attributes() -> (
+    None
+):
+    client = FakeSemanticModelClient(
+        metrics=[
+            _metric_object("CONSOL_METRIC", "YoY Growth"),
+            _metric_object("CONSOL_METRIC2", "YoY Growth 2"),
+        ],
+        metric_models={
+            "CONSOL_METRIC": {
+                "expression": {
+                    "tokens": [{"objectId": "CONSOL1", "subType": "consolidation"}],
+                }
+            },
+            "CONSOL_METRIC2": {
+                "expression": {
+                    "tokens": [{"objectId": "CONSOL1", "subType": "consolidation"}],
+                }
+            },
+        },
+        consolidation_models={
+            "CONSOL1": {
+                "elements": [
+                    {
+                        "expression": {
+                            "tree": {
+                                "type": "elements_object",
+                                "elements": [
+                                    {
+                                        "attribute": {
+                                            "objectId": "ATTR1",
+                                            "subType": "attribute",
+                                        }
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+    )
+    mapper = _mapper(client)
+    model_tables = [_table("DIM", attributes=[_attribute("ATTR1", "Region")], facts=[])]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    metric_urn = (
+        "urn:li:metric:(urn:li:dataPlatform:microstrategy,project-1,CONSOL_METRIC)"
+    )
+    upstreams = aspects[metric_urn]["MetricUpstreamsClass"]
+    assert isinstance(upstreams, MetricUpstreamsClass)
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.DIM,PROD)"
+    )
+    assert upstreams.datasetUpstreams
+    assert upstreams.datasetUpstreams[0].destinationUrn == dataset_urn
+    # Two metrics share one consolidation; its definition is only fetched once.
+    assert client.consolidation_calls == ["CONSOL1"]
+
+
+def test_metric_model_fetch_failure_warns_and_skips_that_metric() -> None:
+    client = FakeSemanticModelClient(
+        metrics=[_metric_object("BROKEN", "Broken Metric")],
+        metric_models={},  # no fixture -> get_metric_model raises via override below
+    )
+
+    def _raise(project_id: str, metric_id: str) -> Dict[str, Any]:
+        raise MicroStrategyAPIError("boom")
+
+    client.get_metric_model = _raise  # type: ignore[method-assign]
+    mapper = _mapper(client)
+    model_tables = [_table("SALES", attributes=[], facts=[_fact("FACT1", "Revenue")])]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    metric_urn = "urn:li:metric:(urn:li:dataPlatform:microstrategy,project-1,BROKEN)"
+    assert metric_urn not in aspects
+    assert mapper.report.metric_expression_api_failures == 1
+    assert list(mapper.report.failed_metric_model_ids) == ["BROKEN"]

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_semantic_model.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_semantic_model.py
@@ -37,15 +37,19 @@ class FakeSemanticModelClient:
         metric_models: Optional[Dict[str, Dict[str, Any]]] = None,
         attribute_relationships: Optional[Dict[str, Dict[str, Any]]] = None,
         consolidation_models: Optional[Dict[str, Dict[str, Any]]] = None,
+        search_metrics_fails: bool = False,
     ) -> None:
         self._metrics = metrics or []
         self._metric_models = metric_models or {}
         self._attribute_relationships = attribute_relationships or {}
         self._consolidation_models = consolidation_models or {}
+        self._search_metrics_fails = search_metrics_fails
         self.attribute_relationship_calls: List[str] = []
         self.consolidation_calls: List[str] = []
 
     def search_metrics(self, project_id: str) -> Iterator[MicroStrategyObject]:
+        if self._search_metrics_fails:
+            raise MicroStrategyAPIError("metric search unavailable")
         return iter(self._metrics)
 
     def get_metric_model(self, project_id: str, metric_id: str) -> Dict[str, Any]:
@@ -124,12 +128,32 @@ def _fact(object_id: str, name: str) -> Dict[str, Any]:
 
 
 def _table(
-    table_name: str, attributes: List[Dict[str, Any]], facts: List[Dict[str, Any]]
+    table_name: str,
+    attributes: List[Dict[str, Any]],
+    facts: List[Dict[str, Any]],
+    logical_table_id: Optional[str] = None,
+    logical_table_name: Optional[str] = None,
+    physical_table_name: Optional[str] = None,
 ) -> Dict[str, Any]:
+    # The logical table (this dict's own top-level "information") and the
+    # physical table it maps to (nested under "physicalTable") are distinct
+    # MicroStrategy objects with distinct object ids -- the attribute
+    # hierarchy API's relationshipTable refers to the logical table, and more
+    # than one logical table can map to the same physical table (role-
+    # playing). Defaulting the logical id/name to the table_name keeps
+    # existing single-role fixtures unchanged while still exercising real,
+    # distinct ids end to end.
     return {
+        "information": {
+            "objectId": logical_table_id or f"LGT-{table_name}",
+            "name": logical_table_name or table_name,
+        },
         "physicalTable": {
-            "tableName": table_name,
-            "information": {"objectId": f"TBL-{table_name}", "name": table_name},
+            "tableName": physical_table_name or table_name,
+            "information": {
+                "objectId": f"TBL-{physical_table_name or table_name}",
+                "name": physical_table_name or table_name,
+            },
         },
         "attributes": attributes,
         "facts": facts,
@@ -213,6 +237,61 @@ def test_table_with_no_usable_fields_is_skipped_with_warning() -> None:
     assert mapper.report.warnings
 
 
+def test_role_playing_logical_tables_get_distinct_dataset_identities() -> None:
+    # Regression: two logical tables role-playing one physical table (e.g.
+    # "Order Date"/"Ship Date" both backed by one shared date-lookup table)
+    # used to collide on the physical table name as their dataset alias, so
+    # the second table's SemanticModelDataset silently overwrote the first's
+    # under one URN.
+    mapper = _mapper(FakeSemanticModelClient())
+    model_tables = [
+        _table(
+            "ORDER_DATE",
+            attributes=[_attribute("ATTR-ORDER-DATE", "Order Date")],
+            facts=[],
+            logical_table_id="LGT-ORDER-DATE",
+            logical_table_name="Order Date",
+            physical_table_name="LU_DATE",
+        ),
+        _table(
+            "SHIP_DATE",
+            attributes=[_attribute("ATTR-SHIP-DATE", "Ship Date")],
+            facts=[],
+            logical_table_id="LGT-SHIP-DATE",
+            logical_table_name="Ship Date",
+            physical_table_name="LU_DATE",
+        ),
+    ]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    order_date_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.Order Date,PROD)"
+    )
+    ship_date_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.Ship Date,PROD)"
+    )
+    assert order_date_urn in aspects
+    assert ship_date_urn in aspects
+
+    order_schema = aspects[order_date_urn]["SchemaMetadataClass"]
+    ship_schema = aspects[ship_date_urn]["SchemaMetadataClass"]
+    assert isinstance(order_schema, SchemaMetadataClass)
+    assert isinstance(ship_schema, SchemaMetadataClass)
+    assert {f.fieldPath for f in order_schema.fields} == {"Order Date"}
+    assert {f.fieldPath for f in ship_schema.fields} == {"Ship Date"}
+
+
 def test_relationship_emitted_for_attribute_shared_across_two_tables() -> None:
     client = FakeSemanticModelClient(
         attribute_relationships={
@@ -222,7 +301,7 @@ def test_relationship_emitted_for_attribute_shared_across_two_tables() -> None:
                         "parent": {"objectId": "ATTR-SHARED", "subType": "attribute"},
                         "child": {"objectId": "ATTR-CHILD", "subType": "attribute"},
                         "relationshipTable": {
-                            "objectId": "TBL-PARENT",
+                            "objectId": "LGT-PARENT",
                             "subType": "logical_table",
                         },
                         "relationshipType": "one_to_many",
@@ -327,7 +406,7 @@ def test_unrecognized_relationship_type_warns_but_still_emits_relationship() -> 
                     {
                         "parent": {"objectId": "ATTR-SHARED", "subType": "attribute"},
                         "child": {"objectId": "ATTR-CHILD", "subType": "attribute"},
-                        "relationshipTable": {"objectId": "TBL-PARENT"},
+                        "relationshipTable": {"objectId": "LGT-PARENT"},
                         "relationshipType": "weird_type",
                     }
                 ]
@@ -558,3 +637,42 @@ def test_metric_model_fetch_failure_warns_and_skips_that_metric() -> None:
     assert metric_urn not in aspects
     assert mapper.report.metric_expression_api_failures == 1
     assert list(mapper.report.failed_metric_model_ids) == ["BROKEN"]
+
+
+def test_metric_search_failure_preserves_model_and_dataset_entities() -> None:
+    # Regression: metric discovery is a separate API call from the tables
+    # fetch that already succeeded by the time this runs. A failure here
+    # used to propagate out of emit() before it yielded anything, dropping
+    # the structural semantic-model entities (model, logical datasets) along
+    # with the metrics.
+    client = FakeSemanticModelClient(search_metrics_fails=True)
+    mapper = _mapper(client)
+    model_tables = [
+        _table(
+            "SALES",
+            attributes=[_attribute("ATTR1", "Region")],
+            facts=[_fact("FACT1", "Revenue")],
+        )
+    ]
+
+    aspects = _aspects_by_urn(
+        list(
+            mapper.emit(
+                project_id="project-1",
+                project_name="Project One",
+                model_tables=model_tables,
+                warehouse_context=None,
+                project_container_key=_project_container_key(),
+            )
+        )
+    )
+
+    model_urn = (
+        "urn:li:semanticModel:(urn:li:dataPlatform:microstrategy,project-1,schema)"
+    )
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:microstrategy,project-1.SALES,PROD)"
+    )
+    assert model_urn in aspects
+    assert dataset_urn in aspects
+    assert mapper.report.semantic_model_metric_search_api_failures == 1

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_source.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_source.py
@@ -901,3 +901,71 @@ def test_project_lineage_apis_skipped_when_all_dashboards_filtered() -> None:
     assert not lineage_context._context_resolved
     assert fake_client.model_table_calls == 0
     assert fake_client.connection_calls == 0
+
+
+def test_model_tables_shared_between_lineage_and_semantic_model() -> None:
+    source = _source(
+        {"extract_model_lineage": True, "emit_semantic_model_entities": True}
+    )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.model_table_calls = 0
+
+        def list_model_tables(self, *args: Any, **kwargs: Any) -> ModelTablesResponse:
+            self.model_table_calls += 1
+            return ModelTablesResponse(
+                tables=[
+                    {
+                        "physicalTable": {"tableName": "T1"},
+                        "attributes": [],
+                        "facts": [],
+                    }
+                ],
+                total=1,
+            )
+
+    fake_client = FakeClient()
+    source.client = fake_client  # type: ignore[assignment]
+
+    datasource = Datasource.model_validate(
+        {"id": "source-1", "name": "Warehouse", "database": {"type": "snowflake"}}
+    )
+    lineage_context = _LazyProjectLineage(source, "project-1", [datasource])
+
+    # Classic model-lineage path and the semantic-model path both read the
+    # same underlying data.
+    _ = lineage_context.model_lineage_index
+    _ = lineage_context.model_tables
+
+    assert fake_client.model_table_calls == 1
+
+
+def _assert_semantic_model_called_only_when_enabled(enabled: bool) -> None:
+    project = Project.model_validate({"id": "project-1", "name": "Project 1"})
+    source = _source(
+        {
+            "emit_semantic_model_entities": enabled,
+            "extract_dashboards": False,
+            "extract_reports": False,
+            "extract_source_warehouses": False,
+        }
+    )
+    calls: List[bool] = []
+
+    def fake_process_project_semantic_model(
+        project: Project, lineage_context: _LazyProjectLineage
+    ) -> Iterator[Any]:
+        calls.append(True)
+        return iter([])
+
+    source._process_project_semantic_model = (  # type: ignore[method-assign]
+        fake_process_project_semantic_model
+    )
+    list(source._process_project(project))
+    assert bool(calls) is enabled
+
+
+def test_process_project_calls_semantic_model_only_when_enabled() -> None:
+    _assert_semantic_model_called_only_when_enabled(True)
+    _assert_semantic_model_called_only_when_enabled(False)

--- a/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_source.py
+++ b/metadata-ingestion/tests/unit/microstrategy/test_microstrategy_source.py
@@ -850,6 +850,32 @@ def test_lazy_project_lineage_resolves_once_and_caches_failures() -> None:
     assert fake_client.model_table_calls == 1
 
 
+def test_fetch_project_model_tables_requests_logical_table_information() -> None:
+    # Regression: the semantic-model mapper reads each table's top-level
+    # "information" block for the logical table id/name (needed to resolve
+    # attribute-hierarchy relationships and to keep role-played tables
+    # distinct), but MicroStrategy's `fields` parameter is a root-level
+    # whitelist -- omitting "information" there means the API never returns
+    # it at all, regardless of what the mapper does with the response.
+    source = _source({"extract_model_lineage": True})
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.fields_requested: List[str] = []
+
+        def list_model_tables(self, *args: Any, **kwargs: Any) -> ModelTablesResponse:
+            self.fields_requested.append(kwargs.get("fields", ""))
+            return ModelTablesResponse(tables=[], total=0)
+
+    fake_client = FakeClient()
+    source.client = fake_client  # type: ignore[assignment]
+
+    source._fetch_project_model_tables("project-1")
+
+    assert fake_client.fields_requested
+    assert all("information" in fields for fields in fake_client.fields_requested)
+
+
 def test_project_lineage_apis_skipped_when_all_dashboards_filtered() -> None:
     source = _source(
         {


### PR DESCRIPTION
## Summary
- Add opt-in `emit_semantic_model_entities` flag emitting each MicroStrategy project's schema as a `semanticModel` entity, additive to existing dashboard/report/dataset emission.
- One `SemanticModelDataset` per logical table from `/api/model/tables` (attributes -> Dimension fields, facts -> Measure fields), with coarse upstream lineage to the physical warehouse table.
- One `metric` entity per project metric (Base, Derived/Compound, Consolidated), with lineage resolved from the metric's own expression tokens: Base -> `metricUpstreams` to backing datasets, Derived/Compound -> `metricRelationships.derivedFrom` to other metrics, Consolidated -> resolved through the consolidation's own attribute references.
- Table-to-table `semanticModelRelationship` joins derived from the attribute hierarchy API (`/api/model/systemHierarchy/attributes/{id}/relationships`), for attributes shared across multiple logical tables.
- Mirrors the Cube connector's `semanticModel`/`metric` emission (#19440), built on the shared `datahub.sdk.semantic_model` / `datahub.sdk.metric` SDK — no SDK changes needed.

## Test plan
- [x] `../gradlew :metadata-ingestion:lintFix` / `lint` clean on all touched/new files
- [x] `pytest tests/unit/microstrategy/ -q` — all existing tests green, plus 23 new tests covering client methods, lineage token parsing, config flag, source wiring, and the new mapper (table/field mapping, relationship resolution incl. cardinality inversion, Base/Derived/Consolidated metric classification and lineage, consolidation-fetch caching, opt-in default-off regression guard)
- [x] Live validation against MicroStrategy's public demo tenant (`demo.microstrategy.com`) with guest auth: confirmed the tenant is real/reachable, guest login works, and the new project-wide metric search (`search_metrics`) returns correct real data. Guest auth is blocked (403) from all `/api/model/*` modeling endpoints on this tenant — same documented limitation the existing `extract_model_lineage`/`extract_metric_expressions` features already have — so the modeling-API-dependent logic (table/attribute/fact parsing, relationships, consolidated-metric resolution) is validated via fixture-based unit tests and endpoints verified against MicroStrategy's official REST API docs, not live guest-tier calls.
- [ ] Docs preview (`microstrategy_post.md` Semantic Model section, `microstrategy_recipe.yml` example)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `emit_semantic_model_entities` flag that emits each MicroStrategy project's schema as a `semanticModel` entity, separate from the existing dashboard/report/dataset emission.

- Emits one `SemanticModelDataset` per logical table, with attributes as Dimension fields and facts as Measure fields, plus upstream lineage to the warehouse table.
- Datasets use the logical table's name for identity, so role-played tables sharing one physical table stay distinct; the model-tables fetch now requests each table's `information` block, which the API's fields whitelist would otherwise omit.
- Emits one `metric` entity per project metric (Base, Derived/Compound, and Consolidated), with lineage resolved from metric expression tokens.
- Emits `semanticModelRelationship` joins from the attribute hierarchy API for attributes shared across tables, resolving the relationship table by logical id.
- A failed metric-search call degrades to no metrics instead of dropping the already-built model and datasets.
- Requires a DataHub server that registers `semanticModel`/`metric` entities (Cloud >= 2.1.0, or OSS with `METRICS_ENABLED=true`).
- Guest-tier MicroStrategy logins cannot reach the modeling APIs, so the model-dependent paths are validated with fixture-based unit tests rather than live calls.

<sup>Written for commit b4618238997682a0d7ed4e90702a1728fbfe200c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

