### PR TITLE
ci(smoke): run only p0 smoke tests on PRs when PYTEST_P0_SMOKE is set

### DIFF
--- a/.github/scripts/check_p0_dependencies.py
+++ b/.github/scripts/check_p0_dependencies.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Fail if a p0 smoke test depends on a test that is not p0.
+
+pytest-dependency SKIPS a test whose declared dependency did not run. Under the
+PR tier (``-m p0``) a non-p0 dependency is deselected, so the dependent p0 test
+skips and the batch still reports green -- the p0 marker buys nothing, and it
+does so invisibly. This check fails loudly instead.
+
+It is a pre-commit hook rather than a pytest test because the smoke-test suite
+has a session-scoped autouse ``auth_session`` fixture that logs into the
+frontend, so any test in that suite needs a running DataHub; this check is pure
+static analysis and should cost nothing.
+
+Limitation: only dependencies declared with ``@pytest.mark.dependency(depends=[...])``
+are visible here. Tests that rely on ordering implicitly -- needing data another
+test happened to create, with no ``depends=`` -- cannot be detected statically and
+will only surface once the p0 tier runs in CI.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_ROOT = REPO_ROOT / "smoke-test"
+_DEPENDS = re.compile(r"depends=\[([^\]]*)\]", re.S)
+_NAME = re.compile(r"name=['\"]([^'\"]+)['\"]")
+
+
+def _test_modules() -> list[Path]:
+    found = set(SMOKE_ROOT.rglob("test_*.py")) | set(SMOKE_ROOT.rglob("*_test.py"))
+    return sorted(
+        p for p in found if not {"venv", "build", "node_modules"} & set(p.parts)
+    )
+
+
+def _module_applies_p0(tree: ast.Module) -> bool:
+    """True when a module-level pytestmark marks every test in the file p0."""
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in node.targets
+        ):
+            if "mark.p0" in ast.unparse(node.value):
+                return True
+    return False
+
+
+def _scan(path: Path) -> tuple[set[str], dict[str, list[str]], dict[str, str]]:
+    """Return (p0 test names, {test: declared depends}, {alias: test})."""
+    tree = ast.parse(path.read_text(errors="replace"))
+    module_p0 = _module_applies_p0(tree)
+    p0: set[str] = set()
+    depends: dict[str, list[str]] = {}
+    aliases: dict[str, str] = {}
+
+    def visit(body: list[ast.stmt]) -> None:
+        for node in body:
+            if isinstance(node, ast.ClassDef):
+                visit(node.body)
+                continue
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("test_"):
+                continue
+            decorators = " ".join(ast.unparse(d) for d in node.decorator_list)
+            if module_p0 or "mark.p0" in decorators:
+                p0.add(node.name)
+            if "mark.dependency" in decorators:
+                declared = _DEPENDS.search(decorators)
+                if declared:
+                    depends[node.name] = [
+                        part.strip().strip("'\"")
+                        for part in declared.group(1).split(",")
+                        if part.strip()
+                    ]
+                alias = _NAME.search(decorators)
+                if alias:
+                    aliases[alias.group(1)] = node.name
+
+    visit(tree.body)
+    return p0, depends, aliases
+
+
+def main() -> int:
+    if not SMOKE_ROOT.is_dir():
+        return 0
+    gaps: list[str] = []
+    for path in _test_modules():
+        try:
+            p0, depends, aliases = _scan(path)
+        except SyntaxError:
+            continue  # unparseable modules are caught by collection, not here
+        if not p0 or not depends:
+            continue
+        rel = path.relative_to(REPO_ROOT)
+        for test, declared in depends.items():
+            if test not in p0:
+                continue
+            missing = [d for d in declared if aliases.get(d, d) not in p0]
+            if missing:
+                gaps.append(f"  {rel}::{test} -> depends on non-p0: {', '.join(missing)}")
+
+    if gaps:
+        print("p0 tests depend on tests that are not p0.\n")
+        print("\n".join(gaps))
+        print(
+            "\npytest-dependency will SKIP these under `-m p0`, so the p0 marker has "
+            "no effect and CI still goes green.\nMark the listed dependencies p0 as well."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_p0_dependencies.py
+++ b/.github/scripts/check_p0_dependencies.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Fail if a p0 smoke test depends on a test that is not p0.
 
-pytest-dependency SKIPS a test whose declared dependency did not run. Under the
-PR tier (``-m p0``) a non-p0 dependency is deselected, so the dependent p0 test
-skips and the batch still reports green -- the p0 marker buys nothing, and it
-does so invisibly. This check fails loudly instead.
+pytest-dependency SKIPS a test whose declared dependency did not run. When the
+PR tier selects only ``p0`` tests, a non-p0 dependency is deselected, so the
+dependent p0 test skips and the batch still reports green -- the p0 marker buys
+nothing, and it does so invisibly. This check fails loudly instead.
 
 It is a pre-commit hook rather than a pytest test because the smoke-test suite
 has a session-scoped autouse ``auth_session`` fixture that logs into the
@@ -20,14 +20,11 @@ will only surface once the p0 tier runs in CI.
 from __future__ import annotations
 
 import ast
-import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SMOKE_ROOT = REPO_ROOT / "smoke-test"
-_DEPENDS = re.compile(r"depends=\[([^\]]*)\]", re.S)
-_NAME = re.compile(r"name=['\"]([^'\"]+)['\"]")
 
 
 def _test_modules() -> list[Path]:
@@ -46,6 +43,57 @@ def _module_applies_p0(tree: ast.Module) -> bool:
         ):
             if "mark.p0" in ast.unparse(node.value):
                 return True
