### PR TITLE
perf(ingest/aws): cache the S3 resource per thread

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -3,7 +3,18 @@ import threading
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from urllib.parse import parse_qs, urlparse
 
 import boto3
@@ -42,6 +53,9 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client, S3ServiceResource
     from mypy_boto3_sagemaker import SageMakerClient
     from mypy_boto3_sts import STSClient
+
+_S3CacheKeyT = TypeVar("_S3CacheKeyT")
+_S3CacheValueT = TypeVar("_S3CacheValueT")
 
 
 class AwsEnvironment(Enum):
@@ -273,12 +287,17 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
-    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
-    # shared across threads; only construction is guarded by the lock.
+    # boto3 clients are thread-safe (Sessions are not), so the client cache is keyed
+    # by verify_ssl alone and shared across threads. boto3 resources are NOT
+    # thread-safe, so the resource cache is keyed by (thread id, verify_ssl) to hand
+    # each thread its own instance. One lock guards both caches (shared invalidation).
     _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
         default_factory=dict
     )
-    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _s3_resource_cache: Dict[
+        Tuple[int, Optional[Union[bool, str]]], "S3ServiceResource"
+    ] = PrivateAttr(default_factory=dict)
+    _s3_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -466,50 +485,81 @@ class AwsConnectionConfig(ConfigModel):
             **self.aws_advanced_config,
         )
 
+    def _invalidate_s3_caches_if_stale(self) -> None:
+        # Caller must hold self._s3_lock. _cached_credentials is set only when a role
+        # was actually assumed (see get_session); that is the one path whose static
+        # creds expire. Guard on it rather than on aws_role merely being configured,
+        # else a role that matches the ambient identity (never assumed, so no expiry
+        # recorded) would rebuild on every call. Both caches share these credentials,
+        # so both are dropped together (the resource cache is cleared for all threads;
+        # each thread lazily rebuilds its own entry).
+        if self._cached_credentials is not None and self._should_refresh_credentials():
+            self._s3_client_cache.clear()
+            self._s3_resource_cache.clear()
+
+    def _get_or_build_cached(
+        self,
+        cache: Dict[_S3CacheKeyT, _S3CacheValueT],
+        key: _S3CacheKeyT,
+        build: Callable[[], _S3CacheValueT],
+    ) -> _S3CacheValueT:
+        # Serializes construction and applies the shared invalidation rule to both
+        # the client and resource caches. Keeps the lock + cache invariants in one
+        # place so the two get_s3_* paths cannot drift apart.
+        with self._s3_lock:
+            self._invalidate_s3_caches_if_stale()
+            if key not in cache:
+                cache[key] = build()
+            return cache[key]
+
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
         # Building a session + client per call is expensive (fresh TLS pool and
