### PR TITLE
fix(test): isolate lineage smoke test from migrate xdist collision

### DIFF
--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
@@ -63,11 +63,14 @@ ENV = "PROD"
 _suffix = randint(10, 100000)
 
 # --- platform2instance scenario ---
+# Unique platform so catalog-wide dataplatform2instance cannot rewrite other
+# xdist workers' snowflake datasets (e.g. lineage smoke tests).
+P2I_PLATFORM = f"migp2i_{_suffix}"
 P2I_INSTANCE = f"mig_p2i_{_suffix}"
-P2I_TABLE = "my_db.my_schema.p2i_tbl"
-p2i_src = make_dataset_urn_with_platform_instance(PLATFORM, P2I_TABLE, None, ENV)
+P2I_TABLE = f"my_db.my_schema.p2i_tbl_{_suffix}"
+p2i_src = make_dataset_urn_with_platform_instance(P2I_PLATFORM, P2I_TABLE, None, ENV)
 p2i_dst = make_dataset_urn_with_platform_instance(
-    PLATFORM, P2I_TABLE, P2I_INSTANCE, ENV
+    P2I_PLATFORM, P2I_TABLE, P2I_INSTANCE, ENV
 )
 
 # --- preserve scenario ---
@@ -127,10 +130,10 @@ _ct_dst_key.instance = CT_NEW
 ct_dst = f"urn:li:container:{_ct_dst_key.guid()}"
 
 
