### PR TITLE
fix(lineage): don't scan the whole graph index for entities with no lineage edges

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
@@ -67,6 +67,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.common.lucene.search.function.CombineFunction;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -516,7 +517,10 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
     // clause-less bool would degrade to match_all -- dropping the source-urn filter and
     // scanning the whole graph index. Such an entity genuinely has no lineage: match none.
     if (entityTypeQueries.should().isEmpty()) {
-      return QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery());
+      log.debug(
+          "No registered lineage edges for entity types {}; matching none",
+          urnsPerEntityType.keySet());
+      return new MatchNoneQueryBuilder();
     }
     entityTypeQueries.minimumShouldMatch(1);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/GraphQueryBaseDAO.java
@@ -510,6 +510,14 @@ public abstract class GraphQueryBaseDAO implements GraphQueryDAO {
           buildLineageGraphFiltersQuery(opContext, entityType, urns, lineageGraphFilters)
               .ifPresent(entityTypeQueries::should);
         });
+
+    // No should clauses means no entity type in this hop has registered lineage edges.
+    // minimumShouldMatch does not apply to a bool query without should clauses, so the
+    // clause-less bool would degrade to match_all -- dropping the source-urn filter and
+    // scanning the whole graph index. Such an entity genuinely has no lineage: match none.
+    if (entityTypeQueries.should().isEmpty()) {
+      return QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery());
+    }
     entityTypeQueries.minimumShouldMatch(1);
 
     BoolQueryBuilder finalQuery = QueryBuilders.boolQuery();

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAOTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.Constants.CHART_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DASHBOARD_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATA_JOB_ENTITY_NAME;
+import static com.linkedin.metadata.graph.elastic.TestUtils.assertMatchesNothing;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createEmptySearchResponse;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeLineageHits;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeSearchResponse;
@@ -65,7 +66,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -383,14 +383,7 @@ public class GraphQueryElasticsearch7DAOTest {
     QueryBuilder result =
         dao.getLineageQuery(operationContext, urnsPerEntityType, lineageGraphFilters);
 
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result instanceof BoolQueryBuilder);
-    BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
-    Assert.assertTrue(
-        boolQuery.filter().isEmpty() && boolQuery.must().isEmpty() && boolQuery.should().isEmpty(),
-        "match-none query should carry no positive clauses");
-    Assert.assertEquals(boolQuery.mustNot().size(), 1);
-    Assert.assertTrue(boolQuery.mustNot().get(0) instanceof MatchAllQueryBuilder);
+    assertMatchesNothing(result);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryElasticsearch7DAOTest.java
@@ -65,6 +65,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -377,27 +378,19 @@ public class GraphQueryElasticsearch7DAOTest {
             null,
             new ConcurrentHashMap<>());
 
-    // Call the method - internal buildLineageGraphFiltersQuery should return empty Optional
-    // But getLineageQuery should still build a query with minimumShouldMatch(1)
+    // buildLineageGraphFiltersQuery returns empty for every entity type, so the query must
+    // match nothing rather than degrade to match_all over the whole graph index.
     QueryBuilder result =
         dao.getLineageQuery(operationContext, urnsPerEntityType, lineageGraphFilters);
 
-    // Verify that we still got a query
     Assert.assertNotNull(result);
     Assert.assertTrue(result instanceof BoolQueryBuilder);
-
-    // Verify that the query was structured as expected for empty URNs
     BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
