### PR TITLE
fix(graph): stop entity-graph cache from silently dropping relationships

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -5,6 +5,7 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.metadata.Constants.CORP_GROUP_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATAHUB_ROLE_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DOMAIN_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.GLOSSARY_NODE_ENTITY_NAME;
@@ -250,11 +251,10 @@ public class EntityRelationshipsResultResolver
         && relationshipTypes.equals(ROLE_MEMBERSHIP_RELATIONSHIP_TYPES)) {
       return true;
     }
-    // dataHubRole INCOMING IsMemberOfRole is intentionally NOT served from the membership cache: a
-    // role's members include groups as well as users, but the cache snapshot's reverse role lookup
-    // is user-only and would silently drop group grants. Fall through to the live graph, which
-    // returns both.
-    return false;
+    // Role members are users and groups (both IsMemberOfRole edges in the membership snapshot).
+    return DATAHUB_ROLE_ENTITY_NAME.equals(entityType)
+        && direction == RelationshipDirection.INCOMING
+        && relationshipTypes.equals(ROLE_MEMBERSHIP_RELATIONSHIP_TYPES);
   }
 
   private static boolean isSubsetOf(@Nonnull Set<String> requested, @Nonnull Set<String> allowed) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -5,7 +5,6 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.metadata.Constants.CORP_GROUP_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
-import static com.linkedin.metadata.Constants.DATAHUB_ROLE_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DOCUMENT_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DOMAIN_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.GLOSSARY_NODE_ENTITY_NAME;
@@ -251,9 +250,11 @@ public class EntityRelationshipsResultResolver
         && relationshipTypes.equals(ROLE_MEMBERSHIP_RELATIONSHIP_TYPES)) {
       return true;
     }
-    return DATAHUB_ROLE_ENTITY_NAME.equals(entityType)
-        && direction == RelationshipDirection.INCOMING
-        && relationshipTypes.equals(ROLE_MEMBERSHIP_RELATIONSHIP_TYPES);
+    // dataHubRole INCOMING IsMemberOfRole is intentionally NOT served from the membership cache: a
+    // role's members include groups as well as users, but the cache snapshot's reverse role lookup
+    // is user-only and would silently drop group grants. Fall through to the live graph, which
+    // returns both.
+    return false;
   }
 
   private static boolean isSubsetOf(@Nonnull Set<String> requested, @Nonnull Set<String> allowed) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -169,7 +169,8 @@ public class EntityRelationshipsResultResolver
                   start,
                   count,
                   relationshipDirection,
-                  includeSoftDelete),
+                  includeSoftDelete,
+                  relatedEntityTypes),
           this.getClass().getSimpleName(),
           "getMembershipRelationships");
     }
@@ -296,7 +297,7 @@ public class EntityRelationshipsResultResolver
     List<EntityRelationship> page = paginateRelationships(relationships, start, count);
     EntityRelationshipsResult result =
         mapEntityRelationshipsFromList(
-            context, page, relationshipDirection, includeSoftDelete, 0, page.size());
+            context, page, relationshipDirection, includeSoftDelete, 0, page.size(), null);
     result.setStart(start != null ? start : 0);
     result.setTotal(relationships.size());
     result.setCount(page.size());
@@ -352,10 +353,12 @@ public class EntityRelationshipsResultResolver
       @Nullable final Integer count,
       @Nonnull
           final com.linkedin.datahub.graphql.generated.RelationshipDirection relationshipDirection,
-      final boolean includeSoftDelete) {
+      final boolean includeSoftDelete,
+      @Nullable final Set<String> relatedEntityTypes) {
     MembershipReadSpec spec = MembershipBindings.membershipSpec(context.getOperationContext());
     Urn seedUrn = UrnUtils.getUrn(urn);
     TraversalDirection traversalDirection = toTraversalDirection(direction);
+    boolean filterByRelatedType = relatedEntityTypes != null && !relatedEntityTypes.isEmpty();
 
     List<EntityRelationship> relationships;
     int total;
@@ -369,9 +372,15 @@ public class EntityRelationshipsResultResolver
           roleUrns.stream()
               .map(role -> new EntityRelationship().setEntity(role).setType("IsMemberOfRole"))
               .collect(Collectors.toList());
+      relationships = filterByRelatedEntityTypes(relationships, relatedEntityTypes);
       total = relationships.size();
       relationships = paginateRelationships(relationships, start, count);
     } else {
+      // When filtering by relatedEntityTypes, page after filter so totals/pages match the
+      // filtered set (same as the live-graph mapper).
+      int fetchStart = filterByRelatedType ? 0 : (start != null ? start : 0);
+      int fetchCount =
+          filterByRelatedType ? Integer.MAX_VALUE : (count != null ? count : Integer.MAX_VALUE);
       MembershipNeighborResult result =
           BoundMembershipAccess.listRelated(
               context.getOperationContext(),
@@ -379,8 +388,8 @@ public class EntityRelationshipsResultResolver
               seedUrn,
               traversalDirection,
               relationshipTypes,
-              start != null ? start : 0,
-              count != null ? count : Integer.MAX_VALUE,
+              fetchStart,
+              fetchCount,
               includeSoftDelete);
       relationships =
           result.neighborsOrEmpty().stream()
@@ -390,8 +399,14 @@ public class EntityRelationshipsResultResolver
                           .setEntity(UrnUtils.getUrn(neighbor.neighborUrn()))
                           .setType(neighbor.relationshipType()))
               .collect(Collectors.toList());
-      total =
-          result instanceof MembershipNeighborResult.Hit hit ? hit.total() : relationships.size();
+      if (filterByRelatedType) {
+        relationships = filterByRelatedEntityTypes(relationships, relatedEntityTypes);
+        total = relationships.size();
+        relationships = paginateRelationships(relationships, start, count);
+      } else {
+        total =
+            result instanceof MembershipNeighborResult.Hit hit ? hit.total() : relationships.size();
+      }
     }
 
     EntityRelationshipsResult mapped =
@@ -401,11 +416,27 @@ public class EntityRelationshipsResultResolver
             relationshipDirection,
             includeSoftDelete,
             0,
-            relationships.size());
+            relationships.size(),
+            relatedEntityTypes);
     mapped.setStart(start != null ? start : 0);
     mapped.setTotal(total);
     mapped.setCount(mapped.getRelationships().size());
     return mapped;
+  }
+
+  @Nonnull
+  private static List<EntityRelationship> filterByRelatedEntityTypes(
+      @Nonnull final List<EntityRelationship> relationships,
+      @Nullable final Set<String> relatedEntityTypes) {
+    if (relatedEntityTypes == null || relatedEntityTypes.isEmpty()) {
+      return relationships;
+    }
+    return relationships.stream()
+        .filter(
+            rel ->
+                relatedEntityTypes.contains(
+                    rel.getEntity().getEntityType().toLowerCase(Locale.ROOT)))
+        .collect(Collectors.toList());
   }
 
   private static TraversalDirection toTraversalDirection(@Nonnull RelationshipDirection direction) {
@@ -436,7 +467,8 @@ public class EntityRelationshipsResultResolver
           final com.linkedin.datahub.graphql.generated.RelationshipDirection relationshipDirection,
       final boolean includeSoftDelete,
       @Nullable final Integer start,
-      @Nullable final Integer count) {
+      @Nullable final Integer count,
+      @Nullable final Set<String> relatedEntityTypes) {
     EntityRelationships entityRelationships =
         new EntityRelationships()
             .setStart(start != null ? start : 0)
@@ -448,7 +480,7 @@ public class EntityRelationshipsResultResolver
         entityRelationships,
         RelationshipDirection.valueOf(relationshipDirection.toString()),
         includeSoftDelete,
-        null);
+        relatedEntityTypes);
   }
 
   private EntityRelationshipsResult mapDomainChildRelationships(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -153,7 +153,8 @@ public class EntityRelationshipsResultResolver
                   start,
                   count,
                   relationshipDirection,
-                  includeSoftDelete),
+                  includeSoftDelete,
+                  relatedEntityTypes),
           this.getClass().getSimpleName(),
           "getSessionUserMembershipRelationships");
     }
