### PR TITLE
fix(ingest/kafka-connect): preserve Debezium pattern table identity

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -3393,6 +3393,11 @@ class DebeziumSourceConnector(BaseConnector):
                 return []
 
             matched_tables = []
+            database_prefix = (
+                f"{database}."
+                if database and has_three_level_hierarchy(platform)
+                else None
+            )
 
             # Try to use Java regex for exact compatibility with Debezium
             try:
@@ -3418,6 +3423,16 @@ class DebeziumSourceConnector(BaseConnector):
                 if not table_name:
                     continue
 
+                normalized_table_name = table_name
+                table_without_database = (
+                    table_name.split(".", 1)[1] if "." in table_name else table_name
+                )
+                if database_prefix:
+                    if not table_name.lower().startswith(database_prefix.lower()):
+                        continue
+                    normalized_table_name = table_name[len(database_prefix) :]
+                    table_without_database = normalized_table_name
+
                 # Try direct match first (handles patterns like "mydb.schema.*")
                 full_name_matches = (
                     regex_pattern.matcher(table_name).matches()
@@ -3426,7 +3441,7 @@ class DebeziumSourceConnector(BaseConnector):
                 )
 
                 if full_name_matches:
-                    matched_tables.append(table_name)
+                    matched_tables.append(normalized_table_name)
                     continue
 
                 # For patterns without database prefix (e.g., "schema.*" or "public.*"),
@@ -3435,7 +3450,6 @@ class DebeziumSourceConnector(BaseConnector):
                 # - PostgreSQL: "public.*" matches "testdb.public.users" (3-tier URN)
                 # - MySQL: "mydb.*" matches "mydb.table1" (2-tier URN, already matched above)
                 if "." in table_name:
-                    table_without_database = table_name.split(".", 1)[1]
                     schema_name_matches = (
                         regex_pattern.matcher(table_without_database).matches()
                         if use_java_regex
@@ -3443,7 +3457,7 @@ class DebeziumSourceConnector(BaseConnector):
                     )
 
                     if schema_name_matches:
-                        matched_tables.append(table_name)
+                        matched_tables.append(table_without_database)
 
             logger.debug(
                 f"Pattern '{pattern}' matched {len(matched_tables)} tables from DataHub"

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -3457,7 +3457,7 @@ class DebeziumSourceConnector(BaseConnector):
                     )
 
                     if schema_name_matches:
-                        matched_tables.append(table_without_database)
+                        matched_tables.append(normalized_table_name)
 
             logger.debug(
                 f"Pattern '{pattern}' matched {len(matched_tables)} tables from DataHub"

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -3393,10 +3393,9 @@ class DebeziumSourceConnector(BaseConnector):
                 return []
 
             matched_tables = []
+            is_three_level_hierarchy = has_three_level_hierarchy(platform)
             database_prefix = (
-                f"{database}."
-                if database and has_three_level_hierarchy(platform)
-                else None
+                f"{database}." if database and is_three_level_hierarchy else None
             )
 
             # Try to use Java regex for exact compatibility with Debezium
@@ -3457,7 +3456,11 @@ class DebeziumSourceConnector(BaseConnector):
                     )
 
                     if schema_name_matches:
-                        matched_tables.append(normalized_table_name)
+                        matched_tables.append(
+                            table_without_database
+                            if is_three_level_hierarchy
+                            else normalized_table_name
+                        )
 
             logger.debug(
                 f"Pattern '{pattern}' matched {len(matched_tables)} tables from DataHub"

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect/source_connectors.py
@@ -3462,6 +3462,7 @@ class DebeziumSourceConnector(BaseConnector):
                             else normalized_table_name
                         )
 
+            matched_tables = list(dict.fromkeys(matched_tables))
             logger.debug(
                 f"Pattern '{pattern}' matched {len(matched_tables)} tables from DataHub"
             )

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py
@@ -534,6 +534,46 @@ class TestDeriveTopicsFromTables:
 class TestGetTopicsFromConfigIntegration:
     """Integration tests for the full get_topics_from_config flow."""
 
