### PR TITLE
fix(ingest): give db2 a real filesystem for CREATE DATABASE, probe readiness by connecting

### DIFF
--- a/metadata-ingestion/tests/integration/db2/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/db2/docker-compose.yml
@@ -6,6 +6,16 @@ services:
     image: icr.io/db2_community/db2:12.1.4.0
     platform: linux/amd64
     privileged: true
+    # DB2 does 512-byte-aligned direct I/O unless DB2_4K_DEVICE_SUPPORT=ON;
+    # on 4K-native-sector storage (CI runners) pwrite fails with EINVAL and
+    # CREATE DATABASE dies with SQL0293N. `su - db2inst1` scrubs the container
+    # environment, so the registry variable is injected via /etc/profile.d.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >-
+        echo 'export DB2_4K_DEVICE_SUPPORT=ON' > /etc/profile.d/db2_4k.sh
+        && exec /var/db2_setup/lib/setup_db2_instance.sh
     environment:
       DBNAME: testdb
       DB2INST1_PASSWORD: password

--- a/metadata-ingestion/tests/integration/db2/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/db2/docker-compose.yml
@@ -2,7 +2,10 @@ services:
   testdb2:
     container_name: "testdb2"
     hostname: db2
-    image: icr.io/db2_community/db2
+    # Pinned: the 'latest' tag moved to 12.1.5.0 on 2026-09-01 and its
+    # bootstrap no longer creates DBNAME before reporting setup complete,
+    # breaking every testIntegrationBatch2 run (SQL30061N: TESTDB not found).
+    image: icr.io/db2_community/db2:12.1.4.0
     platform: linux/amd64
     privileged: true
     environment:

--- a/metadata-ingestion/tests/integration/db2/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/db2/docker-compose.yml
@@ -16,3 +16,12 @@ services:
       ARCHIVE_LOGS: false
     ports:
       - '50000:50000'
+    volumes:
+      # The database path must live on a real filesystem: on the overlayfs
+      # container layer, CREATE DATABASE can fail with SQL0293N (table space
+      # container access) and the setup script only warns and keeps going,
+      # leaving the server up without the database.
+      - db2data:/database
+
+volumes:
+  db2data:

--- a/metadata-ingestion/tests/integration/db2/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/db2/docker-compose.yml
@@ -2,9 +2,7 @@ services:
   testdb2:
     container_name: "testdb2"
     hostname: db2
-    # Pinned: the 'latest' tag moved to 12.1.5.0 on 2026-09-01 and its
-    # bootstrap no longer creates DBNAME before reporting setup complete,
-    # breaking every testIntegrationBatch2 run (SQL30061N: TESTDB not found).
+    # Pinned: 'latest' moves without notice, changing setup behavior under CI.
     image: icr.io/db2_community/db2:12.1.4.0
     platform: linux/amd64
     privileged: true

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import platform
-import subprocess
 
 import pytest
 import sqlalchemy
@@ -16,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.integration_batch_4
 DB2_PORT = 50000
+DB2_URL = f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
 
 
 @pytest.fixture(scope="module")
@@ -23,13 +23,19 @@ def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/db2"
 
 
-def is_db2_up(container_name: str) -> bool:
-    cmd = f"docker logs {container_name} 2>&1 | grep 'Setup has completed.'"
-    ret = subprocess.run(
-        cmd,
-        shell=True,
-    )
-    return ret.returncode == 0
+def is_db2_up() -> bool:
+    """Readiness = the test database accepts a connection. The container log
+    line "Setup has completed." is printed at the START of boot in current
+    images, before the multi-minute instance and database creation, so
+    log-grepping cannot signal readiness."""
+    engine = sqlalchemy.create_engine(DB2_URL)
+    try:
+        with engine.connect():
+            return True
+    except Exception:
+        return False
+    finally:
+        engine.dispose()
 
 
 def _split_statements(sql):
@@ -67,15 +73,13 @@ def db2_runner(docker_compose_runner, pytestconfig, test_resources_dir):
             "testdb2",
             DB2_PORT,
             timeout=600,
-            checker=lambda: is_db2_up("testdb2"),
+            checker=is_db2_up,
         )
 
         setup_filename = test_resources_dir / "setup" / "setup.sql"
         statements = _split_statements(open(setup_filename).read())
 
