### PR TITLE
fix(docker): use printf for requirement lists in datahub-actions image build (1/2 for AI smoke)

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -308,7 +308,7 @@ ENV UV_CONSTRAINT=${DATAHUB_BUNDLED_VENV_PATH}/constraints.txt
 
 USER datahub
 RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
-    echo "-e /metadata-ingestion/ \n -e /datahub-actions/[all]" | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
+    printf -- '-e /metadata-ingestion/\n-e /datahub-actions/[all]\n' | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
 USER 0
 
 COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
@@ -393,7 +393,7 @@ ENV UV_CONSTRAINT=${DATAHUB_BUNDLED_VENV_PATH}/constraints.txt
 
 USER datahub
 RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
-    echo "-e /metadata-ingestion/ \n -e /datahub-actions/[all]" | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
+    printf -- '-e /metadata-ingestion/\n-e /datahub-actions/[all]\n' | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
 USER 0
 
 COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
@@ -472,7 +472,7 @@ ENV UV_CONSTRAINT=${DATAHUB_BUNDLED_VENV_PATH}/constraints.txt
 USER datahub
 # Install only datahub-actions, NOT metadata-ingestion
 RUN --mount=type=secret,id=netrc,target=/home/datahub/.netrc,required=false,uid=1000,gid=1000 \
-    echo "-e /datahub-actions/[all]" | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
+    printf -- '-e /datahub-actions/[all]\n' | uv pip compile /dev/stdin | grep -v "\-e" | uv pip install -r /dev/stdin
 USER 0
 
 COPY --chown=datahub:datahub ./datahub-actions /datahub-actions


### PR DESCRIPTION
> **Part of a two-PR fix for the "AI Smoke Tests (Local Embeddings)" failure.**
> This PR (**1 of 2**) fixes the image-build breakage that kills the workflow at its first step.
> #19562 (2 of 2) fixes the `system-update` `ImmutableMap` mutation the workflow hits next — once
> the build succeeds — and adds this Dockerfile to the workflow's trigger paths. **Merge this first,
> then #19562.** "AI Smoke Tests (Local Embeddings)" is only green end-to-end after both.

## Problem

Every "AI Smoke Tests (Local Embeddings)" run on master has failed since 2026-08-29 (last green: 2026-08-28), and the same job fails on every open PR — which also turns the required **Mergeable** check red repo-wide. The failing step is the datahub-actions image build:

```
error: Distribution not found at: file:///metadata-ingestion/%20%5Cn%20-e%20/datahub-actions
```

## Root cause

The Dockerfile pipes a requirements list to uv with:

```
echo "-e /metadata-ingestion/ \n -e /datahub-actions/[all]" | uv pip compile /dev/stdin | ...
```

This relies on the base image's `/bin/sh` `echo` interpreting `\n`. No repo change landed in the 08-28 → 08-29 break window; a base image update changed the echo behavior, so the escape is now emitted literally and uv receives one mangled requirement line (`/metadata-ingestion/ \n -e /datahub-actions/[all]` as a single path).

## Fix

Use `printf`, which interprets backslash escapes in its format string by POSIX regardless of shell or echo implementation:

```
printf -- '-e /metadata-ingestion/\n-e /datahub-actions/[all]\n' | uv pip compile /dev/stdin | ...
```

All three sites in the Dockerfile converted (the single-line one only for consistency — it wasn't broken).

## Validation

This PR's file (`docker/datahub-actions/Dockerfile`) isn't in the AI-smoke workflow's trigger paths yet — #19562 adds it — so the workflow does not run on this PR alone. Validated via draft #19563, which stacks both fixes: its "Quickstart AI + Semantic Search Smoke Test" run passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `datahub-actions` Docker build so the "AI Smoke Tests (Local Embeddings)" job passes again. A base image update made `echo` emit `\n` escapes literally, so `uv` received one mangled requirement path; switching to `printf` restores POSIX escape interpretation across all three requirement-list sites.

<sup>Written for commit a78f479f9fc43c24ea605f34b83c231cd2b6d3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
