### PR TITLE
feat(search): include metrics and semantic models in global search

### DIFF
--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1,6 +1,34 @@
 #import "./incident.graphql"
 #import "./fragments.graphql"
 
+# Deliberately minimal: name, description and platform icon only.
+#
+# getSearchResultsForMultiple is close to graphql-java's complexity ceiling
+# (GRAPHQL_QUERY_COMPLEXITY_LIMIT, default 2000), and complexity counts each fragment
+# definition once rather than per spread site — so every field added here is a field added
+# to the whole query. Revisit once the shared search fragments are slimmed down.
+fragment metricSearchFields on Metric {
+    id
+    info {
+        name
+        description
+    }
+    platform {
+        ...platformFields
+    }
+}
+
+fragment semanticModelSearchFields on SemanticModel {
+    id
+    info {
+        name
+        description
+    }
+    platform {
+        ...platformFields
+    }
+}
+
 # Lean fields for compact home-widget cards. Omits ownership, tags, lineage, health,
 # structured properties, and Dataset stats/access (those stay on autoCompleteFields).
 fragment searchResultCardFields on Entity {
@@ -439,16 +467,10 @@ fragment searchResultCardFields on Entity {
         }
     }
     ... on Metric {
-        id
-        info {
-            name
-        }
+        ...metricSearchFields
     }
     ... on SemanticModel {
-        id
-        info {
-            name
-        }
+        ...semanticModelSearchFields
     }
 }
 
@@ -1425,6 +1447,12 @@ fragment searchResultsWithoutSchemaField on Entity {
                 }
             }
         }
+    }
+    ... on Metric {
+        ...metricSearchFields
+    }
+    ... on SemanticModel {
+        ...semanticModelSearchFields
     }
 }
 

--- a/docs/features/feature-guides/metrics-and-semantic-models.md
+++ b/docs/features/feature-guides/metrics-and-semantic-models.md
@@ -178,7 +178,7 @@ The **Metrics** left-nav item opens `/metrics`, a landing page with a browse tre
 
 ### Search
 
-Discovery today is centered on the `/metrics` landing page and its browse tree. Surfacing Metrics and Semantic Models as first-class entity types in universal Search and Browse — plus retrieval via DataHub MCP for agentic workflows — is on the near-term roadmap.
+Metrics and Semantic Models appear in **global Search** and the **search-bar autocomplete** when `METRICS_ENABLED=true`. Search by display name, description, or platform; use the **Type** filter to narrow to Metrics or Semantic Models. The dedicated **`/metrics`** browse tree remains the best way to explore metrics grouped by Semantic Model. Browse V2 does not list these entity types — use Search or `/metrics` instead.
 
 ### Lineage
 
@@ -209,7 +209,7 @@ Future releases will ensure AI Context feeds directly into Ask DataHub and any a
 
 We're actively investing in the Metrics experience. Near-term work includes:
 
-- **Metrics & Semantic Models in universal Search and Browse** and available via **DataHub MCP** so agents can retrieve them during agentic workflows.
+- **Metrics & Semantic Models via DataHub MCP** so agents can retrieve them during agentic workflows.
 - **Additional ingestion sources.** Expanding beyond Snowflake Semantic Views to cover dbt Semantic Layer / MetricFlow, Databricks Unity Catalog metric views, Sigma, and BI-tool measures.
 - **Column-level lineage from source columns through to metrics.** Full column-to-metric impact analysis — see which KPIs are affected by a change to a raw column.
 - **Lineage visualization improvements.** Cleaner node labels, collapsed intermediate nodes, and a Semantic Model container view that reduces graph noise.

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -845,6 +845,13 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
                             "text",
                             "semanticText"))
                     .collect(Collectors.toSet()))
