### PR TITLE
chore(uv): narrow chainguard-ci no-build-package to grpcio

### DIFF
--- a/docker/snippets/uv/profiles/chainguard-ci.toml
+++ b/docker/snippets/uv/profiles/chainguard-ci.toml
@@ -26,12 +26,7 @@ index-strategy = "unsafe-best-match"
 # unsafe-best-match then prefers that sdist over a wheel from Chainguard main / PyPI.
 # Force wheels for packages known to hit that path
 no-build-package = [
-    "beautifulsoup4",
-    "grpcio",
-    "orjson",
-    "pydantic",
-    "pypdf",
-    "smmap",
+    "grpcio"
 ]
 
 [[index]]


### PR DESCRIPTION
## Summary

Trims the `no-build-package` list in `docker/snippets/uv/profiles/chainguard-ci.toml` down to `grpcio`.

The list exists to force wheels for packages where a Chainguard remediation lists a version as sdist-only, which `index-strategy = "unsafe-best-match"` would otherwise prefer over a usable wheel from Chainguard main or PyPI. Only `grpcio` still needs that workaround; the remaining entries (`beautifulsoup4`, `orjson`, `pydantic`, `pypdf`, `smmap`) no longer hit that path.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (n/a — resolver config only)
- [ ] Docs related to the changes have been added/updated (n/a)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub (n/a)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the `no-build-package` list in the Chainguard CI uv profile to `grpcio` only. The other entries no longer hit the sdist-only remediation path, so forcing wheels for them is unnecessary.

<sup>Written for commit f9a73b8071adf1618d66890142c0a42532f071b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

