### PR TITLE
ci(smoke): add the run-all-tests PR label to opt out of the p0 tier

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -154,9 +154,17 @@ jobs:
       # Pull requests run only the p0 tier while the PYTEST_P0_SMOKE repository
       # variable is 'true'; post-merge pushes -- and the default with the
       # variable unset -- always run the full suite. smoke.sh reads it as
-      # SMOKE_TIER. A PR that needs the whole suite asks for it with the
-      # full-suite label rather than by any path-based escalation here.
-      smoke_tier: ${{ (github.event_name == 'pull_request' && vars.PYTEST_P0_SMOKE == 'true') && 'p0' || 'full' }}
+      # SMOKE_TIER.
+      #
+      # The `run-all-tests` label opts a single PR back into the whole suite, for
+      # changes whose blast radius is wider than their own touched modules
+      # (shared fixtures, conftest, a broad refactor). Like every other label
+      # this workflow honours (`depot`, `publish`, `build-images`, ...) it is
+      # read from the event payload, so it takes effect on the PR's next push
+      # rather than the moment it is applied -- `labeled` is deliberately absent
+      # from the trigger types above, because pr-labeler.yml labels every PR on
+      # open and would double this workflow's runs.
+      smoke_tier: ${{ (github.event_name == 'pull_request' && vars.PYTEST_P0_SMOKE == 'true' && !contains(github.event.pull_request.labels.*.name, 'run-all-tests')) && 'p0' || 'full' }}
       # Test modules this PR touches; conftest runs these alongside the p0
       # tier. Empty on a full run.
       smoke_changed_tests: ${{ steps.smoke-tier.outputs.changed_tests }}
@@ -292,6 +300,11 @@ jobs:
             | grep -E '^smoke-test/(.*/)?(test_.*|.*_test)\.py$' || true)
           echo "changed_tests=$(printf '%s' "$changed" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           echo "Changed smoke test modules: $(printf '%s' "$changed" | tr '\n' ' ')"
+
+          # Which knobs decided this run's tier, so a surprising selection is
+          # diagnosable from the log alone.
+          echo "PYTEST_P0_SMOKE=${{ vars.PYTEST_P0_SMOKE }}" \
+               "run-all-tests label=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-all-tests') }}"
 
       - name: Determine runner type
         id: set-runner

--- a/smoke-test/README.md
+++ b/smoke-test/README.md
@@ -102,7 +102,14 @@ On a pull request CI additionally runs any test module the PR itself touches,
 even when it carries no `p0` marker — conftest marks those modules p0 during
 collection so `-m p0` keeps them. That is per-module: a change to a shared
 fixture or to `conftest.py` pulls in no test module of its own, so a PR needing
-broader coverage asks for the whole suite with the full-suite PR label.
+broader coverage asks for the whole suite with the `run-all-tests` PR label.
+
+Add `run-all-tests` to a pull request to run every test on it instead of the `p0`
+tier — for changes whose blast radius is wider than their own touched modules,
+such as a shared fixture, `conftest.py`, or a broad refactor. The label is read
+from the event payload, as every other label this CI honours is, so it applies
+on the PR's next push; re-running an existing workflow replays the original
+payload and will not see it.
 
 ## Test Categories
 


### PR DESCRIPTION
Adds a `run-all-tests` pull-request label that opts a single PR out of the `p0` tier and back into the whole smoke suite. Stacked on #19587.

### Why

The `p0` tier plus the changed-module union covers the common case: a PR runs the critical tests plus its own. It does not cover a change whose blast radius is wider than the modules it touches — a shared fixture, `conftest.py`, a broad refactor. This label is the explicit escape hatch for those.

### How it works

`smoke_tier` resolves to `full` when the label is present, so `smoke.sh` runs everything exactly as it does post-merge:

| event | `PYTEST_P0_SMOKE` | `run-all-tests` label | tier |
| --- | --- | --- | --- |
| pull request | `true` | no | `p0` |
| pull request | `true` | **yes** | **full** |
| pull request | unset / `false` | any | full |
| push (post-merge) | any | n/a | full |

The setup job also now logs both knobs, so a surprising selection is diagnosable from the log alone:

```
PYTEST_P0_SMOKE=true run-all-tests label=false
```

### The label applies on the PR's next push

It is read from the event payload, like every other label this workflow honours (`depot`, `publish`, `publish-arm64`, `build-images`, `use-build-pages-pip`), so it takes effect on the next push rather than the moment it is applied. Re-running an existing workflow replays the original payload and will **not** see a newly added label.

`labeled` is deliberately **not** added to the trigger's `types`. `pr-labeler.yml` applies labels to every PR on open, so a `labeled` trigger would fire a second full build-and-smoke run on every pull request in the repo. Two alternatives exist if the extra push proves annoying: add `labeled` and accept that cost, or read labels live via the API, which needs a `pull-requests: read` permission this workflow does not currently hold. Neither seemed worth it against one push.

### Note

The `run-all-tests` label has to exist in the repository before anyone can apply it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `run-all-tests` PR label that makes a pull request run the full smoke suite instead of the default `p0` tier, for changes whose blast radius is wider than the modules they touch (shared fixtures, `conftest.py`, broad refactors). Without it, `PYTEST_P0_SMOKE=true` PRs run only p0 plus their changed-module union; with it, `smoke_tier` resolves to `full` so `smoke.sh` runs everything as it does post-merge.

**Behavior**
- The label is read from the event payload, so it takes effect on the PR's next push; re-running an existing workflow replays the original payload and won't see it.
- `labeled` is deliberately absent from the workflow's trigger types because `pr-labeler.yml` labels every PR on open and would double workflow runs.
- The setup job logs both `PYTEST_P0_SMOKE` and the label state so a surprising tier selection is diagnosable from the log.
- The label must exist in the repository before anyone can apply it.
- `smoke-test/README.md` documents when to use the label.

<sup>Written for commit 8e58be30d1f1a5c3db936a067513252359930949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

