### PR TITLE
fix(ingest/documents): record which text was embedded, and why documents were skipped

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -1085,9 +1085,17 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
         # Get document URN for chunking/embedding
         document_urn = f"urn:li:document:{doc_id}"
 
+        from datahub.ingestion.source.unstructured.chunking_source import (
+            compute_source_text_sha256,
+        )
+
         try:
             yield from self.chunking_source.process_elements_inline(
-                document_urn=document_urn, elements=elements
+                document_urn=document_urn,
+                elements=elements,
+                # Hash the exact text placed on DocumentInfo above, so the embeddings'
+                # sourceTextSha256 byte-matches the server-stamped resolvedTextSha256.
+                source_text_sha256=compute_source_text_sha256(text),
             )
         except RuntimeError as e:
             if self.chunking_source.report.num_documents_limit_reached:

--- a/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluence/confluence_source.py
@@ -1086,6 +1086,7 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
         document_urn = f"urn:li:document:{doc_id}"
 
         from datahub.ingestion.source.unstructured.chunking_source import (
+            SkipMarkerReadError,
             compute_source_text_sha256,
         )
 
@@ -1097,6 +1098,11 @@ class ConfluenceSource(StatefulIngestionSourceBase, TestableSource):
                 # sourceTextSha256 byte-matches the server-stamped resolvedTextSha256.
                 source_text_sha256=compute_source_text_sha256(text),
             )
+        except SkipMarkerReadError as e:
+            # Do not record this page as processed: the skip marker was not written and
+            # must be retried next run rather than swallowed like an embed failure.
+            logger.warning(f"Skip marker deferred for {document_urn}: {e}")
+            return
         except RuntimeError as e:
             if self.chunking_source.report.num_documents_limit_reached:
                 self.report.num_documents_limit_reached = True

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, Optional, cast
 
 from datahub.configuration.common import GraphError, OperationalError
-from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SupportStatus,
@@ -1413,13 +1412,29 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         Returns:
             SHA256 hash hex string
         """
-        hash_input = {
+        hash_input: Dict[str, Any] = {
             "content": text,
             "config": self._get_processing_config_fingerprint(),
         }
+        # The deliberate-skip decision is part of what recorded state means, so its inputs
+        # join the hash -- but only for documents that WOULD be skipped. Raising or lowering
+        # min_text_length then re-evaluates exactly the affected population (skip markers
+        # re-stamped or documents finally embedded) without invalidating the hash of every
+        # already-embedded document, which would trigger a full re-embed wave on upgrade.
+        if self._is_below_embed_minimum(text):
+            hash_input["skip_threshold"] = self.config.min_text_length
         # Deterministic JSON serialization
         hash_str = json.dumps(hash_input, sort_keys=True)
         return hashlib.sha256(hash_str.encode("utf-8")).hexdigest()
+
+    def _is_below_embed_minimum(self, text: str) -> bool:
+        """Single decider for the deliberate length skip.
+
+        Used both by _process_single_document (to emit the skip marker) and by
+        _calculate_text_hash (to make recorded state threshold-aware) -- keep them in
+        lockstep through this helper.
+        """
+        return not text or len(text) < self.config.min_text_length
 
     def _update_document_state(self, document_urn: str, text: str) -> None:
         """Update state after processing document."""
@@ -1501,28 +1516,8 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
     def _build_skip_marker_workunit(
         self, document_urn: str, reason: str
     ) -> MetadataWorkUnit:
-        """Build a semanticContent skip marker for a deliberately-skipped document.
-
-        An empty embeddings map plus skipReason lets downstream consumers (e.g. the
-        coverage dashboard) tell never-embeddable documents apart from indexing lag or
-        failures. The marker is overwritten with real embeddings if the document later
-        becomes embeddable and is processed.
-        """
-        from datahub.metadata.schema_classes import SemanticContentClass
-
-        mcp = MetadataChangeProposalWrapper(
-            entityUrn=document_urn,
-            aspect=SemanticContentClass(
-                embeddings={},
-                skipReason=reason,
-                skippedAt=int(datetime.utcnow().timestamp() * 1000),
-            ),
-        )
-        # Non-primary so AutoStatusAspectProcessor does not emit a Status UPSERT for the
-        # document URN (mirrors _emit_semantic_content in chunking_source).
-        return MetadataWorkUnit(
-            id=f"{document_urn}-semanticContent-skip", mcp=mcp, is_primary_source=False
-        )
+        """See DocumentChunkingSource.build_skip_marker_workunit (single implementation)."""
+        return self.chunking_source.build_skip_marker_workunit(document_urn, reason)
 
     def _throttle_after_indexing(self) -> None:
         """Pause after indexing a document to smooth write load to GMS."""
@@ -1576,7 +1571,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             # never-embeddable documents apart from indexing lag or failures. Returning True
             # records incremental state -- the decision is deterministic for this text, so
             # retrying without a content change is pointless.
-            if not text or len(text) < self.config.min_text_length:
+            if self._is_below_embed_minimum(text):
                 logger.debug(
                     f"Skipping document {document_urn} (text too short: {len(text)} chars)"
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -53,7 +53,10 @@ from datahub.ingestion.source.unstructured.chunking_config import (
     DataHubConnectionConfig,
     DocumentChunkingSourceConfig,
 )
-from datahub.ingestion.source.unstructured.chunking_source import DocumentChunkingSource
+from datahub.ingestion.source.unstructured.chunking_source import (
+    DocumentChunkingSource,
+    compute_source_text_sha256,
+)
 from datahub.ingestion.source.unstructured.event_consumer import DocumentEventConsumer
 
 logger = logging.getLogger(__name__)
@@ -1444,8 +1447,14 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
         Used both by _process_single_document (to emit the skip marker) and by
         _calculate_text_hash (to make recorded state threshold-aware) -- keep them in
         lockstep through this helper.
+
+        skip_empty_text gates only the length check (its pre-existing semantics):
+        empty documents are always skipped, but skip_empty_text=False keeps
+        short-but-non-empty documents embeddable regardless of min_text_length.
         """
-        return not text or len(text) < self.config.min_text_length
+        return not text or (
+            self.config.skip_empty_text and len(text) < self.config.min_text_length
+        )
 
     def _update_document_state(self, document_urn: str, text: str) -> None:
         """Update state after processing document."""
@@ -1524,12 +1533,6 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             return False
         return bool(aspect and aspect.embeddings and model_key in aspect.embeddings)
 
-    def _build_skip_marker_workunit(
-        self, document_urn: str, reason: str
-    ) -> MetadataWorkUnit:
-        """See DocumentChunkingSource.build_skip_marker_workunit (single implementation)."""
-        return self.chunking_source.build_skip_marker_workunit(document_urn, reason)
-
     def _throttle_after_indexing(self) -> None:
         """Pause after indexing a document to smooth write load to GMS."""
         if self.config.index_delay_seconds > 0:
@@ -1587,7 +1590,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"Skipping document {document_urn} (text too short: {len(text)} chars)"
                 )
                 self.report.report_document_skipped_empty()
-                yield self._build_skip_marker_workunit(
+                yield self.chunking_source.build_skip_marker_workunit(
                     document_urn,
                     "EMPTY_TEXT" if not text else "BELOW_MIN_TEXT_LENGTH",
                 )
@@ -1602,7 +1605,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"No elements created from text for document {document_urn}"
                 )
                 self.report.report_document_skipped()
-                yield self._build_skip_marker_workunit(
+                yield self.chunking_source.build_skip_marker_workunit(
                     document_urn, "NO_INDEXABLE_CONTENT"
                 )
                 return True
@@ -1615,7 +1618,7 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             yield from self.chunking_source.process_elements_inline(
                 document_urn=document_urn,
                 elements=elements,
-                source_text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+                source_text_sha256=compute_source_text_sha256(text),
             )
 
         except Exception as e:

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -495,8 +495,19 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"semanticText event for {entity_urn} without readable documentInfo, skipping"
                 )
                 return
-            contents = dict(info_dict.get("contents") or {})
-            contents["semanticText"] = aspect_dict.get("text")
+            raw_info_contents = info_dict.get("contents")
+            override_text = aspect_dict.get("text")
+            if raw_info_contents is None and not override_text:
+                # Partial entity (null contents) with no usable override: skip silently,
+                # mirroring the batch and documentInfo-event guards, rather than stamping
+                # an EMPTY_TEXT marker from a body we could not read.
+                logger.debug(
+                    f"semanticText event for {entity_urn} with empty override and null "
+                    f"contents, skipping"
+                )
+                return
+            contents = dict(raw_info_contents or {})
+            contents["semanticText"] = override_text
             # Downstream source-type filtering reads from the documentInfo shape.
             aspect_dict = info_dict
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, Optional, cast
 
 from datahub.configuration.common import GraphError, OperationalError
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SupportStatus,
@@ -501,17 +502,23 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             aspect_dict = info_dict
         else:
             # documentInfo event: the override (if any) lives in the standalone
-            # semanticText aspect, so fetch it. Contents may be null for
-            # partial entities.
-            contents = dict(aspect_dict.get("contents") or {})
+            # semanticText aspect, so fetch it.
+            raw_contents = aspect_dict.get("contents")
+            if raw_contents is None:
+                # Partial aspect with no contents: skip silently (mirroring batch mode)
+                # rather than stamping a skip marker from content we could not read.
+                logger.debug(
+                    f"documentInfo event for {entity_urn} has null contents, skipping"
+                )
+                return
+            contents = dict(raw_contents)
             contents["semanticText"] = self._fetch_semantic_text(entity_urn)
 
         # semanticText overrides text as the embedding source; see _resolve_embed_text.
+        # Empty text is NOT an early return: _process_single_document emits a skip marker
+        # for it (and for too-short text) so the document is classified rather than
+        # silently invisible, and incremental state stops re-visiting it.
         text = self._resolve_embed_text(contents)
-
-        if not text:
-            logger.debug(f"No text content in document {entity_urn}")
-            return
 
         # Filter by source type (NATIVE vs EXTERNAL)
         # Default to NATIVE if source or sourceType is not set (backward compatibility with old documents)
@@ -995,7 +1002,12 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             # Extract text content (GraphQL returns null for missing aspects).
             # semanticText overrides text as the embedding source; see _resolve_embed_text.
             info = entity.get("info") or {}
-            contents = info.get("contents") or {}
+            contents = info.get("contents")
+            if contents is None:
+                # Null info/contents is a partial entity or hydration anomaly, not a
+                # document with empty text: skip silently rather than stamping a skip
+                # marker onto an entity whose content we could not read.
+                continue
             text = self._resolve_embed_text(contents)
 
             # Default to NATIVE when sourceType is absent (older documents).
@@ -1006,14 +1018,10 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             if not self._should_process_by_source_type(entity, info):
                 continue
 
-            # Skip if no text or too short
-            if not text or (
-                self.config.skip_empty_text and len(text) < self.config.min_text_length
-            ):
-                logger.debug(
-                    f"Skipping document {urn} (empty or too short: {len(text)} chars)"
-                )
-                continue
+            # Empty/too-short documents are NOT filtered here: they flow to
+            # _process_single_document, which emits a semanticContent skip marker for them
+            # (so coverage consumers can tell never-embeddable documents from indexing lag)
+            # and records incremental state so they are not re-visited every run.
 
             num_documents += 1
             self.report.report_document_fetched()
@@ -1490,6 +1498,32 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             return False
         return bool(aspect and aspect.embeddings and model_key in aspect.embeddings)
 
