### PR TITLE
feat(migration): add --pipeline-name filter to dataplatform2instance and instance2instance

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1093,6 +1093,7 @@ Options:
 - `--skip-on-error`: Continue migrating remaining entities when one fails, instead of aborting.
 - `--entity-types`: Comma-separated list of entity types to migrate (default: all). Available: `dataset`, `chart`, `dashboard`, `dataFlow`, `dataJob`.
 - `--checkpoint-file`: Path to a checkpoint file for resumable migrations. Already-migrated source URNs are read from this file and skipped; newly migrated URNs are appended on success. The file is created automatically on first write. Not written during `--dry-run`; errored pairs (under `--skip-on-error`) are not checkpointed, so they retry on resume.
+- `--pipeline-name`: Only migrate entities whose `systemMetadata.pipelineName` matches this value. Use this to scope migration to a single ingestion pipeline when multiple pipelines write to the same platform without a platform instance. Each candidate entity's systemMetadata is checked, so a progress bar is shown during filtering.
 
 **_Note_**: Timeseries aspects such as Usage Statistics and Dataset Profiles are not migrated over to the new entity instances, you will get new data points created when you re-run ingestion using the `usage` or sources with profiling turned on.
 
@@ -1133,6 +1134,23 @@ Num entities created = 4
 Num entities affected = 0
 Num entities migrated = 4
 ```
+
+##### Scoped Migration (filter by pipeline name)
+
+When multiple ingestion pipelines write to the same platform without a platform instance, use `--pipeline-name` to migrate only the entities produced by a specific pipeline:
+
+```console
+datahub migrate dataplatform2instance --platform dbt --instance my_project --pipeline-name "my_dbt_pipeline" --dry-run
+Starting migration: platform:dbt, instance=my_project, force=False, dry-run=True, pipeline-name=my_dbt_pipeline
+This command will migrate DATASET, CHART, DASHBOARD, DATAFLOW, DATAJOB and CONTAINERS.
+Filtering 500 entities by pipeline 'my_dbt_pipeline'...
+Checking pipeline ownership  [####################################]  100%
+  120/500 entities match pipeline 'my_dbt_pipeline'.
+Found 120 dataset entities to migrate.
+...
+```
+
+The pipeline name is set by the `pipeline_name` field in your ingestion recipe. You can check an entity's pipeline name via `datahub get --urn <urn>` and inspecting the `systemMetadata.pipelineName` field.
 
 #### instance2instance
 
@@ -1180,6 +1198,7 @@ Options:
 - `--skip-on-error`: Continue migrating remaining entities when one fails, instead of aborting.
 - `--entity-types`: Comma-separated list of entity types to migrate (default: all). Available: `dataset`, `chart`, `dashboard`, `dataFlow`, `dataJob`.
 - `--checkpoint-file`: Path to a checkpoint file for resumable migrations (see `dataplatform2instance` above).
+- `--pipeline-name`: Only migrate entities produced by a specific ingestion pipeline (see `dataplatform2instance` above).
 
 **⚠️ Note**: `dataFlow` and `dataJob` should always be migrated together. DataJob URNs embed their parent DataFlow URN — migrating one without the other creates orphaned references. The CLI will prompt for confirmation if you attempt to separate them.
 

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -42,7 +42,11 @@ from datahub.metadata.schema_classes import (
     DataPlatformInstanceClass,
 )
 from datahub.migration import engine
-from datahub.migration.fetch import fetch_instance_urns, fetch_platform_urns
+from datahub.migration.fetch import (
+    _matches_pipeline_name,
+    fetch_instance_urns,
+    fetch_platform_urns,
+)
 from datahub.migration.models import (
     ConflictStrategy,
     MigrationOptions,
@@ -107,6 +111,28 @@ def _warn_dataflow_datajob_coupling(
 
 
 # --- Core migration logic ---
+
+
+def _filter_by_pipeline_name(
+    graph: DataHubGraph,
+    urns: List[str],
+    pipeline_name: str,
+) -> List[str]:
+    """Filter URNs to only those produced by *pipeline_name*.
+
+    Each URN requires an API call to check systemMetadata, so a progress bar
+    is shown for user feedback.
+    """
+    matched: List[str] = []
+    click.echo(f"Filtering {len(urns)} entities by pipeline '{pipeline_name}'...")
+    with click.progressbar(urns, label="Checking pipeline ownership") as bar:
+        for urn in bar:
+            if _matches_pipeline_name(graph, urn, pipeline_name):
+                matched.append(urn)
+    click.echo(
+        f"  {len(matched)}/{len(urns)} entities match pipeline '{pipeline_name}'."
+    )
+    return matched
 
 
 def _run_migration(
@@ -182,6 +208,7 @@ def _migrate_containers(
     keep: bool,
     rest_emitter: DataHubGraph,
     report_file: Optional[str] = None,
+    pipeline_name: Optional[str] = None,
 ) -> None:
     """Migrate containers matching a filter to a new platform instance."""
     run_id: str = f"container-migrate-{uuid.uuid4()}"
@@ -207,6 +234,14 @@ def _migrate_containers(
                 log.debug(
                     f"{container['urn']} does not match filter criteria, skipping.. "
                     f"{customProperties}"
+                )
+                skipped_count += 1
+                continue
+            if pipeline_name and not _matches_pipeline_name(
+                rest_emitter, container["urn"], pipeline_name
+            ):
+                log.debug(
+                    f"{container['urn']} not produced by pipeline {pipeline_name}, skipping"
                 )
                 skipped_count += 1
                 continue
@@ -446,6 +481,18 @@ def _process_container_relationships(
         "For 'affected' lines: action, referrer_urn, target_urn, aspect."
     ),
 )
+@click.option(
+    "--pipeline-name",
+    type=str,
+    default=None,
+    callback=lambda _ctx, _param, v: (v.strip() or None) if v else None,
+    help=(
+        "Only migrate entities whose systemMetadata.pipelineName matches "
+        "this value. Use this to scope migration to entities produced by a "
+        "specific ingestion pipeline (e.g. when multiple pipelines write to "
+        "the same platform without a platform instance)."
+    ),
+)
 @telemetry.with_telemetry()
 @upgrade.check_upgrade
 def dataplatform2instance(
@@ -461,6 +508,7 @@ def dataplatform2instance(
     entity_types: Optional[str],
     checkpoint_file: Optional[str],
     migration_report: Optional[str],
+    pipeline_name: Optional[str],
 ) -> None:
     """Migrate entities from one dataplatform to a dataplatform instance.
 
@@ -479,6 +527,7 @@ def dataplatform2instance(
     click.echo(
         f"Starting migration: platform:{platform}, instance={instance}, "
         f"force={force}, dry-run={dry_run}"
+        + (f", pipeline-name={pipeline_name}" if pipeline_name else "")
     )
     run_id = f"migrate-{uuid.uuid4()}"
     graph = get_default_graph(ClientMode.CLI)
@@ -495,11 +544,25 @@ def dataplatform2instance(
     for entity_type in entity_types_to_migrate:
         urns_to_migrate = list(
             fetch_platform_urns(
-                graph, platform=platform, env=env, entity_type=entity_type
+                graph,
+                platform=platform,
+                env=env,
+                entity_type=entity_type,
             )
         )
+        if pipeline_name:
+            urns_to_migrate = _filter_by_pipeline_name(
+                graph, urns_to_migrate, pipeline_name
+            )
         if not urns_to_migrate:
-            click.echo(f"No {entity_type} entities found without instance, skipping.")
+            if pipeline_name:
+                click.echo(
+                    f"No {entity_type} entities matched pipeline '{pipeline_name}', skipping."
+                )
+            else:
+                click.echo(
+                    f"No {entity_type} entities found without instance, skipping."
+                )
             continue
 
         click.echo(f"Found {len(urns_to_migrate)} {entity_type} entities to migrate.")
@@ -537,6 +600,7 @@ def dataplatform2instance(
         keep=keep,
         rest_emitter=graph,
         report_file=migration_report,
+        pipeline_name=pipeline_name,
     )
 
 
@@ -609,6 +673,18 @@ def dataplatform2instance(
         "For 'affected' lines: action, referrer_urn, target_urn, aspect."
     ),
 )
+@click.option(
+    "--pipeline-name",
+    type=str,
+    default=None,
+    callback=lambda _ctx, _param, v: (v.strip() or None) if v else None,
+    help=(
+        "Only migrate entities whose systemMetadata.pipelineName matches "
+        "this value. Use this to scope migration to entities produced by a "
+        "specific ingestion pipeline (e.g. when multiple pipelines write to "
+        "the same platform instance)."
+    ),
+)
 @telemetry.with_telemetry()
 @upgrade.check_upgrade
 def instance2instance(
@@ -625,6 +701,7 @@ def instance2instance(
     entity_types: Optional[str],
     checkpoint_file: Optional[str],
     migration_report: Optional[str],
+    pipeline_name: Optional[str],
 ) -> None:
     """Migrate entities from one platform instance to another.
 
@@ -648,6 +725,7 @@ def instance2instance(
         f"Starting migration: platform:{platform}, "
         f"old-instance={old_instance}, new-instance={new_instance}, "
         f"force={force}, dry-run={dry_run}, on-conflict={conflict.value}"
+        + (f", pipeline-name={pipeline_name}" if pipeline_name else "")
     )
     click.echo(
         f"This command will migrate {', '.join(t.upper() for t in entity_types_to_migrate)} "
@@ -666,8 +744,15 @@ def instance2instance(
                 entity_type=entity_type,
             )
         )
+        if pipeline_name:
+            urns = _filter_by_pipeline_name(graph, urns, pipeline_name)
         if not urns:
-            click.echo(f"No {entity_type} entities found, skipping.")
+            if pipeline_name:
+                click.echo(
+                    f"No {entity_type} entities matched pipeline '{pipeline_name}', skipping."
+                )
+            else:
+                click.echo(f"No {entity_type} entities found, skipping.")
             continue
 
         click.echo(f"Found {len(urns)} {entity_type} entities to migrate.")
@@ -708,6 +793,7 @@ def instance2instance(
         keep=keep,
         rest_emitter=graph,
         report_file=migration_report,
+        pipeline_name=pipeline_name,
     )
 
 

--- a/metadata-ingestion/src/datahub/migration/fetch.py
+++ b/metadata-ingestion/src/datahub/migration/fetch.py
@@ -1,18 +1,32 @@
 """Stage 1 of the migration framework: discover the source URNs to migrate.
 
-Each fetcher is a generator over source URNs for a single entity type; a caller
+Each fetcher returns a list of source URNs for a single entity type; a caller
 combines them with a stage-2 transform (or supplies target URNs directly) to
 produce :class:`MigrationPair` objects for the engine.
 """
 
 import logging
-from typing import Iterator
+from typing import List
 
 from datahub.cli.migration_utils import ENV_ENTITY_TYPES
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import DataPlatformInstanceClass
 
 log = logging.getLogger(__name__)
+
+
+def _matches_pipeline_name(graph: DataHubGraph, urn: str, pipeline_name: str) -> bool:
+    """Check if any aspect on *urn* was last written by *pipeline_name*.
+
+    We look at the systemMetadata attached to each aspect on the entity.
+    If at least one aspect was produced by the given pipeline, we consider
+    the entity as belonging to that pipeline.
+    """
+    mcpws = graph.get_entity_as_mcps(urn)
+    return any(
+        mcpw.systemMetadata and mcpw.systemMetadata.pipelineName == pipeline_name
+        for mcpw in mcpws
+    )
 
 
 def fetch_platform_urns(
@@ -22,12 +36,13 @@ def fetch_platform_urns(
     env: str,
     entity_type: str,
     skip_if_has_instance: bool = True,
-) -> Iterator[str]:
+) -> List[str]:
     """URNs of a platform's entities that have no platform instance yet.
 
     Used by ``dataplatform2instance``: only entities still lacking a
     ``dataPlatformInstance.instance`` are candidates for being assigned one.
     """
+    candidates: List[str] = []
     for src_urn in graph.get_urns_by_filter(
         platform=platform,
         env=env if entity_type in ENV_ENTITY_TYPES else None,
@@ -38,7 +53,9 @@ def fetch_platform_urns(
             if instance_aspect is not None and instance_aspect.instance:
                 log.debug(f"{src_urn} already has instance, skipping")
                 continue
-        yield src_urn
+        candidates.append(src_urn)
+
+    return candidates
 
 
 def fetch_instance_urns(
@@ -48,11 +65,13 @@ def fetch_instance_urns(
     old_instance: str,
     env: str,
     entity_type: str,
-) -> Iterator[str]:
+) -> List[str]:
     """URNs of a platform instance's entities of a given type."""
-    yield from graph.get_urns_by_filter(
-        platform=platform,
-        platform_instance=old_instance,
-        env=env if entity_type in ENV_ENTITY_TYPES else None,
-        entity_types=[entity_type],
+    return list(
+        graph.get_urns_by_filter(
+            platform=platform,
+            platform_instance=old_instance,
+            env=env if entity_type in ENV_ENTITY_TYPES else None,
+            entity_types=[entity_type],
+        )
     )

--- a/metadata-ingestion/tests/unit/cli/test_migration_fetch.py
+++ b/metadata-ingestion/tests/unit/cli/test_migration_fetch.py
@@ -1,0 +1,398 @@
+"""Tests for pipeline_name filtering in migration fetch and CLI layers."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from datahub.cli.migrate import (
+    _filter_by_pipeline_name,
+    dataplatform2instance,
+    instance2instance,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    DataPlatformInstanceClass,
+    DatasetPropertiesClass,
+    SystemMetadataClass,
+)
+from datahub.migration.fetch import (
+    _matches_pipeline_name,
+    fetch_instance_urns,
+    fetch_platform_urns,
+)
+
+DATASET_URN_A = "urn:li:dataset:(urn:li:dataPlatform:dbt,project_a.model,PROD)"
+DATASET_URN_B = "urn:li:dataset:(urn:li:dataPlatform:dbt,project_b.model,PROD)"
+
+
+def _make_mcpw(
+    urn: str, pipeline_name: str = "my-pipeline"
+) -> MetadataChangeProposalWrapper:
+    return MetadataChangeProposalWrapper(
+        entityUrn=urn,
+        aspect=DatasetPropertiesClass(description="test"),
+        systemMetadata=SystemMetadataClass(pipelineName=pipeline_name),
+    )
+
+
+def _make_mcpw_no_pipeline(urn: str) -> MetadataChangeProposalWrapper:
+    return MetadataChangeProposalWrapper(
+        entityUrn=urn,
+        aspect=DatasetPropertiesClass(description="test"),
+        systemMetadata=SystemMetadataClass(),
+    )
+
+
+class TestMatchesPipelineName:
+    def test_matches_when_pipeline_present(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [
+            _make_mcpw(DATASET_URN_A, "my-dbt-pipeline")
+        ]
+        assert _matches_pipeline_name(graph, DATASET_URN_A, "my-dbt-pipeline") is True
+
+    def test_no_match_when_different_pipeline(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [
+            _make_mcpw(DATASET_URN_A, "other-pipeline")
+        ]
+        assert _matches_pipeline_name(graph, DATASET_URN_A, "my-dbt-pipeline") is False
+
+    def test_no_match_when_no_system_metadata(self) -> None:
+        graph = MagicMock()
+        mcpw = MetadataChangeProposalWrapper(
+            entityUrn=DATASET_URN_A,
+            aspect=DatasetPropertiesClass(description="test"),
+        )
+        graph.get_entity_as_mcps.return_value = [mcpw]
+        assert _matches_pipeline_name(graph, DATASET_URN_A, "my-dbt-pipeline") is False
+
+    def test_no_match_when_pipeline_name_is_none(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [_make_mcpw_no_pipeline(DATASET_URN_A)]
+        assert _matches_pipeline_name(graph, DATASET_URN_A, "my-dbt-pipeline") is False
+
+    def test_matches_if_any_aspect_has_pipeline(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [
+            _make_mcpw_no_pipeline(DATASET_URN_A),
+            _make_mcpw(DATASET_URN_A, "my-dbt-pipeline"),
+        ]
+        assert _matches_pipeline_name(graph, DATASET_URN_A, "my-dbt-pipeline") is True
+
+
+class TestFetchPlatformUrns:
+    def test_returns_all_without_instance(self) -> None:
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [DATASET_URN_A, DATASET_URN_B]
+        graph.get_aspect.return_value = None
+
+        result = fetch_platform_urns(
+            graph, platform="dbt", env="PROD", entity_type="dataset"
+        )
+        assert result == [DATASET_URN_A, DATASET_URN_B]
+
+    def test_skips_entities_with_instance(self) -> None:
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [DATASET_URN_A]
+        graph.get_aspect.return_value = DataPlatformInstanceClass(
+            platform="urn:li:dataPlatform:dbt",
+            instance="urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,existing)",
+        )
+
+        result = fetch_platform_urns(
+            graph, platform="dbt", env="PROD", entity_type="dataset"
+        )
+        assert result == []
+
+
+class TestFetchInstanceUrns:
+    def test_returns_all(self) -> None:
+        graph = MagicMock()
+        graph.get_urns_by_filter.return_value = [DATASET_URN_A, DATASET_URN_B]
+
+        result = fetch_instance_urns(
+            graph,
+            platform="dbt",
+            old_instance="old",
+            env="PROD",
+            entity_type="dataset",
+        )
+        assert result == [DATASET_URN_A, DATASET_URN_B]
+
+
+class TestFilterByPipelineName:
+    def test_filters_matching_urns(self) -> None:
+        graph = MagicMock()
+
+        def mock_get_entity_as_mcps(urn: str) -> list:
+            if urn == DATASET_URN_A:
+                return [_make_mcpw(urn, "target-pipeline")]
+            return [_make_mcpw(urn, "other-pipeline")]
+
+        graph.get_entity_as_mcps.side_effect = mock_get_entity_as_mcps
+
+        result = _filter_by_pipeline_name(
+            graph, [DATASET_URN_A, DATASET_URN_B], "target-pipeline"
+        )
+        assert result == [DATASET_URN_A]
+
+    def test_returns_empty_when_no_match(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [
+            _make_mcpw(DATASET_URN_A, "other-pipeline")
+        ]
+
+        result = _filter_by_pipeline_name(
+            graph, [DATASET_URN_A, DATASET_URN_B], "target-pipeline"
+        )
+        assert result == []
+
+    def test_returns_all_when_all_match(self) -> None:
+        graph = MagicMock()
+        graph.get_entity_as_mcps.return_value = [
+            _make_mcpw(DATASET_URN_A, "target-pipeline")
+        ]
+
+        result = _filter_by_pipeline_name(
+            graph, [DATASET_URN_A, DATASET_URN_B], "target-pipeline"
+        )
+        assert result == [DATASET_URN_A, DATASET_URN_B]
+
+    def test_empty_input_returns_empty(self) -> None:
+        graph = MagicMock()
+
+        result = _filter_by_pipeline_name(graph, [], "target-pipeline")
+        assert result == []
+        graph.get_entity_as_mcps.assert_not_called()
+
+
+class TestDataplatform2instancePipelineNameCli:
+    """CLI-level tests proving --pipeline-name excludes non-matching entities."""
+
+    @patch("datahub.cli.migrate._migrate_containers")
+    @patch("datahub.cli.migrate._run_entity_migration")
+    @patch("datahub.cli.migrate._filter_by_pipeline_name")
+    @patch("datahub.cli.migrate.fetch_platform_urns")
+    @patch("datahub.cli.migrate.get_default_graph")
+    def test_pipeline_name_filters_before_migration(
+        self,
+        mock_graph: MagicMock,
+        mock_fetch: MagicMock,
+        mock_filter: MagicMock,
+        mock_run: MagicMock,
+        mock_containers: MagicMock,
+    ) -> None:
+        mock_graph.return_value = MagicMock()
+        mock_fetch.return_value = [DATASET_URN_A, DATASET_URN_B]
+        mock_filter.return_value = [DATASET_URN_A]
+        mock_run.return_value = MagicMock(__str__=lambda _: "report")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            dataplatform2instance,
+            [
+                "--platform",
+                "dbt",
+                "--instance",
+                "my_inst",
+                "--pipeline-name",
+                "my-pipeline",
+                "--dry-run",
+                "--force",
+                "--entity-types",
+                "dataset",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_filter.assert_called_once()
+        # Only the filtered URN should reach migration
+        args = mock_run.call_args
+        assert args.kwargs["urns"] == [DATASET_URN_A]
+
+    @patch("datahub.cli.migrate._migrate_containers")
+    @patch("datahub.cli.migrate._run_entity_migration")
+    @patch("datahub.cli.migrate._filter_by_pipeline_name")
+    @patch("datahub.cli.migrate.fetch_platform_urns")
+    @patch("datahub.cli.migrate.get_default_graph")
+    def test_no_pipeline_name_skips_filter(
+        self,
+        mock_graph: MagicMock,
+        mock_fetch: MagicMock,
+        mock_filter: MagicMock,
+        mock_run: MagicMock,
+        mock_containers: MagicMock,
+    ) -> None:
+        mock_graph.return_value = MagicMock()
+        mock_fetch.return_value = [DATASET_URN_A, DATASET_URN_B]
+        mock_run.return_value = MagicMock(__str__=lambda _: "report")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            dataplatform2instance,
+            [
+                "--platform",
+                "dbt",
+                "--instance",
+                "my_inst",
+                "--dry-run",
+                "--force",
+                "--entity-types",
+                "dataset",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_filter.assert_not_called()
+
+
+class TestInstance2instancePipelineNameCli:
+    """CLI-level tests proving --pipeline-name wiring in instance2instance."""
+
+    @patch("datahub.cli.migrate._migrate_containers")
+    @patch("datahub.cli.migrate._run_entity_migration")
+    @patch("datahub.cli.migrate._filter_by_pipeline_name")
+    @patch("datahub.cli.migrate.fetch_instance_urns")
+    @patch("datahub.cli.migrate.get_default_graph")
+    def test_pipeline_name_filters_before_migration(
+        self,
+        mock_graph: MagicMock,
+        mock_fetch: MagicMock,
+        mock_filter: MagicMock,
+        mock_run: MagicMock,
+        mock_containers: MagicMock,
+    ) -> None:
+        mock_graph.return_value = MagicMock()
+        mock_fetch.return_value = [DATASET_URN_A, DATASET_URN_B]
+        mock_filter.return_value = [DATASET_URN_B]
+        mock_run.return_value = MagicMock(__str__=lambda _: "report")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            instance2instance,
+            [
+                "--platform",
+                "dbt",
+                "--old-instance",
+                "old",
+                "--new-instance",
+                "new",
+                "--pipeline-name",
+                "my-pipeline",
+                "--dry-run",
+                "--force",
+                "--entity-types",
+                "dataset",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_filter.assert_called_once()
+        args = mock_run.call_args
+        assert args.kwargs["urns"] == [DATASET_URN_B]
+
+
+class TestMigrateContainersPipelineName:
+    """Container migration respects --pipeline-name when set."""
+
+    _SAMPLE_CONTAINER = {
+        "urn": "urn:li:container:guid1",
+        "aspects": {
+            "subTypes": {"value": {"typeNames": ["Database"]}},
+            "containerProperties": {
+                "value": {
+                    "customProperties": {
+                        "platform": "snowflake",
+                        "env": "PROD",
+                        "database": "db1",
+                    }
+                }
+            },
+        },
+    }
+
+    @patch("datahub.cli.migrate._process_container_relationships")
+    @patch("datahub.cli.migration_utils.clone_aspect", return_value=[])
+    @patch("datahub.cli.migrate._matches_pipeline_name")
+    @patch("datahub.cli.migrate._get_containers_for_migration")
+    def test_skips_container_not_matching_pipeline(
+        self,
+        mock_get: MagicMock,
+        mock_matches: MagicMock,
+        _mock_clone: MagicMock,
+        _mock_rels: MagicMock,
+    ) -> None:
+        from datahub.cli.migrate import _migrate_containers
+
+        mock_get.return_value = [self._SAMPLE_CONTAINER]
+        mock_matches.return_value = False
+        emitter = MagicMock()
+
+        _migrate_containers(
+            env="PROD",
+            platform="snowflake",
+            target_instance="newinst",
+            should_migrate=lambda props: True,
+            dry_run=False,
+            hard=False,
+            keep=True,
+            rest_emitter=emitter,
+            pipeline_name="my-pipeline",
+        )
+        mock_matches.assert_called_once()
+        emitter.emit_mcp.assert_not_called()
+
+    @patch("datahub.cli.migrate._process_container_relationships")
+    @patch("datahub.cli.migration_utils.clone_aspect", return_value=[])
+    @patch("datahub.cli.migrate._matches_pipeline_name")
+    @patch("datahub.cli.migrate._get_containers_for_migration")
+    def test_migrates_container_matching_pipeline(
+        self,
+        mock_get: MagicMock,
+        mock_matches: MagicMock,
+        _mock_clone: MagicMock,
+        _mock_rels: MagicMock,
+    ) -> None:
+        from datahub.cli.migrate import _migrate_containers
+
+        mock_get.return_value = [self._SAMPLE_CONTAINER]
+        mock_matches.return_value = True
+        emitter = MagicMock()
+
+        _migrate_containers(
+            env="PROD",
+            platform="snowflake",
+            target_instance="newinst",
+            should_migrate=lambda props: True,
+            dry_run=False,
+            hard=False,
+            keep=True,
+            rest_emitter=emitter,
+            pipeline_name="my-pipeline",
+        )
+        mock_matches.assert_called_once()
+        emitter.emit_mcp.assert_called()
+
+    @patch("datahub.cli.migrate._process_container_relationships")
+    @patch("datahub.cli.migration_utils.clone_aspect", return_value=[])
+    @patch("datahub.cli.migrate._get_containers_for_migration")
+    def test_no_pipeline_name_skips_check(
+        self,
+        mock_get: MagicMock,
+        _mock_clone: MagicMock,
+        _mock_rels: MagicMock,
+    ) -> None:
+        from datahub.cli.migrate import _migrate_containers
+
+        mock_get.return_value = [self._SAMPLE_CONTAINER]
+        emitter = MagicMock()
+
+        _migrate_containers(
+            env="PROD",
+            platform="snowflake",
+            target_instance="newinst",
+            should_migrate=lambda props: True,
+            dry_run=False,
+            hard=False,
+            keep=True,
+            rest_emitter=emitter,
+        )
+        emitter.emit_mcp.assert_called()


### PR DESCRIPTION
## Summary

Adds a `--pipeline-name` option to `datahub migrate dataplatform2instance` and `datahub migrate instance2instance` that scopes the migration to only entities produced by a specific ingestion pipeline.

## Motivation

When multiple ingestion pipelines write to the same platform without a platform instance (e.g. several dbt projects all on platform `dbt`), `dataplatform2instance` picks up **all** entities on that platform — including those
from other pipelines that should remain without an instance. There was no way to target a single pipeline's entities without resorting to the lower-level `urns-mapping` command.

## How it works

The new `--pipeline-name` option filters candidate entities by checking `systemMetadata.pipelineName` on each entity's aspects. Since this requires one API call per entity, a progress bar is shown during filtering. The filter
runs after the existing platform/instance/env filters, so only candidates that pass those checks are inspected.

**Example:**
```console
datahub migrate dataplatform2instance \
  --platform dbt \
  --instance my_project \
  --pipeline-name "my_dbt_pipeline" \
  --dry-run
```

Changes

- metadata-ingestion/src/datahub/migration/fetch.py: Added _matches_pipeline_name() helper that checks systemMetadata.pipelineName on entity aspects. Updated return types from Iterator to List (all callers already materialized
with list()).
- metadata-ingestion/src/datahub/cli/migrate.py: Added --pipeline-name CLI option to both commands and _filter_by_pipeline_name() with progress bar in the CLI layer.
- metadata-ingestion/tests/unit/cli/test_migration_fetch.py: 8 new unit tests covering the pipeline name matching logic and fetch functions.
- docs/cli.md: Documented the new option for both commands with a usage example.

Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly PR Title Format
 (https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated
- [ ] For any breaking change — No breaking changes; --pipeline-name defaults to None (fully backwards compatible)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--pipeline-name` option to `datahub migrate dataplatform2instance` and `instance2instance` so you can scope a migration to one ingestion pipeline's entities. Previously, `dataplatform2instance` migrated every entity on a platform without an instance—including entities from unrelated pipelines—so this filter targets only entities whose `systemMetadata.pipelineName` matches the supplied value.

**Details**
- Each entity is checked with an API call, so filtering shows a progress bar.
- Filtering runs after the existing platform/instance/env filters, so only candidates that pass those checks are inspected.
- The option defaults to `None`, so existing behavior is unchanged and the change is fully backwards compatible.
- `fetch_platform_urns` and `fetch_instance_urns` now return lists instead of generators; all callers already materialized them with `list()`.
- Container migration also respects the filter, skipping containers not produced by the matching pipeline.
- Docs now explain how to find an entity's pipeline name (the `pipeline_name` recipe field) and include a usage example.

<sup>Written for commit dd1bd5df1c4bf27d2c1e11cff5ba4ba3a2c102bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

