### PR TITLE
fix(usage): avoid cached user group from misattributing usage

### DIFF
--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -45,6 +45,7 @@ from tests.metrics.usage_aggregation_metrics import (
     resolve_usage_actor_class,
     session_corp_user_urn,
     try_mint_personal_access_token,
+    warm_up_actor_class_cache,
     wait_for_metric_at_least,
     wait_for_metric_delta,
 )
@@ -332,6 +333,8 @@ class TestUsageAggregationGraphqlOutputDedup:
         )
         tags = graphql_metadata_query_tags("support")
         try:
+            warm_up_actor_class_cache(support_session, auth_session, gms_url, tags)
+
             output_baseline = fetch_metric_total(
                 auth_session, gms_url, OUTPUT_BYTES_METRIC, tags
             )

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -45,9 +45,9 @@ from tests.metrics.usage_aggregation_metrics import (
     resolve_usage_actor_class,
     session_corp_user_urn,
     try_mint_personal_access_token,
-    warm_up_actor_class_cache,
     wait_for_metric_at_least,
     wait_for_metric_delta,
+    warm_up_actor_class_cache,
 )
 from tests.tokens.token_utils import revoke_access_token
 from tests.utilities.domains import Domain

--- a/smoke-test/tests/metrics/test_usage_aggregation_audit.py
+++ b/smoke-test/tests/metrics/test_usage_aggregation_audit.py
@@ -45,9 +45,9 @@ from tests.metrics.usage_aggregation_metrics import (
     resolve_usage_actor_class,
     session_corp_user_urn,
     try_mint_personal_access_token,
+    warm_up_actor_class_cache,
     wait_for_metric_at_least,
     wait_for_metric_delta,
-    warm_up_actor_class_cache,
 )
 from tests.tokens.token_utils import revoke_access_token
 from tests.utilities.domains import Domain
@@ -333,7 +333,9 @@ class TestUsageAggregationGraphqlOutputDedup:
         )
         tags = graphql_metadata_query_tags("support")
         try:
