### PR TITLE
docs: add Otto the Otter community FAQ

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -1561,6 +1561,7 @@ module.exports = {
       },
       items: [
         "docs/slack",
+        { type: "doc", label: "Otto (Community Assistant)", id: "docs/otto" },
         "docs/townhalls",
         //        "docs/townhall-history",
         "docs/CODE_OF_CONDUCT",

--- a/docs/otto.md
+++ b/docs/otto.md
@@ -1,0 +1,98 @@
+---
+title: Otto the Otter
+description: "Otto is DataHub's AI community assistant, in public beta — how to tag it, where it works, what it can answer, and how to give feedback."
+---
+
+# Meet Otto the Otter 🦦
+
+Otto is DataHub's new community assistant — ready to help, still learning.
+
+:::info PUBLIC BETA
+Otto is live for real community use. Every answer cites its sources — worth a look before you act on it.
+:::
+
+## What is Otto?
+
+It answers your DataHub questions grounded in the official docs and the DataHub codebase, and helps route the right conversations to the right people.
+
+Tag `@Otto the Otter` in a community channel with your question — it'll reply in-thread.
+
+## Why the change from Herald?
+
+Herald served the community well and gave us a lot to learn. Otto takes those learnings forward as our own dedicated assistant, tuned for how the community actually uses it — an experience we can shape and evolve over time.
+
+## Is Otto in public beta?
+
+Yes. Otto is live in public beta, which means it's ready for real community use, but we're still tuning based on how people use it. If something feels off, react with 👎 or push back in-thread tagging `@datahub-team` — that's the fastest way for us to improve it.
+
+## Is Otto here to stay?
+
+Yes — Otto is a core part of DataHub's community going forward. Beta just means we're actively tuning, not that Otto might disappear.
+
+## Where does Otto get its answers?
+
+Otto answers from the official DataHub documentation ([docs.datahub.com](https://docs.datahub.com/docs/)) and the DataHub codebase. Every response includes source links — docs pages, file paths, or code references — so you can verify what it says and dig deeper.
+
+## How do I use Otto?
+
+Tag `@Otto the Otter` in a community channel and ask your question. No special format needed. A few tips:
+
+- Include your DataHub version and what you're integrating with (Snowflake, dbt, MSSQL, etc.) — helps Otto give a version-specific answer
+- Share error messages or logs as text if you have them
+- Follow-up questions in the same thread work — Otto keeps thread context
+
+## Which channels does Otto work in?
+
+Otto works in the main community channels — `#start-here`, `#troubleshoot`, `#ingestion`, `#deploy`, and `#ui`. If you tag Otto somewhere else and it doesn't respond, that channel may not have Otto enabled yet — just try one of the main ones. For now, Otto only responds in channels — not DMs.
+
+## Can I DM Otto directly?
+
+For now, Otto only responds in community channels — not DMs. This keeps community learning shared and helps others benefit from your questions and Otto's answers. Just tag `@Otto the Otter` in the relevant channel to get started.
+
+## Can I share screenshots or images?
+
+Yes. Share error screenshots, UI captures, or diagrams in-thread and Otto can read them as part of your question. For code, error messages, or logs, sharing as text usually works better than a screenshot.
+
+## Does Otto understand other languages?
+
+Yes — Otto can understand and respond in multiple languages, not just English. Response quality is strongest in English for now, since most of our documentation is in English. Feel free to ask in your native language.
+
+## How long does Otto take to respond?
+
+Most answers come back within a few seconds. Complex questions with multiple parts or thread context may take a bit longer. If Otto seems stuck, tag it again to nudge it.
+
+## What if Otto doesn't know the answer?
+
+Otto will say so. If the docs and code don't cover something, it won't guess. In those cases, the DataHub team or community members can jump in.
+
+## Should I still tag `@Herald` or `@RunLLM`?
+
+No — `@Otto the Otter` is your bot for DataHub community questions going forward. Herald is still around, but Otto is where we're focusing for the community. RunLLM was renamed to Herald a while back.
+
+## What if Otto gets something wrong?
+
+Otto is grounded in the docs and codebase and cites its sources, but it's not perfect — that's why we're calling it beta, so be gentle with it 🦦. If an answer looks off:
+
+- React with 👎 so we can catch and improve it
+- Push back in the thread — Otto handles follow-ups and other community members can weigh in
+- The `@datahub-team` monitors threads and posts corrections when needed
+
+Feedback flows to our team so we can review it and improve responses over time. We'd much rather catch a wrong answer than let it sit unchallenged.
+
+## Is my conversation with Otto private?
+
+Otto conversations happen in public community channels, so they're visible to everyone in that channel — just like any other Slack thread. Otto's answers and the questions asked also help us improve response quality over time.
+
+## Can Otto do things beyond answering questions?
+
+Otto is currently read-only — it answers questions but doesn't take actions on your behalf. If you find a bug or want to request a feature, please file it directly on [github.com/datahub-project/datahub](https://github.com/datahub-project/datahub) or tag `@datahub-team`.
+
+## What's next?
+
+Otto's just getting started. Beta is our chance to learn from real community use and shape what Otto becomes.
+
+If there's something you'd love to see Otto do, tell us in `#start-here`.
+
+---
+
+**TL;DR:** Tag `@Otto the Otter` for DataHub help, expect docs and code-backed answers with source links, use 👍/👎 to help us tune it or tag `@datahub-team`.


### PR DESCRIPTION
## Summary

Adds a community FAQ for Otto the Otter, DataHub's community assistant — what it is, how to tag it, where it works, and how to give feedback.

## Changes

- **New:** `docs/otto.md` → served at `/docs/otto`
- **Modified:** `docs-website/sidebars.js` — added under **Community**, after Slack

Verified locally: page renders, sidebar entry in place, site compiles with no broken links.

## Checklist

- [x] Conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (PR Title Format)
- [ ] Links to related issues — n/a
- [ ] Tests added/updated — n/a, docs-only
- [x] Docs added/updated
- [ ] [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) entry — n/a, no breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a community FAQ page for Otto the Otter, DataHub's community assistant, covering what it is, how to tag it, where it works, and how to give feedback. Also adds the page to the docs sidebar under Community.

<sup>Written for commit 0467ad73567be4a50ae2f548afefc2e5845783f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

