### PR TITLE
feat(ingest/powerbi): lineage between tables of one dataset

### DIFF
--- a/metadata-ingestion/docs/sources/powerbi/powerbi_post.md
+++ b/metadata-ingestion/docs/sources/powerbi/powerbi_post.md
@@ -261,6 +261,51 @@ Native queries reached this way honour `native_query_parsing`: with it disabled,
 referenced query containing `Value.NativeQuery` is not followed, the same as a table's
 own expression.
 
+#### Tables built on other tables
+
+A table can also be built on another table of the same dataset — one that is loaded, so
+it appears in the report in its own right. That reference becomes an edge to it:
+
+```shell
+Sales Enriched        -- loaded
+  = Table.Combine({Sales Current, Sales Archive})
+        |
+        +-----------> Sales Current      -- loaded
+        +-----------> Sales Archive      -- loaded
+                        = Table.SelectRows(Sales Raw, ...)
+                            |
+                            +-----------> Sales Raw    -- loaded
+                                            holds the warehouse connection
+```
+
+Every hop is a table in the model, so every hop is an entity, and the chain can be
+walked from `Sales Enriched` back to the warehouse one table at a time.
+
+This is the counterpart to the section above, and the difference is worth knowing when
+deciding whether to switch "Enable load" off. A query with the switch **off** has no
+entity, so the warehouse table is attributed to whichever loaded table is built on it
+and the intermediate steps do not appear. A query with the switch **on** is a table, so
+it keeps its own lineage and the chain runs through it. Neither shape loses lineage;
+they differ in whether the intermediate steps show up in the graph.
+
+Column-level lineage is matched by column name. The references followed here carry
+columns through unchanged — `Table.Combine`, `Table.SelectRows` and similar — so a
+column present on both tables is treated as the same column. A column that exists on
+only one side is left alone rather than guessed at, which is what a renaming or
+aggregating step produces, so expect no column edges across a `Table.Group` or a
+renamed column.
+
+A name is only treated as a reference when it matches an actual table of that dataset.
+Step names such as `Source`, `Data` or `Calendar` are plausible as table names too, but
+a step binds its own name, so the step wins and no edge appears. A table cannot
+reference itself.
+
+Set `extract_table_to_table_lineage: false` to switch this off. Two counters describe
+what happened: `m_query_table_to_table_lineage` counts the edges emitted, and
+`m_query_unresolved_references` counts names that could not be accounted for at all —
+usually a parameter or an argument to an unsupported source. If a model has references
+of this kind and no edges appear, the second counter is the place to look.
+
 #### Extract endorsements to tags
 
 By default, extracting endorsement information to tags is disabled. The feature may be useful if organization uses [endorsements](https://learn.microsoft.com/en-us/power-bi/collaborate-share/service-endorse-content) to identify content quality.

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/config.py
@@ -268,6 +268,11 @@ class PowerBiDashboardSourceReport(StaleEntityRemovalSourceReport):
     # whether the M was bad or whether we understood it and declined to walk.
     m_query_referenced_query_failures: int = 0
     m_query_referenced_query_not_followed: int = 0
+    # Edges emitted from one table to another in the same dataset.
+    m_query_table_to_table_lineage: int = 0
+    # Names the walk could not account for at all -- usually an M parameter or
+    # an unsupported source's argument. The denominator for the counter above.
+    m_query_unresolved_references: int = 0
     m_query_resolver_no_lineage: int = 0
     m_query_resolver_successes: int = 0
 
@@ -662,6 +667,16 @@ class PowerBiDashboardSourceConfig(
     extract_independent_datasets: bool = pydantic.Field(
         default=False,
         description="Whether to extract datasets not used in any PowerBI visualization",
+    )
+
+    extract_table_to_table_lineage: bool = pydantic.Field(
+        default=True,
+        description="Whether a table built on another table in the same dataset "
+        "gets an edge to it. A reference is only followed when it names an "
+        "actual table of that dataset, so switching this off is an escape hatch "
+        "rather than a correctness fix. Queries with 'Enable load' switched off "
+        "are unaffected -- they have no entity to point an edge at and are "
+        "always followed to the data source they hold.",
     )
 
     platform_instance: Optional[str] = pydantic.Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/data_classes.py
@@ -63,12 +63,18 @@ class DataPlatformTable:
 
 @dataclass
 class Lineage:
-    upstreams: List[DataPlatformTable]
-    column_lineage: List[ColumnLineageInfo]
+    upstreams: List[DataPlatformTable] = field(default_factory=list)
+    column_lineage: List[ColumnLineageInfo] = field(default_factory=list)
+    # Full names of tables in the same dataset that this table is built on.
+    # Unlike a query with "Enable load" off, a loaded table has an entity of its
+    # own, so the chain is expressed as an edge to it rather than by following
+    # the chain inline -- following it would attribute the data source to this
+    # table and drop the intermediate tables that do exist.
+    powerbi_table_upstreams: List[str] = field(default_factory=list)
 
     @staticmethod
     def empty() -> "Lineage":
-        return Lineage(upstreams=[], column_lineage=[])
+        return Lineage()
 
 
 class FunctionName(Enum):

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/parser.py
@@ -69,6 +69,7 @@ def get_upstream_tables(
     config: PowerBiDashboardSourceConfig,
     parameters: Optional[Dict[str, str]] = None,
     expressions: Optional[Dict[str, str]] = None,
+    tables: Optional[Dict[str, str]] = None,
     cache: Optional[ExpressionCache] = None,
 ) -> List[Lineage]:
     """Parse the M-Query expression on *table* and return upstream lineage.
@@ -102,6 +103,10 @@ def get_upstream_tables(
 
     shared = SharedExpressions(
         texts=shared_texts,
+        # The dataset's own loaded tables. A reference to one of these is an
+        # edge to an existing entity, not a chain to follow; the caller passes
+        # nothing when table-to-table lineage is switched off.
+        tables=tables or {},
         parse=lambda text: _parse_with_bridge(text, config.m_query_parse_timeout),
         # Shared across the dataset's tables when the caller supplies one, so a
         # referenced query is parsed once per dataset rather than once per table.
@@ -219,6 +224,11 @@ def get_upstream_tables(
             if lineage.upstreams:
                 lineages.append(lineage)
 
+        # Sibling tables are a lineage of their own: no data-access function was
+        # reached, so they cannot ride along on one of the entries above.
+        if shared.table_refs:
+            lineages.append(Lineage(powerbi_table_upstreams=sorted(shared.table_refs)))
+
         if lineages:
             reporter.m_query_resolver_successes += 1
         else:
@@ -251,6 +261,10 @@ def get_upstream_tables(
         # which referenced queries came up short -- that is the diagnostic the
         # operator needs most when a table ends up with no lineage.
         _report_referenced_query_stops(reporter, table, shared)
+        # A denominator for table-to-table lineage: a model that should have
+        # sibling edges and has none leaves nothing else in the report to look
+        # at. Not a warning -- an M parameter lands here routinely.
+        reporter.m_query_unresolved_references += len(shared.unresolved)
 
 
 def _report_referenced_query_stops(

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/resolver.py
@@ -402,6 +402,7 @@ def _walk_shared_expression(
     text = shared.lookup(name)
     if text is None:
         logger.debug("Nothing in this dataset defines '%s'", name)
+        shared.unresolved.add(name)
         return
 
     sub_map = shared.parsed(name, text)
@@ -477,9 +478,14 @@ def _walk_identifier_name(
 
     found = _resolve_in_scopes(node_map, scopes, name)
     if found is None:
-        # Nothing in this expression binds the name, so it may belong to another
-        # query in the model -- one that is not loaded and therefore has no
-        # entity of its own to point an edge at.
+        # Nothing in this expression binds the name, so it belongs to something
+        # else in the model. A loaded table is checked first: the scan states
+        # outright which tables exist, while a query with "Enable load" off is
+        # known only by its presence among the dataset's expressions.
+        sibling = shared.sibling(name)
+        if sibling is not None:
+            shared.table_refs.add(sibling)
+            return
         _walk_shared_expression(name, accessor_chain, results, parameters, shared)
         return
     binding_let_id, resolved, binding_scopes = found

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/shared_expressions.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/m_query/shared_expressions.py
@@ -2,7 +2,7 @@ import dataclasses
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Mapping, Optional, Set, Tuple
 
 from datahub.ingestion.source.powerbi.m_query._bridge import (
     MQueryBridgeError,
@@ -124,6 +124,11 @@ class SharedExpressions:
 
     texts: Dict[str, str]
     parse: Callable[[str], NodeIdMap]
+    # The dataset's loaded tables, name -> full name. A referenced name matching
+    # one of these is a sibling table, which has an entity of its own, so it
+    # becomes an edge instead of a chain to follow. Empty when the caller has
+    # switched table-to-table lineage off, which makes the walk ignore them.
+    tables: Mapping[str, str] = field(default_factory=dict)
     chain: Tuple[str, ...] = ()
     # Both shared across the whole walk rather than per path: parsing is
     # deterministic, so a query reached by several routes should be sent to the
@@ -137,6 +142,24 @@ class SharedExpressions:
     # free text so the caller can report each reason under its own title and
     # counter instead of calling every one of them a parse failure.
     stops: Dict[str, Tuple["StopReason", Optional[str]]] = field(default_factory=dict)
+    # Full names of sibling tables this walk reached. Collected on the walk
+    # rather than returned, because the chain forks per path while the set
+    # belongs to the table being resolved.
+    table_refs: Set[str] = field(default_factory=set)
+    # Names that resolved to nothing at all: not a step in scope, not a sibling
+    # table, not one of the dataset's other queries. Almost always an M
+    # parameter or an unsupported source's argument, so this is a denominator
+    # for the operator rather than a failure -- without it, a model that should
+    # have table-to-table edges and has none gives the report nothing to show.
+    unresolved: Set[str] = field(default_factory=set)
+
+    def sibling(self, name: str) -> Optional[str]:
+        """The full name of the loaded table this name refers to, if any.
+
+        Resolved the way every other name here is -- unquoted and
+        case-insensitively -- so `#"Base Rows"` finds the table `Base Rows`.
+        """
+        return resolve_parameter_value(self.tables, name)
 
     def lookup(self, name: str) -> Optional[str]:
         """The M text bound to a name, or None if the dataset has no such query."""

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -267,6 +267,66 @@ class Mapper:
 
         return fine_grained_lineages
 
+    def make_sibling_column_lineage(
+        self,
+        table: powerbi_data_classes.Table,
+        dataset_urn: str,
+        sibling_urns: Dict[str, str],
+    ) -> List[FineGrainedLineage]:
+        """Column edges between tables of one dataset, matched by column name.
+
+        The references this follows are pass-through steps -- `Table.Combine`,
+        `Table.SelectRows` and the like carry columns through unchanged -- so a
+        column present on both sides is the same column. A name on only one side
+        is left alone rather than guessed at, which is what a renaming or
+        aggregating step produces.
+
+        Not routed through make_fine_grained_lineage_class: that lowercases the
+        upstream dataset with convert_lineage_urns_to_lowercase, which tracks the
+        casing of *other* platforms. A sibling is a Power BI asset, so it has to
+        agree with how its own entity was built -- convert_urns_to_lowercase --
+        or the edge points at a dataset that does not exist.
+        """
+        if (
+            not self.__config.extract_column_level_lineage
+            or not self.__config.extract_lineage
+            or not sibling_urns
+            or not table.columns
+            or not table.dataset
+        ):
+            return []
+
+        by_full_name = {t.full_name: t for t in table.dataset.tables}
+        # column name -> upstream schemaField URNs, so one downstream column
+        # carries every sibling it came from.
+        upstreams_by_column: Dict[str, List[str]] = {}
+        for full_name, sibling_urn in sibling_urns.items():
+            sibling = by_full_name.get(full_name)
+            if sibling is None or not sibling.columns:
+                continue
+            sibling_columns = {
+                c.name.casefold(): c.name for c in sibling.columns if c.name
+            }
+            for column in table.columns:
+                if not column.name:
+                    continue
+                upstream_name = sibling_columns.get(column.name.casefold())
+                if upstream_name is None:
+                    continue
+                upstreams_by_column.setdefault(column.name, []).append(
+                    builder.make_schema_field_urn(sibling_urn, upstream_name)
+                )
+
+        return [
+            FineGrainedLineage(
+                downstreamType=FineGrainedLineageDownstreamType.FIELD,
+                downstreams=[builder.make_schema_field_urn(dataset_urn, column_name)],
+                upstreamType=FineGrainedLineageUpstreamType.FIELD_SET,
+                upstreams=upstreams,
+            )
+            for column_name, upstreams in upstreams_by_column.items()
+        ]
+
     def extract_directlake_lineage(
         self,
         table: powerbi_data_classes.Table,
@@ -393,9 +453,22 @@ class Mapper:
         # table.dataset should always be set, but we check it just in case.
         parameters = table.dataset.parameters if table.dataset else {}
         expressions = table.dataset.expressions if table.dataset else {}
+        # Name -> full name for the dataset's own tables, so a reference to one
+        # is matched against a table that exists rather than guessed at. Empty
+        # without a dataset back-pointer, which means no reference can be
+        # collected that the mapper would then have to discard.
+        sibling_tables = (
+            {t.name: t.full_name for t in table.dataset.tables if t.name != table.name}
+            if table.dataset and self.__config.extract_table_to_table_lineage
+            else {}
+        )
 
         upstream: List[UpstreamClass] = []
         cll_lineage: List[FineGrainedLineage] = []
+        # Sibling full name -> its URN, gathered across every lineage so a column
+        # reached through two siblings lands as one edge with two upstreams
+        # rather than two edges naming the same column.
+        sibling_urns: Dict[str, str] = {}
 
         logger.debug(
             f"Extracting lineage for table {table.full_name} in dataset {table.dataset.name if table.dataset else None}"
@@ -411,6 +484,7 @@ class Mapper:
             config=self.__config,
             parameters=parameters,
             expressions=expressions,
+            tables=sibling_tables,
             cache=self.expression_cache_for(table.dataset),
         )
 
@@ -438,6 +512,24 @@ class Mapper:
                     )
                 )
 
+            # A table in the same dataset already has an entity, so it is named
+            # directly. The resolver only collects names that matched one of the
+            # dataset's tables, so no validation is repeated here.
+            for sibling_full_name in lineage.powerbi_table_upstreams:
+                sibling_urn = self.assets_urn_to_lowercase(
+                    builder.make_dataset_urn_with_platform_instance(
+                        platform=self.__config.platform_name,
+                        name=sibling_full_name,
+                        platform_instance=self.__config.platform_instance,
+                        env=self.__config.env,
+                    )
+                )
+                upstream.append(
+                    UpstreamClass(sibling_urn, DatasetLineageTypeClass.TRANSFORMED)
+                )
+                self.__reporter.m_query_table_to_table_lineage += 1
+                sibling_urns[sibling_full_name] = sibling_urn
+
             # Column edges belong to the lineage, not to each of its upstreams --
             # building them per upstream produced one identical copy per upstream.
             # Still gated on an upstream surviving dataset_type_mapping, so a
@@ -449,6 +541,10 @@ class Mapper:
                         dataset_urn=ds_urn,
                     )
                 )
+
+        cll_lineage.extend(
+            self.make_sibling_column_lineage(table, ds_urn, sibling_urns)
+        )
 
         # One table can reach the same upstream by more than one route -- two
         # queries filtering a common source, or both branches of a conditional --

--- a/metadata-ingestion/tests/unit/powerbi/test_table_to_table.py
+++ b/metadata-ingestion/tests/unit/powerbi/test_table_to_table.py
@@ -1,0 +1,373 @@
+"""Unit tests for lineage between tables of one dataset.
+
+A query with "Enable load" switched off has no entity, so its chain is followed
+inline to the data source it holds. A loaded table does have an entity, so the
+reference becomes an edge to it instead -- following it inline would attribute
+the data source to the referring table and drop the intermediate tables that
+actually exist.
+
+The M here is parsed by the real bridge rather than hand-built into a NodeIdMap,
+so a change in what the parser emits shows up as a failure instead of passing
+against a fabricated tree.
+"""
+
+from typing import Dict, List, Optional
+from unittest.mock import MagicMock
+
+import datahub.emitter.mce_builder as builder
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.powerbi.config import (
+    PowerBiDashboardSourceConfig,
+    PowerBiDashboardSourceReport,
+)
+from datahub.ingestion.source.powerbi.dataplatform_instance_resolver import (
+    create_dataplatform_instance_resolver,
+)
+from datahub.ingestion.source.powerbi.m_query import parser
+from datahub.ingestion.source.powerbi.powerbi import Mapper
+from datahub.ingestion.source.powerbi.rest_api_wrapper.data_classes import (
+    Column,
+    PowerBIDataset,
+    Table,
+    Workspace,
+)
+from datahub.metadata.schema_classes import StringTypeClass
+
+# A three-step MSSQL connector: the only shape here that reaches a data source.
+CONNECTED = (
+    'let\n    database = Sql.Database("a-server", "a-db"),\n'
+    '    tbl = database{[Schema="a_schema",Item="a_table"]}[Data]\nin\n    tbl'
+)
+EXPECTED_SOURCE = "mssql,a-db.a_schema.a_table,PROD"
+
+
+def _config(**kwargs: object) -> PowerBiDashboardSourceConfig:
+    return PowerBiDashboardSourceConfig.parse_obj(
+        {
+            "tenant_id": "a-tenant",
+            "client_id": "a-client",
+            "client_secret": "a-secret",
+            "extract_lineage": True,
+            "native_query_parsing": True,
+            **kwargs,
+        }
+    )
+
+
+def _dataset(
+    tables: Dict[str, str], expressions: Optional[Dict[str, str]] = None
+) -> PowerBIDataset:
+    dataset = PowerBIDataset(
+        id="a-dataset",
+        name="A Dataset",
+        description="",
+        webUrl=None,
+        workspace_id="a-workspace",
+        workspace_name="A Workspace",
+        parameters={},
+        tables=[],
+        tags=[],
+        expressions=expressions or {},
+    )
+    dataset.tables = [
+        Table(name=name, full_name=f"a_dataset.{name}", expression=m, dataset=dataset)
+        for name, m in tables.items()
+    ]
+    return dataset
+
+
+def _resolve(
+    dataset: PowerBIDataset,
+    table_name: str,
+    config: Optional[PowerBiDashboardSourceConfig] = None,
+) -> List[str]:
+    """Upstream names the resolver produces for one table of the dataset."""
+    config = config or _config()
+    table = next(t for t in dataset.tables if t.name == table_name)
+    lineages = parser.get_upstream_tables(
+        table=table,
+        reporter=PowerBiDashboardSourceReport(),
+        platform_instance_resolver=create_dataplatform_instance_resolver(config),
+        ctx=PipelineContext(run_id="t"),
+        config=config,
+        expressions=dataset.expressions,
+        tables={t.name: t.full_name for t in dataset.tables if t.name != table_name},
+    )
+    return sorted(
+        [u.urn for lineage in lineages for u in lineage.upstreams]
+        + [name for lineage in lineages for name in lineage.powerbi_table_upstreams]
+    )
+
+
+def test_a_table_built_on_a_sibling_names_the_sibling() -> None:
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+
+    assert _resolve(dataset, "derived") == ["a_dataset.base"]
+
+
+def test_the_sibling_keeps_its_own_lineage_to_the_data_source() -> None:
+    """The chain is base -> source and derived -> base, not derived -> source."""
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+
+    assert EXPECTED_SOURCE in _resolve(dataset, "base")[0]
+
+
+def test_a_table_combining_two_siblings_names_both() -> None:
+    dataset = _dataset(
+        {
+            "base": CONNECTED,
+            "kept": "let s = base in s",
+            "dropped": "let s = base in s",
+            "merged": "let s = Table.Combine({kept, dropped}) in s",
+        }
+    )
+
+    assert _resolve(dataset, "merged") == ["a_dataset.dropped", "a_dataset.kept"]
+
+
+def test_a_reference_is_matched_case_insensitively_and_unquoted() -> None:
+    """M identifiers are case-insensitive, and `#"..."` is just a quoting form."""
+    dataset = _dataset({"Base Rows": CONNECTED, "derived": 'let s = #"base rows" in s'})
+
+    assert _resolve(dataset, "derived") == ["a_dataset.Base Rows"]
+
+
+def test_a_step_name_is_not_mistaken_for_a_sibling() -> None:
+    """`Source` is the default Power Query step name and a plausible table name.
+
+    The step binds it, so scope resolution wins and no edge is invented.
+    """
+    dataset = _dataset(
+        {
+            "Source": CONNECTED,
+            "derived": 'let Source = Sql.Database("s", "d") in Source',
+        }
+    )
+
+    assert _resolve(dataset, "derived") == []
+
+
+def test_a_name_that_is_neither_a_table_nor_a_query_yields_nothing() -> None:
+    """An M parameter reaches here routinely; it must not become an edge."""
+    dataset = _dataset({"derived": "let s = SomeParameter in s"})
+
+    assert _resolve(dataset, "derived") == []
+
+
+def test_a_table_does_not_reference_itself() -> None:
+    """A table's own name is withheld, so a self-reference cannot become an edge."""
+    dataset = _dataset({"derived": "let s = derived in s"})
+
+    assert _resolve(dataset, "derived") == []
+
+
+def test_a_hidden_query_still_wins_over_nothing() -> None:
+    """With the sibling absent, the same name resolves as a hidden query and is
+    followed inline to the source it holds."""
+    dataset = _dataset(
+        {"derived": "let s = base in s"}, expressions={"base": CONNECTED}
+    )
+
+    resolved = _resolve(dataset, "derived")
+    assert len(resolved) == 1 and EXPECTED_SOURCE in resolved[0]
+
+
+def test_switching_the_feature_off_stops_collecting_references() -> None:
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+    config = _config(extract_table_to_table_lineage=False)
+    table = next(t for t in dataset.tables if t.name == "derived")
+
+    lineages = parser.get_upstream_tables(
+        table=table,
+        reporter=PowerBiDashboardSourceReport(),
+        platform_instance_resolver=create_dataplatform_instance_resolver(config),
+        ctx=PipelineContext(run_id="t"),
+        config=config,
+        expressions=dataset.expressions,
+        tables={},  # what the mapper passes when the flag is off
+    )
+
+    assert [n for lin in lineages for n in lin.powerbi_table_upstreams] == []
+
+
+def test_an_unaccounted_name_is_counted_for_the_operator() -> None:
+    """The denominator: a model that should have edges and has none needs
+    something in the report to look at."""
+    dataset = _dataset({"derived": "let s = SomeParameter in s"})
+    config = _config()
+    reporter = PowerBiDashboardSourceReport()
+    table = next(t for t in dataset.tables if t.name == "derived")
+
+    parser.get_upstream_tables(
+        table=table,
+        reporter=reporter,
+        platform_instance_resolver=create_dataplatform_instance_resolver(config),
+        ctx=PipelineContext(run_id="t"),
+        config=config,
+        expressions={},
+        tables={},
+    )
+
+    assert reporter.m_query_unresolved_references == 1
+
+
+def _workspace() -> Workspace:
+    return Workspace(
+        id="a-workspace",
+        name="A Workspace",
+        type="Workspace",
+        datasets={},
+        dashboards={},
+        reports={},
+        report_endorsements={},
+        dashboard_endorsements={},
+        scan_result={},
+        independent_datasets={},
+        app=None,
+    )
+
+
+def _mapper(config: PowerBiDashboardSourceConfig) -> Mapper:
+    return Mapper(
+        ctx=MagicMock(),
+        config=config,
+        reporter=PowerBiDashboardSourceReport(),
+        dataplatform_instance_resolver=create_dataplatform_instance_resolver(config),
+    )
+
+
+def test_the_emitted_edge_points_at_the_siblings_own_urn() -> None:
+    """The URN has to be built the way the sibling's own entity is built, or the
+    edge points at a dataset that does not exist."""
+    config = _config()
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+    mapper = _mapper(config)
+    derived = next(t for t in dataset.tables if t.name == "derived")
+
+    mcps = mapper.extract_lineage(
+        derived,
+        "urn:li:dataset:(urn:li:dataPlatform:powerbi,a_dataset.derived,PROD)",
+        _workspace(),
+    )
+    edges = [
+        u.dataset for mcp in mcps for u in getattr(mcp.aspect, "upstreams", []) or []
+    ]
+
+    assert edges == ["urn:li:dataset:(urn:li:dataPlatform:powerbi,a_dataset.base,PROD)"]
+
+
+# --- column edges between siblings -------------------------------------------
+
+
+def _with_columns(dataset: PowerBIDataset, columns: Dict[str, List[str]]) -> None:
+    """Give each named table the listed columns."""
+    for table in dataset.tables:
+        names = columns.get(table.name)
+        if names is None:
+            continue
+        table.columns = [
+            Column(
+                name=name,
+                dataType="string",
+                isHidden=False,
+                datahubDataType=StringTypeClass(),
+            )
+            for name in names
+        ]
+
+
+def _column_edges(
+    dataset: PowerBIDataset,
+    table_name: str,
+    config: Optional[PowerBiDashboardSourceConfig] = None,
+) -> List[tuple]:
+    config = config or _config()
+    mapper = _mapper(config)
+    table = next(t for t in dataset.tables if t.name == table_name)
+    ds_urn = builder.make_dataset_urn_with_platform_instance(
+        platform="powerbi", name=table.full_name, platform_instance=None, env="PROD"
+    )
+    mcps = mapper.extract_lineage(table, ds_urn, _workspace())
+    return sorted(
+        (
+            fl.downstreams[0].split(",")[-1],
+            tuple(sorted(u.split(",")[-1] for u in fl.upstreams)),
+        )
+        for mcp in mcps
+        for fl in (getattr(mcp.aspect, "fineGrainedLineages", None) or [])
+    )
+
+
+def test_a_column_present_on_both_sides_gets_an_edge() -> None:
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+    _with_columns(dataset, {"base": ["amount"], "derived": ["amount"]})
+
+    assert _column_edges(dataset, "derived") == [("amount)", ("amount)",))]
+
+
+def test_a_column_only_the_downstream_has_is_left_alone() -> None:
+    """A renaming or aggregating step produces this; guessing would invent an edge."""
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+    _with_columns(dataset, {"base": ["amount"], "derived": ["amount", "computed"]})
+
+    assert _column_edges(dataset, "derived") == [("amount)", ("amount)",))]
+
+
+def test_one_column_reached_through_two_siblings_is_one_edge() -> None:
+    """Table.Combine unions two tables, so the column has two upstreams -- but
+    only one downstream entry, or the aspect names the same column twice."""
+    dataset = _dataset(
+        {
+            "base": CONNECTED,
+            "kept": "let s = base in s",
+            "dropped": "let s = base in s",
+            "merged": "let s = Table.Combine({kept, dropped}) in s",
+        }
+    )
+    _with_columns(
+        dataset,
+        {"kept": ["amount"], "dropped": ["amount"], "merged": ["amount"]},
+    )
+
+    edges = _column_edges(dataset, "merged")
+    assert len(edges) == 1
+    downstream, upstreams = edges[0]
+    assert downstream == "amount)" and len(upstreams) == 2
+
+
+def test_column_edges_follow_the_asset_casing_flag_not_the_lineage_one() -> None:
+    """A sibling is a Power BI asset, so its URN has to agree with how its own
+    entity is built. Using convert_lineage_urns_to_lowercase would point the
+    edge at a dataset that does not exist."""
+    dataset = _dataset({"Base": CONNECTED, "derived": "let s = Base in s"})
+    _with_columns(dataset, {"Base": ["amount"], "derived": ["amount"]})
+    config = _config(
+        convert_urns_to_lowercase=False, convert_lineage_urns_to_lowercase=True
+    )
+    mapper = _mapper(config)
+    derived = next(t for t in dataset.tables if t.name == "derived")
+    ds_urn = builder.make_dataset_urn_with_platform_instance(
+        platform="powerbi", name=derived.full_name, platform_instance=None, env="PROD"
+    )
+
+    mcps = mapper.extract_lineage(derived, ds_urn, _workspace())
+    upstreams = [
+        u
+        for mcp in mcps
+        for fl in (getattr(mcp.aspect, "fineGrainedLineages", None) or [])
+        for u in fl.upstreams
+    ]
+
+    assert upstreams == [
+        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:powerbi,"
+        "a_dataset.Base,PROD),amount)"
+    ]
+
+
+def test_switching_column_lineage_off_drops_the_edges_not_the_table_edge() -> None:
+    dataset = _dataset({"base": CONNECTED, "derived": "let s = base in s"})
+    _with_columns(dataset, {"base": ["amount"], "derived": ["amount"]})
+    config = _config(extract_column_level_lineage=False)
+
+    assert _column_edges(dataset, "derived", config) == []
+    assert _resolve(dataset, "derived", config) == ["a_dataset.base"]


### PR DESCRIPTION
## Summary

A table built on another table in the same dataset had no lineage. The reference resolves to nothing in the referring table's own `let`, so the walk stopped there and the table looked disconnected — even when the table it was built on was correctly connected to the warehouse right beside it.

```
a   = Sql.Database(...){[Schema=…,Item=…]}[Data]   ← connected to the warehouse
b   = Table.SelectRows(a, …)                        ← no lineage
c   = Table.SelectRows(a, …)                        ← no lineage
d   = Table.Combine({b, c})                         ← no lineage, and d is the table people use
```

Only `a` had an upstream. `d` — the table reports are built on — appeared orphaned, and because no Power BI → Power BI edges existed there was no chain to walk back either.

## Approach

Such a reference becomes an **edge** to that table.

An edge rather than a chain to follow, because a loaded table has an entity of its own. Following it inline would attribute the warehouse to the referring table and drop the intermediate tables that do exist — trading no lineage for misleading lineage. That is the opposite of a query with "Enable load" switched off, which has no entity and so must be followed to the data source it holds; the two cases are complementary and share one branch in the resolver:

```python
sibling = shared.sibling(name)
if sibling is not None:
    shared.table_refs.add(sibling)
    return
_walk_shared_expression(name, accessor_chain, results, parameters, shared)
```

A loaded table is checked first because the scan states outright which tables exist, while a query with "Enable load" off is known only by its presence among the dataset's expressions.

## Not inventing edges

A name is only taken as a reference when it **names an actual table of that dataset**. `Source`, `Data` and `Calendar` are all plausible as both a Power Query step name and a table name — and a step binds its own name, so scope resolution wins and no edge appears. A table's own name is withheld, so a self-reference cannot become an edge either. Both are tested.

This depends on the scope stack: an outer-scope step name read from inside a nested `let` has to resolve as a step, not fall through as a candidate table name.

## Column lineage

Matched by column name, case-insensitively, emitting each side's own casing. The references this follows are pass-through steps — `Table.Combine`, `Table.SelectRows` — which carry columns through unchanged, so a column present on both sides is the same column. A name on only one side is left alone rather than guessed at, which is what a renaming or aggregating step produces.

Edges are merged per downstream column, so a column reached through two tables lands as one edge with two upstreams rather than two edges naming the same column.

`make_sibling_column_lineage` deliberately does not route through `make_fine_grained_lineage_class`. That lowercases the upstream dataset with `convert_lineage_urns_to_lowercase`, which tracks the casing of *other* platforms; a sibling is a Power BI asset, so it has to agree with how its own entity was built (`convert_urns_to_lowercase`) or the edge points at a dataset that does not exist. A test sets the two flags to opposite values and asserts the exact URN.

## Config and observability

- `extract_table_to_table_lineage` (default on) switches it off. The mapper then passes no table names, so nothing is collected — an escape hatch rather than a correctness fix.
- `m_query_table_to_table_lineage` counts edges emitted.
- `m_query_unresolved_references` counts names the walk could not account for — usually an M parameter or an unsupported source's argument. It is a counter rather than a warning because those are routine, and it gives a model that should have these edges and has none something in the report to look at.

No reference can be collected without a dataset back-pointer, so there is no path where names are found and then silently discarded.

## Testing

`443 passed, 2 xfailed` · ruff, format and mypy clean · no existing goldens changed.

16 new tests, parsed by the real M bridge rather than hand-built into a `NodeIdMap`, so a change in what the parser emits fails instead of passing against a fabricated tree. Each was checked against a mutation of the behaviour it covers — the casing flag swapped, column edges left unmerged, an edge emitted for every column whether matched or not, and the column-level flag ignored — and every one is caught by exactly the intended test.

Verified end to end against a live tenant on a model with four loaded tables in this shape: `a` keeps its warehouse edge, `b` and `c` gain an edge to `a`, `d` gains edges to `b` and `c`, and `d`'s column carries two upstreams in a single edge. Before this change only `a` had any lineage.

## Stacked

Based on `feat/powerbi-shared-expressions` (#19372), which contains the scope stack this relies on. The diff here is only this change; GitHub will retarget to `master` when that merges.

## Checklist

- [x] PR conforms to the Contributing Guideline (particularly PR Title Format)
- [x] Tests for the changes have been added
- [x] Docs — connector docs describe the new behaviour under "Tables built on other tables"
- [ ] Breaking changes — none