+    @pytest.mark.parametrize(
+        "table_pattern",
+        [r"public\..*", r"my_db\.public\..*"],
+    )
+    def test_pattern_expansion_preserves_schema_table_identity(
+        self, table_pattern: str
+    ) -> None:
+        """Pattern matches should not retain the database prefix from resolver URNs."""
+        connector_config = {
+            "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+            "database.dbname": "my_db",
+            "table.include.list": table_pattern,
+            "topic.prefix": "server",
+        }
+        schema_resolver = Mock(spec=SchemaResolver)
+        schema_resolver.platform_instance = "my_instance"
+        schema_resolver.get_urns.return_value = {
+            (
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,"
+                "my_instance.my_db.public.orders,PROD)"
+            ),
+            (
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,"
+                "my_instance.other_db.public.orders,PROD)"
+            ),
+        }
+        connector = create_debezium_connector(
+            connector_config,
+            schema_resolver=schema_resolver,
+            use_schema_resolver=True,
+        )
+        connector.config.schema_resolver_finegrained_lineage = False
+        connector.connector_manifest.topic_names = ["server.public.orders"]
+
+        lineages = connector.extract_lineages()
+
+        assert len(lineages) == 1
+        assert lineages[0].source_dataset == "my_db.public.orders"
+        assert lineages[0].target_dataset == "server.public.orders"
+
     def test_full_flow_without_schema_resolver(self) -> None:
         """Test complete flow using only table.include.list."""
         connector_config = {

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -157,9 +157,9 @@ class TestSchemaResolverTableExpansion:
 
         # Should match only public schema tables
         assert len(result) == 2
-        assert "testdb.public.users" in result
-        assert "testdb.public.orders" in result
-        assert "testdb.private.secrets" not in result
+        assert "public.users" in result
+        assert "public.orders" in result
+        assert "private.secrets" not in result
 
     def test_pattern_expansion_no_matches(self):
         """Test pattern expansion when no tables match."""
@@ -251,8 +251,8 @@ class TestSchemaResolverTableExpansion:
 
         # Should expand pattern and keep explicit table name
         assert len(result) == 3
-        assert "testdb.public.users" in result
-        assert "testdb.public.orders" in result
+        assert "public.users" in result
+        assert "public.orders" in result
         assert "private.accounts" in result
 
     def test_pattern_expansion_disabled_via_config(self):
@@ -735,10 +735,10 @@ class TestJavaRegexPatternMatching:
 
         # Should match only tables starting with bg_ or cp_ in public schema
         assert len(result) == 2
-        assert "testdb.public.bg_users" in result
-        assert "testdb.public.cp_orders" in result
-        assert "testdb.public.fg_data" not in result
-        assert "testdb.public.users" not in result
+        assert "public.bg_users" in result
+        assert "public.cp_orders" in result
+        assert "public.fg_data" not in result
+        assert "public.users" not in result
 
     def test_character_class_pattern(self):
         """Test character class pattern: public\\.test[0-9]+"""
@@ -785,10 +785,10 @@ class TestJavaRegexPatternMatching:
 
         # Should match only test followed by one or more digits
         assert len(result) == 2
-        assert "testdb.public.test1" in result
-        assert "testdb.public.test23" in result
-        assert "testdb.public.test" not in result
-        assert "testdb.public.testA" not in result
+        assert "public.test1" in result
+        assert "public.test23" in result
+        assert "public.test" not in result
+        assert "public.testA" not in result
 
     def test_complex_grouping_pattern(self):
         """Test complex grouping: (public|private)\\.(users|orders)"""
@@ -837,12 +837,12 @@ class TestJavaRegexPatternMatching:
 
         # Should match exactly: public.users, public.orders, private.users, private.orders
         assert len(result) == 4
-        assert "testdb.public.users" in result
-        assert "testdb.public.orders" in result
-        assert "testdb.private.users" in result
-        assert "testdb.private.orders" in result
-        assert "testdb.public.products" not in result
-        assert "testdb.admin.users" not in result
+        assert "public.users" in result
+        assert "public.orders" in result
+        assert "private.users" in result
+        assert "private.orders" in result
+        assert "public.products" not in result
+        assert "admin.users" not in result
 
     def test_mysql_two_tier_pattern(self):
         """Test MySQL 2-tier pattern: mydb\\.user.*"""
@@ -935,8 +935,8 @@ class TestJavaRegexPatternMatching:
 
         # Escaped dot should match only literal dot, not any character
         assert len(result) == 1
-        assert "testdb.public.user" in result
-        assert "testdb.publicXuser" not in result
+        assert "public.user" in result
+        assert "publicXuser" not in result
 
     def test_postgres_schema_without_database_prefix(self):
         """Test PostgreSQL pattern without database prefix: public\\..*"""
@@ -980,9 +980,9 @@ class TestJavaRegexPatternMatching:
 
         # Should match all tables in public schema (without database in pattern)
         assert len(result) == 2
-        assert "testdb.public.users" in result
-        assert "testdb.public.orders" in result
-        assert "testdb.private.secrets" not in result
+        assert "public.users" in result
+        assert "public.orders" in result
+        assert "private.secrets" not in result
 
     def test_quantifier_patterns(self):
         """Test various quantifiers: +, *"""
@@ -1030,11 +1030,11 @@ class TestJavaRegexPatternMatching:
 
         # Should match only tables with one or more lowercase letters after user_
         assert len(result) == 3
-        assert "testdb.public.user_ab" in result
-        assert "testdb.public.user_abc" in result
-        assert "testdb.public.user_abcd" in result
-        assert "testdb.public.user_" not in result
-        assert "testdb.public.user_123" not in result
+        assert "public.user_ab" in result
+        assert "public.user_abc" in result
+        assert "public.user_abcd" in result
+        assert "public.user_" not in result
+        assert "public.user_123" not in result
 
 
 class TestFineGrainedLineagePlatformInstance:

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -894,6 +894,43 @@ class TestJavaRegexPatternMatching:
         assert "mydb.orders" not in result
         assert "otherdb.users" not in result
 
+    def test_mysql_table_only_pattern_preserves_database(self):
+        """Test MySQL table-only patterns retain the 2-tier dataset identity."""
+        config = KafkaConnectSourceConfig(
+            connect_uri="http://test:8083",
+            cluster_name="test",
+            use_schema_resolver=True,
+            schema_resolver_expand_patterns=True,
+        )
+        report = KafkaConnectSourceReport()
+        connector_manifest = ConnectorManifest(
+            name="mysql-source",
+            type="source",
+            config={
+                "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+                "database.dbname": "mydb",
+                "table.include.list": "user.*",
+                "database.server.name": "mysqlserver",
+            },
+            tasks=[],
+        )
+        mock_resolver = MockSchemaResolver(
+            platform="mysql",
+            mock_urns=[
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,mydb.users,PROD)",
+            ],
+        )
+        connector = DebeziumSourceConnector(
+            connector_manifest=connector_manifest,
+            config=config,
+            report=report,
+            schema_resolver=mock_resolver,  # type: ignore[arg-type]
+        )
+
+        result = connector._expand_table_patterns("user.*", "mysql", "mydb")
+
+        assert result == ["mydb.users"]
+
     def test_escaped_dots_vs_any_char(self):
         """Test that escaped dots (\\.) match literal dots, not any character."""
         config = KafkaConnectSourceConfig(
@@ -983,6 +1020,43 @@ class TestJavaRegexPatternMatching:
         assert "public.users" in result
         assert "public.orders" in result
         assert "private.secrets" not in result
+
+    def test_postgres_schema_pattern_without_configured_database(self):
+        """Test 3-tier schema patterns omit the discovered database."""
+        config = KafkaConnectSourceConfig(
+            connect_uri="http://test:8083",
+            cluster_name="test",
+            use_schema_resolver=True,
+            schema_resolver_expand_patterns=True,
+        )
+        report = KafkaConnectSourceReport()
+        connector_manifest = ConnectorManifest(
+            name="postgres-source",
+            type="source",
+            config={
+                "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+                "table.include.list": "public\\..*",
+                "database.server.name": "testserver",
+            },
+            tasks=[],
+        )
+        mock_resolver = MockSchemaResolver(
+            platform="postgres",
+            mock_urns=[
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.users,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.private.secrets,PROD)",
+            ],
+        )
+        connector = DebeziumSourceConnector(
+            connector_manifest=connector_manifest,
+            config=config,
+            report=report,
+            schema_resolver=mock_resolver,  # type: ignore[arg-type]
+        )
+
+        result = connector._expand_table_patterns("public\\..*", "postgres", None)
+
+        assert result == ["public.users"]
 
     def test_quantifier_patterns(self):
         """Test various quantifiers: +, *"""

