### PR TITLE
fix(ci): bump product version

### DIFF
--- a/metadata-service/configuration/src/main/resources/product-update-saas.json
+++ b/metadata-service/configuration/src/main/resources/product-update-saas.json
@@ -1,6 +1,6 @@
 {
   "enabled": true,
-  "id": "v2.1",
+  "id": "v2.2",
   "requiredVersion": null,
   "header": null,
   "title": "DataHub Cloud July Updates",

--- a/metadata-service/configuration/src/main/resources/product-update-saas.json
+++ b/metadata-service/configuration/src/main/resources/product-update-saas.json
@@ -3,7 +3,7 @@
   "id": "v2.2",
   "requiredVersion": null,
   "header": null,
-  "title": "DataHub Cloud July Updates",
+  "title": "DataHub Cloud September Updates",
   "description": "Business meaning meets your agents",
   "image": "https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/in-product-release-jul2026.png",
   "ctaText": "Explore DataHub Cloud 2.2",

--- a/metadata-service/configuration/src/main/resources/product-update-saas.json
+++ b/metadata-service/configuration/src/main/resources/product-update-saas.json
@@ -6,8 +6,8 @@
   "title": "DataHub Cloud July Updates",
   "description": "Business meaning meets your agents",
   "image": "https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/in-product-release-jul2026.png",
-  "ctaText": "Explore DataHub Cloud 2.1",
-  "ctaLink": "https://datahub.com/blog/datahub-cloud-2-1",
+  "ctaText": "Explore DataHub Cloud 2.2",
+  "ctaLink": "https://datahub.com/blog/datahub-cloud-2-2",
   "secondaryCtaText": null,
   "secondaryCtaLink": null,
   "features": []


### PR DESCRIPTION
failing here https://github.com/datahub-project/datahub/actions/runs/33713763630/job/100518606101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the product version to `v2.2` so the CI pipeline no longer fails, and updates the release title, CTA text, and CTA link to match.

<sup>Written for commit 981f408c5829aa267b0f4d4e85a870753661ff0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

