### PR TITLE
fix(gms): share AWS credentials to prevent IRSA refresh task leaks

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/SearchClientShimUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/SearchClientShimUtil.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -133,6 +134,7 @@ import org.opensearch.search.suggest.phrase.PhraseSuggestion;
 import org.opensearch.search.suggest.phrase.PhraseSuggestionBuilder;
 import org.opensearch.search.suggest.term.TermSuggestion;
 import org.opensearch.search.suggest.term.TermSuggestionBuilder;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Factory for creating appropriate SearchClientShim implementations based on the target search
@@ -569,6 +571,7 @@ public class SearchClientShimUtil {
     private String pathPrefix;
     private boolean useAwsIamAuth = false;
     private String region;
+    @Nullable private AwsCredentialsProvider awsCredentialsProvider;
     private Integer threadCount = 1;
     private Integer connectionRequestTimeout = 5000;
     private Integer socketTimeout = 30000;
@@ -587,6 +590,7 @@ public class SearchClientShimUtil {
       this.pathPrefix = existing.getPathPrefix();
       this.useAwsIamAuth = existing.isUseAwsIamAuth();
       this.region = existing.getRegion();
+      this.awsCredentialsProvider = existing.getAwsCredentialsProvider();
       this.threadCount = existing.getThreadCount();
       this.connectionRequestTimeout = existing.getConnectionRequestTimeout();
       this.socketTimeout = existing.getSocketTimeout();
@@ -631,6 +635,12 @@ public class SearchClientShimUtil {
       return this;
     }
 
+    public ShimConfigurationBuilder withAwsCredentialsProvider(
+        @Nullable AwsCredentialsProvider awsCredentialsProvider) {
+      this.awsCredentialsProvider = awsCredentialsProvider;
+      return this;
+    }
+
     public ShimConfigurationBuilder withThreadCount(Integer threadCount) {
       this.threadCount = threadCount;
       return this;
@@ -671,7 +681,8 @@ public class SearchClientShimUtil {
           connectionRequestTimeout,
           socketTimeout,
           sSLContext,
-          engineTypeAutoDetected);
+          engineTypeAutoDetected,
+          awsCredentialsProvider);
     }
   }
 
