### PR TITLE
docs: fix typo arbitary -> arbitrary

### DIFF
--- a/metadata-integration/java/openlineage-converter/README.md
+++ b/metadata-integration/java/openlineage-converter/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-It converts arbitary Openlineage events to a DataHub Aspects.
+It converts arbitrary Openlineage events to a DataHub Aspects.
 
 ## Known Issues
 


### PR DESCRIPTION
Corrects the misspelling `arbitary` -> `arbitrary` in `metadata-integration/java/openlineage-converter/README.md`.

Documentation only, no behaviour change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misspelling `arbitary` → `arbitrary` in the `openlineage-converter` README. Documentation only, no behavior change.

<sup>Written for commit 92e8b1e93ea52fa23a766395e09c20c2a096d884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

