### PR TITLE
docs(smoke-test): fix review-skill nits from PR 19580

### DIFF
--- a/.agent-skills/test-review/SKILL.md
+++ b/.agent-skills/test-review/SKILL.md
@@ -228,7 +228,7 @@ guide: `smoke-test/AGENTS.md`.
 3. **Authentication** -- `auth_session` fixture, `make_step_actor_user()`, never inline
 4. **Retry patterns** -- Trace API, `wait_for_writes_to_sync()`, `@with_test_retry()`, no bare `time.sleep()`
 5. **GraphQL / REST** -- `execute_graphql()`, `restli_default_headers`, `ingest_file_via_rest()`
-6. **Markers** -- required `domain(...)`, `p0`, `read_only`, `global_policy_mutator`
+6. **Markers** -- required `domain(...)`; `p0` only for regressions that must run on every PR; `read_only` only when the test never mutates; `global_policy_mutator` only when mutating shared platform policy
 7. **Environment variables** -- `env_vars.py` registry, no hardcoded URLs
 8. **Guaranteed cleanup** -- fixture `yield` or `try/finally`
 9. **Multi-environment config** -- URLs via env vars, `USE_STATIC_SLEEP` fallback

--- a/.agent-skills/test-review/references/smoke-test-patterns.md
+++ b/.agent-skills/test-review/references/smoke-test-patterns.md
@@ -288,6 +288,38 @@ assert any(e["entityUrn"] == expected_urn for e in events)
 
 ---
 
+## Integration Service Status Polling
+
+For tests involving DataHub actions/integrations, poll the action status API instead of sleeping.
+
+**Source:** `smoke-test/tests/integrations_service_utils.py`
+
+```python
+def wait_until_action_has_processed_event(action_urn, integrations_url, event_time, timeout=120):
+    """Poll action stats endpoint until at least one event has been processed."""
+    url = f"{integrations_url}/private/actions/{action_urn}/stats"
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        response = requests.get(url)
+        if response.status_code == 200:
+            stats = response.json()
+            last_processed = stats.get("live", {}).get(
+                "customProperties", {}
+            ).get("event_processing_stats.last_event_processed_time")
+            if last_processed:
+                return
+        time.sleep(1)
+    raise TimeoutError(...)
+
+def wait_for_reload_completion(action_urn, integrations_url, timeout=120):
+    """Poll action status until it transitions back to 'running' after a config reload."""
+    # Polls until status == "running" or timeout
+```
+
+**When to use:** In tests that configure and trigger DataHub actions/integrations, and need to confirm the action has finished initializing or processing events.
+
+---
+
 ## GraphQL with Exponential Backoff
 
 For GraphQL calls that may fail under server load, use the retry-aware wrapper.

--- a/.agent-skills/test-review/references/smoke-test-patterns.md
+++ b/.agent-skills/test-review/references/smoke-test-patterns.md
@@ -288,38 +288,6 @@ assert any(e["entityUrn"] == expected_urn for e in events)
 
 ---
 
-## Integration Service Status Polling
-
-For tests involving DataHub actions/integrations, poll the action status API instead of sleeping.
-
-**Source:** `smoke-test/tests/integrations_service_utils.py`
-
-```python
-def wait_until_action_has_processed_event(action_urn, integrations_url, event_time, timeout=120):
-    """Poll action stats endpoint until at least one event has been processed."""
-    url = f"{integrations_url}/private/actions/{action_urn}/stats"
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        response = requests.get(url)
-        if response.status_code == 200:
-            stats = response.json()
-            last_processed = stats.get("live", {}).get(
-                "customProperties", {}
-            ).get("event_processing_stats.last_event_processed_time")
-            if last_processed:
-                return
-        time.sleep(1)
-    raise TimeoutError(...)
-
-def wait_for_reload_completion(action_urn, integrations_url, timeout=120):
-    """Poll action status until it transitions back to 'running' after a config reload."""
-    # Polls until status == "running" or timeout
-```
-
-**When to use:** In tests that configure and trigger DataHub actions/integrations, and need to confirm the action has finished initializing or processing events.
-
----
-
 ## GraphQL with Exponential Backoff
 
 For GraphQL calls that may fail under server load, use the retry-aware wrapper.

--- a/.agent-skills/test-review/standards/smoke.md
+++ b/.agent-skills/test-review/standards/smoke.md
@@ -126,7 +126,6 @@ Never use `time.sleep()` to wait for GMS, search, or Kafka.
 | After bulk ingest or cleanup            | `wait_for_writes_to_sync()` (`mcp_only` / `mae_only` when only one store matters) |
 | One known async write with a `trace_id` | Trace API (`/openapi/v1/trace/write/{trace_id}`)                                  |
 | Custom timing                           | `tenacity` with `stop_after_delay`                                                |