+            .put(
+                EntityType.METRIC,
+                Stream.concat(COMMON.stream(), Stream.of("path", "semanticModel", "parentMetric"))
+                    .collect(Collectors.toSet()))
+            .put(
+                EntityType.SEMANTIC_MODEL,
+                Stream.concat(COMMON.stream(), Stream.of("path")).collect(Collectors.toSet()))
             .build();
 
     for (String entityName : parseCsv(DEFAULT_SEARCH_ENTITY_TYPES)) {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/EntityTypeListConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/EntityTypeListConfig.java
@@ -30,13 +30,13 @@ public class EntityTypeListConfig {
    * in sync for tests and docs — production still loads from YAML.
    */
   public static final String DEFAULT_SEARCH_ENTITY_TYPES =
-      "dataset,dashboard,chart,mlModel,mlModelGroup,mlFeatureTable,mlFeature,mlPrimaryKey,dataFlow,dataJob,glossaryTerm,glossaryNode,tag,role,corpuser,corpGroup,container,domain,dataProduct,notebook,businessAttribute,schemaField,application,document";
+      "dataset,dashboard,chart,mlModel,mlModelGroup,mlFeatureTable,mlFeature,mlPrimaryKey,dataFlow,dataJob,glossaryTerm,glossaryNode,tag,role,corpuser,corpGroup,container,domain,dataProduct,notebook,businessAttribute,schemaField,application,document,metric,semanticModel";
 
   /**
    * Mirrors {@code elasticsearch.search.autocompleteEntityTypes.value} in {@code application.yaml}.
    */
   public static final String DEFAULT_AUTOCOMPLETE_ENTITY_TYPES =
-      "dataset,dashboard,chart,container,mlModel,mlModelGroup,mlFeatureTable,dataFlow,dataJob,glossaryTerm,tag,corpuser,corpGroup,notebook,dataProduct,domain,businessAttribute,application,structuredProperty";
+      "dataset,dashboard,chart,container,mlModel,mlModelGroup,mlFeatureTable,dataFlow,dataJob,glossaryTerm,tag,corpuser,corpGroup,notebook,dataProduct,domain,businessAttribute,application,structuredProperty,metric,semanticModel";
 
   /** Mirrors {@code elasticsearch.search.browseEntityTypes.value} in {@code application.yaml}. */
   public static final String DEFAULT_BROWSE_ENTITY_TYPES =

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1000,13 +1000,13 @@ elasticsearch:
     # Default entity types when callers omit types. No code baseline — configure via YAML/env.
     # Example: SEARCH_DEFAULT_ENTITY_TYPES_REMOVE=schemaField,document
     defaultEntityTypes:
-      value: ${SEARCH_DEFAULT_ENTITY_TYPES:dataset,dashboard,chart,mlModel,mlModelGroup,mlFeatureTable,mlFeature,mlPrimaryKey,dataFlow,dataJob,glossaryTerm,glossaryNode,tag,role,corpuser,corpGroup,container,domain,dataProduct,notebook,businessAttribute,schemaField,application,document}
+      value: ${SEARCH_DEFAULT_ENTITY_TYPES:dataset,dashboard,chart,mlModel,mlModelGroup,mlFeatureTable,mlFeature,mlPrimaryKey,dataFlow,dataJob,glossaryTerm,glossaryNode,tag,role,corpuser,corpGroup,container,domain,dataProduct,notebook,businessAttribute,schemaField,application,document,metric,semanticModel}
       add: ${SEARCH_DEFAULT_ENTITY_TYPES_ADD:}
       remove: ${SEARCH_DEFAULT_ENTITY_TYPES_REMOVE:}
 
     # Default entity types for autocomplete-across-entities when callers omit types.
     autocompleteEntityTypes:
-      value: ${SEARCH_AUTOCOMPLETE_ENTITY_TYPES:dataset,dashboard,chart,container,mlModel,mlModelGroup,mlFeatureTable,dataFlow,dataJob,glossaryTerm,tag,corpuser,corpGroup,notebook,dataProduct,domain,businessAttribute,application,structuredProperty}
+      value: ${SEARCH_AUTOCOMPLETE_ENTITY_TYPES:dataset,dashboard,chart,container,mlModel,mlModelGroup,mlFeatureTable,dataFlow,dataJob,glossaryTerm,tag,corpuser,corpGroup,notebook,dataProduct,domain,businessAttribute,application,structuredProperty,metric,semanticModel}
       add: ${SEARCH_AUTOCOMPLETE_ENTITY_TYPES_ADD:}
       remove: ${SEARCH_AUTOCOMPLETE_ENTITY_TYPES_REMOVE:}
 


### PR DESCRIPTION
## Summary
- Cherry-pick of `d119cd8770` from DataHub Cloud [#12041](https://github.com/acryldata/datahub-fork/pull/12041) onto OSS `master`.
- Adds `metric` and `semanticModel` to GMS default search and autocomplete entity-type lists so global Search, Discover, and the search bar include them when callers omit `types`.
- Adds lean `metricSearchFields` / `semanticModelSearchFields` GraphQL fragments (name, description, platform) so cards render without pushing `getSearchResultsForMultiple` over the default GraphQL complexity limit.

Conflict resolution vs Cloud: kept OSS entity-type lists (including `schemaField` on search defaults) and only appended `metric,semanticModel`. Did not bring Cloud-only types (`aiAgent`, `api`, `repository`, `agentSkill`, `service`).

## Checklist
- [x] PR conforms to the [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (especially the [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests added/updated
- [x] Docs added/updated if needed
- [ ] Breaking changes documented in `docs/how/updating-datahub.md`

## Test plan
- [ ] CI on this PR
- [ ] With `METRICS_ENABLED=true`, search for a metric / semantic model in global Search and autocomplete


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Metrics and Semantic Models appear in global Search and the search-bar autocomplete by adding them to the default search and autocomplete entity-type lists. Adds lean search-result GraphQL fragments for `Metric` and `SemanticModel` so result cards render without pushing `getSearchResultsForMultiple` over the query complexity limit.

- Keeps the OSS entity-type lists intact, only appending `metric,semanticModel` to the search and autocomplete defaults, and keeps the Java constant and `application.yaml` in sync.
- Extends `SearchRequestHandlerTest` with field expectations for the two new entity types.
- Updates the metrics and semantic models feature guide to describe search and type-filter behavior and clarifies that Browse V2 does not list these types.
- The fragments stay minimal (name, description, platform) because every fragment field multiplies across the whole search query near graphql-java's complexity ceiling.

<sup>Written for commit a10aa023f2f86d0a729b4af5720e15bef2c529a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