+    def _build_skip_marker_workunit(
+        self, document_urn: str, reason: str
+    ) -> MetadataWorkUnit:
+        """Build a semanticContent skip marker for a deliberately-skipped document.
+
+        An empty embeddings map plus skipReason lets downstream consumers (e.g. the
+        coverage dashboard) tell never-embeddable documents apart from indexing lag or
+        failures. The marker is overwritten with real embeddings if the document later
+        becomes embeddable and is processed.
+        """
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn=document_urn,
+            aspect=SemanticContentClass(
+                embeddings={},
+                skipReason=reason,
+                skippedAt=int(datetime.utcnow().timestamp() * 1000),
+            ),
+        )
+        # Non-primary so AutoStatusAspectProcessor does not emit a Status UPSERT for the
+        # document URN (mirrors _emit_semantic_content in chunking_source).
+        return MetadataWorkUnit(
+            id=f"{document_urn}-semanticContent-skip", mcp=mcp, is_primary_source=False
+        )
+
     def _throttle_after_indexing(self) -> None:
         """Pause after indexing a document to smooth write load to GMS."""
         if self.config.index_delay_seconds > 0:
@@ -1538,12 +1572,19 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             document_urn = doc["urn"]
             text = doc.get("text", "")
 
-            # Skip if empty or too short
+            # Deliberate skip: emit a marker so consumers (e.g. coverage reporting) can tell
+            # never-embeddable documents apart from indexing lag or failures. Returning True
+            # records incremental state -- the decision is deterministic for this text, so
+            # retrying without a content change is pointless.
             if not text or len(text) < self.config.min_text_length:
                 logger.debug(
                     f"Skipping document {document_urn} (text too short: {len(text)} chars)"
                 )
                 self.report.report_document_skipped_empty()
+                yield self._build_skip_marker_workunit(
+                    document_urn,
+                    "EMPTY_TEXT" if not text else "BELOW_MIN_TEXT_LENGTH",
+                )
                 return True
 
             # Partition text as markdown into unstructured elements
@@ -1555,12 +1596,20 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
                     f"No elements created from text for document {document_urn}"
                 )
                 self.report.report_document_skipped()
+                yield self._build_skip_marker_workunit(
+                    document_urn, "NO_INDEXABLE_CONTENT"
+                )
                 return True
 
             # Delegate chunking + embedding + SemanticContent emission to chunking_source.
             # DocumentChunkingSource enforces max_documents and raises RuntimeError when exceeded.
+            # The hash is over the exact resolved text (semanticText override else body) and is
+            # stored on the embeddings as staleness provenance: consumers compare it against a
+            # hash of the current resolved text instead of modification timestamps.
             yield from self.chunking_source.process_elements_inline(
-                document_urn=document_urn, elements=elements
+                document_urn=document_urn,
+                elements=elements,
+                source_text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
             )
 
         except Exception as e:

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -2168,9 +2168,21 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
 
         # Generate embeddings inline using ChunkingSource.
         # DocumentChunkingSource enforces max_documents and raises RuntimeError when exceeded.
+        from datahub.ingestion.source.unstructured.chunking_source import (
+            compute_source_text_sha256,
+        )
+
+        # Hash the exact text build_document_entity put on DocumentInfo (the same
+        # extraction over the same elements), so the embeddings' sourceTextSha256
+        # byte-matches the server-stamped resolvedTextSha256 of the indexed body.
+        source_text = self.document_builder.content_mapper.extract_text_content(
+            elements
+        )
         try:
             yield from self.chunking_source.process_elements_inline(
-                document_urn=document_urn, elements=elements
+                document_urn=document_urn,
+                elements=elements,
+                source_text_sha256=compute_source_text_sha256(source_text),
             )
         except RuntimeError as e:
             if self.chunking_source.report.num_documents_limit_reached:

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -2169,6 +2169,7 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
         # Generate embeddings inline using ChunkingSource.
         # DocumentChunkingSource enforces max_documents and raises RuntimeError when exceeded.
         from datahub.ingestion.source.unstructured.chunking_source import (
+            SkipMarkerReadError,
             compute_source_text_sha256,
         )
 
@@ -2184,6 +2185,12 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
                 elements=elements,
                 source_text_sha256=compute_source_text_sha256(source_text),
             )
+        except SkipMarkerReadError as e:
+            # Do not fall through to _update_document_state: recording state here would
+            # permanently drop the skip marker. Leaving the document unrecorded retries
+            # it next run.
+            logger.warning(f"Skip marker deferred for {page_id}: {e}")
+            return
         except RuntimeError as e:
             if self.chunking_source.report.num_documents_limit_reached:
                 self.report.num_documents_limit_reached = True

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -43,6 +43,11 @@ from datahub.ingestion.source.unstructured.embedding_providers.factory import (
     create_embedding_provider,
     derive_model_id,
 )
+from datahub.metadata.schema_classes import (
+    EmbeddingChunkClass,
+    EmbeddingModelDataClass,
+    SemanticContentClass,
+)
 from datahub.utilities.ratelimiter import RateLimiter
 
 if TYPE_CHECKING:
@@ -861,17 +866,39 @@ class DocumentChunkingSource(Source):
     ) -> MetadataWorkUnit:
         """Build a semanticContent skip marker for a deliberately-skipped document.
 
-        An empty embeddings map plus skipReason lets downstream consumers (e.g. coverage
-        reporting) tell never-embeddable documents apart from indexing lag or failures.
-        The marker is overwritten with real embeddings if the document later becomes
-        embeddable and is processed.
+        A skipReason (with no entry for this pipeline's model) lets downstream consumers
+        (e.g. coverage reporting) tell never-embeddable documents apart from indexing lag
+        or failures. The marker is overwritten with real embeddings if the document later
+        becomes embeddable and is processed.
+
+        SemanticContent.embeddings is a multi-model map written as a full-aspect UPSERT,
+        so the marker carries forward every other model's existing entry (dropping only
+        this pipeline's own) — otherwise one pipeline's skip would erase other models'
+        embeddings, and the index projection would clear their vectors.
         """
