### PR TITLE
perf(ingest/dbt): parallel artifact prefetch and scale-test framework for multi-project ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union, cast
 
 from packaging import version
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -54,6 +54,7 @@ from datahub.ingestion.source.dbt.dbt_tests import (
     parse_freshness_criteria,
 )
 from datahub.ingestion.source.gcs.gcs_utils import is_gcs_uri
+from datahub.utilities.backpressure_aware_executor import BackpressureAwareExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,16 @@ class DBTCoreConfig(DBTCommonConfig):
         default=False,
         description="[experimental] If true, only include nodes that are also present in the catalog file. "
         "This is useful if you only want to include models that have been built by the associated run.",
+    )
+
+    artifact_read_concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Number of parallel reads used to fetch dbt artifact files when manifest_path "
+        "is a glob pattern. Peak memory grows with concurrency (roughly concurrency x the largest "
+        "project's raw artifact bytes), so lower this for estates with very large manifest or "
+        "catalog files. Set to 1 to read artifacts sequentially. Has no effect when manifest_path "
+        "is a single file.",
     )
 
     # Because we now also collect model performance metadata, the "test_results" field was renamed to "run_results".
@@ -789,6 +800,10 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
     def __init__(self, config: DBTCommonConfig, ctx: PipelineContext):
         super().__init__(config, ctx)
         self.report = DBTCoreReport()
+        # Artifact bytes (or the exception their read raised) prefetched for the
+        # project currently being processed, keyed by URI. Filled and consumed on
+        # the main thread only; see _load_artifact_json / _prefetch_in_order.
+        self._prefetched_artifacts: Dict[str, Union[bytes, Exception]] = {}
 
     @classmethod
     def create(cls, config_dict, ctx):
@@ -971,6 +986,70 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
             expanded_paths.extend(self._expand_glob_path(path))
         return expanded_paths
 
+    def _load_artifact_json(self, uri: str) -> Dict:
+        """Load one artifact, preferring bytes prefetched by _prefetch_in_order.
+
+        A prefetched Exception is the exact exception the inline read would have
+        raised (workers only capture, they never classify), so re-raising it here
+        keeps _is_missing_file_error and per-project failure isolation unchanged.
+        """
+        prefetched = self._prefetched_artifacts.pop(uri, None)
+        if prefetched is None:
+            return self.load_file_as_json(
+                uri, self.config.aws_connection, self.config.gcs_connection
+            )
+        if isinstance(prefetched, Exception):
+            raise prefetched
+        # json.loads on raw bytes sniffs the BOM, matching load_file_as_json.
+        return json.loads(prefetched)
+
+    def _fetch_artifact_group(
+        self, index: int, uris: List[str]
+    ) -> Tuple[int, Dict[str, Union[bytes, Exception]]]:
+        # Runs on a worker thread: fetch only - never parse, classify, or touch
+        # self.report. A failed read hands its exception back for the main thread
+        # to re-raise at the original call site.
+        fetched: Dict[str, Union[bytes, Exception]] = {}
+        for uri in uris:
+            try:
+                fetched[uri] = read_file_as_bytes(
+                    uri, self.config.aws_connection, self.config.gcs_connection
+                )
+            except Exception as e:
+                fetched[uri] = e
+        return index, fetched
+
+    def _prefetch_in_order(
+        self, uri_groups: List[List[str]], concurrency: int
+    ) -> Iterator[Dict[str, Union[bytes, Exception]]]:
+        """Fetch each group's files on a bounded pool, yielding groups in input order.
+
+        BackpressureAwareExecutor completes out of order, so a small reorder
+        buffer (bounded by its max_pending) restores input order; in-flight raw
+        bytes stay bounded at roughly 2 x concurrency groups.
+        """
+        buffered: Dict[int, Dict[str, Union[bytes, Exception]]] = {}
+        next_index = 0
+        for future in BackpressureAwareExecutor.map(
+            self._fetch_artifact_group,
+            [(index, uris) for index, uris in enumerate(uri_groups)],
+            max_workers=concurrency,
+            max_pending=concurrency,
+        ):
+            index, fetched = future.result()
+            buffered[index] = fetched
+            while next_index in buffered:
+                yield buffered.pop(next_index)
+                next_index += 1
+
+    def _maybe_prefetch(
+        self, uri_groups: List[List[str]], *, enabled: bool
+    ) -> Optional[Iterator[Dict[str, Union[bytes, Exception]]]]:
+        concurrency = min(self.config.artifact_read_concurrency, len(uri_groups))
+        if not enabled or concurrency <= 1:
+            return None
+        return self._prefetch_in_order(uri_groups, concurrency)
+
     def _load_optional_artifact_json(
         self, path: Optional[str], *, optional_artifacts: bool
     ) -> Tuple[Optional[Dict[str, Any]], Optional[Exception]]:
