### PR TITLE
fix(docker): cache-bust python apk layer in datahub-actions image for setuptools CVE-2025-47273

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -25,7 +25,14 @@ RUN addgroup -g 1000 datahub && \
 ARG PYTHON_VERSION
 RUN test -n "${PYTHON_VERSION}"  # PYTHON_VERSION must be set
 
+# Cache-bust the python apk layer. Wolfi is a rolling distro, so a cached build layer
+# can keep shipping a stale, vulnerable package set even after upstream fixes it (a
+# stale cache shipped setuptools 70.3.0 / CVE-2025-47273 at /usr/share/python-wheels/;
+# current Wolfi ships a fixed setuptools). Bump WOLFI_PKG_REFRESH to force a fresh
+# `apk add` whenever base packages need refreshing.
+ARG WOLFI_PKG_REFRESH=2026-08-31
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    echo "wolfi pkg refresh: ${WOLFI_PKG_REFRESH}" && \
     apk add --no-cache --update-cache \
     ca-certificates \
     python-${PYTHON_VERSION} \


### PR DESCRIPTION
## Summary

Image scans of `datahub-actions` flagged setuptools 70.3.0 (CVE-2025-47273) at `/usr/share/python-wheels/`. A fresh `apk add python-3.11` on current `cgr.dev/chainguard/wolfi-base:latest` installs a fixed setuptools (84.0.0), so the vulnerable copy comes from a stale cached build layer for the `apk add python-*` step, not from what Wolfi ships today.

Wolfi is a rolling distro, so any cached `apk add` layer can keep shipping an outdated package set long after upstream fixes it. This adds a `WOLFI_PKG_REFRESH` build arg to that layer, echoed as the first command in the `RUN`, so bumping the date forces one fresh `apk add` and then caches normally again.

The `rm -rf .../site-packages/setuptools*` approach does not work here because the flagged wheel lives under `/usr/share/python-wheels/`, not `site-packages`.

## Changes

- `docker/datahub-actions/Dockerfile`: add `ARG WOLFI_PKG_REFRESH` and the cache-bust echo to the `python-base` stage's `apk add` layer.

## Verification

- `docker buildx build --check` reports no warnings.
- Pre-commit hooks pass, including the quickstart compose consistency check.
- Fresh `apk add python-3.11` on current `wolfi-base` yields only `/usr/share/python-wheels/setuptools-84.0.0`, with nothing in `site-packages` and no 70.3.0.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable) - n/a, image build change
- [ ] Docs related to the changes have been added/updated (if applicable) - n/a
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) - not a breaking change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `datahub-actions` from reusing a stale Wolfi `apk` layer that can retain setuptools 70.3.0 and CVE-2025-47273. The Dockerfile now uses `WOLFI_PKG_REFRESH` to force a fresh package resolution while preserving normal caching afterward.

- The vulnerable wheel is installed under `/usr/share/python-wheels/`, not `site-packages`.
- Bump `WOLFI_PKG_REFRESH` when Wolfi packages need to be refreshed.

<sup>Written for commit e582e1b365983604b7f77a7f664b2889231f2191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