@@ -270,7 +271,8 @@ public class EntityRelationshipsResultResolver
       @Nullable final Integer count,
       @Nonnull
           final com.linkedin.datahub.graphql.generated.RelationshipDirection relationshipDirection,
-      final boolean includeSoftDelete) {
+      final boolean includeSoftDelete,
+      @Nullable final Set<String> relatedEntityTypes) {
     ActorContext sessionActor = context.getOperationContext().getSessionActorContext();
     List<EntityRelationship> relationships = new ArrayList<>();
 
@@ -294,10 +296,17 @@ public class EntityRelationshipsResultResolver
       }
     }
 
+    relationships = filterByRelatedEntityTypes(relationships, relatedEntityTypes);
     List<EntityRelationship> page = paginateRelationships(relationships, start, count);
     EntityRelationshipsResult result =
         mapEntityRelationshipsFromList(
-            context, page, relationshipDirection, includeSoftDelete, 0, page.size(), null);
+            context,
+            page,
+            relationshipDirection,
+            includeSoftDelete,
+            0,
+            page.size(),
+            relatedEntityTypes);
     result.setStart(start != null ? start : 0);
     result.setTotal(relationships.size());
     result.setCount(page.size());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolver.java
@@ -300,13 +300,7 @@ public class EntityRelationshipsResultResolver
     List<EntityRelationship> page = paginateRelationships(relationships, start, count);
     EntityRelationshipsResult result =
         mapEntityRelationshipsFromList(
-            context,
-            page,
-            relationshipDirection,
-            includeSoftDelete,
-            0,
-            page.size(),
-            relatedEntityTypes);
+            context, page, relationshipDirection, includeSoftDelete, 0, page.size(), null);
     result.setStart(start != null ? start : 0);
     result.setTotal(relationships.size());
     result.setCount(page.size());
@@ -386,10 +380,11 @@ public class EntityRelationshipsResultResolver
       relationships = paginateRelationships(relationships, start, count);
     } else {
       // When filtering by relatedEntityTypes, page after filter so totals/pages match the
-      // filtered set (same as the live-graph mapper).
+      // filtered set (same as the live-graph mapper). Cap the pre-filter fetch at the membership
+      // graph's bounds.maxEdges (via MembershipReadSpec) and fail closed if truncated.
+      int fetchCap = spec.getRelatedTypeFilterFetchCap();
       int fetchStart = filterByRelatedType ? 0 : (start != null ? start : 0);
-      int fetchCount =
-          filterByRelatedType ? Integer.MAX_VALUE : (count != null ? count : Integer.MAX_VALUE);
+      int fetchCount = filterByRelatedType ? fetchCap : (count != null ? count : Integer.MAX_VALUE);
       MembershipNeighborResult result =
           BoundMembershipAccess.listRelated(
               context.getOperationContext(),
@@ -409,6 +404,15 @@ public class EntityRelationshipsResultResolver
                           .setType(neighbor.relationshipType()))
               .collect(Collectors.toList());
       if (filterByRelatedType) {
+        if (result instanceof MembershipNeighborResult.Hit hit
+            && hit.total() > relationships.size()) {
+          throw new IllegalStateException(
+              "Membership listing for "
+                  + urn
+                  + " exceeds relatedEntityTypes fetch cap ("
+                  + fetchCap
+                  + " from membership bounds.maxEdges); refusing truncated filter+page results");
+        }
         relationships = filterByRelatedEntityTypes(relationships, relatedEntityTypes);
         total = relationships.size();
         relationships = paginateRelationships(relationships, start, count);
@@ -426,7 +430,7 @@ public class EntityRelationshipsResultResolver
             includeSoftDelete,
             0,
             relationships.size(),
-            relatedEntityTypes);
+            null);
     mapped.setStart(start != null ? start : 0);
     mapped.setTotal(total);
     mapped.setCount(mapped.getRelationships().size());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -895,12 +895,11 @@ public class EntityRelationshipsResultResolverTest {
 
   /**
    * A role's members ({@code IsMemberOfRole} INCOMING) can be both users and groups. The membership
-   * cache snapshot is user-centric — its reverse role lookup returns only user members, silently
-   * dropping group grants. So {@code dataHubRole.relationships(IsMemberOfRole, INCOMING)} must not
-   * be served from the membership cache; it has to go through the live graph, which returns both.
+   * graph stores both edge types; reverse listing must be served from the membership path and
+   * surface group grants alongside users (not drop groups or bypass to the live graph).
    */
   @Test
-  public void testDataHubRoleIncomingMembersIncludeGroupsViaLiveGraph()
+  public void testDataHubRoleIncomingMembersIncludeGroupsViaMembershipCache()
       throws ExecutionException, InterruptedException, URISyntaxException {
     Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
     Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
@@ -910,7 +909,6 @@ public class EntityRelationshipsResultResolverTest {
     roleSource.setUrn(roleUrn.toString());
     when(mockEnv.getSource()).thenReturn(roleSource);
 
-    // Membership cache reverse role lookup returns only the user (drops the group) — the defect.
     EntityGraphCache entityGraphCache = mock(EntityGraphCache.class);
     EntityGraphBinding binding =
         EntityGraphBinding.builder()
@@ -932,22 +930,9 @@ public class EntityRelationshipsResultResolverTest {
         .thenReturn(
             MembershipNeighborResult.fromNeighbors(
                 List.of(
-                    new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole")),
-                1));
-
-    // The live graph holds BOTH a user and a group as members of the role.
-    EntityRelationships roleMembers =
-        new EntityRelationships()
-            .setStart(0)
-            .setCount(2)
-            .setTotal(2)
-            .setRelationships(
-                new EntityRelationshipArray(
-                    new EntityRelationship().setEntity(userUrn).setType("IsMemberOfRole"),
-                    new EntityRelationship().setEntity(groupUrn).setType("IsMemberOfRole")));
-    when(_graphClient.getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any()))
-        .thenReturn(roleMembers);
-    when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+                    new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole"),
+                    new MembershipNeighborResult.Neighbor(groupUrn.toString(), "IsMemberOfRole")),
+                2));
 
     QueryContext queryContext = getMockAllowContext();
     OperationContext baseContext = queryContext.getOperationContext();
@@ -973,6 +958,8 @@ public class EntityRelationshipsResultResolverTest {
     membersInput.setCount(50);
     when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
 
+    when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+
     EntityRelationshipsResult result = resolver.get(mockEnv).get();
 
     Set<String> members = new HashSet<>();
@@ -983,8 +970,7 @@ public class EntityRelationshipsResultResolverTest {
         members.contains(groupUrn.toString()),
         "role member listing must include group grants, not only users");
     assertTrue(members.contains(userUrn.toString()));
-    verify(_graphClient)
-        .getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any());
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 import com.datahub.authorization.SessionActorIdentity;
 import com.linkedin.common.EntityRelationship;
@@ -49,6 +50,7 @@ import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
@@ -941,11 +943,67 @@ public class EntityRelationshipsResultResolverTest {
    * surface group grants alongside users (not drop groups or bypass to the live graph).
    */
   @Test
+  public void testDataHubRoleIncomingMembersHonorsRelatedEntityTypes()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, List.of("corpuser"), null, 2);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getTotal().intValue(), 1);
+    assertEquals(result.getCount().intValue(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testDataHubRoleIncomingMembersRelatedEntityTypesUsesMaxEdgesFetchCap()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+    int fetchCap = 2;
+    EntityGraphCache entityGraphCache =
+        setupDataHubRoleIncomingMembersMembershipCache(
+            userUrn, groupUrn, List.of("corpuser"), fetchCap, 2);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getTotal().intValue(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
+    verify(entityGraphCache)
+        .listRelated(
+            eq("membership"),
+            eq(GraphSnapshotSource.GRAPH),
+            eq("urn:li:dataHubRole:Editor"),
+            eq(TraversalDirection.REVERSE),
+            eq(Set.of("IsMemberOfRole")),
+            anyInt(),
+            eq(0),
+            eq(fetchCap),
+            any(ReadMode.class));
+  }
+
+  @Test
+  public void testDataHubRoleIncomingMembersRelatedEntityTypesFailsClosedWhenFetchTruncated()
+      throws URISyntaxException {
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+    // Cap fetches 2 neighbors but backend reports total 5 → refuse truncated filter+page.
+    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, List.of("corpuser"), 2, 5);
+
+    ExecutionException thrown =
+        expectThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
+    assertTrue(thrown.getCause() instanceof IllegalStateException);
+    assertTrue(thrown.getCause().getMessage().contains("fetch cap"));
+  }
+
+  @Test
   public void testDataHubRoleIncomingMembersIncludeGroupsViaMembershipCache()
       throws ExecutionException, InterruptedException, URISyntaxException {
     Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
     Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
-    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, null);
+    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, null, null, 2);
 
     EntityRelationshipsResult result = resolver.get(mockEnv).get();
 