@@ -987,12 +1066,7 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
         if path is None:
             return None, None
         try:
-            return (
-                self.load_file_as_json(
-                    path, self.config.aws_connection, self.config.gcs_connection
-                ),
-                None,
-            )
+            return self._load_artifact_json(path), None
         except (json.JSONDecodeError, UnicodeDecodeError):
             # A file that exists but cannot be decoded is corrupt, never missing.
             # UnicodeDecodeError is a ValueError subclass but not a JSONDecodeError,
@@ -1021,11 +1095,7 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
         (True) where the file simply not existing beside this particular manifest is
         expected and must warn rather than fail.
         """
-        dbt_manifest_json = self.load_file_as_json(
-            manifest_path,
-            self.config.aws_connection,
-            self.config.gcs_connection,
-        )
+        dbt_manifest_json = self._load_artifact_json(manifest_path)
         dbt_manifest_metadata = dbt_manifest_json["metadata"]
         if not optional_artifacts:
             # manifest_info/catalog_info are single report-level fields, so in glob
@@ -1284,7 +1354,7 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
         if is_multi_project:
             self.report.manifest_paths_expanded = manifest_paths
 
-        all_nodes: List[DBTNode] = []
+        project_paths: List[Tuple[str, Optional[str], Optional[str]]] = []
         for manifest_path in manifest_paths:
             catalog_path: Optional[str]
             sources_path: Optional[str]
@@ -1304,6 +1374,20 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
             else:
                 catalog_path = self.config.catalog_path
                 sources_path = self.config.sources_path
+            project_paths.append((manifest_path, catalog_path, sources_path))
+
+        # Overlap the per-project artifact reads (the dominant cost on object
+        # stores) while keeping processing order, reporting, and error
+        # classification identical to the sequential path.
+        prefetched_projects = self._maybe_prefetch(
+            [[path for path in paths if path is not None] for paths in project_paths],
+            enabled=is_multi_project,
+        )
+
+        all_nodes: List[DBTNode] = []
+        for manifest_path, catalog_path, sources_path in project_paths:
+            if prefetched_projects is not None:
+                self._prefetched_artifacts = next(prefetched_projects)
 
             try:
                 project_nodes = self._load_project_nodes(
@@ -1332,14 +1416,15 @@ class DBTCoreSource(DBTSourceBase, TestableSource):
         expanded_run_results_paths = self._expand_run_results_paths()
         if expanded_run_results_paths:
             self.report.run_results_paths_expanded = expanded_run_results_paths
+        prefetched_run_results = self._maybe_prefetch(
+            [[path] for path in expanded_run_results_paths], enabled=is_multi_project
+        )
         for run_results_path in expanded_run_results_paths:
+            if prefetched_run_results is not None:
+                self._prefetched_artifacts = next(prefetched_run_results)
             all_nodes = load_run_results(
                 self.config,
-                self.load_file_as_json(
-                    run_results_path,
-                    self.config.aws_connection,
-                    self.config.gcs_connection,
-                ),
+                self._load_artifact_json(run_results_path),
                 all_nodes,
             )
 

--- a/metadata-ingestion/tests/performance/dbt/seed_projects.py
+++ b/metadata-ingestion/tests/performance/dbt/seed_projects.py
@@ -1,0 +1,169 @@
+"""Seed N cloned dbt artifact sets into S3 or a local directory.
+
+Used to scale-test multi-project (glob manifest_path) dbt ingestion:
+
+    python -m tests.performance.dbt.seed_projects --target s3://bucket/prefix --count 1000
+    python -m tests.performance.dbt.seed_projects --target s3://bucket/prefix --clean
+"""
+
+import argparse
+import logging
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from itertools import islice
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Iterator, Optional, Tuple
+from urllib.parse import urlparse
+
+import boto3
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
+logger = logging.getLogger(__name__)
+
+# Checked-in single-project artifacts used as the clone template. One raw-text
+# replacement of the "jaffle_shop" token per clone uniquifies both cross-project
+# collision dimensions at once: the dbt package name embedded in every unique_id
+# (model.jaffle_shop.customers -> model.jaffle_shop_00042.customers) and the
+# target schema (jaffle_shop -> jaffle_shop_00042), so N clones ingest as N
+# independent, non-colliding dbt projects.
+_TEMPLATE_DIR = Path(__file__).parents[2] / "integration" / "dbt"
+_PROJECT_TOKEN = "jaffle_shop"
+_TEMPLATE_FILES: Dict[str, str] = {
+    "manifest.json": "jaffle_shop_manifest.json",
+    "catalog.json": "jaffle_shop_catalog.json",
+}
+_RUN_RESULTS_FILE: Tuple[str, str] = (
+    "run_results.json",
+    "jaffle_shop_test_results.json",
+)
+
+
+def project_name(index: int) -> str:
+    return f"{_PROJECT_TOKEN}_{index:05d}"
+
+
+def _load_templates(include_run_results: bool) -> Dict[str, str]:
+    files = dict(_TEMPLATE_FILES)
+    if include_run_results:
+        files[_RUN_RESULTS_FILE[0]] = _RUN_RESULTS_FILE[1]
+    return {
+        name: (_TEMPLATE_DIR / source).read_text() for name, source in files.items()
+    }
+
+
+def _iter_objects(templates: Dict[str, str], count: int) -> Iterator[Tuple[str, str]]:
+    """Yield (relative path, rendered content) for every file of every clone."""
+    for index in range(count):
+        name = project_name(index)
+        for filename, text in templates.items():
+            yield f"{name}/{filename}", text.replace(_PROJECT_TOKEN, name)
+
+
+def _make_s3_client(profile: Optional[str]) -> "S3Client":
+    session = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    return session.client("s3")
+
+
+def _parse_s3_uri(uri: str) -> Tuple[str, str]:
+    parsed = urlparse(uri)
+    return parsed.netloc, parsed.path.strip("/")
+
+
+def seed(
+    target: str,
+    count: int,
+    *,
+    include_run_results: bool = False,
+    profile: Optional[str] = None,
+    max_workers: int = 16,
+) -> None:
+    """Write count cloned projects to target/<project_name>/<artifact>.json."""
+    templates = _load_templates(include_run_results)
+    if target.startswith("s3://"):
+        bucket, prefix = _parse_s3_uri(target)
+        client = _make_s3_client(profile)
+        objects = _iter_objects(templates, count)
+        uploaded = 0
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # Submit in bounded batches: rendering is lazy, so this caps rendered
+            # manifest bodies in memory at ~one batch instead of count * files.
+            while batch := list(islice(objects, max_workers * 4)):
+                futures = [
+                    executor.submit(
+                        client.put_object,
+                        Bucket=bucket,
+                        Key=f"{prefix}/{path}" if prefix else path,
+                        Body=content.encode("utf-8"),
+                    )
+                    for path, content in batch
+                ]
+                for future in futures:
+                    future.result()
+                uploaded += len(batch)
+                logger.info(f"Uploaded {uploaded} objects to s3://{bucket}/{prefix}")
+    else:
+        root = Path(target)
+        for path, content in _iter_objects(templates, count):
+            file_path = root / path
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text(content)
+    logger.info(
+        f"Seeded {count} projects ({count * len(templates)} files) into {target}"
+    )
+
+
+def clean(target: str, *, profile: Optional[str] = None) -> None:
+    """Delete everything under target (an S3 prefix or a local directory)."""
+    if target.startswith("s3://"):
+        bucket, prefix = _parse_s3_uri(target)
+        client = _make_s3_client(profile)
+        paginator = client.get_paginator("list_objects_v2")
+        deleted = 0
+        for page in paginator.paginate(
+            Bucket=bucket, Prefix=f"{prefix}/" if prefix else ""
+        ):
+            keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            if keys:
+                client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+                deleted += len(keys)
+        logger.info(f"Deleted {deleted} objects under {target}")
+    else:
+        shutil.rmtree(target, ignore_errors=True)
+        logger.info(f"Removed {target}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target", required=True, help="s3://bucket/prefix or a local directory"
+    )
+    parser.add_argument("--count", type=int, default=100)
+    parser.add_argument(
+        "--run-results",
+        action="store_true",
+        help="also seed a run_results.json per project",
+    )
+    parser.add_argument(
+        "--clean", action="store_true", help="delete everything under target and exit"
+    )
+    parser.add_argument("--profile", help="AWS profile name for boto3")
+    parser.add_argument("--workers", type=int, default=16)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    if args.clean:
+        clean(args.target, profile=args.profile)
+        return
+    seed(
+        args.target,
+        args.count,
+        include_run_results=args.run_results,
+        profile=args.profile,
+        max_workers=args.workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/metadata-ingestion/tests/performance/dbt/test_dbt_multi_project.py
+++ b/metadata-ingestion/tests/performance/dbt/test_dbt_multi_project.py
@@ -1,0 +1,203 @@
+"""Scale/throughput harness for multi-project (glob manifest_path) dbt ingestion.
+
+Runs the dbt source in-process and drains its workunits, reporting wall-clock,
+workunits/sec, peak memory, and the source's multi-project counters.
+
+    # Algorithmic scalability sweep against an in-process S3 mock (self-seeding):
+    python -m tests.performance.dbt.test_dbt_multi_project --moto --sizes 3,10,100
+
+    # Real-world throughput against a bucket seeded via seed_projects:
+    python -m tests.performance.dbt.test_dbt_multi_project \
+        --manifest-glob "s3://bucket/prefix/*/manifest.json" --profile my-profile
+
+    # Emit a recipe for a manual end-to-end run against a live DataHub instance:
+    python -m tests.performance.dbt.test_dbt_multi_project \
+        --manifest-glob "s3://bucket/prefix/*/manifest.json" --emit-recipe dbt_perf.yml
+"""
+
+import argparse
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import boto3
+import humanfriendly
+import psutil
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.dbt.dbt_core import DBTCoreConfig, DBTCoreSource
+from datahub.utilities.perf_timer import PerfTimer
+from tests.performance.dbt.seed_projects import seed
+from tests.performance.helpers import workunit_sink
+
+logger = logging.getLogger(__name__)
+
+_MOTO_BUCKET = "dbt-multi-project-perf"
+_MOTO_REGION = "us-east-1"
+# The jaffle_shop template artifacts were generated with the bigquery adapter.
+_TARGET_PLATFORM = "bigquery"
+
+
+@dataclass
+class RunResult:
+    seconds: float
+    workunits: int
+    peak_memory_delta: int
+    manifests_loaded: int
+    manifests_failed: int
+    duplicates: int
+
+
+def run_ingestion(
+    manifest_glob: str, aws_connection: Optional[Dict[str, str]]
+) -> RunResult:
+    config = DBTCoreConfig(
+        manifest_path=manifest_glob,
+        aws_connection=aws_connection,
+        target_platform=_TARGET_PLATFORM,
+        # The default (PATCH) requires a DataHub graph connection; this harness
+        # measures the source in isolation.
+        write_semantics="OVERRIDE",
+    )
+    source = DBTCoreSource(config, PipelineContext(run_id="dbt-multi-project-perf"))
+    pre_memory = psutil.Process(os.getpid()).memory_info().rss
+    with PerfTimer() as timer:
+        workunits, peak_memory = workunit_sink(source.get_workunits())
+    report = source.report
+    duplicates = sum(
+        counter or 0
+        for counter in (
+            report.duplicate_models_detected,
+            report.duplicate_node_unique_ids_detected,
+            report.duplicate_exposure_unique_ids_detected,
+        )
+    )
+    return RunResult(
+        seconds=timer.elapsed_seconds(digits=2),
+        workunits=workunits,
+        peak_memory_delta=peak_memory - pre_memory,
+        manifests_loaded=report.manifests_loaded,
+        manifests_failed=report.manifests_failed,
+        duplicates=duplicates,
+    )
+
+
+def run_moto_sweep(
+    sizes: List[int], include_run_results: bool
+) -> List[Tuple[str, RunResult]]:
+    from moto import mock_aws
+
+    results: List[Tuple[str, RunResult]] = []
+    with mock_aws():
+        boto3.client("s3", region_name=_MOTO_REGION).create_bucket(Bucket=_MOTO_BUCKET)
+        for size in sizes:
+            target = f"s3://{_MOTO_BUCKET}/n{size}"
+            logger.info(f"Seeding {size} projects into mock bucket at {target}")
+            seed(target, size, include_run_results=include_run_results)
+            result = run_ingestion(
+                f"{target}/*/manifest.json",
+                aws_connection={"aws_region": _MOTO_REGION},
+            )
+            # Every sweep run doubles as a correctness check of the glob fan-out.
+            assert result.manifests_loaded == size, result
+            assert result.manifests_failed == 0, result
+            assert result.duplicates == 0, result
+            assert result.workunits > 0, result
+            results.append((f"n{size}", result))
+    return results
+
+
+def run_real(
+    manifest_glob: str, profile: Optional[str], region: str
+) -> List[Tuple[str, RunResult]]:
+    aws_connection: Optional[Dict[str, str]] = None
+    if manifest_glob.startswith("s3://"):
+        aws_connection = {"aws_region": region}
+        if profile:
+            aws_connection["aws_profile"] = profile
+    return [("run", run_ingestion(manifest_glob, aws_connection))]
+
+
+def emit_recipe(
+    path: str, manifest_glob: str, region: str, profile: Optional[str]
+) -> None:
+    profile_line = f"\n      aws_profile: {profile}" if profile else ""
+    recipe = f"""source:
+  type: dbt
+  config:
+    manifest_path: "{manifest_glob}"
+    target_platform: {_TARGET_PLATFORM}
+    aws_connection:
+      aws_region: {region}{profile_line}
+sink:
+  type: datahub-rest
+  config:
+    server: "${{DATAHUB_GMS_URL:-http://localhost:8080}}"
+    token: "${{DATAHUB_GMS_TOKEN:-}}"
+"""
+    Path(path).write_text(recipe)
+    logger.info(f"Wrote recipe to {path}; run with: datahub ingest -c {path}")
+
+
+def print_results(results: List[Tuple[str, RunResult]]) -> None:
+    print(
+        f"{'run':>8} {'projects':>9} {'failed':>7} {'dups':>5}"
+        f" {'workunits':>10} {'seconds':>8} {'wu/s':>8} {'peak mem':>10}"
+    )
+    for label, r in results:
+        wu_per_sec = r.workunits / r.seconds if r.seconds else 0.0
+        print(
+            f"{label:>8} {r.manifests_loaded:>9} {r.manifests_failed:>7}"
+            f" {r.duplicates:>5} {r.workunits:>10} {r.seconds:>8.2f}"
+            f" {wu_per_sec:>8.1f} {humanfriendly.format_size(r.peak_memory_delta):>10}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--moto",
+        action="store_true",
+        help="sweep against an in-process S3 mock, seeding each size itself",
+    )
+    mode.add_argument(
+        "--manifest-glob",
+        help="run once against an already-seeded glob, e.g. 's3://bucket/prefix/*/manifest.json'",
+    )
+    parser.add_argument(
+        "--sizes", default="3,10,100", help="moto mode: comma-separated project counts"
+    )
+    parser.add_argument(
+        "--run-results",
+        action="store_true",
+        help="moto mode: also seed and ingest run_results.json per project",
+    )
+    parser.add_argument("--profile", help="AWS profile name")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument(
+        "--emit-recipe",
+        metavar="PATH",
+        help="write a datahub ingest recipe for --manifest-glob and exit",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    if args.emit_recipe:
+        if not args.manifest_glob:
+            parser.error("--emit-recipe requires --manifest-glob")
+        emit_recipe(args.emit_recipe, args.manifest_glob, args.region, args.profile)
+        return
+
+    if args.moto:
+        sizes = [int(s) for s in args.sizes.split(",")]
+        results = run_moto_sweep(sizes, args.run_results)
+    else:
+        results = run_real(args.manifest_glob, args.profile, args.region)
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_multi_project.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_multi_project.py
@@ -1674,3 +1674,58 @@ def test_exposure_collision_ignored_when_exposures_are_disabled(
     assert len(exposures) == 2
     assert not source.report.failures
     assert source.report.duplicate_exposure_unique_ids_detected is None
+
+
+def test_artifact_read_concurrency_matches_sequential_results(
+    tmp_path: pathlib.Path,
+) -> None:
+    for i in range(5):
+        _write_project(
+            tmp_path,
+            f"project_{i}",
+            [{"name": f"model_{i}", "database": "db", "schema": f"sch_{i}"}],
+            catalog_generated_at="2026-01-01T00:00:00.000000Z",
+        )
+
+    sequential = _make_source(
+        manifest_path=f"{tmp_path}/*/manifest.json", artifact_read_concurrency=1
+    ).load_nodes()
+    parallel_source = _make_source(
+        manifest_path=f"{tmp_path}/*/manifest.json", artifact_read_concurrency=4
+    )
+    parallel = parallel_source.load_nodes()
+
+    # Same nodes in the same order: prefetch must not reorder project processing.
+    assert [node.dbt_name for node in parallel] == [
+        node.dbt_name for node in sequential
+    ]
+    assert parallel_source.report.manifests_loaded == 5
+    assert parallel_source.report.manifests_failed == 0
+
+
+def test_artifact_read_concurrency_replays_fetch_errors_per_project(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A fetch error captured in a worker must fail only its own project.
+
+    manifest.json as a directory makes the read raise (IsADirectoryError) inside
+    the prefetch worker; the error must surface on the main thread through the
+    same per-project isolation path as a sequential read failure.
+    """
+    for name in ["project_a", "project_c"]:
+        _write_project(
+            tmp_path, name, [{"name": f"m_{name}", "database": "db", "schema": name}]
+        )
+    (tmp_path / "project_b" / "manifest.json").mkdir(parents=True)
+
+    source = _make_source(
+        manifest_path=f"{tmp_path}/*/manifest.json", artifact_read_concurrency=4
+    )
+    nodes = source.load_nodes()
+
+    assert {node.dbt_name for node in nodes} == {
+        "model.project_a.m_project_a",
+        "model.project_c.m_project_c",
+    }
+    assert source.report.manifests_loaded == 2
+    assert source.report.manifests_failed == 1


