### PR TITLE
fix(i18n): fix German translation to avoid overflow

### DIFF
--- a/datahub-web-react/src/i18n/locales/de/entity.types.json
+++ b/datahub-web-react/src/i18n/locales/de/entity.types.json
@@ -321,7 +321,7 @@
     "user.invalidUrlError": "keine gültige URL",
     "user.name": "Person",
     "user.namePlural": "Personen",
-    "user.slackMemberIdHelp": "Finde deine Member-ID über das <icon></icon>-Menü in deinem Slack-Profil. Mehr Infos <anchor>hier.</anchor>",
+    "user.slackMemberIdHelp": "Member ID: Slack Profil <icon></icon> Menü. Mehr Infos <anchor>hier.</anchor>",
     "user.slackMemberIdLabel": "Slack-Member-ID",
     "user.tab.groups": "Gruppen",
     "user.tab.ownerOf": "Owner von",


### PR DESCRIPTION

<img width="680" height="968" alt="image" src="https://github.com/user-attachments/assets/2e724f2b-410a-4445-9f83-be5ba9eeb8a2" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the German translation for the Slack Member ID help text so it no longer overflows the UI. Shortens the wording while keeping the same instructional content.

<sup>Written for commit 3048f901ce1cea2241fbc49346c6e8c2852e4eb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