-        # credential resolution, ~seconds with an SSO profile), so memoize the
-        # client per verify_ssl value. Manually-assumed role credentials are
-        # static, so drop cached clients once those credentials need a refresh;
-        # profile and explicit-key sessions self-refresh inside botocore.
-        with self._s3_client_lock:
-            # _cached_credentials is set only when a role was actually assumed (see
-            # get_session); that is the one path whose static creds expire. Guard on
-            # it rather than on aws_role merely being configured, else a role that
-            # matches the ambient identity (never assumed, so no expiry recorded)
-            # would rebuild the client on every call.
-            if (
-                self._cached_credentials is not None
-                and self._should_refresh_credentials()
-            ):
-                self._s3_client_cache.clear()
-            if verify_ssl not in self._s3_client_cache:
-                self._s3_client_cache[verify_ssl] = self.get_session().client(
-                    "s3",
-                    endpoint_url=self.aws_endpoint_url,
-                    config=self._aws_config(),
-                    verify=verify_ssl,
-                )
-            return self._s3_client_cache[verify_ssl]
+        # credential resolution, ~seconds with an SSO profile), so memoize the client
+        # per verify_ssl. boto3 clients are thread-safe, so the cached client is
+        # shared across threads; profile and explicit-key sessions self-refresh inside
+        # botocore, and assumed-role credentials are handled by the cache invalidation.
+        return self._get_or_build_cached(
+            self._s3_client_cache,
+            verify_ssl,
+            lambda: self.get_session().client(
+                "s3",
+                endpoint_url=self.aws_endpoint_url,
+                config=self._aws_config(),
+                verify=verify_ssl,
+            ),
+        )
 
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3ServiceResource":
-        resource = self.get_session().resource(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
+        # boto3 resources are NOT thread-safe, so key the cache by thread id as well
+        # as verify_ssl: each thread gets its own resource rather than sharing one.
+        # (The GCS OAuth subclass re-applies its before-send handlers on the returned
+        # resource's client each call, but those register with botocore unique_ids so
+        # re-application on a cached resource is a no-op — see
+        # _register_gcs_oauth_before_send.)
+        def build() -> "S3ServiceResource":
+            resource = self.get_session().resource(
+                "s3",
+                endpoint_url=self.aws_endpoint_url,
+                config=self._aws_config(),
+                verify=verify_ssl,
+            )
+            # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
+            # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
+            # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
+            # to override the functionality rather than removing it altogether.
+            if self.aws_endpoint_url is not None and self.aws_proxy is not None:
+                resource.meta.client.meta.events.unregister(
+                    "before-sign.s3", fix_s3_host
+                )
+            return resource
+
+        return self._get_or_build_cached(
+            self._s3_resource_cache, (threading.get_ident(), verify_ssl), build
         )
-        # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
-        # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
-        # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
-        # to override the functionality rather than removing it altogether.
-        if self.aws_endpoint_url is not None and self.aws_proxy is not None:
-            resource.meta.client.meta.events.unregister("before-sign.s3", fix_s3_host)
-        return resource
 
     def get_glue_client(self) -> "GlueClient":
         # TODO: apply aws_endpoint_url consistently across all service clients (and

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from http import HTTPStatus
@@ -11,6 +12,7 @@ from boto3.session import Session
 from botocore.config import DEFAULT_TIMEOUT, Config
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 from botocore.utils import fix_s3_host
+from pydantic import PrivateAttr
 from pydantic.fields import Field
 
 from datahub.configuration.common import (
@@ -271,6 +273,12 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
+    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
+    # shared across threads; only construction is guarded by the lock.
+    _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
+        default_factory=dict
+    )
+    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -461,12 +469,22 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
-        return self.get_session().client(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
-        )
+        # Building a session + client per call is expensive (fresh TLS pool and
+        # credential resolution, ~seconds with an SSO profile), so memoize the
+        # client per verify_ssl value. Manually-assumed role credentials are
+        # static, so drop cached clients once those credentials need a refresh;
+        # profile and explicit-key sessions self-refresh inside botocore.
+        with self._s3_client_lock:
+            if self._normalized_aws_roles() and self._should_refresh_credentials():
+                self._s3_client_cache.clear()
+            if verify_ssl not in self._s3_client_cache:
+                self._s3_client_cache[verify_ssl] = self.get_session().client(
+                    "s3",
+                    endpoint_url=self.aws_endpoint_url,
+                    config=self._aws_config(),
+                    verify=verify_ssl,
+                )
+            return self._s3_client_cache[verify_ssl]
 
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -273,16 +273,12 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
-    # boto3 clients and resources are thread-safe (Sessions are not), so cached
-    # instances may be shared across threads; only construction is guarded by the
-    # lock. A single lock covers both caches since they share one invalidation rule.
+    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
+    # shared across threads; only construction is guarded by the lock.
     _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
         default_factory=dict
     )
-    _s3_resource_cache: Dict[Optional[Union[bool, str]], "S3ServiceResource"] = (
-        PrivateAttr(default_factory=dict)
-    )
-    _s3_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -470,27 +466,25 @@ class AwsConnectionConfig(ConfigModel):
             **self.aws_advanced_config,
         )
 
-    def _invalidate_s3_caches_if_stale(self) -> None:
-        # Caller must hold self._s3_lock. _cached_credentials is set only when a role
-        # was actually assumed (see get_session); that is the one path whose static
-        # creds expire. Guard on it rather than on aws_role merely being configured,
-        # else a role that matches the ambient identity (never assumed, so no expiry
-        # recorded) would rebuild on every call. Both caches share these credentials,
-        # so both are dropped together.
-        if self._cached_credentials is not None and self._should_refresh_credentials():
-            self._s3_client_cache.clear()
-            self._s3_resource_cache.clear()
-
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
         # Building a session + client per call is expensive (fresh TLS pool and
         # credential resolution, ~seconds with an SSO profile), so memoize the
