### PR TITLE
docs(okta): replace example token in okta_api_token field description

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -66,7 +66,7 @@ class OktaConfig(StatefulIngestionConfigBase):
     )
     # Required: An API token generated from Okta.
     okta_api_token: TransparentSecretStr = Field(
-        description="An API token generated for the DataHub application inside your Okta Developer Console. e.g. <YOUR_OKTA_API_TOKEN>",
+        description="An API token generated for the DataHub application inside your Okta Developer Console.",
     )
 
     # Optional: Whether to ingest users, groups, or both.

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -66,7 +66,7 @@ class OktaConfig(StatefulIngestionConfigBase):
     )
     # Required: An API token generated from Okta.
     okta_api_token: TransparentSecretStr = Field(
-        description="An API token generated for the DataHub application inside your Okta Developer Console. e.g. 00be4R_M2MzDqXawbWgfKGpKee0kuEOfX1RCQSRx00",
+        description="An API token generated for the DataHub application inside your Okta Developer Console. e.g. <YOUR_OKTA_API_TOKEN>",
     )
 
     # Optional: Whether to ingest users, groups, or both.


### PR DESCRIPTION
### Summary

Follow-up to #19598. The `okta_api_token` field in `OktaConfig` embedded a token-format example string in its `description=`, which flows into the generated JSON schema and connector docs and is picked up by secret scanners. This replaces it with `<YOUR_OKTA_API_TOKEN>`.

#19598 covered the recipe (`okta_recipe.yml`), the ingestion UI recipe-builder examples, and the `sources.json` templates; this covers the remaining example value in the config model's field description.

### Checklist
- [x] Docs/example copy only — Okta ingestion behavior is unchanged.
- [x] No functional code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the example token from the `okta_api_token` field description so secret scanners no longer flag the generated docs and schema. The description now ends at the sentence with no example placeholder.

Completes the credential-hygiene cleanup that covered the recipe and UI examples; no Okta ingestion behavior changes.

<sup>Written for commit cf99cabd96fe14c4380e85b1b79874bfda5062f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

