### PR TITLE
fix(graphql): map structured property text containing an urn as text

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapper.java
@@ -25,6 +25,8 @@ public class StructuredPropertiesMapper {
 
   public static final StructuredPropertiesMapper INSTANCE = new StructuredPropertiesMapper();
 
+  private static final String URN_PREFIX = "urn:";
+
   public static com.linkedin.datahub.graphql.generated.StructuredProperties map(
       @Nullable QueryContext context,
       @Nonnull final StructuredProperties structuredProperties,
@@ -86,8 +88,8 @@ public class StructuredPropertiesMapper {
       String stringValue,
       List<PropertyValue> values,
       List<Entity> entities) {
-    try {
-      final Urn urnValue = Urn.createFromString(stringValue);
+    final Urn urnValue = parseValueAsUrn(stringValue.trim());
+    if (urnValue != null) {
       // UrnToEntityMapper returns null for entity types it does not know how to map. A string value
       // that merely parses as a URN (e.g. free text on a non-urn property, or a URN of an unmapped
       // entity type) must not contribute a null entity, otherwise downstream resolution of
@@ -102,9 +104,53 @@ public class StructuredPropertiesMapper {
             stringValue,
             urnValue.getEntityType());
       }
+    }
+    values.add(new StringValue(stringValue));
+  }
+
+  /**
+   * Returns the urn a string value refers to, or null when the value is plain text. Only a value
+   * that is entirely a well formed urn is an entity reference, and no parse failure is propagated.
+   *
+   * <p>{@link Urn#createFromString(String)} on its own is not enough: it stops caring about the
+   * input once the parentheses of a tuple entity key balance, so free text that merely contains
+   * something urn shaped, such as "urn:li:dataset:(urn:li:dataPlatform:hive,tbl,PROD) (hop 1):
+   * stale", parses into a dataset urn whose last key part is "PROD) (hop 1): stale". Mapping that
+   * as a value entity succeeds here, but resolving the entity afterwards throws
+   * IllegalArgumentException ("No enum constant com.linkedin.common.FabricType...") and takes down
+   * the entity page and every search that returns it.
+   */
+  @Nullable
+  private static Urn parseValueAsUrn(String value) {
+    try {
+      final Urn urnValue = Urn.createFromString(value);
+      // Re-encoding the parsed urn from its parts drops anything the parser tolerated after the
+      // entity key, so it reproduces the value only when the value was a complete urn.
+      final Urn reEncoded =
+          new Urn(urnValue.getNamespace(), urnValue.getEntityType(), urnValue.getEntityKey());
+      if (value.equals(reEncoded.toString()) && hasValidKeyParts(urnValue)) {
+        return urnValue;
+      }
+      log.debug("String value is not entirely an urn for this structured property entry");
     } catch (Exception e) {
       log.debug("String value is not an urn for this structured property entry");
     }
-    values.add(new StringValue(stringValue));
+    return null;
+  }
+
+  private static boolean hasValidKeyParts(Urn urn) {
+    for (String part : urn.getEntityKey().getParts()) {
+      if (part.startsWith(URN_PREFIX)) {
+        // A nested urn has to be a complete urn itself.
+        if (parseValueAsUrn(part) == null) {
+          return false;
+        }
+      } else if (part.contains("(") || part.contains(")")) {
+        // Urn components cannot hold unencoded parentheses, so a part such as "PROD) (hop 1)" is
+        // text the tuple parser absorbed rather than a real key component.
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertiesMapperTest.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertEquals;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.StringValue;
 import com.linkedin.structured.PrimitivePropertyValue;
 import com.linkedin.structured.PrimitivePropertyValueArray;
 import com.linkedin.structured.StructuredProperties;
@@ -17,6 +18,18 @@ public class StructuredPropertiesMapperTest {
   private static final Urn PROPERTY_URN = UrnUtils.getUrn("urn:li:structuredProperty:test");
   private static final Urn ENTITY_URN =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.table,PROD)");
+  private static final Urn DATASET_VALUE_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,marketing_etl,PROD)");
+
+  // The value reported in #19019: free text that contains an urn shaped substring. The urn parser
+  // stops at the closing paren of the tuple key, so this used to be mapped as a dataset value
+  // entity whose fabric was "PROD) (hop 1): stale for 30.0h", and resolving that entity threw
+  // IllegalArgumentException ("No enum constant com.linkedin.common.FabricType...") and killed the
+  // entity page.
+  private static final String TEXT_CONTAINING_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:hive,marketing_etl,PROD) (hop 1): stale for 30.0h";
+  private static final String TEXT_ENDING_WITH_PARENS =
+      "urn:li:dataset:(urn:li:dataPlatform:hive,marketing_etl,PROD) (hop 1)";
 
   private static StructuredProperties propertiesWithValue(String value) {
     StructuredPropertyValueAssignment assignment = new StructuredPropertyValueAssignment();
@@ -36,6 +49,61 @@ public class StructuredPropertiesMapperTest {
     assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 1);
     assertEquals(
         mapped.getProperties().get(0).getValueEntities().get(0).getType(), EntityType.DOMAIN);
+  }
+
+  // A tuple urn is still an entity reference: the fix must only reject values that are more than
+  // an urn, not every value whose key is parenthesized.
+  @Test
+  public void testFullTupleUrnValueProducesValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(
+            null, propertiesWithValue(DATASET_VALUE_URN.toString()), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 1);
+    assertEquals(
+        mapped.getProperties().get(0).getValueEntities().get(0).getType(), EntityType.DATASET);
+    assertEquals(
+        mapped.getProperties().get(0).getValueEntities().get(0).getUrn(),
+        DATASET_VALUE_URN.toString());
+  }
+
+  @Test
+  public void testUrnValueWithSurroundingWhitespaceProducesValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(
+            null, propertiesWithValue("  urn:li:domain:marketing  "), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 1);
+    assertEquals(
+        mapped.getProperties().get(0).getValueEntities().get(0).getType(), EntityType.DOMAIN);
+  }
+
+  // A value that only contains an urn is text, and mapping it must never throw (#19019).
+  @Test
+  public void testTextContainingUrnProducesNoValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(null, propertiesWithValue(TEXT_CONTAINING_URN), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 0);
+    assertEquals(mapped.getProperties().get(0).getValues().size(), 1);
+    assertEquals(
+        ((StringValue) mapped.getProperties().get(0).getValues().get(0)).getStringValue(),
+        TEXT_CONTAINING_URN);
+  }
+
+  // Same, for text whose trailing part happens to end with a paren, which leaves the parentheses
+  // of the value balanced.
+  @Test
+  public void testTextEndingWithParensProducesNoValueEntity() {
+    com.linkedin.datahub.graphql.generated.StructuredProperties mapped =
+        StructuredPropertiesMapper.map(
+            null, propertiesWithValue(TEXT_ENDING_WITH_PARENS), ENTITY_URN);
+
+    assertEquals(mapped.getProperties().get(0).getValueEntities().size(), 0);
+    assertEquals(mapped.getProperties().get(0).getValues().size(), 1);
+    assertEquals(
+        ((StringValue) mapped.getProperties().get(0).getValues().get(0)).getStringValue(),
+        TEXT_ENDING_WITH_PARENS);
   }
 
   // A value that parses as a URN of an entity type UrnToEntityMapper cannot map (here a valid but


