### PR TITLE
fix(dataproducts): fixes for data marketplace

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
@@ -13,6 +13,7 @@ import {
     OptionContainer,
     OptionLabel,
     OptionList,
+    Required,
     SelectBase,
     SelectLabel,
     SelectLabelContainer,
@@ -197,7 +198,11 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
 
     return (
         <Container ref={selectRef} size={size || 'md'} width={props.width} $minWidth={props.minWidth}>
-            {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
+            {label && (
+                <SelectLabel onClick={handleSelectClick}>
+                    {label} {isRequired && <Required>*</Required>}
+                </SelectLabel>
+            )}
             {isVisible && (
                 <Dropdown
                     open={isOpen}

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
@@ -9,6 +9,7 @@ import {
     Container,
     DropdownContainer,
     OptionList,
+    Required,
     SelectBase,
     SelectLabel,
 } from '@components/components/Select/components';
@@ -268,7 +269,11 @@ export const NestedSelect = <OptionType extends NestedSelectOption = NestedSelec
 
     return (
         <Container ref={selectRef} size={size || 'md'} width={props.width || 255} $minWidth={props.minWidth}>
-            {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
+            {label && (
+                <SelectLabel onClick={handleSelectClick}>
+                    {label} {isRequired && <Required>*</Required>}
+                </SelectLabel>
+            )}
             {isVisible && (
                 <Dropdown
                     open={isOpen}

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/NestedSelect.test.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/NestedSelect.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { describe, expect, it } from 'vitest';
+
+import { NestedSelect } from '@components/components/Select/Nested/NestedSelect';
+
+import themeV2 from '@conf/theme/themeV2';
+
+describe('NestedSelect', () => {
+    it('renders label without asterisk when isRequired is false', () => {
+        render(
+            <ThemeProvider theme={themeV2}>
+                <NestedSelect label="Domain" options={[]} isRequired={false} />
+            </ThemeProvider>,
+        );
+
+        expect(screen.getByText('Domain')).toBeInTheDocument();
+        expect(screen.queryByText('*')).not.toBeInTheDocument();
+    });
+
+    it('renders label with asterisk when isRequired is true', () => {
+        render(
+            <ThemeProvider theme={themeV2}>
+                <NestedSelect label="Domain" options={[]} isRequired />
+            </ThemeProvider>,
+        );
+
+        expect(screen.getByText('Domain')).toBeInTheDocument();
+        expect(screen.getByText('*')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -227,6 +227,10 @@ export const HighlightedLabel = styled.span`
     color: ${(props) => props.theme?.colors?.textSecondary};
 `;
 
+export const Required = styled.span(({ theme }) => ({
+    color: theme.colors.textError,
+}));
+
 export const StyledBubbleButton = styled(Button)(({ theme }) => ({
     backgroundColor: theme?.colors?.bgHover,
     border: `1px solid ${theme?.colors?.bgHover}`,

--- a/datahub-web-react/src/app/entityV2/shared/DomainSelector/DomainSelector.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/DomainSelector/DomainSelector.tsx
@@ -30,6 +30,7 @@ type DomainSelectorProps = {
     placeholder?: string;
     label?: string;
     isMultiSelect?: boolean;
+    isRequired?: boolean;
 };
 
 /**
@@ -49,6 +50,7 @@ const DomainSelector: React.FC<DomainSelectorProps> = ({
     placeholder,
     label,
     isMultiSelect = false,
+    isRequired = false,
 }) => {
     const { t } = useTranslation('entity.shared.selectors');
     const resolvedPlaceholder =
@@ -250,6 +252,7 @@ const DomainSelector: React.FC<DomainSelectorProps> = ({
             scrollRef={scrollRef}
             width="full"
             isMultiSelect={isMultiSelect}
+            isRequired={isRequired}
             showSearch
             implicitlySelectChildren={false}
             areParentsSelectable

--- a/datahub-web-react/src/app/marketplace/CreateMarketplaceDataProductModal.tsx
+++ b/datahub-web-react/src/app/marketplace/CreateMarketplaceDataProductModal.tsx
@@ -106,6 +106,7 @@ export default function CreateMarketplaceDataProductModal({ open, onClose, onCre
                         selectedDomains={selectedDomainUrns}
                         onDomainsChange={(urns) => setSelectedDomainUrns(urns.length ? [urns[0]] : [])}
                         isMultiSelect={false}
+                        isRequired
                     />
                     <DataProductBuilderForm builderState={builderState} updateBuilderState={updateBuilderState} />
                 </FormFields>

--- a/datahub-web-react/src/app/marketplace/MarketplaceSidebar.tsx
+++ b/datahub-web-react/src/app/marketplace/MarketplaceSidebar.tsx
@@ -311,7 +311,17 @@ export default function MarketplaceSidebar({ isCollapsed, onToggleCollapsed, onE
         </Tooltip>
     );
 
-    const filters = (
+    const hasVisibleFilters =
+        domainOptions.length > 0 ||
+        selectedDomainUrns.length > 0 ||
+        ownerOptions.length > 0 ||
+        selectedOwnerUrns.length > 0 ||
+        tagOptions.length > 0 ||
+        selectedTagUrns.length > 0 ||
+        promotedBrowseFilters.size > 0 ||
+        addFilterOptions.length > 0;
+
+    const filters = hasVisibleFilters ? (
         <>
             <MarketplaceSidebarSearchFilters
                 selectedDomainUrns={selectedDomainUrns}
@@ -341,7 +351,7 @@ export default function MarketplaceSidebar({ isCollapsed, onToggleCollapsed, onE
                 dataTestId="marketplace-sidebar-add-filter"
             />
         </>
-    );
+    ) : null;
 
     return (
         <HierarchicalBrowseSidebar

--- a/datahub-web-react/src/app/marketplace/MarketplaceSidebarSearchFilters.tsx
+++ b/datahub-web-react/src/app/marketplace/MarketplaceSidebarSearchFilters.tsx
@@ -49,80 +49,87 @@ export default function MarketplaceSidebarSearchFilters({
 }: Props) {
     const { t } = useTranslation('misc');
 
+    const showDomainFilter = domainOptions.length > 0 || selectedDomainUrns.length > 0;
+    const showOwnerFilter = ownerOptions.length > 0 || selectedOwnerUrns.length > 0;
+    const showTagFilter = tagOptions.length > 0 || selectedTagUrns.length > 0;
+
     return (
         <>
-            <SimpleSelect<FacetSelectOption>
-                size="sm"
-                width="fit-content"
-                isMultiSelect
-                showSearch
-                filterResultsByQuery
-                isDisabled={domainOptions.length === 0 && selectedDomainUrns.length === 0}
-                placeholder={t('context.domainFilter.placeholder')}
-                selectLabelProps={{ variant: 'labeled', label: t('context.domainFilter.label') }}
-                options={domainOptions}
-                values={selectedDomainUrns}
-                onUpdate={onDomainsChange}
-                renderCustomOptionText={(option) => {
-                    if (!isDomain(option.entity)) return option.label;
-                    return (
-                        <DomainLink
-                            domain={option.entity}
-                            readOnly
-                            enableTooltip={false}
-                            iconSize={20}
-                            iconFontSize={12}
-                        />
-                    );
-                }}
-                dataTestId="marketplace-sidebar-domain-filter"
-            />
-            <SimpleSelect
-                size="sm"
-                width="fit-content"
-                isMultiSelect
-                showSearch
-                filterResultsByQuery
-                isDisabled={ownerOptions.length === 0 && selectedOwnerUrns.length === 0}
-                placeholder={t('metrics.ownersFilter.placeholder')}
-                selectLabelProps={{ variant: 'labeled', label: t('metrics.ownersFilter.label') }}
-                options={ownerOptions}
-                values={selectedOwnerUrns}
-                onUpdate={onOwnersChange}
-                renderCustomOptionText={(option) => {
-                    const { creator } = option as AuthorFacetOption;
-                    return (
-                        <OwnerOptionRow>
-                            <Avatar
-                                name={creator.displayName}
-                                imageUrl={creator.pictureLink ?? undefined}
-                                type={creator.type === EntityType.CorpGroup ? AvatarType.group : AvatarType.user}
-                                showInPill
-                                size="sm"
+            {showDomainFilter && (
+                <SimpleSelect<FacetSelectOption>
+                    size="sm"
+                    width="fit-content"
+                    isMultiSelect
+                    showSearch
+                    filterResultsByQuery
+                    placeholder={t('context.domainFilter.placeholder')}
+                    selectLabelProps={{ variant: 'labeled', label: t('context.domainFilter.label') }}
+                    options={domainOptions}
+                    values={selectedDomainUrns}
+                    onUpdate={onDomainsChange}
+                    renderCustomOptionText={(option) => {
+                        if (!isDomain(option.entity)) return option.label;
+                        return (
+                            <DomainLink
+                                domain={option.entity}
+                                readOnly
+                                enableTooltip={false}
+                                iconSize={20}
+                                iconFontSize={12}
                             />
-                        </OwnerOptionRow>
-                    );
-                }}
-                dataTestId="marketplace-sidebar-owners-filter"
-            />
-            <SimpleSelect<FacetSelectOption>
-                size="sm"
-                width="fit-content"
-                isMultiSelect
-                showSearch
-                filterResultsByQuery
-                isDisabled={tagOptions.length === 0 && selectedTagUrns.length === 0}
-                placeholder={t('context.tagFilter.placeholder')}
-                selectLabelProps={{ variant: 'labeled', label: t('context.tagFilter.label') }}
-                options={tagOptions}
-                values={selectedTagUrns}
-                onUpdate={onTagsChange}
-                renderCustomOptionText={(option) => {
-                    if (!isTag(option.entity)) return option.label;
-                    return <TagLink tag={option.entity} enableTooltip={false} enableDrawer={false} />;
-                }}
-                dataTestId="marketplace-sidebar-tag-filter"
-            />
+                        );
+                    }}
+                    dataTestId="marketplace-sidebar-domain-filter"
+                />
+            )}
+            {showOwnerFilter && (
+                <SimpleSelect
+                    size="sm"
+                    width="fit-content"
+                    isMultiSelect
+                    showSearch
+                    filterResultsByQuery
+                    placeholder={t('metrics.ownersFilter.placeholder')}
+                    selectLabelProps={{ variant: 'labeled', label: t('metrics.ownersFilter.label') }}
+                    options={ownerOptions}
+                    values={selectedOwnerUrns}
+                    onUpdate={onOwnersChange}
+                    renderCustomOptionText={(option) => {
+                        const { creator } = option as AuthorFacetOption;
+                        return (
+                            <OwnerOptionRow>
+                                <Avatar
+                                    name={creator.displayName}
+                                    imageUrl={creator.pictureLink ?? undefined}
+                                    type={creator.type === EntityType.CorpGroup ? AvatarType.group : AvatarType.user}
+                                    showInPill
+                                    size="sm"
+                                />
+                            </OwnerOptionRow>
+                        );
+                    }}
+                    dataTestId="marketplace-sidebar-owners-filter"
+                />
+            )}
+            {showTagFilter && (
+                <SimpleSelect<FacetSelectOption>
+                    size="sm"
+                    width="fit-content"
+                    isMultiSelect
+                    showSearch
+                    filterResultsByQuery
+                    placeholder={t('context.tagFilter.placeholder')}
+                    selectLabelProps={{ variant: 'labeled', label: t('context.tagFilter.label') }}
+                    options={tagOptions}
+                    values={selectedTagUrns}
+                    onUpdate={onTagsChange}
+                    renderCustomOptionText={(option) => {
+                        if (!isTag(option.entity)) return option.label;
+                        return <TagLink tag={option.entity} enableTooltip={false} enableDrawer={false} />;
+                    }}
+                    dataTestId="marketplace-sidebar-tag-filter"
+                />
+            )}
         </>
     );
 }

--- a/datahub-web-react/src/app/marketplace/__tests__/MarketplaceSidebarSearchFilters.test.tsx
+++ b/datahub-web-react/src/app/marketplace/__tests__/MarketplaceSidebarSearchFilters.test.tsx
@@ -1,0 +1,68 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import MarketplaceSidebarSearchFilters from '@app/marketplace/MarketplaceSidebarSearchFilters';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType } from '@types';
+
+describe('MarketplaceSidebarSearchFilters', () => {
+    it('hides all filters when no options and no selections exist', () => {
+        render(
+            <MockedProvider mocks={[]}>
+                <TestPageContainer>
+                    <MarketplaceSidebarSearchFilters
+                        selectedDomainUrns={[]}
+                        selectedOwnerUrns={[]}
+                        selectedTagUrns={[]}
+                        domainOptions={[]}
+                        ownerOptions={[]}
+                        tagOptions={[]}
+                        onDomainsChange={vi.fn()}
+                        onOwnersChange={vi.fn()}
+                        onTagsChange={vi.fn()}
+                    />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+        expect(screen.queryByTestId('marketplace-sidebar-domain-filter')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('marketplace-sidebar-owners-filter')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('marketplace-sidebar-tag-filter')).not.toBeInTheDocument();
+    });
+
+    it('renders only filters that have options or active selections', () => {
+        render(
+            <MockedProvider mocks={[]}>
+                <TestPageContainer>
+                    <MarketplaceSidebarSearchFilters
+                        selectedDomainUrns={['urn:li:domain:engineering']}
+                        selectedOwnerUrns={[]}
+                        selectedTagUrns={[]}
+                        domainOptions={[]}
+                        ownerOptions={[
+                            {
+                                value: 'urn:li:corpuser:alice',
+                                label: 'Alice',
+                                creator: {
+                                    urn: 'urn:li:corpuser:alice',
+                                    type: EntityType.CorpUser,
+                                    displayName: 'Alice',
+                                },
+                            },
+                        ]}
+                        tagOptions={[]}
+                        onDomainsChange={vi.fn()}
+                        onOwnersChange={vi.fn()}
+                        onTagsChange={vi.fn()}
+                    />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+        expect(screen.getByTestId('marketplace-sidebar-domain-filter')).toBeInTheDocument();
+        expect(screen.getByTestId('marketplace-sidebar-owners-filter')).toBeInTheDocument();
+        expect(screen.queryByTestId('marketplace-sidebar-tag-filter')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
1. Added Required * Indicator for Domain in Create Data Product Modal
Problem: Selecting a Domain is mandatory to create a data product (the Create button is disabled without one), but the field label lacked the red asterisk * indicating it was required.
Fix:
Added Required component support to NestedSelect and BasicSelect when isRequired is passed.
Added the isRequired prop to DomainSelector.
Set isRequired={true} on <DomainSelector /> inside CreateMarketplaceDataProductModal.
2. Hide Sidebar Filters with No Data (Instead of Showing Disabled Dropdowns)
Problem: If an environment has no data for a given facet (e.g. no Tags), the filter button still showed up in the sidebar as a disabled pill, causing clutter and confusion.
Fix:
Updated MarketplaceSidebarSearchFilters to conditionally render Domain, Owner, and Tag filters only when they have available facet options or active selections.
Updated MarketplaceSidebar so the entire filter row and divider clean up gracefully if no filters have data or are selected.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data marketplace behavior: filters with no options or active selections are now hidden instead of disabled, and required select fields show an asterisk on their labels.

- The data product creation modal marks the domain selector as required; `BasicSelect`, `NestedSelect`, and `DomainSelector` now render a required indicator when `isRequired` is set.
- `MarketplaceSidebarSearchFilters` only renders domain, owner, and tag filters when they have options or a current selection, and `MarketplaceSidebar` hides the entire filter section when nothing is visible.
- Removed the `isDisabled` state for empty filters since hiding replaces it.
- Added tests covering required-label rendering and filter visibility.

<sup>Written for commit f7fd3052bedcac80f25362acc0d088903a73d230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

