### PR TITLE
docs(managed-datahub): release notes for v2.1.5

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -45,8 +45,6 @@ This release rolls up hotfixes on top of v2.1.4.
 
 - Fixed `Container.relationships(types: [IsPartOf], direction: INCOMING)` returning incomplete or empty contained-asset lists when the nesting-only entity graph cache was enabled; the resolver again uses the live graph for this listing.
 - Fixed GraphQL `entity(urn:)` throwing 403 for view-restricted assets (for example query nodes in lineage) instead of returning a **Restricted** placeholder, which broke the lineage sidebar after opening a restricted neighbor.
-- Fixed support login retaining a prior user session when `sudo_arn` was used while already logged in; support login always re-authenticates and clears the stale session/cookie before the IdP redirect.
-- Fixed pac4j OIDC state being dropped on the support-login redirect path.
 
 ### v2.1.4
 

--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,48 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.5
+
+This release rolls up hotfixes on top of v2.1.4.
+
+#### Release Availability Date
+
+1-Sep-2026
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.5-cloud, v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
+#### Platform
+
+- **Anonymous OAuth DCR client reclaim** — when anonymous Dynamic Client Registration approaches `OAUTH2_DCR_MAX_CLIENTS`, GMS reclaims idle anonymous DCR clients (no token issued within `OAUTH2_DCR_EVICT_IDLE_DAYS`, default 7) instead of refusing every new registration and taking MCP sign-in offline instance-wide. The cap is enforced on every write path to `dataHubOAuthClient`, not only `POST /auth/oauth2/register`. Tunables: `OAUTH2_DCR_EVICT_THRESHOLD_PERCENT` (default `90`), `OAUTH2_DCR_EVICT_BATCH_SIZE` (default `100`); set `OAUTH2_DCR_EVICT_IDLE_DAYS=0` to keep refuse-at-cap behavior. Admin-created and IAT-attributed clients are never reclaimed.
+- **Entity graph cache relationship correctness** — hierarchical search-filter expansion no longer double-counts seed URNs or silently truncates descendant/ancestor sets; role-membership and related-entity graph reads fail closed when expansion is truncated instead of returning a partial set that looked complete.
+- **Search Access Controls glossary and domain expansion** — glossary hierarchy expansion for SAC filters is cache-first, and multi-root domain / multi-value EQUAL graph scrolls are level-batched, cutting load on large homepage and policy-evaluation paths.
+- **AWS IRSA credential providers** — shared AWS credential providers used by GMS are closed correctly so IRSA token refresh no longer leaks threads/connections under long-running workloads.
+
+#### Breaking Changes
+
+- **Role and group membership writes** — writes that grant privileges are now authorized at the aspect layer across GraphQL, OpenAPI, and Rest.li (`PrivilegeGrantAuthorizationValidator`). Adding a role (`roleMembership`) requires **Manage Policies**; adding a user to a group (`groupMembership` / `nativeGroupMembership`) requires **Edit Group Members**; adding a corpGroup owner requires **Edit Owners**; when the acting user is the one being added, both require **Manage Users & Groups**. Removals, unchanged re-ingestion, and system/bootstrap writes are unchanged. Previously **Edit Entity** on a user (or on a group you own) was enough to grant Admin. **Action:** grant **Manage Policies** to automation that writes `roleMembership` outside the UI; group-membership sync (LDAP, Okta, Azure AD, `datahub user upsert`) needs **Edit Group Members** or **Manage Users & Groups**. Toggle via `metadataChangeProposal.validation.aspectAuthorization.privilegeGrant.enabled` (default `true`).
+
+#### Security / Dependencies
+
+- **SCIM provisioning authorization** — `/openapi/scim/v2/*` now requires **Manage Users & Groups**. Authenticated callers without that privilege receive **403** (previously any authenticated principal could enumerate, create Admin users, overwrite credentials, or deprovision via SCIM).
+- **Remote executor config listing** — `listExecutorConfigs` now requires **Manage Ingestion**. The resolver returns live remote-executor cloud credentials and queue config; unprivileged callers are denied before any assume-role call.
+- **Aspect authorization spoofing** — validators no longer trust client-writable `systemMetadata.properties.appSource=systemUpdate` (or a hardcoded system URN) to skip privilege checks. Only a real system `OperationContext` skips those checks; non-system writers have reserved `appSource=systemUpdate` stripped from batches.
+- **GMS `/auth` helpers** — `POST /auth/signUp`, `/auth/resetNativeUserCredentials`, `/auth/verifyNativeUserCredentials`, and `/auth/getSsoSettings` require GMS **system client** credentials (same as `/auth/generateSessionTokenForUser`). Frontend login, signup, password reset, and SSO are unchanged. A user session token calling GMS `/auth/*` directly receives **401**.
+- **Python / Java dependency floors** — cryptography 50.0.1 (CVE-2026-69247), gitpython 3.1.61 (multiple GHSAs), mcp ≥1.28.1 (CVE-2026-59950 WebSocket Host/Origin), mlflow 3.15.1 (CVE-2026-64849), micrometer-core 1.16.6, reactor-netty-core 1.3.6, and httpcore5 5.4.3 (CVE-2026-54399). Executor and integrations-service hotfix runtimes enforce the secure Python floors.
+
+#### Bug Fixes
+
+- Fixed `Container.relationships(types: [IsPartOf], direction: INCOMING)` returning incomplete or empty contained-asset lists when the nesting-only entity graph cache was enabled; the resolver again uses the live graph for this listing.
+- Fixed GraphQL `entity(urn:)` throwing 403 for view-restricted assets (for example query nodes in lineage) instead of returning a **Restricted** placeholder, which broke the lineage sidebar after opening a restricted neighbor.
+- Fixed support login retaining a prior user session when `sudo_arn` was used while already logged in; support login always re-authenticates and clears the stale session/cookie before the IdP redirect.
+- Fixed pac4j OIDC state being dropped on the support-login redirect path.
+
 ### v2.1.4
 
 This release rolls up hotfixes on top of v2.1.3. There are no breaking changes or deprecations.


### PR DESCRIPTION
DataHub Cloud v2.1.5 release notes.

See the added `### v2.1.5` section under `docs/managed-datahub/release-notes/v_2_1_0.md`.

## Test plan
- [ ] `### v2.1.5` appears at the top of the Release Changelog (above v2.1.4)
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions filled in before marking ready


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the DataHub Cloud v2.1.5 release notes, including platform improvements, breaking changes to privilege authorization, security hardening, and bug fixes. The breaking changes affect role/group membership writes and require granting Manage Policies to automation outside the UI.

<sup>Written for commit 284b6317068b60a3a28871b56350c9018a33f141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

