### PR TITLE
perf(ingest/aws): reuse the S3 client in AwsConnectionConfig

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -472,8 +472,10 @@ class AwsConnectionConfig(ConfigModel):
         # Building a session + client per call is expensive (fresh TLS pool and
         # credential resolution, ~seconds with an SSO profile), so memoize the
         # client per verify_ssl value. Manually-assumed role credentials are
-        # static, so drop cached clients once those credentials need a refresh;
-        # profile and explicit-key sessions self-refresh inside botocore.
+        # static, so drop cached clients once those credentials need a refresh.
+        # This invalidation only covers the manual assume-role path; profile,
+        # instance-profile, ECS task-role, and explicit-key sessions self-refresh
+        # inside botocore's cached client and need no invalidation here.
         with self._s3_client_lock:
             # _cached_credentials is set only when a role was actually assumed (see
             # get_session); that is the one path whose static creds expire. Guard on

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from http import HTTPStatus
@@ -11,6 +12,7 @@ from boto3.session import Session
 from botocore.config import DEFAULT_TIMEOUT, Config
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 from botocore.utils import fix_s3_host
+from pydantic import PrivateAttr
 from pydantic.fields import Field
 
 from datahub.configuration.common import (
@@ -271,6 +273,12 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
+    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
+    # shared across threads; only construction is guarded by the lock.
+    _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
+        default_factory=dict
+    )
+    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -461,12 +469,22 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
-        return self.get_session().client(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
-        )
+        # Building a session + client per call is expensive (fresh TLS pool and
+        # credential resolution, ~seconds with an SSO profile), so memoize the
+        # client per verify_ssl value. Manually-assumed role credentials are
+        # static, so drop cached clients once those credentials need a refresh;
+        # profile and explicit-key sessions self-refresh inside botocore.
+        with self._s3_client_lock:
+            if self._normalized_aws_roles() and self._should_refresh_credentials():
+                self._s3_client_cache.clear()
+            if verify_ssl not in self._s3_client_cache:
+                self._s3_client_cache[verify_ssl] = self.get_session().client(
+                    "s3",
+                    endpoint_url=self.aws_endpoint_url,
+                    config=self._aws_config(),
+                    verify=verify_ssl,
+                )
+            return self._s3_client_cache[verify_ssl]
 
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -273,16 +273,12 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
-    # boto3 clients and resources are thread-safe (Sessions are not), so cached
-    # instances may be shared across threads; only construction is guarded by the
-    # lock. A single lock covers both caches since they share one invalidation rule.
+    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
+    # shared across threads; only construction is guarded by the lock.
     _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
         default_factory=dict
     )
-    _s3_resource_cache: Dict[Optional[Union[bool, str]], "S3ServiceResource"] = (
-        PrivateAttr(default_factory=dict)
-    )
-    _s3_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -470,27 +466,25 @@ class AwsConnectionConfig(ConfigModel):
             **self.aws_advanced_config,
         )
 
-    def _invalidate_s3_caches_if_stale(self) -> None:
-        # Caller must hold self._s3_lock. _cached_credentials is set only when a role
-        # was actually assumed (see get_session); that is the one path whose static
-        # creds expire. Guard on it rather than on aws_role merely being configured,
-        # else a role that matches the ambient identity (never assumed, so no expiry
-        # recorded) would rebuild on every call. Both caches share these credentials,
-        # so both are dropped together.
-        if self._cached_credentials is not None and self._should_refresh_credentials():
-            self._s3_client_cache.clear()
-            self._s3_resource_cache.clear()
-
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
         # Building a session + client per call is expensive (fresh TLS pool and
         # credential resolution, ~seconds with an SSO profile), so memoize the
-        # client per verify_ssl value; profile and explicit-key sessions self-refresh
-        # inside botocore, and assumed-role credentials are handled by the cache
-        # invalidation above.
-        with self._s3_lock:
-            self._invalidate_s3_caches_if_stale()
+        # client per verify_ssl value. Manually-assumed role credentials are
+        # static, so drop cached clients once those credentials need a refresh;
+        # profile and explicit-key sessions self-refresh inside botocore.
+        with self._s3_client_lock:
+            # _cached_credentials is set only when a role was actually assumed (see
+            # get_session); that is the one path whose static creds expire. Guard on
+            # it rather than on aws_role merely being configured, else a role that
+            # matches the ambient identity (never assumed, so no expiry recorded)
+            # would rebuild the client on every call.
+            if (
+                self._cached_credentials is not None
+                and self._should_refresh_credentials()
+            ):
+                self._s3_client_cache.clear()
             if verify_ssl not in self._s3_client_cache:
                 self._s3_client_cache[verify_ssl] = self.get_session().client(
                     "s3",
@@ -503,29 +497,19 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3ServiceResource":
-        # Memoized per verify_ssl like get_s3_client. The GCS OAuth subclass
-        # re-applies its before-send handlers on the returned resource's client each
-        # call, but those register with botocore unique_ids so re-application on a
-        # cached resource is a no-op (see _register_gcs_oauth_before_send).
-        with self._s3_lock:
-            self._invalidate_s3_caches_if_stale()
-            if verify_ssl not in self._s3_resource_cache:
-                resource = self.get_session().resource(
-                    "s3",
-                    endpoint_url=self.aws_endpoint_url,
-                    config=self._aws_config(),
-                    verify=verify_ssl,
-                )
-                # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
-                # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
-                # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
-                # to override the functionality rather than removing it altogether.
-                if self.aws_endpoint_url is not None and self.aws_proxy is not None:
-                    resource.meta.client.meta.events.unregister(
-                        "before-sign.s3", fix_s3_host
-                    )
-                self._s3_resource_cache[verify_ssl] = resource
-            return self._s3_resource_cache[verify_ssl]
+        resource = self.get_session().resource(
+            "s3",
+            endpoint_url=self.aws_endpoint_url,
+            config=self._aws_config(),
+            verify=verify_ssl,
+        )
+        # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
+        # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
+        # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
+        # to override the functionality rather than removing it altogether.
+        if self.aws_endpoint_url is not None and self.aws_proxy is not None:
+            resource.meta.client.meta.events.unregister("before-sign.s3", fix_s3_host)
+        return resource
 
     def get_glue_client(self) -> "GlueClient":
         # TODO: apply aws_endpoint_url consistently across all service clients (and

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -273,12 +273,16 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
-    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
-    # shared across threads; only construction is guarded by the lock.
+    # boto3 clients and resources are thread-safe (Sessions are not), so cached
+    # instances may be shared across threads; only construction is guarded by the
+    # lock. A single lock covers both caches since they share one invalidation rule.
     _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
         default_factory=dict
     )
-    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _s3_resource_cache: Dict[Optional[Union[bool, str]], "S3ServiceResource"] = (
+        PrivateAttr(default_factory=dict)
+    )
+    _s3_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -466,17 +470,27 @@ class AwsConnectionConfig(ConfigModel):
             **self.aws_advanced_config,
         )
 
+    def _invalidate_s3_caches_if_stale(self) -> None:
+        # Caller must hold self._s3_lock. _cached_credentials is set only when a role
+        # was actually assumed (see get_session); that is the one path whose static
+        # creds expire. Guard on it rather than on aws_role merely being configured,
+        # else a role that matches the ambient identity (never assumed, so no expiry
+        # recorded) would rebuild on every call. Both caches share these credentials,
+        # so both are dropped together.
+        if self._cached_credentials is not None and self._should_refresh_credentials():
+            self._s3_client_cache.clear()
+            self._s3_resource_cache.clear()
+
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
         # Building a session + client per call is expensive (fresh TLS pool and
         # credential resolution, ~seconds with an SSO profile), so memoize the