### PR DESCRIPTION
> **Stacked on #19473** (base branch is `feat/dbt-multi-project-glob`). Will be rebased onto master once #19473 merges. Pairs with #19496 (S3 client reuse) — the measurements below include both.

## Summary

With a globbed `manifest_path`, artifact loading dominates the run: each project's manifest, catalog, and sources were fetched strictly sequentially, so wall-clock at scale is mostly idle network wait. Measured with 1000 cloned jaffle-shop artifact sets on S3: ~5.5s/project, ~92 minutes projected, against a ~5 minute CPU floor.

### `perf`: bounded parallel artifact prefetch

- New `artifact_read_concurrency` config (default 8, `ge=1`, `1` = sequential; default sits inside boto3's 10-connection pool). Glob mode only — a single-file `manifest_path` keeps today's code path untouched.
- Workers do **only** `read_file_as_bytes`; JSON parsing, node building, all reporting, and error classification stay on the main thread. A worker hands back the exact exception a failed read raised, re-raised at the original call site — so `_is_missing_file_error` classification and per-project failure isolation are unchanged by construction.
- Plumbed through the existing `BackpressureAwareExecutor` with a small reorder buffer (its completion order is unordered), so projects are processed in the same sorted order as before and in-flight raw bytes stay bounded at ~2× concurrency projects. The config description documents the memory trade-off for estates with very large manifests.
- `run_results` files are prefetched the same way; `load_run_results` itself stays sequential.

### `test`: multi-project scale-test framework (`tests/performance/dbt/`)

- `seed_projects.py` clones the checked-in jaffle-shop artifacts N times into S3 or a local directory, uniquifying the dbt package name and target schema per clone so N clones ingest as N independent, non-colliding projects. No dbt invocation needed.
- `test_dbt_multi_project.py` runs the source in-process (per the existing `tests/performance` pattern) and reports wall-clock, workunits/sec, peak RSS, and the multi-project counters. Supports a self-seeding moto sweep (`--moto --sizes 10,100,1000`), real-S3 runs (`--manifest-glob`), and emitting an end-to-end ingest recipe (`--emit-recipe`).

## Measurements (real S3, us-west-2, this PR + #19496)

| run | before | after | speedup |
|---|---|---|---|
| 10 projects | 57.1s | 6.2s | 9.2× |
| 100 projects | 554.2s | 32.0s | 17.3× |
| 100 projects, moto (CPU floor) | 26.7s | — | — |

At 100 projects the run lands within ~5s of the CPU-only mock run — network is no longer the bottleneck. Identical workunit counts, zero failures, zero duplicate-collision reports in every before/after pair.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://docs.datahub.com/docs/contributing) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues: stacked on #19473, pairs with #19496
- [x] Tests added/updated: parallel-vs-sequential result identity, per-project fetch-error isolation under concurrency (`tests/unit/dbt/test_dbt_multi_project.py`); full dbt unit suite passes
- [x] Docs: config field carries its own description (auto-generated docs); no separate doc change needed
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up dbt multi-project glob ingestion by prefetching artifact files in parallel, cutting a 100-project S3 run from ~554s to ~32s.

**Parallel artifact prefetch**
- Adds `artifact_read_concurrency` (default 8) to bound parallel reads; `1` restores sequential behavior and single-file `manifest_path` is untouched.
- Workers fetch bytes only; JSON parsing, reporting, error classification, and project order stay on the main thread, so output and per-project failure isolation are unchanged.
- Peak memory grows roughly with concurrency × largest manifest size; `run_results` files are prefetched the same way.

**Scale-test framework**
- Adds `tests/performance/dbt/` with a seeder that clones the jaffle-shop artifacts N times into S3 or a local directory.
- Adds a harness that runs the source in-process, reporting wall-clock, workunits/sec, peak RSS, and multi-project counters.

<sup>Written for commit f33b49cf137f13ad766a2b18d63c5af944d433a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

