### PR TITLE
ci(ingest): cut pytest log volume on CI runners

### DIFF
--- a/datahub-actions/tests/conftest.py
+++ b/datahub-actions/tests/conftest.py
@@ -26,7 +26,7 @@ except ImportError:
 
 # Enable debug logging.
 logging.getLogger().setLevel(logging.DEBUG)
-os.putenv("DATAHUB_DEBUG", "0")
+os.environ["DATAHUB_DEBUG"] = "0"
 
 
 @pytest.fixture

--- a/datahub-actions/tests/conftest.py
+++ b/datahub-actions/tests/conftest.py
@@ -26,7 +26,7 @@ except ImportError:
 
 # Enable debug logging.
 logging.getLogger().setLevel(logging.DEBUG)
-os.putenv("DATAHUB_DEBUG", "1")
+os.putenv("DATAHUB_DEBUG", "0")
 
 
 @pytest.fixture

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -2054,3 +2054,45 @@ combine-as-imports = true
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "src/datahub/configuration/pydantic_migration_helpers.py" = ["TID251"]  # Intentional V1 imports for backward compatibility
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-ra -v --continue-on-collection-errors --strict-markers -p no:faker --junit-xml=test-results/junit.full.xml"
+junit_suite_name = "metadata-ingestion-pytest"
+testpaths = [
+    "tests/unit",
+    "tests/integration",
+    "tests/performance",
+]
+markers = [
+    "slow: marks tests that are slow to run, including all docker-based tests (deselect with '-m not slow')",
+    "integration: marks all integration tests, across all batches (deselect with '-m \"not integration\"')",
+    "integration_batch_0: mark tests to run in batch 0 of integration tests. This is done mainly for parallelization in CI. Batch 0 is the default batch.",
+    "integration_batch_1: mark tests to run in batch 1 of integration tests",
+    "integration_batch_2: mark tests to run in batch 2 of integration tests",
+    "integration_batch_3: mark tests to run in batch 3 of integration tests",
+    "integration_batch_4: mark tests to run in batch 4 of integration tests",
+    "integration_batch_5: mark tests to run in batch 5 of integration tests",
+    "integration_batch_recording: mark recording/replay tests that require isolated execution to avoid module patching interference from other tests",
+    "integration_no_balance: pin a connector/test to its existing integration_batch_N marker so it is excluded from weight-based rebalancing (rare; use only when a connector cannot move batches). Batch assignment for non-pinned tests is dynamic via conftest.py bin-packing.",
+    "perf: marks performance benchmarks (deselect with '-m \"not perf\"')",
+    "degraded: marks tests covering graceful-fallback behaviour for undesired but possible failure scenarios (deselect with '-m \"not degraded\"')",
+]
+filterwarnings = [
+    # Ignore some warnings that come from dependencies.
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+    "ignore:Did not recognize type:sqlalchemy.exc.SAWarning",
+    "ignore::datahub.configuration.common.ConfigurationWarning",
+    "ignore:The new datahub SDK:datahub.errors.ExperimentalWarning",
+    # We should not be unexpectedly seeing API tracing warnings.
+    "error::datahub.errors.APITracingWarning",
+]
+# Captured logs (shown on failure) stay at INFO. DEBUG goes to the file under
+# test-results/, which Metadata Ingestion CI uploads as an artifact.
+# log_cli is intentionally off so passing tests do not stream INFO into CI job logs.
+log_level = "INFO"
+log_file = "test-results/pytest-debug.log"
+log_file_level = "DEBUG"
+log_format = "[%(asctime)s] %(levelname)-8s {%(name)s:%(lineno)d} - %(message)s"
+

--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -63,7 +63,9 @@ log_cli = true
 log_cli_level = INFO
 log_file = test-results/pytest-debug.log
 log_file_level = DEBUG
-log_format = [%(asctime)s] %(levelname)-8s {%(name)s:%(lineno)d} - %(message)s
+# Percent signs are doubled so setuptools/ConfigParser does not treat %(asctime)s as interpolation
+# when it parses this file during `pip install -e .`.
+log_format = [%%(asctime)s] %%(levelname)-8s {%%(name)s:%%(lineno)d} - %%(message)s
 junit_suite_name = metadata-ingestion-pytest
 markers =
     slow: marks tests that are slow to run, including all docker-based tests (deselect with '-m not slow')

--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -56,7 +56,14 @@ disallow_untyped_defs = yes
 
 [tool:pytest]
 asyncio_mode = auto
