### PR TITLE
fix(test): gate OL dialect IT writers on seed visibility

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/optimistic/EbeanOptimisticLockingDialectIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/optimistic/EbeanOptimisticLockingDialectIT.java
@@ -101,6 +101,28 @@ abstract class EbeanOptimisticLockingDialectIT {
         null);
   }
 
+  /**
+   * Blocks until a freshly seeded version-0 row is readable, issuing the exact unlocked read the
+   * writer threads perform. A READ COMMITTED snapshot only ever returns committed rows, so once
+   * this read observes the seed the INSERT has committed, and every transaction opened afterwards
+   * (including pool writers, which are submitted only after this returns) takes a snapshot that
+   * contains it. Bounded, and fails at setup with a clear message rather than letting a writer NPE
+   * on a missing urn key inside its own thread and stall a latch for its full timeout (#19116).
+   */
+  private void awaitSeedVisible(EbeanAspectDao dao, String urn) throws InterruptedException {
+    final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+    boolean visible = false;
+    while (!visible && System.nanoTime() < deadlineNanos) {
+      Map<String, SystemAspect> aspects =
+          dao.getLatestAspects(opContext, Map.of(urn, Set.of(STATUS_ASPECT_NAME)), false).get(urn);
+      visible = aspects != null && aspects.get(STATUS_ASPECT_NAME) != null;
+      if (!visible) {
+        Thread.sleep(25);
+      }
+    }
+    assertTrue(visible, "seed aspect for " + urn + " never became visible to a fresh transaction");
+  }
+
   @Test
   public void detectsExpectedDialect() {
     EbeanAspectDao dao = newOptimisticDao();
@@ -209,6 +231,10 @@ abstract class EbeanOptimisticLockingDialectIT {
         null,
         statusAspect(urn, new Status().setRemoved(false), seed),
         ASPECT_LATEST_VERSION);
+    // The seed must be committed and visible before any writer opens its transaction; otherwise a
+    // writer's unlocked read returns no entry for this urn and the chained get NPEs before it can
+    // count down bothRead, stalling the latch for its full timeout.
+    awaitSeedVisible(dao, urn);
 
     AtomicInteger successes = new AtomicInteger();
     AtomicInteger conflicts = new AtomicInteger();

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/optimistic/EbeanOptimisticLockingDialectIT.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/optimistic/EbeanOptimisticLockingDialectIT.java
@@ -328,6 +328,10 @@ abstract class EbeanOptimisticLockingDialectIT {
         null,
         statusAspect(urn, new Status().setRemoved(false), seed),
         ASPECT_LATEST_VERSION);
+    // Same seed-then-submit shape as concurrentWritersConvergeWithVersionBump: a writer whose
+    // transaction begins before the seed commit is visible NPEs on the chained get and fails the
+    // test spuriously via firstError.
+    awaitSeedVisible(dao, urn);
 
     final int writers = 8;
     final HazelcastInstance hz = isolatedHazelcast();
@@ -534,6 +538,11 @@ abstract class EbeanOptimisticLockingDialectIT {
         null,
         statusAspect(urn, new Status().setRemoved(false), seed),
         ASPECT_LATEST_VERSION);
+    // Same race as concurrentWritersConvergeWithVersionBump, and this test shares its failure
+    // mode: a writer that NPEs on the missing seed never counts down bothRead, so the test stalls
+    // on the latch for its full timeout. Visibility is per commit, so either dao can perform the
+    // read-back.
+    awaitSeedVisible(legacy, urn);
 
     AtomicInteger successes = new AtomicInteger();
     AtomicReference<Throwable> firstError = new AtomicReference<>();


### PR DESCRIPTION
Fixes #19116.

## What was flaking

`concurrentWritersConvergeWithVersionBump` seeds a version-0 status row on the main thread and then immediately submits two writer threads. Each writer opens its own transaction and reads the seed with `getLatestAspects(..., forUpdate = false)`, chaining `.get(urn).get(STATUS_ASPECT_NAME)`. On the postgresql shard a writer's transaction could begin before the seed was visible to it, so `.get(urn)` returned null and the chained get threw NPE inside the writer thread, before `bothRead.countDown()`. With one writer dead the latch never reaches zero, so the test sits on `bothRead` for the full 45s and fails with the captured NPE as `firstError`. Only that shard flaked; the other backend shards passed on the same runs.

## The fix

Gate the writer pool on a bounded read-back. `awaitSeedVisible` polls the exact unlocked read the writers perform until the urn key is present (25ms interval, bounded at 30s, assertTrue with a clear message on timeout). A READ COMMITTED snapshot only ever returns committed rows, so once that read observes the seed the INSERT has committed. The writers are submitted only after `awaitSeedVisible` returns, and the submit call establishes the happens-before edge, so every writer transaction begins strictly after that commit and its snapshot contains the row. This removes the race rather than narrowing it: there is no sleep to tune, and a genuine seeding failure now fails at setup with a clear message instead of surfacing as a 45s latch timeout.

Test-only change, confined to setup. The concurrency logic under test is byte-identical, and the assertions the test exists for are untouched: at least one CAS conflict, both writers succeed, and the row converges to version 3.

## Note

`writeGateSerializesConcurrentWritersWithoutCasThrash` and `mixedModeConcurrentLegacyAndOptimisticConverges` seed and then start threads the same way, so they carry the same latent race, even though neither appears in the #19116 failure logs. The second commit gates them too rather than leaving the class inconsistent. Their failure modes differ: the mixed-mode test has a `bothRead` latch and would stall for the full timeout like #19116, while the write-gate test captures the NPE into `firstError` and fails fast.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated
