### PR TITLE
fix(kafka-connect): support Debezium logical topic routing

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
@@ -140,7 +140,7 @@ class RegexRouterPlugin(TransformPlugin):
             try:
                 pattern = JavaPattern.compile(regex_pattern)
                 matcher = pattern.matcher(topic)
-                if matcher.matches():
+                if not isinstance(self, DebeziumLogicalTopicRouterPlugin) or matcher.matches():
                     transformed_topic = str(matcher.replaceFirst(replacement))
                 else:
                     transformed_topic = topic

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
@@ -140,7 +140,10 @@ class RegexRouterPlugin(TransformPlugin):
             try:
                 pattern = JavaPattern.compile(regex_pattern)
                 matcher = pattern.matcher(topic)
-                if not isinstance(self, DebeziumLogicalTopicRouterPlugin) or matcher.matches():
+                if (
+                    not isinstance(self, DebeziumLogicalTopicRouterPlugin)
+                    or matcher.matches()
+                ):
                     transformed_topic = str(matcher.replaceFirst(replacement))
                 else:
                     transformed_topic = topic

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/transform_plugins.py
@@ -37,6 +37,7 @@ except ImportError:
 # Initialize JVM for Java regex support at module level
 try:
     import jpype
+    import jpype.imports
 
     if not jpype.isJVMStarted():
         jpype.startJVM(jpype.getDefaultJVMPath())
@@ -105,6 +106,8 @@ class RegexRouterPlugin(TransformPlugin):
         "org.apache.kafka.connect.transforms.RegexRouter",
         "io.confluent.connect.cloud.transforms.TopicRegexRouter",
     }
+    REGEX_CONFIG_KEY = "regex"
+    REPLACEMENT_CONFIG_KEY = "replacement"
 
     @classmethod
     def supports_transform_type(cls, transform_type: str) -> bool:
@@ -118,8 +121,8 @@ class RegexRouterPlugin(TransformPlugin):
                 "Install with: pip install 'acryl-datahub[kafka-connect]'"
             )
 