### PR DESCRIPTION
Fixes #19019.

A STRING structured property whose value merely contains something urn shaped, for example

```
urn:li:dataset:(urn:li:dataPlatform:hive,marketing_etl,PROD) (hop 1): stale for 30.0h
```

was turned into a value entity. `Urn.createFromString` stops caring about the input once the parentheses of a tuple entity key balance, so everything after the closing paren ends up inside the last key part, here `PROD) (hop 1): stale for 30.0h`. Mapping succeeds, but resolving that value entity afterwards throws `IllegalArgumentException` ("No enum constant com.linkedin.common.FabricType...") and the entity page, plus any search that returns the entity, fails with "Something went wrong".

## Changes

`StructuredPropertiesMapper` now treats a value as an entity reference only when the whole trimmed value is a well formed urn:

- the parsed urn has to re-encode from its parts back to the value exactly, which drops anything the parser tolerated after the entity key, and
- every entity key part has to be either a nested urn that is itself complete, or a component without unencoded parentheses.

Anything else maps as text, and no parse failure is propagated, matching the existing behaviour for values that do not parse at all. Values that are valid urns, tuple and nested ones included, keep producing value entities.

Tests cover the exact value from the issue, the variant that ends on a paren so that the parentheses of the whole value balance, the tuple urn that has to keep resolving, and a urn with surrounding whitespace.

## Notes for review

- Behaviour narrows only on values that currently break pages: a value that used to slip through as a truncated entity reference now renders as the text it is.
- Known remaining gap: a value that is entirely a well formed urn but semantically invalid, for example a dataset urn whose fabric is not a real FabricType, still maps as a value entity and still fails at resolution. Guarding that needs validation against the entity registry at map time, which felt out of scope for this fix; happy to follow up if that protection is wanted.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #19019 by treating structured property string values that merely contain a urn-shaped substring as text instead of as value entities, preventing entity resolution failures that broke the entity page and searches.

Values that are fully well-formed urns (including tuple and nested urns) still map to value entities. The mapper now requires the entire trimmed value to be a valid urn, and any other value maps as text without propagating parse errors.

Known gap: a semantically invalid but well-formed urn (e.g., an unknown fabric in a dataset urn) still maps as a value entity and can fail at resolution; guarding that would require entity registry validation at map time.

<sup>Written for commit 5d5a2a2b28b40f1fde55c154e678a5a1a6297ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