-        # client per verify_ssl value. Manually-assumed role credentials are
-        # static, so drop cached clients once those credentials need a refresh;
-        # profile and explicit-key sessions self-refresh inside botocore.
-        with self._s3_client_lock:
-            if self._normalized_aws_roles() and self._should_refresh_credentials():
-                self._s3_client_cache.clear()
+        # client per verify_ssl value; profile and explicit-key sessions self-refresh
+        # inside botocore, and assumed-role credentials are handled by the cache
+        # invalidation above.
+        with self._s3_lock:
+            self._invalidate_s3_caches_if_stale()
             if verify_ssl not in self._s3_client_cache:
                 self._s3_client_cache[verify_ssl] = self.get_session().client(
                     "s3",
@@ -489,19 +503,29 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3ServiceResource":
-        resource = self.get_session().resource(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
-        )
-        # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
-        # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
-        # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
-        # to override the functionality rather than removing it altogether.
-        if self.aws_endpoint_url is not None and self.aws_proxy is not None:
-            resource.meta.client.meta.events.unregister("before-sign.s3", fix_s3_host)
-        return resource
+        # Memoized per verify_ssl like get_s3_client. The GCS OAuth subclass
+        # re-applies its before-send handlers on the returned resource's client each
+        # call, but those register with botocore unique_ids so re-application on a
+        # cached resource is a no-op (see _register_gcs_oauth_before_send).
+        with self._s3_lock:
+            self._invalidate_s3_caches_if_stale()
+            if verify_ssl not in self._s3_resource_cache:
+                resource = self.get_session().resource(
+                    "s3",
+                    endpoint_url=self.aws_endpoint_url,
+                    config=self._aws_config(),
+                    verify=verify_ssl,
+                )
+                # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
+                # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
+                # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
+                # to override the functionality rather than removing it altogether.
+                if self.aws_endpoint_url is not None and self.aws_proxy is not None:
+                    resource.meta.client.meta.events.unregister(
+                        "before-sign.s3", fix_s3_host
+                    )
+                self._s3_resource_cache[verify_ssl] = resource
+            return self._s3_resource_cache[verify_ssl]
 
     def get_glue_client(self) -> "GlueClient":
         # TODO: apply aws_endpoint_url consistently across all service clients (and

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -86,6 +86,10 @@ def _register_gcs_oauth_before_send(
     for op in _GCS_OAUTH_S3_OPERATIONS:
         # unique_id makes re-registration a no-op: get_s3_client() memoizes the
         # client, so repeated calls would otherwise stack duplicate handlers.
+        # This leans on botocore's documented contract that a handler registered
+        # with an existing unique_id replaces rather than stacks (HierarchicalEmitter
+        # dedupes by unique_id); if that guarantee is unwanted, register once at
+        # client-creation time instead.
         client.meta.events.register(
             f"before-send.s3.{op}", inject_bearer, unique_id=f"datahub-gcs-oauth-{op}"
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -84,7 +84,11 @@ def _register_gcs_oauth_before_send(
             request.headers["x-goog-project-id"] = project_id
 
     for op in _GCS_OAUTH_S3_OPERATIONS:
-        client.meta.events.register(f"before-send.s3.{op}", inject_bearer)
+        # unique_id makes re-registration a no-op: get_s3_client() memoizes the
+        # client, so repeated calls would otherwise stack duplicate handlers.
+        client.meta.events.register(
+            f"before-send.s3.{op}", inject_bearer, unique_id=f"datahub-gcs-oauth-{op}"
+        )
 
 
 class GCSOAuthAwsConnectionConfig(AwsConnectionConfig):

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -526,6 +526,64 @@ class TestAwsCommon:
             # assume_role should only be called once
             assert mock_assume_role.call_count == 1
 
+    def test_get_s3_client_cached_per_verify_ssl(self):
+        """
+        get_s3_client() memoizes the built client: repeated calls on the same
+        instance return the same object, and each verify_ssl value gets its
+        own client.
+        """
+        config = AwsConnectionConfig(
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            aws_region="us-east-1",
+        )
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            client1 = config.get_s3_client()
+            client2 = config.get_s3_client()
+            assert client1 is client2
+            # Only one session/client construction for the repeated call
+            assert mock_get_session.call_count == 1
+
+            client3 = config.get_s3_client(verify_ssl=False)
+            assert client3 is not client1
+            assert mock_get_session.call_count == 2
+            assert config.get_s3_client(verify_ssl=False) is client3
+
+    def test_get_s3_client_rebuilt_when_role_credentials_need_refresh(self):
+        """
+        With assumed roles configured, cached clients hold static credentials,
+        so the client must be rebuilt once the credentials need a refresh.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+
+        with (
+            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
+            patch.object(
+                AwsConnectionConfig, "_should_refresh_credentials"
+            ) as mock_should_refresh,
+        ):
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            mock_should_refresh.return_value = False
+            client1 = config.get_s3_client()
+            assert config.get_s3_client() is client1
+            assert mock_get_session.call_count == 1
+
+            mock_should_refresh.return_value = True
+            client2 = config.get_s3_client()
+            assert client2 is not client1
+            assert mock_get_session.call_count == 2
+
     @mock_aws
     def test_role_assumption_without_caching_before_fix(self):
         """

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -556,13 +556,21 @@ class TestAwsCommon:
 
     def test_get_s3_client_rebuilt_when_role_credentials_need_refresh(self):
         """
-        With assumed roles configured, cached clients hold static credentials,
-        so the client must be rebuilt once the credentials need a refresh.
+        Once a role has actually been assumed, the cached client holds static
+        credentials, so it must be rebuilt when those credentials need a refresh.
         """
         config = AwsConnectionConfig(
             aws_region="us-east-1",
             aws_role="arn:aws:iam::123456789012:role/test-role",
         )
+        # Model the post-assume state: get_session populates _cached_credentials
+        # only when it actually assumes a role, and that is the precondition for
+        # invalidating the cached client.
+        config._cached_credentials = {
+            "AccessKeyId": "ASSUMED_KEY",
+            "SecretAccessKey": "ASSUMED_SECRET",
+            "SessionToken": "ASSUMED_TOKEN",
+        }
 
         with (
             patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
@@ -582,6 +590,91 @@ class TestAwsCommon:
             mock_should_refresh.return_value = True
             client2 = config.get_s3_client()
             assert client2 is not client1
+            assert mock_get_session.call_count == 2
+
+    def test_get_s3_client_cached_when_role_matches_ambient_identity(self):
+        """
+        When a role is configured but never actually assumed (the ambient identity
+        already is that role), get_session records no expiration and leaves
+        _cached_credentials as None. The client must still be cached: invalidation
+        keys off assumed static credentials, not merely on aws_role being set —
+        otherwise _should_refresh_credentials() (always True while expiration is
+        None) would rebuild the client on every call.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+        assert config._cached_credentials is None
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            client1 = config.get_s3_client()
+            assert config.get_s3_client() is client1
+            assert mock_get_session.call_count == 1
+
+    def test_get_s3_resource_cached_per_verify_ssl(self):
+        """
+        get_s3_resource() memoizes like get_s3_client(): repeated calls return the
+        same object, and each verify_ssl value gets its own resource.
+        """
+        config = AwsConnectionConfig(
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            aws_region="us-east-1",
+        )
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.resource.side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
+
+            resource1 = config.get_s3_resource()
+            resource2 = config.get_s3_resource()
+            assert resource1 is resource2
+            assert mock_get_session.call_count == 1
+
+            resource3 = config.get_s3_resource(verify_ssl=False)
+            assert resource3 is not resource1
+            assert mock_get_session.call_count == 2
+            assert config.get_s3_resource(verify_ssl=False) is resource3
+
+    def test_get_s3_resource_rebuilt_when_role_credentials_need_refresh(self):
+        """
+        The resource cache shares the client cache's invalidation, so once assumed
+        role credentials need a refresh the cached resource is rebuilt too.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+        config._cached_credentials = {
+            "AccessKeyId": "ASSUMED_KEY",
+            "SecretAccessKey": "ASSUMED_SECRET",
+            "SessionToken": "ASSUMED_TOKEN",
+        }
+
+        with (
+            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
+            patch.object(
+                AwsConnectionConfig, "_should_refresh_credentials"
+            ) as mock_should_refresh,
+        ):
+            mock_get_session.return_value.resource.side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
+
+            mock_should_refresh.return_value = False
+            resource1 = config.get_s3_resource()
+            assert config.get_s3_resource() is resource1
+            assert mock_get_session.call_count == 1
+
+            mock_should_refresh.return_value = True
+            resource2 = config.get_s3_resource()
+            assert resource2 is not resource1
             assert mock_get_session.call_count == 2
 
     @mock_aws

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -616,67 +616,6 @@ class TestAwsCommon:
             assert config.get_s3_client() is client1
             assert mock_get_session.call_count == 1
 
-    def test_get_s3_resource_cached_per_verify_ssl(self):
-        """
-        get_s3_resource() memoizes like get_s3_client(): repeated calls return the
-        same object, and each verify_ssl value gets its own resource.
-        """
-        config = AwsConnectionConfig(
-            aws_access_key_id="test-key",
-            aws_secret_access_key="test-secret",
-            aws_region="us-east-1",
-        )
-
-        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
-            mock_get_session.return_value.resource.side_effect = (
-                lambda *args, **kwargs: MagicMock()
-            )
-
-            resource1 = config.get_s3_resource()
-            resource2 = config.get_s3_resource()
-            assert resource1 is resource2
-            assert mock_get_session.call_count == 1
-
-            resource3 = config.get_s3_resource(verify_ssl=False)
-            assert resource3 is not resource1
-            assert mock_get_session.call_count == 2
-            assert config.get_s3_resource(verify_ssl=False) is resource3
-
-    def test_get_s3_resource_rebuilt_when_role_credentials_need_refresh(self):
-        """
-        The resource cache shares the client cache's invalidation, so once assumed
-        role credentials need a refresh the cached resource is rebuilt too.
-        """
-        config = AwsConnectionConfig(
-            aws_region="us-east-1",
-            aws_role="arn:aws:iam::123456789012:role/test-role",
-        )
-        config._cached_credentials = {
-            "AccessKeyId": "ASSUMED_KEY",
-            "SecretAccessKey": "ASSUMED_SECRET",
-            "SessionToken": "ASSUMED_TOKEN",
-        }
-
-        with (
-            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
-            patch.object(
-                AwsConnectionConfig, "_should_refresh_credentials"
-            ) as mock_should_refresh,
-        ):
-            mock_get_session.return_value.resource.side_effect = (
-                lambda *args, **kwargs: MagicMock()
-            )
-
-            mock_should_refresh.return_value = False
-            resource1 = config.get_s3_resource()
-            assert config.get_s3_resource() is resource1
-            assert mock_get_session.call_count == 1
-
-            mock_should_refresh.return_value = True
-            resource2 = config.get_s3_resource()
-            assert resource2 is not resource1
-            assert mock_get_session.call_count == 2
-
     @mock_aws
     def test_role_assumption_without_caching_before_fix(self):
         """


### PR DESCRIPTION
## Summary

`AwsConnectionConfig.get_s3_client()` built a brand-new boto3 Session and client on **every** call. Every consumer that reads many objects — `read_file_as_bytes` in `object_store_files.py` (one call per artifact) and the per-object tag helpers in `s3_boto_utils.py` — paid TLS connection setup and credential resolution per read. Measured with an SSO profile: **2.78s per GET with a fresh session vs 1.04s with a reused client — ~1.75s of pure per-call overhead.**

This PR memoizes the S3 **client** on the config instance:

- Cached per `verify_ssl` (the only argument that changes construction), built under a `threading.Lock`. boto3 clients are thread-safe; Sessions are not, so only construction is serialized and the cached client can be shared across threads.
- **Invalidation:** before serving from cache, if a role's manually-assumed credentials are near expiry, the cache is cleared and rebuilt. Invalidation keys off `_cached_credentials` — set only when a role was actually assumed — rather than on `aws_role` merely being configured. This matters: a role that matches the ambient identity is never assumed and records no expiry, so guarding on "roles configured" would rebuild on every call and silently defeat the cache. Profile/SSO and explicit-key sessions self-refresh inside botocore, so they need no invalidation.
- Private attrs use `PrivateAttr(default_factory=...)` (a plain default can't be used: pydantic deep-copies defaults per instance, and a `threading.Lock` is not deep-copyable).
- `GCSOAuthAwsConnectionConfig.get_s3_client()` registers `before-send` handlers on the returned client; with a cached client those would stack duplicates on every call. They now register with botocore `unique_id`s, making re-registration a no-op.

> **Scope:** the sibling `get_s3_resource()` (S3/Excel browse paths) is intentionally **not** cached here — boto3 resources are not thread-safe and need per-thread handling, so that lives in a dedicated follow-up: **#19500**.

## Connectors that benefit

Every connector that builds an `AwsConnectionConfig` inherits the cached client. The impact splits into three groups:

**Directly benefit — repeated per-object/per-file S3 access via the client:**

| Connector | S3 client usage |
| --- | --- |
| **dbt (core)** | reads `manifest`/`catalog`/`run_results` artifacts, one client per artifact (`read_file_as_bytes`, `expand_object_store_glob`) — the measured case below |
| **ODCS** | same helpers, per contract file |
| **GCS** | S3-compatible listing + object reads via `s3_boto_utils` / `read_file_as_bytes` |
| **S3 / data-lake** | `get_s3_client` per table for listing/tags (`s3_boto_utils`) |
| **Data-lake profiling** | `get_s3_client(verify_ssl)` per file profiled |
| **SQL Queries** | client per query-file read |
| **SQLMesh** | client per project download |

**Neutral — already fetched the client once and reused it (unaffected):** Glue (reads once at init via its `s3_client` property), Delta Lake (reads once at init).

**No S3 usage — inherit the method but never call it (no impact):** Kinesis, SageMaker, DynamoDB, QuickSight, and the RDS-IAM SQL sources (TiDB, MySQL, Postgres, pgqueue).

## Measured impact

dbt multi-project ingestion reading 300 artifacts from S3: the artifact-loading phase dropped from **57s to 15s (3.8×)** with identical output.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://docs.datahub.com/docs/contributing) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated: client cached per `verify_ssl`; distinct clients per `verify_ssl`; rebuild on role-credential refresh; role-matches-ambient-identity path stays cached (`tests/unit/test_aws_common.py`)
- [x] Docs: no user-facing behavior change; no docs needed
- [x] No breaking changes
