### PR TITLE
feat(bigquery): emit datasetProfile for materialized views

### DIFF
--- a/metadata-ingestion/docs/sources/bigquery/bigquery_post.md
+++ b/metadata-ingestion/docs/sources/bigquery/bigquery_post.md
@@ -151,6 +151,7 @@ You can set partition explicitly with `partition.partition_datetime` property if
 #### Caveats
 
 - For materialized views, lineage is dependent on logs being retained. If your GCP logging is retained for 30 days (default) and 30 days have passed since the creation of the materialized view we won't be able to get lineage for them.
+- For materialized views, DataHub reports the number of rows **currently materialized** (and the materialized size) as dataset statistics. This is sourced from BigQuery catalog metadata (`tables.get`) and does not require `profiling.enabled`; it can differ from `SELECT COUNT(*)` on the underlying base tables. Set `include_materialized_view_stats: false` to skip these per-view metadata calls.
 
 ### Limitations
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
@@ -390,6 +390,15 @@ class BigQueryV2Config(
         "dataset-scoped but covers base tables only.",
     )
 
+    include_materialized_view_stats: bool = Field(
+        default=True,
+        description="Emit row count and size statistics for materialized views. Materialized view "
+        "stats are fetched from the BigQuery `tables.get` API (a metadata-only call that does not "
+        "scan data and does not require `profiling.enabled`). The stats are emitted as a "
+        "`datasetProfile` aspect so they appear in the DataHub UI Stats panel. Set to `False` to "
+        "skip materialized view stats entirely (no per-view API calls).",
+    )
+
     debug_include_full_payloads: bool = Field(
         default=False,
         description="Include full payload into events. It is only for debugging and internal use.",

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -31,6 +31,7 @@ class BigQuerySchemaApiPerfReport(Report):
     num_get_views_for_dataset_api_requests: int = 0
     num_get_snapshots_for_dataset_api_requests: int = 0
     num_get_table_constraints_for_dataset_api_requests: int = 0
+    num_get_table_metadata_api_requests: int = 0
 
     list_projects_timer: PerfTimer = field(default_factory=PerfTimer)
     list_projects_with_labels_timer: PerfTimer = field(default_factory=PerfTimer)
@@ -44,6 +45,7 @@ class BigQuerySchemaApiPerfReport(Report):
     list_tables_sec: float = 0
     get_views_for_dataset_sec: float = 0
     get_snapshots_for_dataset_sec: float = 0
+    get_table_metadata_sec: float = 0
 
 
 @dataclass
@@ -169,6 +171,13 @@ class BigQueryV2Report(
     snapshots_scanned: int = 0
     num_sharded_tables_scanned: int = 0
     num_sharded_tables_deduped: int = 0
+
+    # Materialized view statistics
+    num_mv_stats_fetched: int = 0
+    num_mv_stats_skipped_legacy: int = 0
+    num_mv_stats_skipped_cap: int = 0
+    num_mv_stats_failed: int = 0
+    num_mv_stats_emitted: int = 0
 
     # view lineage
     sql_aggregator: Optional[SqlAggregatorReport] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -50,6 +50,10 @@ from datahub.utilities.ratelimiter import RateLimiter
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+# Rate limit and per-call timeout for materialized view stats fetched via tables.get.
+_MV_STATS_RATE_LIMITER = RateLimiter(max_calls=50, period=1)
+_MV_STATS_TIMEOUT_SEC = 30
+
 
 @dataclass
 class ExternalTableOptions:
@@ -589,6 +593,40 @@ class BigQuerySchemaApi:
                     )
             self.report.num_get_views_for_dataset_api_requests += 1
             self.report.get_views_for_dataset_sec += current_timer.elapsed_seconds()
+
+    def get_table_metadata(
+        self,
+        project_id: str,
+        dataset_name: str,
+        table_name: str,
+        report: BigQueryV2Report,
+    ) -> Optional[bigquery.Table]:
+        """Fetch a single table's metadata via the BigQuery `tables.get` API.
+
+        This is a metadata-only call (no data scan, no `getData`), used to source
+        row count / size / last-modified time for materialized views, which are not
+        covered by `INFORMATION_SCHEMA.PARTITIONS`. Returns None on failure (a
+        warning is recorded and the caller should proceed without stats).
+        """
+        table_ref = f"{project_id}.{dataset_name}.{table_name}"
+        with PerfTimer() as current_timer:
+            with _MV_STATS_RATE_LIMITER:
+                try:
+                    table = self.bq_client.get_table(
+                        table_ref, timeout=_MV_STATS_TIMEOUT_SEC
+                    )
+                except Exception as e:
+                    report.warning(
+                        title="Failed to fetch materialized view stats",
+                        message="Error fetching materialized view metadata via tables.get",
+                        context=table_ref,
+                        exc=e,
+                    )
+                    report.num_mv_stats_failed += 1
+                    return None
+        self.report.num_get_table_metadata_api_requests += 1
+        self.report.get_table_metadata_sec += current_timer.elapsed_seconds()
+        return table
 
     @staticmethod
     def _make_bigquery_view(view: bigquery.Row) -> BigqueryView:

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -9,6 +9,7 @@ from google.cloud.bigquery.table import TableListItem
 from datahub.api.entities.platformresource.platform_resource import PlatformResource
 from datahub.configuration.pattern_utils import is_schema_allowed, is_tag_allowed
 from datahub.emitter.mce_builder import (
+    get_sys_time,
     make_dataset_urn_with_platform_instance,
     make_schema_field_urn,
     make_tag_urn,
@@ -62,6 +63,7 @@ from datahub.ingestion.source.common.subtypes import (
 )
 from datahub.ingestion.source.sql.sql_utils import (
     add_table_to_schema_container,
+    check_table_with_profile_pattern,
     gen_database_container,
     gen_schema_container,
     get_domain_wu,
@@ -97,7 +99,10 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
 )
 from datahub.metadata.schema_classes import (
     DataPlatformInstanceClass,
+    DatasetProfileClass,
     GlobalTagsClass,
+    PartitionSpecClass,
+    PartitionTypeClass,
     TagAssociationClass,
 )
 from datahub.metadata.urns import TagUrn
@@ -120,6 +125,14 @@ logger: logging.Logger = logging.getLogger(__name__)
 # See https://cloud.google.com/bigquery/docs/table-snapshots-intro.
 SNAPSHOT_TABLE_REGEX = re.compile(r"^(.+)@(\d{13})$")
 CLUSTERING_COLUMN_TAG = "CLUSTERING_COLUMN"
+
+# Upper bound on the number of materialized views for which we fetch stats via
+# tables.get within a single (project, dataset). Materialized views are
+# structurally rare, but this caps the serial metadata fetch on the schema
+# critical path for estates with an unusually large number of MVs. Beyond this
+# limit the fetch is skipped and a warning is emitted; the views are still
+# ingested, just without row count / size stats.
+_MAX_MV_STATS_PER_DATASET = 1000
 
 # Dynamic batch sizing constants for sharded table optimization
 # For datasets with many tables, we increase batch size to reduce API calls
@@ -241,6 +254,15 @@ class BigQuerySchemaGenerator:
             self.data_reader = BigQueryDataReader.create(
                 self.config.get_bigquery_client()
             )
+
+        # Single timestamp stamped once per run and reused for every datasetProfile
+        # aspect emitted for materialized views (the report exposes no run start time).
+        self.run_timestamp_millis: int = get_sys_time()
+
+        # Per-(project, dataset) count of materialized-view stats fetches, used to
+        # bound the serial tables.get calls on the schema critical path.
+        self._mv_stats_fetch_count: Dict[str, int] = defaultdict(int)
+        self._mv_stats_cap_warned: Set[str] = set()
 
         # Global store of table identifiers for lineage filtering
         self.table_refs: Set[str] = set()
@@ -715,15 +737,12 @@ class BigQuerySchemaGenerator:
                     self.report,
                 )
             )