--- a/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
+++ b/metadata-ingestion/tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py
@@ -1044,6 +1044,7 @@ class TestJavaRegexPatternMatching:
             platform="postgres",
             mock_urns=[
                 "urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.public.users,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,otherdb.public.users,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:postgres,testdb.private.secrets,PROD)",
             ],
         )


### PR DESCRIPTION
Prevents Debezium schema-resolver pattern expansion from duplicating database names and dropping valid lineage edges.

<details>
<summary>AI generated description! 👇</summary>

## Context
For hierarchical sources such as PostgreSQL, resolver URNs contain `database.schema.table`, while Debezium's downstream lineage builder expects expanded table names in `schema.table` form. Schema-only patterns matched after removing the database segment but returned the original qualified name, causing the database to be prepended again and the derived Kafka topic to fail validation.

## What changed
- Scope hierarchical resolver matches to the connector's configured database.
- Normalize both schema-only and database-qualified pattern matches to `schema.table`.
- Preserve existing two-tier behavior for sources such as MySQL.
- Update pattern-expansion expectations and add an end-to-end regression covering platform-instance URNs, cross-database candidates, source identity, and topic identity.

## Testing
- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/kafka_connect/test_kafka_connect_schema_resolver.py --no-daemon`
- `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/kafka_connect/test_kafka_connect_debezium_table_discovery.py --no-daemon`
- The new regression fails on `master` because `server.my_db.public.orders` is derived instead of `server.public.orders`; both targeted suites pass with this change.

## Checklist
- [x] The PR conforms to DataHub's contributing guidelines and PR title format.
- [x] Tests for the changes have been added or updated.
- [x] Documentation changes are not required for this internal bug fix.
- [x] This change is non-breaking and requires no Updating DataHub entry.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Debezium pattern expansion so hierarchical source lineage no longer duplicates the database name. Previously, PostgreSQL resolver matches kept the full `database.schema.table` form, breaking topic identity (derived `server.my_db.public.orders` instead of `server.public.orders`); now pattern matches are normalized to `schema.table`.

**Behavior**
- Pattern matches are limited to the connector's configured database, so cross-database tables are excluded.
- Normalized matches are deduplicated, so the same table can't appear twice.
- MySQL two-tier sources keep their existing behavior.
- Updated unit expectations and added a regression covering platform-instance URNs and cross-database candidates.

<sup>Written for commit af5d868ef8301aea414ba6e21e72667ee2e29439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