-            warm_up_actor_class_cache(support_session, auth_session, gms_url, tags)
+            warm_up_actor_class_cache(
+                support_session, auth_session, gms_url, user_urn, "support"
+            )
 
             output_baseline = fetch_metric_total(
                 auth_session, gms_url, OUTPUT_BYTES_METRIC, tags

--- a/smoke-test/tests/metrics/usage_aggregation_metrics.py
+++ b/smoke-test/tests/metrics/usage_aggregation_metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 import urllib.parse
 from typing import Dict, List, Optional
 
@@ -454,14 +455,18 @@ def warm_up_actor_class_cache(
     gms_url: str,
     expected_tags: Dict[str, str],
 ) -> None:
-    """Generate traffic until metrics appear with the expected actor_class tags.
+    """Generate traffic until metrics with the expected actor_class tags are stable.
 
-    The GMS entity client caches corpUserInfo for ~20s. When a user is freshly
-    created and then its flags are changed (e.g. isSupportUser set to true),
-    requests arriving before the cache expires are tagged with the stale
-    actor_class. This helper sends repeated GraphQL traffic and polls Prometheus
-    until the flush exports at least one input_bytes sample proving the cache
-    has refreshed and actor_class resolves correctly.
+    The GMS entity client caches corpUserInfo for ~20s (configured in
+    application.yaml). When a user is freshly created and then its flags are
+    changed (e.g. isSupportUser set to true), requests arriving before the
+    cache expires are tagged with the stale actor_class.
+
+    This helper has two phases:
+    1. Send repeated GraphQL traffic until input_bytes samples with the expected
+       tags appear in Prometheus, proving the cache refreshed.
+    2. Stop generating traffic and wait for output_bytes to stabilize so the
+       caller's baseline isn't contaminated by unflushed warm-up data.
     """
 
     @tenacity.retry(
@@ -469,7 +474,7 @@ def warm_up_actor_class_cache(
         wait=tenacity.wait_fixed(3),
         reraise=True,
     )
-    def _poll() -> None:
+    def _generate_until_visible() -> None:
         generate_graphql_read_traffic(traffic_session, repeat=2)
         content = get_prometheus_metrics(scrape_session, gms_url)
         samples = find_metric_samples(content, INPUT_BYTES_METRIC, expected_tags)
@@ -478,10 +483,33 @@ def warm_up_actor_class_cache(
             f"samples yet with tags {expected_tags}"
         )
 
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(15),
+        wait=tenacity.wait_fixed(5),
+        reraise=True,
+    )
+    def _wait_output_stable() -> None:
+        first = fetch_metric_total(
+            scrape_session, gms_url, OUTPUT_BYTES_METRIC, expected_tags
+        )
+        assert first > 0, (
+            f"Warm-up {OUTPUT_BYTES_METRIC} not yet flushed (tags={expected_tags})"
+        )
+        time.sleep(5)
+        second = fetch_metric_total(
+            scrape_session, gms_url, OUTPUT_BYTES_METRIC, expected_tags
+        )
+        assert first == second, (
+            f"Warm-up {OUTPUT_BYTES_METRIC} still being flushed: "
+            f"{first} -> {second} (tags={expected_tags})"
+        )
+
     logger.info(
         "Warming up actor_class cache — sending traffic until %s appears with %s",
         INPUT_BYTES_METRIC,
         expected_tags,
     )
-    _poll()
+    _generate_until_visible()
+    logger.info("Cache refreshed, waiting for warm-up output_bytes to stabilize")
+    _wait_output_stable()
     logger.info("Actor class cache warm-up complete")

--- a/smoke-test/tests/metrics/usage_aggregation_metrics.py
+++ b/smoke-test/tests/metrics/usage_aggregation_metrics.py
@@ -446,3 +446,42 @@ def wait_for_metric_samples(
     for sample in samples[:3]:
         logger.info("  %s", sample)
     return samples
+
+
+def warm_up_actor_class_cache(
+    traffic_session,
+    scrape_session,
+    gms_url: str,
+    expected_tags: Dict[str, str],
+) -> None:
+    """Generate traffic until metrics appear with the expected actor_class tags.
+
+    The GMS entity client caches corpUserInfo for ~20s. When a user is freshly
+    created and then its flags are changed (e.g. isSupportUser set to true),
+    requests arriving before the cache expires are tagged with the stale
+    actor_class. This helper sends repeated GraphQL traffic and polls Prometheus
+    until the flush exports at least one input_bytes sample proving the cache
+    has refreshed and actor_class resolves correctly.
+    """
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(35),
+        wait=tenacity.wait_fixed(3),
+        reraise=True,
+    )
+    def _poll() -> None:
+        generate_graphql_read_traffic(traffic_session, repeat=2)
+        content = get_prometheus_metrics(scrape_session, gms_url)
+        samples = find_metric_samples(content, INPUT_BYTES_METRIC, expected_tags)
+        assert samples, (
+            f"Waiting for actor_class cache refresh: no {INPUT_BYTES_METRIC} "
+            f"samples yet with tags {expected_tags}"
+        )
+
+    logger.info(
+        "Warming up actor_class cache — sending traffic until %s appears with %s",
+        INPUT_BYTES_METRIC,
+        expected_tags,
+    )
+    _poll()
+    logger.info("Actor class cache warm-up complete")

--- a/smoke-test/tests/metrics/usage_aggregation_metrics.py
+++ b/smoke-test/tests/metrics/usage_aggregation_metrics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-import time
 import urllib.parse
 from typing import Dict, List, Optional
 
@@ -421,6 +420,51 @@ def corpuser_entity_exists(auth_session, corp_user_urn: str) -> bool:
     return response.status_code == 200
 
 
+def warm_up_actor_class_cache(
+    traffic_session,
+    scrape_session,
+    gms_url: str,
+    corp_user_urn: str,
+    actor_class: str,
+) -> None:
+    """Generate OpenAPI traffic until the entity client cache reflects the expected actor_class.
+
+    PR #19476 switched CorpUserFlags to the CachingAspectRetriever which
+    caches corpUserInfo for ~20s.  After setup writes isSupportUser (or
+    similar), requests arriving before the cache expires are tagged with
+    the stale actor_class.
+
+    Uses OpenAPI (not GraphQL) so the warm-up traffic lands in a separate
+    Prometheus series (request_api=openapi) and cannot contaminate a
+    caller's GraphQL metric baseline.
+    """
+    openapi_tags = aggregation_tags(
+        actor_class, usage_operation="metadata_read", request_api="openapi"
+    )
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(35),
+        wait=tenacity.wait_fixed(3),
+        reraise=True,
+    )
+    def _poll() -> None:
+        generate_openapi_corpuser_read_traffic(traffic_session, corp_user_urn, repeat=1)
+        content = get_prometheus_metrics(scrape_session, gms_url)
+        samples = find_metric_samples(content, OUTPUT_BYTES_METRIC, openapi_tags)
+        assert samples, (
+            f"Waiting for actor_class cache refresh: no {OUTPUT_BYTES_METRIC} "
+            f"samples yet with tags {openapi_tags}"
+        )
+
+    logger.info(
+        "Warming up actor_class cache via OpenAPI traffic until %s appears with %s",
+        OUTPUT_BYTES_METRIC,
+        openapi_tags,
+    )
+    _poll()
+    logger.info("Actor class cache warm-up complete")
+
+
 @tenacity.retry(
     stop=tenacity.stop_after_attempt(25),
     wait=tenacity.wait_fixed(3),
@@ -447,69 +491,3 @@ def wait_for_metric_samples(
     for sample in samples[:3]:
         logger.info("  %s", sample)
     return samples
-
-
-def warm_up_actor_class_cache(
-    traffic_session,
-    scrape_session,
-    gms_url: str,
-    expected_tags: Dict[str, str],
-) -> None:
-    """Generate traffic until metrics with the expected actor_class tags are stable.
-
-    The GMS entity client caches corpUserInfo for ~20s (configured in
-    application.yaml). When a user is freshly created and then its flags are
-    changed (e.g. isSupportUser set to true), requests arriving before the
-    cache expires are tagged with the stale actor_class.
-
-    This helper has two phases:
-    1. Send repeated GraphQL traffic until input_bytes samples with the expected
-       tags appear in Prometheus, proving the cache refreshed.
-    2. Stop generating traffic and wait for output_bytes to stabilize so the
-       caller's baseline isn't contaminated by unflushed warm-up data.
-    """
-
-    @tenacity.retry(
-        stop=tenacity.stop_after_attempt(35),
-        wait=tenacity.wait_fixed(3),
-        reraise=True,
-    )
-    def _generate_until_visible() -> None:
-        generate_graphql_read_traffic(traffic_session, repeat=2)
-        content = get_prometheus_metrics(scrape_session, gms_url)
-        samples = find_metric_samples(content, INPUT_BYTES_METRIC, expected_tags)
-        assert samples, (
-            f"Waiting for actor_class cache refresh: no {INPUT_BYTES_METRIC} "
-            f"samples yet with tags {expected_tags}"
-        )
-
-    @tenacity.retry(
-        stop=tenacity.stop_after_attempt(15),
-        wait=tenacity.wait_fixed(5),
-        reraise=True,
-    )
-    def _wait_output_stable() -> None:
-        first = fetch_metric_total(
-            scrape_session, gms_url, OUTPUT_BYTES_METRIC, expected_tags
-        )
-        assert first > 0, (
-            f"Warm-up {OUTPUT_BYTES_METRIC} not yet flushed (tags={expected_tags})"
-        )
-        time.sleep(5)
-        second = fetch_metric_total(
-            scrape_session, gms_url, OUTPUT_BYTES_METRIC, expected_tags
-        )
-        assert first == second, (
-            f"Warm-up {OUTPUT_BYTES_METRIC} still being flushed: "
-            f"{first} -> {second} (tags={expected_tags})"
-        )
-
-    logger.info(
-        "Warming up actor_class cache — sending traffic until %s appears with %s",
-        INPUT_BYTES_METRIC,
-        expected_tags,
-    )
-    _generate_until_visible()
-    logger.info("Cache refreshed, waiting for warm-up output_bytes to stabilize")
-    _wait_output_stable()
-    logger.info("Actor class cache warm-up complete")


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes usage aggregation smoke tests so a stale cached `corpUserInfo` no longer misattributes metrics to the wrong actor class. The warm-up now sends OpenAPI traffic instead of GraphQL, keeping it out of the GraphQL metric baseline that the tests assert on.

<sup>Written for commit 1a3843097ace555a9db8442dd56b34bf9d5a16d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

