### PR TITLE
diag(ingest/sigma): identify what the parentId walk lands on [DO NOT MERGE]

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -17,6 +17,7 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
+from datahub.utilities.lossy_collections import LossyList
 
 
 class Constant:
@@ -172,6 +173,20 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
 
     number_of_files_metadata: Dict[str, int] = field(default_factory=dict)
     empty_workspaces: List[str] = field(default_factory=list)
+
+    # DIAGNOSTIC ONLY -- do not merge.
+    # What the ``parentId`` walk landed on, per outcome:
+    #   workspace         -- correct; the walk found a known workspace
+    #   folder-alias      -- landed on a FOLDER that Sigma resolves to another
+    #                        workspace, so entities are parented under a
+    #                        Container nothing ever names (the "undershoot")
+    #   root-sentinel     -- climbed to the root of the tree (the "overshoot")
+    #   walk-failed       -- climbed past the root and 404'd
+    #   forbidden         -- terminal id returns 403
+    #   workspace-unlisted-- resolves to itself but was not in /workspaces
+    diag_walk_outcomes: Dict[str, int] = field(default_factory=dict)
+    # One line per non-"workspace" outcome, sampled.
+    diag_walk_examples: LossyList[str] = field(default_factory=LossyList)
 
     # Sheet upstream skipped because the upstream element was filtered out
     # of the chart map (e.g. pivot-table blocked by page-element allowlist).

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -52,6 +52,10 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
+# DIAGNOSTIC ONLY -- do not merge. Sigma reports this id as the parent of every
+# top-level workspace, i.e. the root of the file tree.
+DIAG_ROOT_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
 
 class SigmaAPI:
     def __init__(self, config: SigmaSourceConfig, report: SigmaSourceReport) -> None:
@@ -219,6 +223,7 @@ class SigmaAPI:
     def get_workspace_id_from_file_path(
         self, parent_id: str, path: str
     ) -> Optional[str]:
+        hops = 0
         try:
             path_list = path.split("/")
             while len(path_list) != 1:  # means current parent id is folder's id
@@ -228,12 +233,60 @@ class SigmaAPI:
                 response.raise_for_status()
                 parent_id = response.json()[Constant.PARENTID]
                 path_list.pop()
+                hops += 1
+            self._diag_record(path, hops, parent_id)
             return parent_id
         except Exception as e:
+            self._diag_record(path, hops, None)
             logger.error(
                 f"Unable to find workspace id using file path '{path}'. Exception: {e}"
             )
             return None
+
+    # ---------------------------------------------------------------- diag
+    # DIAGNOSTIC ONLY -- do not merge. Answers one question: when the
+    # ``parentId`` walk finishes, has it landed on a workspace or on something
+    # else? Nothing below changes what the connector emits.
+
+    @functools.lru_cache(maxsize=None)
+    def _diag_classify(self, terminal_id: str) -> str:
+        """What kind of node did the walk stop on?
+
+        Deliberately does not use ``get_workspace``: that populates
+        ``self.workspaces`` and would change behaviour. Cached per id, so this
+        costs at most one extra call per distinct terminal (bounded by the
+        number of workspaces, not by the number of files).
+        """
+        if terminal_id == DIAG_ROOT_SENTINEL:
+            return "root-sentinel"
+        if terminal_id in self.workspaces:
+            return "workspace"
+        try:
+            r = self._get_api_call(f"{self.config.api_url}/workspaces/{terminal_id}")
+            if r.status_code == 403:
+                return "forbidden"
+            r.raise_for_status()
+            answered = r.json().get(Constant.WORKSPACEID)
+            if answered and answered != terminal_id:
+                return "folder-alias"
+            return "workspace-unlisted"
+        except Exception:
+            return "unresolved"
+
+    def _diag_record(self, path: str, hops: int, terminal_id: Optional[str]) -> None:
+        kind = (
+            "walk-failed" if terminal_id is None else self._diag_classify(terminal_id)
+        )
+        self.report.diag_walk_outcomes[kind] = (
+            self.report.diag_walk_outcomes.get(kind, 0) + 1
+        )
+        detail = (
+            f"kind={kind} segments={len(path.split('/')) if path else 0} "
+            f"hops={hops} terminal={terminal_id} path={path!r}"
+        )
+        if kind != "workspace":
+            self.report.diag_walk_examples.append(detail)
+        logger.info("sigma-diag walk %s", detail)
 
     @functools.lru_cache
     def _get_files_metadata(self, file_type: str) -> Dict[str, File]:

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -288,6 +288,31 @@ class SigmaAPI:
             self.report.diag_walk_examples.append(detail)
         logger.info("sigma-diag walk %s", detail)
 
