### PR TITLE
feat(api): add per-platform entity inventory counts

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountEntry.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountEntry.java
@@ -1,0 +1,22 @@
+package com.linkedin.metadata.systemmetadata;
+
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+/** One (entityType, platform) inventory row from the entity search index. */
+@Value
+@Builder
+public class PlatformEntityCountEntry {
+  @Nonnull String entityType;
+
+  /** Short platform id (e.g. {@code snowflake}) or {@link PlatformEntityCounts#NO_PLATFORM}. */
+  @Nonnull String platform;
+
+  long activeCount;
+  long softDeletedCount;
+
+  public long totalCount() {
+    return activeCount + softDeletedCount;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountResult.java
@@ -1,0 +1,15 @@
+package com.linkedin.metadata.systemmetadata;
+
+import java.time.Instant;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PlatformEntityCountResult {
+  @Nonnull List<PlatformEntityCountEntry> counts;
+  @Nonnull List<String> requestedTypes;
+  @Nonnull Instant computedAt;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
@@ -1,0 +1,221 @@
+package com.linkedin.metadata.systemmetadata;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.SearchableFieldSpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.utils.ESUtils;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import io.datahubproject.metadata.context.OperationContext;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RequestOptions;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.filter.Filter;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Inventory counts by {@code platform} from entity search indexes (not system-metadata). Thin
+ * orchestration over a terms aggregation with a {@link #NO_PLATFORM} missing bucket — not a
+ * parallel count domain service.
+ */
+@Slf4j
+public class PlatformEntityCounts {
+
+  /** Sentinel for documents with no platform value (matches semantic coverage). */
+  public static final String NO_PLATFORM = "NO_PLATFORM";
+
+  private static final String PLATFORM_FIELD = "platform";
+  private static final String PLATFORM_AGG_FIELD = "platform.keyword";
+  private static final String PLATFORM_AGG_NAME = "by_platform";
+  private static final String ACTIVE_AGG_NAME = "active";
+  private static final String SOFT_DELETED_AGG_NAME = "soft_deleted";
+  private static final int MAX_PLATFORM_BUCKETS = 500;
+  private static final String DATA_PLATFORM_INSTANCE_ASPECT = "dataPlatformInstance";
+
+  private final SearchClientShim<?> searchClient;
+  private final EntityRegistry entityRegistry;
+  private final int maxEntityTypes;
+
+  public PlatformEntityCounts(
+      @Nonnull SearchClientShim<?> searchClient,
+      @Nonnull EntityRegistry entityRegistry,
+      int maxEntityTypes) {
+    this.searchClient = Objects.requireNonNull(searchClient, "searchClient");
+    this.entityRegistry = Objects.requireNonNull(entityRegistry, "entityRegistry");
+    this.maxEntityTypes = maxEntityTypes;
+  }
+
+  @Nonnull
+  public PlatformEntityCountResult getCountsByPlatform(
+      @Nonnull OperationContext opContext, @Nullable List<String> entityTypes) {
+    List<String> resolved = resolveEntityTypes(entityTypes);
+    List<PlatformEntityCountEntry> entries = new ArrayList<>();
+    for (String entityType : resolved) {
+      if (!hasPlatformSearchField(entityType)) {
+        log.debug("Skipping entity type {} — no searchable platform field", entityType);
+        continue;
+      }
+      try {
+        entries.addAll(countEntityTypeByPlatform(opContext, entityType));
+      } catch (IOException e) {
+        log.warn("Platform count failed for entity type {}; skipping", entityType, e);
+      }
+    }
+    return PlatformEntityCountResult.builder()
+        .counts(entries)
+        .requestedTypes(resolved)
+        .computedAt(Instant.now())
+        .build();
+  }
+
+  @Nonnull
+  private List<PlatformEntityCountEntry> countEntityTypeByPlatform(
+      @Nonnull OperationContext opContext, @Nonnull String entityType) throws IOException {
+    String indexName =
+        opContext.getSearchContext().getIndexConvention().getEntityIndexName(opContext, entityType);
+
+    SearchSourceBuilder source =
+        new SearchSourceBuilder()
+            .query(QueryBuilders.matchAllQuery())
+            .size(0)
+            .trackTotalHits(false)
+            .aggregation(
+                AggregationBuilders.terms(PLATFORM_AGG_NAME)
+                    .field(PLATFORM_AGG_FIELD)
+                    .missing(NO_PLATFORM)
+                    .size(MAX_PLATFORM_BUCKETS)
+                    .subAggregation(
+                        AggregationBuilders.filter(
+                            ACTIVE_AGG_NAME,
+                            QueryBuilders.boolQuery()
+                                .mustNot(QueryBuilders.termQuery(ESUtils.REMOVED, true))))
+                    .subAggregation(
+                        AggregationBuilders.filter(
+                            SOFT_DELETED_AGG_NAME,
+                            QueryBuilders.termQuery(ESUtils.REMOVED, true))));
+
+    SearchRequest request = new SearchRequest(indexName).source(source);
+    SearchResponse response;
+    try {
+      response = searchClient.search(opContext, request, RequestOptions.DEFAULT);
+    } catch (OpenSearchStatusException e) {
+      if (e.status() == RestStatus.NOT_FOUND) {
+        log.debug("Entity index {} not found; returning empty platform counts", indexName);
+        return List.of();
+      }
+      throw e;
+    }
+
+    Terms platformTerms = response.getAggregations().get(PLATFORM_AGG_NAME);
+    if (platformTerms == null) {
+      return List.of();
+    }
+    long otherDocCount = platformTerms.getSumOfOtherDocCounts();
+    if (otherDocCount > 0) {
+      log.warn(
+          "Platform terms aggregation for {} truncated {} docs outside top {} buckets",
+          entityType,
+          otherDocCount,
+          MAX_PLATFORM_BUCKETS);
+    }
+
+    List<PlatformEntityCountEntry> entries = new ArrayList<>();
+    for (Terms.Bucket bucket : platformTerms.getBuckets()) {
+      Filter activeFilter = bucket.getAggregations().get(ACTIVE_AGG_NAME);
+      Filter softFilter = bucket.getAggregations().get(SOFT_DELETED_AGG_NAME);
+      long active = activeFilter != null ? activeFilter.getDocCount() : 0L;
+      long soft = softFilter != null ? softFilter.getDocCount() : 0L;
+      if (active == 0L && soft == 0L) {
+        continue;
+      }
+      entries.add(
+          PlatformEntityCountEntry.builder()
+              .entityType(entityType)
+              .platform(normalizePlatform(bucket.getKeyAsString()))
+              .activeCount(active)
+              .softDeletedCount(soft)
+              .build());
+    }
+    return entries;
+  }
+
+  @Nonnull
+  static String normalizePlatform(@Nonnull String raw) {
+    if (NO_PLATFORM.equals(raw) || raw.isBlank()) {
+      return NO_PLATFORM;
+    }
+    String trimmed = raw.trim();
+    if (trimmed.startsWith("urn:li:dataPlatform:")) {
+      try {
+        return Urn.createFromString(trimmed).getId();
+      } catch (URISyntaxException e) {
+        int colon = trimmed.lastIndexOf(':');
+        if (colon >= 0 && colon < trimmed.length() - 1) {
+          return trimmed.substring(colon + 1);
+        }
+      }
+    }
+    return trimmed;
+  }
+
+  boolean hasPlatformSearchField(@Nonnull String entityType) {
+    EntitySpec spec = entityRegistry.getEntitySpec(entityType);
+    if (spec == null) {
+      return false;
+    }
+    if (Boolean.TRUE.equals(spec.hasAspect(DATA_PLATFORM_INSTANCE_ASPECT))) {
+      return true;
+    }
+    for (SearchableFieldSpec fieldSpec : spec.getSearchableFieldSpecs()) {
+      if (PLATFORM_FIELD.equals(fieldSpec.getSearchableAnnotation().getFieldName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Nonnull
+  private List<String> resolveEntityTypes(@Nullable List<String> entityTypes) {
+    if (entityTypes == null || entityTypes.isEmpty()) {
+      return entityRegistry.getEntitySpecs().keySet().stream()
+          .sorted(Comparator.naturalOrder())
+          .collect(Collectors.toList());
+    }
+    List<String> normalized =
+        entityTypes.stream()
+            .map(t -> t.toLowerCase(Locale.ROOT))
+            .distinct()
+            .sorted()
+            .collect(Collectors.toList());
+    if (normalized.size() > maxEntityTypes) {
+      throw new IllegalArgumentException(
+          "Requested entity type count "
+              + normalized.size()
+              + " exceeds maximum "
+              + maxEntityTypes);
+    }
+    for (String entityType : normalized) {
+      if (!entityRegistry.getEntitySpecs().containsKey(entityType)) {
+        throw new IllegalArgumentException("Unknown entity type: " + entityType);
+      }
+    }
+    return normalized;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
@@ -156,11 +156,15 @@ public class PlatformEntityCounts {
 
     Aggregations aggregations = response.getAggregations();
     if (aggregations == null) {
-      return List.of();
+      throw new RuntimeException(
+          "Platform count query for entity type " + entityType + " returned no aggregations");
     }
     Terms platformTerms = aggregations.get(PLATFORM_AGG_NAME);
     if (platformTerms == null) {
-      return List.of();
+      throw new RuntimeException(
+          "Platform count query for entity type "
+              + entityType
+              + " omitted the by_platform aggregation");
     }
     long otherDocCount = platformTerms.getSumOfOtherDocCounts();
     if (otherDocCount > 0) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/PlatformEntityCounts.java
@@ -1,10 +1,12 @@
 package com.linkedin.metadata.systemmetadata;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.utils.ESUtils;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
@@ -24,8 +26,10 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.bucket.filter.Filter;
 import org.opensearch.search.aggregations.bucket.terms.Terms;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -42,23 +46,26 @@ public class PlatformEntityCounts {
   public static final String NO_PLATFORM = "NO_PLATFORM";
 
   private static final String PLATFORM_FIELD = "platform";
-  private static final String PLATFORM_AGG_FIELD = "platform.keyword";
   private static final String PLATFORM_AGG_NAME = "by_platform";
   private static final String ACTIVE_AGG_NAME = "active";
   private static final String SOFT_DELETED_AGG_NAME = "soft_deleted";
+  private static final String ENTITY_TYPE_FIELD = "_entityType";
   private static final int MAX_PLATFORM_BUCKETS = 500;
   private static final String DATA_PLATFORM_INSTANCE_ASPECT = "dataPlatformInstance";
 
   private final SearchClientShim<?> searchClient;
   private final EntityRegistry entityRegistry;
+  private final EntityIndexConfiguration entityIndexConfiguration;
   private final int maxEntityTypes;
 
   public PlatformEntityCounts(
       @Nonnull SearchClientShim<?> searchClient,
       @Nonnull EntityRegistry entityRegistry,
+      @Nullable EntityIndexConfiguration entityIndexConfiguration,
       int maxEntityTypes) {
     this.searchClient = Objects.requireNonNull(searchClient, "searchClient");
     this.entityRegistry = Objects.requireNonNull(entityRegistry, "entityRegistry");
+    this.entityIndexConfiguration = entityIndexConfiguration;
     this.maxEntityTypes = maxEntityTypes;
   }
 
@@ -66,6 +73,14 @@ public class PlatformEntityCounts {
   public PlatformEntityCountResult getCountsByPlatform(
       @Nonnull OperationContext opContext, @Nullable List<String> entityTypes) {
     List<String> resolved = resolveEntityTypes(entityTypes);
+    if (!v2Enabled() && !v3Enabled()) {
+      return PlatformEntityCountResult.builder()
+          .counts(List.of())
+          .requestedTypes(resolved)
+          .computedAt(Instant.now())
+          .build();
+    }
+
     List<PlatformEntityCountEntry> entries = new ArrayList<>();
     for (String entityType : resolved) {
       if (!hasPlatformSearchField(entityType)) {
@@ -75,7 +90,9 @@ public class PlatformEntityCounts {
       try {
         entries.addAll(countEntityTypeByPlatform(opContext, entityType));
       } catch (IOException e) {
-        log.warn("Platform count failed for entity type {}; skipping", entityType, e);
+        throw new RuntimeException("Platform count query failed for entity type " + entityType, e);
+      } catch (OpenSearchStatusException e) {
+        throw new RuntimeException("Platform count query failed for entity type " + entityType, e);
       }
     }
     return PlatformEntityCountResult.builder()
@@ -88,17 +105,31 @@ public class PlatformEntityCounts {
   @Nonnull
   private List<PlatformEntityCountEntry> countEntityTypeByPlatform(
       @Nonnull OperationContext opContext, @Nonnull String entityType) throws IOException {
+    EntitySpec spec = entityRegistry.getEntitySpec(entityType);
+    IndexConvention convention = opContext.getSearchContext().getIndexConvention();
+    boolean useV3 = !v2Enabled() && v3Enabled();
     String indexName =
-        opContext.getSearchContext().getIndexConvention().getEntityIndexName(opContext, entityType);
+        useV3
+            ? convention.getEntityIndexNameV3(opContext, spec.getSearchGroup())
+            : convention.getEntityIndexName(opContext, entityType);
+    String aggField =
+        useV3
+            ? PLATFORM_FIELD
+            : ESUtils.toKeywordField(
+                opContext, PLATFORM_FIELD, false, opContext.getAspectRetriever());
+    QueryBuilder query =
+        useV3
+            ? QueryBuilders.termQuery(ENTITY_TYPE_FIELD, entityType)
+            : QueryBuilders.matchAllQuery();
 
     SearchSourceBuilder source =
         new SearchSourceBuilder()
-            .query(QueryBuilders.matchAllQuery())
+            .query(query)
             .size(0)
             .trackTotalHits(false)
             .aggregation(
                 AggregationBuilders.terms(PLATFORM_AGG_NAME)
-                    .field(PLATFORM_AGG_FIELD)
+                    .field(aggField)
                     .missing(NO_PLATFORM)
                     .size(MAX_PLATFORM_BUCKETS)
                     .subAggregation(
@@ -123,17 +154,24 @@ public class PlatformEntityCounts {
       throw e;
     }
 
-    Terms platformTerms = response.getAggregations().get(PLATFORM_AGG_NAME);
+    Aggregations aggregations = response.getAggregations();
+    if (aggregations == null) {
+      return List.of();
+    }
+    Terms platformTerms = aggregations.get(PLATFORM_AGG_NAME);
     if (platformTerms == null) {
       return List.of();
     }
     long otherDocCount = platformTerms.getSumOfOtherDocCounts();
     if (otherDocCount > 0) {
-      log.warn(
-          "Platform terms aggregation for {} truncated {} docs outside top {} buckets",
-          entityType,
-          otherDocCount,
-          MAX_PLATFORM_BUCKETS);
+      throw new IllegalStateException(
+          "Platform terms aggregation for "
+              + entityType
+              + " truncated "
+              + otherDocCount
+              + " docs outside top "
+              + MAX_PLATFORM_BUCKETS
+              + " buckets");
     }
 
     List<PlatformEntityCountEntry> entries = new ArrayList<>();
@@ -189,6 +227,18 @@ public class PlatformEntityCounts {
       }
     }
     return false;
+  }
+
+  private boolean v2Enabled() {
+    return entityIndexConfiguration != null
+        && entityIndexConfiguration.getV2() != null
+        && entityIndexConfiguration.getV2().isEnabled();
+  }
+
+  private boolean v3Enabled() {
+    return entityIndexConfiguration != null
+        && entityIndexConfiguration.getV3() != null
+        && entityIndexConfiguration.getV3().isEnabled();
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisher.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisher.java
@@ -3,6 +3,8 @@ package com.linkedin.metadata.systemmetadata.metrics;
 import com.linkedin.metadata.config.EntityCountMetricsConfiguration;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountService;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCounts;
 import io.datahubproject.metadata.context.OperationContext;
 import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.Executors;
@@ -17,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 public class EntityCountMetricsPublisher implements AutoCloseable {
 
   private final KeyAspectEntityCountService keyAspectEntityCountService;
+  @Nullable private final PlatformEntityCounts platformEntityCounts;
   private final OperationContext systemOperationContext;
   private final EntityCountMetricsSink sink;
   @Nullable private final MicrometerEntityCountMetricsSink micrometerLifecycleSink;
@@ -25,11 +28,13 @@ public class EntityCountMetricsPublisher implements AutoCloseable {
 
   public EntityCountMetricsPublisher(
       @Nonnull KeyAspectEntityCountService keyAspectEntityCountService,
+      @Nullable PlatformEntityCounts platformEntityCounts,
       @Nonnull OperationContext systemOperationContext,
       @Nonnull EntityCountMetricsSink sink,
       @Nullable MicrometerEntityCountMetricsSink micrometerLifecycleSink,
       @Nonnull EntityCountMetricsConfiguration config) {
     this.keyAspectEntityCountService = keyAspectEntityCountService;
+    this.platformEntityCounts = platformEntityCounts;
     this.systemOperationContext = systemOperationContext;
     this.sink = sink;
     this.micrometerLifecycleSink = micrometerLifecycleSink;
@@ -65,6 +70,14 @@ public class EntityCountMetricsPublisher implements AutoCloseable {
       KeyAspectEntityCountResult result =
           keyAspectEntityCountService.getCounts(systemOperationContext, null, config.isSkipCache());
       sink.publish(result);
+      if (platformEntityCounts != null) {
+        PlatformEntityCountResult platformResult =
+            platformEntityCounts.getCountsByPlatform(systemOperationContext, null);
+        sink.publishPlatform(platformResult);
+        log.debug(
+            "Refreshed platform entity count metrics for {} series",
+            platformResult.getCounts().size());
+      }
       if (micrometerLifecycleSink != null) {
         micrometerLifecycleSink.recordRefreshSuccess();
       }

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSink.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSink.java
@@ -1,10 +1,17 @@
 package com.linkedin.metadata.systemmetadata.metrics;
 
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import javax.annotation.Nonnull;
 
 /** Extension point — additional entity count sinks register as Spring beans. */
 public interface EntityCountMetricsSink {
 
   void publish(@Nonnull KeyAspectEntityCountResult result);
+
+  /**
+   * Optional platform×entity_type inventory land. Default no-op so Micrometer and other type-only
+   * sinks stay unchanged.
+   */
+  default void publishPlatform(@Nonnull PlatformEntityCountResult result) {}
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposer.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.systemmetadata.metrics;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
 import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,35 +19,26 @@ public class EntityCountMetricsSinkComposer implements EntityCountMetricsSink {
 
   @Override
   public void publish(@Nonnull KeyAspectEntityCountResult result) {
-    RuntimeException lastFailure = null;
-    for (EntityCountMetricsSink sink : delegates) {
-      if (sink == this) {
-        continue;
-      }
-      try {
-        sink.publish(result);
-      } catch (RuntimeException e) {
-        log.warn("Entity count metrics sink {} failed", sink.getClass().getSimpleName(), e);
-        lastFailure = e;
-      }
-    }
-    if (lastFailure != null) {
-      throw lastFailure;
-    }
+    forEachSink(sink -> sink.publish(result), "Entity count metrics sink {} failed");
   }
 
   @Override
   public void publishPlatform(@Nonnull PlatformEntityCountResult result) {
+    forEachSink(
+        sink -> sink.publishPlatform(result), "Entity count platform metrics sink {} failed");
+  }
+
+  private void forEachSink(
+      @Nonnull Consumer<EntityCountMetricsSink> action, @Nonnull String failureMessage) {
     RuntimeException lastFailure = null;
     for (EntityCountMetricsSink sink : delegates) {
       if (sink == this) {
         continue;
       }
       try {
-        sink.publishPlatform(result);
+        action.accept(sink);
       } catch (RuntimeException e) {
-        log.warn(
-            "Entity count platform metrics sink {} failed", sink.getClass().getSimpleName(), e);
+        log.warn(failureMessage, sink.getClass().getSimpleName(), e);
         lastFailure = e;
       }
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposer.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.systemmetadata.metrics;
 
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,26 @@ public class EntityCountMetricsSinkComposer implements EntityCountMetricsSink {
         sink.publish(result);
       } catch (RuntimeException e) {
         log.warn("Entity count metrics sink {} failed", sink.getClass().getSimpleName(), e);
+        lastFailure = e;
+      }
+    }
+    if (lastFailure != null) {
+      throw lastFailure;
+    }
+  }
+
+  @Override
+  public void publishPlatform(@Nonnull PlatformEntityCountResult result) {
+    RuntimeException lastFailure = null;
+    for (EntityCountMetricsSink sink : delegates) {
+      if (sink == this) {
+        continue;
+      }
+      try {
+        sink.publishPlatform(result);
+      } catch (RuntimeException e) {
+        log.warn(
+            "Entity count platform metrics sink {} failed", sink.getClass().getSimpleName(), e);
         lastFailure = e;
       }
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/RecordingEntityCountMetricsSink.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/metrics/RecordingEntityCountMetricsSink.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.systemmetadata.metrics;
 
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -11,10 +12,17 @@ public class RecordingEntityCountMetricsSink implements EntityCountMetricsSink {
 
   private final List<KeyAspectEntityCountResult> results =
       Collections.synchronizedList(new ArrayList<>());
+  private final List<PlatformEntityCountResult> platformResults =
+      Collections.synchronizedList(new ArrayList<>());
 
   @Override
   public void publish(@Nonnull KeyAspectEntityCountResult result) {
     results.add(result);
+  }
+
+  @Override
+  public void publishPlatform(@Nonnull PlatformEntityCountResult result) {
+    platformResults.add(result);
   }
 
   @Nonnull
@@ -22,7 +30,13 @@ public class RecordingEntityCountMetricsSink implements EntityCountMetricsSink {
     return List.copyOf(results);
   }
 
+  @Nonnull
+  public List<PlatformEntityCountResult> platformResults() {
+    return List.copyOf(platformResults);
+  }
+
   public void clear() {
     results.clear();
+    platformResults.clear();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/usage/UsageDimensions.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/usage/UsageDimensions.java
@@ -31,6 +31,9 @@ public final class UsageDimensions {
   public static final String ACTOR_CLASS = "actor_class";
   public static final String ENTITY_TYPE = "entity_type";
 
+  /** Inventory breakdown dimension for data-platform affiliation. */
+  public static final String PLATFORM = "platform";
+
   /**
    * Preferred key order when serializing dimension maps (access-channel keys first, then {@link
    * #ACTOR_CLASS}, then inventory dimensions).
@@ -44,7 +47,8 @@ public final class UsageDimensions {
           AUTH_CHANNEL,
           INGESTION_RUNNER,
           ACTOR_CLASS,
-          ENTITY_TYPE);
+          ENTITY_TYPE,
+          PLATFORM);
 
   private UsageDimensions() {}
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
@@ -1,10 +1,58 @@
 package com.linkedin.metadata.systemmetadata;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
+import com.linkedin.metadata.config.search.EntityIndexConfiguration;
+import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.filter.Filter;
+import org.opensearch.search.aggregations.bucket.terms.Terms;
+import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class PlatformEntityCountsTest {
+
+  private SearchClientShim<?> searchClient;
+  private EntityRegistry entityRegistry;
+  private EntitySpec datasetSpec;
+  private OperationContext opContext;
+
+  @BeforeMethod
+  public void setUp() {
+    searchClient = mock(SearchClientShim.class);
+    entityRegistry = mock(EntityRegistry.class);
+    datasetSpec = mock(EntitySpec.class);
+    when(datasetSpec.hasAspect("dataPlatformInstance")).thenReturn(true);
+    when(datasetSpec.getSearchGroup()).thenReturn("primary");
+    when(entityRegistry.getEntitySpec("dataset")).thenReturn(datasetSpec);
+    when(entityRegistry.getEntitySpecs()).thenReturn(Map.of("dataset", datasetSpec));
+    opContext = TestOperationContexts.systemContextNoSearchAuthorization();
+  }
 
   @Test
   public void testNormalizePlatform_shortId() {
@@ -18,10 +66,217 @@ public class PlatformEntityCountsTest {
   }
 
   @Test
+  public void testNormalizePlatform_malformedUrnFallsBackToLastSegment() {
+    assertEquals(
+        PlatformEntityCounts.normalizePlatform("urn:li:dataPlatform:snow flake"), "snow flake");
+  }
+
+  @Test
+  public void testNormalizePlatform_trailingColonReturnsRaw() {
+    assertEquals(
+        PlatformEntityCounts.normalizePlatform("urn:li:dataPlatform:"), "urn:li:dataPlatform:");
+  }
+
+  @Test
   public void testNormalizePlatform_missing() {
     assertEquals(
         PlatformEntityCounts.normalizePlatform(PlatformEntityCounts.NO_PLATFORM), "NO_PLATFORM");
     assertEquals(PlatformEntityCounts.normalizePlatform(""), "NO_PLATFORM");
     assertEquals(PlatformEntityCounts.normalizePlatform("   "), "NO_PLATFORM");
+  }
+
+  @Test
+  public void v2QueriesPerEntityIndexAndPlatformKeyword() throws Exception {
+    SearchResponse response = responseWithSnowflakeBucket(7, 1);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    PlatformEntityCountResult result =
+        v2Counts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    SearchRequest request = capturedSearch();
+    String expectedIndex =
+        opContext.getSearchContext().getIndexConvention().getEntityIndexName(opContext, "dataset");
+    assertEquals(request.indices()[0], expectedIndex);
+    assertTrue(request.source().query() instanceof MatchAllQueryBuilder);
+    assertEquals(platformAggField(request), "platform.keyword");
+    assertEquals(result.getCounts().size(), 1);
+    assertEquals(result.getCounts().get(0).getPlatform(), "snowflake");
+    assertEquals(result.getCounts().get(0).getActiveCount(), 7);
+    assertEquals(result.getCounts().get(0).getSoftDeletedCount(), 1);
+  }
+
+  @Test
+  public void v3QueriesSearchGroupIndexAndPlatformField() throws Exception {
+    SearchResponse response = responseWithSnowflakeBucket(4, 0);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    v3Counts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    SearchRequest request = capturedSearch();
+    String expectedIndex =
+        opContext
+            .getSearchContext()
+            .getIndexConvention()
+            .getEntityIndexNameV3(opContext, "primary");
+    assertEquals(request.indices()[0], expectedIndex);
+    assertTrue(request.source().query() instanceof TermQueryBuilder);
+    TermQueryBuilder term = (TermQueryBuilder) request.source().query();
+    assertEquals(term.fieldName(), "_entityType");
+    assertEquals(term.value(), "dataset");
+    assertEquals(platformAggField(request), "platform");
+  }
+
+  @Test
+  public void prefersV2WhenBothEnabled() throws Exception {
+    SearchResponse response = responseWithSnowflakeBucket(1, 0);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    bothEnabledCounts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    SearchRequest request = capturedSearch();
+    assertEquals(
+        request.indices()[0],
+        opContext.getSearchContext().getIndexConvention().getEntityIndexName(opContext, "dataset"));
+    assertEquals(platformAggField(request), "platform.keyword");
+  }
+
+  @Test
+  public void neitherIndexEnabledReturnsEmptyWithoutSearch() throws Exception {
+    EntityIndexConfiguration config =
+        EntityIndexConfiguration.builder()
+            .v2(EntityIndexVersionConfiguration.builder().enabled(false).build())
+            .v3(EntityIndexVersionConfiguration.builder().enabled(false).build())
+            .build();
+    PlatformEntityCounts counts =
+        new PlatformEntityCounts(searchClient, entityRegistry, config, 50);
+
+    PlatformEntityCountResult result = counts.getCountsByPlatform(opContext, List.of("dataset"));
+
+    assertTrue(result.getCounts().isEmpty());
+    verify(searchClient, never()).search(any(), any(), any());
+  }
+
+  @Test
+  public void missingIndexReturnsEmpty() throws Exception {
+    when(searchClient.search(any(), any(), any()))
+        .thenThrow(new OpenSearchStatusException("missing", RestStatus.NOT_FOUND));
+
+    PlatformEntityCountResult result =
+        v2Counts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    assertTrue(result.getCounts().isEmpty());
+  }
+
+  @Test
+  public void ioExceptionFailsRequest() throws Exception {
+    when(searchClient.search(any(), any(), any())).thenThrow(new IOException("search failed"));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> v2Counts().getCountsByPlatform(opContext, List.of("dataset")));
+  }
+
+  @Test
+  public void nonNotFoundOpenSearchExceptionFailsRequest() throws Exception {
+    when(searchClient.search(any(), any(), any()))
+        .thenThrow(new OpenSearchStatusException("unavailable", RestStatus.INTERNAL_SERVER_ERROR));
+
+    assertThrows(
+        RuntimeException.class,
+        () -> v2Counts().getCountsByPlatform(opContext, List.of("dataset")));
+  }
+
+  @Test
+  public void nullAggregationsReturnsEmpty() throws Exception {
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(null);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    PlatformEntityCountResult result =
+        v2Counts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    assertTrue(result.getCounts().isEmpty());
+  }
+
+  @Test
+  public void truncatedTermsAggregationFailsRequest() throws Exception {
+    Terms terms = mock(Terms.class);
+    when(terms.getSumOfOtherDocCounts()).thenReturn(12L);
+    Aggregations aggregations = mock(Aggregations.class);
+    when(aggregations.get("by_platform")).thenReturn(terms);
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(aggregations);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> v2Counts().getCountsByPlatform(opContext, List.of("dataset")));
+  }
+
+  @Test
+  public void skipsTypesWithoutPlatformSearchField() throws Exception {
+    when(datasetSpec.hasAspect("dataPlatformInstance")).thenReturn(false);
+    when(datasetSpec.getSearchableFieldSpecs()).thenReturn(List.of());
+
+    PlatformEntityCountResult result =
+        v2Counts().getCountsByPlatform(opContext, List.of("dataset"));
+
+    assertTrue(result.getCounts().isEmpty());
+    verify(searchClient, never()).search(any(), any(), any());
+  }
+
+  private PlatformEntityCounts v2Counts() {
+    return new PlatformEntityCounts(searchClient, entityRegistry, indexConfig(true, false), 50);
+  }
+
+  private PlatformEntityCounts v3Counts() {
+    return new PlatformEntityCounts(searchClient, entityRegistry, indexConfig(false, true), 50);
+  }
+
+  private PlatformEntityCounts bothEnabledCounts() {
+    return new PlatformEntityCounts(searchClient, entityRegistry, indexConfig(true, true), 50);
+  }
+
+  private static EntityIndexConfiguration indexConfig(boolean v2, boolean v3) {
+    return EntityIndexConfiguration.builder()
+        .v2(EntityIndexVersionConfiguration.builder().enabled(v2).build())
+        .v3(EntityIndexVersionConfiguration.builder().enabled(v3).build())
+        .build();
+  }
+
+  private SearchRequest capturedSearch() throws IOException {
+    ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(searchClient).search(eq(opContext), captor.capture(), any());
+    return captor.getValue();
+  }
+
+  private static String platformAggField(SearchRequest request) {
+    return ((TermsAggregationBuilder)
+            request.source().aggregations().getAggregatorFactories().iterator().next())
+        .field();
+  }
+
+  private static SearchResponse responseWithSnowflakeBucket(long active, long softDeleted) {
+    Filter activeFilter = mock(Filter.class);
+    when(activeFilter.getDocCount()).thenReturn(active);
+    Filter softFilter = mock(Filter.class);
+    when(softFilter.getDocCount()).thenReturn(softDeleted);
+    Aggregations bucketAggs = mock(Aggregations.class);
+    when(bucketAggs.get("active")).thenReturn(activeFilter);
+    when(bucketAggs.get("soft_deleted")).thenReturn(softFilter);
+
+    Terms.Bucket bucket = mock(Terms.Bucket.class);
+    when(bucket.getKeyAsString()).thenReturn("snowflake");
+    when(bucket.getAggregations()).thenReturn(bucketAggs);
+
+    Terms terms = mock(Terms.class);
+    when(terms.getSumOfOtherDocCounts()).thenReturn(0L);
+    doReturn(List.of(bucket)).when(terms).getBuckets();
+
+    Aggregations aggregations = mock(Aggregations.class);
+    when(aggregations.get("by_platform")).thenReturn(terms);
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(aggregations);
+    return response;
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
@@ -1,0 +1,27 @@
+package com.linkedin.metadata.systemmetadata;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class PlatformEntityCountsTest {
+
+  @Test
+  public void testNormalizePlatform_shortId() {
+    assertEquals(PlatformEntityCounts.normalizePlatform("snowflake"), "snowflake");
+  }
+
+  @Test
+  public void testNormalizePlatform_urn() {
+    assertEquals(
+        PlatformEntityCounts.normalizePlatform("urn:li:dataPlatform:snowflake"), "snowflake");
+  }
+
+  @Test
+  public void testNormalizePlatform_missing() {
+    assertEquals(
+        PlatformEntityCounts.normalizePlatform(PlatformEntityCounts.NO_PLATFORM), "NO_PLATFORM");
+    assertEquals(PlatformEntityCounts.normalizePlatform(""), "NO_PLATFORM");
+    assertEquals(PlatformEntityCounts.normalizePlatform("   "), "NO_PLATFORM");
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/PlatformEntityCountsTest.java
@@ -187,15 +187,27 @@ public class PlatformEntityCountsTest {
   }
 
   @Test
-  public void nullAggregationsReturnsEmpty() throws Exception {
+  public void nullAggregationsFailsRequest() throws Exception {
     SearchResponse response = mock(SearchResponse.class);
     when(response.getAggregations()).thenReturn(null);
     when(searchClient.search(any(), any(), any())).thenReturn(response);
 
-    PlatformEntityCountResult result =
-        v2Counts().getCountsByPlatform(opContext, List.of("dataset"));
+    assertThrows(
+        RuntimeException.class,
+        () -> v2Counts().getCountsByPlatform(opContext, List.of("dataset")));
+  }
 
-    assertTrue(result.getCounts().isEmpty());
+  @Test
+  public void missingByPlatformAggregationFailsRequest() throws Exception {
+    Aggregations aggregations = mock(Aggregations.class);
+    when(aggregations.get("by_platform")).thenReturn(null);
+    SearchResponse response = mock(SearchResponse.class);
+    when(response.getAggregations()).thenReturn(aggregations);
+    when(searchClient.search(any(), any(), any())).thenReturn(response);
+
+    assertThrows(
+        RuntimeException.class,
+        () -> v2Counts().getCountsByPlatform(opContext, List.of("dataset")));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisherTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisherTest.java
@@ -14,6 +14,9 @@ import com.linkedin.metadata.config.EntityCountMetricsConfiguration;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountEntry;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountService;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountEntry;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCounts;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -182,6 +185,57 @@ public class EntityCountMetricsPublisherTest {
     clampedPublisher.close();
   }
 
+  @Test
+  public void refreshPublishesPlatformCountsWhenConfigured() {
+    PlatformEntityCounts platformEntityCounts = mock(PlatformEntityCounts.class);
+    RecordingEntityCountMetricsSink recordingSink = new RecordingEntityCountMetricsSink();
+    EntityCountMetricsPublisher platformPublisher =
+        new EntityCountMetricsPublisher(
+            keyAspectEntityCountService,
+            platformEntityCounts,
+            systemOperationContext,
+            recordingSink,
+            micrometerSink,
+            config);
+    KeyAspectEntityCountResult result = sampleResult();
+    PlatformEntityCountResult platformResult = samplePlatformResult();
+    when(keyAspectEntityCountService.getCounts(systemOperationContext, null, false))
+        .thenReturn(result);
+    when(platformEntityCounts.getCountsByPlatform(systemOperationContext, null))
+        .thenReturn(platformResult);
+
+    platformPublisher.refresh();
+
+    verify(platformEntityCounts).getCountsByPlatform(systemOperationContext, null);
+    assertEquals(recordingSink.results(), List.of(result));
+    assertEquals(recordingSink.platformResults(), List.of(platformResult));
+    platformPublisher.close();
+  }
+
+  @Test
+  public void refreshRecordsErrorWhenPlatformCountsFail() {
+    PlatformEntityCounts platformEntityCounts = mock(PlatformEntityCounts.class);
+    EntityCountMetricsPublisher platformPublisher =
+        new EntityCountMetricsPublisher(
+            keyAspectEntityCountService,
+            platformEntityCounts,
+            systemOperationContext,
+            micrometerSink,
+            micrometerSink,
+            config);
+    when(keyAspectEntityCountService.getCounts(systemOperationContext, null, false))
+        .thenReturn(sampleResult());
+    when(platformEntityCounts.getCountsByPlatform(systemOperationContext, null))
+        .thenThrow(new RuntimeException("platform search failed"));
+
+    platformPublisher.refresh();
+
+    assertEquals(
+        registry.get(MicrometerEntityCountMetricsSink.REFRESH_ERRORS_METRIC).counter().count(),
+        1.0);
+    platformPublisher.close();
+  }
+
   private static KeyAspectEntityCountResult sampleResult() {
     return KeyAspectEntityCountResult.builder()
         .counts(
@@ -195,6 +249,21 @@ public class EntityCountMetricsPublisherTest {
         .requestedTypes(List.of("dataset"))
         .computedAt(Instant.now())
         .cacheHit(false)
+        .build();
+  }
+
+  private static PlatformEntityCountResult samplePlatformResult() {
+    return PlatformEntityCountResult.builder()
+        .counts(
+            List.of(
+                PlatformEntityCountEntry.builder()
+                    .entityType("dataset")
+                    .platform("snowflake")
+                    .activeCount(6)
+                    .softDeletedCount(1)
+                    .build()))
+        .requestedTypes(List.of("dataset"))
+        .computedAt(Instant.parse("2026-02-01T23:00:00Z"))
         .build();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisherTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsPublisherTest.java
@@ -42,6 +42,7 @@ public class EntityCountMetricsPublisherTest {
     publisher =
         new EntityCountMetricsPublisher(
             keyAspectEntityCountService,
+            /* platformEntityCounts= */ null,
             systemOperationContext,
             micrometerSink,
             micrometerSink,
@@ -108,7 +109,12 @@ public class EntityCountMetricsPublisherTest {
         new EntityCountMetricsSinkComposer(List.of(micrometerSink, recordingSink));
     EntityCountMetricsPublisher multiSinkPublisher =
         new EntityCountMetricsPublisher(
-            keyAspectEntityCountService, systemOperationContext, composer, micrometerSink, config);
+            keyAspectEntityCountService,
+            null,
+            systemOperationContext,
+            composer,
+            micrometerSink,
+            config);
     KeyAspectEntityCountResult result = sampleResult();
     when(keyAspectEntityCountService.getCounts(systemOperationContext, null, false))
         .thenReturn(result);
@@ -139,6 +145,7 @@ public class EntityCountMetricsPublisherTest {
     EntityCountMetricsPublisher oneShotPublisher =
         new EntityCountMetricsPublisher(
             keyAspectEntityCountService,
+            null,
             systemOperationContext,
             micrometerSink,
             micrometerSink,
@@ -163,6 +170,7 @@ public class EntityCountMetricsPublisherTest {
     EntityCountMetricsPublisher clampedPublisher =
         new EntityCountMetricsPublisher(
             keyAspectEntityCountService,
+            null,
             systemOperationContext,
             micrometerSink,
             micrometerSink,

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/metrics/EntityCountMetricsSinkComposerTest.java
@@ -5,8 +5,11 @@ import static org.testng.Assert.assertThrows;
 
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountEntry;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountEntry;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import java.time.Instant;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.testng.annotations.Test;
 
 public class EntityCountMetricsSinkComposerTest {
@@ -41,6 +44,42 @@ public class EntityCountMetricsSinkComposerTest {
     assertEquals(recordingSink.results(), List.of(result));
   }
 
+  @Test
+  public void publishPlatformDelegatesToAllSinks() {
+    RecordingEntityCountMetricsSink first = new RecordingEntityCountMetricsSink();
+    RecordingEntityCountMetricsSink second = new RecordingEntityCountMetricsSink();
+    EntityCountMetricsSinkComposer composer =
+        new EntityCountMetricsSinkComposer(List.of(first, second));
+    PlatformEntityCountResult result = samplePlatformResult();
+
+    composer.publishPlatform(result);
+
+    assertEquals(first.platformResults(), List.of(result));
+    assertEquals(second.platformResults(), List.of(result));
+  }
+
+  @Test
+  public void publishPlatformContinuesAfterSinkFailureAndRethrowsLastFailure() {
+    RecordingEntityCountMetricsSink recordingSink = new RecordingEntityCountMetricsSink();
+    EntityCountMetricsSinkComposer composer =
+        new EntityCountMetricsSinkComposer(
+            List.of(
+                recordingSink,
+                new EntityCountMetricsSink() {
+                  @Override
+                  public void publish(@Nonnull KeyAspectEntityCountResult ignored) {}
+
+                  @Override
+                  public void publishPlatform(@Nonnull PlatformEntityCountResult ignored) {
+                    throw new RuntimeException("platform sink failed");
+                  }
+                }));
+    PlatformEntityCountResult result = samplePlatformResult();
+
+    assertThrows(RuntimeException.class, () -> composer.publishPlatform(result));
+    assertEquals(recordingSink.platformResults(), List.of(result));
+  }
+
   private static KeyAspectEntityCountResult sampleResult() {
     return KeyAspectEntityCountResult.builder()
         .counts(
@@ -54,6 +93,21 @@ public class EntityCountMetricsSinkComposerTest {
         .requestedTypes(List.of("dataset"))
         .computedAt(Instant.now())
         .cacheHit(false)
+        .build();
+  }
+
+  private static PlatformEntityCountResult samplePlatformResult() {
+    return PlatformEntityCountResult.builder()
+        .counts(
+            List.of(
+                PlatformEntityCountEntry.builder()
+                    .entityType("dataset")
+                    .platform("snowflake")
+                    .activeCount(6)
+                    .softDeletedCount(1)
+                    .build()))
+        .requestedTypes(List.of("dataset"))
+        .computedAt(Instant.parse("2026-02-01T23:00:00Z"))
         .build();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageDimensionsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/usage/UsageDimensionsTest.java
@@ -20,6 +20,7 @@ public class UsageDimensionsTest {
     Assert.assertEquals(UsageDimensions.INGESTION_RUNNER, "ingestion_runner");
     Assert.assertEquals(UsageDimensions.ACTOR_CLASS, "actor_class");
     Assert.assertEquals(UsageDimensions.ENTITY_TYPE, "entity_type");
+    Assert.assertEquals(UsageDimensions.PLATFORM, "platform");
   }
 
   @Test
@@ -34,7 +35,8 @@ public class UsageDimensionsTest {
             UsageDimensions.AUTH_CHANNEL,
             UsageDimensions.INGESTION_RUNNER,
             UsageDimensions.ACTOR_CLASS,
-            UsageDimensions.ENTITY_TYPE));
+            UsageDimensions.ENTITY_TYPE,
+            UsageDimensions.PLATFORM));
   }
 
   @Test

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/EntityCountMetricsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/EntityCountMetricsFactory.java
@@ -53,6 +53,8 @@ public class EntityCountMetricsFactory {
   public EntityCountMetricsPublisher entityCountMetricsPublisher(
       @Qualifier("keyAspectEntityCountService")
           KeyAspectEntityCountService keyAspectEntityCountService,
+      @Autowired(required = false) @Qualifier("platformEntityCounts")
+          com.linkedin.metadata.systemmetadata.PlatformEntityCounts platformEntityCounts,
       @Qualifier("systemOperationContext") OperationContext systemOperationContext,
       EntityCountMetricsSinkComposer entityCountMetricsSinkComposer,
       @Autowired(required = false)
@@ -62,6 +64,7 @@ public class EntityCountMetricsFactory {
     entityCountMetricsPublisher =
         new EntityCountMetricsPublisher(
             keyAspectEntityCountService,
+            platformEntityCounts,
             systemOperationContext,
             entityCountMetricsSinkComposer,
             micrometerEntityCountMetricsSink,

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/PlatformEntityCountsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/PlatformEntityCountsFactory.java
@@ -1,0 +1,25 @@
+package com.linkedin.gms.factory.systemmetadata;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCounts;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import javax.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PlatformEntityCountsFactory {
+
+  @Bean(name = "platformEntityCounts")
+  @Nonnull
+  protected PlatformEntityCounts platformEntityCounts(
+      @Qualifier("searchClientShim") SearchClientShim<?> searchClient,
+      @Qualifier("entityRegistry") EntityRegistry entityRegistry,
+      ConfigurationProvider configurationProvider) {
+    int maxEntityTypes =
+        configurationProvider.getCache().getEntityCounts().getKeyAspect().getMaxEntityTypes();
+    return new PlatformEntityCounts(searchClient, entityRegistry, maxEntityTypes);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/PlatformEntityCountsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/systemmetadata/PlatformEntityCountsFactory.java
@@ -20,6 +20,10 @@ public class PlatformEntityCountsFactory {
       ConfigurationProvider configurationProvider) {
     int maxEntityTypes =
         configurationProvider.getCache().getEntityCounts().getKeyAspect().getMaxEntityTypes();
-    return new PlatformEntityCounts(searchClient, entityRegistry, maxEntityTypes);
+    return new PlatformEntityCounts(
+        searchClient,
+        entityRegistry,
+        configurationProvider.getElasticSearch().getEntityIndex(),
+        maxEntityTypes);
   }
 }

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/entities/EntityTypeCountDto.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v1/models/entities/EntityTypeCountDto.java
@@ -12,6 +12,10 @@ import lombok.NoArgsConstructor;
 public class EntityTypeCountDto {
   private String entityType;
   private String keyAspect;
+
+  /** Present when {@code groupBy=platform}; absent/null for type-only counts. */
+  private String platform;
+
   private long activeCount;
   private long softDeletedCount;
   private Long totalCount;

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsController.java
@@ -63,7 +63,10 @@ public class EntityCountsController {
       description =
           "Returns active and soft-deleted entity counts per registry key aspect. "
               + "Omit types for all entity types. Pass groupBy=platform for a "
-              + "(entityType, platform) breakdown from the entity search index.")
+              + "(entityType, platform) breakdown from the entity search index "
+              + "(live aggregation; skipCache does not apply). With groupBy=platform, "
+              + "includeTotal sums only returned (entityType, platform) rows; types "
+              + "without a searchable platform field are omitted.")
   public ResponseEntity<EntityCountsResponseDto> getEntityCounts(
       HttpServletRequest request,
       @Parameter(description = "Entity types to include. Omit for all registry entity types.")
@@ -75,10 +78,17 @@ public class EntityCountsController {
                       + "NO_PLATFORM for missing values).")
           @RequestParam(name = "groupBy", required = false)
           String groupBy,
-      @Parameter(description = "When true, include totalCount rollups in the response.")
+      @Parameter(
+              description =
+                  "When true, include totalCount rollups in the response. With "
+                      + "groupBy=platform, totals sum only returned (entityType, platform) "
+                      + "rows; types without a searchable platform field are omitted.")
           @RequestParam(name = "includeTotal", required = false, defaultValue = "false")
           boolean includeTotal,
-      @Parameter(description = "When true, bypass the distributed entity count cache.")
+      @Parameter(
+              description =
+                  "When true, bypass the distributed entity count cache. Ignored when "
+                      + "groupBy=platform (platform counts are always computed live).")
           @RequestParam(name = "skipCache", required = false, defaultValue = "false")
           boolean skipCache) {
     OperationContext opContext = buildSession(request, "getEntityCounts", types);

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsController.java
@@ -9,6 +9,8 @@ import com.datahub.authorization.AuthorizerChain;
 import com.linkedin.metadata.authorization.ApiGroup;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountService;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCounts;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.openapi.exception.UnauthorizedException;
@@ -36,30 +38,43 @@ import org.springframework.web.bind.annotation.RestController;
     description = "Entity counts from the system metadata index by key aspect.")
 public class EntityCountsController {
 
+  private static final String GROUP_BY_PLATFORM = "platform";
+
   private final AuthorizerChain authorizerChain;
   private final OperationContext systemOperationContext;
   private final KeyAspectEntityCountService keyAspectEntityCountService;
+  private final PlatformEntityCounts platformEntityCounts;
 
   public EntityCountsController(
       AuthorizerChain authorizerChain,
       @Qualifier("systemOperationContext") OperationContext systemOperationContext,
       @Qualifier("keyAspectEntityCountService")
-          KeyAspectEntityCountService keyAspectEntityCountService) {
+          KeyAspectEntityCountService keyAspectEntityCountService,
+      @Qualifier("platformEntityCounts") PlatformEntityCounts platformEntityCounts) {
     this.authorizerChain = authorizerChain;
     this.systemOperationContext = systemOperationContext;
     this.keyAspectEntityCountService = keyAspectEntityCountService;
+    this.platformEntityCounts = platformEntityCounts;
   }
 
   @GetMapping(path = "/counts", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(
       summary = "Get entity counts by type",
       description =
-          "Returns active and soft-deleted entity counts per registry key aspect. Omit types for all entity types.")
+          "Returns active and soft-deleted entity counts per registry key aspect. "
+              + "Omit types for all entity types. Pass groupBy=platform for a "
+              + "(entityType, platform) breakdown from the entity search index.")
   public ResponseEntity<EntityCountsResponseDto> getEntityCounts(
       HttpServletRequest request,
       @Parameter(description = "Entity types to include. Omit for all registry entity types.")
           @RequestParam(name = "types", required = false)
           List<String> types,
+      @Parameter(
+              description =
+                  "Optional breakdown. Supported: platform (search-index terms agg with "
+                      + "NO_PLATFORM for missing values).")
+          @RequestParam(name = "groupBy", required = false)
+          String groupBy,
       @Parameter(description = "When true, include totalCount rollups in the response.")
           @RequestParam(name = "includeTotal", required = false, defaultValue = "false")
           boolean includeTotal,
@@ -68,6 +83,17 @@ public class EntityCountsController {
           boolean skipCache) {
     OperationContext opContext = buildSession(request, "getEntityCounts", types);
     authorizeCountsRead(opContext);
+
+    if (groupBy != null && !groupBy.isBlank()) {
+      if (!GROUP_BY_PLATFORM.equalsIgnoreCase(groupBy.trim())) {
+        throw new IllegalArgumentException(
+            "Unsupported groupBy='" + groupBy + "'. Supported values: platform");
+      }
+      PlatformEntityCountResult platformResult =
+          platformEntityCounts.getCountsByPlatform(opContext, types);
+      return ResponseEntity.ok(
+          EntityCountsResponseMapper.toPlatformBatchResponse(platformResult, includeTotal));
+    }
 
     KeyAspectEntityCountResult result =
         keyAspectEntityCountService.getCounts(opContext, types, skipCache);

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsResponseMapper.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntityCountsResponseMapper.java
@@ -2,6 +2,8 @@ package io.datahubproject.openapi.v1.entities;
 
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountEntry;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountEntry;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
 import io.datahubproject.openapi.v1.models.entities.EntityCountsResponseDto;
 import io.datahubproject.openapi.v1.models.entities.EntityTypeCountDto;
 import io.datahubproject.openapi.v1.models.entities.EntityTypeCountResponseDto;
@@ -39,6 +41,34 @@ final class EntityCountsResponseMapper {
   }
 
   @Nonnull
+  static EntityCountsResponseDto toPlatformBatchResponse(
+      @Nonnull PlatformEntityCountResult result, boolean includeTotal) {
+    List<EntityTypeCountDto> counts =
+        result.getCounts().stream()
+            .map(entry -> toPlatformCountDto(entry, includeTotal))
+            .collect(Collectors.toList());
+
+    EntityCountsResponseDto.EntityCountsResponseDtoBuilder builder =
+        EntityCountsResponseDto.builder()
+            .counts(counts)
+            .requestedTypes(result.getRequestedTypes())
+            .computedAtMillis(result.getComputedAt().toEpochMilli())
+            .cacheHit(false);
+
+    if (includeTotal) {
+      long active =
+          result.getCounts().stream().mapToLong(PlatformEntityCountEntry::getActiveCount).sum();
+      long soft =
+          result.getCounts().stream()
+              .mapToLong(PlatformEntityCountEntry::getSoftDeletedCount)
+              .sum();
+      builder.activeTotal(active).softDeletedTotal(soft).totalCount(active + soft);
+    }
+
+    return builder.build();
+  }
+
+  @Nonnull
   static EntityTypeCountResponseDto toSingleResponse(
       @Nonnull KeyAspectEntityCountResult result, boolean includeTotal) {
     KeyAspectEntityCountEntry entry = result.getCounts().get(0);
@@ -65,6 +95,23 @@ final class EntityCountsResponseMapper {
         EntityTypeCountDto.builder()
             .entityType(entry.getEntityType())
             .keyAspect(entry.getKeyAspect())
+            .activeCount(entry.getActiveCount())
+            .softDeletedCount(entry.getSoftDeletedCount());
+
+    if (includeTotal) {
+      builder.totalCount(entry.totalCount());
+    }
+
+    return builder.build();
+  }
+
+  @Nonnull
+  private static EntityTypeCountDto toPlatformCountDto(
+      @Nonnull PlatformEntityCountEntry entry, boolean includeTotal) {
+    EntityTypeCountDto.EntityTypeCountDtoBuilder builder =
+        EntityTypeCountDto.builder()
+            .entityType(entry.getEntityType())
+            .platform(entry.getPlatform())
             .activeCount(entry.getActiveCount())
             .softDeletedCount(entry.getSoftDeletedCount());
 

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntityCountsControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntityCountsControllerTest.java
@@ -220,6 +220,22 @@ public class EntityCountsControllerTest {
   }
 
   @Test
+  public void getEntityCountsUnsupportedGroupByReturnsBadRequest() throws Exception {
+    authUtilMock
+        .when(
+            () ->
+                AuthUtil.isAPIAuthorized(
+                    any(OperationContext.class), eq(ApiGroup.COUNTS), eq(ApiOperation.READ)))
+        .thenReturn(true);
+
+    mockMvc
+        .perform(
+            get("/openapi/v1/entities/counts?types=dataset&groupBy=foo")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   public void getEntityTypeCountReturnsSingleType() throws Exception {
     authUtilMock
         .when(

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntityCountsControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntityCountsControllerTest.java
@@ -17,6 +17,9 @@ import com.linkedin.metadata.authorization.ApiOperation;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountEntry;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountResult;
 import com.linkedin.metadata.systemmetadata.KeyAspectEntityCountService;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountEntry;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCountResult;
+import com.linkedin.metadata.systemmetadata.PlatformEntityCounts;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
@@ -36,6 +39,7 @@ public class EntityCountsControllerTest {
   private MockMvc mockMvc;
   private AuthorizerChain mockAuthorizerChain;
   private KeyAspectEntityCountService keyAspectEntityCountService;
+  private PlatformEntityCounts platformEntityCounts;
   private OperationContext operationContext;
   private MockedStatic<AuthUtil> authUtilMock;
   private MockedStatic<AuthenticationContext> authContextMock;
@@ -44,6 +48,7 @@ public class EntityCountsControllerTest {
   public void setup() {
     mockAuthorizerChain = mock(AuthorizerChain.class);
     keyAspectEntityCountService = mock(KeyAspectEntityCountService.class);
+    platformEntityCounts = mock(PlatformEntityCounts.class);
     operationContext = TestOperationContexts.systemContextNoSearchAuthorization();
     Authentication authentication = mock(Authentication.class);
 
@@ -53,7 +58,10 @@ public class EntityCountsControllerTest {
 
     EntityCountsController controller =
         new EntityCountsController(
-            mockAuthorizerChain, operationContext, keyAspectEntityCountService);
+            mockAuthorizerChain,
+            operationContext,
+            keyAspectEntityCountService,
+            platformEntityCounts);
     mockMvc =
         MockMvcBuilders.standaloneSetup(controller)
             .setControllerAdvice(new GlobalControllerExceptionHandler())
@@ -161,6 +169,54 @@ public class EntityCountsControllerTest {
         .andExpect(jsonPath("$.softDeletedTotal").value(2))
         .andExpect(jsonPath("$.totalCount").value(12))
         .andExpect(jsonPath("$.computedAtMillis").exists());
+  }
+
+  @Test
+  public void getEntityCountsGroupByPlatformReturnsPlatformRows() throws Exception {
+    authUtilMock
+        .when(
+            () ->
+                AuthUtil.isAPIAuthorized(
+                    any(OperationContext.class), eq(ApiGroup.COUNTS), eq(ApiOperation.READ)))
+        .thenReturn(true);
+
+    PlatformEntityCountResult result =
+        PlatformEntityCountResult.builder()
+            .counts(
+                List.of(
+                    PlatformEntityCountEntry.builder()
+                        .entityType("dataset")
+                        .platform("snowflake")
+                        .activeCount(10L)
+                        .softDeletedCount(2L)
+                        .build(),
+                    PlatformEntityCountEntry.builder()
+                        .entityType("dataset")
+                        .platform(PlatformEntityCounts.NO_PLATFORM)
+                        .activeCount(1L)
+                        .softDeletedCount(0L)
+                        .build()))
+            .requestedTypes(List.of("dataset"))
+            .computedAt(Instant.parse("2026-07-07T15:00:00Z"))
+            .build();
+    when(platformEntityCounts.getCountsByPlatform(
+            any(OperationContext.class), eq(List.of("dataset"))))
+        .thenReturn(result);
+
+    mockMvc
+        .perform(
+            get("/openapi/v1/entities/counts?types=dataset&groupBy=platform&includeTotal=true")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.counts[0].entityType").value("dataset"))
+        .andExpect(jsonPath("$.counts[0].platform").value("snowflake"))
+        .andExpect(jsonPath("$.counts[0].activeCount").value(10))
+        .andExpect(jsonPath("$.counts[0].softDeletedCount").value(2))
+        .andExpect(jsonPath("$.counts[0].totalCount").value(12))
+        .andExpect(jsonPath("$.counts[1].platform").value(PlatformEntityCounts.NO_PLATFORM))
+        .andExpect(jsonPath("$.activeTotal").value(11))
+        .andExpect(jsonPath("$.softDeletedTotal").value(2))
+        .andExpect(jsonPath("$.totalCount").value(13));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds `PlatformEntityCounts` — search-index terms aggregation over `platform` (with `NO_PLATFORM` for missing values) to produce active/soft-deleted inventory by `(entityType, platform)`.
- Extends `GET /openapi/v1/entities/counts` with optional `groupBy=platform` for dimensional breakdowns.
- Wires platform inventory into the entity count metrics publisher via a new `publishPlatform` sink hook (default no-op for existing sinks like Micrometer).

`groupBy=platform` is always computed live (`skipCache` does not apply). With `includeTotal`, totals sum only returned `(entityType, platform)` rows; types without a searchable `platform` field are omitted.

## Test plan

- [x] `./gradlew :metadata-io:test --tests "com.linkedin.metadata.systemmetadata.*" --tests "com.linkedin.metadata.usage.UsageDimensionsTest"`
- [x] `./gradlew :metadata-service:openapi-servlet:test --tests "io.datahubproject.openapi.v1.entities.EntityCountsControllerTest"`
- [ ] Manual: `GET /openapi/v1/entities/counts?types=dataset&groupBy=platform&includeTotal=true` against a dev instance with indexed datasets