### PR TITLE
refactor(ui): converge app/sharedV2 with the SaaS frontend

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -157,7 +157,7 @@ export function IngestionSourceCreatePage() {
         <DiscardUnsavedChangesConfirmationProvider
             enableRedirectHandling={!isSubmitting}
             confirmationModalTitle={t('multiStep.builder.discard.title')}
-            confirmationModalContent={
+            confirmModalContent={
                 <Text color="gray" colorLevel={1700}>
                     {t('multiStep.builder.discard.description')}
                 </Text>

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
@@ -210,7 +210,7 @@ export function IngestionSourceUpdatePage() {
         <DiscardUnsavedChangesConfirmationProvider
             enableRedirectHandling={!isSubmitting}
             confirmationModalTitle={t('multiStep.builder.discard.title')}
-            confirmationModalContent={
+            confirmModalContent={
                 <Text color="gray" colorLevel={1700}>
                     {t('multiStep.builder.discard.description')}
                 </Text>

--- a/datahub-web-react/src/app/sharedV2/OverflowList.tsx
+++ b/datahub-web-react/src/app/sharedV2/OverflowList.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 const Container = styled.div<{ $gap?: number; $shouldFillAllAvailableSpace?: boolean }>`
     display: flex;
     flex-direction: row;
+    position: relative;
     ${(props) => props.$shouldFillAllAvailableSpace && 'justify-content: end;'}
     width: ${(props) => (props.$shouldFillAllAvailableSpace ? '100%' : 'fit-content')};
     overflow: hidden;

--- a/datahub-web-react/src/app/sharedV2/__tests__/useGetEntities.test.ts
+++ b/datahub-web-react/src/app/sharedV2/__tests__/useGetEntities.test.ts
@@ -105,6 +105,24 @@ describe('useGetEntities', () => {
         expect(result.current.entities.length).toBe(0);
     });
 
+    it('should filter out null entities returned for non-existent urns', () => {
+        // entities() returns a null member for any urn with no backing entity (e.g. an
+        // LLM-hallucinated urn:li:document:... in a chat answer). Nulls must be dropped so
+        // consumers that assume a non-null Entity[] don't dereference null and crash.
+        useGetEntitiesQueryMock.mockReturnValue({
+            data: { entities: [null, MOCK_ENTITIES[0], null, MOCK_ENTITIES[1]] },
+            loading: false,
+        });
+        const { result } = renderHook(() => useGetEntities([...VALID_URNS]));
+        expect(result.current.entities).toEqual(MOCK_ENTITIES);
+    });
+
+    it('should return an empty array when every urn resolves to null', () => {
+        useGetEntitiesQueryMock.mockReturnValue({ data: { entities: [null, null] }, loading: false });
+        const { result } = renderHook(() => useGetEntities([...VALID_URNS]));
+        expect(result.current.entities).toEqual([]);
+    });
+
     it('should call with skip: true if all urns are filtered out (not matching urn:li:)', () => {
         renderHook(() => useGetEntities(['foo', 'bar']));
         expect(useGetEntitiesQueryMock).toHaveBeenCalledWith({

--- a/datahub-web-react/src/app/sharedV2/buttons/BackButton.tsx
+++ b/datahub-web-react/src/app/sharedV2/buttons/BackButton.tsx
@@ -1,37 +1,7 @@
-import { Tooltip } from '@components';
-import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace';
-import { Button } from 'antd';
+import { Button, Tooltip } from '@components';
+import { ArrowLeft } from '@phosphor-icons/react/dist/csr/ArrowLeft';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
-
-const StyledButton = styled(Button)`
-    height: 25px;
-    width: 25px;
-    color: ${(p) => p.theme.colors.iconBrand};
-    padding: 0px;
-    border-radius: 20px;
-    border: 1px solid ${(p) => p.theme.colors.borderBrand};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: -4px;
-    margin-right: 10px;
-    margin-top: 2px;
-
-    &:hover {
-        color: ${(p) => p.theme.colors.iconBrand};
-        border-color: ${(p) => p.theme.colors.borderBrand};
-    }
-`;
-
-const StyledLeftOutlined = styled(KeyboardBackspaceIcon)`
-    && {
-        font-size: 20px;
-        margin: 0px;
-        padding 0px;
-    }
-`;
 
 interface Props {
     onGoBack?: () => void;
@@ -41,9 +11,7 @@ export const BackButton = ({ onGoBack }: Props) => {
     const { t } = useTranslation('shared.misc');
     return (
         <Tooltip title={t('backButton.tooltip')} showArrow={false} placement="bottom">
-            <StyledButton onClick={onGoBack}>
-                <StyledLeftOutlined />
-            </StyledButton>
+            <Button onClick={onGoBack} variant="text" icon={{ icon: ArrowLeft, size: 'xl' }} size="xl" />
         </Tooltip>
     );
 };

--- a/datahub-web-react/src/app/sharedV2/colors/colorUtils.ts
+++ b/datahub-web-react/src/app/sharedV2/colors/colorUtils.ts
@@ -22,21 +22,6 @@ export function hexToRgb(rawHex: string): [number, number, number] {
     return [parseInt(hex.substring(0, 2), 16), parseInt(hex.substring(2, 4), 16), parseInt(hex.substring(4, 6), 16)];
 }
 
-/**
- * Create an opaque color, that has the same hue as the input color with the specified opacity against the background color.
- * @param hex The input color in hex format.
- * @param backgroundHex The background color in hex format.
- * @param opacity The opacity value between 0 and 100.
- */
-export function applyOpacity(hex: string, backgroundHex: string, opacity: number) {
-    const [inputR, inputG, inputB] = hexToRgb(hex);
-    const [backgroundR, backgroundG, backgroundB] = hexToRgb(backgroundHex);
-    const r = Math.round((1 - opacity / 100) * backgroundR + (opacity / 100) * inputR);
-    const g = Math.round((1 - opacity / 100) * backgroundG + (opacity / 100) * inputG);
-    const b = Math.round((1 - opacity / 100) * backgroundB + (opacity / 100) * inputB);
-    return `rgb(${r}, ${g}, ${b})`;
-}
-
 export function useGenerateDomainColorFromPalette() {
     const { theme } = useCustomTheme();
 

--- a/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
@@ -9,7 +9,7 @@ interface Props {
     enableTabClosingHandling?: boolean;
     enableRedirectHandling?: boolean;
     confirmationModalTitle?: string;
-    confirmationModalContent?: React.ReactNode;
+    confirmModalContent?: React.ReactNode;
     confirmButtonText?: string;
     closeButtonText?: string;
 }
@@ -37,7 +37,7 @@ export function DiscardUnsavedChangesConfirmationProvider({
     enableTabClosingHandling = true,
     enableRedirectHandling = true,
     confirmationModalTitle,
-    confirmationModalContent,
+    confirmModalContent,
     confirmButtonText,
     closeButtonText,
 }: React.PropsWithChildren<Props>) {
@@ -102,7 +102,7 @@ export function DiscardUnsavedChangesConfirmationProvider({
             <ConfirmationModal
                 isOpen={isConfirmationShown}
                 modalTitle={confirmationModalTitle ?? t('unsavedChanges.title')}
-                modalText={confirmationModalContent ?? t('unsavedChanges.text')}
+                modalText={confirmModalContent ?? t('unsavedChanges.text')}
                 closeButtonColor="gray"
                 handleConfirm={() => {
                     setIsConfirmationShown(false);
@@ -121,7 +121,7 @@ export function DiscardUnsavedChangesConfirmationProvider({
                     <ConfirmationModal
                         isOpen={isRedirectConfirmationShown}
                         modalTitle={confirmationModalTitle ?? t('unsavedChanges.title')}
-                        modalText={confirmationModalContent ?? t('unsavedChanges.text')}
+                        modalText={confirmModalContent ?? t('unsavedChanges.text')}
                         closeButtonColor="gray"
                         handleConfirm={() => setIsRedirectConfirmationShown(false)}
                         confirmButtonText={confirmButtonText ?? tc('continue')}

--- a/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
@@ -195,7 +195,7 @@ describe('DiscardUnsavedChangesConfirmationContext', () => {
                             enableTabClosingHandling
                             enableRedirectHandling
                             confirmationModalTitle="Custom Title"
-                            confirmationModalContent="Custom Text"
+                            confirmModalContent="Custom Text"
                         >
                             <div>Test Child</div>
                         </DiscardUnsavedChangesConfirmationProvider>

--- a/datahub-web-react/src/app/sharedV2/icons/InfoPopover.tsx
+++ b/datahub-web-react/src/app/sharedV2/icons/InfoPopover.tsx
@@ -13,12 +13,13 @@ interface Props {
     content: React.ReactNode;
     className?: string;
     iconColor?: string;
+    placement?: string;
 }
 
-export default function InfoPopover({ content, className, iconColor }: Props) {
+export default function InfoPopover({ content, className, iconColor, placement = 'top' }: Props) {
     return (
         <InfoWrapper className={className} $iconColor={iconColor}>
-            <Popover placement="top" content={content} trigger="hover" showArrow={false}>
+            <Popover placement={placement as any} content={content} trigger="hover" showArrow={false}>
                 <Icon icon={Info} size="sm" weight="regular" color="inherit" />
             </Popover>
         </InfoWrapper>

--- a/datahub-web-react/src/app/sharedV2/icons/PlatformIcon.tsx
+++ b/datahub-web-react/src/app/sharedV2/icons/PlatformIcon.tsx
@@ -21,11 +21,12 @@ type PlatformIconProps = {
     title?: string;
     imageStyles?: CSSObject | undefined;
     className?: string;
+    customLogoUrl?: string;
     onError?: () => void;
     dataTestId?: string;
 };
 
-const IconContainer = styled.div<{ background?: string; styles: CSSObject | undefined }>`
+const IconContainer = styled.div<{ background?: string; styles: CSSObject | undefined; size: number }>`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -33,6 +34,7 @@ const IconContainer = styled.div<{ background?: string; styles: CSSObject | unde
     padding: 6px;
     border-radius: 8px;
     background-color: ${(props) => props.background || 'transparent'};
+    font-size: ${(props) => props.size}px;
     ${({ styles }) => (styles ? css(styles) : undefined)};
 `;
 
@@ -55,6 +57,7 @@ const PlatformIcon: React.FC<PlatformIconProps> = ({
     styles,
     imageStyles,
     className,
+    customLogoUrl,
     onError,
     dataTestId,
 }) => {
@@ -62,12 +65,16 @@ const PlatformIcon: React.FC<PlatformIconProps> = ({
     const imgRef = useRef<HTMLImageElement>(null);
     const entityRegistry = useEntityRegistry();
     const theme = useTheme();
-    // Prefer the platform's own logo URL when present, otherwise fall back
-    // to the static asset registered under the platform URN in
-    // PLATFORM_URN_TO_LOGO. This covers known platforms whose backend
-    // metadata doesn't include a `logoUrl` (e.g. ingested-document source
-    // platforms surfaced in the Context Documents sidebar).
-    const logoUrl = platform?.properties?.logoUrl || (platform?.urn ? PLATFORM_URN_TO_LOGO[platform.urn] : undefined);
+    // Logo resolution order:
+    //   1. Explicit `customLogoUrl` prop (caller override)
+    //   2. The platform's persisted `properties.logoUrl` (set via ingestion / admin UI)
+    //   3. Bundled fallback in PLATFORM_URN_TO_LOGO — keeps common platforms (Notion,
+    //      Confluence, GitHub, Snowflake, ...) showing the right logo even when GMS
+    //      has no logoUrl populated, instead of falling through to the default cylinder.
+    const logoUrl =
+        customLogoUrl ??
+        platform?.properties?.logoUrl ??
+        (platform?.urn ? PLATFORM_URN_TO_LOGO[platform.urn] : undefined);
 
     const handleError = useCallback(() => {
         const img = imgRef.current;
@@ -87,6 +94,7 @@ const PlatformIcon: React.FC<PlatformIconProps> = ({
     return (
         <IconContainer
             background={background}
+            size={size}
             styles={styles}
             title={title}
             className={className}

--- a/datahub-web-react/src/app/sharedV2/layouts/PageLayout.tsx
+++ b/datahub-web-react/src/app/sharedV2/layouts/PageLayout.tsx
@@ -1,6 +1,8 @@
 import { PageTitle } from '@components';
-import React from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+
+import { PanelResizeHandle } from '@app/sharedV2/layouts/PanelResizeHandle';
 
 const Card = styled.div`
     background-color: ${(props) => props.theme.colors.bg};
@@ -11,11 +13,13 @@ const Card = styled.div`
     box-shadow: ${(props) => props.theme.colors.shadowNavbar};
 `;
 
-const PageWrapper = styled(Card)<{ $hasBottomPanel?: boolean }>`
+const PageWrapper = styled(Card)`
     display: flex;
-    width: 100%;
-    height: calc(100vh - ${(props) => (props.$hasBottomPanel ? '156px' : '78px')});
-    overflow-y: hidden;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
 `;
 
 const PageTitleWrapper = styled.div`
@@ -23,7 +27,8 @@ const PageTitleWrapper = styled.div`
 `;
 
 const ContentWrapper = styled.div`
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
 `;
 
@@ -31,9 +36,43 @@ const Panel = styled(Card)`
     padding: 16px;
 `;
 
-const SidePannel = styled(Panel)`
-    max-width: 30%;
+const SidePanel = styled(Panel)<{ $closed?: boolean; $width?: number; $noTransition?: boolean }>`
+    width: ${({ $closed, $width }) => {
+        if ($closed) return '0px';
+        if ($width) return `${$width}px`;
+        return '33.333%';
+    }};
+    flex-shrink: 0;
+    /* Flex items default to min-width auto, so wide unwrappable chat content
+       (SQL blocks, long entity links) would inflate the panel past its 33%
+       and push it off-viewport, clipping the text. Clamp it: inner content
+       scrolls instead. */
+    min-width: 0;
+    min-height: 0;
+    max-width: ${({ $closed, $width }) => {
+        if ($closed) return '0px';
+        if ($width) return `${$width}px`;
+        return '33.333%';
+    }};
+    overflow: hidden;
+    height: 100%;
+    padding: 0;
+    opacity: ${({ $closed }) => ($closed ? 0 : 1)};
+    ${({ $closed, $noTransition }) => {
+        if ($noTransition) return 'transition: opacity 0.2s ease;';
+        return $closed
+            ? 'box-shadow: none; transition: width 0.4s ease-in-out, opacity 0.2s ease;'
+            : 'transition: width 0.4s ease-in-out, opacity 0.8s ease;';
+    }}
 `;
+
+const MIN_RIGHT_PANEL_WIDTH = 320;
+const MAX_RIGHT_PANEL_WIDTH_RATIO = 0.6;
+
+function clampRightPanelWidth(width: number): number {
+    const max = window.innerWidth * MAX_RIGHT_PANEL_WIDTH_RATIO;
+    return Math.min(Math.max(width, MIN_RIGHT_PANEL_WIDTH), max);
+}
 
 const BottomPanel = styled(Panel)`
     height: 62px;
@@ -44,13 +83,28 @@ const VerticalContainer = styled.div`
     flex: 1;
     flex-direction: column;
     gap: 16px;
+    /* Without this, one wide unbreakable descendant (a code block in the chat
+       rail, a long link) inflates this column's min-content past the app row
+       and the whole layout lays out wider than the viewport. */
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
 `;
 
-const HorizontalContainer = styled.div`
+const HorizontalContainer = styled.div<{ $hasBottomPanel?: boolean; $isRightPanelCollapsed?: boolean }>`
     flex: 1;
     display: flex;
     flex-direction: row;
-    gap: 16px;
+    gap: 8px;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    max-height: calc(100vh - ${(props) => (props.$hasBottomPanel ? '156px' : '78px')});
+    ${(props) =>
+        props.$isRightPanelCollapsed &&
+        `
+            margin-right: -8px;
+        `}
 `;
 
 const TopContainer = styled.div`
@@ -73,7 +127,19 @@ interface Props {
     rightPanelContent?: React.ReactNode;
     bottomPanelContent?: React.ReactNode;
     topBreadcrumb?: React.ReactNode;
+    isRightPanelCollapsed?: boolean;
     topRightContent?: React.ReactNode;
+    /** Allow the user to drag-resize the right panel. Off by default. */
+    isRightPanelResizable?: boolean;
+    /** When set, the resized right panel width is persisted to localStorage under this key. */
+    rightPanelWidthLocalStorageKey?: string;
+}
+
+function readStoredWidth(key: string | undefined): number | undefined {
+    if (!key) return undefined;
+    const stored = window.localStorage.getItem(key);
+    const parsed = stored ? Number(stored) : NaN;
+    return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 export function PageLayout({
@@ -85,21 +151,89 @@ export function PageLayout({
     rightPanelContent,
     bottomPanelContent,
     topBreadcrumb,
+    isRightPanelCollapsed,
     topRightContent,
+    isRightPanelResizable,
+    rightPanelWidthLocalStorageKey,
 }: React.PropsWithChildren<Props>) {
+    const sidePanelRef = useRef<HTMLDivElement>(null);
+    const [rightPanelWidth, setRightPanelWidth] = useState<number | undefined>(() =>
+        readStoredWidth(rightPanelWidthLocalStorageKey),
+    );
+    const [isDragging, setIsDragging] = useState(false);
+
+    const getInitialWidth = useCallback(
+        () => rightPanelWidth ?? sidePanelRef.current?.offsetWidth ?? MIN_RIGHT_PANEL_WIDTH,
+        [rightPanelWidth],
+    );
+
+    const handleResize = useCallback((width: number) => {
+        setIsDragging(true);
+        setRightPanelWidth(clampRightPanelWidth(width));
+    }, []);
+
+    const handleResizeEnd = useCallback(
+        (width: number) => {
+            setIsDragging(false);
+            const clamped = clampRightPanelWidth(width);
+            setRightPanelWidth(clamped);
+            if (rightPanelWidthLocalStorageKey) {
+                window.localStorage.setItem(rightPanelWidthLocalStorageKey, String(clamped));
+            }
+        },
+        [rightPanelWidthLocalStorageKey],
+    );
+
+    const rightPanel = useMemo(() => {
+        if (!rightPanelContent) return null;
+        if (!isRightPanelResizable) {
+            return <SidePanel $closed={isRightPanelCollapsed}>{rightPanelContent}</SidePanel>;
+        }
+        // Rendered as siblings (not wrapped in a div) so SidePanel remains a direct flex child of
+        // HorizontalContainer — its percentage/pixel width is computed against that container, not
+        // against an intermediate wrapper with no defined width of its own.
+        return (
+            <>
+                {!isRightPanelCollapsed && (
+                    <PanelResizeHandle
+                        getInitialWidth={getInitialWidth}
+                        onResize={handleResize}
+                        onResizeEnd={handleResizeEnd}
+                    />
+                )}
+                <SidePanel
+                    ref={sidePanelRef}
+                    $closed={isRightPanelCollapsed}
+                    $width={rightPanelWidth}
+                    $noTransition={isDragging}
+                >
+                    {rightPanelContent}
+                </SidePanel>
+            </>
+        );
+    }, [
+        rightPanelContent,
+        isRightPanelResizable,
+        isRightPanelCollapsed,
+        getInitialWidth,
+        handleResize,
+        handleResizeEnd,
+        rightPanelWidth,
+        isDragging,
+    ]);
+
     return (
         <VerticalContainer>
-            <HorizontalContainer>
-                {leftPanelContent && <SidePannel>{leftPanelContent}</SidePannel>}
+            <HorizontalContainer $hasBottomPanel={!!bottomPanelContent} $isRightPanelCollapsed={isRightPanelCollapsed}>
+                {leftPanelContent && <SidePanel>{leftPanelContent}</SidePanel>}
 
-                <PageWrapper $hasBottomPanel={!!bottomPanelContent}>
+                <PageWrapper>
                     {(topBreadcrumb || topRightContent) && (
                         <TopContainer>
                             {topBreadcrumb && <>{topBreadcrumb}</>}
                             {topRightContent && <TopRightContentContainer>{topRightContent}</TopRightContentContainer>}
                         </TopContainer>
                     )}
-
                     {title && (
                         <PageTitleWrapper>
                             <PageTitle title={title} subTitle={subTitle} titlePill={titlePill} />
@@ -108,7 +242,7 @@ export function PageLayout({
                     <ContentWrapper>{children}</ContentWrapper>
                 </PageWrapper>
 
-                {rightPanelContent && <SidePannel>{rightPanelContent}</SidePannel>}
+                {rightPanel}
             </HorizontalContainer>
             {bottomPanelContent && <BottomPanel>{bottomPanelContent}</BottomPanel>}
         </VerticalContainer>

--- a/datahub-web-react/src/app/sharedV2/layouts/PanelResizeHandle.tsx
+++ b/datahub-web-react/src/app/sharedV2/layouts/PanelResizeHandle.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useRef } from 'react';
+import styled from 'styled-components';
+
+const HandleBar = styled.div`
+    min-height: 100%;
+    width: 4px;
+    flex-shrink: 0;
+    cursor: col-resize;
+    background: transparent;
+    /* Pull tight against the panel it resizes, rather than floating in the middle
+       of the flex container's gap. */
+    margin-right: -4px;
+
+    &:hover {
+        background: ${(props) => props.theme.colors.borderHover};
+    }
+`;
+
+type Props = {
+    getInitialWidth: () => number;
+    onResize: (width: number) => void;
+    onResizeEnd?: (width: number) => void;
+    isSidebarOnLeft?: boolean;
+};
+
+export function PanelResizeHandle({ getInitialWidth, onResize, onResizeEnd, isSidebarOnLeft }: Props) {
+    const dragState = useRef<{ initialX: number; initialWidth: number; latestWidth: number } | null>(null);
+
+    const dragContinue = useCallback(
+        (event: MouseEvent) => {
+            if (!dragState.current) return;
+            const { initialX, initialWidth } = dragState.current;
+            // For a right-docked panel (the default), the handle sits on the panel's left edge:
+            // dragging left grows the panel, dragging right shrinks it.
+            const xDifference = isSidebarOnLeft ? initialX - event.clientX : event.clientX - initialX;
+            const nextWidth = initialWidth - xDifference;
+            dragState.current.latestWidth = nextWidth;
+            onResize(nextWidth);
+        },
+        [isSidebarOnLeft, onResize],
+    );
+
+    const stopDragging = useCallback(() => {
+        window.removeEventListener('mousemove', dragContinue);
+        window.removeEventListener('mouseup', stopDragging);
+        document.body.style.userSelect = '';
+        if (dragState.current) {
+            onResizeEnd?.(dragState.current.latestWidth);
+        }
+        dragState.current = null;
+    }, [dragContinue, onResizeEnd]);
+
+    const onMouseDown = useCallback(
+        (event: React.MouseEvent) => {
+            dragState.current = {
+                initialX: event.clientX,
+                initialWidth: getInitialWidth(),
+                latestWidth: getInitialWidth(),
+            };
+            document.body.style.userSelect = 'none';
+            window.addEventListener('mousemove', dragContinue);
+            window.addEventListener('mouseup', stopDragging);
+            event.preventDefault();
+        },
+        [getInitialWidth, dragContinue, stopDragging],
+    );
+
+    return <HandleBar onMouseDown={onMouseDown} data-testid="panel-resize-handle" />;
+}

--- a/datahub-web-react/src/app/sharedV2/owners/ActorPill.tsx
+++ b/datahub-web-react/src/app/sharedV2/owners/ActorPill.tsx
@@ -42,12 +42,13 @@ interface Props {
     onClose?: (e: any) => void;
     hideLink?: boolean;
     propagationDetails?: AttributionDetails;
+    onClick?: () => void;
 }
 
-export default function ActorPill({ actor, isProposed, onClose, hideLink, propagationDetails }: Props) {
+export default function ActorPill({ actor, isProposed, onClose, hideLink, propagationDetails, onClick }: Props) {
     const entityRegistry = useEntityRegistryV2();
     const name = actor && entityRegistry.getDisplayName(actor.type, actor);
-    const avatarUrl = actor?.editableProperties?.pictureLink || undefined;
+    const avatarUrl = (actor && 'editableProperties' in actor && actor.editableProperties?.pictureLink) || undefined;
     const linkProps = useEmbeddedProfileLinkProps();
 
     if (!actor) return null;
@@ -60,6 +61,7 @@ export default function ActorPill({ actor, isProposed, onClose, hideLink, propag
                 to={hideLink ? null : `${entityRegistry.getEntityUrl(actor.type, actor.urn)}`}
                 data-testid={`owner-${actor.urn}`}
                 {...linkProps}
+                onClick={onClick}
             >
                 <ContentWrapper $isProposed={isProposed} data-testid={`${isProposed ? 'proposed-' : ''}owner-${name}`}>
                     <Avatar name={name || ''} imageUrl={avatarUrl} type={avatarType} />

--- a/datahub-web-react/src/app/sharedV2/propagation/HoverCardAttributionDetails.tsx
+++ b/datahub-web-react/src/app/sharedV2/propagation/HoverCardAttributionDetails.tsx
@@ -39,7 +39,7 @@ export default function HoverCardAttributionDetails({ propagationDetails, addMar
     const time = propagationDetails?.attribution?.time;
 
     return (
-        <DetailsWrapper $addMargin={addMargin}>
+        <DetailsWrapper $addMargin={addMargin} data-testid="docPropagationIndicator">
             <Text color="gray" weight="bold" colorLevel={600} size="sm">
                 {t('propagated')}
             </Text>

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/types/values.ts
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/types/values.ts
@@ -204,7 +204,7 @@ export type SelectParams = {
     options: SelectOption[];
 };
 
-export type EntitySearchParams = {
+type EntitySearchParams = {
     entityTypes: EntityType[];
 };
 

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import AutoCompleteEntityItem from '@app/searchV2/autoCompleteV2/AutoCompleteEntityItem';
+import { addUserFiltersToMultiEntitySearchInput } from '@app/shared/userSearchUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { mergeArraysOfObjects } from '@app/utils/arrayUtils';
 
@@ -100,14 +101,19 @@ export const EntitySearchValueInput = ({
     };
 
     const onSearch = (text: string) => {
+        const input = addUserFiltersToMultiEntitySearchInput(
+            {
+                types: entityTypes,
+                query: text,
+                start: 0,
+                count: 10,
+            },
+            entityTypes,
+        );
+
         searchResources({
             variables: {
-                input: {
-                    types: entityTypes,
-                    query: text,
-                    start: 0,
-                    count: 10,
-                },
+                input,
             },
         });
     };

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/EntityAutocompleteDropdown.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/EntityAutocompleteDropdown.tsx
@@ -48,7 +48,7 @@ type Props = {
 
 /**
  * Debounced autocomplete search bar with dropdown results, shared by hierarchical
- * browse sidebars (glossary, marketplace, etc.).
+ * browse sidebars (glossary, data products, etc.).
  */
 export default function EntityAutocompleteDropdown({ entityTypes, placeholder, dataTestId }: Props) {
     const [searchInput, setSearchInput] = useState('');

--- a/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarFilteredResults.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/HierarchicalBrowseSidebar/SidebarFilteredResults.tsx
@@ -39,6 +39,11 @@ type Props = {
     onClear: () => void;
     clearTestId?: string;
     dataTestId?: string;
+    /** A DataHub View is applied to the query and may be filtering out results. */
+    hasSelectedView?: boolean;
+    /** Clears the selected View (only rendered alongside `hasSelectedView`). */
+    onClearView?: () => void;
+    clearViewTestId?: string;
 };
 
 /**
@@ -56,6 +61,9 @@ export default function SidebarFilteredResults({
     onClear,
     clearTestId = 'sidebar-clear-filters',
     dataTestId = 'sidebar-filtered-results',
+    hasSelectedView = false,
+    onClearView,
+    clearViewTestId = 'sidebar-clear-view',
 }: Props) {
     const { t } = useTranslation('misc');
     const { t: tc } = useTranslation('common.actions');
@@ -74,9 +82,19 @@ export default function SidebarFilteredResults({
                 <Text size="sm" color="gray">
                     {tc('noResults')}
                 </Text>
+                {hasSelectedView && (
+                    <Text size="sm" color="gray">
+                        {t('context.viewMayBeHidingResults')}
+                    </Text>
+                )}
                 <Button variant="text" size="sm" onClick={onClear} data-testid={clearTestId}>
                     {t('context.clearSearch')}
                 </Button>
+                {hasSelectedView && onClearView && (
+                    <Button variant="text" size="sm" onClick={onClearView} data-testid={clearViewTestId}>
+                        {t('context.clearSelectedView')}
+                    </Button>
+                )}
             </StateWrap>
         );
     }

--- a/datahub-web-react/src/app/sharedV2/sidebar/components.tsx
+++ b/datahub-web-react/src/app/sharedV2/sidebar/components.tsx
@@ -1,24 +1,8 @@
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import React from 'react';
-import styled, { useTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
 
 import { RotatingButton } from '@app/shared/components';
-
-export const SidebarWrapper = styled.div<{ width: number; $isShowNavBarRedesign?: boolean }>`
-    max-height: 100%;
-    width: ${(props) => props.width}px;
-    min-width: ${(props) => props.width}px;
-    display: ${(props) => (props.width ? 'block' : 'none')};
-    background-color: ${(props) => props.theme.colors.bg};
-    border-radius: ${(props) =>
-        props.$isShowNavBarRedesign ? props.theme.styles['border-radius-navbar-redesign'] : '8px'};
-    ${(props) => !props.$isShowNavBarRedesign && 'margin-bottom: 12px;'}
-    ${(props) =>
-        props.$isShowNavBarRedesign &&
-        `
-        box-shadow: ${props.theme.colors.shadowSm};
-    `}
-`;
 
 export function RotatingTriangle({
     isOpen,

--- a/datahub-web-react/src/app/sharedV2/tags/DomainLink.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/DomainLink.tsx
@@ -68,7 +68,7 @@ interface DomainContentProps {
     iconFontSize?: number;
 }
 
-function DomainContent({
+export function DomainContent({
     domain,
     name,
     closable,

--- a/datahub-web-react/src/app/sharedV2/tags/TagPill.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/TagPill.tsx
@@ -9,10 +9,10 @@ import PillRemoveIcon from '@app/sharedV2/icons/PillRemoveIcon';
  * `borderless` — inline-with-text usage (breadcrumbs, mentions, modal option rows). No chip body.
  * `highlighted` — chip is the active search match. Uses the hover border/background tokens.
  */
-export type TagPillVariant = 'default' | 'borderless' | 'highlighted';
+type TagPillVariant = 'default' | 'borderless' | 'highlighted';
 
 /** `md` is the canonical sidebar/modal size; `sm` is the compact size used in dense filter rows. */
-export type TagPillSize = 'sm' | 'md';
+type TagPillSize = 'sm' | 'md';
 
 // Shared color-hash instance — matches StyledTag.tsx so URN-derived colors line up with the rest of
 // the app's tag chips.

--- a/datahub-web-react/src/app/sharedV2/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/TagTermGroup.tsx
@@ -243,6 +243,7 @@ export default function TagTermGroup({
                         refetch={refetch}
                         fontSize={fontSize}
                         showOneAndCount={showOneAndCount}
+                        context={orderedTerm.term.context}
                     />
                 );
 
@@ -271,6 +272,7 @@ export default function TagTermGroup({
                         refetch={refetch}
                         fontSize={fontSize}
                         showOneAndCount={showOneAndCount}
+                        context={orderedTag.tag.context}
                     />
                 );
 

--- a/datahub-web-react/src/app/sharedV2/tags/usePropagationContextEntities.ts
+++ b/datahub-web-react/src/app/sharedV2/tags/usePropagationContextEntities.ts
@@ -7,6 +7,7 @@ export interface PropagationContext {
     origin?: string;
     actor?: string;
     relationship?: string;
+    propagation_direction?: string;
 }
 
 export function usePropagationContextEntities(contextObj?: PropagationContext | null) {

--- a/datahub-web-react/src/app/sharedV2/useGetEntities.ts
+++ b/datahub-web-react/src/app/sharedV2/useGetEntities.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useGetEntitiesQuery } from '@graphql/entity.generated';
 import { Entity } from '@types';
@@ -21,15 +21,19 @@ export function useGetEntities(
         fetchPolicy: 'cache-first',
     });
 
-    const [entities, setEntities] = useState<Entity[]>([]);
-
-    useEffect(() => {
-        if (data?.entities && data.entities.length > 0) {
-            setEntities(data.entities as Entity[]);
-        } else if (!loading && (!data?.entities || data.entities.length === 0)) {
-            setEntities([]);
-        }
-    }, [data, loading]);
+    // Derived directly from `data` (not useState+useEffect) so `entities` updates in the same
+    // render as `loading` flips to false — an effect-based copy lags one render behind, which
+    // is enough for callers to briefly render their "not yet loaded" fallback (e.g. a raw urn).
+    const entities = useMemo(() => {
+        if (!data || !Array.isArray(data?.entities)) return [];
+        // `entities(urns)` returns a null element for any URN with no backing entity
+        // (its GraphQL type is `[Entity]`, i.e. nullable members). This happens for
+        // hallucinated or since-deleted URNs — e.g. a `urn:li:document:...` an LLM
+        // invents in a chat answer. Drop nulls so callers that treat the result as a
+        // non-null `Entity[]` (e.g. rendering source-reference chips) don't dereference
+        // null and crash the page.
+        return (data.entities as (Entity | null)[]).filter((entity): entity is Entity => entity != null);
+    }, [data]);
 
     return { entities, loading };
 }

--- a/datahub-web-react/src/i18n/locales/en/misc.json
+++ b/datahub-web-react/src/i18n/locales/en/misc.json
@@ -83,6 +83,8 @@
     "context.statusFilter.placeholder": "All",
     "context.statusFilter.published": "Published",
     "context.statusFilter.unpublished": "Unpublished",
+    "context.viewMayBeHidingResults": "Your selected view may also be hiding results.",
+    "context.clearSelectedView": "Clear view",
     "sidebarSort.ariaLabel": "Sort",
     "sidebarSort.tooltip": "Sort",
     "sidebarSort.nameAtoZ": "Name A to Z",

--- a/datahub-web-react/src/i18n/locales/ja/misc.json
+++ b/datahub-web-react/src/i18n/locales/ja/misc.json
@@ -82,6 +82,8 @@
     "context.statusFilter.placeholder": "すべて",
     "context.statusFilter.published": "公開済み",
     "context.statusFilter.unpublished": "未公開",
+    "context.viewMayBeHidingResults": "選択したViewが結果を非表示にしている可能性もあります。",
+    "context.clearSelectedView": "Viewをクリア",
     "sidebarSort.ariaLabel": "並べ替え",
     "sidebarSort.tooltip": "並べ替え",
     "sidebarSort.nameAtoZ": "名前（A→Z）",


### PR DESCRIPTION
Port the non-SaaS-specific changes that had accumulated in the SaaS frontend back into OSS, so the regular OSS -> SaaS auto-merge has less to conflict over in this directory. Addressable divergence in src/app/sharedV2 drops from 3.41% to 0.93% (360 of 496 lines).

Notable changes:

- PageLayout: fix the SidePannel -> SidePanel typo, harden the flex containers with min-width/min-height/overflow so one wide unbreakable descendant can no longer inflate the layout past the viewport, and move the bottom-panel viewport-height calc onto HorizontalContainer. Adds the optional drag-resize plumbing plus PanelResizeHandle; both are opt-in and no OSS caller enables them yet.
- useGetEntities: derive entities from the query result with useMemo instead of a lagging useState/useEffect, and drop the null members that a nullable [Entity] can return.
- TagTermGroup: pass the association context through to the tag and term pills so the propagation tooltip actually receives it.
- DiscardUnsavedChangesConfirmationContext: rename the confirmationModalContent prop to confirmModalContent, updating both ingestV2 call sites.
- BackButton: replace the antd Button and MUI icon with the design-system Button and a phosphor ArrowLeft.
- PlatformIcon: add a customLogoUrl override and scale the container font size with the icon size. Note the logo resolution chain now uses ?? rather than ||, so an empty-string logoUrl wins over the PLATFORM_URN_TO_LOGO fallback.
- ActorPill: add an optional onClick and guard the editableProperties lookup across the OwnerType union.
- SidebarFilteredResults: add an opt-in empty-state hint that the selected View may be hiding results.
- Delete the unused applyOpacity and SidebarWrapper, and de-export three symbols that have no external consumers.

SaaS-only functionality was deliberately left out: the tag/term proposal flow, the AskDataHub chat plumbing, Sentry error reporting, agent owner types (which need OwnerEntityType and
Owner.associatedOwnerUrn schema changes) and the failing-assertions search property.

Verified with a clean tsc --noEmit across the project, a successful production build, and lint over every ported file.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the non-SaaS-specific changes that had accumulated in the SaaS frontend back into OSS `src/app/sharedV2`, cutting addressable divergence from 3.41% to 0.93% so the OSS → SaaS auto-merge has fewer conflicts in this directory.

**Bug Fixes**
- Hardens PageLayout's flex containers so a wide unbreakable descendant can no longer inflate the layout past the viewport.
- Derives entities with useMemo in `useGetEntities` and drops the null members a nullable `[Entity]` can return for nonexistent urns.
- Passes the association context through TagTermGroup so the propagation tooltip receives it, and guards ActorPill's `editableProperties` lookup.

**Refactors**
- Fixes the `SidePannel` → `SidePanel` typo and adds opt-in drag-resize to PageLayout via a new `PanelResizeHandle`.
- Renames `confirmationModalContent` to `confirmModalContent` in `DiscardUnsavedChangesConfirmationContext`, updating both ingestV2 call sites.
- Swaps BackButton to the design-system Button and phosphor ArrowLeft, and adds a `customLogoUrl` override to PlatformIcon (an empty-string `logoUrl` now wins over the fallback).
- Adds an opt-in View-hiding-results hint to SidebarFilteredResults and removes unused `applyOpacity`, `SidebarWrapper`, and de-exported symbols.

SaaS-only functionality (proposal flow, chat plumbing, Sentry, agent owner types) was deliberately left out.

<sup>Written for commit 2b3cc1f2c18c65919aa57a19d9ed7b8c97983d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

