### PR TITLE
fix(ingest/executor): key the venv cache on what requirements resolve to

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -270,7 +270,13 @@ class VenvConfig(pydantic.BaseModel):
         # Without these, `pkg==2.1.*` hashes identically forever: the first venv is reused on
         # every subsequent run, the index is never consulted again, and a newly published release
         # is silently never installed. Nothing looks broken -- the source just stops updating.
-        suffix.update(str(resolved_pins or []).encode("utf-8"))
+        #
+        # Only included when non-empty. A failed resolution returns [] and must fall back to the
+        # pre-resolution name — the same name the warm venv was originally built under — so that
+        # an expired token or unreachable index degrades to "stale dependencies" rather than
+        # "cache key flip → rebuild → install 401 → hard failure".
+        if resolved_pins:
+            suffix.update(str(resolved_pins).encode("utf-8"))
 
         return f"{self.main_plugin}-{suffix.digest().hex()[:16]}"
 
@@ -464,14 +470,20 @@ async def resolve_moving_pins(
     name it had, and a warm venv is reused -- so a registry outage leaves an ingestion source
     running on slightly stale dependencies rather than failing it outright.
     """
+    # Option lines (--extra-index-url, -c, etc.) must reach the resolver so it sees the same
+    # indexes and constraints the install path does. Without them, sources with private indexes
+    # in extra_pip_requirements 401 on every resolve.
+    option_lines = [req for req in expanded_pip_reqs if req.lstrip().startswith("-")]
     moving = [req for req in expanded_pip_reqs if is_moving_requirement(req)]
     if not moving:
         return []
 
+    compile_input = option_lines + moving
+
     try:
         result = await anyio.run_process(
             [_find_uv(), "pip", "compile", "--no-deps", "--refresh", "--quiet", "-"],
-            input="\n".join(moving).encode("utf-8"),
+            input="\n".join(compile_input).encode("utf-8"),
             env={**os.environ, **extra_env_vars},
             check=True,
         )
@@ -598,6 +610,28 @@ async def setup_venv(
         [_find_uv(), "venv", "--python", sys.executable, str(venv_loc)]
     )
 
+    try:
+        await _install_into_venv(venv_config, runner, venv_loc, expanded_pip_reqs)
+    except Exception:
+        # Delete the half-built venv so it can't be adopted as warm on the next run.
+        # A venv with bin/python but missing packages would pass the exists() check
+        # and silently run with the wrong dependencies.
+        import shutil
+
+        shutil.rmtree(venv_loc, ignore_errors=True)
+        raise
+
+    return venv_reference
+
+
+async def _install_into_venv(
+    venv_config: "VenvConfig",
+    runner: SubprocessRunner,
+    venv_loc: pathlib.Path,
+    expanded_pip_reqs: list[str],
+) -> None:
+    """Install packages into a freshly created venv. Extracted so setup_venv can clean up on failure."""
+
     venv_env = {
         **os.environ,
         **venv_config.extra_env_vars,
@@ -682,7 +716,6 @@ async def setup_venv(
             env=venv_env,
         )
 
-    return venv_reference
 
 
 def validate_dependency_resolution_enabled(version: str) -> None:

--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -31,7 +31,11 @@ from datahub.executor.common.env_config import (
     get_bundled_venv_path,
     get_dependency_resolution_enabled,
 )
-from datahub.executor.execution.venv_utils import is_moving_requirement
+from datahub.executor.execution.venv_utils import (
+    ReqKind,
+    is_moving_requirement,
+    partition_requirements,
+)
 
 
 def _expand_pip_req(req: str) -> str:
@@ -457,7 +461,7 @@ class SubprocessRunner:
 # support for handling bundled venvs.
 async def resolve_moving_pins(
     expanded_pip_reqs: list[str],
-    extra_env_vars: dict[str, str],
+    env: dict[str, str],
 ) -> list[str]:
     """Resolve requirements that can move to the concrete versions available right now.
 
@@ -469,22 +473,24 @@ async def resolve_moving_pins(
     Best effort by design. If the index is unreachable this returns nothing, the venv keeps the
     name it had, and a warm venv is reused -- so a registry outage leaves an ingestion source
     running on slightly stale dependencies rather than failing it outright.
+
+    Args:
+        expanded_pip_reqs: The full list of requirement lines (including option lines).
+        env: The shared environment dict (os.environ + extra_env_vars), same as the install path.
     """
-    # Option lines (--extra-index-url, -c, etc.) must reach the resolver so it sees the same
-    # indexes and constraints the install path does. Without them, sources with private indexes
-    # in extra_pip_requirements 401 on every resolve.
-    option_lines = [req for req in expanded_pip_reqs if req.lstrip().startswith("-")]
-    moving = [req for req in expanded_pip_reqs if is_moving_requirement(req)]
-    if not moving:
+    parts = partition_requirements(expanded_pip_reqs)
+    if not parts[ReqKind.MOVING]:
         return []
 
-    compile_input = option_lines + moving
+    # Option lines (--extra-index-url, -c, etc.) reach the resolver so it sees the same
+    # indexes and constraints the install path does.
+    compile_input = parts[ReqKind.OPTION] + parts[ReqKind.MOVING]
 
     try:
         result = await anyio.run_process(
             [_find_uv(), "pip", "compile", "--no-deps", "--refresh", "--quiet", "-"],
             input="\n".join(compile_input).encode("utf-8"),
-            env={**os.environ, **extra_env_vars},
+            env=env,
             check=True,
         )
     except Exception as e:
@@ -568,13 +574,15 @@ async def setup_venv(
     # requirements file see the same os.environ snapshot.
     expanded_pip_reqs = venv_config.resolve_pip_requirements()
 
+    # Shared base env for both the resolve and install paths. Built once so
+    # they cannot diverge on index URLs, auth tokens, or uv configuration.
+    base_env = {**os.environ, **venv_config.extra_env_vars}
+
     # Resolve before naming, because the name decides whether the venv below is reused. A range
     # pin resolves to a concrete version here, so publishing a new release changes the name and
     # forces a rebuild; naming first would answer "does this venv exist?" from a string that can
     # never change.
-    resolved_pins = await resolve_moving_pins(
-        expanded_pip_reqs, venv_config.extra_env_vars
-    )
+    resolved_pins = await resolve_moving_pins(expanded_pip_reqs, base_env)
     if resolved_pins:
         runner._logs.append(
             f"Resolved moving requirements: {', '.join(resolved_pins)}\n"
@@ -611,7 +619,7 @@ async def setup_venv(
     )
 
     try:
-        await _install_into_venv(venv_config, runner, venv_loc, expanded_pip_reqs)
+        await _install_into_venv(venv_config, runner, venv_loc, expanded_pip_reqs, base_env)
     except Exception:
         # Delete the half-built venv so it can't be adopted as warm on the next run.
         # A venv with bin/python but missing packages would pass the exists() check
@@ -629,14 +637,13 @@ async def _install_into_venv(
     runner: SubprocessRunner,
     venv_loc: pathlib.Path,
     expanded_pip_reqs: list[str],
+    base_env: dict[str, str],
 ) -> None:
     """Install packages into a freshly created venv. Extracted so setup_venv can clean up on failure."""
 
-    venv_env = {
-        **os.environ,
-        **venv_config.extra_env_vars,
-        "VIRTUAL_ENV": str(venv_loc),
-    }
+    # Extend the shared base env with the venv-specific VIRTUAL_ENV. The base_env is the same
+    # dict the resolve path uses, so indexes and auth agree by construction.
+    venv_env = {**base_env, "VIRTUAL_ENV": str(venv_loc)}
 
     version = venv_config.version
 

--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -33,7 +33,6 @@ from datahub.executor.common.env_config import (
 )
 from datahub.executor.execution.venv_utils import (
     ReqKind,
-    is_moving_requirement,
     partition_requirements,
 )
 
@@ -495,7 +494,7 @@ async def resolve_moving_pins(
         )
     except Exception as e:
         logger.warning(
-            f"Could not resolve {len(moving)} moving requirement(s) for the venv cache key; "
+            f"Could not resolve {len(parts[ReqKind.MOVING])} moving requirement(s) for the venv cache key; "
             f"reusing any existing venv. A newer release will not be picked up until this "
             f"succeeds. Cause: {e}"
         )

--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -31,6 +31,7 @@ from datahub.executor.common.env_config import (
     get_bundled_venv_path,
     get_dependency_resolution_enabled,
 )
+from datahub.executor.execution.venv_utils import is_moving_requirement
 
 
 def _expand_pip_req(req: str) -> str:
@@ -230,7 +231,9 @@ class VenvConfig(pydantic.BaseModel):
         return [_expand_pip_req(r) for r in self.extra_pip_requirements]
 
     def get_stable_venv_name(
-        self, expanded_pip_reqs: Union[list[str], None] = None
+        self,
+        expanded_pip_reqs: Union[list[str], None] = None,
+        resolved_pins: Union[list[str], None] = None,
     ) -> Union[str, None]:
         if self.requirements_file is not None:
             suffix = hashlib.sha256()
@@ -263,6 +266,11 @@ class VenvConfig(pydantic.BaseModel):
         )
         suffix.update(str(reqs_for_hash).encode("utf-8"))
         suffix.update(str(self.extra_pip_plugins).encode("utf-8"))
+        # Concrete versions for any requirement whose text is stable but whose resolution is not.
+        # Without these, `pkg==2.1.*` hashes identically forever: the first venv is reused on
+        # every subsequent run, the index is never consulted again, and a newly published release
+        # is silently never installed. Nothing looks broken -- the source just stops updating.
+        suffix.update(str(resolved_pins or []).encode("utf-8"))
 
         return f"{self.main_plugin}-{suffix.digest().hex()[:16]}"
 
@@ -441,6 +449,48 @@ class SubprocessRunner:
 
 # I had to change this from the base file because we needed to introduce
 # support for handling bundled venvs.
+async def resolve_moving_pins(
+    expanded_pip_reqs: list[str],
+    extra_env_vars: dict[str, str],
+) -> list[str]:
+    """Resolve requirements that can move to the concrete versions available right now.
+
+    Only the moving ones are resolved, and with ``--no-deps``: this is a fingerprint for the venv
+    cache key, not an install plan. Resolving a superset would cost a full dependency solve on
+    every run for every source, and resolving a subset only risks an extra venv rebuild, which is
+    the harmless direction.
+
+    Best effort by design. If the index is unreachable this returns nothing, the venv keeps the
+    name it had, and a warm venv is reused -- so a registry outage leaves an ingestion source
+    running on slightly stale dependencies rather than failing it outright.
+    """
+    moving = [req for req in expanded_pip_reqs if is_moving_requirement(req)]
+    if not moving:
+        return []
+
+    try:
+        result = await anyio.run_process(
+            [_find_uv(), "pip", "compile", "--no-deps", "--refresh", "--quiet", "-"],
+            input="\n".join(moving).encode("utf-8"),
+            env={**os.environ, **extra_env_vars},
+            check=True,
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not resolve {len(moving)} moving requirement(s) for the venv cache key; "
+            f"reusing any existing venv. A newer release will not be picked up until this "
+            f"succeeds. Cause: {e}"
+        )
+        return []
+
+    pins = [
+        line.strip()
+        for line in result.stdout.decode("utf-8", errors="replace").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    return sorted(pins)
+
+
 async def setup_venv(
     venv_config: VenvConfig,
     runner: SubprocessRunner,
@@ -506,9 +556,21 @@ async def setup_venv(
     # requirements file see the same os.environ snapshot.
     expanded_pip_reqs = venv_config.resolve_pip_requirements()
 
+    # Resolve before naming, because the name decides whether the venv below is reused. A range
+    # pin resolves to a concrete version here, so publishing a new release changes the name and
+    # forces a rebuild; naming first would answer "does this venv exist?" from a string that can
+    # never change.
+    resolved_pins = await resolve_moving_pins(
+        expanded_pip_reqs, venv_config.extra_env_vars
+    )
+    if resolved_pins:
+        runner._logs.append(
+            f"Resolved moving requirements: {', '.join(resolved_pins)}\n"
+        )
+
     # Versions that are "moving targets" get random names, everything else gets a stable name
     venv_name_candidate = venv_config.get_stable_venv_name(
-        expanded_pip_reqs=expanded_pip_reqs
+        expanded_pip_reqs=expanded_pip_reqs, resolved_pins=resolved_pins
     )
     if venv_name_candidate is None:
         venv_name = f"eph-{hashlib.sha256(os.urandom(32)).hexdigest()[:16]}"

--- a/metadata-ingestion/src/datahub/executor/execution/venv_utils.py
+++ b/metadata-ingestion/src/datahub/executor/execution/venv_utils.py
@@ -8,6 +8,8 @@ performing any actual venv creation or management.
 import hashlib
 from typing import Union
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 # Version constants
 VENV_VERSION_LATEST = "latest"
 VENV_VERSION_BUNDLED = "bundled"
@@ -22,6 +24,36 @@ def is_bundled_version(version: str) -> bool:
 def should_use_bundled_venv(version: str) -> bool:
     """Determine if bundled venv should be used based on version."""
     return is_bundled_version(version)
+
+
+def is_moving_requirement(requirement: str) -> bool:
+    """Whether this requirement can resolve to a different build over time.
+
+    A venv is cached under a hash of the requirement *strings*, so a requirement whose text is
+    stable but whose resolution is not -- ``acryl-datahub-cloud-docs==2.1.*``, ``>=1.2``, or a
+    bare package name -- would keep the first venv forever and never see a newer release. The
+    caller resolves these to concrete versions before naming the venv; everything else is already
+    pinned and needs no lookup.
+
+    Direct references (``pkg @ file:///path``, ``pkg @ https://...``) count as pinned: they name
+    exactly one artifact, and re-resolving them would cost a network round trip to learn nothing.
+    """
+    try:
+        parsed = Requirement(requirement)
+    except InvalidRequirement:
+        # Not something we can reason about (a bare path, an option line). Treat it as pinned
+        # rather than resolving it on every run -- the previous behaviour, unchanged.
+        return False
+
+    if parsed.url:
+        return False
+
+    specs = list(parsed.specifier)
+    if len(specs) != 1:
+        # No specifier at all, or a compound range. Either way the resolution can move.
+        return True
+    only = specs[0]
+    return only.operator not in ("==", "===") or "*" in only.version
 
 
 def get_venv_name(

--- a/metadata-ingestion/src/datahub/executor/execution/venv_utils.py
+++ b/metadata-ingestion/src/datahub/executor/execution/venv_utils.py
@@ -6,6 +6,7 @@ performing any actual venv creation or management.
 """
 
 import hashlib
+from enum import Enum, auto
 from typing import Union
 
 from packaging.requirements import InvalidRequirement, Requirement
@@ -26,34 +27,63 @@ def should_use_bundled_venv(version: str) -> bool:
     return is_bundled_version(version)
 
 
-def is_moving_requirement(requirement: str) -> bool:
-    """Whether this requirement can resolve to a different build over time.
+class ReqKind(Enum):
+    """Three-way classification of requirement lines.
 
-    A venv is cached under a hash of the requirement *strings*, so a requirement whose text is
-    stable but whose resolution is not -- ``acryl-datahub-cloud-docs==2.1.*``, ``>=1.2``, or a
-    bare package name -- would keep the first venv forever and never see a newer release. The
-    caller resolves these to concrete versions before naming the venv; everything else is already
-    pinned and needs no lookup.
-
-    Direct references (``pkg @ file:///path``, ``pkg @ https://...``) count as pinned: they name
-    exactly one artifact, and re-resolving them would cost a network round trip to learn nothing.
+    The install path writes all lines verbatim to a requirements file (option lines are valid
+    there). The resolve path needs only MOVING lines but must forward OPTION lines so the
+    resolver sees the same indexes and constraints. PINNED lines are skipped entirely — they
+    name exactly one artifact and re-resolving them costs a round trip to learn nothing.
     """
+
+    PINNED = auto()
+    MOVING = auto()
+    OPTION = auto()
+
+
+def classify_requirement(requirement: str) -> ReqKind:
+    """Classify a single requirement line."""
+    stripped = requirement.lstrip()
+    if stripped.startswith("-"):
+        return ReqKind.OPTION
+
     try:
         parsed = Requirement(requirement)
     except InvalidRequirement:
-        # Not something we can reason about (a bare path, an option line). Treat it as pinned
-        # rather than resolving it on every run -- the previous behaviour, unchanged.
-        return False
+        return ReqKind.PINNED
 
     if parsed.url:
-        return False
+        return ReqKind.PINNED
 
     specs = list(parsed.specifier)
     if len(specs) != 1:
-        # No specifier at all, or a compound range. Either way the resolution can move.
-        return True
+        return ReqKind.MOVING
     only = specs[0]
-    return only.operator not in ("==", "===") or "*" in only.version
+    if only.operator not in ("==", "===") or "*" in only.version:
+        return ReqKind.MOVING
+    return ReqKind.PINNED
+
+
+def partition_requirements(
+    reqs: list[str],
+) -> dict[ReqKind, list[str]]:
+    """Partition a list of requirement lines into PINNED, MOVING, and OPTION.
+
+    Used by both the resolve path (feeds OPTION + MOVING to uv pip compile)
+    and the install path (writes all lines verbatim).
+    """
+    result: dict[ReqKind, list[str]] = {k: [] for k in ReqKind}
+    for req in reqs:
+        result[classify_requirement(req)].append(req)
+    return result
+
+
+def is_moving_requirement(requirement: str) -> bool:
+    """Whether this requirement can resolve to a different build over time.
+
+    Convenience wrapper around classify_requirement for callers that only need the boolean.
+    """
+    return classify_requirement(requirement) == ReqKind.MOVING
 
 
 def get_venv_name(

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -23,6 +23,7 @@ from datahub.executor.execution.runner import (
     _bundled_constraints_path,
     _expand_pip_req,
     _validate_wheel_url,
+    resolve_moving_pins,
     setup_venv,
     validate_dependency_resolution_enabled,
 )
@@ -1405,3 +1406,71 @@ def test_get_stable_venv_name_stable_when_env_var_unchanged(
         ],
     )
     assert config.get_stable_venv_name() == config.get_stable_venv_name()
+
+
+class TestResolvedPinsInVenvCacheKey:
+    """The venv cache key must follow what a requirement resolves to, not how it was written.
+
+    Regression cover for a silent failure: a source pinned to `pkg==2.1.*` kept its first venv
+    forever. Publishing a new release changed nothing -- same requirement string, same hash, same
+    venv, index never re-consulted -- so the source quietly stopped updating while every run
+    reported success.
+    """
+
+    def _config(self):
+        return VenvConfig(
+            version="1.7.0.6",
+            main_plugin="datahub-cloud-docs",
+            extra_pip_requirements=["acryl-datahub-cloud-docs==2.1.*"],
+        )
+
+    def test_a_new_resolution_changes_the_venv_name(self):
+        config = self._config()
+        older = config.get_stable_venv_name(
+            resolved_pins=["acryl-datahub-cloud-docs==2.1.0.1"]
+        )
+        newer = config.get_stable_venv_name(
+            resolved_pins=["acryl-datahub-cloud-docs==2.1.0.2"]
+        )
+        assert older is not None and newer is not None
+        assert older != newer, "a newly published release must force a fresh venv"
+
+    def test_an_unchanged_resolution_reuses_the_venv(self):
+        config = self._config()
+        pins = ["acryl-datahub-cloud-docs==2.1.0.2"]
+        assert config.get_stable_venv_name(
+            resolved_pins=pins
+        ) == config.get_stable_venv_name(resolved_pins=pins)
+
+    def test_no_pins_is_distinguishable_from_pins(self):
+        # Resolution failing (offline index) must not collide with a successful resolution, or an
+        # outage would quietly adopt some other run's venv.
+        config = self._config()
+        assert config.get_stable_venv_name() != config.get_stable_venv_name(
+            resolved_pins=["acryl-datahub-cloud-docs==2.1.0.2"]
+        )
+
+
+class TestResolveMovingPins:
+    @pytest.mark.asyncio
+    async def test_nothing_moving_means_no_resolution(self):
+        # Exact pins, paths and URLs cannot move, so they must not cost a resolve on every run
+        # for every source. An empty result here is what keeps that path free.
+        pins = await resolve_moving_pins(
+            [
+                "acryl-datahub-cloud-docs==2.1.0.2",
+                "acryl-datahub-cloud@/metadata-ingestion-modules/acryl-cloud",
+            ],
+            {},
+        )
+        assert pins == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_resolution_degrades_to_no_pins(self, monkeypatch):
+        # An unreachable index must leave the venv name unchanged so a warm venv is reused: the
+        # failure mode is "dependencies are stale", never "ingestion is down".
+        async def boom(*args, **kwargs):
+            raise OSError("index unreachable")
+
+        monkeypatch.setattr("datahub.executor.execution.runner.anyio.run_process", boom)
+        assert await resolve_moving_pins(["pkg>=1.0"], {}) == []

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -1502,7 +1502,6 @@ class TestSetupVenvResolvesBeforeNaming:
     async def test_venv_name_changes_when_resolved_pins_change(
         self, tmp_path: pathlib.Path
     ):
-        from unittest.mock import AsyncMock, call
 
         logs = LogHolder()
         runner = SubprocessRunner(logs)

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -1474,3 +1474,80 @@ class TestResolveMovingPins:
 
         monkeypatch.setattr("datahub.executor.execution.runner.anyio.run_process", boom)
         assert await resolve_moving_pins(["pkg>=1.0"], {}) == []
+
+    @pytest.mark.asyncio
+    async def test_a_successful_resolution_returns_sorted_pins(self, monkeypatch):
+        async def fake_resolve(*args, **kwargs):
+            from unittest.mock import MagicMock
+
+            result = MagicMock()
+            result.stdout = b"# uv resolved\npkg-b==2.0.0\npkg-a==1.5.3\n"
+            return result
+
+        monkeypatch.setattr(
+            "datahub.executor.execution.runner.anyio.run_process", fake_resolve
+        )
+        pins = await resolve_moving_pins(["pkg-a>=1.0", "pkg-b>=2.0"], {})
+        assert pins == ["pkg-a==1.5.3", "pkg-b==2.0.0"]
+
+
+class TestSetupVenvResolvesBeforeNaming:
+    """The venv cache key must incorporate resolved pins so a new release changes the name.
+
+    Without resolved_pins flowing through setup_venv → get_stable_venv_name, a range
+    pin like ==2.1.* hashes identically forever and the venv is silently reused.
+    """
+
+    @pytest.mark.asyncio
+    async def test_venv_name_changes_when_resolved_pins_change(
+        self, tmp_path: pathlib.Path
+    ):
+        from unittest.mock import AsyncMock, call
+
+        logs = LogHolder()
+        runner = SubprocessRunner(logs)
+
+        created_venvs: list[str] = []
+
+        async def mock_execute(command, env=None, cwd=None):
+            if "venv" in command:
+                venv_path = Path(command[-1])
+                venv_path.mkdir(parents=True, exist_ok=True)
+                (venv_path / "bin").mkdir(exist_ok=True)
+                (venv_path / "bin" / "python").touch()
+                created_venvs.append(venv_path.name)
+
+        resolve_call_count = 0
+
+        async def fake_resolve(reqs, env_vars):
+            nonlocal resolve_call_count
+            resolve_call_count += 1
+            if resolve_call_count == 1:
+                return ["acryl-datahub-cloud-docs==2.1.0.1"]
+            return ["acryl-datahub-cloud-docs==2.1.0.2"]
+
+        config = VenvConfig(
+            version="0.14.0",
+            main_plugin="snowflake",
+            extra_pip_requirements=["acryl-datahub-cloud-docs==2.1.*"],
+        )
+
+        with (
+            patch.object(runner, "execute", side_effect=mock_execute),
+            patch(
+                "datahub.executor.execution.runner.resolve_moving_pins",
+                side_effect=fake_resolve,
+            ),
+        ):
+            ref1 = await setup_venv(config, runner, tmp_path)
+            # Remove the venv so the second call can't reuse it by path
+            import shutil
+
+            shutil.rmtree(ref1.venv_loc)
+
+            ref2 = await setup_venv(config, runner, tmp_path)
+
+        assert ref1.venv_loc.name != ref2.venv_loc.name, (
+            "The venv name must change when resolved pins change, "
+            f"but both were {ref1.venv_loc.name}"
+        )

--- a/metadata-ingestion/tests/unit/executor/test_venv_utils.py
+++ b/metadata-ingestion/tests/unit/executor/test_venv_utils.py
@@ -213,3 +213,70 @@ class TestIsMovingRequirement:
         assert not venv_utils.is_moving_requirement(
             "--extra-index-url https://example.invalid"
         )
+
+
+class TestClassifyRequirement:
+    """Three-way classification: PINNED, MOVING, or OPTION."""
+
+    def test_option_lines(self):
+        assert (
+            venv_utils.classify_requirement("--extra-index-url https://host/simple")
+            == venv_utils.ReqKind.OPTION
+        )
+        assert (
+            venv_utils.classify_requirement("-c constraints.txt")
+            == venv_utils.ReqKind.OPTION
+        )
+        assert (
+            venv_utils.classify_requirement("  --find-links /local/wheels")
+            == venv_utils.ReqKind.OPTION
+        )
+
+    def test_pinned(self):
+        assert (
+            venv_utils.classify_requirement("pkg==1.2.3")
+            == venv_utils.ReqKind.PINNED
+        )
+        assert (
+            venv_utils.classify_requirement("pkg @ https://example.invalid/pkg.whl")
+            == venv_utils.ReqKind.PINNED
+        )
+
+    def test_moving(self):
+        assert (
+            venv_utils.classify_requirement("pkg>=1.0") == venv_utils.ReqKind.MOVING
+        )
+        assert (
+            venv_utils.classify_requirement("pkg==2.1.*") == venv_utils.ReqKind.MOVING
+        )
+        assert (
+            venv_utils.classify_requirement("bare-package")
+            == venv_utils.ReqKind.MOVING
+        )
+
+
+class TestPartitionRequirements:
+    def test_mixed_list(self):
+        reqs = [
+            "--extra-index-url https://private.host/simple",
+            "pinned-pkg==1.0.0",
+            "moving-pkg>=2.0",
+            "-c constraints.txt",
+            "bare-name",
+        ]
+        parts = venv_utils.partition_requirements(reqs)
+        assert parts[venv_utils.ReqKind.OPTION] == [
+            "--extra-index-url https://private.host/simple",
+            "-c constraints.txt",
+        ]
+        assert parts[venv_utils.ReqKind.PINNED] == ["pinned-pkg==1.0.0"]
+        assert parts[venv_utils.ReqKind.MOVING] == ["moving-pkg>=2.0", "bare-name"]
+
+    def test_empty_list(self):
+        parts = venv_utils.partition_requirements([])
+        assert all(v == [] for v in parts.values())
+
+    def test_all_pinned(self):
+        parts = venv_utils.partition_requirements(["a==1.0", "b==2.0"])
+        assert parts[venv_utils.ReqKind.MOVING] == []
+        assert parts[venv_utils.ReqKind.OPTION] == []

--- a/metadata-ingestion/tests/unit/executor/test_venv_utils.py
+++ b/metadata-ingestion/tests/unit/executor/test_venv_utils.py
@@ -174,3 +174,42 @@ class TestVenvUtilsIntegration:
         # Get venv path
         venv_path = venv_utils.get_venv_path(venv_name, "/tmp/dynamic")
         assert venv_path == f"/tmp/dynamic/venv-{venv_name}"
+
+
+class TestIsMovingRequirement:
+    """A requirement is "moving" when its text is stable but its resolution is not.
+
+    This is the distinction the venv cache turns on: the cache key is a hash of the requirement
+    strings, so a requirement like `pkg==2.1.*` hashes identically forever. Without resolving it
+    first, the venv built on the first run is reused on every later run, the index is never
+    consulted again, and a newly published release is silently never installed.
+    """
+
+    def test_a_range_can_move(self):
+        assert venv_utils.is_moving_requirement("acryl-datahub-cloud-docs==2.1.*")
+        assert venv_utils.is_moving_requirement("pkg>=1.2")
+        assert venv_utils.is_moving_requirement("pkg~=1.2")
+        assert venv_utils.is_moving_requirement("pkg>=1.0,<2.0")
+
+    def test_an_unpinned_name_can_move(self):
+        assert venv_utils.is_moving_requirement("acryl-datahub-integrations")
+        assert venv_utils.is_moving_requirement("pkg[extra]")
+
+    def test_an_exact_pin_cannot_move(self):
+        assert not venv_utils.is_moving_requirement("acryl-datahub-cloud-docs==2.1.0.2")
+        assert not venv_utils.is_moving_requirement("acryl-datahub[snowflake]==1.7.0.6")
+
+    def test_a_direct_reference_cannot_move(self):
+        # One named artifact. Re-resolving these would cost a round trip to learn nothing.
+        assert not venv_utils.is_moving_requirement(
+            "pkg @ https://example.invalid/pkg.whl"
+        )
+        assert not venv_utils.is_moving_requirement(
+            "acryl-datahub-cloud@/metadata-ingestion-modules/acryl-cloud"
+        )
+
+    def test_an_unparseable_line_is_left_alone(self):
+        # Better to keep the previous behaviour than to resolve something we cannot reason about.
+        assert not venv_utils.is_moving_requirement(
+            "--extra-index-url https://example.invalid"
+        )


### PR DESCRIPTION
## Problem

A dynamic ingestion venv is cached under a hash of its requirement **strings**:

```python
# VenvConfig.get_stable_venv_name / venv_utils.get_venv_name
suffix.update(version.encode("utf-8"))
suffix.update(str(extra_pip_requirements or []).encode("utf-8"))
```

That is correct only for a requirement naming exactly one artifact. For a requirement whose text
is stable but whose **resolution** is not — `pkg>=1.2`, `pkg==2.1.*`, or a bare `pkg` — the hash
never changes, so:

1. The venv built on the first run is reused on every later run.
2. `setup_venv` returns early at the `venv_loc.exists()` check, before any resolution happens.
3. The package index is therefore never consulted again.
4. A newly published release is **silently never installed**.

The failure is invisible. Every run reports success, the logs look normal, and the source simply
stops picking up new versions of its dependencies. There is no error to search for, and nothing in
the run report says which build is actually in use.

### Who hits this

Any UI-managed ingestion source that sets a concrete **CLI Version** and lists a non-exact entry
under **Extra Pip Libraries** in the source builder's Advanced section. `["sqlparse==0.4.3"]` is
unaffected — it names one artifact — but `["sqlparse>=0.4"]`, `["sqlparse"]`, or any range pins
that library to whatever happened to be current the first time the source ran, for the life of the
executor's temp directory.

The same applies to any programmatic caller that passes a range in `extra_pip_requirements`.

## Reproduction

Measured against a running instance and a local PEP 503 index. One ingestion source with a
requirement pinned to `==2.1.*`; a newer build published to the index between runs 2 and 3; and
**nothing else touched** — same recipe, same environment, no restart:

| run | index contains | venv | resolved | index requests |
| --- | --- | --- | --- | --- |
| 1 | `2.1.0.1` | `…9781ab57…` | `2.1.0.1` | 0 |
| 2 | `2.1.0.1` | `…9781ab57…` | `2.1.0.1` | 0 |
| 3 | `2.1.0.1`, **`2.1.0.2`** | `…9781ab57…` | **`2.1.0.1`** | **0** |

Identical venv hash throughout, and zero index requests on run 3 — the newer build was never seen.

## Fix

Resolve **before** naming, so that the name deciding venv reuse reflects resolved reality rather
than a string that cannot change.

- **`venv_utils.is_moving_requirement()`** — a pure predicate for requirements whose resolution can
  move. Exact pins and direct references (`pkg @ https://…`, `pkg @ file:///…`) are treated as
  fixed, since they already name one artifact.
- **`runner.resolve_moving_pins()`** — runs `uv pip compile --no-deps --refresh` over *only* the
  moving requirements and returns concrete `name==version` lines.
- **`VenvConfig.get_stable_venv_name(resolved_pins=…)`** — folds those into the cache key.

Same setup as above, after the fix, with the source configuration untouched:

| run | index contains | venv | resolved |
| --- | --- | --- | --- |
| 4 | `2.1.0.1`, `2.1.0.2` | `…a770dfb9…` | **`2.1.0.2`** |

```
Resolved moving requirements: <pkg>==2.1.0.2
Creating new venv: /tmp/datahub/ingest/…/venv-…-a770dfb9953c0380
```

## Design choices

**Only moving requirements are resolved.** Exact pins, paths and URLs skip the lookup entirely, so
sources that pin properly pay nothing. `--no-deps` keeps it to the named packages: this is a
*fingerprint for a cache key*, not an install plan. Resolving a subset of the real dependency graph
can only cause an extra venv rebuild — the harmless direction — whereas resolving a superset would
mean a full dependency solve on every run of every source.

**Resolution is best effort.** If the index is unreachable, `resolve_moving_pins` logs a warning
and returns nothing; the venv name is then unchanged and the warm venv is reused. A registry
outage therefore degrades a source to *stale dependencies* rather than failing it outright. The
tests pin this, including that a failed resolution and a successful one never produce the same
name — otherwise an outage could quietly adopt a different run's venv.

## Tests

`metadata-ingestion/tests/unit/executor/` — **296 passed**.

- `TestIsMovingRequirement` — ranges, compound ranges, bare names, extras, exact pins, direct
  references, and unparseable option lines such as `--extra-index-url`.
- `TestResolvedPinsInVenvCacheKey` — the venv name **changes** when the resolution changes, **does
  not** when it is unchanged, and "no pins" is distinguishable from "pins".
- `TestResolveMovingPins` — no lookup at all when nothing can move; graceful degradation to no pins
  when resolution raises.

## Compatibility

No behaviour change for sources whose requirements are all exact pins, paths or URLs: the cache key
is unchanged and no resolution is performed.

Sources with a moving requirement rebuild their venv **once** on the first run after this lands
(the key now includes resolved versions), and thereafter only when the resolution actually changes.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added
- [ ] Docs — no user-facing surface changes; the behaviour is internal to venv caching
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keys dynamic ingestion venv caches on the concrete versions requirements resolve to, so newly published releases create fresh venvs instead of reusing stale ones. Exact pins, paths, and URLs keep their existing behavior; resolution failures reuse the existing cache key and may leave dependencies stale.

- Resolves only moving requirements with `uv pip compile --no-deps --refresh` before the cache lookup.
- Classifies requirement lines as pinned, moving, or option; option lines like `--extra-index-url` and `-c` are forwarded so the resolver sees the same indexes and constraints as install.
- Uses one shared environment dict for resolve and install so index URLs and auth tokens agree.
- Deletes half-built venvs when installation fails so they cannot be reused later.
- Adds coverage for requirement classification, resolution outcomes, cache-key changes, and the `setup_venv` flow.

<sup>Written for commit 527f797060c3586161b819beb2df1f03d290140a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