@@ -692,6 +703,7 @@ public class SearchClientShimUtil {
     private final Integer socketTimeout;
     private final SSLContext sSLContext;
     private final boolean engineTypeAutoDetected;
+    @Nullable private final AwsCredentialsProvider awsCredentialsProvider;
 
     public ShimConfigurationImpl(
         SearchEngineType engineType,
@@ -707,7 +719,8 @@ public class SearchClientShimUtil {
         Integer connectionRequestTimeout,
         Integer socketTimeout,
         SSLContext sslContext,
-        boolean engineTypeAutoDetected) {
+        boolean engineTypeAutoDetected,
+        @Nullable AwsCredentialsProvider awsCredentialsProvider) {
       this.engineType = engineType;
       this.host = host;
       this.port = port;
@@ -722,6 +735,7 @@ public class SearchClientShimUtil {
       this.socketTimeout = socketTimeout;
       this.sSLContext = sslContext;
       this.engineTypeAutoDetected = engineTypeAutoDetected;
+      this.awsCredentialsProvider = awsCredentialsProvider;
     }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/OpenSearch2SearchClientShim.java
@@ -119,7 +119,7 @@ import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.index.reindex.UpdateByQueryRequest;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.signer.Aws4Signer;
 
 /**
@@ -305,10 +305,13 @@ public class OpenSearch2SearchClientShim extends AbstractBulkProcessorShim<BulkP
       throw new IllegalArgumentException(
           "Region must not be null when opensearchUseAwsIamAuth is enabled");
     }
+    AwsCredentialsProvider credentialsProvider = shimConfiguration.getAwsCredentialsProvider();
+    if (credentialsProvider == null) {
+      throw new IllegalStateException(
+          "AwsCredentialsProvider must be configured when opensearchUseAwsIamAuth is enabled");
+    }
     Aws4Signer signer = Aws4Signer.create();
-    // Uses default AWS credentials
-    return new AwsRequestSigningApacheInterceptor(
-        "es", signer, DefaultCredentialsProvider.create(), region);
+    return new AwsRequestSigningApacheInterceptor("es", signer, credentialsProvider, region);
   }
 
   // Core search operations

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/embedding/AwsBedrockEmbeddingProvider.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/embedding/AwsBedrockEmbeddingProvider.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
@@ -21,16 +21,11 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
  * Implementation of {@link EmbeddingProvider} that directly calls AWS Bedrock to generate query
  * embeddings using Cohere Embed models.
  *
- * <p>This provider uses the AWS SDK for Java v2 with the default credential provider chain, which
- * supports:
- *
- * <ul>
- *   <li>Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
- *   <li>System properties
- *   <li>AWS_PROFILE environment variable (reads from ~/.aws/credentials)
- *   <li>EC2 instance profile credentials (for production deployments)
- *   <li>Container credentials (ECS tasks)
- * </ul>
+ * <p>This provider uses credentials from a shared {@link AwsCredentialsProvider} (typically the
+ * {@code defaultAwsCredentialsProvider} bean in GMS). The {@link BedrockRuntimeClient} region is
+ * set independently (typically via {@code embeddingProvider.bedrock.awsRegion}), so Bedrock can be
+ * called in a different region than the pod's {@code AWS_REGION} without creating additional
+ * credential providers.
  *
  * <p>Supports Cohere Embed v3 models with proper input_type and truncation handling.
  *
@@ -50,36 +45,38 @@ public class AwsBedrockEmbeddingProvider implements EmbeddingProvider {
   private final int maxCharacterLength;
 
   /**
-   * Creates a new AwsBedrockEmbeddingProvider with default settings.
+   * Creates a provider using an injected shared credentials provider (required in GMS).
    *
    * @param awsRegion AWS region where Bedrock is available (e.g., "us-west-2", "us-east-1")
+   * @param credentialsProvider shared process-wide provider from {@code AwsClientFactory}
    */
-  public AwsBedrockEmbeddingProvider(@Nonnull String awsRegion) {
-    this(awsRegion, DEFAULT_MODEL, DEFAULT_MAX_CHARACTER_LENGTH);
+  public AwsBedrockEmbeddingProvider(
+      @Nonnull String awsRegion, @Nonnull AwsCredentialsProvider credentialsProvider) {
+    this(awsRegion, DEFAULT_MODEL, DEFAULT_MAX_CHARACTER_LENGTH, credentialsProvider);
   }
 
   /**
-   * Creates a new AwsBedrockEmbeddingProvider with custom configuration.
+   * Creates a provider using an injected shared credentials provider (required in GMS).
    *
-   * @param awsRegion AWS region where Bedrock is available
-   * @param defaultModel Default embedding model (e.g., "cohere.embed-english-v3")
-   * @param maxCharacterLength Maximum text length before truncation (Cohere enforces 2048)
+   * @param credentialsProvider shared process-wide provider from {@code AwsClientFactory}
    */
   public AwsBedrockEmbeddingProvider(
-      @Nonnull String awsRegion, @Nonnull String defaultModel, int maxCharacterLength) {
+      @Nonnull String awsRegion,
+      @Nonnull String defaultModel,
+      int maxCharacterLength,
+      @Nonnull AwsCredentialsProvider credentialsProvider) {
     Objects.requireNonNull(awsRegion, "awsRegion cannot be null");
     Objects.requireNonNull(defaultModel, "defaultModel cannot be null");
+    Objects.requireNonNull(credentialsProvider, "credentialsProvider cannot be null");
 
     this.defaultModel = defaultModel;
     this.maxCharacterLength = maxCharacterLength;
     this.objectMapper = new ObjectMapper();
 
-    // Create Bedrock Runtime client with default credential chain
-    // This automatically supports AWS_PROFILE, EC2 instance roles, etc.
     this.bedrockClient =
         BedrockRuntimeClient.builder()
             .region(Region.of(awsRegion))
-            .credentialsProvider(DefaultCredentialsProvider.create())
+            .credentialsProvider(credentialsProvider)
             .build();
 
     log.info(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/embedding/AwsBedrockEmbeddingProviderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/embedding/AwsBedrockEmbeddingProviderTest.java
@@ -7,6 +7,8 @@ import static org.testng.Assert.*;
 import java.nio.charset.StandardCharsets;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
 import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelRequest;
@@ -214,19 +216,33 @@ public class AwsBedrockEmbeddingProviderTest {
 
   @Test
   public void testConstructorWithRegion() {
-    // Test that constructor with region string doesn't throw
-    AwsBedrockEmbeddingProvider providerWithRegion = new AwsBedrockEmbeddingProvider("us-west-2");
+    AwsBedrockEmbeddingProvider providerWithRegion =
+        new AwsBedrockEmbeddingProvider(
+            "us-west-2",
+            "cohere.embed-english-v3",
+            2048,
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")));
     assertNotNull(providerWithRegion);
     providerWithRegion.close();
   }
 
   @Test
   public void testConstructorWithAllParameters() {
-    // Test constructor with all parameters
     AwsBedrockEmbeddingProvider providerWithParams =
-        new AwsBedrockEmbeddingProvider("us-east-1", "cohere.embed-multilingual-v3", 1024);
+        new AwsBedrockEmbeddingProvider(
+            "us-east-1",
+            "cohere.embed-multilingual-v3",
+            1024,
+            StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")));
     assertNotNull(providerWithParams);
     providerWithParams.close();
+  }
+
+  @Test
+  public void testConstructorRejectsNullCredentialsProvider() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new AwsBedrockEmbeddingProvider("us-west-2", "cohere.embed-english-v3", 2048, null));
   }
 
   @Test

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.aws;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.ObjectStorageConfiguration;
+import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.EmbeddingProviderConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -28,6 +30,9 @@ import software.amazon.awssdk.utils.SdkAutoCloseable;
  * <p>Centralizes {@link DefaultCredentialsProvider#create()} and shared S3 clients so IRSA refresh
  * tasks are not orphaned by per-call client construction. Callers should inject these beans rather
  * than creating their own credential providers or S3 clients.
+ *
+ * <p>Non-AWS environments (no region/endpoint, no IAM auth, no Bedrock, no object-storage role)
+ * skip bean creation and do not fail startup.
  */
 @Slf4j
 @Configuration
@@ -46,14 +51,15 @@ public class AwsClientFactory {
   /**
    * The only place in GMS that calls {@link DefaultCredentialsProvider#create()}.
    *
-   * <p>Created when AWS region/endpoint configuration or Bedrock embedding is present.
+   * <p>Created when AWS region/endpoint, OpenSearch IAM auth, Bedrock embedding, or object-storage
+   * role assumption is configured.
    */
   @Bean(name = "defaultAwsCredentialsProvider")
   @Nullable
   protected AwsCredentialsProvider defaultAwsCredentialsProvider() {
     if (!isAwsCredentialsRequired()) {
       log.debug(
-          "Skipping DefaultCredentialsProvider (no AWS region, endpoint, or Bedrock embedding configured)");
+          "Skipping DefaultCredentialsProvider (no AWS region/endpoint, OpenSearch IAM, Bedrock, or object-storage roleArn)");
       return null;
     }
     log.info("Creating shared DefaultCredentialsProvider bean");
@@ -67,15 +73,16 @@ public class AwsClientFactory {
       @Autowired(required = false) @Qualifier("defaultAwsCredentialsProvider")
           AwsCredentialsProvider defaultProvider,
       @Autowired(required = false) @Qualifier("stsClient") StsClient stsClient) {
-    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
-    String roleArn =
-        objectStorageConfiguration != null ? objectStorageConfiguration.getRoleArn() : null;
-    if (roleArn == null || roleArn.trim().isEmpty()) {
+    String roleArn = getObjectStorageRoleArn();
+    if (roleArn == null) {
       return defaultProvider;
     }
     if (stsClient == null) {
-      throw new IllegalStateException(
-          "StsClient bean is required when datahub.objectStorage.roleArn is configured");
+      // Soft-skip so search-only / non-AWS processes that import this factory still start.
+      // objectStorageS3Client fails fast when roleArn is set with AWS region/endpoint present.
+      log.warn(
+          "datahub.objectStorage.roleArn is set but StsClient is unavailable; skipping assume-role credentials");
+      return null;
     }
     log.info("Creating shared StsAssumeRoleCredentialsProvider for object storage");
     objectStorageRoleCredentialsProvider =
@@ -92,18 +99,12 @@ public class AwsClientFactory {
   protected S3Client objectStorageS3Client(
       @Autowired(required = false) @Qualifier("objectStorageCredentialsProvider")
           AwsCredentialsProvider credentialsProvider) {
-    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
-    String roleArn =
-        objectStorageConfiguration != null ? objectStorageConfiguration.getRoleArn() : null;
-    boolean hasRoleArn = roleArn != null && !roleArn.trim().isEmpty();
+    String roleArn = getObjectStorageRoleArn();
+    boolean hasRoleArn = roleArn != null;
 
     String endpointUrl = envOrProperty("AWS_ENDPOINT_URL");
-    String awsRegion = envOrProperty("AWS_REGION");
-    String awsRegionProp = System.getProperty("aws.region");
     boolean hasAwsEndpoint = endpointUrl != null && !endpointUrl.isEmpty();
-    boolean hasAwsRegion =
-        (awsRegion != null && !awsRegion.trim().isEmpty())
-            || (awsRegionProp != null && !awsRegionProp.trim().isEmpty());
+    boolean hasAwsRegion = hasAwsRegion();
 
     if (!hasRoleArn && !hasAwsEndpoint && !hasAwsRegion) {
       log.debug(
@@ -112,6 +113,14 @@ public class AwsClientFactory {
     }
 
     if (hasRoleArn && credentialsProvider == null) {
+      if (hasAwsRegion || hasAwsEndpoint) {
+        throw new IllegalStateException(
+            "StsClient / object-storage credentials are required when datahub.objectStorage.roleArn "
+                + "is configured with AWS region or endpoint");
+      }
+      log.warn(
+          "datahub.objectStorage.roleArn is set but assume-role credentials are unavailable "
+              + "(no AWS region/endpoint); skipping shared S3Client for non-AWS environments");
       return null;
     }
 
@@ -132,8 +141,19 @@ public class AwsClientFactory {
       managedObjectStorageS3Client = clientBuilder.build();
       return managedObjectStorageS3Client;
     } catch (Exception e) {
-      log.error("Failed to create shared object storage S3Client", e);
-      return null;
+      // Explicit role assumption misconfiguration should fail fast. Opportunistic
+      // region/endpoint-only setup (including invalid LocalStack URLs in tests / non-AWS)
+      // soft-skips.
+      if (hasRoleArn) {
+        throw new IllegalStateException("Failed to create shared object storage S3Client", e);
+      }
+      if (isExpectedNonAwsFailure(e) || isInvalidEndpointConfiguration(e)) {
+        log.debug(
+            "Skipping shared object storage S3Client (AWS SDK not usable in this environment): {}",
+            e.getMessage());
+        return null;
+      }
+      throw new IllegalStateException("Failed to create shared object storage S3Client", e);
     }
   }
 
@@ -187,6 +207,19 @@ public class AwsClientFactory {
     return configurationProvider.getDatahub().getObjectStorage();
   }
 
+  @Nullable
+  private String getObjectStorageRoleArn() {
+    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
+    if (objectStorageConfiguration == null) {
+      return null;
+    }
+    String roleArn = objectStorageConfiguration.getRoleArn();
+    if (roleArn == null || roleArn.trim().isEmpty()) {
+      return null;
+    }
+    return roleArn.trim();
+  }
+
   static boolean isAwsConfigured() {
     return hasAwsEndpoint() || hasAwsRegion();
   }
@@ -215,8 +248,25 @@ public class AwsClientFactory {
         && !bedrock.getAwsRegion().trim().isEmpty();
   }
 
-  private boolean isAwsCredentialsRequired() {
-    return isAwsConfigured() || isBedrockEmbeddingConfigured();
+  /** True when OpenSearch requests are signed with AWS IAM. */
+  boolean isOpenSearchIamAuthConfigured() {
+    if (configurationProvider == null || configurationProvider.getElasticSearch() == null) {
+      return false;
+    }
+    ElasticSearchConfiguration esConfig = configurationProvider.getElasticSearch();
+    return esConfig.isOpensearchUseAwsIamAuth();
+  }
+
+  /** True when object storage is configured to assume an IAM role. */
+  boolean isObjectStorageRoleArnConfigured() {
+    return getObjectStorageRoleArn() != null;
+  }
+
+  boolean isAwsCredentialsRequired() {
+    return isAwsConfigured()
+        || isBedrockEmbeddingConfigured()
+        || isOpenSearchIamAuthConfigured()
+        || isObjectStorageRoleArnConfigured();
   }
 
   private static boolean hasAwsEndpoint() {
@@ -231,6 +281,42 @@ public class AwsClientFactory {
     }
     String awsRegionProp = System.getProperty("aws.region");
     return awsRegionProp != null && !awsRegionProp.trim().isEmpty();
+  }
+
+  static boolean isExpectedNonAwsFailure(@Nonnull Throwable error) {
+    Throwable current = error;
+    while (current != null) {
+      if (current instanceof SdkClientException) {
+        String msg = current.getMessage();
+        if (msg != null
+            && (msg.contains("Unable to load region")
+                || msg.contains("EC2 metadata service")
+                || msg.contains("Unable to load credentials"))) {
+          return true;
+        }
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  static boolean isInvalidEndpointConfiguration(@Nonnull Throwable error) {
+    Throwable current = error;
+    while (current != null) {
+      if (current instanceof IllegalArgumentException
+          || current instanceof java.net.URISyntaxException) {
+        String msg = current.getMessage();
+        if (msg != null
+            && (msg.contains("URI")
+                || msg.contains("uri")
+                || msg.contains("Illegal character")
+                || msg.contains("endpoint"))) {
+          return true;
+        }
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   @Nullable

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
@@ -1,0 +1,255 @@
+package com.linkedin.gms.factory.aws;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.ObjectStorageConfiguration;
+import com.linkedin.metadata.config.search.EmbeddingProviderConfiguration;
+import com.linkedin.metadata.config.search.EntityIndexConfiguration;
+import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
+import jakarta.annotation.Nullable;
+import jakarta.annotation.PreDestroy;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
+
+/**
+ * Process-wide AWS credential and object-storage client lifecycle for GMS.
+ *
+ * <p>Centralizes {@link DefaultCredentialsProvider#create()} and shared S3 clients so IRSA refresh
+ * tasks are not orphaned by per-call client construction. Callers should inject these beans rather
+ * than creating their own credential providers or S3 clients.
+ */
+@Slf4j
+@Configuration
+public class AwsClientFactory {
+
+  private static final String OBJECT_STORAGE_SESSION_NAME = "object-storage-session";
+
+  @Autowired(required = false)
+  private ConfigurationProvider configurationProvider;
+
+  @Nullable private DefaultCredentialsProvider defaultCredentialsProvider;
+  @Nullable private StsAssumeRoleCredentialsProvider objectStorageRoleCredentialsProvider;
+  @Nullable private S3Client managedObjectStorageS3Client;
+  @Nullable private S3Presigner managedObjectStorageS3Presigner;
+
+  /**
+   * The only place in GMS that calls {@link DefaultCredentialsProvider#create()}.
+   *
+   * <p>Created when AWS region/endpoint configuration or Bedrock embedding is present.
+   */
+  @Bean(name = "defaultAwsCredentialsProvider")
+  @Nullable
+  protected AwsCredentialsProvider defaultAwsCredentialsProvider() {
+    if (!isAwsCredentialsRequired()) {
+      log.debug(
+          "Skipping DefaultCredentialsProvider (no AWS region, endpoint, or Bedrock embedding configured)");
+      return null;
+    }
+    log.info("Creating shared DefaultCredentialsProvider bean");
+    defaultCredentialsProvider = DefaultCredentialsProvider.create();
+    return defaultCredentialsProvider;
+  }
+
+  @Bean(name = "objectStorageCredentialsProvider")
+  @Nullable
+  protected AwsCredentialsProvider objectStorageCredentialsProvider(
+      @Autowired(required = false) @Qualifier("defaultAwsCredentialsProvider")
+          AwsCredentialsProvider defaultProvider,
+      @Autowired(required = false) @Qualifier("stsClient") StsClient stsClient) {
+    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
+    String roleArn =
+        objectStorageConfiguration != null ? objectStorageConfiguration.getRoleArn() : null;
+    if (roleArn == null || roleArn.trim().isEmpty()) {
+      return defaultProvider;
+    }
+    if (stsClient == null) {
+      throw new IllegalStateException(
+          "StsClient bean is required when datahub.objectStorage.roleArn is configured");
+    }
+    log.info("Creating shared StsAssumeRoleCredentialsProvider for object storage");
+    objectStorageRoleCredentialsProvider =
+        StsAssumeRoleCredentialsProvider.builder()
+            .stsClient(stsClient)
+            .refreshRequest(r -> r.roleArn(roleArn).roleSessionName(OBJECT_STORAGE_SESSION_NAME))
+            .asyncCredentialUpdateEnabled(true)
+            .build();
+    return objectStorageRoleCredentialsProvider;
+  }
+
+  @Bean(name = "objectStorageS3Client")
+  @Nullable
+  protected S3Client objectStorageS3Client(
+      @Autowired(required = false) @Qualifier("objectStorageCredentialsProvider")
+          AwsCredentialsProvider credentialsProvider) {
+    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
+    String roleArn =
+        objectStorageConfiguration != null ? objectStorageConfiguration.getRoleArn() : null;
+    boolean hasRoleArn = roleArn != null && !roleArn.trim().isEmpty();
+
+    String endpointUrl = envOrProperty("AWS_ENDPOINT_URL");
+    String awsRegion = envOrProperty("AWS_REGION");
+    String awsRegionProp = System.getProperty("aws.region");
+    boolean hasAwsEndpoint = endpointUrl != null && !endpointUrl.isEmpty();
+    boolean hasAwsRegion =
+        (awsRegion != null && !awsRegion.trim().isEmpty())
+            || (awsRegionProp != null && !awsRegionProp.trim().isEmpty());
+
+    if (!hasRoleArn && !hasAwsEndpoint && !hasAwsRegion) {
+      log.debug(
+          "Skipping shared object storage S3Client (no roleArn, AWS_ENDPOINT_URL, AWS_REGION, or aws.region)");
+      return null;
+    }
+
+    if (hasRoleArn && credentialsProvider == null) {
+      return null;
+    }
+
+    try {
+      var clientBuilder = S3Client.builder();
+      if (credentialsProvider != null) {
+        clientBuilder.credentialsProvider(credentialsProvider);
+      }
+      if (hasAwsEndpoint) {
+        clientBuilder.endpointOverride(java.net.URI.create(endpointUrl));
+        clientBuilder.forcePathStyle(true);
+        if (!hasAwsRegion) {
+          clientBuilder.region(Region.US_EAST_1);
+        }
+      }
+
+      log.info("Creating shared object storage S3Client bean");
+      managedObjectStorageS3Client = clientBuilder.build();
+      return managedObjectStorageS3Client;
+    } catch (Exception e) {
+      log.error("Failed to create shared object storage S3Client", e);
+      return null;
+    }
+  }
+
+  @Bean(name = "objectStorageS3Presigner")
+  @Nullable
+  protected S3Presigner objectStorageS3Presigner(
+      @Autowired(required = false) @Qualifier("objectStorageS3Client") S3Client s3Client) {
+    if (s3Client == null) {
+      return null;
+    }
+    managedObjectStorageS3Presigner = buildPresigner(s3Client);
+    return managedObjectStorageS3Presigner;
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    closeQuietly(managedObjectStorageS3Presigner);
+    managedObjectStorageS3Presigner = null;
+    closeQuietly(managedObjectStorageS3Client);
+    managedObjectStorageS3Client = null;
+    closeQuietly(objectStorageRoleCredentialsProvider);
+    objectStorageRoleCredentialsProvider = null;
+    closeQuietly(defaultCredentialsProvider);
+    defaultCredentialsProvider = null;
+  }
+
+  @Nonnull
+  private static S3Presigner buildPresigner(@Nonnull S3Client s3Client) {
+    var presignerBuilder =
+        S3Presigner.builder()
+            .credentialsProvider(s3Client.serviceClientConfiguration().credentialsProvider())
+            .region(s3Client.serviceClientConfiguration().region());
+
+    String endpointUrl = envOrProperty("AWS_ENDPOINT_URL");
+    if (endpointUrl != null && !endpointUrl.isEmpty()) {
+      presignerBuilder.endpointOverride(java.net.URI.create(endpointUrl));
+      presignerBuilder.serviceConfiguration(
+          software.amazon.awssdk.services.s3.S3Configuration.builder()
+              .pathStyleAccessEnabled(true)
+              .build());
+    }
+
+    return presignerBuilder.build();
+  }
+
+  @Nullable
+  private ObjectStorageConfiguration getObjectStorageConfiguration() {
+    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
+      return null;
+    }
+    return configurationProvider.getDatahub().getObjectStorage();
+  }
+
+  static boolean isAwsConfigured() {
+    return hasAwsEndpoint() || hasAwsRegion();
+  }
+
+  /** True when semantic search uses aws-bedrock and a target region is configured. */
+  boolean isBedrockEmbeddingConfigured() {
+    if (configurationProvider == null || configurationProvider.getElasticSearch() == null) {
+      return false;
+    }
+    EntityIndexConfiguration entityIndex =
+        configurationProvider.getElasticSearch().getEntityIndex();
+    if (entityIndex == null) {
+      return false;
+    }
+    SemanticSearchConfiguration semanticSearch = entityIndex.getSemanticSearch();
+    if (semanticSearch == null || !semanticSearch.isEnabled()) {
+      return false;
+    }
+    EmbeddingProviderConfiguration embeddingProvider = semanticSearch.getEmbeddingProvider();
+    if (embeddingProvider == null || !"aws-bedrock".equalsIgnoreCase(embeddingProvider.getType())) {
+      return false;
+    }
+    EmbeddingProviderConfiguration.BedrockConfig bedrock = embeddingProvider.getBedrock();
+    return bedrock != null
+        && bedrock.getAwsRegion() != null
+        && !bedrock.getAwsRegion().trim().isEmpty();
+  }
+
+  private boolean isAwsCredentialsRequired() {
+    return isAwsConfigured() || isBedrockEmbeddingConfigured();
+  }
+
+  private static boolean hasAwsEndpoint() {
+    String endpointUrl = envOrProperty("AWS_ENDPOINT_URL");
+    return endpointUrl != null && !endpointUrl.isEmpty();
+  }
+
+  private static boolean hasAwsRegion() {
+    String awsRegion = envOrProperty("AWS_REGION");
+    if (awsRegion != null && !awsRegion.trim().isEmpty()) {
+      return true;
+    }
+    String awsRegionProp = System.getProperty("aws.region");
+    return awsRegionProp != null && !awsRegionProp.trim().isEmpty();
+  }
+
+  @Nullable
+  private static String envOrProperty(@Nonnull String name) {
+    String value = System.getenv(name);
+    if (value == null || value.isEmpty()) {
+      value = System.getProperty(name);
+    }
+    return value;
+  }
+
+  private static void closeQuietly(@Nullable SdkAutoCloseable closeable) {
+    if (closeable == null) {
+      return;
+    }
+    try {
+      closeable.close();
+    } catch (Exception e) {
+      log.warn("Failed to close AWS client during shutdown", e);
+    }
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/aws/AwsClientFactory.java
@@ -113,14 +113,11 @@ public class AwsClientFactory {
     }
 
     if (hasRoleArn && credentialsProvider == null) {
-      if (hasAwsRegion || hasAwsEndpoint) {
-        throw new IllegalStateException(
-            "StsClient / object-storage credentials are required when datahub.objectStorage.roleArn "
-                + "is configured with AWS region or endpoint");
-      }
+      // Soft-skip so search-only contexts that import AwsClientFactory without StsClientFactory
+      // (e.g. MAE) still start when DATAHUB_ROLE_ARN is present alongside AWS_REGION.
       log.warn(
-          "datahub.objectStorage.roleArn is set but assume-role credentials are unavailable "
-              + "(no AWS region/endpoint); skipping shared S3Client for non-AWS environments");
+          "datahub.objectStorage.roleArn is set but assume-role credentials are unavailable; "
+              + "skipping shared S3Client (object storage will be unavailable until StsClient is wired)");
       return null;
     }
 
@@ -201,15 +198,23 @@ public class AwsClientFactory {
 
   @Nullable
   private ObjectStorageConfiguration getObjectStorageConfiguration() {
-    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
-      return null;
-    }
-    return configurationProvider.getDatahub().getObjectStorage();
+    return resolveObjectStorageConfiguration(configurationProvider);
   }
 
   @Nullable
   private String getObjectStorageRoleArn() {
-    ObjectStorageConfiguration objectStorageConfiguration = getObjectStorageConfiguration();
+    return resolveObjectStorageRoleArn(configurationProvider);
+  }
+
+  /**
+   * Shared object-storage roleArn lookup for factories that need to know whether STS/S3 should be
+   * created for assume-role.
+   */
+  @Nullable
+  public static String resolveObjectStorageRoleArn(
+      @Nullable ConfigurationProvider configurationProvider) {
+    ObjectStorageConfiguration objectStorageConfiguration =
+        resolveObjectStorageConfiguration(configurationProvider);
     if (objectStorageConfiguration == null) {
       return null;
     }
@@ -218,6 +223,20 @@ public class AwsClientFactory {
       return null;
     }
     return roleArn.trim();
+  }
+
+  public static boolean isObjectStorageRoleArnConfigured(
+      @Nullable ConfigurationProvider configurationProvider) {
+    return resolveObjectStorageRoleArn(configurationProvider) != null;
+  }
+
+  @Nullable
+  private static ObjectStorageConfiguration resolveObjectStorageConfiguration(
+      @Nullable ConfigurationProvider configurationProvider) {
+    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
+      return null;
+    }
+    return configurationProvider.getDatahub().getObjectStorage();
   }
 
   static boolean isAwsConfigured() {
@@ -259,7 +278,7 @@ public class AwsClientFactory {
 
   /** True when object storage is configured to assume an IAM role. */
   boolean isObjectStorageRoleArnConfigured() {
-    return getObjectStorageRoleArn() != null;
+    return isObjectStorageRoleArnConfigured(configurationProvider);
   }
 
   boolean isAwsCredentialsRequired() {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/objectstorage/ObjectStorageClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/objectstorage/ObjectStorageClientFactory.java
@@ -2,7 +2,9 @@ package com.linkedin.gms.factory.objectstorage;
 
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.linkedin.gms.factory.aws.AwsClientFactory;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.gms.factory.s3.StsClientFactory;
 import com.linkedin.metadata.config.ObjectStorageConfiguration;
 import com.linkedin.metadata.utils.objectstorage.GcsObjectStorageClient;
 import com.linkedin.metadata.utils.objectstorage.LocalObjectStorageClient;
@@ -14,21 +16,27 @@ import jakarta.annotation.Nullable;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.regions.Region;
+import org.springframework.context.annotation.Import;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Slf4j
 @Configuration
+@Import({AwsClientFactory.class, StsClientFactory.class})
 public class ObjectStorageClientFactory {
 
   @Autowired private ConfigurationProvider configurationProvider;
 
   @Autowired(required = false)
-  private StsClient stsClient;
+  @Qualifier("objectStorageS3Client")
+  private S3Client objectStorageS3Client;
+
+  @Autowired(required = false)
+  @Qualifier("objectStorageS3Presigner")
+  private S3Presigner objectStorageS3Presigner;
 
   @Bean(name = "objectStorageClient")
   @Nullable
@@ -86,12 +94,12 @@ public class ObjectStorageClientFactory {
     return switch (location.provider()) {
       case LOCAL -> new LocalObjectStorageClient(location.localRoot());
       case S3 -> {
-        S3Client s3Client = createS3Client(config);
-        if (s3Client == null) {
+        if (objectStorageS3Client == null || objectStorageS3Presigner == null) {
           yield null;
         }
         yield new S3ObjectStorageClient(
-            s3Client,
+            objectStorageS3Client,
+            objectStorageS3Presigner,
             location.bucket(),
             emptyToNull(location.keyPrefix()),
             multipartThreshold,
@@ -110,65 +118,9 @@ public class ObjectStorageClientFactory {
   }
 
   @Nullable
-  private S3Client createS3Client(@Nullable ObjectStorageConfiguration objectStorageConfiguration) {
-    String roleArn =
-        objectStorageConfiguration != null ? objectStorageConfiguration.getRoleArn() : null;
-    if (roleArn != null && !roleArn.trim().isEmpty()) {
-      if (stsClient == null) {
-        throw new IllegalStateException(
-            "StsClient bean is required when datahub.objectStorage.roleArn is configured");
-      }
-      StsAssumeRoleCredentialsProvider credentialsProvider =
-          StsAssumeRoleCredentialsProvider.builder()
-              .stsClient(stsClient)
-              .refreshRequest(r -> r.roleArn(roleArn).roleSessionName("object-storage-session"))
-              .asyncCredentialUpdateEnabled(true)
-              .build();
-      return buildS3ClientBuilder().credentialsProvider(credentialsProvider).build();
-    }
-
-    String endpointUrl = envOrProperty("AWS_ENDPOINT_URL");
-    String awsRegion = envOrProperty("AWS_REGION");
-    String awsRegionProp = System.getProperty("aws.region");
-    boolean hasAwsEndpoint = endpointUrl != null && !endpointUrl.isEmpty();
-    boolean hasAwsRegion =
-        (awsRegion != null && !awsRegion.trim().isEmpty())
-            || (awsRegionProp != null && !awsRegionProp.trim().isEmpty());
-
-    if (!hasAwsEndpoint && !hasAwsRegion) {
-      log.debug(
-          "Skipping S3 ObjectStorageClient (no roleArn, AWS_ENDPOINT_URL, AWS_REGION, or aws.region)");
-      return null;
-    }
-
-    var clientBuilder = buildS3ClientBuilder();
-    if (hasAwsEndpoint) {
-      clientBuilder.endpointOverride(java.net.URI.create(endpointUrl));
-      clientBuilder.forcePathStyle(true);
-      if (!hasAwsRegion) {
-        clientBuilder.region(Region.US_EAST_1);
-      }
-    }
-    return clientBuilder.build();
-  }
-
-  private software.amazon.awssdk.services.s3.S3ClientBuilder buildS3ClientBuilder() {
-    return S3Client.builder();
-  }
-
-  @Nullable
   private static String emptyToNull(@Nullable String value) {
     if (value == null || value.isEmpty()) {
       return null;
-    }
-    return value;
-  }
-
-  @Nullable
-  private static String envOrProperty(@Nonnull String name) {
-    String value = System.getenv(name);
-    if (value == null || value.isEmpty()) {
-      value = System.getProperty(name);
     }
     return value;
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
@@ -2,7 +2,6 @@ package com.linkedin.gms.factory.s3;
 
 import com.linkedin.gms.factory.aws.AwsClientFactory;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
-import com.linkedin.metadata.config.ObjectStorageConfiguration;
 import jakarta.annotation.PreDestroy;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -49,7 +48,8 @@ public class StsClientFactory {
     boolean hasAwsRegion =
         (awsRegion != null && !awsRegion.trim().isEmpty())
             || (awsRegionProp != null && !awsRegionProp.trim().isEmpty());
-    boolean hasObjectStorageRoleArn = isObjectStorageRoleArnConfigured();
+    boolean hasObjectStorageRoleArn =
+        AwsClientFactory.isObjectStorageRoleArnConfigured(configurationProvider);
 
     if (!hasAwsEndpoint && !hasAwsRegion && !hasObjectStorageRoleArn) {
       log.debug(
@@ -97,19 +97,6 @@ public class StsClientFactory {
       }
       return null;
     }
-  }
-
-  private boolean isObjectStorageRoleArnConfigured() {
-    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
-      return false;
-    }
-    ObjectStorageConfiguration objectStorage =
-        configurationProvider.getDatahub().getObjectStorage();
-    if (objectStorage == null) {
-      return false;
-    }
-    String roleArn = objectStorage.getRoleArn();
-    return roleArn != null && !roleArn.trim().isEmpty();
   }
 
   @PreDestroy

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
@@ -1,9 +1,16 @@
 package com.linkedin.gms.factory.s3;
 
+import com.linkedin.gms.factory.aws.AwsClientFactory;
+import jakarta.annotation.PreDestroy;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -11,11 +18,18 @@ import software.amazon.awssdk.services.sts.StsClient;
 
 @Slf4j
 @Configuration
+@Import(AwsClientFactory.class)
 public class StsClientFactory {
 
+  @Autowired(required = false)
+  @Qualifier("defaultAwsCredentialsProvider")
+  private AwsCredentialsProvider defaultAwsCredentialsProvider;
+
+  @Nullable private StsClient managedStsClient;
+
   @Bean(name = "stsClient")
+  @Nullable
   protected StsClient getInstance() {
-    // Env takes precedence; system properties allow overrides (e.g. tests in/outside AWS)
     String endpointUrl = System.getenv("AWS_ENDPOINT_URL");
     if (endpointUrl == null || endpointUrl.isEmpty()) {
       endpointUrl = System.getProperty("AWS_ENDPOINT_URL");
@@ -51,13 +65,14 @@ public class StsClientFactory {
             StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")));
 
         clientBuilder.region(Region.US_EAST_1);
-      } else {
-        log.info("Using default AWS STS configuration");
+      } else if (defaultAwsCredentialsProvider != null) {
+        log.info("Using shared DefaultCredentialsProvider for StsClient");
+        clientBuilder.credentialsProvider(defaultAwsCredentialsProvider);
       }
 
-      StsClient client = clientBuilder.build();
+      managedStsClient = clientBuilder.build();
       log.info("Successfully created StsClient");
-      return client;
+      return managedStsClient;
 
     } catch (Exception e) {
       String msg = e.getMessage();
@@ -71,6 +86,18 @@ public class StsClientFactory {
         log.error("Failed to create STS client", e);
       }
       return null;
+    }
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    if (managedStsClient != null) {
+      try {
+        managedStsClient.close();
+      } catch (Exception e) {
+        log.warn("Failed to close StsClient during shutdown", e);
+      }
+      managedStsClient = null;
     }
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/s3/StsClientFactory.java
@@ -1,6 +1,8 @@
 package com.linkedin.gms.factory.s3;
 
 import com.linkedin.gms.factory.aws.AwsClientFactory;
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.ObjectStorageConfiguration;
 import jakarta.annotation.PreDestroy;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,9 @@ public class StsClientFactory {
   @Qualifier("defaultAwsCredentialsProvider")
   private AwsCredentialsProvider defaultAwsCredentialsProvider;
 
+  @Autowired(required = false)
+  private ConfigurationProvider configurationProvider;
+
   @Nullable private StsClient managedStsClient;
 
   @Bean(name = "stsClient")
@@ -44,10 +49,11 @@ public class StsClientFactory {
     boolean hasAwsRegion =
         (awsRegion != null && !awsRegion.trim().isEmpty())
             || (awsRegionProp != null && !awsRegionProp.trim().isEmpty());
+    boolean hasObjectStorageRoleArn = isObjectStorageRoleArnConfigured();
 
-    if (!hasAwsEndpoint && !hasAwsRegion) {
+    if (!hasAwsEndpoint && !hasAwsRegion && !hasObjectStorageRoleArn) {
       log.debug(
-          "Skipping STS client creation (no AWS_ENDPOINT_URL, AWS_REGION, or aws.region set)");
+          "Skipping STS client creation (no AWS_ENDPOINT_URL, AWS_REGION, aws.region, or objectStorage.roleArn)");
       return null;
     }
 
@@ -68,6 +74,8 @@ public class StsClientFactory {
       } else if (defaultAwsCredentialsProvider != null) {
         log.info("Using shared DefaultCredentialsProvider for StsClient");
         clientBuilder.credentialsProvider(defaultAwsCredentialsProvider);
+        // When only roleArn is configured, leave region to the SDK default chain (IRSA / IMDS /
+        // AWS_REGION). Explicit region/endpoint paths set region above or via the environment.
       }
 
       managedStsClient = clientBuilder.build();
@@ -79,7 +87,9 @@ public class StsClientFactory {
       boolean expectedNonAws =
           e instanceof SdkClientException
               && msg != null
-              && (msg.contains("Unable to load region") || msg.contains("EC2 metadata service"));
+              && (msg.contains("Unable to load region")
+                  || msg.contains("EC2 metadata service")
+                  || msg.contains("Unable to load credentials"));
       if (expectedNonAws) {
         log.debug("STS client not available (not running in AWS or AWS not configured): {}", msg);
       } else {
@@ -87,6 +97,19 @@ public class StsClientFactory {
       }
       return null;
     }
+  }
+
+  private boolean isObjectStorageRoleArnConfigured() {
+    if (configurationProvider == null || configurationProvider.getDatahub() == null) {
+      return false;
+    }
+    ObjectStorageConfiguration objectStorage =
+        configurationProvider.getDatahub().getObjectStorage();
+    if (objectStorage == null) {
+      return false;
+    }
+    String roleArn = objectStorage.getRoleArn();
+    return roleArn != null && !roleArn.trim().isEmpty();
   }
 
   @PreDestroy

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchClientShimFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchClientShimFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.search;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.gms.factory.aws.AwsClientFactory;
 import com.linkedin.gms.factory.common.ElasticsearchSSLContextFactory;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.MaeConsumerConfiguration;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Spring factory for creating SearchClientShim instances based on DataHub configuration. This
@@ -27,7 +29,7 @@ import org.springframework.context.annotation.Import;
  */
 @Slf4j
 @Configuration
-@Import({ElasticsearchSSLContextFactory.class})
+@Import({ElasticsearchSSLContextFactory.class, AwsClientFactory.class})
 public class SearchClientShimFactory {
 
   // New shim-specific configuration properties
@@ -42,6 +44,10 @@ public class SearchClientShimFactory {
   @Autowired
   @Qualifier("elasticSearchSSLContext")
   private SSLContext elasticSearchSSLContext;
+
+  @Autowired(required = false)
+  @Qualifier("defaultAwsCredentialsProvider")
+  private AwsCredentialsProvider defaultAwsCredentialsProvider;
 
   /**
    * Create the SearchClientShim bean. This can be configured to either: (1) auto-detect the search
@@ -123,6 +129,7 @@ public class SearchClientShimFactory {
             .withSSLContext(elasticSearchSSLContext)
             .withPathPrefix(esConfig.getPathPrefix())
             .withAwsIamAuth(esConfig.isOpensearchUseAwsIamAuth(), esConfig.getRegion())
+            .withAwsCredentialsProvider(defaultAwsCredentialsProvider)
             .withThreadCount(esConfig.getThreadCount())
             .withConnectionRequestTimeout(connectionRequestTimeoutMs)
             .withSocketTimeout(socketTimeoutMs);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.search.semantic;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.linkedin.gms.factory.aws.AwsClientFactory;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.search.EmbeddingProviderConfiguration;
 import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
@@ -11,13 +12,18 @@ import com.linkedin.metadata.search.embedding.LocalEmbeddingProvider;
 import com.linkedin.metadata.search.embedding.NoOpEmbeddingProvider;
 import com.linkedin.metadata.search.embedding.OpenAIEmbeddingProvider;
 import com.linkedin.metadata.search.embedding.VertexAiEmbeddingProvider;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Factory for creating embedding providers used in semantic search.
@@ -35,21 +41,23 @@ import org.springframework.context.annotation.Configuration;
  * <p>The provider is conditionally created only when semantic search is enabled in the
  * configuration.
  *
- * <p>AWS Bedrock credentials are resolved automatically using the default AWS credential provider
- * chain:
- *
- * <ul>
- *   <li>Environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
- *   <li>AWS_PROFILE environment variable (reads from ~/.aws/credentials)
- *   <li>EC2 instance profile credentials (for production deployments)
- *   <li>Container credentials (ECS tasks)
- * </ul>
+ * <p>AWS Bedrock uses the shared {@code defaultAwsCredentialsProvider} bean from {@link
+ * AwsClientFactory}. The Bedrock Runtime client region comes from {@code
+ * embeddingProvider.bedrock.awsRegion} and may differ from the pod {@code AWS_REGION} for
+ * cross-region model access.
  */
 @Slf4j
 @Configuration
+@Import(AwsClientFactory.class)
 public class EmbeddingProviderFactory {
 
   @Autowired private ConfigurationProvider configurationProvider;
+
+  @Autowired(required = false)
+  @Qualifier("defaultAwsCredentialsProvider")
+  private AwsCredentialsProvider defaultAwsCredentialsProvider;
+
+  @Nullable private AwsBedrockEmbeddingProvider managedBedrockProvider;
 
   /**
    * Creates an EmbeddingProvider bean for generating query embeddings.
@@ -90,16 +98,54 @@ public class EmbeddingProviderFactory {
   }
 
   private EmbeddingProvider createAwsBedrockProvider(EmbeddingProviderConfiguration config) {
+    if (defaultAwsCredentialsProvider == null) {
+      throw new IllegalStateException(
+          "Shared DefaultCredentialsProvider is required when using the aws-bedrock embedding provider. "
+              + "Configure AWS_REGION/aws.region/AWS_ENDPOINT_URL on the pod, or enable aws-bedrock with bedrock.awsRegion set.");
+    }
+
     EmbeddingProviderConfiguration.BedrockConfig bedrockConfig = config.getBedrock();
+    String bedrockRegion = bedrockConfig.getAwsRegion();
+    if (bedrockRegion == null || bedrockRegion.trim().isEmpty()) {
+      throw new IllegalStateException(
+          "embeddingProvider.bedrock.awsRegion is required when using the aws-bedrock embedding provider");
+    }
+    bedrockRegion = bedrockRegion.trim();
+
+    String podRegion = System.getenv("AWS_REGION");
+    if (podRegion == null || podRegion.isBlank()) {
+      podRegion = System.getProperty("AWS_REGION");
+    }
+    if (podRegion != null
+        && !podRegion.isBlank()
+        && !podRegion.trim().equalsIgnoreCase(bedrockRegion)) {
+      log.info(
+          "Bedrock embedding region {} differs from pod AWS_REGION {}; using shared credentials with cross-region Bedrock client",
+          bedrockRegion,
+          podRegion.trim());
+    }
 
     log.info(
-        "Configuring AWS Bedrock embedding provider: region={}, model={}, maxCharLength={}",
-        bedrockConfig.getAwsRegion(),
+        "Configuring AWS Bedrock embedding provider: bedrockRegion={}, model={}, maxCharLength={}",
+        bedrockRegion,
         bedrockConfig.getModel(),
         config.getMaxCharacterLength());
 
-    return new AwsBedrockEmbeddingProvider(
-        bedrockConfig.getAwsRegion(), bedrockConfig.getModel(), config.getMaxCharacterLength());
+    managedBedrockProvider =
+        new AwsBedrockEmbeddingProvider(
+            bedrockRegion,
+            bedrockConfig.getModel(),
+            config.getMaxCharacterLength(),
+            defaultAwsCredentialsProvider);
+    return managedBedrockProvider;
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    if (managedBedrockProvider != null) {
+      managedBedrockProvider.close();
+      managedBedrockProvider = null;
+    }
   }
 
   private EmbeddingProvider createOpenAIProvider(EmbeddingProviderConfiguration config) {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactory.java
@@ -65,9 +65,13 @@ public class EmbeddingProviderFactory {
    * <p>Returns a no-op provider if semantic search is not enabled, allowing the system to start
    * without requiring embedding configuration.
    *
+   * <p>{@code destroyMethod} is disabled so this factory's {@link PreDestroy} is the sole closer of
+   * the Bedrock Runtime client (avoids double-close with Spring's inferred {@code Closeable}
+   * destroy).
+   *
    * @return EmbeddingProvider instance configured based on application.yaml settings
    */
-  @Bean(name = "embeddingProvider")
+  @Bean(name = "embeddingProvider", destroyMethod = "")
   @Nonnull
   protected EmbeddingProvider getInstance() {
     SemanticSearchConfiguration semanticSearchConfig =

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
@@ -1,0 +1,57 @@
+package com.linkedin.gms.factory.aws;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.testng.annotations.Test;
+
+/**
+ * Guards against reintroducing inline AWS credential/client creation in GMS factories that can
+ * orphan IRSA credential refresh tasks.
+ */
+public class AwsAuthEfficiencyTest {
+
+  private static final Path FACTORIES_MAIN = Path.of("src/main/java/com/linkedin/gms/factory");
+
+  private static final List<Pattern> BANNED_PATTERNS =
+      List.of(
+          Pattern.compile("DefaultCredentialsProvider\\.create\\(\\)"),
+          Pattern.compile("StsClient\\.create\\(\\)"),
+          Pattern.compile("S3Client\\.builder\\(\\)\\.build\\(\\)"));
+
+  private static final List<String> ALLOWED_FILES =
+      List.of("aws/AwsClientFactory.java", "s3/StsClientFactory.java");
+
+  @Test
+  public void factoriesDoNotCreateInlineAwsCredentialProviders() throws IOException {
+    assertTrue(Files.isDirectory(FACTORIES_MAIN), "Expected factories main source directory");
+
+    try (Stream<Path> paths = Files.walk(FACTORIES_MAIN)) {
+      paths
+          .filter(path -> path.toString().endsWith(".java"))
+          .forEach(
+              path -> {
+                String relative = FACTORIES_MAIN.relativize(path).toString().replace('\\', '/');
+                if (ALLOWED_FILES.contains(relative)) {
+                  return;
+                }
+                try {
+                  String source = Files.readString(path);
+                  for (Pattern pattern : BANNED_PATTERNS) {
+                    assertFalse(
+                        pattern.matcher(source).find(),
+                        "Banned AWS pattern " + pattern.pattern() + " found in " + relative);
+                  }
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+    }
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
@@ -24,7 +24,9 @@ public class AwsAuthEfficiencyTest {
           Pattern.compile("DefaultCredentialsProvider\\.create\\(\\)"),
           Pattern.compile("StsClient\\.create\\(\\)"),
           Pattern.compile("S3Client\\.builder\\(\\)"),
-          Pattern.compile("S3Presigner\\.builder\\(\\)"));
+          Pattern.compile("S3Client\\.create\\(\\)"),
+          Pattern.compile("S3Presigner\\.builder\\(\\)"),
+          Pattern.compile("S3Presigner\\.create\\(\\)"));
 
   private static final List<String> ALLOWED_FILES =
       List.of("aws/AwsClientFactory.java", "s3/StsClientFactory.java");

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsAuthEfficiencyTest.java
@@ -23,7 +23,8 @@ public class AwsAuthEfficiencyTest {
       List.of(
           Pattern.compile("DefaultCredentialsProvider\\.create\\(\\)"),
           Pattern.compile("StsClient\\.create\\(\\)"),
-          Pattern.compile("S3Client\\.builder\\(\\)\\.build\\(\\)"));
+          Pattern.compile("S3Client\\.builder\\(\\)"),
+          Pattern.compile("S3Presigner\\.builder\\(\\)"));
 
   private static final List<String> ALLOWED_FILES =
       List.of("aws/AwsClientFactory.java", "s3/StsClientFactory.java");

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryBedrockCredentialsTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryBedrockCredentialsTest.java
@@ -5,6 +5,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.ObjectStorageConfiguration;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.EmbeddingProviderConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
@@ -31,6 +33,10 @@ public class AwsClientFactoryBedrockCredentialsTest {
     System.clearProperty("AWS_REGION");
     System.clearProperty("AWS_ENDPOINT_URL");
     System.clearProperty("aws.region");
+
+    DataHubConfiguration dataHubConfiguration = new DataHubConfiguration();
+    dataHubConfiguration.setObjectStorage(new ObjectStorageConfiguration());
+    when(configurationProvider.getDatahub()).thenReturn(dataHubConfiguration);
   }
 
   @AfterMethod
@@ -47,6 +53,7 @@ public class AwsClientFactoryBedrockCredentialsTest {
   public void bedrockEmbeddingConfigRequiresSharedCredentialsEvenWithoutPodRegion() {
     wireBedrockConfig("us-west-2");
     assertTrue(awsClientFactory.isBedrockEmbeddingConfigured());
+    assertTrue(awsClientFactory.isAwsCredentialsRequired());
   }
 
   @Test
@@ -64,6 +71,30 @@ public class AwsClientFactoryBedrockCredentialsTest {
     when(configurationProvider.getElasticSearch()).thenReturn(esConfig);
 
     assertFalse(awsClientFactory.isBedrockEmbeddingConfigured());
+  }
+
+  @Test
+  public void openSearchIamAuthRequiresSharedCredentialsEvenWithoutPodRegion() {
+    ElasticSearchConfiguration esConfig = new ElasticSearchConfiguration();
+    esConfig.setOpensearchUseAwsIamAuth(true);
+    esConfig.setRegion("us-east-1");
+    when(configurationProvider.getElasticSearch()).thenReturn(esConfig);
+
+    assertTrue(awsClientFactory.isOpenSearchIamAuthConfigured());
+    assertTrue(awsClientFactory.isAwsCredentialsRequired());
+  }
+
+  @Test
+  public void objectStorageRoleArnRequiresSharedCredentialsEvenWithoutPodRegion() {
+    DataHubConfiguration dataHubConfiguration = new DataHubConfiguration();
+    ObjectStorageConfiguration objectStorage = new ObjectStorageConfiguration();
+    objectStorage.setRoleArn("arn:aws:iam::123456789012:role/test-role");
+    dataHubConfiguration.setObjectStorage(objectStorage);
+    when(configurationProvider.getDatahub()).thenReturn(dataHubConfiguration);
+    when(configurationProvider.getElasticSearch()).thenReturn(new ElasticSearchConfiguration());
+
+    assertTrue(awsClientFactory.isObjectStorageRoleArnConfigured());
+    assertTrue(awsClientFactory.isAwsCredentialsRequired());
   }
 
   private void wireBedrockConfig(String bedrockRegion) {

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryBedrockCredentialsTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryBedrockCredentialsTest.java
@@ -1,0 +1,90 @@
+package com.linkedin.gms.factory.aws;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
+import com.linkedin.metadata.config.search.EmbeddingProviderConfiguration;
+import com.linkedin.metadata.config.search.EntityIndexConfiguration;
+import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class AwsClientFactoryBedrockCredentialsTest {
+
+  @Mock private ConfigurationProvider configurationProvider;
+
+  private AwsClientFactory awsClientFactory;
+  private AutoCloseable mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    awsClientFactory = new AwsClientFactory();
+    ReflectionTestUtils.setField(awsClientFactory, "configurationProvider", configurationProvider);
+    System.clearProperty("AWS_REGION");
+    System.clearProperty("AWS_ENDPOINT_URL");
+    System.clearProperty("aws.region");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    System.clearProperty("AWS_REGION");
+    System.clearProperty("AWS_ENDPOINT_URL");
+    System.clearProperty("aws.region");
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  public void bedrockEmbeddingConfigRequiresSharedCredentialsEvenWithoutPodRegion() {
+    wireBedrockConfig("us-west-2");
+    assertTrue(awsClientFactory.isBedrockEmbeddingConfigured());
+  }
+
+  @Test
+  public void nonBedrockSemanticSearchDoesNotRequireBedrockCredentials() {
+    SemanticSearchConfiguration semanticSearch = new SemanticSearchConfiguration();
+    semanticSearch.setEnabled(true);
+    EmbeddingProviderConfiguration embeddingProvider = new EmbeddingProviderConfiguration();
+    embeddingProvider.setType("openai");
+    semanticSearch.setEmbeddingProvider(embeddingProvider);
+
+    EntityIndexConfiguration entityIndex = new EntityIndexConfiguration();
+    entityIndex.setSemanticSearch(semanticSearch);
+    ElasticSearchConfiguration esConfig = new ElasticSearchConfiguration();
+    esConfig.setEntityIndex(entityIndex);
+    when(configurationProvider.getElasticSearch()).thenReturn(esConfig);
+
+    assertFalse(awsClientFactory.isBedrockEmbeddingConfigured());
+  }
+
+  private void wireBedrockConfig(String bedrockRegion) {
+    EmbeddingProviderConfiguration.BedrockConfig bedrock =
+        new EmbeddingProviderConfiguration.BedrockConfig();
+    bedrock.setAwsRegion(bedrockRegion);
+
+    EmbeddingProviderConfiguration embeddingProvider = new EmbeddingProviderConfiguration();
+    embeddingProvider.setType("aws-bedrock");
+    embeddingProvider.setBedrock(bedrock);
+
+    SemanticSearchConfiguration semanticSearch = new SemanticSearchConfiguration();
+    semanticSearch.setEnabled(true);
+    semanticSearch.setEmbeddingProvider(embeddingProvider);
+
+    EntityIndexConfiguration entityIndex = new EntityIndexConfiguration();
+    entityIndex.setSemanticSearch(semanticSearch);
+
+    ElasticSearchConfiguration esConfig = new ElasticSearchConfiguration();
+    esConfig.setEntityIndex(entityIndex);
+
+    when(configurationProvider.getElasticSearch()).thenReturn(esConfig);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryObjectStorageTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryObjectStorageTest.java
@@ -1,0 +1,137 @@
+package com.linkedin.gms.factory.aws;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.ObjectStorageConfiguration;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.SkipException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.sts.StsClient;
+
+/**
+ * Covers object-storage S3 client construction paths that used to live in
+ * ObjectStorageClientFactoryTest (endpoint-only and role-arn assume-role).
+ */
+public class AwsClientFactoryObjectStorageTest {
+
+  @Mock private ConfigurationProvider configurationProvider;
+
+  private AwsClientFactory awsClientFactory;
+  private AutoCloseable mocks;
+  private DataHubConfiguration dataHubConfiguration;
+
+  @BeforeMethod
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    awsClientFactory = new AwsClientFactory();
+    ReflectionTestUtils.setField(awsClientFactory, "configurationProvider", configurationProvider);
+
+    dataHubConfiguration = new DataHubConfiguration();
+    dataHubConfiguration.setObjectStorage(new ObjectStorageConfiguration());
+    when(configurationProvider.getDatahub()).thenReturn(dataHubConfiguration);
+
+    System.clearProperty("AWS_REGION");
+    System.clearProperty("AWS_ENDPOINT_URL");
+    System.clearProperty("aws.region");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    System.clearProperty("AWS_REGION");
+    System.clearProperty("AWS_ENDPOINT_URL");
+    System.clearProperty("aws.region");
+    awsClientFactory.shutdown();
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  private static void skipIfAwsEnvironmentConfigured() {
+    if (AwsClientFactory.isAwsConfigured()) {
+      throw new SkipException(
+          "AWS_REGION/AWS_ENDPOINT_URL/aws.region present; cannot assert non-AWS skip paths");
+    }
+  }
+
+  @Test
+  public void skipsS3ClientWhenNoAwsConfig() {
+    skipIfAwsEnvironmentConfigured();
+    S3Client client = awsClientFactory.objectStorageS3Client(null);
+    assertNull(client);
+  }
+
+  @Test
+  public void createsS3ClientFromEndpointOnly() {
+    System.setProperty("AWS_ENDPOINT_URL", "http://localhost:9999");
+
+    S3Client client = awsClientFactory.objectStorageS3Client(null);
+    assertNotNull(client);
+  }
+
+  @Test
+  public void createsS3ClientWithRoleCredentialsAndRegion() {
+    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
+    System.setProperty("aws.region", "us-east-1");
+
+    AwsCredentialsProvider roleCredentials =
+        StaticCredentialsProvider.create(AwsBasicCredentials.create("test-key", "test-secret"));
+
+    S3Client client = awsClientFactory.objectStorageS3Client(roleCredentials);
+    assertNotNull(client);
+  }
+
+  @Test
+  public void roleArnWithoutStsReturnsNullCredentialsInNonAws() {
+    skipIfAwsEnvironmentConfigured();
+    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
+
+    AwsCredentialsProvider provider =
+        awsClientFactory.objectStorageCredentialsProvider(/* defaultProvider= */ null, null);
+    assertNull(provider);
+  }
+
+  @Test
+  public void roleArnWithRegionButMissingCredentialsFailsFast() {
+    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
+    System.setProperty("aws.region", "us-east-1");
+
+    IllegalStateException thrown =
+        expectThrows(
+            IllegalStateException.class, () -> awsClientFactory.objectStorageS3Client(null));
+    assertTrue(thrown.getMessage().contains("roleArn"));
+  }
+
+  @Test
+  public void roleArnWithoutRegionSkipsS3ClientInNonAws() {
+    skipIfAwsEnvironmentConfigured();
+    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
+
+    S3Client client = awsClientFactory.objectStorageS3Client(null);
+    assertNull(client);
+  }
+
+  @Test
+  public void objectStorageCredentialsProviderUsesStsWhenAvailable() {
+    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
+    StsClient stsClient = mock(StsClient.class);
+
+    AwsCredentialsProvider provider =
+        awsClientFactory.objectStorageCredentialsProvider(/* defaultProvider= */ null, stsClient);
+    assertNotNull(provider);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryObjectStorageTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryObjectStorageTest.java
@@ -4,8 +4,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.DataHubConfiguration;
@@ -106,14 +104,12 @@ public class AwsClientFactoryObjectStorageTest {
   }
 
   @Test
-  public void roleArnWithRegionButMissingCredentialsFailsFast() {
+  public void roleArnWithRegionButMissingCredentialsSoftSkips() {
     dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
     System.setProperty("aws.region", "us-east-1");
 
-    IllegalStateException thrown =
-        expectThrows(
-            IllegalStateException.class, () -> awsClientFactory.objectStorageS3Client(null));
-    assertTrue(thrown.getMessage().contains("roleArn"));
+    S3Client client = awsClientFactory.objectStorageS3Client(null);
+    assertNull(client);
   }
 
   @Test

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryShutdownTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryShutdownTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -66,5 +67,16 @@ public class AwsClientFactoryShutdownTest {
 
     verify(roleProvider).close();
     verify(s3Client).close();
+  }
+
+  @Test
+  public void shutdownClosesDefaultCredentialsProvider() {
+    DefaultCredentialsProvider credentialsProvider = mock(DefaultCredentialsProvider.class);
+    ReflectionTestUtils.setField(
+        awsClientFactory, "defaultCredentialsProvider", credentialsProvider);
+
+    awsClientFactory.shutdown();
+
+    verify(credentialsProvider).close();
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryShutdownTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/aws/AwsClientFactoryShutdownTest.java
@@ -1,0 +1,70 @@
+package com.linkedin.gms.factory.aws;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.ObjectStorageConfiguration;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+
+public class AwsClientFactoryShutdownTest {
+
+  @Mock private ConfigurationProvider configurationProvider;
+
+  private AwsClientFactory awsClientFactory;
+  private AutoCloseable mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    awsClientFactory = new AwsClientFactory();
+    ReflectionTestUtils.setField(awsClientFactory, "configurationProvider", configurationProvider);
+
+    DataHubConfiguration dataHubConfiguration = new DataHubConfiguration();
+    dataHubConfiguration.setObjectStorage(new ObjectStorageConfiguration());
+    org.mockito.Mockito.when(configurationProvider.getDatahub()).thenReturn(dataHubConfiguration);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  public void shutdownClosesManagedS3ClientAndPresigner() {
+    S3Client s3Client = mock(S3Client.class);
+    S3Presigner presigner = mock(S3Presigner.class);
+    ReflectionTestUtils.setField(awsClientFactory, "managedObjectStorageS3Client", s3Client);
+    ReflectionTestUtils.setField(awsClientFactory, "managedObjectStorageS3Presigner", presigner);
+
+    awsClientFactory.shutdown();
+
+    verify(presigner).close();
+    verify(s3Client).close();
+  }
+
+  @Test
+  public void shutdownClosesObjectStorageRoleProvider() {
+    S3Client s3Client = mock(S3Client.class);
+    StsAssumeRoleCredentialsProvider roleProvider = mock(StsAssumeRoleCredentialsProvider.class);
+    ReflectionTestUtils.setField(awsClientFactory, "managedObjectStorageS3Client", s3Client);
+    ReflectionTestUtils.setField(
+        awsClientFactory, "objectStorageRoleCredentialsProvider", roleProvider);
+
+    awsClientFactory.shutdown();
+
+    verify(roleProvider).close();
+    verify(s3Client).close();
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/objectstorage/ObjectStorageClientFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/objectstorage/ObjectStorageClientFactoryTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.gms.factory.objectstorage;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
@@ -15,18 +14,14 @@ import com.linkedin.metadata.utils.objectstorage.LocalObjectStorageClient;
 import com.linkedin.metadata.utils.objectstorage.ObjectStorageClient;
 import com.linkedin.metadata.utils.objectstorage.ObjectStorageProvider;
 import com.linkedin.metadata.utils.objectstorage.S3ObjectStorageClient;
-import java.time.Instant;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
-import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
-import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 public class ObjectStorageClientFactoryTest {
 
@@ -34,12 +29,19 @@ public class ObjectStorageClientFactoryTest {
 
   private ObjectStorageClientFactory factory;
   private DataHubConfiguration dataHubConfiguration;
+  private S3Client sharedS3Client;
+  private S3Presigner sharedS3Presigner;
 
   @BeforeMethod
   public void setUp() {
     MockitoAnnotations.openMocks(this);
     factory = new ObjectStorageClientFactory();
     ReflectionTestUtils.setField(factory, "configurationProvider", configurationProvider);
+
+    sharedS3Client = mock(S3Client.class);
+    sharedS3Presigner = mock(S3Presigner.class);
+    ReflectionTestUtils.setField(factory, "objectStorageS3Client", sharedS3Client);
+    ReflectionTestUtils.setField(factory, "objectStorageS3Presigner", sharedS3Presigner);
 
     dataHubConfiguration = new DataHubConfiguration();
     ObjectStorageConfiguration objectStorageConfiguration = new ObjectStorageConfiguration();
@@ -80,47 +82,13 @@ public class ObjectStorageClientFactoryTest {
   }
 
   @Test
-  public void testCreatesS3ClientFromUriWithAwsRegion() {
+  public void testCreatesS3ClientFromUriWithSharedBean() {
     dataHubConfiguration.getObjectStorage().setUri("s3://my-bucket/prefix");
-    System.setProperty("aws.region", "us-east-1");
 
     ObjectStorageClient client = factory.getInstance();
     assertNotNull(client);
     assertTrue(client instanceof S3ObjectStorageClient);
     assertTrue(client.provider() == ObjectStorageProvider.S3);
-  }
-
-  @Test
-  public void testCreatesS3ClientFromUriWithEndpointOnly() {
-    dataHubConfiguration.getObjectStorage().setUri("s3://my-bucket");
-    System.setProperty("AWS_ENDPOINT_URL", "http://localhost:9999");
-
-    ObjectStorageClient client = factory.getInstance();
-    assertNotNull(client);
-    assertTrue(client instanceof S3ObjectStorageClient);
-  }
-
-  @Test
-  public void testCreatesS3ClientWithRoleArn() {
-    dataHubConfiguration.getObjectStorage().setUri("s3://my-bucket");
-    dataHubConfiguration.getObjectStorage().setRoleArn("arn:aws:iam::123456789012:role/test-role");
-    System.setProperty("aws.region", "us-east-1");
-
-    StsClient stsClient = mock(StsClient.class);
-    Credentials credentials =
-        Credentials.builder()
-            .accessKeyId("test-access-key")
-            .secretAccessKey("test-secret-key")
-            .sessionToken("test-session-token")
-            .expiration(Instant.now().plusSeconds(3600))
-            .build();
-    when(stsClient.assumeRole(any(AssumeRoleRequest.class)))
-        .thenReturn(AssumeRoleResponse.builder().credentials(credentials).build());
-    ReflectionTestUtils.setField(factory, "stsClient", stsClient);
-
-    ObjectStorageClient client = factory.getInstance();
-    assertNotNull(client);
-    assertTrue(client instanceof S3ObjectStorageClient);
   }
 
   @Test
@@ -134,23 +102,13 @@ public class ObjectStorageClientFactoryTest {
   }
 
   @Test
-  public void testReturnsNullWhenS3LocationWithoutAwsConfig() {
-    if (hasAwsEnvironmentConfig()) {
-      throw new SkipException("AWS env vars are set; cannot assert null S3 client");
-    }
+  public void testReturnsNullWhenS3LocationWithoutSharedClient() {
+    ReflectionTestUtils.setField(factory, "objectStorageS3Client", null);
+    ReflectionTestUtils.setField(factory, "objectStorageS3Presigner", null);
     dataHubConfiguration.getObjectStorage().setUri("s3://my-bucket");
 
     ObjectStorageClient client = factory.getInstance();
     assertNull(client);
-  }
-
-  private static boolean hasAwsEnvironmentConfig() {
-    String awsRegion = System.getenv("AWS_REGION");
-    if (awsRegion != null && !awsRegion.isBlank()) {
-      return true;
-    }
-    String endpointUrl = System.getenv("AWS_ENDPOINT_URL");
-    return endpointUrl != null && !endpointUrl.isBlank();
   }
 
   @Test

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/s3/StsClientFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/s3/StsClientFactoryTest.java
@@ -3,6 +3,7 @@ package com.linkedin.gms.factory.s3;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
+import com.linkedin.gms.factory.aws.AwsClientFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -47,7 +48,7 @@ final class SetAwsEndpointForStsInitializer
 }
 
 /** Tests StsClient creation when region and endpoint are set (deterministic in CI). */
-@SpringBootTest(classes = {StsClientFactory.class})
+@SpringBootTest(classes = {AwsClientFactory.class, StsClientFactory.class})
 @ContextConfiguration(initializers = SetAwsRegionAndEndpointForStsInitializer.class)
 class StsClientFactoryWithRegionTest extends AbstractTestNGSpringContextTests {
 
@@ -62,7 +63,7 @@ class StsClientFactoryWithRegionTest extends AbstractTestNGSpringContextTests {
 }
 
 /** Tests StsClient creation with custom endpoint (LocalStack/custom endpoint path). */
-@SpringBootTest(classes = {StsClientFactory.class})
+@SpringBootTest(classes = {AwsClientFactory.class, StsClientFactory.class})
 @ContextConfiguration(initializers = SetAwsEndpointForStsInitializer.class)
 class StsClientFactoryWithEndpointTest extends AbstractTestNGSpringContextTests {
 
@@ -87,7 +88,7 @@ final class InvalidEndpointForStsInitializer
 }
 
 /** Tests StsClient is null when factory throws (covers catch block / exception path). */
-@SpringBootTest(classes = {StsClientFactory.class})
+@SpringBootTest(classes = {AwsClientFactory.class, StsClientFactory.class})
 @ContextConfiguration(initializers = InvalidEndpointForStsInitializer.class)
 class StsClientFactoryExceptionTest extends AbstractTestNGSpringContextTests {
 
@@ -103,7 +104,7 @@ class StsClientFactoryExceptionTest extends AbstractTestNGSpringContextTests {
 }
 
 /** Tests StsClient is null when no AWS config is present. */
-@SpringBootTest(classes = {StsClientFactory.class})
+@SpringBootTest(classes = {AwsClientFactory.class, StsClientFactory.class})
 @ContextConfiguration(initializers = ClearAwsPropertiesForStsInitializer.class)
 class StsClientFactoryNoAwsConfigTest extends AbstractTestNGSpringContextTests {
 

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/semantic/EmbeddingProviderFactoryTest.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Unit tests for the vertex_ai branch in {@link EmbeddingProviderFactory}.
@@ -92,6 +93,16 @@ public class EmbeddingProviderFactoryTest {
     field.setAccessible(true);
     field.set(factory, configProvider);
 
+    return factory;
+  }
+
+  private static TestableFactory factoryWithConfigAndAwsCredentials(
+      EmbeddingProviderConfiguration embeddingConfig) throws Exception {
+    TestableFactory factory = factoryWithConfig(embeddingConfig);
+    Field awsField =
+        EmbeddingProviderFactory.class.getDeclaredField("defaultAwsCredentialsProvider");
+    awsField.setAccessible(true);
+    awsField.set(factory, mock(AwsCredentialsProvider.class));
     return factory;
   }
 
@@ -342,7 +353,7 @@ public class EmbeddingProviderFactoryTest {
     EmbeddingProviderConfiguration config =
         configWithBedrock("us-west-2", "cohere.embed-english-v3");
 
-    TestableFactory factory = factoryWithConfig(config);
+    TestableFactory factory = factoryWithConfigAndAwsCredentials(config);
     EmbeddingProvider provider = factory.getInstance();
 
     assertNotNull(provider);
@@ -357,11 +368,36 @@ public class EmbeddingProviderFactoryTest {
     EmbeddingProviderConfiguration config =
         configWithBedrock("us-east-1", "amazon.titan-embed-text-v2:0");
 
-    TestableFactory factory = factoryWithConfig(config);
+    TestableFactory factory = factoryWithConfigAndAwsCredentials(config);
     EmbeddingProvider provider = factory.getInstance();
 
     assertNotNull(provider);
     assertTrue(provider instanceof AwsBedrockEmbeddingProvider);
+  }
+
+  @Test
+  public void rejectsAwsBedrockWithoutSharedCredentialsProvider() throws Exception {
+    EmbeddingProviderConfiguration config =
+        configWithBedrock("us-west-2", "cohere.embed-english-v3");
+
+    IllegalStateException error =
+        expectThrows(IllegalStateException.class, () -> factoryWithConfig(config).getInstance());
+
+    assertTrue(error.getMessage().contains("DefaultCredentialsProvider"));
+  }
+
+  @Test
+  public void rejectsAwsBedrockWithoutBedrockRegion() throws Exception {
+    EmbeddingProviderConfiguration config =
+        configWithBedrock("us-west-2", "cohere.embed-english-v3");
+    config.getBedrock().setAwsRegion(" ");
+
+    IllegalStateException error =
+        expectThrows(
+            IllegalStateException.class,
+            () -> factoryWithConfigAndAwsCredentials(config).getInstance());
+
+    assertTrue(error.getMessage().contains("bedrock.awsRegion"));
   }
 
   // ------- OpenAI provider tests -------

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/SearchClientShim.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -72,6 +73,7 @@ import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.index.reindex.UpdateByQueryRequest;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Shim interface that abstracts different Elasticsearch/OpenSearch client implementations. This
@@ -155,6 +157,12 @@ public interface SearchClientShim<T> extends Closeable, IndexSettingsComparison 
     Integer getSocketTimeout();
 
     SSLContext getSSLContext();
+
+    /** Shared AWS credentials for IAM request signing (OpenSearch). Null uses no IAM auth. */
+    @Nullable
+    default AwsCredentialsProvider getAwsCredentialsProvider() {
+      return null;
+    }
 
     /** Whether the engine type was auto-detected rather than explicitly configured. */
     default boolean isEngineTypeAutoDetected() {


### PR DESCRIPTION
## Summary
- Centralize process-wide `DefaultCredentialsProvider` and object-storage S3 client/presigner lifecycle in a new `AwsClientFactory`, and shut them down via `@PreDestroy`.
- Wire OpenSearch IAM signing, Bedrock embeddings, STS, and `ObjectStorageClientFactory` to inject those shared beans instead of creating per-call credential providers/clients (which can orphan IRSA refresh threads).
- Adapted for current master after `datahub.s3` / `S3UtilFactory` were replaced by `datahub.objectStorage` (`ObjectStorageConfiguration`).

## Test plan
- [x] `./gradlew :metadata-service:factories:test --tests 'com.linkedin.gms.factory.aws.*' --tests 'com.linkedin.gms.factory.objectstorage.ObjectStorageClientFactoryTest' --tests 'com.linkedin.gms.factory.s3.StsClientFactory*' --tests 'com.linkedin.gms.factory.search.semantic.EmbeddingProviderFactoryTest'`
- [x] `./gradlew :metadata-io:test --tests 'com.linkedin.metadata.search.embedding.AwsBedrockEmbeddingProviderTest'`
- [x] `spotlessApply`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the process-wide `DefaultCredentialsProvider` and S3 client lifecycle in a new `AwsClientFactory`, so OpenSearch IAM signing, Bedrock embeddings, STS, and object storage reuse one credential provider and shut down cleanly via `@PreDestroy`. Previously each component created its own provider/client, leaking IRSA refresh threads.

Non-AWS deployments without region/endpoint, IAM auth, Bedrock, or object-storage role skip bean creation. STS and S3 beans soft-skip when AWS is unavailable, and object-storage S3 now soft-skips when `roleArn` is set without an `StsClient` instead of failing startup; explicit role-assumption build errors still fail fast.

**Migration**
- `AwsBedrockEmbeddingProvider` constructors now require an injected `AwsCredentialsProvider`; update direct instantiations.
- `embeddingProvider.bedrock.awsRegion` is now required when using the aws-bedrock provider.

<sup>Written for commit 51055ffe251051e593cd4dbe63f78fc842709e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