-addopts = --durations=20 -vv --continue-on-collection-errors --strict-markers -p no:faker --junit-xml=test-results/junit.full.xml
+addopts = -ra -v --continue-on-collection-errors --strict-markers -p no:faker --junit-xml=test-results/junit.full.xml
+# Console stays at INFO so CI job logs stay small. DEBUG goes to the file under
+# test-results/, which Metadata Ingestion CI uploads as an artifact.
+log_cli = true
+log_cli_level = INFO
+log_file = test-results/pytest-debug.log
+log_file_level = DEBUG
+log_format = [%(asctime)s] %(levelname)-8s {%(name)s:%(lineno)d} - %(message)s
 junit_suite_name = metadata-ingestion-pytest
 markers =
     slow: marks tests that are slow to run, including all docker-based tests (deselect with '-m not slow')

--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -54,46 +54,6 @@ disallow_untyped_defs = yes
 [mypy-datahub.utilities.*]
 disallow_untyped_defs = yes
 
-[tool:pytest]
-asyncio_mode = auto
-addopts = -ra -v --continue-on-collection-errors --strict-markers -p no:faker --junit-xml=test-results/junit.full.xml
-# Console stays at INFO so CI job logs stay small. DEBUG goes to the file under
-# test-results/, which Metadata Ingestion CI uploads as an artifact.
-log_cli = true
-log_cli_level = INFO
-log_file = test-results/pytest-debug.log
-log_file_level = DEBUG
-# Percent signs are doubled so setuptools/ConfigParser does not treat %(asctime)s as interpolation
-# when it parses this file during `pip install -e .`.
-log_format = [%%(asctime)s] %%(levelname)-8s {%%(name)s:%%(lineno)d} - %%(message)s
-junit_suite_name = metadata-ingestion-pytest
-markers =
-    slow: marks tests that are slow to run, including all docker-based tests (deselect with '-m not slow')
-    integration: marks all integration tests, across all batches (deselect with '-m "not integration"')
-    integration_batch_0: mark tests to run in batch 0 of integration tests. This is done mainly for parallelization in CI. Batch 0 is the default batch.
-    integration_batch_1: mark tests to run in batch 1 of integration tests
-    integration_batch_2: mark tests to run in batch 2 of integration tests
-    integration_batch_3: mark tests to run in batch 3 of integration tests
-    integration_batch_4: mark tests to run in batch 4 of integration tests
-    integration_batch_5: mark tests to run in batch 5 of integration tests
-    integration_batch_recording: mark recording/replay tests that require isolated execution to avoid module patching interference from other tests
-    integration_no_balance: pin a connector/test to its existing integration_batch_N marker so it is excluded from weight-based rebalancing (rare; use only when a connector cannot move batches). Batch assignment for non-pinned tests is dynamic via conftest.py bin-packing.
-    perf: marks performance benchmarks (deselect with '-m "not perf"')
-    degraded: marks tests covering graceful-fallback behaviour for undesired but possible failure scenarios (deselect with '-m "not degraded"')
-testpaths =
-    tests/unit
-    tests/integration
-    tests/performance
-filterwarnings =
-    # Ignore some warnings that come from dependencies.
-    ignore:Deprecated call to \`pkg_resources.declare_namespace:DeprecationWarning
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
-    ignore:Did not recognize type:sqlalchemy.exc.SAWarning
-    ignore::datahub.configuration.common.ConfigurationWarning
-    ignore:The new datahub SDK:datahub.errors.ExperimentalWarning
-    # We should not be unexpectedly seeing API tracing warnings.
-    error::datahub.errors.APITracingWarning
-
 [coverage:run]
 # Because of some quirks in the way setup.cfg, coverage.py, pytest-cov,
 # and tox interact, we should not uncomment the following line.

--- a/metadata-ingestion/src/datahub/testing/docker_utils.py
+++ b/metadata-ingestion/src/datahub/testing/docker_utils.py
@@ -57,11 +57,20 @@ def _dump_container_logs(container_name: str) -> None:
     stdout and pytest captured it. Capture subprocess output so a dump error
     cannot replace the original wait exception.
     """
-    result = subprocess.run(
-        ["docker", "logs", container_name],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["docker", "logs", container_name],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to fetch logs for container %s: %s",
+            container_name,
+            exc,
+        )
+        return
     output = "\n".join(part for part in (result.stdout, result.stderr) if part)
     if result.returncode != 0:
         logger.error(

--- a/metadata-ingestion/src/datahub/testing/docker_utils.py
+++ b/metadata-ingestion/src/datahub/testing/docker_utils.py
@@ -50,6 +50,34 @@ def is_responsive(container_name: str, port: int, hostname: Optional[str]) -> bo
     return ret.returncode == 0
 
 
+def _dump_container_logs(container_name: str) -> None:
+    """Log ``docker logs`` after a wait failure (never on the happy path).
+
+    Spark/NiFi/Hadoop logs filled CI disks when every successful wait dumped to
+    stdout and pytest captured it. Capture subprocess output so a dump error
+    cannot replace the original wait exception.
+    """
+    result = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True,
+        text=True,
+    )
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    if result.returncode != 0:
+        logger.error(
+            "Failed to fetch logs for container %s (exit %s): %s",
+            container_name,
+            result.returncode,
+            output or "(no output)",
+        )
+        return
+    logger.error(
+        "Logs for container %s:\n%s",
+        container_name,
+        output or "(empty)",
+    )
+
+
 def wait_for_port(
     docker_services: pytest_docker.plugin.Services,
     container_name: str,
@@ -69,10 +97,10 @@ def wait_for_port(
                 else lambda: is_responsive(container_name, container_port, hostname)
             ),
         )
-        logger.info(f"Container {container_name} is ready!")
-    finally:
-        # use check=True to raise an error if command gave bad exit code
-        subprocess.run(f"docker logs {container_name}", shell=True, check=True)
+    except Exception:
+        _dump_container_logs(container_name)
+        raise
+    logger.info("Container %s is ready!", container_name)
 
 
 DOCKER_DEFAULT_UNLIMITED_PARALLELISM = -1

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -16,9 +16,8 @@ import time_machine
 os.environ["DATAHUB_SUPPRESS_LOGGING_MANAGER"] = "1"
 os.environ["DATAHUB_TEST_MODE"] = "1"
 
-# Enable debug logging.
-logging.getLogger().setLevel(logging.DEBUG)
-os.environ["DATAHUB_DEBUG"] = "1"
+# Pytest log_file in setup.cfg is relative to cwd (metadata-ingestion/).
+pathlib.Path("test-results").mkdir(exist_ok=True)
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -16,7 +16,7 @@ import time_machine
 os.environ["DATAHUB_SUPPRESS_LOGGING_MANAGER"] = "1"
 os.environ["DATAHUB_TEST_MODE"] = "1"
 
-# Pytest log_file in setup.cfg is relative to cwd (metadata-ingestion/).
+# Pytest log_file in pyproject.toml is relative to cwd (metadata-ingestion/).
 pathlib.Path("test-results").mkdir(exist_ok=True)
 
 # Disable telemetry

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import platform
-import subprocess
 
 import pytest
 import sqlalchemy
@@ -16,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.integration_batch_4
 DB2_PORT = 50000
+DB2_URL = f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
 
 
 @pytest.fixture(scope="module")
@@ -23,13 +23,18 @@ def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/db2"
 
 
-def is_db2_up(container_name: str) -> bool:
-    cmd = f"docker logs {container_name} 2>&1 | grep 'Setup has completed.'"
-    ret = subprocess.run(
-        cmd,
-        shell=True,
-    )
-    return ret.returncode == 0
+def is_db2_up(_container_name: str) -> bool:
+    # The image prints "Setup has completed." before alias testdb is catalogued.
+    # SQL30061 until a real connection succeeds.
+    engine = sqlalchemy.create_engine(DB2_URL)
+    try:
+        with engine.connect() as conn:
+            conn.execute(sqlalchemy.text("SELECT 1 FROM SYSIBM.SYSDUMMY1"))
+        return True
+    except Exception:
+        return False
+    finally:
+        engine.dispose()
 
 
 def _split_statements(sql):
@@ -73,9 +78,7 @@ def db2_runner(docker_compose_runner, pytestconfig, test_resources_dir):
         setup_filename = test_resources_dir / "setup" / "setup.sql"
         statements = _split_statements(open(setup_filename).read())
 
-        engine = sqlalchemy.create_engine(
-            f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
-        )
+        engine = sqlalchemy.create_engine(DB2_URL)
         with engine.begin() as conn:
             for statement in statements:
                 logger.info("Executing SQL: " + statement)

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import platform
+import subprocess
 
 import pytest
 import sqlalchemy
@@ -16,6 +17,11 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.integration_batch_4
 DB2_PORT = 50000
 DB2_URL = f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
+# ibm_db_sa drops CONNECTTIMEOUT from the SQLAlchemy URL; set it on the probe DSN.
+DB2_PROBE_DSN = (
+    f"DATABASE=testdb;HOSTNAME=localhost;PORT={DB2_PORT};PROTOCOL=TCPIP;"
+    "UID=db2inst1;PWD=password;CONNECTTIMEOUT=5;"
+)
 
 
 @pytest.fixture(scope="module")
@@ -23,18 +29,26 @@ def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/db2"
 
 
-def is_db2_up(_container_name: str) -> bool:
-    # The image prints "Setup has completed." before alias testdb is catalogued.
-    # SQL30061 until a real connection succeeds.
-    engine = sqlalchemy.create_engine(DB2_URL)
+def is_db2_up(container_name: str) -> bool:
+    # Cheap boot wait: the image prints this before testdb is catalogued.
+    logs = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if "Setup has completed." not in f"{logs.stdout}{logs.stderr}":
+        return False
+    # Then require a real connection so we do not race SQL30061. Short
+    # CONNECTTIMEOUT keeps a half-open listener from blocking wait_for_port.
     try:
-        with engine.connect() as conn:
-            conn.execute(sqlalchemy.text("SELECT 1 FROM SYSIBM.SYSDUMMY1"))
+        import ibm_db
+
+        conn = ibm_db.connect(DB2_PROBE_DSN, "", "")
+        ibm_db.close(conn)
         return True
     except Exception:
         return False
-    finally:
-        engine.dispose()
 
 
 def _split_statements(sql):

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -419,9 +419,14 @@ def test_get_folder_info_ignores_disallowed_path(s3_resource, caplog):
     s3_source = _get_s3_source(path_spec)
 
     # act
-    with patch(
-        "datahub.ingestion.source.data_lake_common.path_spec.PathSpec.allowed"
-    ) as allowed:
+    # The skip path logs at DEBUG; raise capture above pytest's log_level so
+    # this assertion does not depend on ini/CLI logging settings.
+    with (
+        caplog.at_level(logging.DEBUG, logger="datahub.ingestion.source.s3.source"),
+        patch(
+            "datahub.ingestion.source.data_lake_common.path_spec.PathSpec.allowed"
+        ) as allowed,
+    ):
         allowed.return_value = False
         res = s3_source.get_folder_info(path_spec, "s3://my-bucket/my-folder")
         res = list(res)

--- a/metadata-ingestion/tests/unit/testing/test_docker_utils.py
+++ b/metadata-ingestion/tests/unit/testing/test_docker_utils.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datahub.testing.docker_utils import wait_for_port
+
+
+def _unready_services() -> MagicMock:
+    services = MagicMock()
+    services.wait_until_responsive.side_effect = RuntimeError("timeout")
+    return services
+
+
+@patch("datahub.testing.docker_utils.subprocess.run")
+def test_wait_for_port_does_not_dump_logs_when_ready(mock_run: MagicMock) -> None:
+    services = MagicMock()
+
+    wait_for_port(
+        docker_services=services,
+        container_name="nifi1",
+        container_port=8080,
+    )
+
+    services.wait_until_responsive.assert_called_once()
+    mock_run.assert_not_called()
+
+
+@patch("datahub.testing.docker_utils.subprocess.run")
+def test_wait_for_port_dumps_logs_when_not_ready(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="boot log", stderr="")
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        wait_for_port(
+            docker_services=_unready_services(),
+            container_name="nifi1",
+            container_port=8080,
+        )
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["docker", "logs", "nifi1"]
+    assert mock_run.call_args.kwargs["capture_output"] is True
+    assert mock_run.call_args.kwargs["text"] is True
+
+
+@patch("datahub.testing.docker_utils.subprocess.run")
+def test_wait_for_port_still_raises_original_when_log_dump_fails(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="No such container"
+    )
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        wait_for_port(
+            docker_services=_unready_services(),
+            container_name="nifi1",
+            container_port=8080,
+        )
+
+    mock_run.assert_called_once()

--- a/metadata-ingestion/tests/unit/testing/test_docker_utils.py
+++ b/metadata-ingestion/tests/unit/testing/test_docker_utils.py
@@ -40,6 +40,7 @@ def test_wait_for_port_dumps_logs_when_not_ready(mock_run: MagicMock) -> None:
     assert mock_run.call_args.args[0] == ["docker", "logs", "nifi1"]
     assert mock_run.call_args.kwargs["capture_output"] is True
     assert mock_run.call_args.kwargs["text"] is True
+    assert mock_run.call_args.kwargs["timeout"] == 10
 
 
 @patch("datahub.testing.docker_utils.subprocess.run")
@@ -49,6 +50,22 @@ def test_wait_for_port_still_raises_original_when_log_dump_fails(
     mock_run.return_value = MagicMock(
         returncode=1, stdout="", stderr="No such container"
     )
+
+    with pytest.raises(RuntimeError, match="timeout"):
+        wait_for_port(
+            docker_services=_unready_services(),
+            container_name="nifi1",
+            container_port=8080,
+        )
+
+    mock_run.assert_called_once()
+
+
+@patch("datahub.testing.docker_utils.subprocess.run")
+def test_wait_for_port_still_raises_original_when_log_dump_raises(
+    mock_run: MagicMock,
+) -> None:
+    mock_run.side_effect = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
 
     with pytest.raises(RuntimeError, match="timeout"):
         wait_for_port(

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -63,7 +63,7 @@ run_pytest_policy_phases() {
   echo "SMOKE POLICY PHASE 1: non-mutator tests"
   echo "=========================================="
   set +e
-  SMOKE_POLICY_PHASE=1 pytest -rP --durations=20 -vv --continue-on-collection-errors \
+  SMOKE_POLICY_PHASE=1 pytest -ra -v --continue-on-collection-errors \
     ${xdist_args[@]+"${xdist_args[@]}"} \
     --junit-xml="${junit_prefix}-phase1.xml" \
     ${extra_args[@]+"${extra_args[@]}"}
@@ -78,7 +78,7 @@ run_pytest_policy_phases() {
   echo "=========================================="
   set +e
   # No xdist: mutators must not run concurrently against shared policy state.
-  SMOKE_POLICY_PHASE=2 pytest -rP --durations=20 -vv --continue-on-collection-errors \
+  SMOKE_POLICY_PHASE=2 pytest -ra -v --continue-on-collection-errors \
     --reruns 1 --reruns-delay 1 \
     --junit-xml="${junit_prefix}-phase2.xml" \
     ${extra_args[@]+"${extra_args[@]}"}


### PR DESCRIPTION
## Summary
- Dump `docker logs` from `wait_for_port` only when the wait fails, so healthy Spark/NiFi/Hadoop startups no longer flood pytest capture and the job log (ING-3415 disk exhaustion).
- Keep pytest console at INFO (`-v`, `log_cli_level = INFO`); write DEBUG to `test-results/pytest-debug.log`, which is already uploaded by the Metadata Ingestion **Report test results** artifact.
- Match the quieter pytest flags in smoke tests and stop forcing `DATAHUB_DEBUG` in datahub-actions tests.

## Test plan
- [ ] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/testing/test_docker_utils.py`
- [ ] Confirm a Metadata Ingestion CI job artifact `metadata-ingestion-test-results-*` contains `pytest-debug.log`
- [ ] Spot-check job logs: INFO-level pytest/live logs, no full container dumps on passing waits


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts ingestion pytest log volume on CI runners by dumping `docker logs` from `wait_for_port` only when a wait fails, and sends DEBUG logs to `test-results/pytest-debug.log` (already uploaded as an artifact) instead of the job log.

- A failed log dump logs an error and still re-raises the original wait exception.
- Keeps pytest capture at INFO and sets smoke test flags to the quieter `-ra -v`; datahub-actions tests now set `DATAHUB_DEBUG=0` instead of forcing `1`.
- Moves pytest config from `setup.cfg` to `pyproject.toml` because setuptools' ConfigParser interpolated `%(...)` in `log_format`, breaking editable installs and `installPackageOnly` CI jobs.
- Ingestion tests create `test-results/` at startup, and the S3 disallowed-path test captures DEBUG via `caplog.at_level`, so the log file always has a destination and the assertion doesn't depend on pytest log settings.
- Db2 tests wait for `testdb` to accept connections by polling a real query after the setup log appears, with a short connect timeout, instead of grepping `docker logs` (which raced SQL30061 errors).

<sup>Written for commit e7310ff284431dacbfc4f4404400a27ccd30b6ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

