### PR TITLE
fix(metadata-service): add StarRocks platform metadata

### DIFF
--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -13,7 +13,7 @@ bootstrap:
       mcps_location: "bootstrap_mcps/root-user.yaml"
 
     - name: data-platforms
-      version: v16
+      version: v17
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/data-platforms.yaml"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/data-platforms.yaml
@@ -100,6 +100,16 @@
     displayName: Apache Doris
     type: OLAP_DATASTORE
     logoUrl: "assets/platforms/dorislogo.png"
+- entityUrn: urn:li:dataPlatform:starrocks
+  entityType: dataPlatform
+  aspectName: dataPlatformInfo
+  changeType: UPSERT
+  aspect:
+    datasetNameDelimiter: "."
+    name: starrocks
+    displayName: StarRocks
+    type: OLAP_DATASTORE
+    logoUrl: "assets/platforms/starrockslogo.svg"
 - entityUrn: urn:li:dataPlatform:couchbase
   entityType: dataPlatform
   aspectName: dataPlatformInfo


### PR DESCRIPTION
## Summary

Adds the missing `dataPlatformInfo` bootstrap metadata for `urn:li:dataPlatform:starrocks` so StarRocks datasets display correctly in the UI.

- Adds `StarRocks` display name, `OLAP_DATASTORE` type, `.` dataset delimiter, and existing StarRocks logo asset.
- Bumps the `data-platforms` bootstrap version from `v16` to `v17` so the metadata is reapplied to existing deployments.

### Before
<img width="429" height="244" alt="image" src="https://github.com/user-attachments/assets/07f438d4-8f2c-41dc-a21e-f7d0e5038cb9" />
<img width="199" height="98" alt="image" src="https://github.com/user-attachments/assets/b4f1ff4b-a659-4728-a4b1-dd155943e334" />

### After
<img width="356" height="248" alt="image" src="https://github.com/user-attachments/assets/32ea8723-3254-47a1-904e-20efb526e60b" />
<img width="199" height="83" alt="image" src="https://github.com/user-attachments/assets/68f39d09-edd4-488a-a425-0df60de4a9ae" />



## Validation

- Verified the running local GMS returns populated StarRocks platform properties through GraphQL.
- No recipe changes are required; StarRocks ingestion already emits the correct platform URN.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format)).
- [x] Links to related issues (if applicable).
- [x] Tests for the changes have been added/updated (if applicable).
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing StarRocks platform metadata so StarRocks datasets show the correct display name, icon, and dataset delimiter in the UI. Also bumps the `data-platforms` bootstrap version from `v16` to `v17` so existing deployments reapply the metadata.

<sup>Written for commit 6c08964353fbf868236dff814c89738eab4bcc05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

