### PR TITLE
fix(openlineage): assign domains to entities from the REST endpoint

### DIFF
--- a/docs/lineage/openlineage.md
+++ b/docs/lineage/openlineage.md
@@ -125,8 +125,9 @@ DATAHUB_OPENLINEAGE_DOMAINS=urn:li:domain:finance,urn:li:domain:reporting
 ```
 
 Values must be full domain URNs. A domain name such as `finance` cannot be resolved here and is
-skipped with a warning. If none of the configured values parse, no domains aspect is emitted, so an
-existing domain assignment is never cleared.
+skipped with a warning. The remaining valid domains are written as the entity's complete domain
+list, replacing any existing assignment — including one made in the UI. If no configured value
+parses at all, nothing is emitted, so a bad value cannot silently clear domains.
 
 ##### Usage Examples
 

--- a/docs/lineage/openlineage.md
+++ b/docs/lineage/openlineage.md
@@ -104,7 +104,7 @@ The DataHub OpenLineage integration can be configured using environment variable
 | `DATAHUB_OPENLINEAGE_CAPTURE_COLUMN_LEVEL_LINEAGE`     | `datahub.openlineage.capture-column-level-lineage`     | Boolean | `true`  | Whether to capture column-level lineage information                                                               |
 | `DATAHUB_OPENLINEAGE_USE_PATCH`                        | `datahub.openlineage.use-patch`                        | Boolean | `false` | Whether to use patch operations for lineage/incremental lineage                                                   |
 | `DATAHUB_OPENLINEAGE_FILE_PARTITION_REGEXP_PATTERN`    | `datahub.openlineage.file-partition-regexp-pattern`    | String  | `null`  | Regular expression pattern for file partition detection                                                           |
-| `DATAHUB_OPENLINEAGE_DOMAINS`                          | `datahub.openlineage.domains`                          | List    | empty   | Comma-separated domain URNs (`urn:li:domain:<id>`) attached to the DataFlow and DataJob                           |
+| `DATAHUB_OPENLINEAGE_DOMAINS`                          | `datahub.openlineage.domains`                          | List    | `empty` | Comma-separated domain URNs (`urn:li:domain:<id>`) attached to the DataFlow and DataJob                           |
 
 > **Valid `env` values**: `PROD`, `DEV`, `TEST`, `QA`, `UAT`, `EI`, `PRE`, `STG`, `NON_PROD`, `CORP`, `RVW`, `PRD`, `TST`, `SIT`, `SBX`, `SANDBOX`, `CERT`
 >

--- a/docs/lineage/openlineage.md
+++ b/docs/lineage/openlineage.md
@@ -104,6 +104,7 @@ The DataHub OpenLineage integration can be configured using environment variable
 | `DATAHUB_OPENLINEAGE_CAPTURE_COLUMN_LEVEL_LINEAGE`     | `datahub.openlineage.capture-column-level-lineage`     | Boolean | `true`  | Whether to capture column-level lineage information                                                               |
 | `DATAHUB_OPENLINEAGE_USE_PATCH`                        | `datahub.openlineage.use-patch`                        | Boolean | `false` | Whether to use patch operations for lineage/incremental lineage                                                   |
 | `DATAHUB_OPENLINEAGE_FILE_PARTITION_REGEXP_PATTERN`    | `datahub.openlineage.file-partition-regexp-pattern`    | String  | `null`  | Regular expression pattern for file partition detection                                                           |
+| `DATAHUB_OPENLINEAGE_DOMAINS`                          | `datahub.openlineage.domains`                          | List    | empty   | Comma-separated domain URNs (`urn:li:domain:<id>`) attached to the DataFlow and DataJob                           |
 
 > **Valid `env` values**: `PROD`, `DEV`, `TEST`, `QA`, `UAT`, `EI`, `PRE`, `STG`, `NON_PROD`, `CORP`, `RVW`, `PRD`, `TST`, `SIT`, `SBX`, `SANDBOX`, `CERT`
 >
@@ -113,6 +114,19 @@ The DataHub OpenLineage integration can be configured using environment variable
 > - **For advanced scenarios**, use `platform-instance` to override the DataFlow cluster or `common-dataset-env` to override the Dataset environment independently
 >
 > **Note**: The `env` property naming matches DataHub SDK conventions where `env` is the user-facing parameter that internally maps to the URN `cluster` field.
+
+##### Assigning Domains
+
+OpenLineage has no domain facet, so a domain cannot be carried on the event itself. Set it on the
+endpoint instead — every DataFlow and DataJob created from events on this endpoint gets these domains:
+
+```bash
+DATAHUB_OPENLINEAGE_DOMAINS=urn:li:domain:finance,urn:li:domain:reporting
+```
+
+Values must be full domain URNs. A domain name such as `finance` cannot be resolved here and is
+skipped with a warning. If none of the configured values parse, no domains aspect is emitted, so an
+existing domain assignment is never cleared.
 
 ##### Usage Examples
 

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/config/DatahubOpenlineageConfig.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/config/DatahubOpenlineageConfig.java
@@ -21,6 +21,9 @@ public class DatahubOpenlineageConfig {
   @Builder.Default private final String pipelineName = null;
   private final String orchestrator;
   @Builder.Default private final FabricType fabricType = FabricType.PROD;
+  // Domain URNs (urn:li:domain:<id>) attached to the emitted DataFlow and DataJob. OpenLineage has
+  // no domain facet, so this is the only way to convey domain ownership for a pipeline.
+  @Builder.Default private final List<String> domains = Collections.emptyList();
 
   // Platform configuration
   private final String platformInstance;

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -373,14 +374,19 @@ public class OpenLineageToDataHub {
   }
 
   public static Domains generateDomains(List<String> domains) {
-    domains.sort(String::compareToIgnoreCase);
+    // Copy before sorting: the caller's list may be an immutable config value.
+    List<String> sortedDomains = new ArrayList<>(domains);
+    sortedDomains.sort(String::compareToIgnoreCase);
     Domains datahubDomains = new Domains();
     UrnArray domainArray = new UrnArray();
-    for (String domain : domains) {
+    for (String domain : sortedDomains) {
       try {
         domainArray.add(Urn.createFromString(domain));
       } catch (URISyntaxException e) {
-        log.warn("Unable to create domain urn for domain urn: {}", domain);
+        log.warn(
+            "Skipping domain '{}': a full domain URN is required (urn:li:domain:<id>), "
+                + "a domain name cannot be resolved here.",
+            domain);
       }
     }
     datahubDomains.setDomains(domainArray);
@@ -448,6 +454,20 @@ public class OpenLineageToDataHub {
 
     GlobalTags tags = generateTags(event);
     jobBuilder.flowGlobalTags(tags);
+
+    // OpenLineage has no domain facet, so domains come from configuration only.
+    if (datahubConf.getDomains() != null && !datahubConf.getDomains().isEmpty()) {
+      Domains domains = generateDomains(datahubConf.getDomains());
+      if (domains.getDomains().isEmpty()) {
+        log.warn(
+            "None of the configured domains {} could be parsed as domain URNs; "
+                + "no domains aspect will be emitted.",
+            datahubConf.getDomains());
+      } else {
+        jobBuilder.flowDomains(domains);
+        jobBuilder.jobDomains(domains);
+      }
+    }
 
     DatahubJob datahubJob = jobBuilder.build();
     convertJobToDataJob(datahubJob, event, datahubConf);

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -391,6 +391,12 @@ public class OpenLineageToDataHub {
               domainUrn.getEntityType());
           continue;
         }
+        // "urn:li:domain" parses with entity type "domain" but carries no id, so the entity key
+        // has to be checked separately.
+        if (domainUrn.getEntityKey().size() == 0) {
+          log.warn("Skipping '{}': a domain URN must carry an id (urn:li:domain:<id>).", domain);
+          continue;
+        }
         domainArray.add(domainUrn);
       } catch (URISyntaxException e) {
         log.warn(

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -373,6 +373,8 @@ public class OpenLineageToDataHub {
     return globalTags;
   }
 
+  private static final String DOMAIN_ENTITY_TYPE = "domain";
+
   public static Domains generateDomains(List<String> domains) {
     // Copy before sorting: the caller's list may be an immutable config value.
     List<String> sortedDomains = new ArrayList<>(domains);
@@ -381,7 +383,15 @@ public class OpenLineageToDataHub {
     UrnArray domainArray = new UrnArray();
     for (String domain : sortedDomains) {
       try {
-        domainArray.add(Urn.createFromString(domain));
+        Urn domainUrn = Urn.createFromString(domain);
+        if (!DOMAIN_ENTITY_TYPE.equals(domainUrn.getEntityType())) {
+          log.warn(
+              "Skipping '{}': expected a domain URN (urn:li:domain:<id>) but got entity type '{}'.",
+              domain,
+              domainUrn.getEntityType());
+          continue;
+        }
+        domainArray.add(domainUrn);
       } catch (URISyntaxException e) {
         log.warn(
             "Skipping domain '{}': a full domain URN is required (urn:li:domain:<id>), "

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -376,8 +376,8 @@ public class OpenLineageToDataHub {
   private static final String DOMAIN_ENTITY_TYPE = "domain";
 
   public static Domains generateDomains(List<String> domains) {
-    // Copy before sorting: the caller's list may be an immutable config value.
-    List<String> sortedDomains = new ArrayList<>(domains);
+    // Copy before sorting: the caller's list is a shared, possibly immutable config value.
+    List<String> sortedDomains = domains == null ? new ArrayList<>() : new ArrayList<>(domains);
     sortedDomains.sort(String::compareToIgnoreCase);
     Domains datahubDomains = new Domains();
     UrnArray domainArray = new UrnArray();
@@ -404,6 +404,12 @@ public class OpenLineageToDataHub {
                 + "a domain name cannot be resolved here.",
             domain);
       }
+    }
+    if (domainArray.isEmpty() && !sortedDomains.isEmpty()) {
+      log.warn(
+          "None of the configured domains {} could be parsed as domain URNs; "
+              + "no domains aspect will be emitted.",
+          domains);
     }
     datahubDomains.setDomains(domainArray);
     return datahubDomains;
@@ -471,19 +477,11 @@ public class OpenLineageToDataHub {
     GlobalTags tags = generateTags(event);
     jobBuilder.flowGlobalTags(tags);
 
-    // OpenLineage has no domain facet, so domains come from configuration only.
-    if (datahubConf.getDomains() != null && !datahubConf.getDomains().isEmpty()) {
-      Domains domains = generateDomains(datahubConf.getDomains());
-      if (domains.getDomains().isEmpty()) {
-        log.warn(
-            "None of the configured domains {} could be parsed as domain URNs; "
-                + "no domains aspect will be emitted.",
-            datahubConf.getDomains());
-      } else {
-        jobBuilder.flowDomains(domains);
-        jobBuilder.jobDomains(domains);
-      }
-    }
+    // OpenLineage has no domain facet, so domains come from configuration only. An empty or
+    // fully-rejected list yields an empty aspect, which DatahubJob then declines to emit.
+    Domains domains = generateDomains(datahubConf.getDomains());
+    jobBuilder.flowDomains(domains);
+    jobBuilder.jobDomains(domains);
 
     DatahubJob datahubJob = jobBuilder.build();
     convertJobToDataJob(datahubJob, event, datahubConf);

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
@@ -73,7 +73,6 @@ public class DatahubJob {
   public static final String DATASET_ENTITY_TYPE = "dataset";
   public static final String DATA_FLOW_ENTITY_TYPE = "dataFlow";
   public static final String DATA_PROCESS_INSTANCE_ENTITY_TYPE = "dataProcessInstance";
-  public static final String DATAFLOW_ENTITY_TYPE = "dataflow";
   public static final String DATAJOB_ENTITY_TYPE = "dataJob";
   DataFlowUrn flowUrn;
   DataFlowInfo dataFlowInfo;
@@ -151,7 +150,7 @@ public class DatahubJob {
     generateFlowGlobalTagsAspect(flowUrn, flowGlobalTags, config, mcps);
 
     // Generate and add domain Aspect
-    generateDomainsAspect(flowUrn, DATAFLOW_ENTITY_TYPE, flowDomains, mcps);
+    generateDomainsAspect(flowUrn, DATA_FLOW_ENTITY_TYPE, flowDomains, mcps);
     generateDomainsAspect(jobUrn, DATAJOB_ENTITY_TYPE, jobDomains, mcps);
 
     log.info(

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
@@ -424,17 +424,10 @@ public class DatahubJob {
       Urn entityUrn, String entityType, Domains domains, List<MetadataChangeProposal> mcps) {
     // An empty domains aspect would clear domains set by other sources, so only emit a populated
     // one.
-    if (domains == null || domains.getDomains() == null || domains.getDomains().isEmpty()) {
+    if (domains == null || domains.getDomains().isEmpty()) {
       return;
     }
-    MetadataChangeProposalWrapper domainsMcpw =
-        MetadataChangeProposalWrapper.create(
-            b -> b.entityType(entityType).entityUrn(entityUrn).upsert().aspect(domains));
-    try {
-      mcps.add(eventFormatter.convert(domainsMcpw));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    addAspectToMcps(entityUrn, entityType, domains, mcps);
   }
 
   private void generateFlowGlobalTagsAspect(

--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/dataset/DatahubJob.java
@@ -82,6 +82,7 @@ public class DatahubJob {
   Ownership flowOwnership;
   GlobalTags flowGlobalTags;
   Domains flowDomains;
+  Domains jobDomains;
   DataPlatformInstance flowPlatformInstance;
   DataPlatformInstance jobPlatformInstance;
   DataProcessInstanceRunEvent dataProcessInstanceRunEvent;
@@ -150,7 +151,8 @@ public class DatahubJob {
     generateFlowGlobalTagsAspect(flowUrn, flowGlobalTags, config, mcps);
 
     // Generate and add domain Aspect
-    generateFlowDomainsAspect(mcps, customProperties);
+    generateDomainsAspect(flowUrn, DATAFLOW_ENTITY_TYPE, flowDomains, mcps);
+    generateDomainsAspect(jobUrn, DATAJOB_ENTITY_TYPE, jobDomains, mcps);
 
     log.info(
         "Adding input and output to {} Number of outputs: {}, Number of inputs {}",
@@ -419,21 +421,20 @@ public class DatahubJob {
     return Pair.of(inputUrnArray, inputEdges);
   }
 
-  private void generateFlowDomainsAspect(
-      List<MetadataChangeProposal> mcps, StringMap customProperties) {
-    if (flowDomains != null) {
-      MetadataChangeProposalWrapper domains =
-          MetadataChangeProposalWrapper.create(
-              b ->
-                  b.entityType(DATAFLOW_ENTITY_TYPE)
-                      .entityUrn(flowUrn)
-                      .upsert()
-                      .aspect(flowDomains));
-      try {
-        mcps.add(eventFormatter.convert(domains));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+  private void generateDomainsAspect(
+      Urn entityUrn, String entityType, Domains domains, List<MetadataChangeProposal> mcps) {
+    // An empty domains aspect would clear domains set by other sources, so only emit a populated
+    // one.
+    if (domains == null || domains.getDomains() == null || domains.getDomains().isEmpty()) {
+      return;
+    }
+    MetadataChangeProposalWrapper domainsMcpw =
+        MetadataChangeProposalWrapper.create(
+            b -> b.entityType(entityType).entityUrn(entityUrn).upsert().aspect(domains));
+    try {
+      mcps.add(eventFormatter.convert(domainsMcpw));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
@@ -3,6 +3,8 @@ package io.datahubproject.openlineage;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.FabricType;
 import com.linkedin.mxe.MetadataChangeProposal;
 import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
@@ -10,14 +12,18 @@ import io.datahubproject.openlineage.converter.OpenLineageToDataHub;
 import io.datahubproject.openlineage.dataset.DatahubJob;
 import io.openlineage.client.OpenLineage;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 
 public class OpenLineageDomainsTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static OpenLineage.RunEvent runEvent() {
     OpenLineage ol = new OpenLineage(URI.create("https://github.com/OpenLineage/OpenLineage"));
@@ -31,7 +37,8 @@ public class OpenLineageDomainsTest {
         .build();
   }
 
-  private static Map<String, List<String>> domainUrnsByEntity(List<String> configuredDomains)
+  /** Maps entity type to the domain URNs actually carried in that entity's domains aspect. */
+  private static Map<String, List<String>> emittedDomains(List<String> configuredDomains)
       throws Exception {
     DatahubOpenlineageConfig config =
         DatahubOpenlineageConfig.builder()
@@ -40,30 +47,35 @@ public class OpenLineageDomainsTest {
             .domains(configuredDomains)
             .build();
     DatahubJob job = OpenLineageToDataHub.convertRunEventToJob(runEvent(), config);
-    return job.toMcps(config).stream()
-        .filter(mcp -> "domains".equals(mcp.getAspectName()))
-        .collect(
-            Collectors.groupingBy(
-                MetadataChangeProposal::getEntityType,
-                Collectors.mapping(mcp -> mcp.getEntityUrn().toString(), Collectors.toList())));
+
+    Map<String, List<String>> byEntity = new HashMap<>();
+    for (MetadataChangeProposal mcp : job.toMcps(config)) {
+      if (!"domains".equals(mcp.getAspectName())) {
+        continue;
+      }
+      JsonNode aspect =
+          MAPPER.readTree(mcp.getAspect().getValue().asString(StandardCharsets.UTF_8));
+      List<String> urns = new ArrayList<>();
+      aspect.get("domains").forEach(n -> urns.add(n.asText()));
+      byEntity.put(mcp.getEntityType(), urns);
+    }
+    return byEntity;
   }
 
   @Test
   public void testConfiguredDomainsLandOnFlowAndJob() throws Exception {
-    Map<String, List<String>> byEntity = domainUrnsByEntity(List.of("urn:li:domain:finance"));
+    Map<String, List<String>> byEntity =
+        emittedDomains(List.of("urn:li:domain:reporting", "urn:li:domain:finance"));
 
-    assertEquals(byEntity.keySet().size(), 2, "expected a domains aspect on both flow and job");
-    assertTrue(
-        byEntity.containsKey(DatahubJob.DATA_FLOW_ENTITY_TYPE),
-        "missing DataFlow domains aspect: " + byEntity);
-    assertTrue(
-        byEntity.containsKey(DatahubJob.DATAJOB_ENTITY_TYPE),
-        "missing DataJob domains aspect: " + byEntity);
+    List<String> expected = List.of("urn:li:domain:finance", "urn:li:domain:reporting");
+    assertEquals(byEntity.get(DatahubJob.DATA_FLOW_ENTITY_TYPE), expected);
+    assertEquals(byEntity.get(DatahubJob.DATAJOB_ENTITY_TYPE), expected);
+    assertEquals(byEntity.size(), 2, "domains should reach the flow and the job only: " + byEntity);
   }
 
   @Test
   public void testNoDomainsConfiguredEmitsNoDomainsAspect() throws Exception {
-    assertTrue(domainUrnsByEntity(List.of()).isEmpty());
+    assertTrue(emittedDomains(List.of()).isEmpty());
   }
 
   /**
@@ -72,20 +84,30 @@ public class OpenLineageDomainsTest {
    */
   @Test
   public void testUnparseableDomainEmitsNothing() throws Exception {
-    assertTrue(domainUrnsByEntity(List.of("finance")).isEmpty());
+    assertTrue(emittedDomains(List.of("finance")).isEmpty());
   }
 
   /** A syntactically valid URN for some other entity is not a domain and must not be emitted. */
   @Test
   public void testNonDomainUrnIsRejected() throws Exception {
-    assertTrue(domainUrnsByEntity(List.of("urn:li:corpuser:jdoe")).isEmpty());
+    assertTrue(emittedDomains(List.of("urn:li:corpuser:jdoe")).isEmpty());
+  }
+
+  /** "urn:li:domain" parses as entity type "domain" but carries no id. */
+  @Test
+  public void testDomainUrnWithoutIdIsRejected() throws Exception {
+    assertTrue(emittedDomains(List.of("urn:li:domain")).isEmpty());
   }
 
   @Test
-  public void testValidDomainsSurviveAlongsideRejectedOnes() throws Exception {
+  public void testOnlyValidDomainsSurviveAlongsideRejectedOnes() throws Exception {
     Map<String, List<String>> byEntity =
-        domainUrnsByEntity(List.of("urn:li:corpuser:jdoe", "urn:li:domain:finance", "finance"));
-    assertEquals(byEntity.keySet().size(), 2);
+        emittedDomains(
+            List.of("urn:li:corpuser:jdoe", "urn:li:domain:finance", "finance", "urn:li:domain"));
+
+    List<String> expected = List.of("urn:li:domain:finance");
+    assertEquals(byEntity.get(DatahubJob.DATA_FLOW_ENTITY_TYPE), expected);
+    assertEquals(byEntity.get(DatahubJob.DATAJOB_ENTITY_TYPE), expected);
   }
 
   @Test

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
@@ -1,0 +1,84 @@
+package io.datahubproject.openlineage;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.FabricType;
+import com.linkedin.mxe.MetadataChangeProposal;
+import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
+import io.datahubproject.openlineage.converter.OpenLineageToDataHub;
+import io.datahubproject.openlineage.dataset.DatahubJob;
+import io.openlineage.client.OpenLineage;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.testng.annotations.Test;
+
+public class OpenLineageDomainsTest {
+
+  private static OpenLineage.RunEvent runEvent() {
+    OpenLineage ol = new OpenLineage(URI.create("https://github.com/OpenLineage/OpenLineage"));
+    return ol.newRunEventBuilder()
+        .eventTime(ZonedDateTime.now())
+        .eventType(OpenLineage.RunEvent.EventType.COMPLETE)
+        .run(ol.newRunBuilder().runId(UUID.randomUUID()).build())
+        .job(ol.newJobBuilder().namespace("my_namespace").name("my_job").build())
+        .inputs(java.util.Collections.emptyList())
+        .outputs(java.util.Collections.emptyList())
+        .build();
+  }
+
+  private static Map<String, List<String>> domainUrnsByEntity(List<String> configuredDomains)
+      throws Exception {
+    DatahubOpenlineageConfig config =
+        DatahubOpenlineageConfig.builder()
+            .fabricType(FabricType.PROD)
+            .orchestrator("spark")
+            .domains(configuredDomains)
+            .build();
+    DatahubJob job = OpenLineageToDataHub.convertRunEventToJob(runEvent(), config);
+    return job.toMcps(config).stream()
+        .filter(mcp -> "domains".equals(mcp.getAspectName()))
+        .collect(
+            Collectors.groupingBy(
+                MetadataChangeProposal::getEntityType,
+                Collectors.mapping(mcp -> mcp.getEntityUrn().toString(), Collectors.toList())));
+  }
+
+  @Test
+  public void testConfiguredDomainsLandOnFlowAndJob() throws Exception {
+    Map<String, List<String>> byEntity = domainUrnsByEntity(List.of("urn:li:domain:finance"));
+
+    assertEquals(byEntity.keySet().size(), 2, "expected a domains aspect on both flow and job");
+    assertTrue(
+        byEntity.containsKey(DatahubJob.DATAFLOW_ENTITY_TYPE),
+        "missing DataFlow domains aspect: " + byEntity);
+    assertTrue(
+        byEntity.containsKey(DatahubJob.DATAJOB_ENTITY_TYPE),
+        "missing DataJob domains aspect: " + byEntity);
+  }
+
+  @Test
+  public void testNoDomainsConfiguredEmitsNoDomainsAspect() throws Exception {
+    assertTrue(domainUrnsByEntity(List.of()).isEmpty());
+  }
+
+  /**
+   * A domain name is not resolvable to a URN here, so nothing is emitted rather than an empty
+   * aspect that would clear domains set elsewhere.
+   */
+  @Test
+  public void testUnparseableDomainEmitsNothing() throws Exception {
+    assertTrue(domainUrnsByEntity(List.of("finance")).isEmpty());
+  }
+
+  @Test
+  public void testImmutableConfiguredDomainListIsNotMutated() {
+    List<String> immutable = List.of("urn:li:domain:zeta", "urn:li:domain:alpha");
+    OpenLineageToDataHub.generateDomains(immutable);
+    assertEquals(immutable, List.of("urn:li:domain:zeta", "urn:li:domain:alpha"));
+  }
+}

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageDomainsTest.java
@@ -54,7 +54,7 @@ public class OpenLineageDomainsTest {
 
     assertEquals(byEntity.keySet().size(), 2, "expected a domains aspect on both flow and job");
     assertTrue(
-        byEntity.containsKey(DatahubJob.DATAFLOW_ENTITY_TYPE),
+        byEntity.containsKey(DatahubJob.DATA_FLOW_ENTITY_TYPE),
         "missing DataFlow domains aspect: " + byEntity);
     assertTrue(
         byEntity.containsKey(DatahubJob.DATAJOB_ENTITY_TYPE),
@@ -73,6 +73,19 @@ public class OpenLineageDomainsTest {
   @Test
   public void testUnparseableDomainEmitsNothing() throws Exception {
     assertTrue(domainUrnsByEntity(List.of("finance")).isEmpty());
+  }
+
+  /** A syntactically valid URN for some other entity is not a domain and must not be emitted. */
+  @Test
+  public void testNonDomainUrnIsRejected() throws Exception {
+    assertTrue(domainUrnsByEntity(List.of("urn:li:corpuser:jdoe")).isEmpty());
+  }
+
+  @Test
+  public void testValidDomainsSurviveAlongsideRejectedOnes() throws Exception {
+    Map<String, List<String>> byEntity =
+        domainUrnsByEntity(List.of("urn:li:corpuser:jdoe", "urn:li:domain:finance", "finance"));
+    assertEquals(byEntity.keySet().size(), 2);
   }
 
   @Test

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/DatahubOpenlineageProperties.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/DatahubOpenlineageProperties.java
@@ -1,5 +1,7 @@
 package io.datahubproject.openapi.openlineage.config;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -13,6 +15,9 @@ public class DatahubOpenlineageProperties {
   private String pipelineName;
   private String orchestrator;
   private String env;
+  // Full domain URNs (urn:li:domain:<id>). OpenLineage carries no domain facet, so domains for
+  // events arriving on this endpoint can only be supplied here.
+  private List<String> domains = new ArrayList<>();
 
   // Platform configuration
   private String platformInstance;

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfig.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfig.java
@@ -59,6 +59,7 @@ public class OpenLineageServletConfig {
             .usePatch(properties.isUsePatch())
             .fabricType(fabricType)
             .orchestrator(properties.getOrchestrator())
+            .domains(properties.getDomains())
             .parentJobUrn(null)
             .build();
     log.info("Starting OpenLineage Endpoint with config: {}", datahubOpenlineageConfig);

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfigTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/openlineage/config/OpenLineageServletConfigTest.java
@@ -7,7 +7,9 @@ import static org.testng.Assert.assertNull;
 import com.linkedin.common.FabricType;
 import io.datahubproject.openapi.openlineage.mapping.RunEventMapper;
 import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -331,4 +333,32 @@ public class OpenLineageServletConfigTest extends AbstractTestNGSpringContextTes
       return props;
     }
   }
+
+  /**
+   * Unlike the cases above, which hand-build the properties bean and so never exercise binding,
+   * this one enables real {@code @ConfigurationProperties} binding. It covers both the {@code
+   * .domains(...)} wiring in {@link OpenLineageServletConfig#mappingConfig()} and {@code
+   * DATAHUB_OPENLINEAGE_DOMAINS} parsing as a comma-separated list.
+   */
+  @SpringBootTest(classes = {OpenLineageServletConfig.class, TestConfigBoundProperties.class})
+  @TestPropertySource(
+      properties = {
+        "datahub.openlineage.env=PROD",
+        "datahub.openlineage.domains=urn:li:domain:finance,urn:li:domain:reporting"
+      })
+  public static class BoundDomainsTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired private RunEventMapper.MappingConfig mappingConfig;
+
+    @Test
+    public void testCommaSeparatedDomainsBindAndReachConverterConfig() {
+      assertEquals(
+          mappingConfig.getDatahubConfig().getDomains(),
+          List.of("urn:li:domain:finance", "urn:li:domain:reporting"));
+    }
+  }
+
+  @Configuration
+  @EnableConfigurationProperties(DatahubOpenlineageProperties.class)
+  static class TestConfigBoundProperties {}
 }


### PR DESCRIPTION
Fixes #19518

## Problem

Entities created by the OpenLineage REST endpoint (`POST /openapi/openlineage/api/v1/lineage`) never receive a `domains` aspect, so there is no way to assign a domain to them.

`DatahubJob` already has a `flowDomains` field and `generateFlowDomainsAspect()`, but nothing on the REST path populates it — `flowDomains` stays `null` and the aspect is skipped without any log line. Domains were only reachable from the Spark agent via `spark.datahub.domains`. Every step of the chain was missing on the REST side: no `domains` field on `DatahubOpenlineageConfig`, no property on `DatahubOpenlineageProperties`, no injection in `OpenLineageServletConfig`, no `setFlowDomains` in `RunEventMapper`.

## Change

Adds `datahub.openlineage.domains` (`DATAHUB_OPENLINEAGE_DOMAINS`) and carries it through `DatahubOpenlineageConfig` into the converter, which stamps the `domains` aspect on both the DataFlow and the DataJob.

Also fixes two defects in `OpenLineageToDataHub.generateDomains()` that this wiring makes reachable:

1. It sorted the caller's list in place, so a Spring-bound (immutable) config list threw `UnsupportedOperationException`. The Spark path passes a `LinkedList`, which is why this never surfaced.
2. When no entry parsed as a URN it still emitted an *empty* `domains` aspect, clearing domains set by other sources. Nothing is emitted now, and the warning states that a full `urn:li:domain:<id>` is required.

## Before / after

Same OpenLineage event, aspects persisted in `metadata_aspect_v2`:

**Before**

```
dataFlow  browsePathsV2, dataFlowInfo, dataFlowKey, dataPlatformInstance, status
dataJob   browsePathsV2, dataJobInfo, dataJobInputOutput, dataJobKey,
          dataPlatformInstance, status