+    return False
+
+
+def _dependency_kwargs(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[list[str] | None, str | None]:
+    """Read ``depends=`` and ``name=`` off a ``@pytest.mark.dependency`` decorator.
+
+    Taken from the AST rather than by regex. A declared dependency may name a
+    parametrized instance (``test_foo[case]``), and a regex bounded by the first
+    ``]`` truncates the list at that inner bracket -- silently discarding every
+    later entry and leaving a malformed name that can never match a test.
+    """
+    depends: list[str] | None = None
+    alias: str | None = None
+    for dec in node.decorator_list:
+        if not isinstance(dec, ast.Call):
+            continue
+        if not ast.unparse(dec.func).endswith("mark.dependency"):
+            continue
+        for kw in dec.keywords:
+            if kw.arg == "depends" and isinstance(kw.value, (ast.List, ast.Tuple)):
+                depends = [
+                    elt.value
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                ]
+            elif (
+                kw.arg == "name"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                alias = kw.value.value
+    return depends, alias
+
+
+def _dependency_target(dep: str) -> str:
+    """The test function a declared dependency refers to.
+
+    pytest-dependency accepts a bare name, a parametrized instance
+    (``test_foo[case]``) or a node id (``TestClass::test_foo``). The p0 marker
+    attaches to the function, so all three forms resolve to the function name.
+    """
+    return dep.split("::")[-1].split("[", 1)[0]
+
+
+def _resolves_to_p0(dep: str, aliases: dict[str, str], p0: set[str]) -> bool:
+    """True when a declared dependency names a p0 test, directly or by alias."""
+    for candidate in (dep, _dependency_target(dep)):
+        if aliases.get(candidate, candidate) in p0:
+            return True
     return False
 
 
@@ -69,17 +117,11 @@ def _scan(path: Path) -> tuple[set[str], dict[str, list[str]], dict[str, str]]:
             decorators = " ".join(ast.unparse(d) for d in node.decorator_list)
             if module_p0 or "mark.p0" in decorators:
                 p0.add(node.name)
-            if "mark.dependency" in decorators:
-                declared = _DEPENDS.search(decorators)
-                if declared:
-                    depends[node.name] = [
-                        part.strip().strip("'\"")
-                        for part in declared.group(1).split(",")
-                        if part.strip()
-                    ]
-                alias = _NAME.search(decorators)
-                if alias:
-                    aliases[alias.group(1)] = node.name
+            declared, alias = _dependency_kwargs(node)
+            if declared is not None:
+                depends[node.name] = declared
+            if alias:
+                aliases[alias] = node.name
 
     visit(tree.body)
     return p0, depends, aliases
@@ -100,7 +142,7 @@ def main() -> int:
         for test, declared in depends.items():
             if test not in p0:
                 continue
-            missing = [d for d in declared if aliases.get(d, d) not in p0]
+            missing = [d for d in declared if not _resolves_to_p0(d, aliases, p0)]
             if missing:
                 gaps.append(f"  {rel}::{test} -> depends on non-p0: {', '.join(missing)}")
 
@@ -108,7 +150,7 @@ def main() -> int:
         print("p0 tests depend on tests that are not p0.\n")
         print("\n".join(gaps))
         print(
-            "\npytest-dependency will SKIP these under `-m p0`, so the p0 marker has "
+            "\npytest-dependency will SKIP these when only p0 runs, so the p0 marker has "
             "no effect and CI still goes green.\nMark the listed dependencies p0 as well."
         )
         return 1

--- a/.github/scripts/check_p0_dependencies.py
+++ b/.github/scripts/check_p0_dependencies.py
@@ -11,8 +11,9 @@ has a session-scoped autouse ``auth_session`` fixture that logs into the
 frontend, so any test in that suite needs a running DataHub; this check is pure
 static analysis and should cost nothing.
 
-Limitation: only dependencies declared with ``@pytest.mark.dependency(depends=[...])``
-are visible here. Tests that rely on ordering implicitly -- needing data another
+Limitation: tests are tracked by bare function name, so two same-named methods
+in different classes of one module are indistinguishable here. Only dependencies
+declared with ``@pytest.mark.dependency(depends=[...])`` are visible at all. Tests that rely on ordering implicitly -- needing data another
 test happened to create, with no ``depends=`` -- cannot be detected statically and
 will only surface once the p0 tier runs in CI.
 """
@@ -34,9 +35,13 @@ def _test_modules() -> list[Path]:
     )
 
 
-def _module_applies_p0(tree: ast.Module) -> bool:
-    """True when a module-level pytestmark marks every test in the file p0."""
-    for node in tree.body:
+def _pytestmark_applies_p0(body: list[ast.stmt]) -> bool:
+    """True when a ``pytestmark`` assignment in this body marks everything p0.
+
+    Valid at module scope and inside a class body; pytest propagates both to
+    every test they contain.
+    """
+    for node in body:
         if isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name) and target.id == "pytestmark"
             for target in node.targets
@@ -100,22 +105,33 @@ def _resolves_to_p0(dep: str, aliases: dict[str, str], p0: set[str]) -> bool:
 def _scan(path: Path) -> tuple[set[str], dict[str, list[str]], dict[str, str]]:
     """Return (p0 test names, {test: declared depends}, {alias: test})."""
     tree = ast.parse(path.read_text(errors="replace"))
-    module_p0 = _module_applies_p0(tree)
+    module_p0 = _pytestmark_applies_p0(tree.body)
     p0: set[str] = set()
     depends: dict[str, list[str]] = {}
     aliases: dict[str, str] = {}
 
-    def visit(body: list[ast.stmt]) -> None:
+    def visit(body: list[ast.stmt], inherited_p0: bool) -> None:
         for node in body:
             if isinstance(node, ast.ClassDef):
-                visit(node.body)
+                # pytest applies a class's marks to every test method inside it,
+                # so p0 has to travel down with the recursion. Without this a
+                # dependency declared inside a p0-marked class is never checked
+                # (the method is absent from ``p0``, so main() skips it) and a
+                # dependency *on* such a method is wrongly reported as non-p0.
+                class_marks = " ".join(ast.unparse(d) for d in node.decorator_list)
+                visit(
+                    node.body,
+                    inherited_p0
+                    or "mark.p0" in class_marks
+                    or _pytestmark_applies_p0(node.body),
+                )
                 continue
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             if not node.name.startswith("test_"):
                 continue
             decorators = " ".join(ast.unparse(d) for d in node.decorator_list)
-            if module_p0 or "mark.p0" in decorators:
+            if inherited_p0 or "mark.p0" in decorators:
                 p0.add(node.name)
             declared, alias = _dependency_kwargs(node)
             if declared is not None:
@@ -123,7 +139,7 @@ def _scan(path: Path) -> tuple[set[str], dict[str, list[str]], dict[str, str]]:
             if alias:
                 aliases[alias] = node.name
 
-    visit(tree.body)
+    visit(tree.body, module_p0)
     return p0, depends, aliases
 
 

--- a/.github/scripts/pre-commit/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit/pre-commit-override.yaml
@@ -103,3 +103,16 @@ repos:
         # Keep pass_filenames: false: betterleaks reads the staged diff itself; passing files
         # would switch it to `dir` semantics (whole-file, and broken/slow on multiple file args).
         stages: [pre-commit]
+      - id: smoke-test-p0-dependencies
+        name: p0 smoke tests must not depend on non-p0 tests
+        description:
+          pytest-dependency skips a test whose dependency was deselected,
+          so a p0 test depending on a non-p0 test silently does nothing under -m p0
+        entry: python3 .github/scripts/check_p0_dependencies.py
+        language: system
+        files: ^smoke-test/.*\.py$
+        # The script globs smoke-test/ itself; it needs the whole tree, not the diff.
+        pass_filenames: false
+        # Also runs in CI via lint-jobs.yml smoke-test-lint, which is the real
+        # guard — pre-commit is local convenience and no workflow invokes it.
+        stages: [pre-commit]

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -124,6 +124,15 @@ jobs:
       yarn_cache_key_prefix: ${{ steps.yarn-cache-key.outputs.yarn_cache_key_prefix }}
       playwright_matrix: ${{ steps.set-playwright-matrix.outputs.matrix }}
       playwright_change: ${{ steps.ci-optimize.outputs.playwright-change == 'true' }}
+      # Pull requests run only the p0 tier while the PYTEST_P0_SMOKE repository
+      # variable is 'true'; post-merge pushes -- and the default with the
+      # variable unset -- always run the full suite. smoke.sh reads it as
+      # SMOKE_TIER. A PR that needs the whole suite asks for it with the
+      # full-suite label rather than by any path-based escalation here.
+      smoke_tier: ${{ (github.event_name == 'pull_request' && vars.PYTEST_P0_SMOKE == 'true') && 'p0' || 'full' }}
+      # Test modules this PR touches; conftest runs these alongside the p0
+      # tier. Empty on a full run.
+      smoke_changed_tests: ${{ steps.smoke-tier.outputs.changed_tests }}
       smoke_build_task: ${{ steps.smoke-profile.outputs.smoke_build_task }}
       smoke_profile_name: ${{ steps.smoke-profile.outputs.smoke_profile_name }}
       # Gradle modules base_build has to bake; empty means every image in the
@@ -239,6 +248,23 @@ jobs:
           SMOKE_BUILD_TASK: ${{ steps.smoke-profile.outputs.smoke_build_task }}
           CHANGED_FILES: ${{ steps.ci-optimize.outputs.changed-files }}
         run: .github/scripts/resolve_image_builds.sh
+
+      - name: Resolve smoke-test tier inputs
+        id: smoke-tier
+        env:
+          CHANGED_FILES: ${{ steps.ci-optimize.outputs.changed-files }}
+        run: |
+          files=""
+          if [[ -n "${CHANGED_FILES:-}" ]] && jq -e 'type == "array"' <<<"$CHANGED_FILES" >/dev/null 2>&1; then
+            files=$(jq -r '.[]' <<<"$CHANGED_FILES")
+          fi
+
+          # Test modules this PR touches; conftest runs these alongside the p0
+          # tier (SMOKE_CHANGED_TESTS).
+          changed=$(printf '%s\n' "$files" \
+            | grep -E '^smoke-test/(.*/)?(test_.*|.*_test)\.py$' || true)
+          echo "changed_tests=$(printf '%s' "$changed" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "Changed smoke test modules: $(printf '%s' "$changed" | tr '\n' ' ')"
 
       - name: Determine runner type
         id: set-runner
@@ -542,6 +568,12 @@ jobs:
         run: |
           if [[ "${{ env.IS_FORK }}" == "true" ]]; then
             echo "python_batch_count=3" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ needs.setup.outputs.smoke_tier }}" == "p0" ]]; then
+            # The p0 tier is 357 of 1209 collected tests, so 4 batches carry a
+            # lighter per-batch load than the full suite's 7 while cutting the
+            # per-batch fixed cost (caches, image pull, quickstart) that dominates
+            # a short run. Revisit once p0 batch durations have been measured.
+            echo "python_batch_count=4" >> "$GITHUB_OUTPUT"
           else
             echo "python_batch_count=7" >> "$GITHUB_OUTPUT"
           fi
@@ -932,6 +964,11 @@ jobs:
           TEST_STRATEGY: pytests
           BATCH_COUNT: ${{ matrix.batch_count }}
           BATCH_NUMBER: ${{ matrix.batch }}
+          # 'p0' or 'full' -- see the setup job's smoke_tier output.
+          SMOKE_TIER: ${{ needs.setup.outputs.smoke_tier }}
+          # Test modules this PR touches; they run alongside the p0 tier.
+          # Ignored on a full run.
+          SMOKE_CHANGED_TESTS: ${{ needs.setup.outputs.smoke_changed_tests }}
           PYTEST_XDIST_WORKERS: "3"
           # GMS here runs with a 1s bulk-flush and 1s index refresh interval
           # (see run-quickstart.sh), so the trailing post-wait sleep can match.

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -268,6 +268,13 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+
+      # Ahead of the uv/gradle steps on purpose: the check is stdlib-only, so it
+      # still runs when the venv install breaks, and it fails in seconds rather
+      # than after the install.
+      - name: Check p0 test dependencies
+        run: python ./.github/scripts/check_p0_dependencies.py
+
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       # Restore-only: this workflow is pull_request-only, so a save here would be
       # ref-scoped to the PR and never shared. The master-scoped entry is written by

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -674,6 +674,17 @@ repos:
         stages:
           - pre-commit
 
+      - id: smoke-test-p0-dependencies
+        name: p0 smoke tests must not depend on non-p0 tests
+        description: pytest-dependency skips a test whose dependency was deselected,
+          so a p0 test depending on a non-p0 test silently does nothing under -m p0
+        language: system
+        files: ^smoke-test/.*\.py$
+        entry: python3 .github/scripts/check_p0_dependencies.py
+        pass_filenames: false
+        stages:
+          - pre-commit
+
       - id: docusaurus-markdown-lint
         name: Lint Docusaurus Markdown
         description: Catches Docusaurus-specific Markdown issues that Prettier cannot

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -674,17 +674,6 @@ repos:
         stages:
           - pre-commit
 
-      - id: smoke-test-p0-dependencies
-        name: p0 smoke tests must not depend on non-p0 tests
-        description: pytest-dependency skips a test whose dependency was deselected,
-          so a p0 test depending on a non-p0 test silently does nothing under -m p0
-        language: system
-        files: ^smoke-test/.*\.py$
-        entry: python3 .github/scripts/check_p0_dependencies.py
-        pass_filenames: false
-        stages:
-          - pre-commit
-
       - id: docusaurus-markdown-lint
         name: Lint Docusaurus Markdown
         description: Catches Docusaurus-specific Markdown issues that Prettier cannot
@@ -729,6 +718,17 @@ repos:
           binary)
         entry: betterleaks git --staged --redact --verbose --config .betterleaks.toml
         language: system
+        pass_filenames: false
+        stages:
+          - pre-commit
+
+      - id: smoke-test-p0-dependencies
+        name: p0 smoke tests must not depend on non-p0 tests
+        description: pytest-dependency skips a test whose dependency was deselected,
+          so a p0 test depending on a non-p0 test silently does nothing under -m p0
+        entry: python3 .github/scripts/check_p0_dependencies.py
+        language: system
+        files: ^smoke-test/.*\.py$
         pass_filenames: false
         stages:
           - pre-commit

--- a/smoke-test/README.md
+++ b/smoke-test/README.md
@@ -74,8 +74,31 @@ pytest --domain catalog --domain ingestion -vv
 
 A test that spans domains declares all of them, e.g.
 `@pytest.mark.domain(Domain.CATALOG, Domain.INGESTION)`, and is selected by
-either. Tests marked `p0` are the ones critical enough to run on every pull
-request; combine the two with `pytest -m p0 --domain catalog`.
+either.
+
+#### Selecting tests by criticality tier
+
+Tests critical enough to gate every pull request carry `@pytest.mark.p0`. Select
+them with an ordinary marker expression:
+
+```bash
+# Only the p0 tier
+pytest -m p0 -vv
+
+# The p0 tier within one domain
+pytest -m p0 --domain catalog -vv
+```
+
+CI drives the choice through the `SMOKE_TIER` env var that `smoke.sh` reads:
+`docker-unified.yml` sets it to `p0` for pull requests while the
+`PYTEST_P0_SMOKE` repository variable is `true`, and leaves post-merge runs on
+the full suite.
+
+On a pull request CI additionally runs any test module the PR itself touches,
+even when it carries no `p0` marker — conftest marks those modules p0 during
+collection so `-m p0` keeps them. That is per-module: a change to a shared
+fixture or to `conftest.py` pulls in no test module of its own, so a PR needing
+broader coverage asks for the whole suite with the full-suite PR label.
 
 ## Test Categories
 

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import pytest
 import requests
@@ -233,6 +233,34 @@ def pytest_configure(config: pytest.Config) -> None:
         raise pytest.UsageError(str(exc)) from exc
 
 
+# Test modules this PR touches, from CI. Read once: the environment is fixed for
+# the life of the process.
+_CHANGED_TESTS: List[str] = env_vars.get_smoke_changed_tests()
+_CHANGED_MATCHED: Set[str] = set()
+
+
+def pytest_itemcollected(item: Item) -> None:
+    """Mark tests from modules this PR touches as p0.
+
+    Runs per item during collection, before any ``pytest_collection_modifyitems``
+    hook, so pytest's own ``-m`` deselection then keeps them. This is the
+    marker-injection pattern from pytest's docs, and it is what lets a PR's own
+    new or edited tests run under ``-m p0`` without a second selection mechanism.
+
+    ``_CHANGED_TESTS`` holds repo-relative paths while ``item.fspath`` is
+    absolute, so match by suffix -- the same approach the FILTERED_TESTS retry
+    path uses.
+    """
+    if not _CHANGED_TESTS:
+        return
+    module_path = str(item.fspath)
+    for path in _CHANGED_TESTS:
+        if module_path.endswith(path):
+            _CHANGED_MATCHED.add(path)
+            item.add_marker(pytest.mark.p0)
+            break
+
+
 def _apply_domain_filter(config: pytest.Config, items: List[Item]) -> None:
     """Deselect tests outside the domains requested with --domain."""
     requested = parse_requested_domains(config.getoption("--domain"))
@@ -437,11 +465,25 @@ def _apply_smoke_policy_phase_filter(items: List[Item]) -> None:
     logger.warning("Unknown SMOKE_POLICY_PHASE=%r; running all collected tests", phase)
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(
     session: pytest.Session, config: pytest.Config, items: List[Item]
 ) -> None:
     # Runs before every early return below, and before the weight-based batching,
     # so batches are packed from the selected tests only.
+    if _CHANGED_TESTS:
+        unmatched = [p for p in _CHANGED_TESTS if p not in _CHANGED_MATCHED]
+        if unmatched:
+            # Deleted test files land here harmlessly, but so would a change in
+            # the path format CI emits -- which would silently stop a PR's own
+            # tests being marked p0, the exact failure this injection prevents.
+            logger.warning(
+                "SMOKE_CHANGED_TESTS: %s of %s path(s) matched no collected module: %s",
+                len(unmatched),
+                len(_CHANGED_TESTS),
+                ", ".join(sorted(unmatched)[:5]),
+            )
+
     _apply_domain_filter(config, items)
 
     # Check if FILTERED_TESTS is set (for retry logic)

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -43,6 +43,25 @@ if [[ "${PYTEST_XDIST_WORKERS:-0}" =~ ^[1-9][0-9]*$ ]]; then
   xdist_args=(-n "${PYTEST_XDIST_WORKERS}" --dist=loadscope)
 fi
 
+# SMOKE_TIER: which criticality tier to run. "p0" selects only tests carrying
+# the p0 marker -- the pull-request gate; "full" or unset runs the whole suite.
+# CI sets it from the PYTEST_P0_SMOKE repository variable.
+#
+# Selection is a plain marker expression, so conftest's batching -- which runs
+# @pytest.hookimpl(trylast=True) -- packs the set that will actually run.
+tier_args=()
+case "${SMOKE_TIER:-full}" in
+  full) ;;
+  p0)
+    echo "SMOKE_TIER=p0: selecting only p0-marked tests"
+    tier_args=(-m p0)
+    ;;
+  *)
+    echo "ERROR: unknown SMOKE_TIER='${SMOKE_TIER}' (expected 'p0' or 'full')" >&2
+    exit 1
+    ;;
+esac
+
 # pytest exit 5 = no tests collected (empty phase for this batch is OK).
 _pytest_ok() {
   local rc=$1
@@ -88,6 +107,16 @@ run_pytest_policy_phases() {
     echo "Phase 2 failed with exit code $rc2"
   fi
 
+  # rc 5 from ONE phase is normal -- most batches hold no policy mutators
+  # (empty phase 2), and a batch of only serial modules has an empty phase 1.
+  # rc 5 from BOTH means the batch collected nothing at all, which _pytest_ok
+  # would otherwise report as success: a green job that tested nothing.
+  if [[ "$rc1" -eq 5 && "$rc2" -eq 5 ]]; then
+    echo "ERROR: both pytest phases collected 0 tests for this batch." \
+         "Refusing to report an empty run as success." >&2
+    return 1
+  fi
+
   _pytest_ok "$rc1" || return "$rc1"
   _pytest_ok "$rc2" || return "$rc2"
   return 0
@@ -96,4 +125,4 @@ run_pytest_policy_phases() {
 # When invoked via the github action, BATCH_COUNT and BATCH_NUMBER env vars are set to run a slice of those tests per
 # worker for parallelism. docker-unified.yml generates a test matrix of pytests in batches. As number of tests
 # increase, the batch_count config (in docker-unified.yml) may need adjustment.
-run_pytest_policy_phases junit.smoke-pytests
+run_pytest_policy_phases junit.smoke-pytests ${tier_args[@]+"${tier_args[@]}"}

--- a/smoke-test/test_authentication_e2e.py
+++ b/smoke-test/test_authentication_e2e.py
@@ -46,7 +46,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
+]
 
 
 # Test constants

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -212,12 +212,14 @@ def test_run_ingestion(auth_session):
     wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_gms_get_user(auth_session):
     username = "jdoe"
     urn = f"urn:li:corpuser:{username}"
     _ensure_user_present(auth_session, urn=urn)
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "platform,dataset_name,env",
     [
@@ -282,6 +284,7 @@ def test_gms_batch_get_v2(auth_session):
     )  # Aspect does not exist.
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "query,min_expected_results",
     [
@@ -305,6 +308,7 @@ def test_gms_search_dataset(auth_session, query, min_expected_results):
     assert len(res_data["value"]["entities"]) >= min_expected_results
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "query,min_expected_results",
     [
@@ -395,6 +399,7 @@ def test_gms_usage_fetch(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_frontend_auth(auth_session):
     pass
 
@@ -424,6 +429,7 @@ def test_frontend_browse_datasets(auth_session):
     assert len(res_data["data"]["browse"]["groups"]) > 0
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "query,min_expected_results",
     [
@@ -458,6 +464,7 @@ def test_frontend_search_datasets(auth_session, query, min_expected_results):
     assert len(res_data["data"]["search"]["searchResults"]) >= min_expected_results
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "query,min_expected_results",
     [
@@ -493,6 +500,7 @@ def test_frontend_search_across_entities(auth_session, query, min_expected_resul
     )
 
 
+@pytest.mark.p0
 def test_frontend_user_info(auth_session):
     urn = get_root_urn()
     query = """query corpUser($urn: String!) {
@@ -517,6 +525,7 @@ def test_frontend_user_info(auth_session):
     assert res_data["data"]["corpUser"]["urn"] == urn
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "platform,dataset_name,env",
     [
@@ -793,6 +802,7 @@ def test_list_groups(auth_session):
     )  # Length of default group set.
 
 
+@pytest.mark.p0
 @pytest.mark.dependency(depends=["test_list_groups"])
 def test_add_remove_members_from_group(auth_session):
     # Assert no group edges for user jdoe
@@ -1111,6 +1121,7 @@ def test_search_results_recommendations(auth_session):
     assert "errors" not in res_data
 
 
+@pytest.mark.p0
 def test_generate_personal_access_token(auth_session):
     # Test success case
     json = {

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -764,6 +764,7 @@ def test_list_users(auth_session):
     )  # Length of default user set.
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 # The bootstrapped groups come from bootstrap_mce.json and are only visible here
 # once Elasticsearch has indexed them. wait_for_writes_to_sync() inside

--- a/smoke-test/test_system_info.py
+++ b/smoke-test/test_system_info.py
@@ -31,6 +31,7 @@ pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)
 # ==============================================
 
 
+@pytest.mark.p0
 def test_system_info_main_endpoint(auth_session):
     """Test that main system info endpoint returns expected structure with authentication."""
     response = auth_session.get(f"{auth_session.gms_url()}/openapi/v1/system-info")
@@ -129,6 +130,7 @@ def test_system_info_properties_endpoint(auth_session):
     logger.info("Detailed properties endpoint test passed")
 
 
+@pytest.mark.p0
 def test_system_info_simple_properties_endpoint(auth_session):
     """Test simple properties endpoint returns flat key-value map."""
     response = auth_session.get(
@@ -269,6 +271,7 @@ def extract_api_token_from_session(session):
     return token_data["accessToken"], token_data["metadata"]["id"]
 
 
+@pytest.mark.p0
 def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     """Test that system info endpoints return HTTP 403 for authenticated users without MANAGE_SYSTEM_OPERATIONS_PRIVILEGE.
 
@@ -355,6 +358,7 @@ def test_system_info_authenticated_non_admin_user_returns_403(auth_session):
     )
 
 
+@pytest.mark.p0
 def test_system_info_unauthorized_access_returns_403():
     """Test that system info endpoints return 401/403 for unauthenticated users."""
     # Make unauthenticated requests (no session) to verify 401/403 responses

--- a/smoke-test/tests/assertions/assertions_test.py
+++ b/smoke-test/tests/assertions/assertions_test.py
@@ -315,6 +315,7 @@ def _gms_get_latest_assertions_results_by_partition(auth_session):
     assert all(row[assertee_urn_index] == urn for row in rows)
 
 
+@pytest.mark.p0
 def test_gms_get_latest_assertions_results_by_partition(
     auth_session, test_run_ingestion
 ):
@@ -346,6 +347,7 @@ def test_gms_get_assertions_on_dataset_field(auth_session, test_run_ingestion):
     assert len(data["relationships"]) == 1
 
 
+@pytest.mark.p0
 def test_gms_get_assertion_info(auth_session, test_run_ingestion):
     assertion_urn = "urn:li:assertion:2d3b06a6e77e1f24adc9860a05ea089b"
     response = auth_session.get(

--- a/smoke-test/tests/assertions/custom_assertions_test.py
+++ b/smoke-test/tests/assertions/custom_assertions_test.py
@@ -99,6 +99,7 @@ def test_data(graph_client):
     delete_urn(graph_client, TEST_DATASET_URN)
 
 
+@pytest.mark.p0
 def test_create_update_delete_dataset_custom_assertion(
     test_data: Any, graph_client: DataHubGraph
 ) -> None:

--- a/smoke-test/tests/audit_events/audit_events_test.py
+++ b/smoke-test/tests/audit_events/audit_events_test.py
@@ -23,7 +23,11 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
+]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/authorization/test_aspect_write_auth.py
+++ b/smoke-test/tests/authorization/test_aspect_write_auth.py
@@ -47,6 +47,7 @@ pytestmark = [
     pytest.mark.no_cypress_suite1,
     pytest.mark.global_policy_mutator,
     pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
 ]
 
 _UNIQUE = uuid.uuid4().hex[:8]

--- a/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
+++ b/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
@@ -55,6 +55,7 @@ pytestmark = [
     pytest.mark.no_cypress_suite1,
     pytest.mark.global_policy_mutator,
     pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
 ]
 
 _UNIQUE = uuid.uuid4().hex[:8]

--- a/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
+++ b/smoke-test/tests/authorization/test_domain_scoped_create_entity_auth.py
@@ -55,7 +55,6 @@ pytestmark = [
     pytest.mark.no_cypress_suite1,
     pytest.mark.global_policy_mutator,
     pytest.mark.domain(Domain.PLATFORM),
-    pytest.mark.p0,
 ]
 
 _UNIQUE = uuid.uuid4().hex[:8]

--- a/smoke-test/tests/authorization/test_query_entity_read_auth.py
+++ b/smoke-test/tests/authorization/test_query_entity_read_auth.py
@@ -48,6 +48,7 @@ pytestmark = [
     pytest.mark.no_cypress_suite1,
     pytest.mark.global_policy_mutator,
     pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
 ]
 
 _UNIQUE = uuid.uuid4().hex[:8]

--- a/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
+++ b/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
@@ -91,6 +91,7 @@ def run_cli_command(cmd, auth_session):
     return result
 
 
+@pytest.mark.p0
 def test_dataset_sync_to_datahub(
     setup_teardown_dataset, graph_client: DataHubGraph, auth_session
 ):

--- a/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
+++ b/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
@@ -20,7 +20,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 test_aspect_name: str = "datasetProfile"
 test_dataset_urn: str = builder.make_dataset_urn_with_platform_instance(

--- a/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
+++ b/smoke-test/tests/cli/graphql_cmd/test_graphql_cli_smoke.py
@@ -150,6 +150,7 @@ class TestGraphQLCLIIntegration:
                 # Human readable format
                 assert len(stdout.strip()) > 0
 
+    @pytest.mark.p0
     def test_graphql_simple_query_execution(self):
         """Test execution of a simple GraphQL query."""
         simple_query = "{ __typename }"

--- a/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
+++ b/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
@@ -9,7 +9,7 @@ from datahub.metadata.schema_classes import DatasetProfileClass
 from tests.utilities.domains import Domain
 from tests.utils import ingest_file_via_rest, run_datahub_cmd, sync_elastic
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 
 def datahub_rollback(auth_session, run_id: str) -> None:

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_instance2instance_smoke.py
@@ -184,6 +184,7 @@ def seeded(graph_client: DataHubGraph):
         wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_instance2instance_rewrites_lineage_and_migrates_aspects(
     graph_client: DataHubGraph, seeded
 ) -> None:

--- a/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
+++ b/smoke-test/tests/cli/migrate_cmd/test_migrate_scenarios_smoke.py
@@ -207,6 +207,7 @@ def test_dataplatform2instance_assigns_instance_and_carries_aspects(
         wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_preserve_leaves_existing_target_untouched(
     graph_client: DataHubGraph,
 ) -> None:

--- a/smoke-test/tests/cli/search_cmd/test_search_cmd.py
+++ b/smoke-test/tests/cli/search_cmd/test_search_cmd.py
@@ -111,6 +111,7 @@ def _run_search(auth_session, args: list) -> tuple:
 class TestSearchBasic:
     """Core output format and structure tests."""
 
+    @pytest.mark.p0
     def test_wildcard_returns_json(self, auth_session):
         """Default search returns valid JSON with results."""
         exit_code, stdout, _ = _run_search(auth_session, ["*", "--limit", "5"])

--- a/smoke-test/tests/cli/user_cmd/test_user_add.py
+++ b/smoke-test/tests/cli/user_cmd/test_user_add.py
@@ -79,6 +79,7 @@ def test_users_cleanup(auth_session: Any, graph_client: DataHubGraph):
         wait_for_writes_to_sync(mae_only=True)
 
 
+@pytest.mark.p0
 def test_user_add_without_role(auth_session: Any, test_users_cleanup: Any) -> None:
     """Test creating a user without specifying a role."""
     email = generate_test_email()

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -88,6 +88,7 @@ def get_group_membership(graph_client: DataHubGraph, user_urn: str) -> List[str]
     return [entity.urn for entity in entities]
 
 
+@pytest.mark.p0
 def test_group_upsert(auth_session: Any, graph_client: DataHubGraph) -> None:
     num_groups: int = 10
     for i, datahub_group in enumerate(gen_datahub_groups(num_groups)):

--- a/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
@@ -12,7 +12,7 @@ from tests.consistency_utils import wait_for_writes_to_sync
 from tests.utilities.domains import Domain
 from tests.utils import run_datahub_cmd
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 
 def datahub_upsert_user(auth_session, user: CorpUser) -> None:

--- a/smoke-test/tests/containers/containers_test.py
+++ b/smoke-test/tests/containers/containers_test.py
@@ -90,6 +90,7 @@ def ingest_cleanup_data(auth_session, graph_client, tmp_path_factory):
         delete_urns_from_file(graph_client, data_file)
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 # The query below reads platform, subTypes, editableProperties and related
 # entities in one shot, and each aspect is indexed independently -- a single

--- a/smoke-test/tests/database/test_database.py
+++ b/smoke-test/tests/database/test_database.py
@@ -9,7 +9,7 @@ from tests.utils import delete_urns, wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 
 generated_urns = [make_dataset_urn("test", f"database_test_{i}") for i in range(0, 100)]

--- a/smoke-test/tests/datapack/test_datapack_smoke.py
+++ b/smoke-test/tests/datapack/test_datapack_smoke.py
@@ -81,6 +81,7 @@ def _restore_soft_deleted_showcase_structured_properties(
 class TestDatapackCLI:
     """Test the `datahub datapack` CLI commands."""
 
+    @pytest.mark.p0
     def test_datapack_list(self):
         """datahub datapack list returns available packs."""
         result = run_datahub_cmd(["datapack", "list", "--format", "json"])

--- a/smoke-test/tests/dataproduct/test_dataproduct.py
+++ b/smoke-test/tests/dataproduct/test_dataproduct.py
@@ -37,7 +37,7 @@ from tests.utils import wait_for_writes_to_sync, with_test_retry
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.CATALOG)
+pytestmark = [pytest.mark.domain(Domain.CATALOG), pytest.mark.p0]
 
 
 start_index = randint(10, 10000)

--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -104,6 +104,7 @@ def test_setup(auth_session, graph_client, tmp_path):
     )
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_delete_reference(graph_client, test_setup):
     tag_urn, dataset_urn = test_setup

--- a/smoke-test/tests/deprecation/deprecation_test.py
+++ b/smoke-test/tests/deprecation/deprecation_test.py
@@ -21,6 +21,7 @@ def dataset_urn(auth_session, graph_client, tmp_path_factory):
     )
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_update_deprecation_all_fields(auth_session, dataset_urn):
     query = """query getDataset($urn: String!) {\n

--- a/smoke-test/tests/domains/domains_test.py
+++ b/smoke-test/tests/domains/domains_test.py
@@ -52,6 +52,7 @@ def _ensure_domain_readable(
     return domain
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_create_list_get_domain(auth_session):
     # Run-unique id so parallel workers never collide on urn:li:domain:test id.

--- a/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
+++ b/smoke-test/tests/entity_graph_cache/test_entity_graph_cache.py
@@ -62,6 +62,7 @@ METRIC_SEARCH_SCROLL = "entity.graph.build.search_scroll"
 METRIC_GRAPH_SCROLL = "entity.graph.build.graph_scroll"
 
 
+@pytest.mark.p0
 def test_domain_parent_domains_hierarchy(auth_session, graph_client):
     run_id = unique_id("egc-domain")
     grandparent_id = f"egc-grand-{run_id}"
@@ -139,6 +140,7 @@ def test_domain_sync_move_reflects_in_parent_domains(auth_session, graph_client)
         cleanup_domains(auth_session, created)
 
 
+@pytest.mark.p0
 def test_glossary_parent_nodes_hierarchy(auth_session, graph_client):
     run_id = unique_id("egc-glossary")
     root_id = f"egc-gnode-root-{run_id}"
@@ -403,6 +405,7 @@ def test_glossary_cache_metrics_when_isolated(auth_session, graph_client):
         cleanup_glossary_entities(graph_client, created)
 
 
+@pytest.mark.p0
 def test_container_parent_containers_hierarchy(auth_session, graph_client):
     run_id = unique_id("egc-container")
     grandparent_id = f"egc-c-grand-{run_id}"
@@ -442,6 +445,7 @@ def test_container_parent_containers_hierarchy(auth_session, graph_client):
         cleanup_containers(graph_client, created)
 
 
+@pytest.mark.p0
 def test_container_relationships_direct_children(auth_session, graph_client):
     run_id = unique_id("egc-container-rel")
     grandparent_id = f"egc-cr-grand-{run_id}"

--- a/smoke-test/tests/forms/forms_test.py
+++ b/smoke-test/tests/forms/forms_test.py
@@ -177,6 +177,7 @@ def unassigned_before_each(auth_session, form_urn):
     wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_batch_assign_and_remove_form(auth_session, form_urn):
     res_data = _assign(auth_session, form_urn, DATASET_URNS)
     assert res_data["data"]["batchAssignForm"] is True

--- a/smoke-test/tests/graph/test_graph_client.py
+++ b/smoke-test/tests/graph/test_graph_client.py
@@ -27,6 +27,7 @@ def ingest_cleanup_data(auth_session, graph_client):
     )
 
 
+@pytest.mark.p0
 def test_get_aspect_v2(graph_client, ingest_cleanup_data):
     urn = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-rollback,PROD)"
     schema_metadata: Optional[SchemaMetadataClass] = graph_client.get_aspect_v2(

--- a/smoke-test/tests/incidents/health_batch_test.py
+++ b/smoke-test/tests/incidents/health_batch_test.py
@@ -101,6 +101,7 @@ def _set_soft_deleted(auth_session, urn: str, deleted: bool) -> None:
     wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_incident_health_survives_soft_deleted_asset(auth_session):
     """A soft-deleted asset still resolves the same incident health.
 

--- a/smoke-test/tests/incidents/incidents_test.py
+++ b/smoke-test/tests/incidents/incidents_test.py
@@ -7,7 +7,7 @@ from conftest import _ingest_cleanup_data_impl
 from tests.utilities.domains import Domain
 from tests.utils import delete_entity, execute_graphql
 
-pytestmark = pytest.mark.domain(Domain.OBSERVE)
+pytestmark = [pytest.mark.domain(Domain.OBSERVE), pytest.mark.p0]
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/smoke-test/tests/institutional_memory/institutional_memory_test.py
+++ b/smoke-test/tests/institutional_memory/institutional_memory_test.py
@@ -65,6 +65,7 @@ mutation upsertLink($input: UpsertLinkInput!) {\n
 ADMIN_USERNAME = get_admin_username()
 
 
+@pytest.mark.p0
 def test_get_institutional_memory(auth_session):
     res_data = execute_graphql(auth_session, QUERY_LIST, {"urn": TEST_DATASET_URN})
 

--- a/smoke-test/tests/knowledge/document_change_history_test.py
+++ b/smoke-test/tests/knowledge/document_change_history_test.py
@@ -50,6 +50,7 @@ def _unique_id(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_document_change_history(auth_session):
     """Test document change history tracking."""

--- a/smoke-test/tests/knowledge/document_change_history_test.py
+++ b/smoke-test/tests/knowledge/document_change_history_test.py
@@ -174,6 +174,7 @@ def test_document_change_history(auth_session):
     assert del_res["data"]["deleteDocument"] is True
 
 
+@pytest.mark.p0
 @pytest.mark.dependency(depends=["test_document_change_history"])
 def test_document_change_history_with_time_range(auth_session):
     """Test document change history with time range parameters."""

--- a/smoke-test/tests/knowledge/document_search_filter_test.py
+++ b/smoke-test/tests/knowledge/document_search_filter_test.py
@@ -105,6 +105,7 @@ def _delete_document(auth_session, urn: str):
     execute_graphql(auth_session, delete_mutation, {"urn": urn}, no_sync_wait=True)
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_search_documents_filters_hidden_context_documents(auth_session):
     """

--- a/smoke-test/tests/knowledge/test_document_crud.py
+++ b/smoke-test/tests/knowledge/test_document_crud.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.domain(Domain.AI)
 
 
 class TestDocumentCrudAndMutations:
+    @pytest.mark.p0
     def test_create_document(self, auth_session):
         document_id = unique_id("smoke-doc-create")
 
@@ -43,6 +44,7 @@ class TestDocumentCrudAndMutations:
         del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
         assert del_res["data"]["deleteDocument"] is True
 
+    @pytest.mark.p0
     def test_get_document(self, auth_session):
         document_id = unique_id("smoke-doc-get")
 
@@ -107,6 +109,7 @@ class TestDocumentCrudAndMutations:
         del_res = execute_graphql(auth_session, delete_mutation, {"urn": urn})
         assert del_res["data"]["deleteDocument"] is True
 
+    @pytest.mark.p0
     def test_update_document_contents(self, auth_session):
         document_id = unique_id("smoke-doc-update")
 

--- a/smoke-test/tests/library_examples/test_library_examples.py
+++ b/smoke-test/tests/library_examples/test_library_examples.py
@@ -23,7 +23,7 @@ from tests.utilities.domains import Domain
 
 from .example_manifest import EXAMPLE_DEPENDENCIES, EXAMPLE_MANIFEST
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 # Path to metadata-ingestion examples
 EXAMPLES_DIR = (

--- a/smoke-test/tests/lineage/test_lineage.py
+++ b/smoke-test/tests/lineage/test_lineage.py
@@ -811,6 +811,7 @@ class Scenario(BaseModel):
 # @tenacity.retry(
 #     stop=tenacity.stop_after_attempt(sleep_times), wait=tenacity.wait_fixed(sleep_sec)
 # )
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "lineage_style",
     [

--- a/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
+++ b/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
@@ -252,6 +252,7 @@ def _ensure_execution_request_present(auth_session, execution_request_urn):
     return res_data
 
 
+@pytest.mark.p0
 def test_create_list_get_remove_secret(auth_session):
     # Get count of existing secrets
     query = """query listSecrets($input: ListSecretsInput!) {\n

--- a/smoke-test/tests/object_storage/test_object_storage.py
+++ b/smoke-test/tests/object_storage/test_object_storage.py
@@ -93,6 +93,7 @@ def test_documentation_file_upload_gated_without_presigned_urls(
     assert enabled is False
 
 
+@pytest.mark.p0
 def test_get_presigned_upload_url_rejects_local_provider(
     auth_session: Any, documentation_dataset_urn: str
 ) -> None:

--- a/smoke-test/tests/openapi/test_openapi.py
+++ b/smoke-test/tests/openapi/test_openapi.py
@@ -17,7 +17,7 @@ from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 _ROOT_FIXTURE_GLOBS = [
     "tests/openapi/v1/*.json",

--- a/smoke-test/tests/openapi/v1/test_tracking.py
+++ b/smoke-test/tests/openapi/v1/test_tracking.py
@@ -32,7 +32,7 @@ from tests.utils import get_kafka_broker_url
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 # Load environment variables from .env file if it exists
 load_dotenv()

--- a/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
+++ b/smoke-test/tests/openapi/v2/test_timeseries_scroll.py
@@ -133,6 +133,7 @@ def setup_timeseries_data(auth_session):
     cleanup_test_data(auth_session)
 
 
+@pytest.mark.p0
 def test_timeseries_scroll_returns_scrollid(auth_session, setup_timeseries_data):
     """Test that scrollId is returned when there are more results than the page size."""
     test_data = setup_timeseries_data

--- a/smoke-test/tests/openapi/v3/test_scroll_entities.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_entities.py
@@ -12,7 +12,7 @@ from datahub.metadata.schema_classes import DatasetKeyClass
 from tests.utilities.domains import Domain
 from tests.utils import with_test_retry
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 PLATFORM = "urn:li:dataPlatform:scrolltest"
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"

--- a/smoke-test/tests/openapi/v3/test_scroll_lineage.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_lineage.py
@@ -33,7 +33,7 @@ from tests.utils import with_test_retry
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"
 GAMMA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,gamma,PROD)"

--- a/smoke-test/tests/openapi/v3/test_scroll_relationships.py
+++ b/smoke-test/tests/openapi/v3/test_scroll_relationships.py
@@ -12,7 +12,7 @@ from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 ALPHA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,alpha,PROD)"
 ZETA = "urn:li:dataset:(urn:li:dataPlatform:scrolltest,zeta,PROD)"

--- a/smoke-test/tests/patch/test_datajob_patches.py
+++ b/smoke-test/tests/patch/test_datajob_patches.py
@@ -22,7 +22,7 @@ from tests.patch.common_patch_tests import (
 )
 from tests.utilities.domains import Domain
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 
 def _make_test_datajob_urn(

--- a/smoke-test/tests/patch/test_dataset_patches.py
+++ b/smoke-test/tests/patch/test_dataset_patches.py
@@ -35,7 +35,7 @@ from tests.patch.common_patch_tests import (
 )
 from tests.utilities.domains import Domain
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 
 @pytest.fixture(params=["graph_client", "openapi_graph_client"])

--- a/smoke-test/tests/patch/test_domain_patches.py
+++ b/smoke-test/tests/patch/test_domain_patches.py
@@ -19,7 +19,7 @@ from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 
 def _make_domain_urn() -> str:

--- a/smoke-test/tests/policies/test_policies.py
+++ b/smoke-test/tests/policies/test_policies.py
@@ -72,6 +72,7 @@ def _ensure_policy_present(auth_session, new_urn):
     assert result[0]["actors"]["allUsers"]
 
 
+@pytest.mark.p0
 def test_frontend_policy_operations(auth_session):
     create_policy_query = """mutation createPolicy($input: PolicyUpdateInput!) {
             createPolicy(input: $input) }"""

--- a/smoke-test/tests/privileges/test_privileges.py
+++ b/smoke-test/tests/privileges/test_privileges.py
@@ -36,6 +36,7 @@ pytestmark = [
     pytest.mark.no_cypress_suite1,
     pytest.mark.global_policy_mutator,
     pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
 ]
 
 # Valid email for auth.native.signUp.enforceValidEmail (Play EmailValidator).

--- a/smoke-test/tests/read_only/test_ingestion_list.py
+++ b/smoke-test/tests/read_only/test_ingestion_list.py
@@ -4,7 +4,7 @@ from tests.test_result_msg import add_datahub_stats
 from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import list_ingestion_sources
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_policies.py
+++ b/smoke-test/tests/read_only/test_policies.py
@@ -4,7 +4,7 @@ from tests.test_result_msg import add_datahub_stats
 from tests.utilities.domains import Domain
 from tests.utilities.metadata_operations import list_policies
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 
 @pytest.mark.read_only

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -24,6 +24,7 @@ default_headers = {
 }
 
 
+@pytest.mark.p0
 @pytest.mark.read_only
 def test_search_works(auth_session):
     """Test that GraphQL entity queries work for all entity types."""

--- a/smoke-test/tests/read_only/test_services_up.py
+++ b/smoke-test/tests/read_only/test_services_up.py
@@ -8,7 +8,7 @@ from tests.utilities.domains import Domain
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 # Kept separate so that it does not cause failures in PRs
 DATAHUB_VERSION = env_vars.get_test_datahub_version()

--- a/smoke-test/tests/restli/test_restli_batch_ingestion.py
+++ b/smoke-test/tests/restli/test_restli_batch_ingestion.py
@@ -116,6 +116,7 @@ def _create_invalid_dataset_mcps() -> List[MetadataChangeProposalWrapper]:
     return bad_mcps
 
 
+@pytest.mark.p0
 def test_restli_batch_ingestion_sync(graph_client):
     # Positive Test (all valid MetadataChangeProposal)
     mcps = _create_valid_dashboard_mcps()

--- a/smoke-test/tests/search/test_search_projection.py
+++ b/smoke-test/tests/search/test_search_projection.py
@@ -79,6 +79,7 @@ class TestSearchProjection:
     """Smoke tests for --projection flag: verifies that custom GQL projections
     execute successfully against a live DataHub instance."""
 
+    @pytest.mark.p0
     def test_minimal_projection(self, graph_client):
         """Projection with only urn+type returns entities without extra fields."""
         query = _build_search_query(semantic=False, projection="urn type")

--- a/smoke-test/tests/semantic/test_current_offset_api.py
+++ b/smoke-test/tests/semantic/test_current_offset_api.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.domain(Domain.AI)
 
 
+@pytest.mark.p0
 def test_get_current_offset_no_params(auth_session: TestSessionWrapper):
     """
     Test that polling Events API with no offsetId and no lookbackWindowDays

--- a/smoke-test/tests/service_accounts/test_service_accounts.py
+++ b/smoke-test/tests/service_accounts/test_service_accounts.py
@@ -20,7 +20,7 @@ from tests.utils import get_sleep_info
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.PLATFORM)
+pytestmark = [pytest.mark.domain(Domain.PLATFORM), pytest.mark.p0]
 
 sleep_sec, sleep_times = get_sleep_info()
 

--- a/smoke-test/tests/status/test_lifecycle_state.py
+++ b/smoke-test/tests/status/test_lifecycle_state.py
@@ -280,6 +280,7 @@ class TestLifecycleStageAPIs:
         self.created_stage_urns.append(stage_urn)
         return stage_urn
 
+    @pytest.mark.p0
     def test_list_lifecycle_stages_includes_ingested(self, auth_session):
         """
         Ingest a custom lifecycle stage and verify it appears in listLifecycleStages.
@@ -306,6 +307,7 @@ class TestLifecycleStageAPIs:
         _assert_listed()
         logger.info("listLifecycleStages returns ingested stage")
 
+    @pytest.mark.p0
     def test_set_lifecycle_stage_mutation(self, auth_session):
         """
         setLifecycleStage mutation sets the stage on an entity and the
@@ -350,6 +352,7 @@ class TestLifecycleStageAPIs:
         assert status.get("lifecycleStage") is None
         logger.info("setLifecycleStage mutation set and cleared stage")
 
+    @pytest.mark.p0
     def test_hidden_stage_excludes_from_cross_entity_search(self, auth_session):
         """
         Entities in a hideInSearch=true stage are excluded from cross-entity

--- a/smoke-test/tests/structured_properties/test_structured_properties.py
+++ b/smoke-test/tests/structured_properties/test_structured_properties.py
@@ -175,6 +175,7 @@ def to_es_filter_name(
         return f"structuredProperties.{qualified_name}"
 
 
+@pytest.mark.p0
 def test_structured_property_string(ingest_cleanup_data, graph_client):
     property_name = f"retention{randint(10, 10000)}Policy"
 

--- a/smoke-test/tests/tags_and_terms/tags_and_terms_test.py
+++ b/smoke-test/tests/tags_and_terms/tags_and_terms_test.py
@@ -28,6 +28,7 @@ def dataset_urn(auth_session, graph_client, tmp_path_factory):
     )
 
 
+@pytest.mark.p0
 def test_add_tag(auth_session, dataset_urn):
     dataset_query = """query getDataset($urn: String!) {
             dataset(urn: $urn) {

--- a/smoke-test/tests/test_kafka_default_sink.py
+++ b/smoke-test/tests/test_kafka_default_sink.py
@@ -85,6 +85,7 @@ def _create_default_sink_pipeline(auth_session, monkeypatch, default_sink, data_
     )
 
 
+@pytest.mark.p0
 @pytest.mark.parametrize(
     "default_sink,expected_sink_type",
     [("rest", "datahub-rest"), ("kafka", "datahub-kafka")],

--- a/smoke-test/tests/test_stateful_ingestion.py
+++ b/smoke-test/tests/test_stateful_ingestion.py
@@ -12,7 +12,7 @@ from datahub.testing.state_helpers import get_current_checkpoint_from_pipeline
 from tests.utilities.domains import Domain
 from tests.utils import get_db_password, get_db_type, get_db_url, get_db_username
 
-pytestmark = pytest.mark.domain(Domain.INGESTION)
+pytestmark = [pytest.mark.domain(Domain.INGESTION), pytest.mark.p0]
 
 
 def test_stateful_ingestion(auth_session):

--- a/smoke-test/tests/timeline/timeline_change_history_test.py
+++ b/smoke-test/tests/timeline/timeline_change_history_test.py
@@ -541,6 +541,7 @@ class TestDatasetTimeline:
             min_events=2,
         )
 
+    @pytest.mark.p0
     def test_dataset_domain_changes(
         self, graph_client, auth_session, timeline_urns: TimelineUrns
     ):
@@ -649,6 +650,7 @@ class TestDatasetTimeline:
             min_events=2,
         )
 
+    @pytest.mark.p0
     def test_dataset_documentation_changes(
         self, graph_client, auth_session, timeline_urns: TimelineUrns
     ):
@@ -857,6 +859,7 @@ class TestGlossaryTermTimeline:
             min_events=2,
         )
 
+    @pytest.mark.p0
     def test_glossary_term_structured_property_changes(
         self, graph_client, auth_session, timeline_urns: TimelineUrns
     ):

--- a/smoke-test/tests/timeline/timeline_test.py
+++ b/smoke-test/tests/timeline/timeline_test.py
@@ -10,6 +10,7 @@ from tests.utils import ingest_file_via_rest, wait_for_writes_to_sync
 pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.CATALOG)]
 
 
+@pytest.mark.p0
 def test_all(auth_session, graph_client):
     platform = "urn:li:dataPlatform:kafka"
     dataset_name = "test-timeline-sample-kafka"

--- a/smoke-test/tests/timeseries/test_dataset_profiles_graphql.py
+++ b/smoke-test/tests/timeseries/test_dataset_profiles_graphql.py
@@ -23,7 +23,7 @@ from tests.utils import (
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.domain(Domain.OBSERVE)
+pytestmark = [pytest.mark.domain(Domain.OBSERVE), pytest.mark.p0]
 
 _DATASET_URNS = [
     f"urn:li:dataset:(urn:li:dataPlatform:test,profilesGraphqlDataset{i},PROD)"

--- a/smoke-test/tests/timeseries/test_stats_summary_graphql.py
+++ b/smoke-test/tests/timeseries/test_stats_summary_graphql.py
@@ -362,6 +362,7 @@ def _expected_top_users(fixture: Dict[str, Any]) -> List[str]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.p0
 def test_dashboard_stats_summary(auth_session: Any) -> None:
     """
     Queries 3 dashboards in a single multi-alias request (exercises the DataLoader
@@ -401,6 +402,7 @@ def test_dashboard_stats_summary(auth_session: Any) -> None:
     assert_dashboard_summaries()
 
 
+@pytest.mark.p0
 def test_dataset_stats_summary(auth_session: Any) -> None:
     """
     Queries 3 datasets in a single multi-alias request (one GraphQL request → the DataLoader

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -20,7 +20,11 @@ from .token_utils import (
     wait_for_user_in_list,
 )
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
+]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/tokens/session_access_token_test.py
+++ b/smoke-test/tests/tokens/session_access_token_test.py
@@ -16,7 +16,11 @@ from tests.utils import (
 
 from .token_utils import getUserId, listUsers, removeUser
 
-pytestmark = [pytest.mark.no_cypress_suite1, pytest.mark.domain(Domain.PLATFORM)]
+pytestmark = [
+    pytest.mark.no_cypress_suite1,
+    pytest.mark.domain(Domain.PLATFORM),
+    pytest.mark.p0,
+]
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/trace/test_api_trace.py
+++ b/smoke-test/tests/trace/test_api_trace.py
@@ -36,6 +36,7 @@ def test_setup(graph_client):
     wait_for_writes_to_sync()
 
 
+@pytest.mark.p0
 def test_successful_async_write(auth_session):
     urn = generated_urns["apiTraceHappyPath"]
     aspect_name = "status"
@@ -67,6 +68,7 @@ def test_successful_async_write(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_mcp_fail_aspect_async_write(auth_session):
     urn = generated_urns["apiTraceMCPFail"]
     aspect_name = "glossaryTerms"
@@ -105,6 +107,7 @@ def test_mcp_fail_aspect_async_write(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_overwritten_async_write(auth_session):
     urn = generated_urns["apiTraceOverwritten"]
     aspect_name = "datasetProperties"
@@ -192,6 +195,7 @@ def test_overwritten_async_write(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_missing_elasticsearch_async_write(auth_session, graph_client):
     urn = generated_urns["apiTraceDroppedElasticsearch"]
     aspect_name = "status"
@@ -268,6 +272,7 @@ def test_missing_elasticsearch_async_write(auth_session, graph_client):
     }
 
 
+@pytest.mark.p0
 def test_timeseries_async_write(auth_session):
     urn = generated_urns["apiTraceTimeseries"]
     aspect_name = "datasetProfile"
@@ -310,6 +315,7 @@ def test_timeseries_async_write(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_noop_async_write(auth_session):
     urn = generated_urns["apiTraceNoop"]
     aspect_name = "status"
@@ -367,6 +373,7 @@ def test_noop_async_write(auth_session):
     }
 
 
+@pytest.mark.p0
 def test_noop_with_fmcp_async_write(auth_session):
     urn = generated_urns["apiTraceNoopWithFMCP"]
     aspect_name = "status"

--- a/smoke-test/tests/utilities/env_vars.py
+++ b/smoke-test/tests/utilities/env_vars.py
@@ -3,7 +3,7 @@
 
 import os
 import re
-from typing import Optional
+from typing import List, Optional
 
 # ============================================================================
 # Core DataHub Configuration
@@ -265,6 +265,16 @@ def get_datahub_usage_event_topic() -> str:
 def get_filtered_tests_file() -> Optional[str]:
     """Path to file containing filtered test paths (one per line)."""
     return os.getenv("FILTERED_TESTS")
+
+
+def get_smoke_changed_tests() -> List[str]:
+    """Test modules the PR under test touches (CI sets SMOKE_CHANGED_TESTS).
+
+    Space-separated repo-relative paths; these run alongside a tier-narrowed
+    selection.
+    """
+    raw = os.getenv("SMOKE_CHANGED_TESTS", "").strip()
+    return raw.split() if raw else []
 
 
 def get_smoke_policy_phase() -> Optional[str]:

--- a/smoke-test/tests/views/views_test.py
+++ b/smoke-test/tests/views/views_test.py
@@ -46,6 +46,7 @@ def _ensure_less_views(
     assert after_count == before_count - 1
 
 
+@pytest.mark.p0
 @pytest.mark.dependency()
 def test_create_list_delete_global_view(auth_session):
     # Get count of existing views
@@ -144,6 +145,7 @@ def test_create_list_delete_global_view(auth_session):
     )
 
 
+@pytest.mark.p0
 @pytest.mark.dependency(depends=["test_create_list_delete_global_view"])
 def test_create_list_delete_personal_view(auth_session):
     # Get count of existing views


### PR DESCRIPTION
Lets pull-request smoke runs execute only the `p0` tier while post-merge runs keep running everything. A PR's own new tests still run. The bin packer is tuned for the narrowed set. Stacked on #19579 (p0 tagging).

### What changed

**Tier selection**

- `smoke-test/smoke.sh` — reads `SMOKE_TIER` and selects with a plain marker expression, `-m p0`, under the tier; nothing extra otherwise.
- `.github/workflows/docker-unified.yml` — `smoke_tier` setup output: `p0` on pull requests while the `PYTEST_P0_SMOKE` repository variable is `true`, `full` otherwise.
- `smoke-test/conftest.py` — the batching hook is now `@pytest.hookimpl(trylast=True)` so it runs after pytest's own `-m` deselection.

**A PR's own tests still run**

- `pytest_itemcollected` adds `pytest.mark.p0` to items from modules the PR touches (CI passes them in `SMOKE_CHANGED_TESTS`), so `-m p0` keeps them. This is the marker-injection pattern from pytest's docs — no second selection mechanism.
- The union is per-module, so a change to a shared fixture or `conftest.py` pulls in no test module of its own. A PR needing broader coverage asks for the whole suite with the `run-all-tests` label (next PR in the stack).
- If a path in `SMOKE_CHANGED_TESTS` matches no collected module, conftest logs a warning. Deleted test files land there harmlessly, but a drift in the path format CI emits would otherwise silently stop a PR's own tests being marked.

**Packer and safety**

- Batch count is tier-conditional: 4 for `p0`, unchanged at 7 for the full suite.
- `smoke.sh` fails a batch when **both** pytest phases exit 5. One empty phase is normal (most batches hold no policy mutators); both means the batch tested nothing and would otherwise have gone green.

### Turning it on

Nothing changes until the variable is set:

```
gh variable set PYTEST_P0_SMOKE --repo datahub-project/datahub --body "true"
```

Post-merge pushes and nightly always run the full suite regardless.

### Measured on real CI runs

p0 tier: run `34100389266` on this branch, 4 batches, all green. Full suite: run `34095346266` on the PR below this one, which has no tier wiring and so still runs all 7 batches. Both sit on the same base commit, so they are directly comparable.

| | full suite | `p0` tier |
| --- | --- | --- |
| tests selected | 1,209 | **342** |
| pytest time | 85 job-min | **36 job-min** |
| slowest batch, wall clock | 24.1 min | **14.0 min** |
| total compute | 117 job-min | **53 job-min** |

**-42% wall clock, -55% compute.** All four batches land within 12.9-14.0 min.

Most of the wall-clock win comes from the PR below this one dropping `p0` from `tests/authorization/test_domain_scoped_create_entity_auth.py`. Its 15 serial tests were 13.1 min of the slowest batch's 18.7 min of pytest time.

### Why the batching hook runs last

pytest applies `-m` deselection *after* a default-priority `pytest_collection_modifyitems`, so the bin packer would otherwise pack bins from the whole suite and then have most of each bin deselected. `trylast` puts conftest's hook after that deselection, so bins are packed from the set that will actually run. Confirmed in the logs: `Batching 342 tests`, not 1209.

### The post-merge path is unchanged

Verified by collecting the per-batch test list on the base commit and on this branch: **byte-identical**, 1209 tests across 154 modules with the same batch assignment. A full run here passes no `-m`, so `trylast` reorders nothing.

### Known limits

- Tests with no recorded runtime keep the packer's existing handling — a newly added test is weighted exactly as it is today.
- The p0 batch count of 4 was derived from test counts; the run above confirms it balances well in practice.