-        # client per verify_ssl value; profile and explicit-key sessions self-refresh
-        # inside botocore, and assumed-role credentials are handled by the cache
-        # invalidation above.
-        with self._s3_lock:
-            self._invalidate_s3_caches_if_stale()
+        # client per verify_ssl value. Manually-assumed role credentials are
+        # static, so drop cached clients once those credentials need a refresh;
+        # profile and explicit-key sessions self-refresh inside botocore.
+        with self._s3_client_lock:
+            # _cached_credentials is set only when a role was actually assumed (see
+            # get_session); that is the one path whose static creds expire. Guard on
+            # it rather than on aws_role merely being configured, else a role that
+            # matches the ambient identity (never assumed, so no expiry recorded)
+            # would rebuild the client on every call.
+            if (
+                self._cached_credentials is not None
+                and self._should_refresh_credentials()
+            ):
+                self._s3_client_cache.clear()
             if verify_ssl not in self._s3_client_cache:
                 self._s3_client_cache[verify_ssl] = self.get_session().client(
                     "s3",
@@ -503,29 +497,19 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3ServiceResource":
-        # Memoized per verify_ssl like get_s3_client. The GCS OAuth subclass
-        # re-applies its before-send handlers on the returned resource's client each
-        # call, but those register with botocore unique_ids so re-application on a
-        # cached resource is a no-op (see _register_gcs_oauth_before_send).
-        with self._s3_lock:
-            self._invalidate_s3_caches_if_stale()
-            if verify_ssl not in self._s3_resource_cache:
-                resource = self.get_session().resource(
-                    "s3",
-                    endpoint_url=self.aws_endpoint_url,
-                    config=self._aws_config(),
-                    verify=verify_ssl,
-                )
-                # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
-                # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
-                # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
-                # to override the functionality rather than removing it altogether.
-                if self.aws_endpoint_url is not None and self.aws_proxy is not None:
-                    resource.meta.client.meta.events.unregister(
-                        "before-sign.s3", fix_s3_host
-                    )
-                self._s3_resource_cache[verify_ssl] = resource
-            return self._s3_resource_cache[verify_ssl]
+        resource = self.get_session().resource(
+            "s3",
+            endpoint_url=self.aws_endpoint_url,
+            config=self._aws_config(),
+            verify=verify_ssl,
+        )
+        # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
+        # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
+        # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
+        # to override the functionality rather than removing it altogether.
+        if self.aws_endpoint_url is not None and self.aws_proxy is not None:
+            resource.meta.client.meta.events.unregister("before-sign.s3", fix_s3_host)
+        return resource
 
     def get_glue_client(self) -> "GlueClient":
         # TODO: apply aws_endpoint_url consistently across all service clients (and

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -273,12 +273,16 @@ class AwsConnectionConfig(ConfigModel):
 
     _credentials_expiration: Optional[datetime] = None
     _cached_credentials: Optional[dict] = None
-    # boto3 clients are thread-safe (Sessions are not), so cached clients may be
-    # shared across threads; only construction is guarded by the lock.
+    # boto3 clients and resources are thread-safe (Sessions are not), so cached
+    # instances may be shared across threads; only construction is guarded by the
+    # lock. A single lock covers both caches since they share one invalidation rule.
     _s3_client_cache: Dict[Optional[Union[bool, str]], "S3Client"] = PrivateAttr(
         default_factory=dict
     )
-    _s3_client_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
+    _s3_resource_cache: Dict[Optional[Union[bool, str]], "S3ServiceResource"] = (
+        PrivateAttr(default_factory=dict)
+    )
+    _s3_lock: threading.Lock = PrivateAttr(default_factory=threading.Lock)
 
     aws_access_key_id: Optional[str] = Field(
         default=None,
@@ -466,17 +470,27 @@ class AwsConnectionConfig(ConfigModel):
             **self.aws_advanced_config,
         )
 
+    def _invalidate_s3_caches_if_stale(self) -> None:
+        # Caller must hold self._s3_lock. _cached_credentials is set only when a role
+        # was actually assumed (see get_session); that is the one path whose static
+        # creds expire. Guard on it rather than on aws_role merely being configured,
+        # else a role that matches the ambient identity (never assumed, so no expiry
+        # recorded) would rebuild on every call. Both caches share these credentials,
+        # so both are dropped together.
+        if self._cached_credentials is not None and self._should_refresh_credentials():
+            self._s3_client_cache.clear()
+            self._s3_resource_cache.clear()
+
     def get_s3_client(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3Client":
         # Building a session + client per call is expensive (fresh TLS pool and
         # credential resolution, ~seconds with an SSO profile), so memoize the
-        # client per verify_ssl value. Manually-assumed role credentials are
-        # static, so drop cached clients once those credentials need a refresh;
-        # profile and explicit-key sessions self-refresh inside botocore.
-        with self._s3_client_lock:
-            if self._normalized_aws_roles() and self._should_refresh_credentials():
-                self._s3_client_cache.clear()
+        # client per verify_ssl value; profile and explicit-key sessions self-refresh
+        # inside botocore, and assumed-role credentials are handled by the cache
+        # invalidation above.
+        with self._s3_lock:
+            self._invalidate_s3_caches_if_stale()
             if verify_ssl not in self._s3_client_cache:
                 self._s3_client_cache[verify_ssl] = self.get_session().client(
                     "s3",
@@ -489,19 +503,29 @@ class AwsConnectionConfig(ConfigModel):
     def get_s3_resource(
         self, verify_ssl: Optional[Union[bool, str]] = None
     ) -> "S3ServiceResource":
-        resource = self.get_session().resource(
-            "s3",
-            endpoint_url=self.aws_endpoint_url,
-            config=self._aws_config(),
-            verify=verify_ssl,
-        )
-        # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
-        # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
-        # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
-        # to override the functionality rather than removing it altogether.
-        if self.aws_endpoint_url is not None and self.aws_proxy is not None:
-            resource.meta.client.meta.events.unregister("before-sign.s3", fix_s3_host)
-        return resource
+        # Memoized per verify_ssl like get_s3_client. The GCS OAuth subclass
+        # re-applies its before-send handlers on the returned resource's client each
+        # call, but those register with botocore unique_ids so re-application on a
+        # cached resource is a no-op (see _register_gcs_oauth_before_send).
+        with self._s3_lock:
+            self._invalidate_s3_caches_if_stale()
+            if verify_ssl not in self._s3_resource_cache:
+                resource = self.get_session().resource(
+                    "s3",
+                    endpoint_url=self.aws_endpoint_url,
+                    config=self._aws_config(),
+                    verify=verify_ssl,
+                )
+                # according to: https://stackoverflow.com/questions/32618216/override-s3-endpoint-using-boto3-configuration-file
+                # boto3 only reads the signature version for s3 from that config file. boto3 automatically changes the endpoint to
+                # your_bucket_name.s3.amazonaws.com when it sees fit. If you'll be working with both your own host and s3, you may wish
+                # to override the functionality rather than removing it altogether.
+                if self.aws_endpoint_url is not None and self.aws_proxy is not None:
+                    resource.meta.client.meta.events.unregister(
+                        "before-sign.s3", fix_s3_host
+                    )
+                self._s3_resource_cache[verify_ssl] = resource
+            return self._s3_resource_cache[verify_ssl]
 
     def get_glue_client(self) -> "GlueClient":
         # TODO: apply aws_endpoint_url consistently across all service clients (and

--- a/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gcs/gcs_source.py
@@ -84,7 +84,11 @@ def _register_gcs_oauth_before_send(
             request.headers["x-goog-project-id"] = project_id
 
     for op in _GCS_OAUTH_S3_OPERATIONS:
-        client.meta.events.register(f"before-send.s3.{op}", inject_bearer)
+        # unique_id makes re-registration a no-op: get_s3_client() memoizes the
+        # client, so repeated calls would otherwise stack duplicate handlers.
+        client.meta.events.register(
+            f"before-send.s3.{op}", inject_bearer, unique_id=f"datahub-gcs-oauth-{op}"
+        )
 
 
 class GCSOAuthAwsConnectionConfig(AwsConnectionConfig):

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -526,6 +526,64 @@ class TestAwsCommon:
             # assume_role should only be called once
             assert mock_assume_role.call_count == 1
 
+    def test_get_s3_client_cached_per_verify_ssl(self):
+        """
+        get_s3_client() memoizes the built client: repeated calls on the same
+        instance return the same object, and each verify_ssl value gets its
+        own client.
+        """
+        config = AwsConnectionConfig(
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            aws_region="us-east-1",
+        )
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            client1 = config.get_s3_client()
+            client2 = config.get_s3_client()
+            assert client1 is client2
+            # Only one session/client construction for the repeated call
+            assert mock_get_session.call_count == 1
+
+            client3 = config.get_s3_client(verify_ssl=False)
+            assert client3 is not client1
+            assert mock_get_session.call_count == 2
+            assert config.get_s3_client(verify_ssl=False) is client3
+
+    def test_get_s3_client_rebuilt_when_role_credentials_need_refresh(self):
+        """
+        With assumed roles configured, cached clients hold static credentials,
+        so the client must be rebuilt once the credentials need a refresh.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+
+        with (
+            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
+            patch.object(
+                AwsConnectionConfig, "_should_refresh_credentials"
+            ) as mock_should_refresh,
+        ):
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            mock_should_refresh.return_value = False
+            client1 = config.get_s3_client()
+            assert config.get_s3_client() is client1
+            assert mock_get_session.call_count == 1
+
+            mock_should_refresh.return_value = True
+            client2 = config.get_s3_client()
+            assert client2 is not client1
+            assert mock_get_session.call_count == 2
+
     @mock_aws
     def test_role_assumption_without_caching_before_fix(self):
         """

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -556,13 +556,21 @@ class TestAwsCommon:
 
     def test_get_s3_client_rebuilt_when_role_credentials_need_refresh(self):
         """
-        With assumed roles configured, cached clients hold static credentials,
-        so the client must be rebuilt once the credentials need a refresh.
+        Once a role has actually been assumed, the cached client holds static
+        credentials, so it must be rebuilt when those credentials need a refresh.
         """
         config = AwsConnectionConfig(
             aws_region="us-east-1",
             aws_role="arn:aws:iam::123456789012:role/test-role",
         )
+        # Model the post-assume state: get_session populates _cached_credentials
+        # only when it actually assumes a role, and that is the precondition for
+        # invalidating the cached client.
+        config._cached_credentials = {
+            "AccessKeyId": "ASSUMED_KEY",
+            "SecretAccessKey": "ASSUMED_SECRET",
+            "SessionToken": "ASSUMED_TOKEN",
+        }
 
         with (
             patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
@@ -582,6 +590,91 @@ class TestAwsCommon:
             mock_should_refresh.return_value = True
             client2 = config.get_s3_client()
             assert client2 is not client1
+            assert mock_get_session.call_count == 2
+
+    def test_get_s3_client_cached_when_role_matches_ambient_identity(self):
+        """
+        When a role is configured but never actually assumed (the ambient identity
+        already is that role), get_session records no expiration and leaves
+        _cached_credentials as None. The client must still be cached: invalidation
+        keys off assumed static credentials, not merely on aws_role being set —
+        otherwise _should_refresh_credentials() (always True while expiration is
+        None) would rebuild the client on every call.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+        assert config._cached_credentials is None
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
+                MagicMock()
+            )
+
+            client1 = config.get_s3_client()
+            assert config.get_s3_client() is client1
+            assert mock_get_session.call_count == 1
+
+    def test_get_s3_resource_cached_per_verify_ssl(self):
+        """
+        get_s3_resource() memoizes like get_s3_client(): repeated calls return the
+        same object, and each verify_ssl value gets its own resource.
+        """
+        config = AwsConnectionConfig(
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            aws_region="us-east-1",
+        )
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            mock_get_session.return_value.resource.side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
+
+            resource1 = config.get_s3_resource()
+            resource2 = config.get_s3_resource()
+            assert resource1 is resource2
+            assert mock_get_session.call_count == 1
+
+            resource3 = config.get_s3_resource(verify_ssl=False)
+            assert resource3 is not resource1
+            assert mock_get_session.call_count == 2
+            assert config.get_s3_resource(verify_ssl=False) is resource3
+
+    def test_get_s3_resource_rebuilt_when_role_credentials_need_refresh(self):
+        """
+        The resource cache shares the client cache's invalidation, so once assumed
+        role credentials need a refresh the cached resource is rebuilt too.
+        """
+        config = AwsConnectionConfig(
+            aws_region="us-east-1",
+            aws_role="arn:aws:iam::123456789012:role/test-role",
+        )
+        config._cached_credentials = {
+            "AccessKeyId": "ASSUMED_KEY",
+            "SecretAccessKey": "ASSUMED_SECRET",
+            "SessionToken": "ASSUMED_TOKEN",
+        }
+
+        with (
+            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
+            patch.object(
+                AwsConnectionConfig, "_should_refresh_credentials"
+            ) as mock_should_refresh,
+        ):
+            mock_get_session.return_value.resource.side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
+
+            mock_should_refresh.return_value = False
+            resource1 = config.get_s3_resource()
+            assert config.get_s3_resource() is resource1
+            assert mock_get_session.call_count == 1
+
+            mock_should_refresh.return_value = True
+            resource2 = config.get_s3_resource()
+            assert resource2 is not resource1
             assert mock_get_session.call_count == 2
 
     @mock_aws

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -526,11 +527,16 @@ class TestAwsCommon:
             # assume_role should only be called once
             assert mock_assume_role.call_count == 1
 
-    def test_get_s3_client_cached_per_verify_ssl(self):
+    @pytest.mark.parametrize(
+        "getter_name, session_attr",
+        [("get_s3_client", "client"), ("get_s3_resource", "resource")],
+    )
+    def test_get_s3_client_or_resource_cached_per_verify_ssl(
+        self, getter_name, session_attr
+    ):
         """
-        get_s3_client() memoizes the built client: repeated calls on the same
-        instance return the same object, and each verify_ssl value gets its
-        own client.
+        Both getters memoize on a single thread: repeated calls return the same
+        object, and each verify_ssl value gets its own instance.
         """
         config = AwsConnectionConfig(
             aws_access_key_id="test-key",
@@ -539,33 +545,37 @@ class TestAwsCommon:
         )
 
         with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
-            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
-                MagicMock()
+            getattr(mock_get_session.return_value, session_attr).side_effect = (
+                lambda *args, **kwargs: MagicMock()
             )
+            getter = getattr(config, getter_name)
 
-            client1 = config.get_s3_client()
-            client2 = config.get_s3_client()
-            assert client1 is client2
-            # Only one session/client construction for the repeated call
+            obj1 = getter()
+            assert getter() is obj1
             assert mock_get_session.call_count == 1
 
-            client3 = config.get_s3_client(verify_ssl=False)
-            assert client3 is not client1
+            obj2 = getter(verify_ssl=False)
+            assert obj2 is not obj1
             assert mock_get_session.call_count == 2
-            assert config.get_s3_client(verify_ssl=False) is client3
+            assert getter(verify_ssl=False) is obj2
 
-    def test_get_s3_client_rebuilt_when_role_credentials_need_refresh(self):
+    @pytest.mark.parametrize(
+        "getter_name, session_attr",
+        [("get_s3_client", "client"), ("get_s3_resource", "resource")],
+    )
+    def test_get_s3_client_or_resource_rebuilt_when_role_credentials_need_refresh(
+        self, getter_name, session_attr
+    ):
         """
-        Once a role has actually been assumed, the cached client holds static
-        credentials, so it must be rebuilt when those credentials need a refresh.
+        Once a role has actually been assumed, the cached client/resource holds
+        static credentials, so it must be rebuilt when those need a refresh.
         """
         config = AwsConnectionConfig(
             aws_region="us-east-1",
             aws_role="arn:aws:iam::123456789012:role/test-role",
         )
-        # Model the post-assume state: get_session populates _cached_credentials
-        # only when it actually assumes a role, and that is the precondition for
-        # invalidating the cached client.
+        # get_session populates _cached_credentials only when it actually assumes a
+        # role; that is the precondition for invalidating the cached instance.
         config._cached_credentials = {
             "AccessKeyId": "ASSUMED_KEY",
             "SecretAccessKey": "ASSUMED_SECRET",
@@ -578,28 +588,35 @@ class TestAwsCommon:
                 AwsConnectionConfig, "_should_refresh_credentials"
             ) as mock_should_refresh,
         ):
-            mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
-                MagicMock()
+            getattr(mock_get_session.return_value, session_attr).side_effect = (
+                lambda *args, **kwargs: MagicMock()
             )
+            getter = getattr(config, getter_name)
 
             mock_should_refresh.return_value = False
-            client1 = config.get_s3_client()
-            assert config.get_s3_client() is client1
+            obj1 = getter()
+            assert getter() is obj1
             assert mock_get_session.call_count == 1
 
             mock_should_refresh.return_value = True
-            client2 = config.get_s3_client()
-            assert client2 is not client1
+            obj2 = getter()
+            assert obj2 is not obj1
             assert mock_get_session.call_count == 2
 
-    def test_get_s3_client_cached_when_role_matches_ambient_identity(self):
+    @pytest.mark.parametrize(
+        "getter_name, session_attr",
+        [("get_s3_client", "client"), ("get_s3_resource", "resource")],
+    )
+    def test_get_s3_client_or_resource_cached_when_role_matches_ambient_identity(
+        self, getter_name, session_attr
+    ):
         """
         When a role is configured but never actually assumed (the ambient identity
         already is that role), get_session records no expiration and leaves
-        _cached_credentials as None. The client must still be cached: invalidation
+        _cached_credentials as None. The instance must still be cached: invalidation
         keys off assumed static credentials, not merely on aws_role being set —
         otherwise _should_refresh_credentials() (always True while expiration is
-        None) would rebuild the client on every call.
+        None) would rebuild on every call.
         """
         config = AwsConnectionConfig(
             aws_region="us-east-1",
@@ -608,13 +625,50 @@ class TestAwsCommon:
         assert config._cached_credentials is None
 
         with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
+            getattr(mock_get_session.return_value, session_attr).side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
+            getter = getattr(config, getter_name)
+
+            obj1 = getter()
+            assert getter() is obj1
+            assert mock_get_session.call_count == 1
+
+    def test_s3_client_shared_but_resource_isolated_across_threads(self):
+        """
+        boto3 clients are thread-safe and may be shared, so the cached client is the
+        same object across threads; boto3 resources are not thread-safe, so each
+        thread gets its own cached resource.
+        """
+        config = AwsConnectionConfig(
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            aws_region="us-east-1",
+        )
+
+        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
             mock_get_session.return_value.client.side_effect = lambda *args, **kwargs: (
                 MagicMock()
             )
+            mock_get_session.return_value.resource.side_effect = (
+                lambda *args, **kwargs: MagicMock()
+            )
 
-            client1 = config.get_s3_client()
-            assert config.get_s3_client() is client1
-            assert mock_get_session.call_count == 1
+            main_client = config.get_s3_client()
+            main_resource = config.get_s3_resource()
+
+            worker: dict = {}
+
+            def run():
+                worker["client"] = config.get_s3_client()
+                worker["resource"] = config.get_s3_resource()
+
+            thread = threading.Thread(target=run)
+            thread.start()
+            thread.join()
+
+            assert worker["client"] is main_client
+            assert worker["resource"] is not main_resource
 
     @mock_aws
     def test_role_assumption_without_caching_before_fix(self):

--- a/metadata-ingestion/tests/unit/test_aws_common.py
+++ b/metadata-ingestion/tests/unit/test_aws_common.py
@@ -616,67 +616,6 @@ class TestAwsCommon:
             assert config.get_s3_client() is client1
             assert mock_get_session.call_count == 1
 
-    def test_get_s3_resource_cached_per_verify_ssl(self):
-        """
-        get_s3_resource() memoizes like get_s3_client(): repeated calls return the
-        same object, and each verify_ssl value gets its own resource.
-        """
-        config = AwsConnectionConfig(
-            aws_access_key_id="test-key",
-            aws_secret_access_key="test-secret",
-            aws_region="us-east-1",
-        )
-
-        with patch.object(AwsConnectionConfig, "get_session") as mock_get_session:
-            mock_get_session.return_value.resource.side_effect = (
-                lambda *args, **kwargs: MagicMock()
-            )
-
-            resource1 = config.get_s3_resource()
-            resource2 = config.get_s3_resource()
-            assert resource1 is resource2
-            assert mock_get_session.call_count == 1
-
-            resource3 = config.get_s3_resource(verify_ssl=False)
-            assert resource3 is not resource1
-            assert mock_get_session.call_count == 2
-            assert config.get_s3_resource(verify_ssl=False) is resource3
-
-    def test_get_s3_resource_rebuilt_when_role_credentials_need_refresh(self):
-        """
-        The resource cache shares the client cache's invalidation, so once assumed
-        role credentials need a refresh the cached resource is rebuilt too.
-        """
-        config = AwsConnectionConfig(
-            aws_region="us-east-1",
-            aws_role="arn:aws:iam::123456789012:role/test-role",
-        )
-        config._cached_credentials = {
-            "AccessKeyId": "ASSUMED_KEY",
-            "SecretAccessKey": "ASSUMED_SECRET",
-            "SessionToken": "ASSUMED_TOKEN",
-        }
-
-        with (
-            patch.object(AwsConnectionConfig, "get_session") as mock_get_session,
-            patch.object(
-                AwsConnectionConfig, "_should_refresh_credentials"
-            ) as mock_should_refresh,
-        ):
-            mock_get_session.return_value.resource.side_effect = (
-                lambda *args, **kwargs: MagicMock()
-            )
-
-            mock_should_refresh.return_value = False
-            resource1 = config.get_s3_resource()
-            assert config.get_s3_resource() is resource1
-            assert mock_get_session.call_count == 1
-
-            mock_should_refresh.return_value = True
-            resource2 = config.get_s3_resource()
-            assert resource2 is not resource1
-            assert mock_get_session.call_count == 2
-
     @mock_aws
     def test_role_assumption_without_caching_before_fix(self):
         """


### PR DESCRIPTION
## Summary

Follow-up to #19496 (S3 client caching). That PR memoizes the S3 **client**; this one extends the same optimization to the S3 **resource** returned by `AwsConnectionConfig.get_s3_resource()`.

**Stacked on #19496** — review/merge that first. Base is `perf/aws-s3-client-reuse`; it will be retargeted to `master` once #19496 merges.

## Why this is separate from the client cache

boto3 **clients are thread-safe; resources are not** — a resource's Python objects carry mutable in-process state (lazy attribute loads, collection/pagination iterators, `meta`), so sharing one across threads can corrupt that state or return wrong results even for pure reads. So the resource can't just be shared like the client.

This PR therefore:

- Keys the **resource** cache by `(thread id, verify_ssl)` — boto3's recommended "a resource per thread" — so each thread gets its own instance and none is ever shared across threads. The **client** cache stays keyed by `verify_ssl` and shared.
- Routes both getters through a single `_get_or_build_cached()` helper, so the lock and the credential-invalidation rule live in one place and the two paths can't drift.
- The GCS OAuth subclass re-applies its `before-send` handlers on the returned resource's client each call; those register with botocore `unique_id`s (added in #19496), so re-application on a cached resource is a no-op.

Today's `get_s3_resource` callers (S3 and Excel sources) are single-threaded, so there is no active race — this keeps the per-thread guarantee correct for shared configs and any future concurrency.

## Which S3 operations use which method

The two data-lake sources split their S3 work across both getters. The **client** operations are cached by #19496; the **resource** operations are what this PR caches. Crucially, `get_s3_*()` is called **once per row below and the returned object is reused within that scope** — so what matters for caching is the *call frequency of the getter*, not the number of underlying API calls.

| Getter | boto3 op(s) | Call site | Getter called… |
| --- | --- | --- | --- |
| **client** (#19496) | GetObject | `object_store_files.read_file_as_bytes` (dbt/ODCS artifacts) | per artifact ⟵ hot |
| **client** | ListObjectsV2 / ListBuckets | `s3_boto_utils.list_folders/list_buckets/list_objects_recursive`, `expand_object_store_glob` — **all S3 source listing/traversal** | per prefix/traversal ⟵ hot |
| **client** | GetObjectTagging | `s3_boto_utils.get_s3_tags` (object branch, `use_s3_object_tags`) | per dataset |
| **client** | GetObject (smart_open) | S3 `get_fields` schema inference, profiler, sql_queries, sqlmesh | per table / per file ⟵ hot |
| **resource** (this PR) | GetObject (`s3.Object().get()`) | **Excel `get_s3_file`** | **per Excel file** ⟵ hot |
| **resource** | GetBucketTagging (`s3.Bucket().Tagging()`) | `s3_boto_utils.get_s3_tags` (bucket branch, `use_s3_bucket_tags`) | **per dataset** |
| **resource** | ListObjectsV2 (`Bucket().objects.filter`) | Excel `s3_browser`; S3 browse wrappers | per path_spec |
| **resource** | HeadObject (`s3.Object().content_type`) | S3 `_process_simple_path` (`use_s3_content_type`) | reuses the one resource already fetched for that path_spec — **no extra benefit** |

Takeaway: the S3 source's heavy per-file/per-prefix work is **client**-side and already covered by #19496. This PR's resource caching concentrates its benefit in **Excel file reads** (per file) and **bucket-tag lookups** (per dataset); pure browse is per-path_spec (small).

## Estimated impact (modeled, not yet measured)

Each avoided `get_s3_resource()` rebuild saves the session-setup overhead measured in #19496: **~1.75 s with an SSO profile** (credential resolution dominates), down to roughly **0.1–0.5 s** with explicit keys or an instance/IRSA role (TLS-dominated). With caching, N getter calls on one config collapse to one build per distinct `verify_ssl`, so:

> **savings ≈ (getter calls − 1) × per-rebuild overhead**

| Scenario | `get_s3_resource` calls (uncached) | Est. savings @ SSO (~1.75 s) | @ explicit key (~0.3 s) |
| --- | --- | --- | --- |
| Excel, 100 files | ~101 | ~175 s | ~30 s |
| Excel, 1000 files | ~1001 | ~29 min | ~5 min |
| S3 + `use_s3_bucket_tags`, 500 datasets | ~500 | ~875 s | ~150 s |
| S3/Excel browse only, 5 path_specs | ~5 | ~7 s | ~1 s |

So unlike the client PR's flat 3.8× on the dbt artifact loop, the resource-path win is **conditional**: large for Excel-over-many-files and bucket-tagging-over-many-datasets, negligible for pure browse. The benefit also scales with auth cost — biggest for SSO, modest for instance-profile ingestion.

## Perf test — high-level design

Mirror the #19496 client micro-benchmark and the dbt in-process harness, targeted at the resource path:

1. **Micro-benchmark (deterministic, no data):** time `get_s3_resource()` in a loop, fresh vs cached, under (a) SSO profile and (b) explicit keys, to pin the per-rebuild overhead the table above assumes. Cheapest signal; mirrors the per-GET number in #19496.
2. **End-to-end, cached vs baseline** (baseline = this PR's parent commit, which leaves the resource uncached), on LocalStack or real S3:
   - **Excel driver:** seed N small `.xlsx` files under one prefix; ingest; vary N (10/100/1000). Exercises `get_s3_file` per file — the primary win.
   - **Bucket-tags driver:** S3 source with `use_s3_bucket_tags=True` over N datasets. Exercises `get_s3_tags` bucket branch per dataset.
   - **Browse-only control:** a few path_specs, no per-file resource ops — expected to show ~no delta, validating the "per-path_spec = small" claim.
3. **Instrumentation:** wrap `get_session().resource` (or the cache) with a counter; assert **1 build (cached) vs N (uncached)**, and report wall-clock delta per driver. Reuse the `tests/performance/` self-seeding harness pattern; `--sizes` sweep; run at both auth modes to bracket the range.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://docs.datahub.com/docs/contributing)
- [ ] Links to related issues (if applicable)
- [x] Tests added/updated: resource cached per `verify_ssl`; rebuild on role-credential refresh; role-matches-ambient-identity path stays cached; **client shared but resource isolated across threads** (`tests/unit/test_aws_common.py`). Incidental end-to-end coverage via the LocalStack-backed S3/Excel integration tests. Perf harness above is a design, not yet implemented.
- [x] Docs: no user-facing behavior change; no docs needed
- [x] No breaking changes
