### PR TITLE
test(smoke): correct domain markers on misclassified smoke modules

### DIFF
--- a/smoke-test/tests/analytics/test_analytics.py
+++ b/smoke-test/tests/analytics/test_analytics.py
@@ -6,7 +6,7 @@ from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.CATALOG)]
 
 
 def test_analytics_charts_have_data(auth_session, analytics_events_loaded):

--- a/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
+++ b/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
@@ -20,7 +20,7 @@ import requests
 from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd, wait_for_healthcheck_util
 
-pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 class TestGraphQLCLIStandalone:

--- a/smoke-test/tests/cli/user_cmd/test_user_add.py
+++ b/smoke-test/tests/cli/user_cmd/test_user_add.py
@@ -11,7 +11,7 @@ from tests.utils import run_datahub_cmd, unique_suffix
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 def generate_test_email() -> str:

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -14,7 +14,7 @@ from tests.utils import delete_urns, run_datahub_cmd, sync_elastic
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 def datahub_upsert_group(auth_session: Any, group: CorpGroup) -> None:

--- a/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
@@ -12,7 +12,7 @@ from tests.consistency_utils import wait_for_writes_to_sync
 from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
-pytestmark = pytest.mark.domain(Domain.INGESTION, Domain.PLATFORM)
+pytestmark = pytest.mark.domain(Domain.INGESTION)
 
 
 def datahub_upsert_user(auth_session, user: CorpUser) -> None:

--- a/smoke-test/tests/read_only/test_analytics.py
+++ b/smoke-test/tests/read_only/test_analytics.py
@@ -7,7 +7,7 @@ from tests.utilities.metadata_operations import (
     get_metadata_analytics_charts,
 )
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = pytest.mark.domain(Domain.CATALOG)
 
 
 @pytest.mark.read_only


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the domain markers on several smoke test modules so they run under the right domains in CI. Tests previously marked as PLATFORM are now marked as CATALOG where they exercise analytics, and CLI tests that were marked as both INGESTION and PLATFORM are now only INGESTION.

<sup>Written for commit 6c83ad10d88c923223eabebd968c57b0779e2c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