-        engine = sqlalchemy.create_engine(
-            f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
-        )
+        engine = sqlalchemy.create_engine(DB2_URL)
         with engine.begin() as conn:
             for statement in statements:
                 logger.info("Executing SQL: " + statement)

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import logging
 import os
 import platform
@@ -23,11 +24,7 @@ def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/db2"
 
 
-def is_db2_up() -> bool:
-    """Readiness = the test database accepts a connection. The container log
-    line "Setup has completed." is printed at the START of boot in current
-    images, before the multi-minute instance and database creation, so
-    log-grepping cannot signal readiness."""
+def _attempt_db2_connection() -> bool:
     engine = sqlalchemy.create_engine(DB2_URL)
     try:
         with engine.connect():
@@ -36,6 +33,24 @@ def is_db2_up() -> bool:
         return False
     finally:
         engine.dispose()
+
+
+def is_db2_up() -> bool:
+    """Readiness = the test database accepts a connection. The container log
+    line "Setup has completed." is printed at the START of boot in current
+    images, before the multi-minute instance and database creation, so
+    log-grepping cannot signal readiness.
+
+    The attempt runs in a worker thread with a hard bound: the poll loop's
+    overall timeout only ticks between checker calls, so a stalled handshake
+    inside connect() would otherwise hang the job instead of failing it."""
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(_attempt_db2_connection).result(timeout=30)
+    except concurrent.futures.TimeoutError:
+        return False
+    finally:
+        pool.shutdown(wait=False)
 
 
 def _split_statements(sql):

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import queue
+import subprocess
 import threading
 
 import pytest