-| Action/integration lifecycle            | Service status polling (`integrations_service_utils`)                             |
 
 **Rules:**
 
@@ -141,8 +140,9 @@ Never use `time.sleep()` to wait for GMS, search, or Kafka.
 
 ## 5. GraphQL and REST
 
-**Source:** `execute_graphql` / `ingest_file_via_rest` / `restli_default_headers`
-in `smoke-test/tests/utils.py`, `smoke-test/AGENTS.md` (Rules).
+**Source:** `execute_graphql` / `ingest_file_via_rest` in
+`smoke-test/tests/utils.py`; per-module `restli_default_headers` (e.g.
+`smoke-test/test_e2e.py`); `smoke-test/AGENTS.md` (Rules).
 
 `execute_graphql()` already asserts a non-empty body, `data` is not `None`,
 and no `errors` key.
@@ -151,8 +151,9 @@ and no `errors` key.
 
 - WARNING: Use `execute_graphql()` instead of a manual GraphQL POST.
 - WARNING: Assert specific field values, not that the response exists.
-- WARNING: Use `restli_default_headers` for Rest.li; ingest with
-  `ingest_file_via_rest()`, not a hand-rolled Pipeline.
+- WARNING: Rest.li calls need `X-RestLi-Protocol-Version: 2.0.0` (copy the
+  per-module `restli_default_headers` dict; it is not in `utils.py`). Ingest
+  with `ingest_file_via_rest()`, not a hand-rolled Pipeline.
 - SUGGESTION: OpenAPI v3 multi-step tests use `concurrent_openapi.run_tests()`.
   Do not add fixtures that only re-check a GraphQL path already covered.
 - SUGGESTION: Tags, terms, and descriptions via

--- a/.agent-skills/test-review/templates/incremental-test-report.md
+++ b/.agent-skills/test-review/templates/incremental-test-report.md
@@ -19,7 +19,6 @@
 ### Classification
 
 - **Smoke tests:** {{SMOKE_COUNT}} files
-- **Filtered out (Cypress / connector):** {{FILTERED_COUNT}} files
 
 ---
 

--- a/.agent-skills/test-review/templates/test-review-report.md
+++ b/.agent-skills/test-review/templates/test-review-report.md
@@ -91,6 +91,7 @@ No warning issues found.
 ### Smoke Test Standards
 
 - [{{SMOKE_ISOLATION}}] Run-unique names (`unique_suffix` / unique ingest); no shared hardcoded URNs
+- [{{SMOKE_FIXTURE}}] Unique ingest (`_ingest_cleanup_unique_dataset_impl` / `materialize_*`) or `_ingest_cleanup_data_impl` only when keys are already unique
 - [{{SMOKE_LIFECYCLE}}] Fixture `yield` teardown (`_ingest_cleanup_unique_dataset_impl` or `_ingest_cleanup_data_impl` when keys are already unique)
 - [{{SMOKE_AUTH}}] Uses `auth_session` fixture (no inline credentials)
 - [{{SMOKE_RETRY}}] Uses `@with_test_retry()` or `wait_for_writes_to_sync()` (no bare `time.sleep`)

--- a/smoke-test/AGENTS.md
+++ b/smoke-test/AGENTS.md
@@ -39,7 +39,7 @@ Put new tests in `tests/<feature>/`, not `test_e2e.py`. Connector tests are plac
   API. `TestSessionWrapper` already waits on POST/PUT — do not extra-sync unless
   you are asserting search/index.
 - **Auth:** `auth_session` / `graph_client`. Extra users:
-  `make_step_actor_user()`. Config: `env_vars.py`, not `os.getenv` or
+  `make_step_actor_user()`. Config: `tests/utilities/env_vars.py`, not `os.getenv` or
   `localhost:8080`. GraphQL: `execute_graphql()` (it already checks `data` /
   `errors`) — assert the fields you care about. Ingest:
   `ingest_file_via_rest()`.


### PR DESCRIPTION
Qualify optional markers, drop the phantom integrations helper, and point restli headers and env_vars at their real locations.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates smoke-test review docs to align with current conventions: clarifies which pytest markers are required, removes the phantom `integrations_service_utils` helper, and points Rest.li headers and `env_vars.py` at their real locations.

- `p0`, `read_only`, and `global_policy_mutator` are conditional on test behavior rather than always required.
- `restli_default_headers` lives in per-module dicts; `env_vars.py` moved to `tests/utilities/`.
- Adds a unique-ingest-fixture checklist item and drops the filtered-out files line from the incremental report.

<sup>Written for commit a0adafa39a7e88399346b3b51d94f5a0d559d6a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

