### PR TITLE
test(db2): remove temporary skip now that the CI fix has landed

### DIFF
--- a/metadata-ingestion/tests/integration/db2/test_db2.py
+++ b/metadata-ingestion/tests/integration/db2/test_db2.py
@@ -16,15 +16,7 @@ from tests.test_helpers.docker_helpers import wait_for_port
 
 logger = logging.getLogger(__name__)
 
-# TEMPORARY, drop before merge if the db2 CI fix (#19574) has landed: the CI
-# runners currently fail db2's CREATE DATABASE with SQL0293N, breaking every
-# batch run regardless of this PR's content.
-pytestmark = [
-    pytest.mark.integration_batch_4,
-    pytest.mark.skip(
-        reason="db2 CREATE DATABASE fails on CI runner storage (SQL0293N) - see PR #19574"
-    ),
-]
+pytestmark = pytest.mark.integration_batch_4
 DB2_PORT = 50000
 DB2_URL = f"db2+ibm_db://db2inst1:password@localhost:{DB2_PORT}/testdb"
 


### PR DESCRIPTION
## What
Remove the temporary `pytest.mark.skip` on the db2 integration tests.

## Why
The skip was added on #19561 to unblock its CI while db2 was broken for every PR; its comment said to drop it once #19574 landed. Both merged in the same window, so the skip reached master alongside the fix. The db2 job on #19574 already ran green (5 passed) with the exact test code master now has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the temporary skip on the db2 integration tests so they run again. The skip was added to unblock CI while db2's `CREATE DATABASE` failed on CI runners (SQL0293N); the fix has landed and the db2 job already passed green with this exact test code.

<sup>Written for commit 1f8559af271d19f477a58629679c5d8a5abd320c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