-
-            for view in db_views[dataset_name]:
-                view_columns = columns.get(view.name, []) if columns else []
-                yield from self._process_view(
-                    view=view,
-                    columns=view_columns,
-                    project_id=project_id,
-                    dataset_name=dataset_name,
-                )
+            yield from self._process_views_for_dataset(
+                project_id=project_id,
+                dataset_name=dataset_name,
+                views=db_views[dataset_name],
+                columns=columns,
+            )
 
         if self.config.include_table_snapshots:
             db_snapshots[dataset_name] = list(
@@ -793,6 +812,81 @@ class BigQuerySchemaGenerator:
         yield from self.gen_table_dataset_workunits(
             table, columns, project_id, dataset_name
         )
+
+    def _enrich_materialized_view_stats(
+        self,
+        view: BigqueryView,
+        project_id: str,
+        dataset_name: str,
+    ) -> None:
+        """Populate row count / size / last-altered for a materialized view via tables.get.
+
+        No-op when the legacy `__TABLES__` path already supplied stats (so the two
+        configs never duplicate work). Bounded per (project, dataset) to avoid a
+        serial fetch dominating the schema critical path on estates with many MVs.
+        """
+        if not self.config.include_materialized_view_stats:
+            return
+        if view.rows_count is not None:
+            self.report.num_mv_stats_skipped_legacy += 1
+            return
+
+        cap_key = f"{project_id}.{dataset_name}"
+        if self._mv_stats_fetch_count[cap_key] >= _MAX_MV_STATS_PER_DATASET:
+            self.report.num_mv_stats_skipped_cap += 1
+            if cap_key not in self._mv_stats_cap_warned:
+                self._mv_stats_cap_warned.add(cap_key)
+                self.report.warning(
+                    title="Materialized view stats skipped",
+                    message=(
+                        "Reached the per-dataset materialized view stats cap; "
+                        "remaining materialized views in this dataset will be "
+                        "ingested without row count / size stats."
+                    ),
+                    context=cap_key,
+                )
+            return
+
+        self._mv_stats_fetch_count[cap_key] += 1
+
+        table = self.schema_api.get_table_metadata(
+            project_id, dataset_name, view.name, self.report
+        )
+        if table is None:
+            return
+
+        self.report.num_mv_stats_fetched += 1
+        # Use is-not-None checks so a zero-row / zero-byte MV still records 0.
+        if view.rows_count is None and table.num_rows is not None:
+            view.rows_count = table.num_rows
+        if view.size_in_bytes is None and table.num_bytes is not None:
+            view.size_in_bytes = table.num_bytes
+        # `Table.modified` is the table-resource last-modified time (same clock the
+        # legacy __TABLES__ path reports); keep parity, do not use lastRefreshTime.
+        if view.last_altered is None and table.modified is not None:
+            view.last_altered = table.modified
+
+    def _process_views_for_dataset(
+        self,
+        project_id: str,
+        dataset_name: str,
+        views: List[BigqueryView],
+        columns: Optional[Dict[str, List[BigqueryColumn]]],
+    ) -> Iterable[MetadataWorkUnit]:
+        for view in views:
+            if view.materialized and self.config.include_materialized_view_stats:
+                self._enrich_materialized_view_stats(
+                    view=view,
+                    project_id=project_id,
+                    dataset_name=dataset_name,
+                )
+            view_columns = columns.get(view.name, []) if columns else []
+            yield from self._process_view(
+                view=view,
+                columns=view_columns,
+                project_id=project_id,
+                dataset_name=dataset_name,
+            )
 
     def _process_view(
         self,
@@ -1086,6 +1180,34 @@ class BigQuerySchemaGenerator:
             ),
             aspect=view_properties_aspect,
         ).as_workunit()