@@ -25,6 +26,48 @@ def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/db2"
 
 
+def _shell(cmd: str) -> str:
+    return subprocess.run(
+        cmd, shell=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _db2_setup_failure() -> str | None:
+    """The container's setup script is fail-open: on CREATE DATABASE failure it
+    logs "(!) Failed to create ..." / an SQL error and still reports setup as
+    completed, so the server comes up without the database and readiness would
+    poll out the full timeout. Detect the failure to abort immediately."""
+    logs = _shell("docker logs testdb2 2>&1")
+    for line in logs.splitlines():
+        if "(!) Failed to create" in line or "SQL0293N" in line:
+            return line.strip()
+    return None
+
+
+def _db2_environment_diagnostics() -> str:
+    """Facts needed to diagnose a CREATE DATABASE failure: what filesystem the
+    database path actually sits on, kernel async-I/O headroom, and the DB2
+    diagnostic log entries with the underlying OS error."""
+    return "\n".join(
+        [
+            "--- df -T /database ---",
+            _shell("docker exec testdb2 df -T /database /database/data 2>&1"),
+            "--- mount options ---",
+            _shell(
+                "docker exec testdb2 sh -c 'mount | grep -E \"/database| / \"' 2>&1"
+            ),
+            "--- aio limits (aio-nr / aio-max-nr) ---",
+            _shell(
+                "docker exec testdb2 sh -c 'cat /proc/sys/fs/aio-nr /proc/sys/fs/aio-max-nr' 2>&1"
+            ),
+            "--- db2diag tail ---",
+            _shell(
+                "docker exec testdb2 sh -c 'tail -n 120 /database/config/db2inst1/sqllib/db2dump/DIAG0000/db2diag.log' 2>&1"
+            ),
+        ]
+    )
+
+
 def _attempt_db2_connection() -> bool:
     engine = sqlalchemy.create_engine(DB2_URL)
     try:
@@ -46,6 +89,13 @@ def is_db2_up() -> bool:
     overall timeout only ticks between checker calls, so a stalled handshake
     inside connect() must neither block the loop nor - were the thread
     non-daemon - the interpreter exit."""
+    setup_failure = _db2_setup_failure()
+    if setup_failure is not None:
+        raise RuntimeError(
+            f"DB2 container setup failed: {setup_failure!r}.\n"
+            f"{_db2_environment_diagnostics()}"
+        )
+
     outcome: "queue.Queue[bool]" = queue.Queue(maxsize=1)
     threading.Thread(
         target=lambda: outcome.put(_attempt_db2_connection()), daemon=True

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -1,7 +1,8 @@
-import concurrent.futures
 import logging
 import os
 import platform
+import queue
+import threading
 
 import pytest
 import sqlalchemy
@@ -37,20 +38,22 @@ def _attempt_db2_connection() -> bool:
 
 def is_db2_up() -> bool:
     """Readiness = the test database accepts a connection. The container log
-    line "Setup has completed." is printed at the START of boot in current
-    images, before the multi-minute instance and database creation, so
-    log-grepping cannot signal readiness.
+    line "Setup has completed." is printed even when database creation failed
+    (the setup script only warns and keeps going), so log-grepping cannot
+    signal readiness.
 
-    The attempt runs in a worker thread with a hard bound: the poll loop's
+    The attempt runs in a daemon thread with a hard bound: the poll loop's
     overall timeout only ticks between checker calls, so a stalled handshake
-    inside connect() would otherwise hang the job instead of failing it."""
-    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    inside connect() must neither block the loop nor - were the thread
+    non-daemon - the interpreter exit."""
+    outcome: "queue.Queue[bool]" = queue.Queue(maxsize=1)
+    threading.Thread(
+        target=lambda: outcome.put(_attempt_db2_connection()), daemon=True
+    ).start()
     try:
-        return pool.submit(_attempt_db2_connection).result(timeout=30)
-    except concurrent.futures.TimeoutError:
+        return outcome.get(timeout=30)
+    except queue.Empty:
         return False
-    finally:
-        pool.shutdown(wait=False)
 
 
 def _split_statements(sql):

--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -60,9 +60,13 @@ def _db2_environment_diagnostics() -> str:
             _shell(
                 "docker exec testdb2 sh -c 'cat /proc/sys/fs/aio-nr /proc/sys/fs/aio-max-nr' 2>&1"
             ),
-            "--- db2diag tail ---",
+            "--- device sector sizes ---",
             _shell(
-                "docker exec testdb2 sh -c 'tail -n 120 /database/config/db2inst1/sqllib/db2dump/DIAG0000/db2diag.log' 2>&1"
+                "docker exec testdb2 sh -c 'cat /sys/block/*/queue/logical_block_size /sys/block/*/queue/physical_block_size 2>/dev/null; blockdev --getss --getpbsz /dev/mapper/root 2>&1'"
+            ),
+            "--- db2diag root errors (first Severe/Error entries with OS errno) ---",
+            _shell(
+                "docker exec testdb2 sh -c \"grep -B3 -A22 -E 'LEVEL: (Severe|Error)' /database/config/db2inst1/sqllib/db2dump/DIAG0000/db2diag.log | head -220\" 2>&1"
             ),
         ]
     )


### PR DESCRIPTION
## What
- Inject `DB2_4K_DEVICE_SUPPORT=ON` into the DB2 instance environment (via `/etc/profile.d`, since `su - db2inst1` scrubs container env).
- Mount a named volume at `/database`; probe readiness with a real connection (bounded, daemon thread) instead of grepping logs; fail fast with storage/aio/db2diag diagnostics when container setup fails; pin the image to `12.1.4.0`.

## Why
Every db2 run since 2026-09-01 ~20:00 UTC fails on master and all PRs. Diagnostics captured from the failing runners show the exact root cause: `CREATE DATABASE` dies with `SQL0293N` because `pwrite` under direct I/O returns `EINVAL (22)` (`sqloseekwrite64`, `DIO/CIO Mode = Yes`) — the runners' storage is now 4K-native-sector NVMe (`blockdev` reports 4096), and DB2 issues 512-byte-aligned DIO unless `DB2_4K_DEVICE_SUPPORT=ON`. The image's setup script is fail-open (it logs `(!) Failed to create testdb database` and still reports "Setup has completed."), which is why the old log-grep readiness probe passed and tests failed later with `SQL30061N`.

Verified locally: the profile.d injection reaches the instance (`db2set -all` shows `[e] DB2_4K_DEVICE_SUPPORT=ON`) and the full db2 suite passes (5/5). The 4Kn behavior itself only reproduces on the CI runners — this PR's run is the definitive test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)