### PR TITLE
docs: fix self-hosted MCP endpoint and document shared HTTP deployment

### DIFF
--- a/docs/dev-guides/agent-context/agent-context.md
+++ b/docs/dev-guides/agent-context/agent-context.md
@@ -69,7 +69,7 @@ The fastest way to connect any agent to DataHub is through the [MCP server](../.
 - **DataHub Cloud** — point your agent at the hosted endpoint: `https://<tenant>.acryl.io/integrations/ai/mcp`
 - **Self-hosted (DataHub Core)** — run the [open-source MCP server](https://github.com/acryldata/mcp-server-datahub), configured with `DATAHUB_GMS_URL` (e.g. `http://<gms-host>:8080`):
   - **Local (stdio)** — `uvx mcp-server-datahub@latest`, launched by your agent
-  - **Shared (HTTP)** — `mcp-server-datahub-http`, then point agents at `http://<host>:8000/mcp`, each with their own DataHub token ([setup](https://github.com/acryldata/mcp-server-datahub#docker-http-deployment))
+  - **Shared (HTTP)** — `mcp-server-datahub-http`, then point agents at `http://<host>:8000/mcp`, each with their own DataHub token ([setup](../../features/feature-guides/mcp.md#shared-http-deployment))
 
 See the [MCP Server Guide](../../features/feature-guides/mcp.md) for authentication and setup.
 

--- a/docs/dev-guides/agent-context/agent-context.md
+++ b/docs/dev-guides/agent-context/agent-context.md
@@ -64,10 +64,12 @@ _"Tag all columns containing email addresses with the PII glossary term across o
 
 ## Getting Started
 
-The fastest way to connect any agent to DataHub is through the [MCP server](../../features/feature-guides/mcp.md) — just point your agent at the endpoint:
+The fastest way to connect any agent to DataHub is through the [MCP server](../../features/feature-guides/mcp.md):
 
-- **DataHub Cloud**: `https://<tenant>.acryl.io/integrations/ai/mcp`
-- **Self-hosted**: `http://<gms-host>:8080/mcp`
+- **DataHub Cloud** — point your agent at the hosted endpoint: `https://<tenant>.acryl.io/integrations/ai/mcp`
+- **Self-hosted (DataHub Core)** — run the [open-source MCP server](https://github.com/acryldata/mcp-server-datahub), configured with `DATAHUB_GMS_URL` (e.g. `http://<gms-host>:8080`):
+  - **Local (stdio)** — `uvx mcp-server-datahub@latest`, launched by your agent
+  - **Shared (HTTP)** — `mcp-server-datahub-http`, then point agents at `http://<host>:8000/mcp`, each with their own DataHub token ([setup](https://github.com/acryldata/mcp-server-datahub#docker-http-deployment))
 
 See the [MCP Server Guide](../../features/feature-guides/mcp.md) for authentication and setup.
 

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -636,7 +636,8 @@ docker run -p 8000:8000 \
 Or without Docker:
 
 ```bash
-DATAHUB_GMS_URL="<your-datahub-url>" FASTMCP_HOST=0.0.0.0 uvx mcp-server-datahub-http
+DATAHUB_GMS_URL="<your-datahub-url>" FASTMCP_HOST=0.0.0.0 \
+  uvx --from mcp-server-datahub mcp-server-datahub-http
 ```
 
 :::caution

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -636,7 +636,7 @@ docker run -p 8000:8000 \
 Or without Docker:
 
 ```bash
-DATAHUB_GMS_URL="<your-datahub-url>" FASTMCP_HOST=0.0.0.0 mcp-server-datahub-http
+DATAHUB_GMS_URL="<your-datahub-url>" FASTMCP_HOST=0.0.0.0 uvx mcp-server-datahub-http
 ```
 
 :::caution

--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -497,7 +497,7 @@ Combine a service account with a default view to create a tightly-scoped MCP con
 
 ## Self-Hosted MCP Server Usage
 
-Run the [open-source MCP server](https://github.com/acryldata/mcp-server-datahub) locally. This works with any DataHub instance — both DataHub Core and DataHub Cloud.
+Run the [open-source MCP server](https://github.com/acryldata/mcp-server-datahub) yourself. This works with any DataHub instance — both DataHub Core and DataHub Cloud. Run it locally for a single user, or as a [shared HTTP service](#shared-http-deployment) for a team.
 
 ### Prerequisites
 
@@ -618,6 +618,46 @@ For other AI tools, provide the following configuration:
   - `DATAHUB_GMS_TOKEN`: `<your-datahub-token>`
 
 </details>
+
+### Shared HTTP Deployment
+
+:::info
+Requires [mcp-server-datahub](https://github.com/acryldata/mcp-server-datahub) v0.7.0+. Earlier versions expose an HTTP transport with no per-request authentication, which is not safe to share between users.
+:::
+
+The setups above run one server per person. To serve a whole team from a single deployment, run the HTTP entry point instead. Each user authenticates with their **own** DataHub token, so permissions, search results, and audit attribution stay per-user.
+
+```bash
+docker run -p 8000:8000 \
+  -e DATAHUB_GMS_URL="<your-datahub-url>" \
+  acryldata/mcp-server-datahub:latest
+```
+
+Or without Docker:
+
+```bash
+DATAHUB_GMS_URL="<your-datahub-url>" FASTMCP_HOST=0.0.0.0 mcp-server-datahub-http
+```
+
+:::caution
+Do **not** set `DATAHUB_GMS_TOKEN` on a shared deployment — the server refuses to start when it is present, because a server-wide token would make every user act as a single identity. Your DataHub instance must also run with `METADATA_SERVICE_AUTH_ENABLED=true` so it can establish each caller's identity.
+:::
+
+Clients connect to `http://<host>:8000/mcp` and send their own [personal access token](../../authentication/personal-access-tokens.md) on every request:
+
+```
+Authorization: Bearer <your-datahub-token>
+```
+
+For example, with Claude Code:
+
+```bash
+claude mcp add --transport http datahub \
+  "http://<host>:8000/mcp" \
+  --header "Authorization: Bearer <your-datahub-token>"
+```
+
+The server also exposes an unauthenticated `GET /health` endpoint for load balancer and Kubernetes probes.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary

The Agent Context Kit's Getting Started section pointed self-hosted users at `http://<gms-host>:8080/mcp`. GMS doesn't serve MCP there — `:8080` is the GMS endpoint the MCP server itself connects to, via `DATAHUB_GMS_URL`.

Replaced it with the two real self-hosted paths, and added a Shared HTTP Deployment section to the MCP Server Guide, which previously covered only the local stdio setup.

## Changes

- `agent-context.md` — self-hosted now shows stdio (`uvx mcp-server-datahub@latest`) and shared HTTP (`:8000/mcp`), with `DATAHUB_GMS_URL` in its correct role
- `mcp.md` — new **Shared HTTP Deployment** section: per-user bearer tokens,
  Docker and CLI invocations, the `DATAHUB_GMS_TOKEN` / `METADATA_SERVICE_AUTH_ENABLED` requirements, and `/health`

## Note for reviewers

The HTTP section is gated on `mcp-server-datahub` **v0.7.0+**. That version number is a placeholder — please correct it to the actual release, and confirm `acryldata/mcp-server-datahub:latest` is published before merging.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable) — n/a
- [ ] Tests for the changes have been added/updated (if applicable) — n/a, docs only
- [x] Docs related to the changes have been added/updated (if applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) — n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the self-hosted MCP endpoint in the Agent Context Kit, which pointed users at GMS's `:8080` endpoint instead of the real MCP server paths, and documents a new shared HTTP deployment mode for the MCP server.

- Self-hosted setup now shows the correct local stdio (`uvx mcp-server-datahub@latest`) and shared HTTP (`http://<host>:8000/mcp`) options, with `DATAHUB_GMS_URL` as the connection to GMS.
- The MCP Server Guide gains a **Shared HTTP Deployment** section covering Docker and CLI startup, per-user bearer tokens, and an unauthenticated `/health` endpoint.
- Shared deployments refuse to start with `DATAHUB_GMS_TOKEN` set and require `METADATA_SERVICE_AUTH_ENABLED=true` so each caller keeps their own identity.

**Note for reviewers**
- The shared HTTP section is gated on `mcp-server-datahub` v0.7.0+; this version is a placeholder and needs correcting to the actual release.
- Confirm `acryldata/mcp-server-datahub:latest` is published before merging.

<sup>Written for commit acf131c99a03bd96e66a06ffa0a1ec6c2eda59ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