+
+        if (
+            view.materialized
+            and self.config.include_materialized_view_stats
+            and view.rows_count is not None
+            and check_table_with_profile_pattern(
+                self.config.profile_pattern,
+                f"{project_id}.{dataset_name}.{table.name}",
+            )
+        ):
+            yield MetadataChangeProposalWrapper(
+                entityUrn=self.identifiers.gen_dataset_urn(
+                    project_id, dataset_name, table.name
+                ),
+                aspect=DatasetProfileClass(
+                    timestampMillis=self.run_timestamp_millis,
+                    rowCount=view.rows_count,
+                    sizeInBytes=view.size_in_bytes,
+                    # partitionSpec must stay set: the UI's latestFullTableProfile
+                    # alias filters on partitionSpec.partition START_WITH
+                    # ["FULL_TABLE_SNAPSHOT","SAMPLE"].
+                    partitionSpec=PartitionSpecClass(
+                        partition="FULL_TABLE_SNAPSHOT",
+                        type=PartitionTypeClass.FULL_TABLE,
+                    ),
+                ),
+            ).as_workunit()
+            self.report.num_mv_stats_emitted += 1
 
     def gen_snapshot_dataset_workunits(
         self,

--- a/metadata-ingestion/tests/unit/bigquery/test_bigquery_mv_stats.py
+++ b/metadata-ingestion/tests/unit/bigquery/test_bigquery_mv_stats.py
@@ -57,8 +57,9 @@ def _make_bq_table(num_rows=42, num_bytes=4096, modified=None):
 
 @pytest.fixture
 def schema_gen():
-    with patch.object(BigQueryV2Config, "get_bigquery_client"), patch.object(
-        BigQueryV2Config, "get_projects_client"
+    with (
+        patch.object(BigQueryV2Config, "get_bigquery_client"),
+        patch.object(BigQueryV2Config, "get_projects_client"),
     ):
         config = BigQueryV2Config.model_validate({"project_id": PROJECT_ID})
         source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
@@ -134,9 +135,7 @@ def test_mv_zero_rows_still_emits_profile(schema_gen):
 
 def test_plain_view_no_fetch_no_profile(schema_gen):
     view = _make_plain_view()
-    with patch.object(
-        schema_gen.schema_api, "get_table_metadata"
-    ) as gt_mock:
+    with patch.object(schema_gen.schema_api, "get_table_metadata") as gt_mock:
         # Plain views are never enriched (the call site gates on materialized);
         # confirm gen_view_dataset_workunits emits no profile for them either.
         aspects = _aspects(
@@ -150,9 +149,7 @@ def test_plain_view_no_fetch_no_profile(schema_gen):
 def test_legacy_stats_skips_fetch_but_emits_profile(schema_gen):
     # use_legacy_table_stats path already populated rows_count; no tables.get needed.
     view = _make_mv(rows_count=7, size_in_bytes=128)
-    with patch.object(
-        schema_gen.schema_api, "get_table_metadata"
-    ) as gt_mock:
+    with patch.object(schema_gen.schema_api, "get_table_metadata") as gt_mock:
         schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
         aspects = _aspects(
             schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
@@ -168,9 +165,7 @@ def test_legacy_stats_skips_fetch_but_emits_profile(schema_gen):
 def test_flag_disabled_no_fetch_no_profile(schema_gen):
     schema_gen.config.include_materialized_view_stats = False
     view = _make_mv()
-    with patch.object(
-        schema_gen.schema_api, "get_table_metadata"
-    ) as gt_mock:
+    with patch.object(schema_gen.schema_api, "get_table_metadata") as gt_mock:
         schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
         aspects = _aspects(
             schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
@@ -214,9 +209,7 @@ def test_cap_skips_fetch_after_limit_and_warns_once(schema_gen):
         _MAX_MV_STATS_PER_DATASET
     )
     view = _make_mv()
-    with patch.object(
-        schema_gen.schema_api, "get_table_metadata"
-    ) as gt_mock:
+    with patch.object(schema_gen.schema_api, "get_table_metadata") as gt_mock:
         schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
     gt_mock.assert_not_called()
     assert schema_gen.report.num_mv_stats_skipped_cap == 1

--- a/metadata-ingestion/tests/unit/bigquery/test_bigquery_mv_stats.py
+++ b/metadata-ingestion/tests/unit/bigquery/test_bigquery_mv_stats.py
@@ -1,0 +1,224 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.bigquery_v2.bigquery import BigqueryV2Source
+from datahub.ingestion.source.bigquery_v2.bigquery_config import BigQueryV2Config
+from datahub.ingestion.source.bigquery_v2.bigquery_schema import BigqueryView
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import ViewProperties
+from datahub.metadata.schema_classes import DatasetProfileClass
+
+PROJECT_ID = "test-project"
+DATASET_NAME = "test-dataset"
+
+
+def _make_mv(name: str = "mv1", rows_count=None, size_in_bytes=None) -> BigqueryView:
+    now = datetime.now(tz=timezone.utc)
+    return BigqueryView(
+        name=name,
+        created=now - timedelta(days=10),
+        last_altered=None,
+        comment="comment",
+        view_definition="CREATE MATERIALIZED VIEW",
+        materialized=True,
+        size_in_bytes=size_in_bytes,
+        rows_count=rows_count,
+        labels=None,
+    )
+
+
+def _make_plain_view(name: str = "v1") -> BigqueryView:
+    now = datetime.now(tz=timezone.utc)
+    return BigqueryView(
+        name=name,
+        created=now - timedelta(days=10),
+        last_altered=None,
+        comment="comment",
+        view_definition="CREATE VIEW",
+        materialized=False,
+        size_in_bytes=None,
+        rows_count=None,
+        labels=None,
+    )
+
+
+def _make_bq_table(num_rows=42, num_bytes=4096, modified=None):
+    return SimpleNamespace(
+        num_rows=num_rows,
+        num_bytes=num_bytes,
+        modified=modified or datetime.now(tz=timezone.utc),
+    )
+
+
+@pytest.fixture
+def schema_gen():
+    with patch.object(BigQueryV2Config, "get_bigquery_client"), patch.object(
+        BigQueryV2Config, "get_projects_client"
+    ):
+        config = BigQueryV2Config.model_validate({"project_id": PROJECT_ID})
+        source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
+        # gen_dataset_workunits needs identifiers/containers we don't want to mock here;
+        # isolate view-level workunits (ViewProperties + DatasetProfile).
+        source.bq_schema_extractor.gen_dataset_workunits = (  # type: ignore[method-assign]
+            lambda *args, **kwargs: []
+        )
+        return source.bq_schema_extractor
+
+
+def _aspects(gen) -> List:
+    aspects = []
+    for wu in gen:
+        metadata = wu.metadata
+        if isinstance(metadata, MetadataChangeProposalWrapper):
+            aspects.append(metadata.aspect)
+    return aspects
+
+
+def _profiles(aspects) -> List[DatasetProfileClass]:
+    return [a for a in aspects if isinstance(a, DatasetProfileClass)]
+
+
+def _enrich_and_emit(schema_gen, view, table_returned):
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata", return_value=table_returned
+    ) as gt_mock:
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+    return aspects, gt_mock
+
+
+def test_mv_profile_emitted_with_profiling_disabled(schema_gen):
+    # The reported bug: profiling.enabled defaults to False, yet MV stats must still show.
+    assert schema_gen.config.is_profiling_enabled() is False
+    view = _make_mv()
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata", return_value=_make_bq_table()
+    ):
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+
+    profiles = _profiles(aspects)
+    assert len(profiles) == 1
+    assert profiles[0].rowCount == 42
+    assert profiles[0].sizeInBytes == 4096
+    assert schema_gen.report.num_mv_stats_emitted == 1
+
+
+def test_mv_profile_has_full_table_snapshot_partition_spec(schema_gen):
+    view = _make_mv()
+    aspects, _ = _enrich_and_emit(schema_gen, view, _make_bq_table())
+    profiles = _profiles(aspects)
+    assert len(profiles) == 1
+    assert profiles[0].partitionSpec is not None
+    assert profiles[0].partitionSpec.partition == "FULL_TABLE_SNAPSHOT"
+    assert profiles[0].partitionSpec.type == "FULL_TABLE"
+
+
+def test_mv_zero_rows_still_emits_profile(schema_gen):
+    # `is not None`, not truthiness: a zero-row MV reports rowCount: 0.
+    view = _make_mv()
+    aspects, _ = _enrich_and_emit(schema_gen, view, _make_bq_table(num_rows=0))
+    profiles = _profiles(aspects)
+    assert len(profiles) == 1
+    assert profiles[0].rowCount == 0
+
+
+def test_plain_view_no_fetch_no_profile(schema_gen):
+    view = _make_plain_view()
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata"
+    ) as gt_mock:
+        # Plain views are never enriched (the call site gates on materialized);
+        # confirm gen_view_dataset_workunits emits no profile for them either.
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+    gt_mock.assert_not_called()
+    assert _profiles(aspects) == []
+    assert schema_gen.report.num_mv_stats_emitted == 0
+
+
+def test_legacy_stats_skips_fetch_but_emits_profile(schema_gen):
+    # use_legacy_table_stats path already populated rows_count; no tables.get needed.
+    view = _make_mv(rows_count=7, size_in_bytes=128)
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata"
+    ) as gt_mock:
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+    gt_mock.assert_not_called()
+    assert schema_gen.report.num_mv_stats_skipped_legacy == 1
+    assert schema_gen.report.num_mv_stats_fetched == 0
+    profiles = _profiles(aspects)
+    assert len(profiles) == 1
+    assert profiles[0].rowCount == 7
+
+
+def test_flag_disabled_no_fetch_no_profile(schema_gen):
+    schema_gen.config.include_materialized_view_stats = False
+    view = _make_mv()
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata"
+    ) as gt_mock:
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+    gt_mock.assert_not_called()
+    assert _profiles(aspects) == []
+    assert schema_gen.report.num_mv_stats_emitted == 0
+
+
+def test_tables_get_failure_warns_and_view_still_emitted(schema_gen):
+    view = _make_mv()
+    # Let the real get_table_metadata run so its try/except handles the error,
+    # records the warning, increments num_mv_stats_failed, and returns None.
+    with patch.object(
+        schema_gen.schema_api.bq_client, "get_table", side_effect=Exception("boom")
+    ):
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+        aspects = _aspects(
+            schema_gen.gen_view_dataset_workunits(view, [], PROJECT_ID, DATASET_NAME)
+        )
+    assert schema_gen.report.num_mv_stats_failed == 1
+    assert schema_gen.report.num_mv_stats_fetched == 0
+    # No profile, but the view itself (ViewProperties) is still emitted.
+    assert _profiles(aspects) == []
+    assert any(isinstance(a, ViewProperties) for a in aspects)
+
+
+def test_mv_last_modified_populated_from_tables_get(schema_gen):
+    modified = datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc)
+    view = _make_mv()
+    _enrich_and_emit(schema_gen, view, _make_bq_table(modified=modified))
+    assert view.last_altered == modified
+
+
+def test_cap_skips_fetch_after_limit_and_warns_once(schema_gen):
+    from datahub.ingestion.source.bigquery_v2.bigquery_schema_gen import (
+        _MAX_MV_STATS_PER_DATASET,
+    )
+
+    schema_gen._mv_stats_fetch_count[f"{PROJECT_ID}.{DATASET_NAME}"] = (
+        _MAX_MV_STATS_PER_DATASET
+    )
+    view = _make_mv()
+    with patch.object(
+        schema_gen.schema_api, "get_table_metadata"
+    ) as gt_mock:
+        schema_gen._enrich_materialized_view_stats(view, PROJECT_ID, DATASET_NAME)
+    gt_mock.assert_not_called()
+    assert schema_gen.report.num_mv_stats_skipped_cap == 1
+    # The warning is recorded exactly once per dataset.
+    assert len(schema_gen.report.warnings) == 1