@@ -960,23 +1018,19 @@ public class EntityRelationshipsResultResolverTest {
     verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
-  @Test
-  public void testDataHubRoleIncomingMembersHonorsRelatedEntityTypes()
-      throws ExecutionException, InterruptedException, URISyntaxException {
-    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
-    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
-    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, List.of("corpuser"));
-
-    EntityRelationshipsResult result = resolver.get(mockEnv).get();
-
-    assertEquals(result.getTotal().intValue(), 1);
-    assertEquals(result.getCount().intValue(), 1);
-    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
-    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
-  }
-
-  private void setupDataHubRoleIncomingMembersMembershipCache(
-      @Nonnull Urn userUrn, @Nonnull Urn groupUrn, @Nullable List<String> relatedEntityTypes)
+  /**
+   * @param relatedTypeFilterFetchCap when non-null (and relatedEntityTypes set), stubs {@code
+   *     maxEdgesForGraph} and expects {@code listRelated} count to match the cap
+   * @param reportedTotal total reported by the membership hit (may exceed fetched neighbors to
+   *     simulate truncation)
+   */
+  @Nonnull
+  private EntityGraphCache setupDataHubRoleIncomingMembersMembershipCache(
+      @Nonnull Urn userUrn,
+      @Nonnull Urn groupUrn,
+      @Nullable List<String> relatedEntityTypes,
+      @Nullable Integer relatedTypeFilterFetchCap,
+      int reportedTotal)
       throws URISyntaxException {
     Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
 
@@ -992,6 +1046,10 @@ public class EntityRelationshipsResultResolverTest {
             .build();
     when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
         .thenReturn(Optional.of(binding));
+    if (relatedTypeFilterFetchCap != null) {
+      when(entityGraphCache.maxEdgesForGraph("membership"))
+          .thenReturn(OptionalInt.of(relatedTypeFilterFetchCap));
+    }
     when(entityGraphCache.listRelated(
             eq("membership"),
             eq(GraphSnapshotSource.GRAPH),
@@ -1000,14 +1058,16 @@ public class EntityRelationshipsResultResolverTest {
             eq(Set.of("IsMemberOfRole")),
             anyInt(),
             eq(0),
-            anyInt(),
+            relatedTypeFilterFetchCap != null && relatedEntityTypes != null
+                ? eq(relatedTypeFilterFetchCap)
+                : anyInt(),
             any(ReadMode.class)))
         .thenReturn(
             MembershipNeighborResult.fromNeighbors(
                 List.of(
                     new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole"),
                     new MembershipNeighborResult.Neighbor(groupUrn.toString(), "IsMemberOfRole")),
-                2));
+                reportedTotal));
 
     QueryContext queryContext = getMockAllowContext();
     OperationContext baseContext = queryContext.getOperationContext();
@@ -1037,6 +1097,7 @@ public class EntityRelationshipsResultResolverTest {
     when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
 
     when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+    return entityGraphCache;
   }
 
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -893,6 +893,100 @@ public class EntityRelationshipsResultResolverTest {
     verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
+  /**
+   * A role's members ({@code IsMemberOfRole} INCOMING) can be both users and groups. The membership
+   * cache snapshot is user-centric — its reverse role lookup returns only user members, silently
+   * dropping group grants. So {@code dataHubRole.relationships(IsMemberOfRole, INCOMING)} must not
+   * be served from the membership cache; it has to go through the live graph, which returns both.
+   */
+  @Test
+  public void testDataHubRoleIncomingMembersIncludeGroupsViaLiveGraph()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+
+    CorpGroup roleSource = new CorpGroup();
+    roleSource.setUrn(roleUrn.toString());
+    when(mockEnv.getSource()).thenReturn(roleSource);
+
+    // Membership cache reverse role lookup returns only the user (drops the group) — the defect.
+    EntityGraphCache entityGraphCache = mock(EntityGraphCache.class);
+    EntityGraphBinding binding =
+        EntityGraphBinding.builder()
+            .graphId("membership")
+            .source(GraphSnapshotSource.GRAPH)
+            .build();
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
+        .thenReturn(Optional.of(binding));
+    when(entityGraphCache.listRelated(
+            eq("membership"),
+            eq(GraphSnapshotSource.GRAPH),
+            eq(roleUrn.toString()),
+            eq(TraversalDirection.REVERSE),
+            eq(Set.of("IsMemberOfRole")),
+            anyInt(),
+            eq(0),
+            anyInt(),
+            any(ReadMode.class)))
+        .thenReturn(
+            MembershipNeighborResult.fromNeighbors(
+                List.of(
+                    new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole")),
+                1));
+
+    // The live graph holds BOTH a user and a group as members of the role.
+    EntityRelationships roleMembers =
+        new EntityRelationships()
+            .setStart(0)
+            .setCount(2)
+            .setTotal(2)
+            .setRelationships(
+                new EntityRelationshipArray(
+                    new EntityRelationship().setEntity(userUrn).setType("IsMemberOfRole"),
+                    new EntityRelationship().setEntity(groupUrn).setType("IsMemberOfRole")));
+    when(_graphClient.getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any()))
+        .thenReturn(roleMembers);
+    when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+
+    QueryContext queryContext = getMockAllowContext();
+    OperationContext baseContext = queryContext.getOperationContext();
+    OperationContext opContext =
+        baseContext.toBuilder()
+            .retrieverContext(
+                RetrieverContext.builder()
+                    .entityGraphCache(entityGraphCache)
+                    .graphRetriever(GraphRetriever.EMPTY)
+                    .searchRetriever(SearchRetriever.EMPTY)
+                    .cachingAspectRetriever(CachingAspectRetriever.EMPTY)
+                    .aspectRetriever(mock(AspectRetriever.class))
+                    .build())
+            .build(baseContext.getSessionAuthentication(), false);
+    when(queryContext.getOperationContext()).thenReturn(opContext);
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    RelationshipsInput membersInput = new RelationshipsInput();
+    membersInput.setTypes(List.of("IsMemberOfRole"));
+    membersInput.setDirection(RelationshipDirection.INCOMING);
+    membersInput.setIncludeSoftDelete(false);
+    membersInput.setStart(0);
+    membersInput.setCount(50);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    Set<String> members = new HashSet<>();
+    for (var rel : result.getRelationships()) {
+      members.add(rel.getEntity().getUrn());
+    }
+    assertTrue(
+        members.contains(groupUrn.toString()),
+        "role member listing must include group grants, not only users");
+    assertTrue(members.contains(userUrn.toString()));
+    verify(_graphClient)
+        .getRelatedEntities(eq(roleUrn.toString()), any(), any(), any(), any(), any());
+  }
+
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(
       Entity entity) {
     return new com.linkedin.datahub.graphql.generated.EntityRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -973,6 +973,77 @@ public class EntityRelationshipsResultResolverTest {
     verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
+  @Test
+  public void testDataHubRoleIncomingMembersHonorsRelatedEntityTypes()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+
+    CorpGroup roleSource = new CorpGroup();
+    roleSource.setUrn(roleUrn.toString());
+    when(mockEnv.getSource()).thenReturn(roleSource);
+
+    EntityGraphCache entityGraphCache = mock(EntityGraphCache.class);
+    EntityGraphBinding binding =
+        EntityGraphBinding.builder()
+            .graphId("membership")
+            .source(GraphSnapshotSource.GRAPH)
+            .build();
+    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
+        .thenReturn(Optional.of(binding));
+    when(entityGraphCache.listRelated(
+            eq("membership"),
+            eq(GraphSnapshotSource.GRAPH),
+            eq(roleUrn.toString()),
+            eq(TraversalDirection.REVERSE),
+            eq(Set.of("IsMemberOfRole")),
+            anyInt(),
+            eq(0),
+            anyInt(),
+            any(ReadMode.class)))
+        .thenReturn(
+            MembershipNeighborResult.fromNeighbors(
+                List.of(
+                    new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole"),
+                    new MembershipNeighborResult.Neighbor(groupUrn.toString(), "IsMemberOfRole")),
+                2));
+
+    QueryContext queryContext = getMockAllowContext();
+    OperationContext baseContext = queryContext.getOperationContext();
+    OperationContext opContext =
+        baseContext.toBuilder()
+            .retrieverContext(
+                RetrieverContext.builder()
+                    .entityGraphCache(entityGraphCache)
+                    .graphRetriever(GraphRetriever.EMPTY)
+                    .searchRetriever(SearchRetriever.EMPTY)
+                    .cachingAspectRetriever(CachingAspectRetriever.EMPTY)
+                    .aspectRetriever(mock(AspectRetriever.class))
+                    .build())
+            .build(baseContext.getSessionAuthentication(), false);
+    when(queryContext.getOperationContext()).thenReturn(opContext);
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    RelationshipsInput membersInput = new RelationshipsInput();
+    membersInput.setTypes(List.of("IsMemberOfRole"));
+    membersInput.setDirection(RelationshipDirection.INCOMING);
+    membersInput.setRelatedEntityTypes(List.of("corpuser"));
+    membersInput.setIncludeSoftDelete(false);
+    membersInput.setStart(0);
+    membersInput.setCount(50);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
+
+    when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getTotal().intValue(), 1);
+    assertEquals(result.getCount().intValue(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(
       Entity entity) {
     return new com.linkedin.datahub.graphql.generated.EntityRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -826,6 +828,44 @@ public class EntityRelationshipsResultResolverTest {
   }
 
   @Test
+  public void testSessionUserOutgoingMembershipHonorsRelatedEntityTypes()
+      throws ExecutionException, InterruptedException, URISyntaxException {
+    Urn actorUrn = Urn.createFromString("urn:li:corpuser:test");
+    Urn groupUrn = Urn.createFromString("urn:li:corpGroup:session-group");
+    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
+
+    CorpUser userSource = new CorpUser();
+    userSource.setUrn(actorUrn.toString());
+    when(mockEnv.getSource()).thenReturn(userSource);
+
+    SessionActorIdentity sessionIdentity =
+        new SessionActorIdentity(actorUrn, List.of(groupUrn), Set.of(roleUrn));
+    QueryContext queryContext =
+        withSessionActorIdentity(getMockAllowContext(actorUrn.toString()), sessionIdentity);
+    when(queryContext
+            .getOperationContext()
+            .getAuthorizationContext()
+            .resolveSessionActorRoles(any(), any()))
+        .thenReturn(Set.of(roleUrn));
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    RelationshipsInput membershipInput = new RelationshipsInput();
+    membershipInput.setTypes(List.of("IsMemberOfGroup", "IsMemberOfRole"));
+    membershipInput.setDirection(RelationshipDirection.OUTGOING);
+    membershipInput.setRelatedEntityTypes(List.of("dataHubRole"));
+    membershipInput.setStart(0);
+    membershipInput.setCount(10);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(membershipInput);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getTotal().intValue(), 1);
+    assertEquals(result.getCount().intValue(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), roleUrn.toString());
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
   public void testCorpGroupIncomingMembersUsesMembershipCache()
       throws ExecutionException, InterruptedException, URISyntaxException {
     Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
@@ -901,64 +941,9 @@ public class EntityRelationshipsResultResolverTest {
   @Test
   public void testDataHubRoleIncomingMembersIncludeGroupsViaMembershipCache()
       throws ExecutionException, InterruptedException, URISyntaxException {
-    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
     Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
     Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
-
-    CorpGroup roleSource = new CorpGroup();
-    roleSource.setUrn(roleUrn.toString());
-    when(mockEnv.getSource()).thenReturn(roleSource);
-
-    EntityGraphCache entityGraphCache = mock(EntityGraphCache.class);
-    EntityGraphBinding binding =
-        EntityGraphBinding.builder()
-            .graphId("membership")
-            .source(GraphSnapshotSource.GRAPH)
-            .build();
-    when(entityGraphCache.bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP))
-        .thenReturn(Optional.of(binding));
-    when(entityGraphCache.listRelated(
-            eq("membership"),
-            eq(GraphSnapshotSource.GRAPH),
-            eq(roleUrn.toString()),
-            eq(TraversalDirection.REVERSE),
-            eq(Set.of("IsMemberOfRole")),
-            anyInt(),
-            eq(0),
-            anyInt(),
-            any(ReadMode.class)))
-        .thenReturn(
-            MembershipNeighborResult.fromNeighbors(
-                List.of(
-                    new MembershipNeighborResult.Neighbor(userUrn.toString(), "IsMemberOfRole"),
-                    new MembershipNeighborResult.Neighbor(groupUrn.toString(), "IsMemberOfRole")),
-                2));
-
-    QueryContext queryContext = getMockAllowContext();
-    OperationContext baseContext = queryContext.getOperationContext();
-    OperationContext opContext =
-        baseContext.toBuilder()
-            .retrieverContext(
-                RetrieverContext.builder()
-                    .entityGraphCache(entityGraphCache)
-                    .graphRetriever(GraphRetriever.EMPTY)
-                    .searchRetriever(SearchRetriever.EMPTY)
-                    .cachingAspectRetriever(CachingAspectRetriever.EMPTY)
-                    .aspectRetriever(mock(AspectRetriever.class))
-                    .build())
-            .build(baseContext.getSessionAuthentication(), false);
-    when(queryContext.getOperationContext()).thenReturn(opContext);
-    when(mockEnv.getContext()).thenReturn(queryContext);
-
-    RelationshipsInput membersInput = new RelationshipsInput();
-    membersInput.setTypes(List.of("IsMemberOfRole"));
-    membersInput.setDirection(RelationshipDirection.INCOMING);
-    membersInput.setIncludeSoftDelete(false);
-    membersInput.setStart(0);
-    membersInput.setCount(50);
-    when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
-
-    when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
+    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, null);
 
     EntityRelationshipsResult result = resolver.get(mockEnv).get();
 
@@ -976,9 +961,22 @@ public class EntityRelationshipsResultResolverTest {
   @Test
   public void testDataHubRoleIncomingMembersHonorsRelatedEntityTypes()
       throws ExecutionException, InterruptedException, URISyntaxException {
-    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
     Urn userUrn = Urn.createFromString("urn:li:corpuser:alice");
     Urn groupUrn = Urn.createFromString("urn:li:corpGroup:eng");
+    setupDataHubRoleIncomingMembersMembershipCache(userUrn, groupUrn, List.of("corpuser"));
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertEquals(result.getTotal().intValue(), 1);
+    assertEquals(result.getCount().intValue(), 1);
+    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  private void setupDataHubRoleIncomingMembersMembershipCache(
+      @Nonnull Urn userUrn, @Nonnull Urn groupUrn, @Nullable List<String> relatedEntityTypes)
+      throws URISyntaxException {
+    Urn roleUrn = Urn.createFromString("urn:li:dataHubRole:Editor");
 
     CorpGroup roleSource = new CorpGroup();
     roleSource.setUrn(roleUrn.toString());
@@ -1028,20 +1026,15 @@ public class EntityRelationshipsResultResolverTest {
     RelationshipsInput membersInput = new RelationshipsInput();
     membersInput.setTypes(List.of("IsMemberOfRole"));
     membersInput.setDirection(RelationshipDirection.INCOMING);
-    membersInput.setRelatedEntityTypes(List.of("corpuser"));
+    if (relatedEntityTypes != null) {
+      membersInput.setRelatedEntityTypes(relatedEntityTypes);
+    }
     membersInput.setIncludeSoftDelete(false);
     membersInput.setStart(0);
     membersInput.setCount(50);
     when(mockEnv.getArgument(eq("input"))).thenReturn(membersInput);
 
     when(_entityService.exists(any(), anySet(), eq(false))).thenAnswer(inv -> inv.getArgument(1));
-
-    EntityRelationshipsResult result = resolver.get(mockEnv).get();
-
-    assertEquals(result.getTotal().intValue(), 1);
-    assertEquals(result.getCount().intValue(), 1);
-    assertEquals(result.getRelationships().get(0).getEntity().getUrn(), userUrn.toString());
-    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -854,7 +854,9 @@ public class EntityRelationshipsResultResolverTest {
     membershipInput.setDirection(RelationshipDirection.OUTGOING);
     membershipInput.setRelatedEntityTypes(List.of("dataHubRole"));
     membershipInput.setStart(0);
-    membershipInput.setCount(10);
+    // count=1 forces filter-before-paginate: page-then-filter would keep only the group and drop
+    // the role.
+    membershipInput.setCount(1);
     when(mockEnv.getArgument(eq("input"))).thenReturn(membershipInput);
 
     EntityRelationshipsResult result = resolver.get(mockEnv).get();

--- a/docs/deploy/gms-entity-graph-cache.md
+++ b/docs/deploy/gms-entity-graph-cache.md
@@ -167,16 +167,18 @@ Production ships a **FULL** graph for actor / group / role membership walks used
 | Population   | `SCHEDULED` (default 600s)                                                                                           |
 | Bounds       | `maxVertices: 21000`, `maxEdges: 60000` (target ~15k users + ~5k groups; raise via `ENTITY_GRAPH_CACHE_CONFIG_JSON`) |
 
+GraphQL `relationships` with `relatedEntityTypes` fetches neighbors up to **`bounds.maxEdges`** before filtering and paginating (fail closed if the listing exceeds that cap). Raise `maxEdges` when large role/group member listings need type-filtered pages.
+
 Membership call sites use [`BoundMembershipAccess`](../../metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/BoundMembershipAccess.java) with [`MembershipBindings.membershipSpec()`](../../metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipBindings.java):
 
-| Call site                                                               | Path                                                                                           | Fallback                                       |
-| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| GraphQL `relationships` OUTGOING on session `corpuser` (groups / roles) | **Session shortcut** — `ActorContext` groups + `AuthorizationContext.resolveSessionActorRoles` | — (no cache / graph)                           |
-| GraphQL `relationships` OUTGOING on `corpuser` (groups)                 | Typed `listRelated` depth 1                                                                    | Aspect read or graph scroll                    |
-| GraphQL `relationships` OUTGOING on `corpuser` (`IsMemberOfRole`)       | **`effectiveRolesForUser`** (direct roles ∪ roles via groups)                                  | `ActorGroupMembershipService` / graph scroll   |
-| GraphQL `relationships` INCOMING on `corpGroup` (members)               | Typed `listRelated` `REVERSE` depth 1                                                          | Graph scroll (ES graph index)                  |
-| GraphQL `relationships` OUTGOING on `corpGroup` (roles)                 | Typed `listRelated` depth 1                                                                    | Batch `RoleMembership` on group / graph scroll |
-| GraphQL `relationships` INCOMING on `dataHubRole` (assigned users)      | Typed `listRelated` `REVERSE` depth 1                                                          | Graph scroll                                   |
+| Call site                                                                         | Path                                                                                           | Fallback                                       |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| GraphQL `relationships` OUTGOING on session `corpuser` (groups / roles)           | **Session shortcut** — `ActorContext` groups + `AuthorizationContext.resolveSessionActorRoles` | — (no cache / graph)                           |
+| GraphQL `relationships` OUTGOING on `corpuser` (groups)                           | Typed `listRelated` depth 1                                                                    | Aspect read or graph scroll                    |
+| GraphQL `relationships` OUTGOING on `corpuser` (`IsMemberOfRole`)                 | **`effectiveRolesForUser`** (direct roles ∪ roles via groups)                                  | `ActorGroupMembershipService` / graph scroll   |
+| GraphQL `relationships` INCOMING on `corpGroup` (members)                         | Typed `listRelated` `REVERSE` depth 1                                                          | Graph scroll (ES graph index)                  |
+| GraphQL `relationships` OUTGOING on `corpGroup` (roles)                           | Typed `listRelated` depth 1                                                                    | Batch `RoleMembership` on group / graph scroll |
+| GraphQL `relationships` INCOMING on `dataHubRole` (members: users **and** groups) | Typed `listRelated` `REVERSE` depth 1                                                          | Graph scroll                                   |
 
 **Effective roles:** Cached / fast-path `IsMemberOfRole` OUTGOING on a `corpuser` returns **effective** roles (direct assignment plus roles inherited via group membership), aligned with [`SessionActorIdentity.resolveAllRoles`](../../li-utils/src/main/java/com/datahub/authorization/SessionActorIdentity.java). This may differ from a raw Elasticsearch graph scroll that lists only direct user→role edges.
 
@@ -351,7 +353,7 @@ Operators define **which graphs exist** (edges, `buildSource`, scope, population
 
 **REVERSE self-only expand:** a root with no descendants returns **`EmptyHit(emptySet)`** — a valid result, not a cache miss. Call sites must not treat this as a miss.
 
-**Seed coverage (all scopes):** when some seed URNs are absent from the materialized snapshot, `expand()` returns reachable vertices for seeds that **are** present (`Hit`) rather than failing closed. PARTIAL multi-root requests fail closed earlier when any root is not cache-ready (see [PARTIAL components](#partial-components)). Call sites that need a complete expansion for every seed should check seed membership or use live fallback when partial results are insufficient.
+**Seed coverage (all scopes):** when **any** requested seed URN is absent from the materialized snapshot, `expand()` returns **`Miss(ABSENT)`** so callers fall back to the live graph (or aspect walk). A partial HIT that expands only present seeds would under-restrict VBAC / policy ancestor expansion and hierarchy reads for newly created or re-parented roots still outside the snapshot. PARTIAL multi-root requests also fail closed earlier when any root is not cache-ready (see [PARTIAL components](#partial-components)).
 
 **LAZY rebuild latency:** missing or stale keys rebuild on the request thread when `rebuildExecution` is `SYNC` (default). **`SCHEDULED`** rebuilds run on `entity-graph-scheduler` (bundled `domain@search`). **`BACKGROUND`** (LAZY + FULL only) enqueues async rebuild — cached reads return **`Miss(STALE_BLOCKED)`** until fresh. While another pod holds `BUILDING`, **FULL**-scope cached reads may still serve the previous `ACTIVE` snapshot until sync invalidation removes stale vertices or drops the graph.
 

--- a/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/EntityGraphCache.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/graph/cache/EntityGraphCache.java
@@ -116,6 +116,16 @@ public interface EntityGraphCache {
   Optional<EntityGraphBinding> bindingForPolicyField(@Nonnull String fieldType);
 
   /**
+   * Configured {@code bounds.maxEdges} for {@code graphId}, when the registry has a definition.
+   * Used as the GraphQL {@code relatedEntityTypes} pre-filter fetch cap so the limit tracks the
+   * membership (or other) graph's configured size rather than an unbounded {@code MAX_VALUE}.
+   */
+  @Nonnull
+  default java.util.OptionalInt maxEdgesForGraph(@Nonnull String graphId) {
+    return java.util.OptionalInt.empty();
+  }
+
+  /**
    * Walks ancestors along stored forward edges (e.g. domain {@code IsPartOf} child → parents), up
    * to {@code maxDepth} levels.
    */

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallback.java
@@ -48,6 +48,15 @@ public final class GraphScrollFallback {
     Set<Urn> frontier = new LinkedHashSet<>(Set.of(rootUrn));
     while (!frontier.isEmpty()) {
       DirectChildrenResult level = childrenOf(opContext, spec, frontier);
+      if (level.isTruncated()) {
+        // A frontier scroll failed. Returning the descendants gathered so far as if the set were
+        // complete silently under-restricts access-control filters built from it, so fail closed
+        // rather than hand back a partial hierarchy that looks whole.
+        throw new IllegalStateException(
+            "Descendant expansion truncated for graph "
+                + spec.getBinding().getGraphId()
+                + "; refusing to return a partial hierarchy as complete");
+      }
       Set<Urn> nextFrontier = new LinkedHashSet<>();
       for (Urn child : level.getChildUrns()) {
         if (descendants.add(child)) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipBindings.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipBindings.java
@@ -13,6 +13,7 @@ public final class MembershipBindings {
 
   @Nonnull
   public static MembershipReadSpec membershipSpec(@Nonnull OperationContext opContext) {
+    EntityGraphCache cache = opContext.getEntityGraphCache();
     return resolve(opContext)
         .orElseGet(
             () ->
@@ -20,7 +21,8 @@ public final class MembershipBindings {
                     EntityGraphBinding.builder()
                         .graphId(KnownEntityGraph.MEMBERSHIP.getConfigKey())
                         .source(KnownEntityGraph.MEMBERSHIP.getExpectedBuildSource())
-                        .build()));
+                        .build(),
+                    relatedTypeFilterFetchCap(cache, KnownEntityGraph.MEMBERSHIP.getConfigKey())));
   }
 
   @Nonnull
@@ -30,6 +32,17 @@ public final class MembershipBindings {
     return cache
         .bindingForKnownGraph(KnownEntityGraph.MEMBERSHIP)
         .flatMap(
-            binding -> MembershipReadSpecs.forKnownGraph(KnownEntityGraph.MEMBERSHIP, binding));
+            binding ->
+                MembershipReadSpecs.forKnownGraph(
+                    KnownEntityGraph.MEMBERSHIP,
+                    binding,
+                    relatedTypeFilterFetchCap(cache, binding.getGraphId())));
+  }
+
+  private static int relatedTypeFilterFetchCap(
+      @Nonnull EntityGraphCache cache, @Nonnull String graphId) {
+    return cache
+        .maxEdgesForGraph(graphId)
+        .orElse(MembershipReadSpec.DEFAULT_RELATED_TYPE_FILTER_FETCH_CAP);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallback.java
@@ -174,9 +174,17 @@ public final class MembershipGraphScrollFallback {
               ? new ScrollConfig(spec.getScrollGroupEntityTypes(), spec.getScrollRoleEntityTypes())
               : new ScrollConfig(spec.getScrollUserEntityTypes(), spec.getScrollGroupEntityTypes());
       case DATAHUB_ROLE_ENTITY_NAME ->
-          new ScrollConfig(spec.getScrollUserEntityTypes(), spec.getScrollRoleEntityTypes());
+          // Matches entity-graph-cache.yaml: both corpuser and corpGroup grant IsMemberOfRole.
+          new ScrollConfig(roleMemberSourceTypes(spec), spec.getScrollRoleEntityTypes());
       default -> null;
     };
+  }
+
+  @Nonnull
+  private static Set<String> roleMemberSourceTypes(@Nonnull MembershipReadSpec spec) {
+    LinkedHashSet<String> sources = new LinkedHashSet<>(spec.getScrollUserEntityTypes());
+    sources.addAll(spec.getScrollGroupEntityTypes());
+    return Set.copyOf(sources);
   }
 
   private record ScrollConfig(

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipReadSpec.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipReadSpec.java
@@ -16,6 +16,13 @@ import lombok.Value;
 @Builder
 public class MembershipReadSpec {
 
+  /**
+   * Fallback when {@code bounds.maxEdges} is unset on the membership graph definition (matches
+   * {@code EntityGraphRegistry}'s default of {@code maxVertices * 1.5} with {@code maxVertices}
+   * default 10000).
+   */
+  public static final int DEFAULT_RELATED_TYPE_FILTER_FETCH_CAP = 15_000;
+
   @Nonnull EntityGraphBinding binding;
 
   @Nonnull @Builder.Default Set<String> groupRelationshipTypes = Set.of();
@@ -28,4 +35,10 @@ public class MembershipReadSpec {
   @Nonnull @Builder.Default Set<String> scrollGroupEntityTypes = Set.of(CORP_GROUP_ENTITY_NAME);
 
   @Nonnull @Builder.Default Set<String> scrollRoleEntityTypes = Set.of(DATAHUB_ROLE_ENTITY_NAME);
+
+  /**
+   * Max neighbors to fetch before client-side {@code relatedEntityTypes} filtering. Taken from the
+   * membership graph's {@code bounds.maxEdges} when configured.
+   */
+  @Builder.Default int relatedTypeFilterFetchCap = DEFAULT_RELATED_TYPE_FILTER_FETCH_CAP;
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipReadSpecs.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/client/MembershipReadSpecs.java
@@ -20,17 +20,32 @@ public class MembershipReadSpecs {
   @Nonnull
   public static Optional<MembershipReadSpec> forKnownGraph(
       @Nonnull KnownEntityGraph known, @Nonnull EntityGraphBinding binding) {
+    return forKnownGraph(known, binding, MembershipReadSpec.DEFAULT_RELATED_TYPE_FILTER_FETCH_CAP);
+  }
+
+  @Nonnull
+  public static Optional<MembershipReadSpec> forKnownGraph(
+      @Nonnull KnownEntityGraph known,
+      @Nonnull EntityGraphBinding binding,
+      int relatedTypeFilterFetchCap) {
     if (known != KnownEntityGraph.MEMBERSHIP) {
       return Optional.empty();
     }
-    return Optional.of(membership(binding));
+    return Optional.of(membership(binding, relatedTypeFilterFetchCap));
   }
 
   @Nonnull
   public static MembershipReadSpec membership(@Nonnull EntityGraphBinding binding) {
+    return membership(binding, MembershipReadSpec.DEFAULT_RELATED_TYPE_FILTER_FETCH_CAP);
+  }
+
+  @Nonnull
+  public static MembershipReadSpec membership(
+      @Nonnull EntityGraphBinding binding, int relatedTypeFilterFetchCap) {
     return MembershipReadSpec.builder()
         .binding(binding)
         .groupRelationshipTypes(GROUP_RELATIONSHIP_TYPES)
+        .relatedTypeFilterFetchCap(relatedTypeFilterFetchCap)
         .build();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/EntityGraphCacheService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/EntityGraphCacheService.java
@@ -164,6 +164,16 @@ public class EntityGraphCacheService implements EntityGraphCache {
     return binding == null ? Optional.empty() : Optional.of(binding);
   }
 
+  @Override
+  @Nonnull
+  public java.util.OptionalInt maxEdgesForGraph(@Nonnull String graphId) {
+    EntityGraphDefinition definition = registry.getDefinition(graphId);
+    if (definition == null || definition.getBounds() == null) {
+      return java.util.OptionalInt.empty();
+    }
+    return definition.getBounds().getMaxEdges();
+  }
+
   public void scheduledRebuild(@Nonnull EntityGraphDefinition definition) {
     if (!properties.isEnabled()) {
       return;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackend.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackend.java
@@ -220,11 +220,11 @@ public class GraphReadBackend {
       @Nonnull EntityGraphView view,
       @Nonnull List<GraphComponentContext> components) {
     Set<String> normalizedRoots = rootsFrom(roots);
-    // If no root is present in the snapshot, the seed was never captured (e.g. created/re-parented
-    // by a write that did not pass the sync gate). Report ABSENT so callers fall back to the live
-    // graph, instead of returning an empty result that reads as an authoritative "no neighbors".
-    // Mirrors the membership read guard in listRelatedFromView.
-    if (normalizedRoots.stream().noneMatch(view::containsVertex)) {
+    // If any requested root is absent from the snapshot, the seed was never captured (e.g.
+    // created/re-parented by a write that did not pass the sync gate). Report ABSENT so callers
+    // fall back to the live graph instead of a partial HIT that expands only present roots and
+    // under-restricts VBAC/policy ancestor expansion. Empty roots keep vacuous allMatch (no miss).
+    if (!normalizedRoots.isEmpty() && !normalizedRoots.stream().allMatch(view::containsVertex)) {
       return GraphReadResult.miss(ReadMissReason.ABSENT);
     }
     int effectiveDepth = resolveExpandDepth(definition, maxDepth, direction, components);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackend.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackend.java
@@ -220,6 +220,13 @@ public class GraphReadBackend {
       @Nonnull EntityGraphView view,
       @Nonnull List<GraphComponentContext> components) {
     Set<String> normalizedRoots = rootsFrom(roots);
+    // If no root is present in the snapshot, the seed was never captured (e.g. created/re-parented
+    // by a write that did not pass the sync gate). Report ABSENT so callers fall back to the live
+    // graph, instead of returning an empty result that reads as an authoritative "no neighbors".
+    // Mirrors the membership read guard in listRelatedFromView.
+    if (normalizedRoots.stream().noneMatch(view::containsVertex)) {
+      return GraphReadResult.miss(ReadMissReason.ABSENT);
+    }
     int effectiveDepth = resolveExpandDepth(definition, maxDepth, direction, components);
     logIncompleteCoverage(definition, direction, components);
     EntityGraphView.ExpandResult expandResult =

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/GraphScrollFallbackTest.java
@@ -242,6 +242,23 @@ public class GraphScrollFallbackTest {
     assertTrue(result.getChildUrns().isEmpty());
   }
 
+  // Descendant expansion feeds search access-control filters. If a frontier scroll fails, the BFS
+  // must NOT return the descendants gathered so far as if they were complete — a partial descendant
+  // set silently under-restricts a NOT_EQUALS/DENY filter (entities under the dropped subtree
+  // leak).
+  // allDescendants must fail closed (throw) on truncation rather than swallow it.
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void allDescendantsFailsClosedOnScrollTruncation() {
+    GraphRetriever graphRetriever = mock(GraphRetriever.class);
+    when(graphRetriever.scrollRelatedEntities(
+            any(), any(), any(), any(), any(), any(), any(), any(), anyInt(), any(), any()))
+        .thenThrow(new RuntimeException("scroll failed"));
+
+    OperationContext opContext = contextWithGraphRetriever(graphRetriever);
+
+    GraphScrollFallback.allDescendants(opContext, HierarchyBindings.domainSpec(opContext), ROOT);
+  }
+
   private static Set<String> urnsInFilter(Filter filter) {
     Set<String> urns = new HashSet<>();
     for (ConjunctiveCriterion orClause : filter.getOr()) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallbackTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/client/MembershipGraphScrollFallbackTest.java
@@ -299,10 +299,10 @@ public class MembershipGraphScrollFallbackTest {
   }
 
   @Test
-  public void listRelatedScrollsRoleReverseToUsers() {
+  public void listRelatedScrollsRoleReverseToUsersAndGroups() {
     GraphRetriever graphRetriever = mock(GraphRetriever.class);
     when(graphRetriever.scrollRelatedEntities(
-            eq(Set.of(CORP_USER_ENTITY_NAME)),
+            eq(Set.of(CORP_USER_ENTITY_NAME, CORP_GROUP_ENTITY_NAME)),
             isNull(),
             eq(Set.of(DATAHUB_ROLE_ENTITY_NAME)),
             any(),
@@ -315,13 +315,19 @@ public class MembershipGraphScrollFallbackTest {
             isNull()))
         .thenReturn(
             new RelatedEntitiesScrollResult(
-                1,
-                1,
+                2,
+                2,
                 null,
                 List.of(
                     new RelatedEntities(
                         IS_MEMBER_OF_ROLE_RELATIONSHIP_NAME,
                         USER.toString(),
+                        ROLE.toString(),
+                        RelationshipDirection.OUTGOING,
+                        null),
+                    new RelatedEntities(
+                        IS_MEMBER_OF_ROLE_RELATIONSHIP_NAME,
+                        GROUP.toString(),
                         ROLE.toString(),
                         RelationshipDirection.OUTGOING,
                         null))));
@@ -339,7 +345,12 @@ public class MembershipGraphScrollFallbackTest {
             10);
 
     assertTrue(result.isHit());
-    assertEquals(result.neighborsOrEmpty().get(0).neighborUrn(), USER.toString());
+    assertEquals(result.neighborsOrEmpty().size(), 2);
+    assertEquals(
+        result.neighborsOrEmpty().stream()
+            .map(MembershipNeighborResult.Neighbor::neighborUrn)
+            .toList(),
+        List.of(USER.toString(), GROUP.toString()));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/EntityGraphCacheServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/EntityGraphCacheServiceTest.java
@@ -262,7 +262,7 @@ public class EntityGraphCacheServiceTest {
   }
 
   @Test
-  public void expandReturnsHitForPresentSeedsWhenSomeSeedsMissingFromFullSnapshot() {
+  public void expandMissesWhenSomeSeedsMissingFromFullSnapshot() {
     String root = "urn:li:domain:root";
     String child = "urn:li:domain:child";
     String missing = "urn:li:domain:missing";
@@ -293,13 +293,20 @@ public class EntityGraphCacheServiceTest {
     when(distributedStore.getGeneration(CACHE_KEY)).thenReturn(1L);
     when(localViews.get(CACHE_KEY, 1L)).thenReturn(Optional.of(new EntityGraphView(edges)));
 
-    Set<String> expanded =
-        expandCached(
-            service, GRAPH_ID, SOURCE, TraversalDirection.REVERSE, Set.of(root, missing), 100);
+    GraphReadResult result =
+        service.expand(
+            GRAPH_ID,
+            SOURCE,
+            TraversalDirection.REVERSE,
+            Set.of(root, missing),
+            100,
+            EntityGraphCache.USE_DEFINITION_MAX_DEPTH,
+            ReadMode.CACHED);
 
-    assertTrue(expanded.contains(root));
-    assertTrue(expanded.contains(child));
-    assertFalse(expanded.contains(missing));
+    // Fail closed: mixed present+absent must not return a partial HIT expanding only present roots.
+    assertTrue(result.isMiss());
+    assertEquals(((GraphReadResult.Miss) result).reason(), ReadMissReason.ABSENT);
+    assertTrue(result.verticesOrEmpty().isEmpty());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackendAbsentSeedTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackendAbsentSeedTest.java
@@ -49,6 +49,10 @@ public class GraphReadBackendAbsentSeedTest {
   }
 
   private static GraphReadResult expand(String seed) {
+    return expand(Set.of(seed));
+  }
+
+  private static GraphReadResult expand(Set<String> seeds) {
     GraphReadBackend backend = new GraphReadBackend(null, null, null, null, null, null);
     EntityGraphView view = viewWithoutAbsentSeed();
     GraphComponentContext component =
@@ -56,7 +60,7 @@ public class GraphReadBackendAbsentSeedTest {
     return backend.expandFromView(
         DEFINITION,
         TraversalDirection.REVERSE,
-        Set.of(seed),
+        seeds,
         Integer.MAX_VALUE,
         15,
         view,
@@ -67,6 +71,16 @@ public class GraphReadBackendAbsentSeedTest {
   public void expandMissesWhenSeedAbsentFromSnapshot() {
     GraphReadResult result = expand(ABSENT);
     assertFalse(result.isHit(), "absent seed must not be served as an authoritative empty hit");
+    assertTrue(result.isMiss());
+    assertEquals(((GraphReadResult.Miss) result).reason(), ReadMissReason.ABSENT);
+  }
+
+  @Test
+  public void expandMissesWhenAnyMultiRootSeedAbsentFromSnapshot() {
+    // Mixed present+absent must not return a partial HIT that expands only PRESENT — callers
+    // (VBAC / policy ancestor paths) would treat that as complete and skip live fallback.
+    GraphReadResult result = expand(Set.of(PRESENT, ABSENT));
+    assertFalse(result.isHit(), "mixed absent seed must not be served as a partial hit");
     assertTrue(result.isMiss());
     assertEquals(((GraphReadResult.Miss) result).reason(), ReadMissReason.ABSENT);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackendAbsentSeedTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/cache/service/read/GraphReadBackendAbsentSeedTest.java
@@ -1,0 +1,82 @@
+package com.linkedin.metadata.graph.cache.service.read;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.metadata.config.entitygraph.EntityGraphCacheProperties.ScopeMode;
+import com.linkedin.metadata.graph.cache.GraphReadResult;
+import com.linkedin.metadata.graph.cache.ReadMissReason;
+import com.linkedin.metadata.graph.cache.TraversalDirection;
+import com.linkedin.metadata.graph.cache.config.EntityGraphModel.EntityGraphDefinition;
+import com.linkedin.metadata.graph.cache.config.EntityGraphModel.EntityGraphScope;
+import com.linkedin.metadata.graph.cache.service.internal.GraphComponentContext;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphSnapshot.DirectedEdge;
+import com.linkedin.metadata.graph.cache.snapshot.EntityGraphView;
+import com.linkedin.metadata.graph.cache.snapshot.TraversalCoverage;
+import java.util.List;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+/**
+ * A hierarchy seed that is absent from the snapshot must produce a cache MISS (so callers fall back
+ * to the live graph), not an empty HIT that is trusted as authoritative. The membership read path
+ * already guards this ({@code listRelatedFromView}); the hierarchy expand path must match it.
+ * Otherwise a domain/container/glossary created or re-parented by a write that did not pass the
+ * sync gate (async ingest, non-UI REST) reads back with empty parents/children and empty VBAC
+ * ancestor expansion until the snapshot rebuilds.
+ */
+public class GraphReadBackendAbsentSeedTest {
+
+  private static final EntityGraphDefinition DEFINITION =
+      EntityGraphDefinition.builder()
+          .graphId("container")
+          .scope(EntityGraphScope.builder().mode(ScopeMode.PARTIAL).maxDepth(15).build())
+          .build();
+
+  private static final String CHILD = "urn:li:container:child";
+  private static final String PRESENT = "urn:li:container:present";
+  private static final String ABSENT = "urn:li:container:absent";
+
+  private static EntityGraphView viewWithoutAbsentSeed() {
+    return new EntityGraphView(
+        List.of(
+            DirectedEdge.builder()
+                .sourceUrn(CHILD)
+                .destinationUrn(PRESENT)
+                .relationshipType("IsPartOf")
+                .build()));
+  }
+
+  private static GraphReadResult expand(String seed) {
+    GraphReadBackend backend = new GraphReadBackend(null, null, null, null, null, null);
+    EntityGraphView view = viewWithoutAbsentSeed();
+    GraphComponentContext component =
+        new GraphComponentContext(view, TraversalCoverage.fullComplete(), "key");
+    return backend.expandFromView(
+        DEFINITION,
+        TraversalDirection.REVERSE,
+        Set.of(seed),
+        Integer.MAX_VALUE,
+        15,
+        view,
+        List.of(component));
+  }
+
+  @Test
+  public void expandMissesWhenSeedAbsentFromSnapshot() {
+    GraphReadResult result = expand(ABSENT);
+    assertFalse(result.isHit(), "absent seed must not be served as an authoritative empty hit");
+    assertTrue(result.isMiss());
+    assertEquals(((GraphReadResult.Miss) result).reason(), ReadMissReason.ABSENT);
+  }
+
+  @Test
+  public void expandReturnsEmptyHitWhenSeedPresentButHasNoChildren() {
+    // CHILD is a vertex in the snapshot but has no incoming (reverse) neighbors: a legitimate leaf.
+    // This must stay a HIT so the guard does not turn every childless node into a live fallback.
+    GraphReadResult result = expand(CHILD);
+    assertTrue(result.isHit(), "present leaf seed must remain an authoritative empty hit");
+    assertTrue(result.verticesOrEmpty().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

The entity-graph cache read path returns **incomplete relationship results as if they were complete** in three independent cases. Each is a spot where a cache/snapshot fast-path silently diverges from the correct live-graph result. All three are fixed here, each behind a test that fails without the change.

1. **Role member listing drops group grants.** `dataHubRole.relationships(types:["IsMemberOfRole"], direction:INCOMING)` was routed to the membership cache, whose reverse role lookup is user-only — group-based role grants were silently omitted (e.g. "who has this role" showed only users). Removed that shape from `isMembershipQuery` so it falls through to the live graph, which returns users **and** groups.

2. **Absent-seed hierarchy reads trusted as authoritative.** `GraphReadBackend.expandFromView` returned an empty result for a seed absent from the snapshot as an authoritative hit instead of falling back to the live graph. It now reports `ABSENT` when no root is present in the snapshot, mirroring the existing membership guard in `listRelatedFromView`. This affects `parentContainers`/`parentDomains`/`parentNodes`, direct-children listings, and VBAC/policy ancestor expansion when an entity was created or re-parented by a write that did not pass the sync gate and is read within the staleness window.

3. **Descendant-expansion fallback swallowed truncation.** `GraphScrollFallback.allDescendants` (used to build search access-control filters) ignored the truncation flag set when a frontier scroll fails, returning a partial descendant set as complete and under-restricting access. It now fails closed on truncation.

## Testing

- New/updated tests, each failing without its fix:
  - `EntityRelationshipsResultResolverTest#testDataHubRoleIncomingMembersIncludeGroupsViaLiveGraph`
  - `GraphReadBackendAbsentSeedTest` (absent seed → `Miss`; present leaf → empty hit)
  - `GraphScrollFallbackTest#allDescendantsFailsClosedOnScrollTruncation`
- `:metadata-io:test` and `:datahub-graphql-core:test` for the affected classes: BUILD SUCCESSFUL. Spotless clean on both modules.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the entity-graph cache read path so it stops returning incomplete relationship results as if they were complete.

**Bug Fixes**
- `dataHubRole` INCOMING `IsMemberOfRole` now scrolls both `corpuser` and `corpGroup` sources on the membership path, so group grants appear alongside users instead of being dropped.
- Membership reads passing `relatedEntityTypes` now fetch up to the membership graph's `maxEdges` cap before filtering and paginating, failing closed when the listing exceeds the cap; session-user membership reads now filter before paginating.
- `GraphReadBackend.expandFromView` now reports `ABSENT` when a seed is missing from the snapshot, falling back to the live graph for parent/child and ancestor-expansion reads.
- `GraphScrollFallback.allDescendants` now throws on truncation instead of returning a partial descendant set that under-restricts search access-control filters.

<sup>Written for commit 233d10995684b70078caf636bb6c561884b4e2f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