-        from datahub.metadata.schema_classes import SemanticContentClass
+        preserved_embeddings: dict[str, EmbeddingModelDataClass] = {}
+        if self.graph is not None:
+            own_key = self.get_model_embedding_key()
+            try:
+                existing = self.graph.get_aspect(
+                    entity_urn=document_urn, aspect_type=SemanticContentClass
+                )
+                if existing is not None and existing.embeddings:
+                    preserved_embeddings = {
+                        key: value
+                        for key, value in existing.embeddings.items()
+                        if key != own_key
+                    }
+            except Exception as e:
+                logger.warning(
+                    f"Could not read existing semanticContent for {document_urn}; "
+                    f"skip marker will not preserve other models' entries: {e}"
+                )
 
         mcp = MetadataChangeProposalWrapper(
             entityUrn=document_urn,
             aspect=SemanticContentClass(
-                embeddings={},
+                embeddings=preserved_embeddings,
                 skipReason=reason,
                 # Timezone-aware: .timestamp() on a naive utcnow() reinterprets the
                 # value as local time, skewing skippedAt on non-UTC hosts.
@@ -892,12 +919,6 @@ class DocumentChunkingSource(Source):
         source_text_sha256: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         """Emit SemanticContent aspect for the document."""
-        from datahub.metadata.schema_classes import (
-            EmbeddingChunkClass,
-            EmbeddingModelDataClass,
-            SemanticContentClass,
-        )
-
         # Use the provider's canonical model_id (e.g. "bedrock/cohere.embed-english-v3").
         # Going through derive_model_id keeps the "local" → "openai/..." mapping
         # consistent with self.embedding_model and the provider instance.

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -56,6 +56,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class SkipMarkerReadError(RuntimeError):
+    """Raised when the existing semanticContent aspect cannot be read while building a
+    skip marker. Callers must leave the document's incremental state unrecorded so the
+    marker is retried next run, instead of swallowing this like a generic embed failure
+    (which would record state and permanently drop the marker)."""
+
+
 def compute_source_text_sha256(text: str) -> str:
     """Fingerprint of the exact resolved source text that was embedded.
 
@@ -894,7 +901,7 @@ class DocumentChunkingSource(Source):
                 # emitting it after a transient read failure would erase other models'
                 # entries. Raising leaves the document unprocessed; the caller reports it
                 # failed and it is retried next run.
-                raise RuntimeError(
+                raise SkipMarkerReadError(
                     f"Could not read existing semanticContent for {document_urn}; "
                     f"not emitting a skip marker that could erase other models' entries"
                 ) from e

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -16,7 +16,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Optional
 
@@ -49,6 +49,17 @@ if TYPE_CHECKING:
     from datahub.ingestion.source.unstructured.chunking_config import EmbeddingConfig
 
 logger = logging.getLogger(__name__)
+
+
+def compute_source_text_sha256(text: str) -> str:
+    """Fingerprint of the exact resolved source text that was embedded.
+
+    Lowercase SHA-256 hex over the UTF-8 bytes, byte-identical to the server-side
+    resolvedTextSha256 stamp (UpdateIndicesV2Strategy.sha256Hex) that coverage
+    reporting compares it against. Any change here is a change to the staleness
+    contract on both sides.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 @dataclass
@@ -289,6 +300,14 @@ class DocumentChunkingSource(Source):
             yield self.build_skip_marker_workunit(document_urn, "NO_INDEXABLE_CONTENT")
             return
 
+        # All-blank chunk text is deterministic for this document: _generate_embeddings
+        # would filter every chunk before calling the provider, so treat it as a
+        # deliberate skip rather than an embedding failure that would retry forever.
+        if not any((chunk.get("text") or "").strip() for chunk in chunks):
+            logger.warning(f"Only blank chunk text for document {document_urn}")
+            yield self.build_skip_marker_workunit(document_urn, "NO_INDEXABLE_CONTENT")
+            return
+
         # Generate embeddings (only if configured).
         # Failures are raised directly so the caller can decide how to handle them.
         embeddings = []
@@ -299,6 +318,15 @@ class DocumentChunkingSource(Source):
                         embeddings = self._generate_embeddings(chunks)
                 else:
                     embeddings = self._generate_embeddings(chunks)
+                # A configured provider returning zero vectors for non-blank chunks is
+                # an anomaly, not a legitimate skip: raise before success accounting so
+                # the document is reported as failed (and retried next run) instead of
+                # counted as successfully embedded with no semanticContent.
+                if not embeddings:
+                    raise RuntimeError(
+                        f"Embedding provider returned no vectors for {document_urn} "
+                        f"({len(chunks)} chunks)"
+                    )
                 self.report.report_embedding_success()
             except Exception as e:
                 short_error = str(e).split("\n")[0][:200]
@@ -307,15 +335,6 @@ class DocumentChunkingSource(Source):
         else:
             logger.debug(
                 f"Skipping embedding generation for {document_urn} - no embedding provider configured"
-            )
-
-        # A configured provider returning zero vectors for non-empty chunks is an anomaly,
-        # not a legitimate skip: raise so the caller treats the document as failed and
-        # retries it next run instead of checkpointing it with no semanticContent.
-        if self.embedding_model and not embeddings:
-            raise RuntimeError(
-                f"Embedding provider returned no vectors for {document_urn} "
-                f"({len(chunks)} chunks)"
             )
 
         # Emit SemanticContent aspect (only if embeddings were generated)
@@ -854,7 +873,9 @@ class DocumentChunkingSource(Source):
             aspect=SemanticContentClass(
                 embeddings={},
                 skipReason=reason,
-                skippedAt=int(datetime.utcnow().timestamp() * 1000),
+                # Timezone-aware: .timestamp() on a naive utcnow() reinterprets the
+                # value as local time, skewing skippedAt on non-UTC hosts.
+                skippedAt=int(datetime.now(timezone.utc).timestamp() * 1000),
             ),
         )
         # Non-primary so AutoStatusAspectProcessor does not emit a Status UPSERT for the

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -254,7 +254,10 @@ class DocumentChunkingSource(Source):
         return re.sub(r"[^a-zA-Z0-9_]", "_", self.config.embedding.model)
 
     def process_elements_inline(
-        self, document_urn: str, elements: list[dict[str, Any]]
+        self,
+        document_urn: str,
+        elements: list[dict[str, Any]],
+        source_text_sha256: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         """Process elements inline and emit SemanticContent aspects.
 
@@ -264,6 +267,9 @@ class DocumentChunkingSource(Source):
         Args:
             document_urn: URN of the document
             elements: Unstructured.io elements to chunk and embed
+            source_text_sha256: SHA-256 hex digest (UTF-8 bytes) of the exact resolved
+                source text the elements were partitioned from, recorded on the emitted
+                embeddings as staleness provenance. None when the caller does not track it.
 
         Yields:
             MetadataWorkUnits containing SemanticContent aspects
@@ -301,7 +307,9 @@ class DocumentChunkingSource(Source):
 
         # Emit SemanticContent aspect (only if embeddings were generated)
         if embeddings:
-            yield from self._emit_semantic_content(document_urn, chunks, embeddings)
+            yield from self._emit_semantic_content(
+                document_urn, chunks, embeddings, source_text_sha256
+            )
 
         self.report.report_document_processed(len(chunks))
         self.report.report_embeddings_generated(len(embeddings))
@@ -821,6 +829,7 @@ class DocumentChunkingSource(Source):
         document_urn: str,
         chunks: list[dict[str, Any]],
         embeddings: list[list[float]],
+        source_text_sha256: Optional[str] = None,
     ) -> Iterable[MetadataWorkUnit]:
         """Emit SemanticContent aspect for the document."""
         from datahub.metadata.schema_classes import (
@@ -865,6 +874,7 @@ class DocumentChunkingSource(Source):
         embedding_model_data = EmbeddingModelDataClass(
             modelVersion=model_version,
             generatedAt=int(datetime.utcnow().timestamp() * 1000),
+            sourceTextSha256=source_text_sha256,
             chunkingStrategy=self.config.chunking.strategy,
             totalChunks=len(chunks),
             chunks=embedding_chunks,

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -276,13 +276,17 @@ class DocumentChunkingSource(Source):
         """
         if not elements:
             logger.warning(f"No elements provided for document {document_urn}")
+            yield self.build_skip_marker_workunit(document_urn, "NO_INDEXABLE_CONTENT")
             return
 
         # Chunk the elements. A chunking failure raises so the calling source
         # does not record the document as successfully processed.
         chunks = self._chunk_elements(elements)
         if not chunks:
+            # Deterministic for this text: emit a skip marker (rather than silently nothing)
+            # so the document is classified as never-embeddable instead of missing.
             logger.warning(f"No chunks created for document {document_urn}")
+            yield self.build_skip_marker_workunit(document_urn, "NO_INDEXABLE_CONTENT")
             return
 
         # Generate embeddings (only if configured).
@@ -303,6 +307,15 @@ class DocumentChunkingSource(Source):
         else:
             logger.debug(
                 f"Skipping embedding generation for {document_urn} - no embedding provider configured"
+            )
+
+        # A configured provider returning zero vectors for non-empty chunks is an anomaly,
+        # not a legitimate skip: raise so the caller treats the document as failed and
+        # retries it next run instead of checkpointing it with no semanticContent.
+        if self.embedding_model and not embeddings:
+            raise RuntimeError(
+                f"Embedding provider returned no vectors for {document_urn} "
+                f"({len(chunks)} chunks)"
             )
 
         # Emit SemanticContent aspect (only if embeddings were generated)
@@ -823,6 +836,32 @@ class DocumentChunkingSource(Source):
         except Exception as e:
             logger.error(f"Failed to generate embeddings: {e}", exc_info=True)
             raise
+
+    def build_skip_marker_workunit(
+        self, document_urn: str, reason: str
+    ) -> MetadataWorkUnit:
+        """Build a semanticContent skip marker for a deliberately-skipped document.
+
+        An empty embeddings map plus skipReason lets downstream consumers (e.g. coverage
+        reporting) tell never-embeddable documents apart from indexing lag or failures.
+        The marker is overwritten with real embeddings if the document later becomes
+        embeddable and is processed.
+        """
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        mcp = MetadataChangeProposalWrapper(
+            entityUrn=document_urn,
+            aspect=SemanticContentClass(
+                embeddings={},
+                skipReason=reason,
+                skippedAt=int(datetime.utcnow().timestamp() * 1000),
+            ),
+        )
+        # Non-primary so AutoStatusAspectProcessor does not emit a Status UPSERT for the
+        # document URN (mirrors _emit_semantic_content).
+        return MetadataWorkUnit(
+            id=f"{document_urn}-semanticContent-skip", mcp=mcp, is_primary_source=False
+        )
 
     def _emit_semantic_content(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unstructured/chunking_source.py
@@ -890,10 +890,14 @@ class DocumentChunkingSource(Source):
                         if key != own_key
                     }
             except Exception as e:
-                logger.warning(
+                # Do NOT fall back to an empty map: the marker is a full-aspect UPSERT, so
+                # emitting it after a transient read failure would erase other models'
+                # entries. Raising leaves the document unprocessed; the caller reports it
+                # failed and it is retried next run.
+                raise RuntimeError(
                     f"Could not read existing semanticContent for {document_urn}; "
-                    f"skip marker will not preserve other models' entries: {e}"
-                )
+                    f"not emitting a skip marker that could erase other models' entries"
+                ) from e
 
         mcp = MetadataChangeProposalWrapper(
             entityUrn=document_urn,

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
@@ -1105,8 +1105,15 @@ def test_skip_marker_read_error_leaves_document_retryable(notion_source):
         SkipMarkerReadError("read failed")
     )
     notion_source.chunking_source.report.num_documents_limit_reached = False
+    # Enable the stateful gate so _update_document_state WOULD be reached on the
+    # swallow-and-continue path — without this the assertion below is vacuous.
+    notion_source.config.stateful_ingestion = MagicMock(enabled=True)
 
     with patch.object(notion_source, "_update_document_state") as update_state:
         list(notion_source._create_document_entity(data))
 
+    # Discriminates the dedicated SkipMarkerReadError handler: if it were removed,
+    # the generic RuntimeError handler swallows the error and execution falls
+    # through to report accounting and the (enabled) state update.
     update_state.assert_not_called()
+    assert notion_source.report.num_files_processed == 0

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
@@ -1075,3 +1075,38 @@ def test_icon_dispatcher_unknown_types_preserves_known_types():
     emoji_result = Icon.from_dict({"type": "emoji", "emoji": "📝"})
     assert isinstance(emoji_result, EmojiIcon)
     assert emoji_result.emoji == "📝"
+
+
+def test_skip_marker_read_error_leaves_document_retryable(notion_source):
+    """A SkipMarkerReadError from the chunking sub-source must not record document
+    state (or count the document processed): state would permanently drop the skip
+    marker; returning early leaves the document retryable next run."""
+    from datahub.ingestion.source.unstructured.chunking_source import (
+        SkipMarkerReadError,
+    )
+
+    data = {
+        "elements": [{"type": "NarrativeText", "text": "hello", "metadata": {}}],
+        "metadata": {
+            "data_source": {"record_locator": {"page_id": "p1"}},
+            "filetype": "notion",
+        },
+    }
+    doc = MagicMock()
+    doc.urn = "urn:li:document:p1"
+    doc.as_workunits.return_value = []
+    notion_source.document_builder = MagicMock()
+    notion_source.document_builder.build_document_entity.return_value = doc
+    notion_source.document_builder.content_mapper.extract_text_content.return_value = (
+        "hello"
+    )
+    notion_source.chunking_source = MagicMock()
+    notion_source.chunking_source.process_elements_inline.side_effect = (
+        SkipMarkerReadError("read failed")
+    )
+    notion_source.chunking_source.report.num_documents_limit_reached = False
+
+    with patch.object(notion_source, "_update_document_state") as update_state:
+        list(notion_source._create_document_entity(data))
+
+    update_state.assert_not_called()

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -16,6 +16,7 @@ from datahub.ingestion.source.unstructured.chunking_config import (
 )
 from datahub.ingestion.source.unstructured.chunking_source import (
     DocumentChunkingSource,
+    compute_source_text_sha256,
 )
 from datahub.ingestion.source.unstructured.embedding_providers.base import (
     EmbeddingResult,
@@ -1225,3 +1226,106 @@ def test_malformed_elements_json_not_recorded_in_state(
         list(source._process_batch())
 
     assert doc["urn"] not in source.document_state
+
+
+class TestSkipMarkersAndEmbedAccounting:
+    """Skip-marker paths and success/failure accounting in process_elements_inline."""
+
+    def _source(self, pipeline_context, chunking_config):
+        return DocumentChunkingSource(
+            ctx=pipeline_context,
+            config=chunking_config,
+            standalone=False,
+            graph=None,
+        )
+
+    def test_no_elements_emits_no_indexable_content_marker(
+        self, pipeline_context, chunking_config
+    ):
+        source = self._source(pipeline_context, chunking_config)
+        wus = list(source.process_elements_inline("urn:li:document:no-elements", []))
+
+        assert len(wus) == 1
+        aspect = wus[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.embeddings == {}
+        assert aspect.skipReason == "NO_INDEXABLE_CONTENT"
+        assert isinstance(aspect.skippedAt, int)
+
+    def test_blank_chunk_text_emits_skip_marker_not_failure(
+        self, pipeline_context, chunking_config
+    ):
+        """All-blank chunk text is deterministic: it must become a deliberate skip,
+        not an embedding failure that retries forever (the provider is never called
+        because _generate_embeddings filters blank texts)."""
+        source = self._source(pipeline_context, chunking_config)
+        elements = [{"type": "NarrativeText", "text": "   "}]
+
+        with patch.object(
+            source, "_chunk_elements", return_value=[{"text": "   "}, {"text": "\n"}]
+        ):
+            wus = list(
+                source.process_elements_inline("urn:li:document:blank", elements)
+            )
+
+        assert len(wus) == 1
+        aspect = wus[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.skipReason == "NO_INDEXABLE_CONTENT"
+        assert source.report.num_embedding_failures == 0
+
+    def test_provider_returning_no_vectors_is_failure_not_success(
+        self, pipeline_context, chunking_config
+    ):
+        """A configured provider returning zero vectors for non-blank chunks must be
+        accounted as a failure (and raise), never as a successful embed."""
+        source = self._source(pipeline_context, chunking_config)
+        elements = [{"type": "NarrativeText", "text": "real content here"}]
+
+        with (
+            patch.object(source, "_generate_embeddings", return_value=[]),
+            pytest.raises(RuntimeError, match="no vectors"),
+        ):
+            list(source.process_elements_inline("urn:li:document:anomaly", elements))
+
+        assert source.report.num_embedding_failures == 1
+        assert source.report.num_documents_with_embeddings == 0
+
+    def test_embed_emission_carries_no_skip_marker(
+        self, pipeline_context, chunking_config
+    ):
+        """A real embed must emit an aspect without skipReason/skippedAt, so it
+        replaces (clears) any previous skip marker for the document."""
+        source = self._source(pipeline_context, chunking_config)
+        elements = [
+            {"type": "Title", "text": "Test Title"},
+            {"type": "NarrativeText", "text": "Test content"},
+        ]
+
+        with patch.object(
+            source, "_generate_embeddings", return_value=[[0.1, 0.2], [0.3, 0.4]]
+        ):
+            wus = list(
+                source.process_elements_inline("urn:li:document:embedded", elements)
+            )
+
+        semantic = [
+            wu
+            for wu in wus
+            if isinstance(wu.metadata.aspect, SemanticContentClass)  # type: ignore[union-attr]
+        ]
+        assert len(semantic) == 1
+        aspect = semantic[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.embeddings
+        assert aspect.skipReason is None
+        assert aspect.skippedAt is None
+
+    def test_compute_source_text_sha256_cross_language_vector(self):
+        """Pinned vector shared with the Java projection test
+        (UpdateIndicesV2StrategyTest): the production helper must produce a digest
+        byte-identical to the server-side resolvedTextSha256 stamp."""
+        assert (
+            compute_source_text_sha256("héllo \U0001f680\r\nworld")
+            == "f319ae6318b99bf8c83d79fe08bdcbc42928dc83c0d9e23145440c83141321a9"
+        )

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -21,7 +21,10 @@ from datahub.ingestion.source.unstructured.chunking_source import (
 from datahub.ingestion.source.unstructured.embedding_providers.base import (
     EmbeddingResult,
 )
-from datahub.metadata.schema_classes import SemanticContentClass
+from datahub.metadata.schema_classes import (
+    EmbeddingModelDataClass,
+    SemanticContentClass,
+)
 
 
 def _semantic_embeddings(workunit: "MetadataWorkUnit") -> dict:
@@ -1329,3 +1332,60 @@ class TestSkipMarkersAndEmbedAccounting:
             compute_source_text_sha256("héllo \U0001f680\r\nworld")
             == "f319ae6318b99bf8c83d79fe08bdcbc42928dc83c0d9e23145440c83141321a9"
         )
+
+    def test_skip_marker_preserves_other_models_embeddings(
+        self, pipeline_context, chunking_config
+    ):
+        """SemanticContent.embeddings is a multi-model map written as a full-aspect
+        UPSERT: a skip marker must carry forward other models' existing entries
+        (dropping only this pipeline's own), otherwise one pipeline's skip erases
+        another model's embeddings and the index projection clears its vectors."""
+        source = self._source(pipeline_context, chunking_config)
+        own_key = source.get_model_embedding_key()
+        assert own_key is not None
+        graph = MagicMock()
+        graph.get_aspect.return_value = SemanticContentClass(
+            embeddings={
+                own_key: EmbeddingModelDataClass(
+                    modelVersion="own/model-v1",
+                    generatedAt=456,
+                    totalChunks=0,
+                    chunks=[],
+                ),
+                "other_model": EmbeddingModelDataClass(
+                    modelVersion="other/model-v1",
+                    generatedAt=123,
+                    totalChunks=0,
+                    chunks=[],
+                ),
+            }
+        )
+        source.graph = graph
+
+        wu = source.build_skip_marker_workunit("urn:li:document:multi", "EMPTY_TEXT")
+
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.skipReason == "EMPTY_TEXT"
+        assert "other_model" in aspect.embeddings
+        assert aspect.embeddings["other_model"].modelVersion == "other/model-v1"
+        assert own_key not in aspect.embeddings
+
+    def test_skip_marker_read_failure_falls_back_to_empty(
+        self, pipeline_context, chunking_config
+    ):
+        """An unreadable existing aspect must not block the marker: fall back to an
+        empty map (the pre-read behavior) rather than failing the skip."""
+        source = self._source(pipeline_context, chunking_config)
+        graph = MagicMock()
+        graph.get_aspect.side_effect = RuntimeError("boom")
+        source.graph = graph
+
+        wu = source.build_skip_marker_workunit(
+            "urn:li:document:unreadable", "EMPTY_TEXT"
+        )
+
+        aspect = wu.metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.embeddings == {}
+        assert aspect.skipReason == "EMPTY_TEXT"

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -16,6 +16,7 @@ from datahub.ingestion.source.unstructured.chunking_config import (
 )
 from datahub.ingestion.source.unstructured.chunking_source import (
     DocumentChunkingSource,
+    SkipMarkerReadError,
     compute_source_text_sha256,
 )
 from datahub.ingestion.source.unstructured.embedding_providers.base import (
@@ -1382,7 +1383,7 @@ class TestSkipMarkersAndEmbedAccounting:
         graph.get_aspect.side_effect = RuntimeError("boom")
         source.graph = graph
 
-        with pytest.raises(RuntimeError, match="not emitting a skip marker"):
+        with pytest.raises(SkipMarkerReadError, match="not emitting a skip marker"):
             source.build_skip_marker_workunit(
                 "urn:li:document:unreadable", "EMPTY_TEXT"
             )

--- a/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/unstructured/test_chunking_source.py
@@ -1371,21 +1371,18 @@ class TestSkipMarkersAndEmbedAccounting:
         assert aspect.embeddings["other_model"].modelVersion == "other/model-v1"
         assert own_key not in aspect.embeddings
 
-    def test_skip_marker_read_failure_falls_back_to_empty(
+    def test_skip_marker_read_failure_raises_instead_of_erasing(
         self, pipeline_context, chunking_config
     ):
-        """An unreadable existing aspect must not block the marker: fall back to an
-        empty map (the pre-read behavior) rather than failing the skip."""
+        """A transient read failure must NOT produce a marker with an empty map (a
+        full-aspect UPSERT that would erase other models' entries); it fails the
+        operation so the document is retried next run."""
         source = self._source(pipeline_context, chunking_config)
         graph = MagicMock()
         graph.get_aspect.side_effect = RuntimeError("boom")
         source.graph = graph
 
-        wu = source.build_skip_marker_workunit(
-            "urn:li:document:unreadable", "EMPTY_TEXT"
-        )
-
-        aspect = wu.metadata.aspect
-        assert isinstance(aspect, SemanticContentClass)
-        assert aspect.embeddings == {}
-        assert aspect.skipReason == "EMPTY_TEXT"
+        with pytest.raises(RuntimeError, match="not emitting a skip marker"):
+            source.build_skip_marker_workunit(
+                "urn:li:document:unreadable", "EMPTY_TEXT"
+            )

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -40,6 +40,10 @@ from datahub.ingestion.source.unstructured.chunking_config import (
     ServerEmbeddingConfig,
     ServerSemanticSearchConfig,
 )
+from datahub.ingestion.source.unstructured.chunking_source import (
+    compute_source_text_sha256,
+)
+from datahub.metadata.schema_classes import SemanticContentClass
 
 
 def _mock_fetch(source, entities, urns=None):
@@ -2535,8 +2539,6 @@ class TestSkipMarkersAndProvenance:
             return items, stop.value
 
     def test_skip_marker_emitted_for_empty_text(self, ctx, config, mock_graph):
-        from datahub.metadata.schema_classes import SemanticContentClass
-
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
             wus, result = self._drain(
@@ -2555,8 +2557,6 @@ class TestSkipMarkersAndProvenance:
         assert isinstance(aspect.skippedAt, int)
 
     def test_skip_marker_emitted_below_min_text_length(self, ctx, config, mock_graph):
-        from datahub.metadata.schema_classes import SemanticContentClass
-
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
             wus, result = self._drain(
@@ -2572,10 +2572,6 @@ class TestSkipMarkersAndProvenance:
         assert aspect.skipReason == "BELOW_MIN_TEXT_LENGTH"
 
     def test_source_text_sha256_passed_to_chunking(self, ctx, config, mock_graph):
-        from datahub.ingestion.source.unstructured.chunking_source import (
-            compute_source_text_sha256,
-        )
-
         text = "This document has enough content to be partitioned and embedded."
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
@@ -2592,8 +2588,6 @@ class TestSkipMarkersAndProvenance:
         assert kwargs["source_text_sha256"] == compute_source_text_sha256(text)
 
     def test_skip_marker_emitted_when_no_elements(self, ctx, config, mock_graph):
-        from datahub.metadata.schema_classes import SemanticContentClass
-
         text = "long enough text that still partitions into nothing"
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
@@ -2616,8 +2610,6 @@ class TestSkipMarkersAndProvenance:
     def test_skip_empty_text_false_embeds_short_documents(self, ctx, mock_graph):
         """skip_empty_text=False keeps short-but-non-empty documents embeddable
         (its pre-existing semantics); empty documents are always skipped."""
-        from datahub.metadata.schema_classes import SemanticContentClass
-
         cfg = DataHubDocumentsSourceConfig(
             platform_filter=None,
             datahub={"server": "http://test-server:8080"},
@@ -2719,8 +2711,6 @@ class TestSkipMarkersAndProvenance:
 
         # End to end: the same short document is marker-skipped at 50 and reaches the
         # embed path at 0 (the state-hash difference above is what re-triggers it).
-        from datahub.metadata.schema_classes import SemanticContentClass
-
         doc = {"urn": "urn:li:document:threshold", "text": short_text}
         wus_50, result_50 = self._drain(at_50._process_single_document(doc))
         assert result_50 is True

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2590,6 +2590,42 @@ class TestSkipMarkersAndProvenance:
             == hashlib.sha256(text.encode("utf-8")).hexdigest()
         )
 
+    def test_threshold_change_reevaluates_skipped_documents(self, ctx, mock_graph):
+        """Recorded state for a skipped document must become invalid when
+        min_text_length changes, so the document is re-evaluated (and embedded once
+        eligible) instead of staying 'unchanged' forever. Embedded documents' hashes
+        must NOT change with the threshold (no re-embed wave)."""
+
+        def make_source(min_len):
+            cfg = DataHubDocumentsSourceConfig(
+                platform_filter=None,
+                datahub={"server": "http://test-server:8080"},
+                embedding={
+                    "provider": "bedrock",
+                    "model": "cohere.embed-english-v3",
+                    "aws_region": "us-west-2",
+                    "allow_local_embedding_config": True,
+                },
+                min_text_length=min_len,
+                stateful_ingestion={"enabled": False},
+            )
+            return DataHubDocumentsSource(ctx, cfg)
+
+        with mock_graph:
+            at_50 = make_source(50)
+            at_0 = make_source(0)
+
+        short_text = "tiny"
+        long_text = "x" * 100
+        # Skipped-at-50 doc: hash differs once threshold changes -> re-evaluated.
+        assert at_50._calculate_text_hash(short_text) != at_0._calculate_text_hash(
+            short_text
+        )
+        # Embedded doc (above both thresholds): hash identical -> no re-embed wave.
+        assert at_50._calculate_text_hash(long_text) == at_0._calculate_text_hash(
+            long_text
+        )
+
     def test_source_text_sha256_cross_language_vector(self):
         """Pinned vector shared with the Java projection test (UpdateIndicesV2Strategy):
         both sides must produce identical digests for identical unicode text."""

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2590,6 +2590,28 @@ class TestSkipMarkersAndProvenance:
             == hashlib.sha256(text.encode("utf-8")).hexdigest()
         )
 
+    def test_empty_override_event_with_null_contents_skips_silently(
+        self, ctx, config, mock_graph
+    ):
+        """A semanticText event with an empty override on a partial entity (null
+        documentInfo.contents) must skip silently -- not stamp an EMPTY_TEXT marker
+        from a body that was never readable (mirrors the batch/documentInfo guards)."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            with patch.object(
+                source,
+                "_fetch_document_info_dict",
+                return_value={"source": {"sourceType": "NATIVE"}, "contents": None},
+            ):
+                event: dict[str, Any] = {
+                    "entityUrn": "urn:li:document:partial-override",
+                    "aspectName": "semanticText",
+                    "aspect": json.dumps({"text": ""}),
+                }
+                workunits = list(source._process_single_event(event))
+
+        assert workunits == []
+
     def test_threshold_change_reevaluates_skipped_documents(self, ctx, mock_graph):
         """Recorded state for a skipped document must become invalid when
         min_text_length changes, so the document is re-evaluated (and embedded once

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2572,6 +2572,10 @@ class TestSkipMarkersAndProvenance:
         assert aspect.skipReason == "BELOW_MIN_TEXT_LENGTH"
 
     def test_source_text_sha256_passed_to_chunking(self, ctx, config, mock_graph):
+        from datahub.ingestion.source.unstructured.chunking_source import (
+            compute_source_text_sha256,
+        )
+
         text = "This document has enough content to be partitioned and embedded."
         with mock_graph:
             source = DataHubDocumentsSource(ctx, config)
@@ -2585,10 +2589,75 @@ class TestSkipMarkersAndProvenance:
 
         assert result is True
         kwargs = source.chunking_source.process_elements_inline.call_args.kwargs
-        assert (
-            kwargs["source_text_sha256"]
-            == hashlib.sha256(text.encode("utf-8")).hexdigest()
+        assert kwargs["source_text_sha256"] == compute_source_text_sha256(text)
+
+    def test_skip_marker_emitted_when_no_elements(self, ctx, config, mock_graph):
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        text = "long enough text that still partitions into nothing"
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            with patch.object(
+                source.text_partitioner, "partition_text", return_value=[]
+            ):
+                wus, result = self._drain(
+                    source._process_single_document(
+                        {"urn": "urn:li:document:no-elements", "text": text}
+                    )
+                )
+
+        assert result is True
+        assert len(wus) == 1
+        aspect = wus[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.embeddings == {}
+        assert aspect.skipReason == "NO_INDEXABLE_CONTENT"
+
+    def test_skip_empty_text_false_embeds_short_documents(self, ctx, mock_graph):
+        """skip_empty_text=False keeps short-but-non-empty documents embeddable
+        (its pre-existing semantics); empty documents are always skipped."""
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        cfg = DataHubDocumentsSourceConfig(
+            platform_filter=None,
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            min_text_length=10,
+            skip_empty_text=False,
+            stateful_ingestion={"enabled": False},
         )
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, cfg)
+            source.chunking_source = Mock()
+            source.chunking_source.process_elements_inline.return_value = iter([])
+
+            wus, result = self._drain(
+                source._process_single_document(
+                    {"urn": "urn:li:document:short-but-wanted", "text": "tiny"}
+                )
+            )
+            assert result is True
+            source.chunking_source.process_elements_inline.assert_called_once()
+
+            # Fresh source (real chunking_source) for the marker path: the marker is
+            # built by chunking_source, which is mocked out above.
+            marker_source = DataHubDocumentsSource(ctx, cfg)
+            wus_empty, result_empty = self._drain(
+                marker_source._process_single_document(
+                    {"urn": "urn:li:document:still-empty", "text": ""}
+                )
+            )
+
+        assert result_empty is True
+        assert len(wus_empty) == 1
+        aspect = wus_empty[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.skipReason == "EMPTY_TEXT"
 
     def test_empty_override_event_with_null_contents_skips_silently(
         self, ctx, config, mock_graph
@@ -2648,12 +2717,42 @@ class TestSkipMarkersAndProvenance:
             long_text
         )
 
-    def test_source_text_sha256_cross_language_vector(self):
+        # End to end: the same short document is marker-skipped at 50 and reaches the
+        # embed path at 0 (the state-hash difference above is what re-triggers it).
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        doc = {"urn": "urn:li:document:threshold", "text": short_text}
+        wus_50, result_50 = self._drain(at_50._process_single_document(doc))
+        assert result_50 is True
+        aspect = wus_50[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.skipReason == "BELOW_MIN_TEXT_LENGTH"
+
+        at_0.chunking_source = Mock()
+        at_0.chunking_source.process_elements_inline.return_value = iter([])
+        wus_0, result_0 = self._drain(at_0._process_single_document(doc))
+        assert result_0 is True
+        at_0.chunking_source.process_elements_inline.assert_called_once()
+
+    def test_source_text_sha256_cross_language_vector(self, ctx, config, mock_graph):
         """Pinned vector shared with the Java projection test (UpdateIndicesV2Strategy):
-        both sides must produce identical digests for identical unicode text."""
+        the digest the connector actually passes to the chunking source must be
+        byte-identical to the server-side resolvedTextSha256 stamp."""
         text = "héllo \U0001f680\r\nworld"
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.chunking_source = Mock()
+            source.chunking_source.process_elements_inline.return_value = iter([])
+            wus, result = self._drain(
+                source._process_single_document(
+                    {"urn": "urn:li:document:unicode", "text": text}
+                )
+            )
+
+        assert result is True
+        kwargs = source.chunking_source.process_elements_inline.call_args.kwargs
         assert (
-            hashlib.sha256(text.encode("utf-8")).hexdigest()
+            kwargs["source_text_sha256"]
             == "f319ae6318b99bf8c83d79fe08bdcbc42928dc83c0d9e23145440c83141321a9"
         )
 

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -951,7 +951,7 @@ class TestStateStorage:
             mock_state_handler.get_document_hash.return_value = None
             mock_state_handler.update_document_state = Mock()
 
-            def _yield_then_fail(document_urn, elements):
+            def _yield_then_fail(document_urn, elements, source_text_sha256=None):
                 yield Mock()
                 raise RuntimeError("embedding provider unavailable")
 
@@ -2489,8 +2489,115 @@ class TestPartialEntityHandling:
 
             documents = list(source._fetch_documents_graphql())
 
-            assert len(documents) == 1
-            assert documents[0]["urn"] == "urn:li:document:valid"
+            # Null info/contents are hydration anomalies and stay silently skipped;
+            # empty TEXT is yielded so _process_single_document can stamp a skip marker.
+            assert len(documents) == 2
+            assert documents[0]["urn"] == "urn:li:document:empty_text"
+            assert documents[1]["urn"] == "urn:li:document:valid"
+
+
+class TestSkipMarkersAndProvenance:
+    """Skip markers for never-embeddable documents + sourceTextSha256 provenance."""
+
+    @pytest.fixture
+    def config(self):
+        return DataHubDocumentsSourceConfig(
+            platform_filter=None,
+            datahub={"server": "http://test-server:8080"},
+            embedding={
+                "provider": "bedrock",
+                "model": "cohere.embed-english-v3",
+                "aws_region": "us-west-2",
+                "allow_local_embedding_config": True,
+            },
+            min_text_length=10,
+            stateful_ingestion={"enabled": False},
+        )
+
+    @pytest.fixture
+    def ctx(self):
+        return PipelineContext(run_id="test-run", pipeline_name="test-pipeline")
+
+    @pytest.fixture
+    def mock_graph(self):
+        return patch(
+            "datahub.ingestion.source.datahub_documents.datahub_documents_source.DataHubGraph"
+        )
+
+    @staticmethod
+    def _drain(gen):
+        """Collect a generator's yields and its StopIteration return value."""
+        items = []
+        try:
+            while True:
+                items.append(next(gen))
+        except StopIteration as stop:
+            return items, stop.value
+
+    def test_skip_marker_emitted_for_empty_text(self, ctx, config, mock_graph):
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            wus, result = self._drain(
+                source._process_single_document(
+                    {"urn": "urn:li:document:empty", "text": ""}
+                )
+            )
+
+        # True: the skip is deterministic for this text, so state should advance.
+        assert result is True
+        assert len(wus) == 1
+        aspect = wus[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.embeddings == {}
+        assert aspect.skipReason == "EMPTY_TEXT"
+        assert isinstance(aspect.skippedAt, int)
+
+    def test_skip_marker_emitted_below_min_text_length(self, ctx, config, mock_graph):
+        from datahub.metadata.schema_classes import SemanticContentClass
+
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            wus, result = self._drain(
+                source._process_single_document(
+                    {"urn": "urn:li:document:short", "text": "tiny"}
+                )
+            )
+
+        assert result is True
+        assert len(wus) == 1
+        aspect = wus[0].metadata.aspect
+        assert isinstance(aspect, SemanticContentClass)
+        assert aspect.skipReason == "BELOW_MIN_TEXT_LENGTH"
+
+    def test_source_text_sha256_passed_to_chunking(self, ctx, config, mock_graph):
+        text = "This document has enough content to be partitioned and embedded."
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+            source.chunking_source = Mock()
+            source.chunking_source.process_elements_inline.return_value = iter([])
+            wus, result = self._drain(
+                source._process_single_document(
+                    {"urn": "urn:li:document:hashed", "text": text}
+                )
+            )
+
+        assert result is True
+        kwargs = source.chunking_source.process_elements_inline.call_args.kwargs
+        assert (
+            kwargs["source_text_sha256"]
+            == hashlib.sha256(text.encode("utf-8")).hexdigest()
+        )
+
+    def test_source_text_sha256_cross_language_vector(self):
+        """Pinned vector shared with the Java projection test (UpdateIndicesV2Strategy):
+        both sides must produce identical digests for identical unicode text."""
+        text = "héllo \U0001f680\r\nworld"
+        assert (
+            hashlib.sha256(text.encode("utf-8")).hexdigest()
+            == "f319ae6318b99bf8c83d79fe08bdcbc42928dc83c0d9e23145440c83141321a9"
+        )
 
 
 class TestMaxDocumentsLimit:

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2SemanticSearchMappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2SemanticSearchMappingsBuilder.java
@@ -166,7 +166,15 @@ public class V2SemanticSearchMappingsBuilder implements MappingsBuilder {
       Map<String, Object> embeddingsProps = (Map<String, Object>) embeddingsField.get("properties");
       Map<String, Object> modelEntry = (Map<String, Object>) embeddingsProps.get(modelKey);
 
-      modelProperties.put(modelKey, modelEntry);
+      // Add the embed-time source-text digest (staleness provenance) with an explicit keyword
+      // mapping so exact-match queries do not depend on dynamic mapping.
+      Map<String, Object> modelEntryProps =
+          new HashMap<>((Map<String, Object>) modelEntry.get("properties"));
+      modelEntryProps.put("sourceTextSha256", ImmutableMap.of("type", "keyword"));
+      Map<String, Object> augmentedModelEntry = new HashMap<>(modelEntry);
+      augmentedModelEntry.put("properties", modelEntryProps);
+
+      modelProperties.put(modelKey, augmentedModelEntry);
     }
 
     return ImmutableMap.of("properties", modelProperties);
@@ -210,6 +218,12 @@ public class V2SemanticSearchMappingsBuilder implements MappingsBuilder {
       ImmutableMap.Builder<String, Object> newPropertiesMap = new ImmutableMap.Builder<>();
       newPropertiesMap.putAll(basePropertiesMap);
       newPropertiesMap.put("embeddings", embeddingFieldConfig);
+      // Staleness/skip provenance fields written by UpdateIndicesV2Strategy (resolvedTextSha256)
+      // and the semanticContent projection (skipReason/skippedAt) -- mapped explicitly so
+      // exact-match and exists queries do not depend on dynamic mapping.
+      newPropertiesMap.put("resolvedTextSha256", ImmutableMap.of("type", "keyword"));
+      newPropertiesMap.put("skipReason", ImmutableMap.of("type", "keyword"));
+      newPropertiesMap.put("skippedAt", ImmutableMap.of("type", "date"));
 
       // Construct new top-level map with new properties map
       ImmutableMap.Builder<String, Object> newMappings = new ImmutableMap.Builder<>();

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
@@ -600,7 +601,8 @@ public class SearchDocumentTransformer {
   }
 
   /** Sets semantic content (embeddings + skip marker) in the search document for vector search. */
-  private void setSemanticContentSearchValue(
+  @VisibleForTesting
+  void setSemanticContentSearchValue(
       final RecordTemplate aspect, final ObjectNode searchDocument, final Boolean forDelete) {
     if (forDelete || aspect == null) {
       searchDocument.set("embeddings", JsonNodeFactory.instance.nullNode());
@@ -611,8 +613,17 @@ public class SearchDocumentTransformer {
     try {
       // Direct pass-through - PDL camelCase matches OpenSearch camelCase
       ObjectMapper mapper = new ObjectMapper();
-      JsonNode embeddingsNode = mapper.valueToTree(aspect.data().get("embeddings"));
-      searchDocument.set("embeddings", embeddingsNode);
+      Object embeddings = aspect.data().get("embeddings");
+      // An empty embeddings map (skip marker) must project as an explicit null: under
+      // doc_as_upsert an empty object is a merge no-op, so {} could not clear a previous
+      // model entry on an embedded -> skipped transition when the diff-mode removal pass
+      // is unavailable (e.g. FORCE_INDEXING / restore), leaving the document permanently
+      // misclassified as embedded-and-stale.
+      if (embeddings instanceof Map && ((Map<?, ?>) embeddings).isEmpty()) {
+        searchDocument.set("embeddings", JsonNodeFactory.instance.nullNode());
+      } else {
+        searchDocument.set("embeddings", mapper.valueToTree(embeddings));
+      }
       // Skip marker fields are ALWAYS set (value or explicit null): index updates merge via
       // doc_as_upsert, so omitting them after a real embed would leave a previous skip marker
       // in place and misclassify an embedded document as deliberately skipped.

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -599,11 +599,13 @@ public class SearchDocumentTransformer {
             });
   }
 
-  /** Sets semantic content (embeddings) in the search document for vector search. */
+  /** Sets semantic content (embeddings + skip marker) in the search document for vector search. */
   private void setSemanticContentSearchValue(
       final RecordTemplate aspect, final ObjectNode searchDocument, final Boolean forDelete) {
     if (forDelete || aspect == null) {
       searchDocument.set("embeddings", JsonNodeFactory.instance.nullNode());
+      searchDocument.set("skipReason", JsonNodeFactory.instance.nullNode());
+      searchDocument.set("skippedAt", JsonNodeFactory.instance.nullNode());
       return;
     }
     try {
@@ -611,6 +613,21 @@ public class SearchDocumentTransformer {
       ObjectMapper mapper = new ObjectMapper();
       JsonNode embeddingsNode = mapper.valueToTree(aspect.data().get("embeddings"));
       searchDocument.set("embeddings", embeddingsNode);
+      // Skip marker fields are ALWAYS set (value or explicit null): index updates merge via
+      // doc_as_upsert, so omitting them after a real embed would leave a previous skip marker
+      // in place and misclassify an embedded document as deliberately skipped.
+      Object skipReason = aspect.data().get("skipReason");
+      searchDocument.set(
+          "skipReason",
+          skipReason != null
+              ? JsonNodeFactory.instance.textNode(skipReason.toString())
+              : JsonNodeFactory.instance.nullNode());
+      Object skippedAt = aspect.data().get("skippedAt");
+      searchDocument.set(
+          "skippedAt",
+          skippedAt instanceof Number
+              ? JsonNodeFactory.instance.numberNode(((Number) skippedAt).longValue())
+              : JsonNodeFactory.instance.nullNode());
       log.debug("Set semantic content embeddings in search document");
     } catch (Exception e) {
       log.error("Error transforming SemanticContent aspect to search document", e);

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -495,7 +495,8 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
 
     // Dual-write to semantic index if enabled for this entity
     if (shouldWrite) {
-      writeToSemanticIndex(opContext, urn, entityName, finalDocumentNode, docId);
+      writeToSemanticIndex(
+          opContext, urn, entityName, aspectSpec.getName(), finalDocumentNode, docId);
     }
 
     // Append runId to search document so rollback/list runs can find touched URNs (MAE path)
@@ -775,9 +776,10 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       @Nonnull OperationContext opContext,
       @Nonnull Urn urn,
       @Nonnull String entityName,
+      @Nonnull String aspectName,
       @Nonnull ObjectNode documentNode,
       @Nonnull String docId) {
-    withResolvedTextSha256(opContext, urn, entityName, documentNode);
+    withResolvedTextSha256(opContext, urn, entityName, aspectName, documentNode);
     String document = documentNode.toString();
     String semanticIndexName = indexConvention.getEntityIndexNameSemantic(opContext, entityName);
     log.info(
@@ -801,22 +803,29 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
    * documentInfo} body) that project on separate MCLs, so the side not carried by the current
    * document is fetched via the aspect retriever rather than derived from the partial document --
    * deriving per-aspect would permanently mis-stamp documents whose override is written once and
-   * never re-projected. Non-embed-source aspects (neither field present) are left untouched: {@code
-   * doc_as_upsert} merging preserves the existing stamp. Stamping is best-effort: on any retrieval
-   * failure the field is left absent (consumers treat absent as unknown, never as stale).
+   * never re-projected. {@code semanticContent} projections also stamp (fetching both sides), so
+   * re-embedding refreshes pre-existing index documents. Other aspects (neither field present) are
+   * left untouched: {@code doc_as_upsert} merging preserves the existing stamp. On a retrieval
+   * failure the field is set to an explicit null, overwriting any previous stamp -- a stale stamp
+   * could misreport a changed document as current, while null reads as unknown.
    */
   @VisibleForTesting
   void withResolvedTextSha256(
       @Nonnull OperationContext opContext,
       @Nonnull Urn urn,
       @Nonnull String entityName,
+      @Nonnull String aspectName,
       @Nonnull ObjectNode document) {
     if (!Constants.DOCUMENT_ENTITY_NAME.equals(entityName)) {
       return;
     }
     boolean hasOverrideField = document.has(SEMANTIC_TEXT_FIELD);
     boolean hasBodyField = document.has(BODY_TEXT_FIELD);
-    if (!hasOverrideField && !hasBodyField) {
+    // semanticContent projections (the embedding pipeline's own writes) also stamp, so a re-embed
+    // or force_reprocess run refreshes the field for documents indexed before this change.
+    boolean isSemanticContentAspect =
+        SearchDocumentTransformer.SEMANTIC_DATA_ASPECTS.contains(aspectName);
+    if (!hasOverrideField && !hasBodyField && !isSemanticContentAspect) {
       return;
     }
     try {
@@ -836,11 +845,17 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       }
       document.put(RESOLVED_TEXT_SHA256_FIELD, sha256Hex(resolved));
     } catch (Exception e) {
+      // Explicit null (not absent): index updates merge via doc_as_upsert, so leaving the field
+      // out would preserve a previously stamped value -- a stale stamp could misreport a changed
+      // document as current, while null reads as unknown.
       log.warn(
-          "Failed to resolve embed text for {}; leaving {} unstamped",
+          "Failed to resolve embed text for {}; clearing {} (reads as unknown, never stale)",
           urn,
           RESOLVED_TEXT_SHA256_FIELD,
           e);
+      document.set(
+          RESOLVED_TEXT_SHA256_FIELD,
+          com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.nullNode());
     }
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -41,7 +41,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -535,12 +534,11 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       return;
     }
 
-    Optional<String> searchDocument;
+    Optional<ObjectNode> searchDocument;
     try {
       searchDocument =
-          searchDocumentTransformer
-              .transformAspect(opContext, urn, aspect, aspectSpec, true, auditStamp)
-              .map(Objects::toString);
+          searchDocumentTransformer.transformAspect(
+              opContext, urn, aspect, aspectSpec, true, auditStamp);
     } catch (Exception e) {
       log.error(
           "Error in getting documents from aspect: {} for aspect {}", e, aspectSpec.getName());
@@ -551,7 +549,21 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       return;
     }
 
-    elasticSearchService.upsertDocument(opContext, entityName, searchDocument.get(), docId);
+    // Serialized before any semantic-only augmentation below, mirroring the upsert path, so the
+    // base V2 index never sees semantic-only fields such as resolvedTextSha256.
+    elasticSearchService.upsertDocument(
+        opContext, entityName, searchDocument.get().toString(), docId);
+
+    // Mirror the upsert path's semantic dual-write for non-key aspect deletes. Without this,
+    // deleting the semanticText override leaves the old override text and resolvedTextSha256 in
+    // the semantic index, and deleting semanticContent leaves vectors and skip fields behind.
+    // writeToSemanticIndex re-stamps resolvedTextSha256 from the surviving aspects (a deleted
+    // override falls back to the document body), and the delete-shaped document nulls the
+    // removed aspect's fields via doc_as_upsert.
+    if (shouldWriteToSemanticIndex(opContext, entityName)) {
+      writeToSemanticIndex(
+          opContext, urn, entityName, aspectSpec.getName(), searchDocument.get(), docId);
+    }
   }
 
   void updateTimeseriesFieldsForEvent(@Nonnull OperationContext opContext, @Nonnull MCLItem event) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -11,6 +11,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
@@ -32,6 +33,9 @@ import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -65,6 +69,18 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
 
   /** Cache TTL for semantic index existence checks (5 minutes) */
   private static final long SEMANTIC_INDEX_CACHE_TTL_MINUTES = 5;
+
+  /** Searchable field carrying the document body ({@code documentInfo.contents.text}). */
+  private static final String BODY_TEXT_FIELD = "text";
+
+  /** Searchable field carrying the curated embed-text override ({@code semanticText.text}). */
+  private static final String SEMANTIC_TEXT_FIELD = "semanticText";
+
+  /**
+   * Semantic-index-only field: SHA-256 hex of the current resolved embed text. See {@link
+   * #withResolvedTextSha256}.
+   */
+  private static final String RESOLVED_TEXT_SHA256_FIELD = "resolvedTextSha256";
 
   private final EntityIndexVersionConfiguration v2Config;
   private final ElasticSearchService elasticSearchService;
@@ -455,10 +471,12 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
       }
     }
 
-    String finalDocument =
+    ObjectNode finalDocumentNode =
         SearchDocumentTransformer.handleRemoveFields(
-                searchDocument.get(), previousSearchDocument.orElse(null))
-            .toString();
+            searchDocument.get(), previousSearchDocument.orElse(null));
+    // Serialized before any semantic-only augmentation below, so the base V2 index never sees
+    // semantic-only fields such as resolvedTextSha256.
+    String finalDocument = finalDocumentNode.toString();
 
     // Write to V2 index
     elasticSearchService.upsertDocument(opContext, entityName, finalDocument, docId);
@@ -477,7 +495,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
 
     // Dual-write to semantic index if enabled for this entity
     if (shouldWrite) {
-      writeToSemanticIndex(opContext, entityName, finalDocument, docId);
+      writeToSemanticIndex(opContext, urn, entityName, finalDocumentNode, docId);
     }
 
     // Append runId to search document so rollback/list runs can find touched URNs (MAE path)
@@ -755,9 +773,12 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
    */
   private void writeToSemanticIndex(
       @Nonnull OperationContext opContext,
+      @Nonnull Urn urn,
       @Nonnull String entityName,
-      @Nonnull String document,
+      @Nonnull ObjectNode documentNode,
       @Nonnull String docId) {
+    withResolvedTextSha256(opContext, urn, entityName, documentNode);
+    String document = documentNode.toString();
     String semanticIndexName = indexConvention.getEntityIndexNameSemantic(opContext, entityName);
     log.info(
         "Semantic dual-write: UPSERT to '{}' for entity '{}', docId='{}', docSize={}",
@@ -766,6 +787,119 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
         docId,
         document.length());
     elasticSearchService.upsertDocumentByIndexName(opContext, semanticIndexName, document, docId);
+  }
+
+  /**
+   * Stamps {@code resolvedTextSha256} -- the SHA-256 hex digest (UTF-8 bytes) of the entity's
+   * resolved embed text, with the {@code semanticText} override winning over the document body --
+   * onto the semantic-index document. The embedding pipeline records the same digest of the text it
+   * embedded ({@code embeddings.<model>.sourceTextSha256}), so consumers such as coverage reporting
+   * can detect genuinely stale embeddings by comparing the two hashes instead of relying on
+   * modification timestamps that move on non-content writes.
+   *
+   * <p>The resolved embed text spans two aspects ({@code semanticText} override and {@code
+   * documentInfo} body) that project on separate MCLs, so the side not carried by the current
+   * document is fetched via the aspect retriever rather than derived from the partial document --
+   * deriving per-aspect would permanently mis-stamp documents whose override is written once and
+   * never re-projected. Non-embed-source aspects (neither field present) are left untouched: {@code
+   * doc_as_upsert} merging preserves the existing stamp. Stamping is best-effort: on any retrieval
+   * failure the field is left absent (consumers treat absent as unknown, never as stale).
+   */
+  @VisibleForTesting
+  void withResolvedTextSha256(
+      @Nonnull OperationContext opContext,
+      @Nonnull Urn urn,
+      @Nonnull String entityName,
+      @Nonnull ObjectNode document) {
+    if (!Constants.DOCUMENT_ENTITY_NAME.equals(entityName)) {
+      return;
+    }
+    boolean hasOverrideField = document.has(SEMANTIC_TEXT_FIELD);
+    boolean hasBodyField = document.has(BODY_TEXT_FIELD);
+    if (!hasOverrideField && !hasBodyField) {
+      return;
+    }
+    try {
+      String override =
+          hasOverrideField
+              ? textValue(document.get(SEMANTIC_TEXT_FIELD))
+              : fetchSemanticTextOverride(opContext, urn);
+      final String resolved;
+      if (override != null && !override.isEmpty()) {
+        resolved = override;
+      } else if (hasBodyField) {
+        String body = textValue(document.get(BODY_TEXT_FIELD));
+        resolved = body != null ? body : "";
+      } else {
+        String body = fetchDocumentBodyText(opContext, urn);
+        resolved = body != null ? body : "";
+      }
+      document.put(RESOLVED_TEXT_SHA256_FIELD, sha256Hex(resolved));
+    } catch (Exception e) {
+      log.warn(
+          "Failed to resolve embed text for {}; leaving {} unstamped",
+          urn,
+          RESOLVED_TEXT_SHA256_FIELD,
+          e);
+    }
+  }
+
+  @Nullable
+  private String fetchSemanticTextOverride(@Nonnull OperationContext opContext, @Nonnull Urn urn) {
+    com.linkedin.entity.Aspect aspect =
+        opContext
+            .getAspectRetriever()
+            .getLatestAspectObject(opContext, urn, Constants.SEMANTIC_TEXT_ASPECT_NAME);
+    if (aspect == null) {
+      return null;
+    }
+    Object text = aspect.data().get("text");
+    return text != null ? text.toString() : null;
+  }
+
+  @Nullable
+  private String fetchDocumentBodyText(@Nonnull OperationContext opContext, @Nonnull Urn urn) {
+    com.linkedin.entity.Aspect aspect =
+        opContext
+            .getAspectRetriever()
+            .getLatestAspectObject(opContext, urn, Constants.DOCUMENT_INFO_ASPECT_NAME);
+    if (aspect == null) {
+      return null;
+    }
+    Object contents = aspect.data().get("contents");
+    if (!(contents instanceof DataMap)) {
+      return null;
+    }
+    Object text = ((DataMap) contents).get("text");
+    return text != null ? text.toString() : null;
+  }
+
+  @Nullable
+  private static String textValue(@Nullable JsonNode node) {
+    return node != null && node.isTextual() ? node.asText() : null;
+  }
+
+  /**
+   * SHA-256 hex (lowercase) over the UTF-8 bytes of the text -- byte-for-byte identical to Python's
+   * {@code hashlib.sha256(text.encode("utf-8")).hexdigest()} used by the embedding pipeline, so the
+   * two sides of the staleness comparison agree.
+   */
+  @Nonnull
+  @VisibleForTesting
+  static String sha256Hex(@Nonnull String text) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(text.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder(hash.length * 2);
+      for (byte b : hash) {
+        sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+        sb.append(Character.forDigit(b & 0xF, 16));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      // SHA-256 is a mandatory JCA algorithm; this cannot happen on a compliant JVM.
+      throw new IllegalStateException("SHA-256 unavailable", e);
+    }
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
@@ -1135,4 +1135,50 @@ public class SearchDocumentTransformerTest {
         "Base64 image should NOT be sanitized for fields without sanitizeRichText annotation");
     assertTrue(indexedName.contains("Dataset Name"), "Original text should be preserved");
   }
+
+  @Test
+  public void testSetSemanticContentSearchValue_EmptyEmbeddingsProjectsExplicitNull() {
+    SearchDocumentTransformer transformer = new SearchDocumentTransformer(1000, 1000, 1000);
+    com.linkedin.common.SemanticContent aspect =
+        new com.linkedin.common.SemanticContent()
+            .setEmbeddings(new com.linkedin.common.EmbeddingModelDataMap())
+            .setSkipReason("EMPTY_TEXT")
+            .setSkippedAt(123L);
+    ObjectNode doc = JsonNodeFactory.instance.objectNode();
+
+    transformer.setSemanticContentSearchValue(aspect, doc, false);
+
+    // Under doc_as_upsert an empty object is a merge no-op: a skip marker's empty
+    // embeddings map must project as explicit null so it clears a previous model entry
+    // even when the diff-mode removal pass is unavailable (e.g. FORCE_INDEXING).
+    assertTrue(doc.get("embeddings").isNull(), "Empty embeddings map must project as null");
+    assertEquals(doc.get("skipReason").asText(), "EMPTY_TEXT");
+    assertEquals(doc.get("skippedAt").asLong(), 123L);
+  }
+
+  @Test
+  public void testSetSemanticContentSearchValue_EmbedClearsSkipMarkerFields() {
+    SearchDocumentTransformer transformer = new SearchDocumentTransformer(1000, 1000, 1000);
+    com.linkedin.common.EmbeddingModelDataMap embeddings =
+        new com.linkedin.common.EmbeddingModelDataMap();
+    embeddings.put(
+        "cohere_embed_v3",
+        new com.linkedin.common.EmbeddingModelData()
+            .setModelVersion("bedrock/cohere.embed-english-v3")
+            .setGeneratedAt(456L)
+            .setTotalChunks(0)
+            .setChunks(new com.linkedin.common.EmbeddingChunkArray()));
+    com.linkedin.common.SemanticContent aspect =
+        new com.linkedin.common.SemanticContent().setEmbeddings(embeddings);
+    ObjectNode doc = JsonNodeFactory.instance.objectNode();
+
+    transformer.setSemanticContentSearchValue(aspect, doc, false);
+
+    assertTrue(doc.get("embeddings").isObject(), "Real embeddings must pass through");
+    assertTrue(doc.get("embeddings").has("cohere_embed_v3"));
+    // Marker fields are ALWAYS set (explicit null on embed) so a re-embed clears a
+    // previous skip marker under doc_as_upsert merging.
+    assertTrue(doc.get("skipReason").isNull(), "Embed must clear skipReason");
+    assertTrue(doc.get("skippedAt").isNull(), "Embed must clear skippedAt");
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -1474,4 +1474,146 @@ public class UpdateIndicesV2StrategyTest {
     when(event.getMetadataChangeLog()).thenReturn(mcl);
     return event;
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // resolvedTextSha256 stamping (semantic-index staleness provenance)
+  // ---------------------------------------------------------------------------------------------
+
+  private static ObjectNode objectNode() {
+    return com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+  }
+
+  private OperationContext contextWithRetriever(
+      com.linkedin.metadata.aspect.AspectRetriever retriever) {
+    OperationContext ctx = mock(OperationContext.class);
+    when(ctx.getAspectRetriever()).thenReturn(retriever);
+    return ctx;
+  }
+
+  private static com.linkedin.entity.Aspect aspectOf(Map<String, Object> data) {
+    return new com.linkedin.entity.Aspect(new DataMap(data));
+  }
+
+  @Test
+  public void testResolvedTextSha256_BodyOnlyDocument() {
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(OperationContext.class), any(Urn.class), eq(Constants.SEMANTIC_TEXT_ASPECT_NAME)))
+        .thenReturn(null);
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("text", "hello world");
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    org.testng.Assert.assertEquals(
+        doc.get("resolvedTextSha256").asText(), UpdateIndicesV2Strategy.sha256Hex("hello world"));
+  }
+
+  @Test
+  public void testResolvedTextSha256_OverrideFetchedOnBodyProjection() {
+    // A documentInfo projection carries only the body; the override must be fetched and win --
+    // deriving from the partial document would permanently mis-stamp write-once overrides.
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(OperationContext.class), any(Urn.class), eq(Constants.SEMANTIC_TEXT_ASPECT_NAME)))
+        .thenReturn(aspectOf(Map.of("text", "curated override")));
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("text", "churning body");
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    org.testng.Assert.assertEquals(
+        doc.get("resolvedTextSha256").asText(),
+        UpdateIndicesV2Strategy.sha256Hex("curated override"));
+  }
+
+  @Test
+  public void testResolvedTextSha256_OverrideProjectionUsesOwnValue() {
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("semanticText", "curated override");
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    org.testng.Assert.assertEquals(
+        doc.get("resolvedTextSha256").asText(),
+        UpdateIndicesV2Strategy.sha256Hex("curated override"));
+    // Override present on the projected document itself: nothing to fetch.
+    verify(retriever, never())
+        .getLatestAspectObject(any(OperationContext.class), any(Urn.class), anyString());
+  }
+
+  @Test
+  public void testResolvedTextSha256_EmptyOverrideFallsBackToFetchedBody() {
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(OperationContext.class), any(Urn.class), eq(Constants.DOCUMENT_INFO_ASPECT_NAME)))
+        .thenReturn(aspectOf(Map.of("contents", new DataMap(Map.of("text", "the body")))));
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("semanticText", "");
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    org.testng.Assert.assertEquals(
+        doc.get("resolvedTextSha256").asText(), UpdateIndicesV2Strategy.sha256Hex("the body"));
+  }
+
+  @Test
+  public void testResolvedTextSha256_NonEmbedAspectUntouched() {
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("removed", false);
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    // doc_as_upsert merging preserves any existing stamp; nothing derived, nothing fetched.
+    org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
+    verify(retriever, never())
+        .getLatestAspectObject(any(OperationContext.class), any(Urn.class), anyString());
+  }
+
+  @Test
+  public void testResolvedTextSha256_NonDocumentEntityUntouched() {
+    OperationContext ctx = mock(OperationContext.class);
+    ObjectNode doc = objectNode();
+    doc.put("text", "dataset description");
+    strategy.withResolvedTextSha256(ctx, testUrn, "dataset", doc);
+    org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
+  }
+
+  @Test
+  public void testResolvedTextSha256_RetrieverFailureLeavesUnstamped() {
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    when(retriever.getLatestAspectObject(any(OperationContext.class), any(Urn.class), anyString()))
+        .thenThrow(new RuntimeException("retriever unavailable"));
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.put("text", "hello world");
+    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+
+    // Best-effort: absent stamp reads as unknown downstream, never as stale.
+    org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
+  }
+
+  @Test
+  public void testSha256Hex_CrossLanguageVector() {
+    // Pinned vector shared with the Python pipeline test
+    // (test_source_text_sha256_cross_language_vector): both sides must produce identical
+    // digests for identical unicode text (non-BMP emoji + CRLF).
+    org.testng.Assert.assertEquals(
+        UpdateIndicesV2Strategy.sha256Hex("h\u00e9llo \uD83D\uDE80\r\nworld"),
+        "f319ae6318b99bf8c83d79fe08bdcbc42928dc83c0d9e23145440c83141321a9");
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -1505,7 +1505,8 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("text", "hello world");
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.DOCUMENT_INFO_ASPECT_NAME, doc);
 
     org.testng.Assert.assertEquals(
         doc.get("resolvedTextSha256").asText(), UpdateIndicesV2Strategy.sha256Hex("hello world"));
@@ -1524,7 +1525,8 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("text", "churning body");
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.DOCUMENT_INFO_ASPECT_NAME, doc);
 
     org.testng.Assert.assertEquals(
         doc.get("resolvedTextSha256").asText(),
@@ -1539,7 +1541,8 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("semanticText", "curated override");
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.SEMANTIC_TEXT_ASPECT_NAME, doc);
 
     org.testng.Assert.assertEquals(
         doc.get("resolvedTextSha256").asText(),
@@ -1560,7 +1563,8 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("semanticText", "");
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.SEMANTIC_TEXT_ASPECT_NAME, doc);
 
     org.testng.Assert.assertEquals(
         doc.get("resolvedTextSha256").asText(), UpdateIndicesV2Strategy.sha256Hex("the body"));
@@ -1574,7 +1578,8 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("removed", false);
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.STATUS_ASPECT_NAME, doc);
 
     // doc_as_upsert merging preserves any existing stamp; nothing derived, nothing fetched.
     org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
@@ -1587,12 +1592,12 @@ public class UpdateIndicesV2StrategyTest {
     OperationContext ctx = mock(OperationContext.class);
     ObjectNode doc = objectNode();
     doc.put("text", "dataset description");
-    strategy.withResolvedTextSha256(ctx, testUrn, "dataset", doc);
+    strategy.withResolvedTextSha256(ctx, testUrn, "dataset", "datasetProperties", doc);
     org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
   }
 
   @Test
-  public void testResolvedTextSha256_RetrieverFailureLeavesUnstamped() {
+  public void testResolvedTextSha256_RetrieverFailureClearsStamp() {
     com.linkedin.metadata.aspect.AspectRetriever retriever =
         mock(com.linkedin.metadata.aspect.AspectRetriever.class);
     when(retriever.getLatestAspectObject(any(OperationContext.class), any(Urn.class), anyString()))
@@ -1601,10 +1606,34 @@ public class UpdateIndicesV2StrategyTest {
 
     ObjectNode doc = objectNode();
     doc.put("text", "hello world");
-    strategy.withResolvedTextSha256(ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, doc);
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, Constants.DOCUMENT_INFO_ASPECT_NAME, doc);
 
-    // Best-effort: absent stamp reads as unknown downstream, never as stale.
-    org.testng.Assert.assertNull(doc.get("resolvedTextSha256"));
+    // Explicit null (not absent): doc_as_upsert would otherwise preserve a stale stamp.
+    assertTrue(doc.get("resolvedTextSha256").isNull());
+  }
+
+  @Test
+  public void testResolvedTextSha256_SemanticContentProjectionStamps() {
+    // The embedding pipeline's own semanticContent write carries neither text field, but must
+    // still stamp (via fetches) so re-embedding refreshes pre-existing index documents.
+    com.linkedin.metadata.aspect.AspectRetriever retriever =
+        mock(com.linkedin.metadata.aspect.AspectRetriever.class);
+    when(retriever.getLatestAspectObject(
+            any(OperationContext.class), any(Urn.class), eq(Constants.SEMANTIC_TEXT_ASPECT_NAME)))
+        .thenReturn(null);
+    when(retriever.getLatestAspectObject(
+            any(OperationContext.class), any(Urn.class), eq(Constants.DOCUMENT_INFO_ASPECT_NAME)))
+        .thenReturn(aspectOf(Map.of("contents", new DataMap(Map.of("text", "the body")))));
+    OperationContext ctx = contextWithRetriever(retriever);
+
+    ObjectNode doc = objectNode();
+    doc.set("embeddings", objectNode());
+    strategy.withResolvedTextSha256(
+        ctx, testUrn, Constants.DOCUMENT_ENTITY_NAME, "semanticContent", doc);
+
+    org.testng.Assert.assertEquals(
+        doc.get("resolvedTextSha256").asText(), UpdateIndicesV2Strategy.sha256Hex("the body"));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -745,6 +745,62 @@ public class UpdateIndicesV2StrategyTest {
             eq(operationContext), eq("datasetindex_v2_semantic"), anyString());
   }
 
+  @Test
+  public void testDeleteSearchData_NonKeyAspectDualWritesSemanticIndex() throws Exception {
+    // Setup: Create strategy with semantic search enabled
+    SemanticSearchConfiguration semanticConfig = mock(SemanticSearchConfiguration.class);
+    when(semanticConfig.isEnabled()).thenReturn(true);
+    when(semanticConfig.getEnabledEntities()).thenReturn(Set.of("dataset"));
+    IndexConvention indexConvention = mock(IndexConvention.class);
+    when(indexConvention.getEntityIndexNameSemantic(operationContext, "dataset"))
+        .thenReturn("datasetindex_v2_semantic");
+    when(elasticSearchService.indexExists(
+            any(OperationContext.class), eq("datasetindex_v2_semantic")))
+        .thenReturn(true);
+
+    UpdateIndicesV2Strategy strategyWithSemantic =
+        new UpdateIndicesV2Strategy(
+            v2Config,
+            elasticSearchService,
+            searchDocumentTransformer,
+            timeseriesAspectService,
+            "MD5",
+            semanticConfig,
+            indexConvention,
+            false,
+            mockMappingsBuilder,
+            null);
+
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(true),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+    when(mockSearchDocument.toString()).thenReturn("{\"semanticText\": null}");
+
+    // Execute with isKeyAspect = false (single-aspect delete)
+    strategyWithSemantic.deleteSearchData(
+        operationContext,
+        testUrn,
+        "dataset",
+        mockAspectSpec,
+        mockAspect,
+        false, // isKeyAspect
+        mockAuditStamp);
+
+    // Verify: the delete-shaped document must reach BOTH indices. Deleting a semantic
+    // aspect (semanticText override, semanticContent embeddings) has to clear/restamp
+    // the semantic index too, not just the base V2 index.
+    verify(elasticSearchService)
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+    verify(elasticSearchService)
+        .upsertDocumentByIndexName(
+            eq(operationContext), eq("datasetindex_v2_semantic"), anyString(), anyString());
+  }
+
   // ==================== processBatch coalescing tests ====================
 
   private MCLItem makeEvent(

--- a/metadata-models/src/main/pegasus/com/linkedin/common/EmbeddingModelData.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/EmbeddingModelData.pdl
@@ -18,6 +18,15 @@ record EmbeddingModelData {
   generatedAt: long
 
   /**
+   * SHA-256 hex digest over the UTF-8 bytes of the exact resolved source text these embeddings
+   * were generated from (the semanticText override when set, else the entity's body text).
+   * Written by the embedding pipeline at generation time so consumers (e.g. coverage reporting)
+   * can detect genuinely stale embeddings by comparing against a hash of the current resolved
+   * text, instead of relying on modification timestamps that move on non-content writes.
+   */
+  sourceTextSha256: optional string
+
+  /**
    * Description of the chunking strategy used.
    * Examples: sentence_boundary_400t, fixed_512_chars, paragraph
    */

--- a/metadata-models/src/main/pegasus/com/linkedin/common/SemanticContent.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/SemanticContent.pdl
@@ -23,4 +23,19 @@ record SemanticContent {
    * Allows storing embeddings from multiple models simultaneously.
    */
   embeddings: map[string, EmbeddingModelData]
+
+  /**
+   * Set (with an empty embeddings map) when the embedding pipeline deliberately declined to
+   * embed this entity, so consumers can distinguish never-embeddable entities from indexing
+   * lag or failures. Values written today: EMPTY_TEXT (no resolved text),
+   * BELOW_MIN_TEXT_LENGTH (resolved text shorter than the recipe's min_text_length),
+   * NO_INDEXABLE_CONTENT (text partitioned to no indexable elements). Overwritten with real
+   * embeddings when the entity later becomes embeddable and is processed.
+   */
+  skipReason: optional string
+
+  /**
+   * Timestamp (milliseconds since epoch) when the skip decision was recorded.
+   */
+  skippedAt: optional Time
 }


### PR DESCRIPTION
## Problem

The semantic-search coverage dashboard decides an embedding is "stale" by comparing timestamps: the document's last-modified time vs. the time the embedding was generated. That comparison is unreliable, because the last-modified time moves on *every* write to the document — renaming it, re-ingesting identical content, editing metadata — while the pipeline only re-embeds when the actual text to embed changes. Result: documents get flagged as "stale" forever even though their embeddings are perfectly current. On a live deployment, every document flagged stale was a false alarm.

A second gap: when the pipeline deliberately skips a document (no text, or text shorter than `min_text_length`), it writes nothing at all. On the dashboard those documents are indistinguishable from real indexing failures, so operators escalate them.

## Fix

Instead of guessing from timestamps, both sides now record exactly which text they saw, as a SHA-256 fingerprint:

1. **When the pipeline embeds a document**, it saves a fingerprint of the exact text it embedded (`sourceTextSha256` on `EmbeddingModelData`).
2. **When the document is written to the semantic search index**, the index entry gets a fingerprint of the document's *current* text (`resolvedTextSha256`). The text can come from two places (the curated `semanticText` override if one is set, otherwise the document body) that live on separate aspects, so the indexing code fetches the other aspect when needed instead of guessing from partial data. Embedding writes themselves also stamp it, so re-embedding (including a `force_reprocess` run) backfills documents indexed before this change. If the lookup fails, the field is explicitly cleared rather than left at its old value — a stale fingerprint could misreport a changed document as current, while a cleared one just reads as "unknown". All new fields get explicit index mappings.
3. **When the pipeline deliberately skips a document**, it now says so: it writes a small marker (`skipReason` on `SemanticContent` — `EMPTY_TEXT`, `BELOW_MIN_TEXT_LENGTH`, or `NO_INDEXABLE_CONTENT`) instead of writing nothing, and remembers the decision so it doesn't re-check the same document every run. The marker is projected into the search index alongside the embeddings, and a later real embed clears it. The remembered decision includes the threshold, so changing `min_text_length` re-evaluates exactly the previously-skipped documents — without invalidating every embedded document (no mass re-embed on upgrade).

With that, a dashboard can answer the real questions with no timestamps involved:

- **Up to date** — the two fingerprints match.
- **Actually stale** — the fingerprints differ: the text changed and the embedding hasn't caught up.
- **Intentionally not embedded** — a skip marker exists; not a failure.
- **Unknown** — no fingerprint recorded yet (data written before this change). Resolves on its own as documents get re-embedded, or immediately via a `force_reprocess` run.

The fingerprint is computed identically in the Python pipeline and the Java indexing code; a shared test vector (with emoji and Windows line endings, the usual encoding traps) pins both to the same output.

All new fields are optional. Existing data needs no migration — anything without a fingerprint just reads as "unknown", never as wrong.