### PR DESCRIPTION
## Summary

Materialized views in BigQuery currently show no row count / size in the UI Stats panel because the connector never emits a `datasetProfile` aspect for them — `__TABLES__` legacy metadata is inconsistent for MVs, and the existing `datasetProfile` emission is gated behind `profiling.enabled`, which most deployments leave off.

This PR makes MV stats visible by fetching them from the **`tables.get` API** (metadata-only, free, no `getData` / data scan) and emitting `datasetProfile` directly from that catalog metadata, ungated by `profiling.enabled`.

## Changes (all inside `bigquery_v2/`)

- **`BigQuerySchemaApi.get_table_metadata`** — fetches MV row count / size / last-modified via `tables.get`, rate-limited (50/s) with a 30s per-call timeout, warns + counts on failure.
- **`_enrich_materialized_view_stats`** — populates the existing `BigqueryView` fields from `tables.get` output; no-op when the legacy `__TABLES__` path already supplied them.
- **`gen_view_dataset_workunits`** — now emits a `datasetProfile` aspect for materialized views with `partitionSpec = FULL_TABLE_SNAPSHOT`. This is what the UI Stats panel reads — the root-cause fix.
- New default-on flag `include_materialized_view_stats`; 5 report counters + 2 perf timers; `DatasetProperties.lastModified` flows through automatically.
- Bounded cap of 1000 MVs per (project, dataset) with a one-time warning, so a large estate can't stall the schema critical path.