-    // There should be a filter clause with the entity type queries
-    Assert.assertTrue(boolQuery.filter().size() > 0);
-
-    // Verify the first filter is a BoolQuery with minimumShouldMatch(1)
-    Object firstFilter = boolQuery.filter().get(0);
-    Assert.assertTrue(firstFilter instanceof BoolQueryBuilder);
-    BoolQueryBuilder entityTypeQueries = (BoolQueryBuilder) firstFilter;
-    Assert.assertEquals(entityTypeQueries.minimumShouldMatch(), "1");
-    // Since URNs are empty, there should be no should clauses
-    Assert.assertEquals(entityTypeQueries.should().size(), 0);
+    Assert.assertTrue(
+        boolQuery.filter().isEmpty() && boolQuery.must().isEmpty() && boolQuery.should().isEmpty(),
+        "match-none query should carry no positive clauses");
+    Assert.assertEquals(boolQuery.mustNot().size(), 1);
+    Assert.assertTrue(boolQuery.mustNot().get(0) instanceof MatchAllQueryBuilder);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAOTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.Constants.DASHBOARD_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATA_JOB_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.GLOSSARY_TERM_ENTITY_NAME;
+import static com.linkedin.metadata.graph.elastic.TestUtils.assertMatchesNothing;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createEmptySearchResponse;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeLineageHits;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeSearchResponse;
@@ -74,7 +75,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -561,18 +561,9 @@ public class GraphQueryPITDAOTest {
     Assert.assertEquals(entityTypeQueries.minimumShouldMatch(), "1");
     // Only the dataset contributes a should clause; the glossaryTerm has no lineage edges.
     Assert.assertEquals(entityTypeQueries.should().size(), 1);
-  }
-
-  /** Asserts the query is a bool that explicitly matches nothing, not an empty (match_all) bool. */
-  private static void assertMatchesNothing(QueryBuilder result) {
-    Assert.assertNotNull(result);
-    Assert.assertTrue(result instanceof BoolQueryBuilder);
-    BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
     Assert.assertTrue(
-        boolQuery.filter().isEmpty() && boolQuery.must().isEmpty() && boolQuery.should().isEmpty(),
-        "match-none query should carry no positive clauses");
-    Assert.assertEquals(boolQuery.mustNot().size(), 1);
-    Assert.assertTrue(boolQuery.mustNot().get(0) instanceof MatchAllQueryBuilder);
+        entityTypeQueries.should().get(0).toString().contains("test-dataset"),
+        "the surviving should clause must be the dataset's");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/GraphQueryPITDAOTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.Constants.CHART_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DASHBOARD_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATA_JOB_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.GLOSSARY_TERM_ENTITY_NAME;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createEmptySearchResponse;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeLineageHits;
 import static com.linkedin.metadata.graph.elastic.TestUtils.createFakeSearchResponse;
@@ -73,6 +74,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -493,27 +495,84 @@ public class GraphQueryPITDAOTest {
             null,
             new ConcurrentHashMap<>());
 
-    // Call the method - internal buildLineageGraphFiltersQuery should return empty Optional
-    // But getLineageQuery should still build a query with minimumShouldMatch(1)
+    // buildLineageGraphFiltersQuery returns empty for every entity type, so the query must
+    // match nothing rather than degrade to match_all over the whole graph index.
     QueryBuilder result =
         dao.getLineageQuery(operationContext, urnsPerEntityType, lineageGraphFilters);
 