+    def _diag_verdict(self, file_type: str) -> None:
+        """Print the answer as soon as a file type is walked, not at the end.
+
+        Every walk happens inside ``_get_files_metadata``, which runs in the
+        first minutes of a run. Waiting for the final report would mean waiting
+        for the whole ingestion -- over seven hours on the tenant this targets.
+        Logged at WARNING when anything landed somewhere other than a
+        workspace, so it survives an INFO-filtered log and is greppable.
+        """
+        outcomes = dict(self.report.diag_walk_outcomes)
+        bad = {k: v for k, v in outcomes.items() if k != "workspace"}
+        banner = f"sigma-diag VERDICT after file_type={file_type}: {outcomes or '{}'}"
+        if not bad:
+            logger.info("%s -- all walks landed on a workspace so far", banner)
+            return
+        logger.warning(
+            "%s -- %d walk(s) did NOT land on a workspace. "
+            "folder-alias => entities are parented under a Container nothing "
+            "names; root-sentinel/walk-failed => the walk climbed past the "
+            "workspace. Examples: %s",
+            banner,
+            sum(bad.values()),
+            list(self.report.diag_walk_examples)[:5],
+        )
+
     @functools.lru_cache
     def _get_files_metadata(self, file_type: str) -> Dict[str, File]:
         logger.debug(f"Fetching file metadata with type {file_type}.")
@@ -311,8 +336,10 @@ class SigmaAPI:
                 else:
                     break
             self.report.number_of_files_metadata[file_type] = len(files_metadata)
+            self._diag_verdict(file_type)
             return files_metadata
         except Exception as e:
+            self._diag_verdict(file_type)
             self._log_http_error(
                 message=f"Unable to fetch files metadata. Exception: {e}"
             )


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — diagnostic build only

Opened so CI publishes a wheel. This adds logging and nothing else; it should be closed once the question below is answered.

## The question

`get_workspace_id_from_file_path` decides how far to climb the folder tree by counting `/` separators in an asset's `path`:

```python
path_list = path.split("/")
while len(path_list) != 1:
    parent_id = GET(f"/files/{parent_id}")["parentId"]
    path_list.pop()
return parent_id
```

When that count disagrees with the real depth, the walk ends somewhere other than a workspace — and it can be wrong in **two directions**, with different consequences:

- **too few hops** → stops on a *folder*. Entities get parented under a Container URN nothing ever names, which the UI renders as a raw `urn:li:container:<guid>`.
- **too many hops** → climbs past the workspace to the root of the tree. The asset ends up with no workspace and is dropped.

**Both fail silently today**, so neither is visible in a customer's logs. Two full ingestion logs from an affected tenant showed no direct evidence of either, which is why this exists rather than a guess.

## What it adds

Classifies the terminal node of every walk and counts the outcomes:

| outcome | meaning |
|---|---|
| `workspace` | the walk was correct |
| `folder-alias` | ended on a folder Sigma resolves to another workspace — **the undershoot** |
| `root-sentinel` | climbed to the root of the tree — **the overshoot** |
| `walk-failed` | climbed past the root and 404'd |
| `forbidden` | terminal id returns 403 |
| `workspace-unlisted` | resolves to itself but was absent from `/workspaces` |

Surfaced two ways — a per-walk `INFO` line, and a report summary:

```
'diag_walk_outcomes': {'workspace': 412, 'folder-alias': 37},
'diag_walk_examples': ["kind=folder-alias segments=1 hops=0 terminal=… path='…'"],
```

## Safety

- **No behaviour change.** The walk returns exactly what it returned before. The full sigma suite passes unchanged at **392**.
- **No meaningful runtime cost.** The classifier is cached per terminal id, so it adds at most one call per distinct *workspace* — not per file. This targets a tenant whose ingestion already runs over seven hours, so that mattered.
- **Read-only**, and it deliberately avoids `get_workspace`, which would populate `self.workspaces` and change behaviour.
- Verified against a live Sigma instance: a healthy tenant reports `{'workspace': 2}` with no examples.

## How the result is used

- `folder-alias` present → the undershoot is real; #19453 fixes it.
- only `root-sentinel` / `walk-failed` → the overshoot is their problem; #19453 does **not** fix it and a different change is needed.
- all `workspace` → the walk is fine and the symptom has another cause.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds diagnostic logging to the Sigma ingestion `parentId` walk to identify why assets sometimes end up without a workspace or under an unnamed container. This is a diagnostic build only — do not merge.

The walk still returns exactly what it returned before. The classifier is cached per terminal id, so it adds at most one extra call per distinct workspace. It logs one line per walk, sampled non-`workspace` outcomes, and a running verdict after each file type is walked — at WARNING if any walk missed a workspace, so the answer is available early instead of after the full run.

**How to read the results**
- `folder-alias` means the walk undershoots and stops on a folder; issue #19453 should fix it.
- `root-sentinel` or `walk-failed` means the walk overshoots past the workspace; #19453 won't fix it.
- All `workspace` means the walk is fine and the symptom has another cause.

<sup>Written for commit e044587fcd8610a3dbccd5be650ccd5f543f4328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