-def _schema(field_name: str) -> SchemaMetadataClass:
+def _schema(field_name: str, platform: str = PLATFORM) -> SchemaMetadataClass:
     return SchemaMetadataClass(
         schemaName="s",
-        platform=make_data_platform_urn(PLATFORM),
+        platform=make_data_platform_urn(platform),
         version=0,
         hash="",
         platformSchema=OtherSchemaClass(rawSchema=""),
@@ -158,7 +161,9 @@ def test_dataplatform2instance_assigns_instance_and_carries_aspects(
     delete_urns(graph_client, all_urns)
     wait_for_writes_to_sync()
     for mcp in [
-        MetadataChangeProposalWrapper(entityUrn=p2i_src, aspect=_schema("id")),
+        MetadataChangeProposalWrapper(
+            entityUrn=p2i_src, aspect=_schema("id", P2I_PLATFORM)
+        ),
         MetadataChangeProposalWrapper(
             entityUrn=p2i_src,
             aspect=DatasetPropertiesClass(description="p2i source"),
@@ -177,7 +182,7 @@ def test_dataplatform2instance_assigns_instance_and_carries_aspects(
                 "migrate",
                 "dataplatform2instance",
                 "--platform",
-                PLATFORM,
+                P2I_PLATFORM,
                 "--instance",
                 P2I_INSTANCE,
                 "--env",
@@ -196,7 +201,7 @@ def test_dataplatform2instance_assigns_instance_and_carries_aspects(
         assert graph_client.get_aspect(p2i_dst, GlobalTagsClass) is not None
         instance = graph_client.get_aspect(p2i_dst, DataPlatformInstanceClass)
         assert instance is not None and instance.instance == (
-            make_dataplatform_instance_urn(PLATFORM, P2I_INSTANCE)
+            make_dataplatform_instance_urn(P2I_PLATFORM, P2I_INSTANCE)
         )
     finally:
         delete_urns(graph_client, all_urns)

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-from random import randint
 
 import pytest
 
@@ -52,7 +51,7 @@ from datahub.metadata.schema_classes import (
 )
 from tests.consistency_utils import wait_for_writes_to_sync
 from tests.utilities.domains import Domain
-from tests.utils import delete_urns, get_sleep_info, run_datahub_cmd
+from tests.utils import delete_urns, get_sleep_info, run_datahub_cmd, unique_suffix
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +59,7 @@ pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 PLATFORM = "snowflake"
 ENV = "PROD"
-_suffix = randint(10, 100000)
+_suffix = unique_suffix()
 
 # --- platform2instance scenario ---
 # Unique platform so catalog-wide dataplatform2instance cannot rewrite other

--- a/smoke-test/tests/lineage/test_lineage.py
+++ b/smoke-test/tests/lineage/test_lineage.py
@@ -39,7 +39,7 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 from datahub.utilities.urns.urn import Urn
 from tests.utilities.domains import Domain
-from tests.utils import ingest_file_via_rest, wait_for_writes_to_sync
+from tests.utils import ingest_file_via_rest, unique_suffix, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
 
@@ -718,14 +718,20 @@ class Scenario(BaseModel):
                 for dataset_urn in self.get_downstream_dataset_urns(hop_index):
                     assert graph.exists(dataset_urn) is True
 
-            if self.lineage_style == Scenario.LineageStyle.DATASET_JOB_DATASET:
-                assert graph.exists(self.get_transformation_job_urn(hop_index)) is True
-                assert graph.exists(self.get_transformation_flow_urn(hop_index)) is True
+                if self.lineage_style == Scenario.LineageStyle.DATASET_JOB_DATASET:
+                    assert (
+                        graph.exists(self.get_transformation_job_urn(hop_index)) is True
+                    )
+                    assert (
+                        graph.exists(self.get_transformation_flow_urn(hop_index))
+                        is True
+                    )
 
-            if self.lineage_style == Scenario.LineageStyle.DATASET_QUERY_DATASET:
-                assert (
-                    graph.exists(self.get_transformation_query_urn(hop_index)) is True
-                )
+                if self.lineage_style == Scenario.LineageStyle.DATASET_QUERY_DATASET:
+                    assert (
+                        graph.exists(self.get_transformation_query_urn(hop_index))
+                        is True
+                    )
 
             wait_for_writes_to_sync(mcp_only=True)  # Wait for the graph to update
             # We would like to check that lineage is correct for all datasets and schema fields for all values of hops and for all directions of lineage exploration
@@ -824,11 +830,15 @@ class Scenario(BaseModel):
 def test_lineage_via_node(
     graph_client: DataHubGraph, lineage_style: Scenario.LineageStyle, graph_level: int
 ) -> None:
+    ns = unique_suffix()
     scenario: Scenario = Scenario(
         hop_platform_map={0: "mysql", 1: "snowflake"},
         lineage_style=lineage_style,
         num_hops=graph_level,
-        default_dataset_prefix=f"{lineage_style.value}.",
+        default_dataset_prefix=f"{lineage_style.value}.{ns}.",
+        transformation_job=f"job1_{ns}",
+        transformation_flow=f"flow1_{ns}",
+        query_id=f"guid-guid-guid-{ns}",
     )
 
     # Create an emitter to the GMS REST API.


### PR DESCRIPTION
## Summary
- Scope `dataplatform2instance` smoke coverage to a unique platform namespace so it no longer rewrites every snowflake dataset in PROD (the cause of flaky `test_lineage_via_node[3-DATASET_JOB_DATASET]` under xdist).
- Give each lineage scenario unique dataset prefixes, job/flow ids, and query ids so via-nodes are not shared across runs.
- Move DataJob/DataFlow/Query existence checks inside the hop loop so every hop is asserted.

Fixes the flake tracked in PFP-5969. The failure was searchAcrossLineage returning `mig_p2i_*` clones of lineage datasets while `test_dataplatform2instance_assigns_instance_and_carries_aspects` ran on another worker.

## Test plan
- [ ] Confirm Pytest Smoke Tests Batch 6/7 is stable on this PR (lineage + migrate modules).
- [ ] Optionally re-run Batch 6 if the lineage test fails once — it should not flake against migrate anymore.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PFP-5969 by isolating the `dataplatform2instance` smoke test from lineage tests that run in parallel under xdist. The migrate test was rewriting every dataset on the shared `PLATFORM` in PROD, so a parallel lineage test could resolve `mig_p2i_*` clones and flake. Both modules now use `unique_suffix()` for the platform, instance, dataset prefixes, job/flow IDs, and query IDs so concurrent runs can't collide, and job/flow/query existence assertions moved inside the hop loop to verify every hop.

<sup>Written for commit 687cb455d04965dc06734e0586aae140d711753f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