-    // Verify that we still got a query
+    assertMatchesNothing(result);
+  }
+
+  /**
+   * An entity type with no registered lineage edges (glossaryTerm, domain, document, ...) has no
+   * lineage. The query must match nothing: a clause-less bool would degrade to match_all, drop the
+   * source-urn filter and scan the whole graph index, timing out its slices on a large graph.
+   */
+  @Test
+  public void testGetLineageQueryEntityTypeWithNoLineageEdges() {
+    SearchClientShim<?> mockClient = mock(SearchClientShim.class);
+    when(mockClient.getEngineType()).thenReturn(SearchClientShim.SearchEngineType.OPENSEARCH_2);
+    GraphQueryPITDAO dao =
+        createTrackedDAO(mockClient, TEST_GRAPH_SERVICE_CONFIG, TEST_OS_SEARCH_CONFIG);
+
+    Map<String, Set<Urn>> urnsPerEntityType = new HashMap<>();
+    urnsPerEntityType.put(
+        GLOSSARY_TERM_ENTITY_NAME,
+        ImmutableSet.of(UrnUtils.getUrn("urn:li:glossaryTerm:test-term")));
+
+    LineageGraphFilters lineageGraphFilters =
+        LineageGraphFilters.withEntityTypes(LineageDirection.UPSTREAM, null);
+
+    assertMatchesNothing(
+        dao.getLineageQuery(operationContext, urnsPerEntityType, lineageGraphFilters));
+  }
+
+  /**
+   * A hop can mix entity types. As long as one of them has lineage edges the query is still built
+   * normally -- only the all-empty case short-circuits.
+   */
+  @Test
+  public void testGetLineageQueryMixedEntityTypesKeepsTypeWithEdges() {
+    SearchClientShim<?> mockClient = mock(SearchClientShim.class);
+    when(mockClient.getEngineType()).thenReturn(SearchClientShim.SearchEngineType.OPENSEARCH_2);
+    GraphQueryPITDAO dao =
+        createTrackedDAO(mockClient, TEST_GRAPH_SERVICE_CONFIG, TEST_OS_SEARCH_CONFIG);
+
+    Map<String, Set<Urn>> urnsPerEntityType = new HashMap<>();
+    urnsPerEntityType.put(
+        GLOSSARY_TERM_ENTITY_NAME,
+        ImmutableSet.of(UrnUtils.getUrn("urn:li:glossaryTerm:test-term")));
+    urnsPerEntityType.put(
+        DATASET_ENTITY_NAME,
+        ImmutableSet.of(
+            UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,test-dataset,PROD)")));
+
+    LineageGraphFilters lineageGraphFilters =
+        LineageGraphFilters.withEntityTypes(LineageDirection.UPSTREAM, null);
+
+    QueryBuilder result =
+        dao.getLineageQuery(operationContext, urnsPerEntityType, lineageGraphFilters);
+
+    Assert.assertTrue(result instanceof BoolQueryBuilder);
+    BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
+    Assert.assertTrue(boolQuery.mustNot().isEmpty(), "should not be a match-none query");
+    Assert.assertEquals(boolQuery.filter().size(), 1);
+    BoolQueryBuilder entityTypeQueries = (BoolQueryBuilder) boolQuery.filter().get(0);
+    Assert.assertEquals(entityTypeQueries.minimumShouldMatch(), "1");
+    // Only the dataset contributes a should clause; the glossaryTerm has no lineage edges.
+    Assert.assertEquals(entityTypeQueries.should().size(), 1);
+  }
+
+  /** Asserts the query is a bool that explicitly matches nothing, not an empty (match_all) bool. */
+  private static void assertMatchesNothing(QueryBuilder result) {
     Assert.assertNotNull(result);
     Assert.assertTrue(result instanceof BoolQueryBuilder);
-
-    // Verify that the query was structured as expected for empty URNs
     BoolQueryBuilder boolQuery = (BoolQueryBuilder) result;
-    // There should be a filter clause with the entity type queries
-    Assert.assertTrue(boolQuery.filter().size() > 0);
-
-    // Verify the first filter is a BoolQuery with minimumShouldMatch(1)
-    Object firstFilter = boolQuery.filter().get(0);
-    Assert.assertTrue(firstFilter instanceof BoolQueryBuilder);
-    BoolQueryBuilder entityTypeQueries = (BoolQueryBuilder) firstFilter;
-    Assert.assertEquals(entityTypeQueries.minimumShouldMatch(), "1");
-    // Since URNs are empty, there should be no should clauses
-    Assert.assertEquals(entityTypeQueries.should().size(), 0);
+    Assert.assertTrue(
+        boolQuery.filter().isEmpty() && boolQuery.must().isEmpty() && boolQuery.should().isEmpty(),
+        "match-none query should carry no positive clauses");
+    Assert.assertEquals(boolQuery.mustNot().size(), 1);
+    Assert.assertTrue(boolQuery.mustNot().get(0) instanceof MatchAllQueryBuilder);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/TestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/TestUtils.java
@@ -29,16 +29,27 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.testng.Assert;
 
 /**
  * Utility class for testing graph query functionality. Contains methods moved from ESGraphQueryDAO
  * for testing purposes.
  */
 public class TestUtils {
+
+  /**
+   * Asserts a lineage query explicitly matches nothing. A clause-less bool would instead behave as
+   * match_all and scan the whole graph index, so the distinction matters.
+   */
+  public static void assertMatchesNothing(QueryBuilder query) {
+    Assert.assertTrue(
+        query instanceof MatchNoneQueryBuilder, "expected a match-none query but got: " + query);
+  }
 
   /**
    * Builds a lineage query for a specific entity type. This method is used for testing the query


### PR DESCRIPTION
## Problem

`searchAcrossLineage` on an entity type that has no lineage aspects registered — `document`, `domain`, `glossaryTerm`, and friends — scans the **entire graph index**. On a deployment with a large graph this exhausts the slice deadline and the caller gets:

```
java.lang.RuntimeException: Slice 0 timed out after 50 seconds
```

Measured against a large deployment, every no-lineage-edge entity type takes ~52s and fails, while a dataset on the same instance returns in ~1s:

| URN entity type | Result |
| --- | --- |
| `document` (upstream) | 51.5s → `Slice 0 timed out after 50 seconds` |
| `document` (downstream) | 51.3s → same |
| **a `document` URN that does not exist** | 52.1s → same |
| `domain` | 52.9s → same |
| `glossaryTerm` | 53.3s → same |
| `dataset` | 1.0s, 6 results |

A URN that does not exist behaving identically to a real one is the tell: the source-urn filter never reaches Elasticsearch.

## Cause

`getLineageQuery` adds one `should` clause per entity type, but `buildLineageGraphFiltersQuery` returns `Optional.empty()` when the type has no registered lineage edges:

```java
if (urns.isEmpty() || edgeInfo.isEmpty()) {
    return Optional.empty();
}
```

When that is true for every type in the hop, `entityTypeQueries` ends up with **zero clauses**. `minimum_should_match` does not apply to a bool query with no `should` clauses, and a clause-less bool is `match_all` — so `finalQuery.filter(entityTypeQueries)` becomes `filter(match_all)` and the query matches every edge in the graph index.

## Fix

Short-circuit to a match-none query when no entity type in the hop contributed a clause. An entity type with no registered lineage edges genuinely has no lineage, so an empty result is the correct answer.

A hop that mixes entity types is unaffected: as long as one type has edges it still contributes its `should` clause and the query is built normally. Only the all-empty case short-circuits.

## Tests

`GraphQueryPITDAOTest` and `GraphQueryElasticsearch7DAOTest` both had a `testGetLineageQueryWithEmptyUrns` that asserted the old shape (`minimumShouldMatch("1")` over zero `should` clauses) without ever checking that the query matched nothing — i.e. they encoded the bug. Both now assert match-none.

`GraphQueryPITDAOTest` also gains:
- `testGetLineageQueryEntityTypeWithNoLineageEdges` — the real-world regression: a `glossaryTerm` URN (non-empty URN set, no registered lineage edges).
- `testGetLineageQueryMixedEntityTypesKeepsTypeWithEdges` — guards against over-correcting, so a mixed hop still builds a normal query.

Verified the new assertions fail without the production change and pass with it. `./gradlew :metadata-io:test --tests "com.linkedin.metadata.graph.*"` → 887 passing.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [ ] Links to related issues — n/a
- [ ] Docs — n/a, internal query-construction fix with no API change
- [ ] Updating DataHub entry — n/a, not a breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `searchAcrossLineage` timing out on entity types with no registered lineage edges (`document`, `domain`, `glossaryTerm`, …) by returning a `MatchNoneQueryBuilder` instead of a clause-less bool query that degraded to `match_all` and scanned the entire graph index, failing with "Slice 0 timed out after 50 seconds". A type with no lineage edges genuinely has no lineage, so an empty result is correct.

- Mixed hops are unaffected: as long as one entity type has edges, the query is built normally.
- Updates both DAO tests to assert the match-none query and adds regression tests for a no-lineage-edge entity type and a mixed-type hop.

<sup>Written for commit 1a6ebfdcbb3f245481e152983ca04df0937e7bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