## Test plan

- [x] 9 new unit tests in `tests/unit/bigquery/test_bigquery_mv_stats.py` covering: profiling-off emission, zero-query assertion, `FULL_TABLE_SNAPSHOT` partition, zero-row MV, plain-view no-op, legacy skip, flag-off no-op, `tables.get` failure path, `lastModified`, cap+warning.
- [x] `ruff` clean on all edited files.
- [x] `mypy` clean on all source files.
- [x] All 311 existing bigquery unit tests pass — no regressions.
- [ ] Manual run against a BigQuery project with materialized views to confirm the UI Stats panel populates.

## Notes

- The `datasetProfile` emission is intentionally ungated by `profiling.enabled`: `tables.get` is a metadata-only call (no data scan), so there is no cost a profiling gate would protect against. Precedent: dbt `catalog_stats`.
- The cap is configurable via the constant `_MAX_MV_STATS_PER_DATASET`; views beyond the cap are still ingested, just without row count / size stats.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes materialized view stats (row count, size, last-modified) appear in the BigQuery UI Stats panel by emitting a `datasetProfile` aspect, instead of leaving them blank when `profiling.enabled` is off.

- Fetches MV stats from the metadata-only `tables.get` API (no data scan) with a 50/s rate limit, 30s timeout, and failure warnings.
- New default-on `include_materialized_view_stats` config flag; set to false to skip all per-view API calls.
- Caps stats fetches at 1000 MVs per (project, dataset) and warns once; views beyond the cap are still ingested without stats.
- Adds 9 unit tests covering profiling-off, zero-row, failure, and cap paths, plus a docs caveat.

<sup>Written for commit 9df35dc9d5ba8b5732f2e6490acf6c0452b4df24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