```

**After**, with `DATAHUB_OPENLINEAGE_DOMAINS=urn:li:domain:finance,urn:li:domain:reporting`

```
dataFlow  browsePathsV2, dataFlowInfo, dataFlowKey, dataPlatformInstance, status, domains
dataJob   browsePathsV2, dataJobInfo, dataJobInputOutput, dataJobKey,
          dataPlatformInstance, status, domains
```

```json
{"domains":["urn:li:domain:finance","urn:li:domain:reporting"]}
```

## Testing

- New `OpenLineageDomainsTest` (4 cases): domains land on both flow and job; nothing emitted when unconfigured; nothing emitted when no value parses as a URN; the configured list is not mutated.
- Existing `openlineage-converter` suite passes (26 tests total).
- End-to-end against a local quickstart GMS (v1.7.0rc1): rebuilt the war, recreated the container with the env var, POSTed an event, and verified both `domains` aspects in MySQL. This also exercises Spring's comma-separated `List<String>` binding, which is what triggers the in-place-sort defect above.

## Blast radius

Confined to the OpenLineage integration.

- Spark agent behaviour is unchanged: `SparkLineageConf` keeps its own `domains` and sets `flowDomains` after conversion, so it still attaches domains to the DataFlow only.
- No behaviour change when `datahub.openlineage.domains` is unset (the default), which is the case for every existing deployment.
- The empty-aspect fix is strictly safer: it can only stop a write that would have cleared domains.

## Notes

`#14458` covers `TagsJobFacet` / `OwnershipJobFacet` being dropped on the same endpoint and is addressed by `#18175`; this PR deliberately leaves that alone and touches only domains.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated
- [ ] Breaking change entry in Updating DataHub — not applicable, no breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Entities created by the OpenLineage REST endpoint never received a `domains` aspect, so domains could only be assigned via the Spark agent. Adds `datahub.openlineage.domains` (`DATAHUB_OPENLINEAGE_DOMAINS`), which stamps the configured URNs on both the DataFlow and the DataJob it creates — no behavior change when unset, and the Spark agent keeps its own path. Fixes #19518.

**Bug Fixes**
- `generateDomains()` sorted the caller's list in place, which threw `UnsupportedOperationException` on Spring's immutable config lists; it now sorts a copy.
- Any syntactically valid URN was emitted as a domain; only `domain`-type URNs that carry an id pass now (e.g., `urn:li:domain` alone is rejected), and invalid values are skipped with a warning.
- When no configured value produced a domain URN, an empty `domains` aspect was emitted, clearing domains set by other sources; nothing is emitted now.
- The DataFlow domains aspect used the `dataflow` entity type instead of the registered `dataFlow` casing; the duplicate constant was dropped.

<sup>Written for commit 02789534d78868dd9605b307297c2d63483c5b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

