### PR TITLE
fix(ingest/dbt): populate assertion description from dbt test description

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
@@ -343,6 +343,9 @@ def make_assertion_from_test(
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
         customProperties=extra_custom_props,
+        # dbt data tests support a user-authored description (dbt >=1.9); the UI
+        # prefers it over generated copy when rendering the assertion.
+        description=node.description or None,
         source=mce_builder.make_assertion_source(),
         customAssertion=custom_assertion,
     )

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -2172,9 +2172,51 @@ def test_make_assertion_from_test_emits_custom_structured_fields() -> None:
     assert mcp.aspect.customAssertion.fields == [field_urn]
     assert mcp.aspect.customAssertion.nativeType == "not_null_id"
     assert mcp.aspect.customAssertion.nativeParameters == {"column_name": "id"}
+    # No description was set on the dbt test node, so none should be emitted.
+    assert mcp.aspect.description is None
     assert mcp.aspect.source is not None
     assert mcp.aspect.source.created is not None
     assert mcp.aspect.source.created.actor == SYSTEM_ACTOR
+
+
+def test_make_assertion_from_test_includes_node_description() -> None:
+    node = DBTNode(
+        database="raw_db",
+        schema="raw",
+        name="not_null_id",
+        alias=None,
+        comment="",
+        description="Every user must have an id.",
+        language="sql",
+        raw_code=None,
+        dbt_adapter="postgres",
+        dbt_name="test.test.not_null_id",
+        dbt_file_path=None,
+        dbt_package_name="test",
+        node_type="test",
+        max_loaded_at=None,
+        materialization=None,
+        catalog_type=None,
+        missing_from_catalog=False,
+        owner=None,
+    )
+    node.test_info = DBTTest(
+        qualified_test_name="not_null",
+        column_name="id",
+        kw_args={"column_name": "id"},
+    )
+    upstream_urn = "urn:li:dataset:(urn:li:dataPlatform:postgres,raw.users,PROD)"
+
+    mcp = make_assertion_from_test(
+        {"dbt_unique_id": node.dbt_name},
+        node,
+        "urn:li:assertion:test",
+        upstream_urn,
+    )
+
+    assert mcp.aspect is not None
+    assert isinstance(mcp.aspect, AssertionInfoClass)
+    assert mcp.aspect.description == "Every user must have an id."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #19436

dbt data tests support a user-authored `description:` (dbt >=1.9), and both the dbt Core and dbt Cloud sources already parse it onto `DBTNode.description` — but `make_assertion_from_test` never copied it onto the emitted `AssertionInfo` aspect, so descriptions defined in dbt schema files were silently dropped and the assertion rendered without a description in the UI.

This change populates `AssertionInfo.description` from the dbt test node's description. When the node has no description, the field is left unset (`None`) so the UI continues to generate structured copy from scope/operator/aggregation (#18750) — this also keeps existing integration golden files unchanged.

Since `make_assertion_from_test` is shared, the fix covers both dbt Core (manifest ingestion) and dbt Cloud (metadata API), matching the pattern already used by other sources that emit CUSTOM assertions (e.g. ODCS, SQLMesh).

## Testing

- Added `test_make_assertion_from_test_includes_node_description` verifying the description flows through to the aspect.
- Extended `test_make_assertion_from_test_emits_custom_structured_fields` to assert that an empty node description results in `description=None` (omitted from serialization).
- `tests/unit/dbt/test_dbt_source.py`: 145 passed. `ruff check` / `ruff format --check` clean on changed files.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable) — n/a, no user-facing config change
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates dbt test descriptions onto emitted assertions so descriptions defined in dbt schema files are no longer dropped and now appear in the UI. If a test has no description, the field stays unset (`None`) so the UI keeps generating structured copy from scope/operator/aggregation. Fixes #19436.

<sup>Written for commit 60eeca3f224a36e4a5e039f8705f3243077a3375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