-        regex_pattern = config.config.get("regex", "")
-        replacement = config.config.get("replacement", "")
+        regex_pattern = config.config.get(self.REGEX_CONFIG_KEY, "")
+        replacement = config.config.get(self.REPLACEMENT_CONFIG_KEY, "")
 
         if not regex_pattern or replacement is None:
             logger.warning(
@@ -137,7 +140,10 @@ class RegexRouterPlugin(TransformPlugin):
             try:
                 pattern = JavaPattern.compile(regex_pattern)
                 matcher = pattern.matcher(topic)
-                transformed_topic = str(matcher.replaceFirst(replacement))
+                if matcher.matches():
+                    transformed_topic = str(matcher.replaceFirst(replacement))
+                else:
+                    transformed_topic = topic
 
                 if transformed_topic != topic:
                     logger.info(
@@ -181,6 +187,17 @@ class RegexRouterPlugin(TransformPlugin):
     @classmethod
     def should_apply_automatically(cls) -> bool:
         return True  # RegexRouter transforms are predictable and safe to apply
+
+
+class DebeziumLogicalTopicRouterPlugin(RegexRouterPlugin):
+    """Plugin for Debezium logical topic routing transforms."""
+
+    SUPPORTED_TYPES = {
+        "io.debezium.transforms.ByLogicalTableRouter",
+        "io.debezium.transforms.ToLogicalTopicRouter",
+    }
+    REGEX_CONFIG_KEY = "topic.regex"
+    REPLACEMENT_CONFIG_KEY = "topic.replacement"
 
 
 class ComplexTransformPlugin(TransformPlugin):
@@ -250,6 +267,7 @@ class TransformPluginRegistry:
     def _register_default_plugins(self):
         """Register default transform plugins."""
         self.register(RegexRouterPlugin())
+        self.register(DebeziumLogicalTopicRouterPlugin())
         self.register(ComplexTransformPlugin())
         self.register(ReplaceFieldPlugin())
 

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_logical_topic_router.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_logical_topic_router.py
@@ -1,0 +1,45 @@
+from datahub.ingestion.source.kafka_connect.common import (
+    SOURCE,
+    ConnectorManifest,
+    KafkaConnectSourceConfig,
+    KafkaConnectSourceReport,
+)
+from datahub.ingestion.source.kafka_connect.connector_registry import ConnectorRegistry
+
+
+def test_debezium_logical_topic_router_emits_rerouted_topic_lineage() -> None:
+    manifest = ConnectorManifest(
+        name="sharded-postgres-cdc",
+        type=SOURCE,
+        config={
+            "connector.class": ("io.debezium.connector.postgresql.PostgresConnector"),
+            "database.dbname": "app_db",
+            "table.include.list": "inventory_shard1.customers",
+            "topic.prefix": "server",
+            "transforms": "reroute",
+            "transforms.reroute.type": ("io.debezium.transforms.ByLogicalTableRouter"),
+            "transforms.reroute.topic.regex": r"^(.*)\..*_shard\d+\.(.*)$",
+            "transforms.reroute.topic.replacement": "$1.$2",
+        },
+        tasks=[],
+        topic_names=["server.customers"],
+    )
+    config = KafkaConnectSourceConfig(
+        connect_uri="http://localhost:8083",
+        env="PROD",
+    )
+
+    connector = ConnectorRegistry.get_connector_for_manifest(
+        manifest,
+        config,
+        KafkaConnectSourceReport(),
+    )
+    assert connector is not None
+
+    lineages = connector.extract_lineages()
+
+    assert len(lineages) == 1
+    lineage = lineages[0]
+    assert lineage.source_dataset == "app_db.inventory_shard1.customers"
+    assert lineage.target_dataset == "server.customers"
+    assert lineage.source_platform == "postgres"

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_transform_pipeline.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_transform_pipeline.py
@@ -8,6 +8,7 @@ import pytest
 
 from datahub.ingestion.source.kafka_connect.transform_plugins import (
     ComplexTransformPlugin,
+    DebeziumLogicalTopicRouterPlugin,
     RegexRouterPlugin,
     ReplaceFieldPlugin,
     TransformConfig,
@@ -156,13 +157,26 @@ class TestRegexRouterPlugin:
         # Should return unchanged (replaceFirst doesn't modify if no match)
         assert result == ["order-events"]
 
-    def test_apply_forward_requires_full_match(self) -> None:
-        """Test that partial regex matches do not reroute topics."""
+    def test_apply_forward_replaces_partial_match(self) -> None:
+        """Test generic RegexRouter preserves replaceFirst semantics."""
         plugin = RegexRouterPlugin()
         config = TransformConfig(
             name="Router",
             type="org.apache.kafka.connect.transforms.RegexRouter",
             config={"regex": "events", "replacement": "orders"},
+        )
+
+        result = plugin.apply_forward(["customer-events"], config)
+
+        assert result == ["customer-orders"]
+
+    def test_debezium_logical_router_requires_full_match(self) -> None:
+        """Test Debezium routers do not reroute partial topic matches."""
+        plugin = DebeziumLogicalTopicRouterPlugin()
+        config = TransformConfig(
+            name="Router",
+            type="io.debezium.transforms.ByLogicalTableRouter",
+            config={"topic.regex": "events", "topic.replacement": "orders"},
         )
 
         result = plugin.apply_forward(["customer-events"], config)

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_transform_pipeline.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_transform_pipeline.py
@@ -156,6 +156,19 @@ class TestRegexRouterPlugin:
         # Should return unchanged (replaceFirst doesn't modify if no match)
         assert result == ["order-events"]
 
+    def test_apply_forward_requires_full_match(self) -> None:
+        """Test that partial regex matches do not reroute topics."""
+        plugin = RegexRouterPlugin()
+        config = TransformConfig(
+            name="Router",
+            type="org.apache.kafka.connect.transforms.RegexRouter",
+            config={"regex": "events", "replacement": "orders"},
+        )
+
+        result = plugin.apply_forward(["customer-events"], config)
+
+        assert result == ["customer-events"]
+
     def test_apply_reverse(self) -> None:
         """Test reverse transformation (limited support)."""
         plugin = RegexRouterPlugin()
@@ -480,6 +493,32 @@ class TestTransformPipeline:
         assert result.topics == ["customer_events"]
         assert result.successful is True
         assert result.fallback_used is False
+
+    @pytest.mark.parametrize(
+        "transform_type",
+        [
+            "io.debezium.transforms.ByLogicalTableRouter",
+            "io.debezium.transforms.ToLogicalTopicRouter",
+        ],
+    )
+    def test_apply_forward_debezium_logical_topic_routers(
+        self, transform_type: str
+    ) -> None:
+        """Test routing sharded Debezium topics to one logical topic."""
+        pipeline = TransformPipeline()
+        config = {
+            "transforms": "Router",
+            "transforms.Router.type": transform_type,
+            "transforms.Router.topic.regex": r"^(.*)\.customers_shard\d+$",
+            "transforms.Router.topic.replacement": "$1.customers",
+        }
+
+        result = pipeline.apply_forward(["server.inventory.customers_shard1"], config)
+
+        assert result.topics == ["server.inventory.customers"]
+        assert result.successful
+        assert not result.fallback_used
+        assert result.warnings == []
 
     def test_apply_forward_multiple_transforms(self) -> None:
         """Test applying multiple transforms in sequence."""


### PR DESCRIPTION
Preserves Kafka Connect lineage when Debezium consolidates physical-table topics into a logical topic.

<details>
<summary>AI generated description! 👇</summary>

## What changed
- Register a Kafka Connect transform plugin for Debezium's `ByLogicalTableRouter` and `ToLogicalTopicRouter` transforms.
- Read Debezium's `topic.regex` and `topic.replacement` settings through the existing Java regex implementation.
- Match the full topic before replacement, mirroring Kafka Connect and Debezium `Matcher.matches()` behavior.
- Enable JPype's Java import hook so regex transforms load in isolated ingestion environments.
- Add transform-level and end-to-end Debezium lineage regression tests.

## Context
DataHub derives a source connector's expected topic before single-message transforms are applied. When Debezium routes several physical tables to one logical topic, validation against the live Kafka topics can therefore drop the database-to-Kafka lineage edge.

## Testing
- `./gradlew :metadata-ingestion:lintFix`
- `metadata-ingestion/venv/bin/python -m pytest -q metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_transform_pipeline.py metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_logical_topic_router.py` — 56 passed

</details>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports Debezium's logical topic router transforms so Kafka Connect lineage is preserved when Debezium aggregates physical-table topics into one logical topic. `ByLogicalTableRouter` and `ToLogicalTopicRouter` are now recognized; they only reroute topics on a full match (`Matcher.matches()`), while the generic `RegexRouter` keeps its existing partial-match behavior.

<sup>Written for commit d5696748c4ba1d67464bc64621feb26c785e14f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

