### PR TITLE
fix(ingest/sigma): recover missing Data Model column-level lineage

### DIFF
--- a/metadata-ingestion/docs/sources/sigma/sigma_post.md
+++ b/metadata-ingestion/docs/sources/sigma/sigma_post.md
@@ -222,6 +222,52 @@ chart_sources_platform_mapping:
 
 Module behavior is constrained by source APIs, permissions, and metadata exposed by the platform. Refer to capability notes for unsupported or conditional features.
 
+#### Column-level lineage coverage for Data Model elements
+
+Column-level lineage for Data Model elements is derived from the column formulas returned by
+Sigma's `/v2/dataModels/{id}/columns` endpoint. A column gets one upstream edge per source
+its formula names, so coverage follows the formula rather than the element's table-level
+upstreams.
+
+The practical consequence shows up on joins. An element can have table-level lineage to two
+sources while one of its columns has a column-level edge to only one of them, because the
+column's formula names only that side — a join key typically resolves to whichever side
+Sigma kept. The join predicate itself is not exposed on `/columns` or on
+`/v2/dataModels/{id}/lineage`, the two endpoints this connector reads. Join keys are
+available on `/v2/dataModels/{id}/spec`, which the connector does not currently consume.
+
+A Data Model can also reference a warehouse table that has since been **deleted from
+Sigma**. The `inode-<urlId>` reference survives in the model while `/v2/files/{urlId}`
+returns 404, so no lookup can supply the table's coordinates and columns naming it can
+never receive warehouse column lineage. These are counted under
+`dm_element_warehouse_stale_reference` and are a tenant data-hygiene issue rather than an
+ingestion gap; on one tenant they accounted for every unresolved table reference.
+
+Two report counters mark data that never arrived, and should be read before treating a
+model's missing lineage as a resolution failure: `data_model_columns_fetch_partial` counts
+Data Models whose `/columns` pagination aborted (that endpoint is the only source of
+formulas and column ids), and `column_formulas_fetch_partial` counts workbooks whose
+`/columns` call aborted, leaving their chart columns with self-referential input fields.
+`pagination_aborted` gives the run-wide total.
+
+Columns no formula reference resolves for — a plain pass-through, which Sigma returns with
+an empty formula, a constant, or a formula using only parameters — still get column-level
+lineage to a warehouse table when their `columnId` identifies the warehouse column. Where
+it does not, the ingestion report separates the two outcomes:
+`data_model_element_fgl_no_ref_warehouse_unresolved` counts columns that named a warehouse
+column but could not be resolved to one, which is worth investigating, while
+`data_model_element_fgl_no_ref_unresolved` counts pass-throughs from another Data Model
+element or Sigma Dataset, which carry no warehouse identity to resolve and are expected.
+
+When a formula does name an upstream element but that element's column list came back
+empty, the edge is dropped under `data_model_element_fgl_upstream_schema_unavailable` (a
+sibling in the same Data Model) or
+`data_model_element_fgl_cross_dm_upstream_schema_unavailable` (an element in another Data
+Model), rather than under `data_model_element_fgl_dropped_unknown_upstream_column`, which
+means the column genuinely is not in the upstream's schema. A `Sigma paginated endpoint
+aborted` warning naming that Data Model confirms a failed fetch; its absence means the
+upstream element really has no columns.
+
 ### Troubleshooting
 
 If ingestion fails, validate credentials, permissions, connectivity, and scope filters first. Then review ingestion logs for source-specific errors and adjust configuration accordingly.

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -194,6 +194,82 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # resolved (includes: no-formula column, unresolvable ref, mixed param+real
     # where the real refs fail). Keeps V2 column list visible unconditionally.
     chart_input_fields_self_ref_fallback: int = 0
+    # Breakdown of the self-ref fallback bucket above, which is normally the
+    # largest in the report and previously said nothing about cause.
+    # No formula at all on the column -- expected, not a defect.
+    chart_input_fields_self_ref_no_formula: int = 0
+    # Column HAD formula refs and none resolved. This is the population worth
+    # investigating; a non-trivial value here alongside
+    # chart_input_fields_multi_segment_ref suggests the chart path shares the
+    # Data Model join-chain parse defect.
+    chart_input_fields_self_ref_unresolved_refs: int = 0
+    # Chart columns carrying a join-chain-shaped ref
+    # ([JoinElement/SourceElement/Column], 3+ segments). The chart resolver has
+    # no schema check, so unlike the DM path a mis-split emits a wrong or
+    # dangling InputField rather than being caught. Non-zero means the chart
+    # path needs the same candidate-split resolution as the DM path.
+    chart_input_fields_multi_segment_ref: int = 0
+    # Workbook elements dropped before indexing because their type is neither
+    # "table" nor "visualization", keyed by type. These never enter the workbook
+    # element index, so a chart formula naming one can never resolve and falls
+    # back to a self-reference. Types such as pivot-table and input-table carry
+    # real data, so a large count here is a candidate explanation for the size
+    # of chart_input_fields_self_ref_unresolved_refs.
+    workbook_elements_skipped_by_type: Dict[str, int] = field(default_factory=dict)
+    # Chart formula ref sources that missed the workbook element index but DO
+    # match an indexed element after case/whitespace normalization -- i.e. the
+    # element is present and the lookup is simply too strict.
+    chart_ref_source_near_miss: int = 0
+    # Of those, the ones actually resolved by the normalized lookup.
+    chart_ref_source_normalized_match: int = 0
+    # Normalized key collapsed two or more genuinely distinct element names;
+    # left unresolved rather than guessed at.
+    chart_ref_source_normalized_ambiguous: int = 0
+
+    # Warehouse columns accepted although the element does not declare the
+    # inode: it declares no inode at all (it is sourced transitively, e.g. only
+    # from other Data Models) and the url_id is in this Data Model's warehouse
+    # map. Kept separate so the relaxation is auditable against the
+    # url_id_not_in_element_source_ids misses it replaces.
+    dm_element_warehouse_transitive_inode_accepted: int = 0
+    # Data Model elements for which no source_id resolved to a URN, so no
+    # upstreamLineage aspect is emitted and no column lineage is even attempted.
+    # The difference between data_model_elements_emitted and the number of
+    # elements carrying upstreamLineage; previously that gap had no counter and
+    # no log line.
+    data_model_element_no_upstreams: int = 0
+    # Warehouse tables recovered from the global /v2/files index because the
+    # owning Data Model's /lineage did not describe them. Sigma reports fewer
+    # type=table rows than its own elements reference; without this those
+    # elements resolve to no warehouse table at all.
+    dm_element_warehouse_recovered_from_global_index: int = 0
+    # url_ids skipped because the connection to attribute them to could not be
+    # inferred unambiguously (a /files entry carries no connectionId).
+    dm_element_warehouse_connection_ambiguous: int = 0
+    # A Data Model element references a warehouse table by urlId that Sigma
+    # returns 404 for -- the table has been deleted but the reference remains.
+    # No lookup can supply coordinates for an object that no longer exists, so
+    # columns naming it can never receive warehouse column lineage. This is
+    # tenant data hygiene, not a connector gap; on one tenant it accounted for
+    # ALL 37 unresolved table references.
+    dm_element_warehouse_stale_reference: int = 0
+    # Paginated calls that aborted partway (HTTP error or a repeated cursor),
+    # losing every entry after the failure point. The per-abort warnings group
+    # under one title, so before this counter existed the report showed a single
+    # warning no matter how many endpoints were truncated -- 29 aborts on one
+    # tenant read as "1".
+    pagination_aborted: int = 0
+    # Data Models whose /columns pagination aborted. /columns is the sole source
+    # of formulas and columnIds, so these models lose column lineage for reasons
+    # unrelated to resolution. Check this before reading a model's missing FGL
+    # as a resolver defect.
+    data_model_columns_fetch_partial: int = 0
+    # Formula refs naming a warehouse TABLE the element declares, resolved to
+    # that table's column. The columnId path covers pass-throughs; this covers
+    # columns with an opaque columnId, whose display name is the only remaining
+    # signal for the warehouse column name -- so these edges carry a reduced
+    # confidence score.
+    data_model_element_fgl_warehouse_table_name_resolved: int = 0
     # Column whose formula refs are exclusively parameter refs (e.g. [P_*]).
     chart_input_fields_skipped_parameter: int = 0
     # Column whose formula refs are exclusively bare sibling refs (e.g. [col]).
@@ -340,6 +416,50 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # Refs whose column name has no matching fieldPath in the upstream element's
     # schema; dropped to avoid a dangling schemaField URN.
     data_model_element_fgl_dropped_unknown_upstream_column: int = 0
+    # Refs whose intra-DM sibling resolved but carries no columns at all (look
+    # for a matching "Sigma paginated endpoint aborted" warning naming this DM).
+    # Split out of dropped_unknown_upstream_column so a fetch problem is
+    # distinguishable from a genuine column-name mismatch. A whole-DM /columns
+    # failure does not land here — that empties the consuming element too, so it
+    # has no columns to resolve; this fires on a partial pagination abort or a
+    # genuinely column-less sibling.
+    data_model_element_fgl_upstream_schema_unavailable: int = 0
+    # Columns from which no bracket ref could be resolved — an empty/absent
+    # formula (Sigma's shape for a pass-through column), a constant expression,
+    # or a formula whose only refs are parameters (`[P_*]`) or bare sibling-column
+    # refs — and whose columnId is not warehouse-shaped, so there was nothing to
+    # resolve against. Dominated by intra-DM and Sigma Dataset passthroughs;
+    # expected volume, not a failure signal.
+    data_model_element_fgl_no_ref_unresolved: int = 0
+    # Same no-resolvable-ref shape, but the columnId IS ``inode-``-shaped, so a
+    # warehouse column was identified and resolution still failed (a /files miss
+    # or an unmappable connection). This one is actionable. Kept apart from
+    # fgl_warehouse_passthrough_deferred, which stays reachable only from
+    # formulas that do produce refs, so its baseline remains comparable.
+    data_model_element_fgl_no_ref_warehouse_unresolved: int = 0
+    # Multi-segment ("join chain") refs of the shape
+    # [JoinElement/SourceElement/Column] -- Sigma's encoding for a column reached
+    # through a join -- resolved by trying alternative (source, column) splits
+    # instead of the legacy first-slash split. Only counted for refs with 3+
+    # segments, so single-slash refs never inflate it.
+    data_model_element_fgl_join_chain_resolved: int = 0
+    # Join-chain refs where no candidate split validated against a real element
+    # name plus that element's schema. A SUB-COUNT of whichever residual bucket
+    # the legacy path then settles on (dropped_unknown_upstream_column,
+    # dropped_orphan_upstream or cross_dm_deferred) -- not an independent drop,
+    # so do not add it to those totals.
+    data_model_element_fgl_join_chain_unresolved: int = 0
+    # Join-chain sources promoted to entity-level upstreams because Sigma's
+    # element /lineage lists only the direct join element, never the transitive
+    # source the formula actually names. Without the promotion the emitted
+    # schemaField would reference a Dataset absent from ``upstreams``.
+    data_model_element_fgl_join_chain_upstream_added: int = 0
+    # Refs whose named sibling was absent from Sigma's /lineage upstreams but
+    # demonstrably owns the referenced column. Accepted on the strength of the
+    # schema and promoted to an entity-level upstream, the same treatment join
+    # chains get. Replaces the earlier _orphan_recoverable_if_gate_relaxed
+    # probe, which measured 162 of 167 such drops before the change was made.
+    data_model_element_fgl_orphan_recovered: int = 0
     # Cross-DM FGL counters (DM = data model throughout).
     # Refs resolved via global bridge index and emitted as cross-DM FGL.
     # Resolution uses entity-level upstreams as a soft collision tiebreaker,
@@ -349,6 +469,13 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     data_model_element_fgl_cross_dm_collision_pick_first: int = 0
     # Cross-DM refs whose column is absent from the resolved upstream element's schema.
     data_model_element_fgl_cross_dm_dropped_unknown_upstream_column: int = 0
+    # Cross-DM equivalent of fgl_upstream_schema_unavailable: the producer
+    # element is in the bridge map but carries no columns, so the producer DM's
+    # /columns fetch came back empty. Kept apart from the intra-DM counter
+    # because an empty sibling and an empty cross-DM producer point at different
+    # data models to investigate. A producer missing from the bridge map
+    # entirely stays on fgl_cross_dm_deferred.
+    data_model_element_fgl_cross_dm_upstream_schema_unavailable: int = 0
 
     # Entries dropped as duplicates by the pagination-level natural-key
     # dedup in ``_paginated_entries`` / lineage raw dedup. Normally 0;
@@ -428,6 +555,18 @@ class SigmaSourceReport(StaleEntityRemovalSourceReport):
     # type=table lineage entry missing inodeId or name; skipped to avoid
     # emitting a malformed URN.
     dm_element_warehouse_table_entry_incomplete: int = 0
+
+    # Why columnId-based warehouse resolution returned nothing, by gate. The
+    # deferred counter it feeds is normally the largest bucket in the report and
+    # said nothing about cause; keys are:
+    #   columnId_not_inode_shaped     -- not a warehouse passthrough at all
+    #   columnId_missing_native_part  -- "inode-<id>" with no "/<COLUMN>"
+    #   url_id_not_in_element_source_ids -- column claims an inode the element
+    #                                    does not declare (payload drift)
+    #   url_id_not_in_warehouse_map   -- /files never resolved that inode
+    #   parent_urn_unresolved         -- connection unmappable / no platform
+    #   connection_not_in_registry    -- connection id absent from /connections
+    warehouse_passthrough_miss_reasons: Dict[str, int] = field(default_factory=dict)
 
 
 class WarehouseConnectionConfig(PlatformInstanceConfigMixin, EnvConfigMixin):

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/formula_parser.py
@@ -86,7 +86,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -119,12 +119,78 @@ class BracketRef:
     AND ``column`` is None. This is a heuristic for Sigma parameter refs, which
     lineage resolvers should skip. `[p_foo]` (lowercase) is NOT flagged;
     `[P_X/col]` (has column part) is NOT flagged.
+
+    `segments` is every unescaped-``/``-delimited part of the body, in order and
+    individually whitespace-stripped (e.g. ``[a/b/c]`` → ``["a", "b", "c"]``).
+    ``source`` / ``column`` keep their first-slash split for backwards
+    compatibility, but resolvers should prefer ``segments``: Sigma writes
+    join-chain refs as ``[JoinElement/SourceElement/Column]``, where the owning
+    element is the second-to-last segment, not the first. Only the scanner may
+    produce this list -- an escaped ``\\/`` is a literal character inside one
+    segment, so re-splitting ``column`` after the fact would corrupt it.
     """
 
     raw: str
     source: str
     column: Optional[str]
     is_parameter: bool
+    # Defaults to the first-slash split so hand-built refs (tests, callers that
+    # construct a ref directly) keep working. Deliberately does NOT split
+    # ``column`` on "/" -- that would reintroduce the ambiguity the scanner
+    # exists to resolve.
+    segments: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        if self.segments is None:
+            default = (
+                [self.source] if self.column is None else [self.source, self.column]
+            )
+            # Frozen dataclass: bypass the immutability guard once, at construction.
+            object.__setattr__(self, "segments", default)
+
+    @property
+    def parts(self) -> List[str]:
+        """``segments`` narrowed to a plain list for type-checked call sites."""
+        return self.segments if self.segments else [self.source]
+
+
+def candidate_source_column_splits(ref: BracketRef) -> List[Tuple[str, str]]:
+    """Return (source, column) readings of a ref, most-likely first.
+
+    Sigma writes a column reached through a join as
+    ``[JoinElement/SourceElement/Column]`` (chaining further for nested joins),
+    so the element that owns the column is the segment immediately before the
+    column -- not the first segment, which is what ``ref.source`` holds.
+
+    Candidates are ordered join-chain reading first, then the "element name
+    itself contains a slash" reading, working right to left. Callers validate
+    each candidate against a real element name *and* that element's schema, and
+    take the first that holds; the final candidate is always the legacy
+    first-slash split, so a single-slash ref resolves exactly as before.
+
+    Returns an empty list for refs with no column part (bare/parameter refs).
+    """
+    segments = ref.parts
+    if ref.column is None or len(segments) < 2:
+        return []
+    out: List[Tuple[str, str]] = []
+    seen = set()
+
+    def add(source: str, column: str) -> None:
+        if not source or not column:
+            return
+        if (source, column) in seen:
+            return
+        seen.add((source, column))
+        out.append((source, column))
+
+    for i in range(len(segments) - 1, 0, -1):
+        column = "/".join(segments[i:])
+        # 1. join-chain: owning element is the segment before the column.
+        add(segments[i - 1], column)
+        # 2. element name containing an unescaped "/".
+        add("/".join(segments[:i]), column)
+    return out
 
 
 def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
@@ -144,6 +210,9 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
     bracket_start_idx = 0
     source_buf: List[str] = []
     column_buf: List[str] = []
+    # One buffer per unescaped-"/"-delimited segment. Accumulated alongside
+    # source_buf/column_buf so the legacy first-slash split is untouched.
+    segment_bufs: List[List[str]] = [[]]
     seen_slash = False
     i = 0
     n = len(formula)
@@ -155,6 +224,7 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
                 bracket_start_idx = i
                 source_buf = []
                 column_buf = []
+                segment_bufs = [[]]
                 seen_slash = False
             elif ch == '"':
                 state = _IN_DOUBLE_STR
@@ -167,6 +237,7 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
                 # finish_bracket: emit_or_skip per decision matrix
                 source = "".join(source_buf).strip()
                 column = "".join(column_buf).strip() if seen_slash else None
+                segments = ["".join(seg).strip() for seg in segment_bufs]
                 if source and (column is None or column):
                     out.append(
                         BracketRef(
@@ -174,6 +245,7 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
                             source=source,
                             column=column,
                             is_parameter=source.startswith("P_") and column is None,
+                            segments=segments,
                         )
                     )
                 else:
@@ -183,18 +255,29 @@ def extract_bracket_refs(formula: Optional[str]) -> List[BracketRef]:
                     )
                 state = _NORMAL
             elif ch == "\\":
-                # escape_peek: consume next char literally into active buffer
+                # escape_peek: consume next char literally into active buffer.
+                # An escaped "/" is a literal character, so it must NOT open a
+                # new segment -- this is why segments can only be built in the
+                # scanner and never by re-splitting source/column afterwards.
                 if i + 1 < n:
                     buf.append(formula[i + 1])
+                    segment_bufs[-1].append(formula[i + 1])
                     i += 2
                     continue
                 # lone backslash at EOF → unterminated bracket; loop ends naturally
-            elif ch == "/" and not seen_slash:
-                # first unescaped slash: switch accumulation to column_buf
-                seen_slash = True
+            elif ch == "/":
+                # Every unescaped slash opens a new segment. For source/column
+                # only the first one separates; later ones stay literal in the
+                # column buffer (unchanged legacy behaviour).
+                segment_bufs.append([])
+                if not seen_slash:
+                    seen_slash = True
+                else:
+                    buf.append(ch)
             else:
-                # covers '[', '"', "'", subsequent '/', and all other chars
+                # covers '[', '"', "'", and all other chars
                 buf.append(ch)
+                segment_bufs[-1].append(ch)
         elif state == _IN_DOUBLE_STR:
             if ch == '"':
                 state = _NORMAL

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -63,6 +63,7 @@ from datahub.ingestion.source.sigma.data_classes import (
 )
 from datahub.ingestion.source.sigma.formula_parser import (
     BracketRef,
+    candidate_source_column_splits,
     extract_bracket_refs,
 )
 from datahub.ingestion.source.sigma.sigma_api import SigmaAPI
@@ -130,6 +131,23 @@ _FGL_CONFIDENCE_SQL_PARSED: float = (
     0.2  # aggregator-derived; matches SqlParsingAggregator
 )
 _FGL_CONFIDENCE_FORMULA_DERIVED: float = 0.1  # SELECT * synthesis from formula refs
+# A formula ref naming a warehouse table the element declares. The table match
+# is exact -- the element's own source_ids carry that inode -- but the warehouse
+# COLUMN name is inferred from Sigma's display name (Title Case of snake_case),
+# because a column with an opaque columnId carries no native name anywhere in
+# the API. Scored below an exact match so consumers can tell the two apart.
+_FGL_CONFIDENCE_WAREHOUSE_NAME_DERIVED: float = 0.5
+
+
+def _warehouse_column_from_display_name(display_name: str) -> str:
+    """Invert Sigma's display-name convention for a warehouse column.
+
+    Sigma renders a warehouse column ``COL_ID`` as ``Col Id``. When the
+    column's ``columnId`` is inode-shaped the native name is carried verbatim
+    and this is not needed; it is only for columns whose columnId is opaque,
+    where the display name is the sole remaining signal.
+    """
+    return display_name.strip().replace(" ", "_").upper()
 
 
 def _dm_column_ranks_above(
@@ -145,6 +163,30 @@ def _dm_column_ranks_above(
     if bool(candidate.formula) != bool(incumbent.formula):
         return bool(candidate.formula)
     return candidate.columnId < incumbent.columnId
+
+
+def _normalize_element_name(name: str) -> str:
+    """Key for tolerant workbook-element-name lookup.
+
+    Sigma element names routinely carry trailing non-breaking spaces, leading
+    spaces, and case differences from what a formula ref spells. Those refs
+    resolve to nothing today: the lookup is exact-match, so the element sits in
+    the index unreachable. Observed on one tenant as 6,493 near-misses plus 30
+    case-only mismatches -- e.g. 'Union of both types of interatctions\xa0'
+    and ' App Events'.
+    """
+    return name.replace("\xa0", " ").strip().casefold()
+
+
+def _is_warehouse_column_id(column_id: Optional[str]) -> bool:
+    """True when a DM column's ``columnId`` names a warehouse column.
+
+    Sigma encodes warehouse pass-throughs as ``inode-<url_id>/<NATIVE_NAME>``.
+    Shared by _try_emit_warehouse_passthrough_fgl (which resolves it) and the
+    no-resolvable-ref counters (which bucket on it), so the two cannot drift
+    and start mis-bucketing a real /files miss as expected volume.
+    """
+    return (column_id or "").startswith("inode-")
 
 
 def _dedup_dm_element_columns(
@@ -331,6 +373,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # element Dataset URN. A name may map to multiple URNs when a DM
         # has duplicate-named elements.
         self.dm_element_urn_by_name: Dict[str, Dict[str, List[str]]] = {}
+        # bridge_key -> columnId -> [(element Dataset URN, column name)].
+        # columnId is a warehouse-column identity Sigma reuses verbatim across
+        # every element that passes the column through, so matching a consumer
+        # column to a producer column by columnId is exact -- unlike matching by
+        # display name, which would guess. Used to recover cross-DM column
+        # lineage for pass-through columns, which carry no formula ref naming
+        # their producer.
+        self.dm_element_columnid_index: Dict[str, Dict[str, List[Tuple[str, str]]]] = {}
         # DM urlId -> DM Container URN. Last-resort fallback.
         self.dm_container_urn_by_url_id: Dict[str, str] = {}
         # DM urlId -> total element count (includes blank-named elements
@@ -415,6 +465,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # is expected to be in the hundreds, not millions.  If this assumption
         # proves wrong, an LRU cap can be added without changing the interface.
         self._files_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+        # Global url_id -> warehouse table, built lazily from /v2/files the
+        # first time a Data Model's own /lineage turns out to omit a table its
+        # elements reference. None until built; {} means built-and-empty.
+        # urlId -> /files entry, or None when Sigma 404s (a stale reference to a
+        # deleted table). One call per distinct url_id.
+        self._warehouse_file_by_url_id: Dict[str, Optional[Dict[str, Any]]] = {}
+        self._stale_warehouse_refs_seen: Set[str] = set()
         # Inodes whose /files path already produced an unparseable warning;
         # prevents N identical warnings when the same inode spans N DMs (H3).
         self._files_path_unparseable_seen: Set[str] = set()
@@ -433,6 +490,10 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # warning has been emitted; dedup so repeated charts with the same unresolved
         # column don't flood the report.
         self._bridge_unresolved_warned: Set[Tuple[str, str]] = set()
+        # Upstream DM elements whose empty schema has already been reported; one
+        # failed /columns fetch empties every element in a DM, so without this
+        # every ref into that DM would emit its own warning.
+        self._upstream_schema_unavailable_warned: Set[str] = set()
         # Once-per-run gate flags so noisy global conditions don't flood logs.
         self._registry_empty_warned: bool = False
         # Per-platform set: platforms for which we've emitted a "first emission"
@@ -727,6 +788,124 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             self._files_cache[inode_id] = self.sigma_api.get_file_metadata(inode_id)
         return self._files_cache[inode_id]
 
+    def _warehouse_ref_from_file_entry(
+        self, entry: Dict[str, Any], connection_id: str
+    ) -> Optional[_WarehouseTableRef]:
+        """Build a table ref from a /files entry, or None if its path is unusable.
+
+        Shares the path contract of :meth:`_build_dm_warehouse_url_id_map`:
+        ``Connection Root/<SCHEMA>`` or ``Connection Root/<DB>/<SCHEMA>``.
+        """
+        path = str(entry.get("path") or "")
+        table_name = str(entry.get("name") or "")
+        parts = path.split("/")
+        if not (table_name and 2 <= len(parts) <= 3 and all(parts)):
+            logger.debug(
+                "GLOBAL WAREHOUSE INDEX reject: url_id=%r path=%r name=%r -- "
+                "expected 2-3 non-empty segments and a table name",
+                entry.get("urlId"),
+                path,
+                table_name,
+            )
+            return None
+        if parts[0] != _FILES_PATH_ROOT:
+            logger.debug(
+                "GLOBAL WAREHOUSE INDEX reject: url_id=%r path root %r is not "
+                "%r; the /files path shape is unrecognised",
+                entry.get("urlId"),
+                parts[0],
+                _FILES_PATH_ROOT,
+            )
+            return None
+        db = parts[1] if len(parts) == 3 else None
+        schema = parts[-1]
+        return _WarehouseTableRef(
+            connection_id=connection_id, db=db, schema=schema, table=table_name
+        )
+
+    def _infer_connection_id(
+        self, warehouse_map: Dict[str, _WarehouseTableRef]
+    ) -> Optional[str]:
+        """Connection to attribute a table /files does not tell us the connection for.
+
+        A /files entry carries no connectionId, so it is taken from the Data
+        Model's own already-resolved tables when they agree, else from the
+        tenant's sole mappable connection. Ambiguity is refused rather than
+        guessed: attributing a table to the wrong connection would emit a URN
+        pointing at the wrong platform or instance.
+        """
+        conns = {ref.connection_id for ref in warehouse_map.values()}
+        if len(conns) == 1:
+            return next(iter(conns))
+        if conns:
+            return None
+        mappable = [
+            cid
+            for cid, rec in self.connection_registry.by_id.items()
+            if rec.is_mappable
+        ]
+        return mappable[0] if len(mappable) == 1 else None
+
+    def _lookup_global_warehouse_table(
+        self, url_id: str, connection_id: str
+    ) -> Optional[_WarehouseTableRef]:
+        """Resolve a url_id the owning Data Model's /lineage never described.
+
+        Asks ``/v2/files/{urlId}`` directly, one call per distinct miss.
+
+        An earlier version listed every table on the tenant and looked the
+        url_id up in that index. Measured against a live tenant, that cost 41
+        paged calls and recovered NOTHING: all 37 unresolved url_ids were absent
+        from a complete 40,564-row listing. Asking about each url_id directly is
+        both cheaper and strictly more informative, because it separates two
+        cases the listing could not:
+
+        * **200** -- the table exists but the Data Model's /lineage omitted it.
+          Recovered, which is what this method was always meant to do.
+        * **404** -- Sigma does not know this file at all. Every one of that
+          tenant's misses answered this way. Verified against a control url_id
+          taken from the listing, which returns 200, so ``/v2/files/{urlId}``
+          does accept a url_id and the 404s are real absences rather than an
+          id-space mismatch. The Data Model still carries an ``inode-<urlId>``
+          reference to a table that has been deleted, and no lookup strategy can
+          produce coordinates for an object that no longer exists -- so these
+          are reported as stale references instead of retried.
+        """
+        if url_id not in self._warehouse_file_by_url_id:
+            self._warehouse_file_by_url_id[url_id] = (
+                self.sigma_api.get_file_metadata_by_url_id(url_id)
+            )
+        entry = self._warehouse_file_by_url_id[url_id]
+        if entry is None:
+            self.reporter.dm_element_warehouse_stale_reference += 1
+            if url_id not in self._stale_warehouse_refs_seen:
+                self._stale_warehouse_refs_seen.add(url_id)
+                logger.debug(
+                    "WAREHOUSE STALE REF: url_id %r is not resolvable in Sigma "
+                    "(/v2/files/{urlId} returned 404). The Data Model still "
+                    "points at this table but it no longer exists, so columns "
+                    "naming it can never receive warehouse column lineage. This "
+                    "is tenant data hygiene, not a connector gap.",
+                    url_id,
+                )
+            return None
+        ref = self._warehouse_ref_from_file_entry(entry, connection_id)
+        if ref is None:
+            self.reporter.dm_element_warehouse_path_unparseable += 1
+            return None
+        self.reporter.dm_element_warehouse_recovered_from_global_index += 1
+        logger.debug(
+            "WAREHOUSE DIRECT LOOKUP hit: url_id %r -> db=%r schema=%r table=%r "
+            "via connection %r (inferred, since a /files entry carries none); "
+            "this table was absent from the owning Data Model's /lineage",
+            url_id,
+            ref.db,
+            ref.schema,
+            ref.table,
+            connection_id,
+        )
+        return ref
+
     def _build_dm_warehouse_url_id_map(
         self, data_model: SigmaDataModel
     ) -> Dict[str, _WarehouseTableRef]:
@@ -749,6 +928,18 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
           - dm_element_warehouse_path_unparseable
         """
         result: Dict[str, _WarehouseTableRef] = {}
+        # This map is the sole bridge between a column's inode-shaped columnId
+        # and a warehouse Dataset URN. It is built from the DM's /lineage
+        # type=table rows only, so a DM whose /lineage reports no table rows
+        # yields an EMPTY map and every warehouse passthrough in it silently
+        # fails with url_id_not_in_warehouse_map -- previously with no way to
+        # see that the map was empty, or which url_ids it did contain.
+        logger.debug(
+            "WAREHOUSE MAP DM %s: building from %d type=table lineage inode(s): %r",
+            data_model.dataModelId,
+            len(data_model.warehouse_inodes_by_inode_id),
+            sorted(data_model.warehouse_inodes_by_inode_id)[:20],
+        )
         for inode_id, raw in data_model.warehouse_inodes_by_inode_id.items():
             conn_id = raw["connectionId"]
             first_attempt = inode_id not in self._files_cache
@@ -805,6 +996,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         ),
                     )
                 continue
+            logger.debug(
+                "WAREHOUSE MAP DM %s: inode %s -> url_id=%r path=%r table=%r",
+                data_model.dataModelId,
+                inode_id,
+                url_id,
+                path,
+                table_name,
+            )
             if url_id in result:
                 logger.warning(
                     "DM %s: two inodes share the same urlId %r; "
@@ -848,6 +1047,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 schema=schema,
                 table=table_name,
             )
+        logger.debug(
+            "WAREHOUSE MAP DM %s: final map has %d url_id(s): %r",
+            data_model.dataModelId,
+            len(result),
+            sorted(result),
+        )
         return result
 
     def _resolve_dm_element_warehouse_upstream(
@@ -885,6 +1090,32 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         """
         ref = warehouse_map.get(url_id_suffix)
         if ref is None:
+            # The owning Data Model's /lineage never described this table. Fall
+            # back to the global /v2/files index before giving up.
+            inferred = self._infer_connection_id(warehouse_map)
+            if inferred is not None:
+                ref = self._lookup_global_warehouse_table(url_id_suffix, inferred)
+            else:
+                self.reporter.dm_element_warehouse_connection_ambiguous += 1
+                logger.debug(
+                    "WAREHOUSE RESOLVE: url_id %r absent from the DM map and the "
+                    "connection could not be inferred unambiguously; skipping "
+                    "the global index",
+                    url_id_suffix,
+                )
+        if ref is None:
+            # Silent until now, and the single most common way a warehouse edge
+            # is lost: the element declares this inode but the DM's /lineage
+            # never produced a type=table row for it, so it is absent from the
+            # map. Compare url_id against the "WAREHOUSE MAP ... final map"
+            # line for this Data Model.
+            logger.debug(
+                "WAREHOUSE RESOLVE miss: url_id %r absent from the warehouse "
+                "map (map has %d entries: %r)",
+                url_id_suffix,
+                len(warehouse_map),
+                sorted(warehouse_map)[:20],
+            )
             return None
 
         record = self.connection_registry.get(ref.connection_id)
@@ -912,6 +1143,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         target_env = conn_override.env if conn_override else self.config.env
         target_platform_instance = (
             conn_override.platform_instance if conn_override else None
+        )
+        logger.debug(
+            "WAREHOUSE RESOLVE hit: url_id %r -> platform=%r fq=%r env=%r "
+            "platform_instance=%r (connection=%r)",
+            url_id_suffix,
+            record.datahub_platform,
+            fq,
+            target_env,
+            target_platform_instance,
+            ref.connection_id,
         )
         # Once-per-platform info when emitting for a platform not in
         # _WAREHOUSE_LOWERCASE_PLATFORMS, so operators know to verify that
@@ -1679,6 +1920,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     )
                 else:
                     self.reporter.dm_customsql_fgl_downstream_unmapped += 1
+                    logger.debug(
+                        "customSQL FGL downstream unmapped: SQL column %r on "
+                        "%s has no matching Sigma display column; known=%r",
+                        field_path,
+                        ds_parent_urn,
+                        sorted(col_mapping.values())[:25],
+                    )
             if rewritten_downstreams:
                 rewritten_fgls.append(
                     FineGrainedLineageClass(
@@ -1900,7 +2148,30 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # not document ordering, and Upstream entries have no semantic order.
         upstream_urns.sort()
         if not upstream_urns:
+            # The most important case to be able to see, and previously the only
+            # one that was completely silent: this element gets NO
+            # upstreamLineage aspect at all, and the early return happens before
+            # the FGL builder, so neither the ELEMENT nor any COLUMN record is
+            # produced either. An element with no lineage whatsoever left no
+            # trace of why.
+            self.reporter.data_model_element_no_upstreams += 1
+            logger.debug(
+                "ELEMENT NO-UPSTREAM DM %s element %s %r: source_ids=%r "
+                "columns=%d -- no source_id resolved to a URN, so no "
+                "upstreamLineage and no column lineage is emitted for this "
+                "element at all. Each unresolved source_id is reported above "
+                "with its shape (intra-DM / inode / cross-DM / customSQL / "
+                "unknown).",
+                data_model.dataModelId,
+                element.elementId,
+                element.name,
+                element.source_ids,
+                len(element.columns),
+            )
             return None
+        # Elements reached only through a join chain: Sigma's /lineage reports
+        # the direct join element, not the transitive source the formula names.
+        discovered_upstreams: Set[str] = set()
         fine_grained = self._build_dm_element_fine_grained_lineages(
             element=element,
             element_dataset_urn=element_dataset_urn,
@@ -1909,6 +2180,37 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             entity_level_upstream_urns=set(upstream_urns),
             data_model=data_model,
             warehouse_url_id_map=warehouse_url_id_map,
+            discovered_upstreams=discovered_upstreams,
+        )
+        # Promote them to entity-level upstreams so every emitted schemaField
+        # has a declared parent Dataset; without this the FGL points at a
+        # Dataset missing from ``upstreams`` and the UI will not render it.
+        for urn in sorted(discovered_upstreams):
+            if urn not in upstream_urns:
+                upstream_urns.append(urn)
+                logger.debug(
+                    "DM %s element %s: promoted join-chain source %s to an "
+                    "entity-level upstream (absent from Sigma /lineage)",
+                    data_model.dataModelId,
+                    element.elementId,
+                    urn,
+                )
+        upstream_urns.sort()
+        # Element-level decision record. Pairs with the per-column COLUMN lines:
+        # this says which upstreams the element ended up declaring and how many
+        # column edges were produced, so "why is there no CLL from X to Y" can be
+        # answered by grepping one element id instead of reconstructing it.
+        logger.debug(
+            "ELEMENT DM %s element %s %r: source_ids=%r -> upstreams=%r "
+            "promoted=%r fgl_count=%d columns=%d",
+            data_model.dataModelId,
+            element.elementId,
+            element.name,
+            element.source_ids,
+            upstream_urns,
+            sorted(discovered_upstreams),
+            len(fine_grained or []),
+            len(element.columns),
         )
         return UpstreamLineage(
             upstreams=[
@@ -1976,6 +2278,37 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             entityUrn=element_dataset_urn, aspect=schema_metadata
         ).as_workunit()
 
+    def _note_warehouse_miss(
+        self,
+        reason: str,
+        column: SigmaDataModelColumn,
+        element: SigmaDataModelElement,
+        col_id: str,
+    ) -> None:
+        """Record why columnId-based warehouse resolution produced nothing.
+
+        Aggregated into a per-reason histogram on the report so the largest
+        deferred bucket becomes triageable without grepping the log, plus a
+        debug line naming the column for the first occurrences.
+        """
+        self.reporter.warehouse_passthrough_miss_reasons[reason] = (
+            self.reporter.warehouse_passthrough_miss_reasons.get(reason, 0) + 1
+        )
+        # Cap generously rather than tightly: at 25 the sample was exhausted by
+        # the first couple of Data Models and the elements actually being
+        # investigated never appeared. Each line is short and only failures
+        # reach here.
+        if self.reporter.warehouse_passthrough_miss_reasons[reason] <= 2000:
+            logger.debug(
+                "warehouse passthrough miss (%s): element=%s column=%r "
+                "columnId=%r source_ids=%r",
+                reason,
+                element.elementId,
+                column.name,
+                col_id,
+                element.source_ids[:8],
+            )
+
     def _try_emit_warehouse_passthrough_fgl(
         self,
         *,
@@ -1997,23 +2330,65 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         the caller's responsibility so that None unambiguously means failure.
         """
         # Parse columnId → url_id + warehouse column name.
+        # Every early return below records WHY, because
+        # fgl_warehouse_passthrough_deferred is the largest bucket in the report
+        # (10,806 on one tenant) and previously said nothing about cause.
         col_id = column.columnId or ""
-        if not col_id.startswith("inode-"):
+        if not _is_warehouse_column_id(col_id):
+            self._note_warehouse_miss(
+                "columnId_not_inode_shaped", column, element, col_id
+            )
             return None
         suffix = col_id[len("inode-") :]
         url_id, sep, warehouse_col = suffix.partition("/")
         if not sep or not warehouse_col:
+            self._note_warehouse_miss(
+                "columnId_missing_native_part", column, element, col_id
+            )
             return None
 
         # Verify this url_id is one of the element's declared warehouse sources.
         # Mismatches can occur if a column belongs to a different element's inode
         # (shouldn't happen with well-formed API data, but guards against drift).
         if f"inode-{url_id}" not in element.source_ids:
-            return None
+            # The element does not declare this inode. That is expected when the
+            # element is sourced transitively -- e.g. every source_id is a
+            # cross-DM ``<dmUrlId>/<suffix>`` ref -- because the warehouse table
+            # is declared by the producer element in the other Data Model, not
+            # here. Same shape of mistake as gating join-chain resolution on
+            # Sigma's direct /lineage list.
+            #
+            # Accept it only when the element declares no inode source at all
+            # AND the url_id is in this Data Model's warehouse map, i.e. some
+            # element here does reach that table. If the element declares its
+            # own inodes and this column names a different one, that is genuine
+            # payload drift and stays rejected.
+            declares_any_inode = any(
+                sid.startswith("inode-") for sid in element.source_ids
+            )
+            if declares_any_inode or url_id not in warehouse_url_id_map:
+                self._note_warehouse_miss(
+                    "url_id_not_in_element_source_ids", column, element, col_id
+                )
+                return None
+            self.reporter.dm_element_warehouse_transitive_inode_accepted += 1
+            logger.debug(
+                "WAREHOUSE transitive accept: element %s column %r columnId=%r "
+                "-- element declares no inode source (source_ids=%r) but url_id "
+                "is in this DM's warehouse map",
+                element.elementId,
+                column.name,
+                col_id,
+                element.source_ids,
+            )
 
         # Guard: url_id must resolve in the warehouse map (i.e. /files succeeded).
         wh_ref = warehouse_url_id_map.get(url_id)
         if wh_ref is None:
+            # /files never resolved this inode into db/schema/table.
+            self._note_warehouse_miss(
+                "url_id_not_in_warehouse_map", column, element, col_id
+            )
             return None
 
         # Resolve the parent Dataset URN.  This is the only allowed path for
@@ -2024,6 +2399,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             warehouse_map=warehouse_url_id_map,
         )
         if parent_urn is None:
+            self._note_warehouse_miss("parent_urn_unresolved", column, element, col_id)
             return None
 
         # Normalize column casing to match the platform convention used by the
@@ -2032,6 +2408,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # dict hits on the same objects.
         record = self.connection_registry.get(wh_ref.connection_id)
         if record is None:
+            self._note_warehouse_miss(
+                "connection_not_in_registry", column, element, col_id
+            )
             return None
         conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
         lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
@@ -2150,6 +2529,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         )
         if not cross_dm_candidate_urns:
             self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+            logger.debug(
+                "element %s: cross-DM deferred, no candidate for ref %r "
+                "(segments=%r, source_dms=%r)",
+                element.elementId,
+                ref.raw,
+                ref.parts,
+                sorted(source_dm_url_ids),
+            )
             return None
         if len(cross_dm_candidate_urns) > 1:
             # Restrict to entity-level confirmed candidates whenever any exist.
@@ -2168,10 +2555,38 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         upstream_cols = self.dm_element_urn_to_cols.get(chosen_upstream_urn)
         if upstream_cols is None:
             self.reporter.data_model_element_fgl_cross_dm_deferred += 1
+            logger.debug(
+                "element %s: cross-DM deferred, producer %s absent from the "
+                "bridge column map for ref %r (segments=%r)",
+                element.elementId,
+                chosen_upstream_urn,
+                ref.raw,
+                ref.parts,
+            )
+            return None
+        if not upstream_cols:
+            # Producer element is known but carries no columns -- the producer
+            # DM's /columns fetch came back empty. Distinct from the `is None`
+            # case above (producer absent from the bridge map entirely), which
+            # stays on the deferred counter. Counted separately from the
+            # intra-DM equivalent: an empty sibling in this DM and an empty
+            # producer in another DM are different investigations.
+            self.reporter.data_model_element_fgl_cross_dm_upstream_schema_unavailable += 1
+            self._warn_upstream_schema_unavailable(chosen_upstream_urn, element)
             return None
         canonical_col = upstream_cols.get(ref.column.lower())
         if canonical_col is None:
             self.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column += 1
+            logger.debug(
+                "element %s: cross-DM drop, ref %r column %r absent from "
+                "producer %s (segments=%r, producer_has=%r)",
+                element.elementId,
+                ref.raw,
+                ref.column,
+                chosen_upstream_urn,
+                ref.parts,
+                sorted(upstream_cols.values())[:25],
+            )
             return None
         return FineGrainedLineageClass(
             downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
@@ -2181,6 +2596,26 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 builder.make_schema_field_urn(chosen_upstream_urn, canonical_col)
             ],
             confidenceScore=1.0,
+        )
+
+    def _warn_upstream_schema_unavailable(
+        self, upstream_urn: str, element: SigmaDataModelElement
+    ) -> None:
+        """Warn once per upstream URN that its schema came back empty."""
+        if upstream_urn in self._upstream_schema_unavailable_warned:
+            return
+        self._upstream_schema_unavailable_warned.add(upstream_urn)
+        self.reporter.warning(
+            title="Sigma DM element upstream schema unavailable",
+            message=(
+                "A formula references a column on an upstream Data Model element "
+                "whose column list came back empty, so the column-level lineage "
+                "edge was dropped. Check for a `Sigma paginated endpoint aborted` "
+                "warning naming that Data Model: if one is present its /columns "
+                "fetch failed partway through, and if none is present the "
+                "upstream element genuinely has no columns."
+            ),
+            context=f"upstream={upstream_urn}, element={element.elementId}",
         )
 
     def _resolve_intra_dm_fgl(
@@ -2198,6 +2633,7 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         fgls: List[FineGrainedLineageClass],
         cross_dm_fgls: List[FineGrainedLineageClass],
         emitted_pairs: Set[Tuple[str, str]],
+        discovered_upstreams: Set[str],
     ) -> None:
         """Resolve a formula ref against intra-DM sibling elements.
 
@@ -2235,7 +2671,60 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 cross_dm_fgls=cross_dm_fgls,
             ):
                 return
+            # The named sibling exists in this Data Model but Sigma's /lineage
+            # did not list it as an upstream. Where that sibling actually owns
+            # the referenced column, the ref is trustworthy and the omission is
+            # a reporting gap -- the same situation as a join chain, whose
+            # owning element /lineage never lists either. Accept it on the
+            # strength of the schema and promote it to an entity-level upstream,
+            # so the emitted schemaField has a declared parent Dataset.
+            # A run measured 162 of 167 orphan drops as recoverable this way.
+            owning = [
+                u
+                for u in candidate_urns
+                if urn_to_cols.get(u, {}).get(ref.column.lower()) is not None
+            ]
+            if owning:
+                chosen = owning[0]
+                canonical = urn_to_cols[chosen][ref.column.lower()]
+                upstream_field = builder.make_schema_field_urn(chosen, canonical)
+                pair = (downstream_field, upstream_field)
+                if pair not in emitted_pairs:
+                    emitted_pairs.add(pair)
+                    fgls.append(
+                        FineGrainedLineageClass(
+                            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                            downstreams=[downstream_field],
+                            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                            upstreams=[upstream_field],
+                            confidenceScore=1.0,
+                        )
+                    )
+                discovered_upstreams.add(chosen)
+                self.reporter.data_model_element_fgl_orphan_recovered += 1
+                logger.debug(
+                    "DM %s element %s: orphan ref %r recovered -- sibling %s "
+                    "owns column %r though /lineage did not list it as an "
+                    "upstream; promoted to an entity-level upstream",
+                    data_model.dataModelId,
+                    element.elementId,
+                    ref.raw,
+                    chosen,
+                    canonical,
+                )
+                return
             self.reporter.data_model_element_fgl_dropped_orphan_upstream += 1
+            logger.debug(
+                "DM %s element %s: orphan drop for ref %r -- name matched an "
+                "intra-DM sibling but /lineage did not list it, the sibling "
+                "does not own the column, and cross-DM rescue failed "
+                "(segments=%r, candidates=%r)",
+                data_model.dataModelId,
+                element.elementId,
+                ref.raw,
+                ref.parts,
+                candidate_urns,
+            )
             return
 
         # Collision handling: multiple siblings passed /lineage filter.
@@ -2259,17 +2748,36 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # Validate and normalise ref.column against the chosen upstream
         # element's schema winners to avoid a dangling schemaField URN.
         source_cols = urn_to_cols.get(chosen_upstream_urn, {})
+        if not source_cols:
+            # The sibling resolved but carries no columns, so the ref cannot be
+            # validated against a real fieldPath. Counted apart from the
+            # name-miss below so operators can tell a fetch problem from a
+            # genuine missing column. Reachable when /columns aborted partway
+            # through pagination (earlier pages are preserved, so some siblings
+            # are populated and later ones are not) or when the sibling really
+            # has no columns -- note a whole-DM /columns failure cannot reach
+            # here, since it empties this element too and the caller's column
+            # loop never runs.
+            self.reporter.data_model_element_fgl_upstream_schema_unavailable += 1
+            self._warn_upstream_schema_unavailable(chosen_upstream_urn, element)
+            return
         canonical_col = source_cols.get(ref.column.lower())
         if canonical_col is None:
             self.reporter.data_model_element_fgl_dropped_unknown_upstream_column += 1
             logger.debug(
                 "DM %s element %s: ref %r column %r not found in upstream "
-                "element %s schema winners; dropping FGL entry",
+                "element %s schema winners; dropping FGL entry. segments=%r, "
+                "upstream_has=%r",
                 data_model.dataModelId,
                 element.elementId,
                 ref.raw,
                 ref.column,
                 chosen_upstream_urn,
+                ref.parts,
+                # Sample of what the chosen upstream actually exposes, so a
+                # verification run shows whether the intended column is there
+                # under a different name (or not at all) without a live API call.
+                sorted(source_cols.values())[:25],
             )
             return
 
@@ -2290,6 +2798,365 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             )
         )
 
+    @staticmethod
+    def _multi_segment_refs(refs: List["BracketRef"]) -> List[str]:
+        """Raw text of refs carrying a join-chain shape (3+ segments).
+
+        Used only to keep the diagnostic probes cheap: the chart path processes
+        hundreds of thousands of columns, so probes log the raw ref text only
+        when the join-chain shape is actually present.
+        """
+        return [r.raw for r in refs if len(r.parts) >= 3]
+
+    def _try_resolve_join_chain_ref(
+        self,
+        *,
+        ref: "BracketRef",
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        element_name_to_eids: Dict[str, List[str]],
+        elementId_to_dataset_urn: Dict[str, str],
+        entity_level_upstream_urns: Set[str],
+        urn_to_cols: Dict[str, Dict[str, str]],
+        downstream_field: str,
+        emitted_pairs: Set[Tuple[str, str]],
+        fgls: List[FineGrainedLineageClass],
+        cross_dm_fgls: List[FineGrainedLineageClass],
+        discovered_upstreams: Set[str],
+    ) -> bool:
+        """Resolve a multi-segment ref by trying alternative (source, column) splits.
+
+        Sigma writes a column reached through a join as
+        ``[JoinElement/SourceElement/Column]``, so the owning element is the
+        segment before the column. ``ref.source`` holds the *first* segment,
+        which for these refs is the join element -- a real sibling, which is why
+        the legacy path resolves it, then fails the column lookup and drops the
+        edge.
+
+        Returns True when an edge was emitted. Deliberately counts nothing on
+        failure: the caller falls through to the legacy path, which owns the
+        residual bucket, so one dropped ref is never counted twice. Each
+        candidate is self-stripped and tried intra-DM *then* cross-DM before the
+        next is considered, so neither the self-name warehouse short-circuit nor
+        an intra-DM first segment can hide a resolvable later segment.
+
+        Refs with fewer than three segments are left entirely to the legacy
+        path -- their only candidate *is* the legacy split -- so single-slash
+        behaviour and its counters are untouched.
+        """
+        if len(ref.parts) < 3:
+            return False
+        # Per-candidate verdicts, so a failure line says WHICH check rejected
+        # WHICH candidate. Without this the previous run could only say "no
+        # candidate resolved" and the blocking gate had to be inferred by
+        # reading the code.
+        trace: List[str] = []
+        for source, col in candidate_source_column_splits(ref):
+            # Intra-DM: sibling elements, self-references stripped per candidate.
+            eids = [
+                eid
+                for eid in element_name_to_eids.get(source.lower(), [])
+                if eid != element.elementId
+            ]
+            urns = sorted(
+                elementId_to_dataset_urn[eid]
+                for eid in eids
+                if eid in elementId_to_dataset_urn
+            )
+            # NOTE: deliberately NOT filtered by entity_level_upstream_urns.
+            # A join chain reaches its owning element *through* the join, so
+            # Sigma's element-level /lineage lists only the direct join element
+            # and never the transitive one. Requiring membership here made every
+            # intra-DM candidate fail: in one production run all 6 successes came
+            # from the cross-DM branch, which has no such gate, and 0 from here.
+            # The chosen element is instead recorded in discovered_upstreams and
+            # added to the entity-level upstreams by the caller, so the emitted
+            # schemaField still has a declared parent Dataset.
+            if not urns:
+                trace.append(f"{source!r}: no intra-DM element with that name")
+            if urns:
+                # Prefer a direct upstream when one matches, purely for
+                # determinism; correctness does not depend on it.
+                ordered = [u for u in urns if u in entity_level_upstream_urns] + [
+                    u for u in urns if u not in entity_level_upstream_urns
+                ]
+                cols_here = urn_to_cols.get(ordered[0], {})
+                canonical = cols_here.get(col.lower())
+                if canonical is None:
+                    trace.append(
+                        f"{source!r}: element found ({ordered[0].split('.')[-1]}) "
+                        f"but column {col!r} absent from its {len(cols_here)} "
+                        f"columns; in_direct_lineage="
+                        f"{ordered[0] in entity_level_upstream_urns}"
+                    )
+                if canonical is not None:
+                    surviving = ordered
+                    if ordered[0] not in entity_level_upstream_urns:
+                        discovered_upstreams.add(ordered[0])
+                        self.reporter.data_model_element_fgl_join_chain_upstream_added += 1
+                    upstream_field = builder.make_schema_field_urn(
+                        ordered[0], canonical
+                    )
+                    pair = (downstream_field, upstream_field)
+                    if pair not in emitted_pairs:
+                        emitted_pairs.add(pair)
+                        fgls.append(
+                            FineGrainedLineageClass(
+                                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                                downstreams=[downstream_field],
+                                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                                upstreams=[upstream_field],
+                                confidenceScore=1.0,
+                            )
+                        )
+                    self.reporter.data_model_element_fgl_join_chain_resolved += 1
+                    logger.debug(
+                        "element %s: join-chain ref %r resolved intra-DM to "
+                        "source=%r column=%r (upstream=%s)",
+                        element.elementId,
+                        ref.raw,
+                        source,
+                        canonical,
+                        surviving[0],
+                    )
+                    return True
+
+            # Cross-DM: the owning element may live in a source data model even
+            # when an earlier segment matched a local sibling.
+            source_dm_url_ids = {
+                sid.partition("/")[0]
+                for sid in element.source_ids
+                if "/" in sid and not sid.startswith("inode-")
+            }
+            for dm_url_id in sorted(source_dm_url_ids):
+                for urn in sorted(
+                    self.dm_element_urn_by_name.get(dm_url_id, {}).get(
+                        source.lower(), []
+                    )
+                ):
+                    if urn == element_dataset_urn:
+                        continue
+                    canonical = (self.dm_element_urn_to_cols.get(urn) or {}).get(
+                        col.lower()
+                    )
+                    if canonical is None:
+                        continue
+                    upstream_field = builder.make_schema_field_urn(urn, canonical)
+                    pair = (downstream_field, upstream_field)
+                    if pair not in emitted_pairs:
+                        emitted_pairs.add(pair)
+                        cross_dm_fgls.append(
+                            FineGrainedLineageClass(
+                                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                                downstreams=[downstream_field],
+                                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                                upstreams=[upstream_field],
+                                confidenceScore=1.0,
+                            )
+                        )
+                    self.reporter.data_model_element_fgl_join_chain_resolved += 1
+                    logger.debug(
+                        "element %s: join-chain ref %r resolved cross-DM to "
+                        "source=%r column=%r (upstream=%s)",
+                        element.elementId,
+                        ref.raw,
+                        source,
+                        canonical,
+                        urn,
+                    )
+                    return True
+        # Sub-count of whichever residual bucket the legacy path settles on --
+        # never an independent drop, so report totals stay additive.
+        self.reporter.data_model_element_fgl_join_chain_unresolved += 1
+        logger.debug(
+            "element %s: no candidate split of ref %r resolved; candidates "
+            "tried=%r verdicts=%r; falling back to the first-slash split",
+            element.elementId,
+            ref.raw,
+            candidate_source_column_splits(ref),
+            trace,
+        )
+        return False
+
+    def _resolve_non_sibling_ref(
+        self,
+        *,
+        ref: "BracketRef",
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        entity_level_upstream_urns: Set[str],
+        downstream_field: str,
+        warehouse_url_id_map: Dict[str, _WarehouseTableRef],
+        emitted_pairs: Set[Tuple[str, str]],
+        fgls: List[FineGrainedLineageClass],
+    ) -> Optional[FineGrainedLineageClass]:
+        """Resolve a ref whose source is not a sibling element in this DM.
+
+        Tries the warehouse-table name first -- it appends to ``fgls`` itself and
+        returns None when it succeeds -- then falls back to cross-DM resolution,
+        whose result the caller appends to ``cross_dm_fgls``.
+        """
+        if self._try_resolve_warehouse_table_name_ref(
+            ref=ref,
+            element=element,
+            downstream_field=downstream_field,
+            warehouse_url_id_map=warehouse_url_id_map,
+            emitted_pairs=emitted_pairs,
+            fgls=fgls,
+        ):
+            return None
+        return self._resolve_cross_dm_fgl(
+            ref=ref,
+            element=element,
+            element_dataset_urn=element_dataset_urn,
+            entity_level_upstream_urns=entity_level_upstream_urns,
+            downstream_field=downstream_field,
+        )
+
+    def _try_resolve_warehouse_table_name_ref(
+        self,
+        *,
+        ref: "BracketRef",
+        element: SigmaDataModelElement,
+        downstream_field: str,
+        warehouse_url_id_map: Dict[str, _WarehouseTableRef],
+        emitted_pairs: Set[Tuple[str, str]],
+        fgls: List[FineGrainedLineageClass],
+    ) -> bool:
+        """Resolve a ref naming a warehouse TABLE the element declares.
+
+        The columnId path handles pass-through columns, whose columnId is
+        ``inode-<urlId>/<NATIVE>``. A calculated or renamed column has an opaque
+        columnId instead, yet its formula still names the warehouse table --
+        e.g. ``[WAREHOUSE_TABLE_A/Col Id]`` on an element
+        declaring that table's inode. Those refs previously resolved to nothing
+        at all: no intra-DM element bears the table's name, and there are no
+        cross-DM sources to search.
+
+        The table match is exact (the element declares that inode and the ref
+        names that table). Only the warehouse column name is inferred, so the
+        edge is emitted at a reduced confidence.
+        """
+        if ref.column is None:
+            return False
+        wanted = ref.source.strip().lower()
+        matches = [
+            (sid[len("inode-") :], warehouse_url_id_map[sid[len("inode-") :]])
+            for sid in element.source_ids
+            if sid.startswith("inode-")
+            and sid[len("inode-") :] in warehouse_url_id_map
+            and warehouse_url_id_map[sid[len("inode-") :]].table.strip().lower()
+            == wanted
+        ]
+        if len(matches) != 1:
+            if matches:
+                logger.debug(
+                    "WAREHOUSE NAME REF ambiguous: element %s ref %r matched %d "
+                    "declared warehouse tables; skipping",
+                    element.elementId,
+                    ref.raw,
+                    len(matches),
+                )
+            return False
+        url_id, wh_ref = matches[0]
+        parent_urn = self._resolve_dm_element_warehouse_upstream(
+            url_id_suffix=url_id, warehouse_map=warehouse_url_id_map
+        )
+        record = self.connection_registry.get(wh_ref.connection_id)
+        if parent_urn is None or record is None:
+            return False
+        conn_override = self.config.connection_to_platform_map.get(wh_ref.connection_id)
+        lowercase = conn_override.convert_urns_to_lowercase if conn_override else True
+        native = _normalize_warehouse_identifier(
+            _warehouse_column_from_display_name(ref.column),
+            record.datahub_platform,
+            lowercase,
+        )
+        upstream_field = builder.make_schema_field_urn(parent_urn, native)
+        pair = (downstream_field, upstream_field)
+        if pair not in emitted_pairs:
+            emitted_pairs.add(pair)
+            fgls.append(
+                FineGrainedLineageClass(
+                    downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                    downstreams=[downstream_field],
+                    upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                    upstreams=[upstream_field],
+                    confidenceScore=_FGL_CONFIDENCE_WAREHOUSE_NAME_DERIVED,
+                )
+            )
+        self.reporter.data_model_element_fgl_warehouse_table_name_resolved += 1
+        logger.debug(
+            "WAREHOUSE NAME REF hit: element %s ref %r -> table %r (url_id=%r), "
+            "column display %r -> native %r, upstream=%s",
+            element.elementId,
+            ref.raw,
+            wh_ref.table,
+            url_id,
+            ref.column,
+            native,
+            parent_urn,
+        )
+        return True
+
+    def _resolve_no_ref_column_fgl(
+        self,
+        *,
+        column: SigmaDataModelColumn,
+        element: SigmaDataModelElement,
+        element_dataset_urn: str,
+        warehouse_fgl: Optional[FineGrainedLineageClass],
+        downstream_field: str,
+        fgls: List[FineGrainedLineageClass],
+        cross_dm_fgls: List[FineGrainedLineageClass],
+        emitted_pairs: Set[Tuple[str, str]],
+    ) -> None:
+        """Handle a column no bracket ref could be resolved from.
+
+        Covers an empty/absent formula (Sigma's shape for a pass-through
+        column), a constant expression, and a formula whose only refs are
+        parameters or bare sibling-column refs. In each case no ref reached a
+        resolver, so the columnId-driven warehouse FGL -- which needs no formula
+        at all -- would otherwise be computed and discarded.
+
+        Callers must gate this on "no ref reached a resolver" rather than on
+        ``warehouse_consumed``: intra-DM resolution never sets that flag, so a
+        "no warehouse append happened" gate would give a column carrying both a
+        sibling ref and an inode columnId a second, wrong upstream.
+        """
+        if warehouse_fgl is None:
+            # Split the same way the ref-bearing path does: an inode-shaped
+            # columnId that failed to resolve is a real warehouse failure (a
+            # /files miss or an unmappable connection) and is worth chasing,
+            # while any other columnId is an intra-DM or Sigma Dataset
+            # passthrough with nothing to resolve against -- expected volume.
+            if _is_warehouse_column_id(column.columnId):
+                self.reporter.data_model_element_fgl_no_ref_warehouse_unresolved += 1
+                logger.debug(
+                    "column %r has a warehouse-shaped columnId %r but no ref "
+                    "resolved and warehouse resolution failed; no CLL emitted",
+                    column.name,
+                    column.columnId,
+                )
+            else:
+                self.reporter.data_model_element_fgl_no_ref_unresolved += 1
+                logger.debug(
+                    "column %r produced no resolvable ref and its columnId %r "
+                    "is not warehouse-shaped; no CLL emitted (formula=%r)",
+                    column.name,
+                    column.columnId,
+                    column.formula,
+                )
+            return
+        assert warehouse_fgl.upstreams
+        # No emitted_pairs check: this runs at most once per column, only when
+        # nothing in the ref loop appended for that column, and downstream_field
+        # is unique per column (columns are deduped by name upstream) -- so the
+        # pair cannot already be present.
+        emitted_pairs.add((downstream_field, warehouse_fgl.upstreams[0]))
+        fgls.append(warehouse_fgl)
+        self.reporter.data_model_element_fgl_warehouse_resolved += 1
+
     def _build_dm_element_fine_grained_lineages(
         self,
         *,
@@ -2300,8 +3167,14 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         entity_level_upstream_urns: Set[str],
         data_model: SigmaDataModel,
         warehouse_url_id_map: Dict[str, _WarehouseTableRef],
+        discovered_upstreams: Set[str],
     ) -> List[FineGrainedLineageClass]:
         """Build FineGrainedLineage entries for intra-DM [ElementName/col] refs.
+
+        ``discovered_upstreams`` is an OUT parameter: elements reached only
+        through a join chain are not in Sigma's direct /lineage list, so the
+        caller must add them to the entity-level upstreams or the emitted
+        schemaField would reference a Dataset absent from ``upstreams``.
 
         element_name_to_eids maps lowercased element name → list of elementIds.
         Self-references are stripped before resolution: when a DM element is named
@@ -2310,6 +3183,16 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         be filtered out to avoid self-referential FGL.  Warehouse-passthrough
         refs are resolved via _try_emit_warehouse_passthrough_fgl; unresolved
         remainder is counted under fgl_warehouse_passthrough_deferred.
+
+        Columns from which no ref reached a resolver -- an empty/absent formula
+        (Sigma's shape for a pass-through column), a constant, or a formula whose
+        only refs are parameters or bare sibling-column refs -- are handled by
+        _resolve_no_ref_column_fgl, which still resolves warehouse lineage from
+        columnId and counts the remainder under fgl_no_ref_warehouse_unresolved
+        (columnId named a warehouse column but did not resolve) or
+        fgl_no_ref_unresolved (nothing to resolve against). Those columns are
+        never name-matched against siblings: with no ref to resolve, matching on
+        column name alone would fabricate an edge to both sides of every join.
 
         When multiple sibling elements share a name and both pass the /lineage filter,
         the lexicographically-first URN is chosen (matching the collision policy
@@ -2333,8 +3216,13 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         # (e.g. If([A/x] = 0, [A/x], [A/x] / 2) → one FGL, not three).
         emitted_pairs: Set[Tuple[str, str]] = set()
         for column in sorted(by_name.values(), key=lambda c: c.name):
-            if not column.formula:
-                continue
+            # Decision record: every column emits exactly one summary line
+            # naming what it resolved to, or nothing. Failure paths each log
+            # their own reason, but successes were silent, so an element whose
+            # columns all resolved produced no output at all and there was no
+            # way to tell WHICH upstream a given column bound to.
+            fgl_mark = len(fgls)
+            cross_mark = len(cross_dm_fgls)
             downstream_field = builder.make_schema_field_urn(
                 element_dataset_urn, column.name
             )
@@ -2349,10 +3237,39 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 warehouse_url_id_map=warehouse_url_id_map,
             )
             warehouse_consumed = False
+            # True once any ref has reached a resolver. Distinct from
+            # `warehouse_consumed`, which only the warehouse branches set:
+            # gating the no-ref fallback on that would append a second, wrong
+            # upstream to a column that already resolved intra-DM.
+            resolution_attempted = False
             for ref in extract_bracket_refs(column.formula):
                 if ref.is_parameter or ref.column is None:
                     # [P_*] parameter refs and bare [col] intra-element refs
                     # are not cross-Dataset lineage; skip.
+                    continue
+                resolution_attempted = True
+
+                # Join-chain refs ([JoinElement/SourceElement/Column], nesting
+                # further for chained joins) name the owning element in the
+                # second-to-last segment, not the first. Try the alternative
+                # readings before the legacy first-slash split, which would
+                # resolve to the wrong sibling and then fail the column check.
+                # Gated on >=3 segments so single-slash refs keep exactly their
+                # current path, counters included.
+                if self._try_resolve_join_chain_ref(
+                    discovered_upstreams=discovered_upstreams,
+                    ref=ref,
+                    element=element,
+                    element_dataset_urn=element_dataset_urn,
+                    element_name_to_eids=element_name_to_eids,
+                    elementId_to_dataset_urn=elementId_to_dataset_urn,
+                    entity_level_upstream_urns=entity_level_upstream_urns,
+                    urn_to_cols=urn_to_cols,
+                    downstream_field=downstream_field,
+                    emitted_pairs=emitted_pairs,
+                    fgls=fgls,
+                    cross_dm_fgls=cross_dm_fgls,
+                ):
                     continue
 
                 candidate_eids = element_name_to_eids.get(ref.source.lower(), [])
@@ -2411,18 +3328,30 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                                 fgls.append(warehouse_fgl)
                                 self.reporter.data_model_element_fgl_warehouse_resolved += 1
                             continue
-                        if (column.columnId or "").startswith("inode-"):
+                        if _is_warehouse_column_id(column.columnId):
+                            # Record the warehouse failure, but do NOT stop
+                            # here. The formula still names a source, and for a
+                            # cross-DM-sourced element that source is a producer
+                            # element in another Data Model -- the warehouse
+                            # inode belongs to the producer, so failing to
+                            # resolve it says nothing about whether the ref
+                            # itself resolves. Falling through to cross-DM
+                            # resolution below is the whole point of having it.
                             self.reporter.data_model_element_fgl_warehouse_passthrough_deferred += 1
-                            continue
 
-                    # Source not in this DM — resolve via cross-DM sources that
-                    # Sigma's /lineage explicitly reported for this element.
-                    cross_dm_fgl = self._resolve_cross_dm_fgl(
+                    # The ref may name a warehouse TABLE this element
+                    # declares, rather than any element. Columns with an opaque
+                    # columnId reach the warehouse only this way. Falls through
+                    # to cross-DM resolution when it does not apply.
+                    cross_dm_fgl = self._resolve_non_sibling_ref(
                         ref=ref,
                         element=element,
                         element_dataset_urn=element_dataset_urn,
                         entity_level_upstream_urns=entity_level_upstream_urns,
                         downstream_field=downstream_field,
+                        warehouse_url_id_map=warehouse_url_id_map,
+                        emitted_pairs=emitted_pairs,
+                        fgls=fgls,
                     )
                     if cross_dm_fgl is not None:
                         assert cross_dm_fgl.upstreams
@@ -2446,7 +3375,36 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                     fgls=fgls,
                     cross_dm_fgls=cross_dm_fgls,
                     emitted_pairs=emitted_pairs,
+                    discovered_upstreams=discovered_upstreams,
                 )
+
+            if not resolution_attempted:
+                self._resolve_no_ref_column_fgl(
+                    column=column,
+                    element=element,
+                    element_dataset_urn=element_dataset_urn,
+                    warehouse_fgl=warehouse_fgl,
+                    downstream_field=downstream_field,
+                    fgls=fgls,
+                    cross_dm_fgls=cross_dm_fgls,
+                    emitted_pairs=emitted_pairs,
+                )
+
+            emitted_now = [(f.upstreams or [""])[0] for f in fgls[fgl_mark:]] + [
+                (f.upstreams or [""])[0] for f in cross_dm_fgls[cross_mark:]
+            ]
+            logger.debug(
+                "COLUMN DM %s element %s %r: columnId=%r formula=%r refs=%r "
+                "ref_resolution_attempted=%s -> emitted=%r",
+                data_model.dataModelId,
+                element.elementId,
+                column.name,
+                column.columnId,
+                column.formula,
+                [r.raw for r in extract_bracket_refs(column.formula)],
+                resolution_attempted,
+                emitted_now,
+            )
         # fgl_emitted is the umbrella count for intra-DM AND warehouse-passthrough
         # FGL (both appended to `fgls`). Cross-DM is tracked separately via
         # fgl_cross_dm_resolved. Warehouse-passthrough is also sub-counted in
@@ -2981,6 +3939,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         return index
 
     @staticmethod
+    def _build_normalized_element_index(
+        wb_element_index: Dict[str, List[Element]],
+    ) -> Dict[str, List[Element]]:
+        """Whitespace/case-insensitive view of the workbook element index.
+
+        Kept as a separate map rather than replacing the exact one: exact
+        matches must keep winning, and a normalized key that collapses two
+        genuinely distinct element names is ambiguous and must not be used.
+        """
+        normalized: Dict[str, List[Element]] = {}
+        for name, elements in wb_element_index.items():
+            normalized.setdefault(_normalize_element_name(name), []).extend(elements)
+        return normalized
+
+    @staticmethod
     def _build_element_warehouse_table_index(
         dataset_inputs: Dict[str, List[str]],
     ) -> Dict[str, List[str]]:
@@ -3049,6 +4022,12 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         entries = self.sigma_api.get_workbook_lineage(workbook.workbookId)
         if entries is None:
             self.reporter.chart_input_fields_warehouse_index_lookup_failed += 1
+            logger.debug(
+                "workbook %s: /lineage returned nothing, so no warehouse-table "
+                "index is available; every chart column in this workbook loses "
+                "warehouse qualification",
+                workbook.workbookId,
+            )
             return _WorkbookWarehouseIndex(by_url_id={}, by_name={})
 
         for entry in entries:
@@ -3235,6 +4214,37 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
 
         candidates = wb_element_index.get(ref.source, [])
         if not candidates:
+            # Exact match failed. Retry on a normalized key -- Sigma element
+            # names routinely differ from the ref only by a trailing
+            # non-breaking space, a leading space, or case. Only accept it when
+            # the normalized key is unambiguous: if it collapses two genuinely
+            # distinct element names, resolving would be a guess.
+            normalized_index = self._build_normalized_element_index(wb_element_index)
+            normalized_hits = normalized_index.get(
+                _normalize_element_name(ref.source), []
+            )
+            distinct_names = {e.name for e in normalized_hits}
+            if normalized_hits and len(distinct_names) == 1:
+                self.reporter.chart_ref_source_normalized_match += 1
+                logger.debug(
+                    "chart element %s: formula ref source %r matched element "
+                    "%r after whitespace/case normalization",
+                    chart_element_id,
+                    ref.source,
+                    next(iter(distinct_names)),
+                )
+                candidates = normalized_hits
+            elif len(distinct_names) > 1:
+                self.reporter.chart_ref_source_normalized_ambiguous += 1
+                logger.debug(
+                    "chart element %s: formula ref source %r normalizes to %d "
+                    "distinct element names %r; refusing to guess",
+                    chart_element_id,
+                    ref.source,
+                    len(distinct_names),
+                    sorted(distinct_names),
+                )
+        if not candidates:
             case_mismatched_names = [
                 name for name in wb_element_index if name.lower() == ref.source.lower()
             ]
@@ -3250,10 +4260,29 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 )
                 return None
             else:
+                # Say WHY the name missed, not just that it did. This is the
+                # single largest unexplained bucket in the report
+                # (chart_input_fields_self_ref_unresolved_refs, ~51k), and the
+                # ref source alone cannot distinguish "the element exists but
+                # the lookup is too strict" from "the element was never indexed
+                # at all" (e.g. dropped for being a pivot-table or input-table).
+                normalized = ref.source.strip().replace("\xa0", " ").casefold()
+                near = [
+                    name
+                    for name in wb_element_index
+                    if name.strip().replace("\xa0", " ").casefold() == normalized
+                ]
+                if near:
+                    self.reporter.chart_ref_source_near_miss += 1
                 logger.debug(
-                    "No exact-case workbook element match for formula ref source %r; "
-                    "falling back to warehouse-table resolution.",
+                    "No exact-case workbook element match for formula ref source "
+                    "%r (normalized=%r); near_matches=%r; index_size=%d "
+                    "index_sample=%r; falling back to warehouse-table resolution.",
                     ref.source,
+                    normalized,
+                    near,
+                    len(wb_element_index),
+                    sorted(wb_element_index)[:15],
                 )
 
         if candidates:
@@ -3614,6 +4643,9 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
         fields: List[InputFieldClass] = []
         for column in element.columns:
             formula = element.column_formulas.get(column)
+            # Bound unconditionally: the diagnostic probes below read it even
+            # for columns with no formula at all.
+            refs: List[BracketRef] = []
             resolved_refs: List[_ResolvedRef] = []
             seen: Set[Tuple[str, str]] = set()
             all_param = False
@@ -3659,6 +4691,21 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                         elif sibling_count == total:
                             all_sibling = True
 
+            multi_segment = self._multi_segment_refs(refs)
+            if multi_segment:
+                # Does the chart path see join-chain refs at all? It shares the
+                # parser with the DM path and returns ref.column with no schema
+                # check, so a mis-split here emits a wrong or dangling
+                # InputField instead of falling back. The counter answers the
+                # scoping question in the report; the log line names the refs.
+                self.reporter.chart_input_fields_multi_segment_ref += 1
+                logger.debug(
+                    "chart element %s column %r: join-chain refs %r (resolved=%s)",
+                    element.elementId,
+                    column,
+                    multi_segment,
+                    bool(resolved_refs),
+                )
             if resolved_refs:
                 self.reporter.chart_input_fields_resolved += 1
                 self.reporter.chart_input_fields_multi_ref_extra += (
@@ -3701,6 +4748,24 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
                 else:
                     schema_field_urn = builder.make_schema_field_urn(chart_urn, column)
                     self.reporter.chart_input_fields_self_ref_fallback += 1
+                    # Split the fallback bucket by cause. It is the largest
+                    # bucket in the report (~81k on one tenant) and today says
+                    # nothing about why: a column with no formula at all is
+                    # expected, whereas a column whose refs failed to resolve is
+                    # the population that could be hiding a parse defect. Only
+                    # the latter is logged, so the probe cannot flood the log.
+                    if refs:
+                        self.reporter.chart_input_fields_self_ref_unresolved_refs += 1
+                        logger.debug(
+                            "chart element %s column %r: self-ref fallback with "
+                            "unresolved refs=%r segment_counts=%r",
+                            element.elementId,
+                            column,
+                            [r.raw for r in refs],
+                            [len(r.parts) for r in refs],
+                        )
+                    else:
+                        self.reporter.chart_input_fields_self_ref_no_formula += 1
                 fields.append(
                     InputFieldClass(
                         schemaFieldUrn=schema_field_urn,

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -63,6 +63,11 @@ class SigmaAPI:
         # report summary readable on large tenants with repeated unknown
         # node types.
         self._unknown_lineage_node_types_warned: Set[str] = set()
+        # Monotonic count of pagination aborts. Callers snapshot it around a
+        # paginated call to learn whether THAT call lost data. Report warnings
+        # cannot answer this: they are grouped by title, so total_elements stops
+        # rising after the first abort of a given kind.
+        self._pagination_aborts: int = 0
         self.session = requests.Session()
 
         # Configure retry strategy for 429/503 with exponential backoff.
@@ -136,7 +141,12 @@ class SigmaAPI:
             )
 
     def _get_api_call(self, url: str) -> requests.Response:
-        """Make an API call with automatic retry on 429/503 and token refresh on 401."""
+        """Make an API call with token refresh on 401.
+
+        The session adapter retries 429/503 for every endpoint; nothing else is
+        retried. A 409 on the Data Model endpoints was tried and reverted --
+        it proved persistent rather than transient on a real tenant.
+        """
         get_response = self.session.get(url)
 
         # Handle token refresh on 401
@@ -682,7 +692,7 @@ class SigmaAPI:
         the partial-data workbook is distinguishable from one with few formulas.
         """
         error_ctx = f"Unable to fetch column formulas for workbook {workbook_id}."
-        warnings_before = self.report.warnings.total_elements
+        aborts_before = self._pagination_aborts
         result: Dict[str, Dict[str, Optional[str]]] = {}
         col_ids: Dict[str, Dict[str, str]] = {}
         for col in self._paginated_raw_entries(
@@ -698,8 +708,17 @@ class SigmaAPI:
                 result.setdefault(elem_id, {})[name] = formula
                 if column_id:
                     col_ids.setdefault(elem_id, {})[name] = column_id
-        if self.report.warnings.total_elements > warnings_before:
+        if self._pagination_aborts > aborts_before:
             self.report.column_formulas_fetch_partial += 1
+            logger.debug(
+                "COLUMNS PARTIAL workbook %s: pagination aborted; %d element(s) "
+                "carry formulas. Every chart column absent from this response "
+                "falls back to a self-referential InputField, so this workbook's "
+                "chart_input_fields_self_ref_* share is not evidence of a "
+                "resolver defect.",
+                workbook_id,
+                len(result),
+            )
         return result, col_ids
 
     def get_page_elements(
@@ -720,8 +739,24 @@ class SigmaAPI:
             for i, element_dict in enumerate(response.json()[Constant.ENTRIES]):
                 # only element of table and visualization type have lineage and sql query supported
                 if element_dict.get("type") not in ["table", "visualization"]:
+                    # Skipped elements never enter the workbook element index, so
+                    # any chart formula referencing one can never resolve and
+                    # falls back to a self-reference. Log the elementId (always
+                    # present) as well as the name, which is frequently absent
+                    # here -- without it a self-ref miss cannot be matched
+                    # against the element that caused it.
+                    el_type = str(element_dict.get("type"))
+                    self.report.workbook_elements_skipped_by_type[el_type] = (
+                        self.report.workbook_elements_skipped_by_type.get(el_type, 0)
+                        + 1
+                    )
                     logger.debug(
-                        f"Skipping lineage and sql query extraction for element {element_dict.get('name')} of type {element_dict.get('type')} of workbook '{workbook.name}'"
+                        "Skipping lineage and sql query extraction for element "
+                        "name=%r elementId=%r of type %r of workbook %r",
+                        element_dict.get("name"),
+                        element_dict.get(Constant.ELEMENTID),
+                        el_type,
+                        workbook.name,
                     )
                     continue
 
@@ -824,6 +859,7 @@ class SigmaAPI:
         try:
             while True:
                 response = self._get_api_call(url)
+                # Swallow expected "no data" statuses before raise_for_status.
                 if first_page and response.status_code in silent_statuses:
                     logger.debug(
                         f"{error_ctx} Swallowed expected status "
@@ -836,6 +872,13 @@ class SigmaAPI:
                 for entry in response_dict.get(Constant.ENTRIES, []):
                     if isinstance(entry, dict):
                         raw_entries.append(entry)
+                logger.debug(
+                    "PAGE %s: +%d entries (running total %d) reported_total=%s",
+                    error_ctx,
+                    len(response_dict.get(Constant.ENTRIES, []) or []),
+                    len(raw_entries),
+                    response_dict.get("total"),
+                )
                 next_page = response_dict.get(Constant.NEXTPAGE)
                 next_token = response_dict.get(Constant.NEXTPAGETOKEN)
                 if next_page:
@@ -847,6 +890,8 @@ class SigmaAPI:
                 else:
                     break
                 if cursor_key in seen_cursors:
+                    self._pagination_aborts += 1
+                    self.report.pagination_aborted += 1
                     self.report.warning(
                         message="Pagination cursor repeated; aborting",
                         context=f"{error_ctx} url={base_url}, cursor={cursor}, "
@@ -870,6 +915,8 @@ class SigmaAPI:
                 if isinstance(e, requests.HTTPError) and e.response is not None
                 else None
             )
+            self._pagination_aborts += 1
+            self.report.pagination_aborted += 1
             self.report.warning(
                 title="Sigma paginated endpoint aborted",
                 message="Pagination aborted; partial results preserved.",
@@ -945,7 +992,8 @@ class SigmaAPI:
 
     def _get_data_model_columns(self, data_model_id: str) -> List[SigmaDataModelColumn]:
         logger.debug(f"Fetching columns for data model '{data_model_id}'.")
-        return self._paginated_entries(
+        aborts_before = self._pagination_aborts
+        columns = self._paginated_entries(
             f"{self.config.api_url}/dataModels/{data_model_id}/columns",
             SigmaDataModelColumn,
             f"Unable to fetch columns for data model '{data_model_id}'.",
@@ -956,6 +1004,18 @@ class SigmaAPI:
             # columns from consumer elements' schemaMetadata.
             dedup_key=lambda column: (column.elementId, column.columnId),
         )
+        if self._pagination_aborts > aborts_before:
+            self.report.data_model_columns_fetch_partial += 1
+            logger.debug(
+                "COLUMNS PARTIAL DM %s: pagination aborted with %d column(s) "
+                "recovered. /columns is the ONLY source of formulas and "
+                "columnIds, so every element in this Data Model loses column "
+                "lineage it would otherwise have -- read this before treating "
+                "the model's empty FGL as a resolver failure.",
+                data_model_id,
+                len(columns),
+            )
+        return columns
 
     def _get_data_model_lineage_entries(
         self, data_model_id: str
@@ -1218,11 +1278,89 @@ class SigmaAPI:
                     )
             # ``type: dataset`` entries (CSV uploads) are terminal.
 
+        self._log_dm_lineage_shape(data_model, lineage_entries)
+
         for element in elements:
             element.columns = columns_by_element.get(element.elementId, [])
             element.source_ids = source_ids_by_element.get(element.elementId, [])
+            logger.debug(
+                "DM ELEMENT ASSEMBLED %s/%s %r: type=%r columns=%d source_ids=%r",
+                data_model.dataModelId,
+                element.elementId,
+                element.name,
+                element.type,
+                len(element.columns),
+                element.source_ids,
+            )
 
         data_model.elements = elements
+
+    @staticmethod
+    def _log_dm_lineage_shape(
+        data_model: SigmaDataModel, lineage_entries: List[Dict[str, Any]]
+    ) -> None:
+        """Classify a Data Model's /lineage payload by entry type.
+
+        Decisive for "why does this element have no warehouse column lineage":
+        the warehouse url_id map is built ONLY from type=table rows, so a Data
+        Model reporting none can never resolve an inode-shaped columnId no
+        matter what its columns say.
+        """
+        entry_types: Dict[str, int] = {}
+        for entry in lineage_entries:
+            key = str(entry.get(Constant.TYPE))
+            entry_types[key] = entry_types.get(key, 0) + 1
+        logger.debug(
+            "DM LINEAGE %s: %d entries by type=%r; table inodes stashed=%d; "
+            "customSQL names=%d; source-DM names=%d",
+            data_model.dataModelId,
+            len(lineage_entries),
+            entry_types,
+            len(data_model.warehouse_inodes_by_inode_id),
+            len(data_model.custom_sql_by_name),
+            len(data_model.source_dm_element_names),
+        )
+
+    def get_file_metadata_by_url_id(self, url_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch ``/v2/files/{urlId}``, or None when Sigma does not know it.
+
+        ``/v2/files/{id}`` accepts either an inodeId (UUID) or a urlId and
+        returns the same document for both -- verified live against a url_id
+        taken from the table listing. That matters because a Data Model
+        element's ``inode-<suffix>`` carries the urlId, not the UUID, so this is
+        the only way to ask about a table the Data Model's own /lineage never
+        described.
+
+        A 404 returns None WITHOUT a warning: on a live tenant every one of the
+        37 unresolved url_ids answered 404, meaning the Data Model references
+        tables that have since been deleted from Sigma. That is tenant hygiene
+        rather than an ingestion problem, so the caller counts it under
+        ``dm_element_warehouse_stale_reference`` instead of alarming operators.
+        """
+        url = f"{self.config.api_url}/files/{quote(url_id, safe='')}"
+        try:
+            response = self._get_api_call(url)
+            if response.status_code == 200:
+                return response.json()
+            if response.status_code != 404:
+                self.report.warning(
+                    title="Sigma /files lookup by urlId returned non-200",
+                    message=(
+                        "Could not resolve a warehouse table referenced by a "
+                        "Data Model element. Column lineage to that table is "
+                        "skipped."
+                    ),
+                    context=f"url_id={url_id}, http_status={response.status_code}",
+                )
+            return None
+        except Exception as e:
+            self.report.warning(
+                title="Sigma /files lookup by urlId failed",
+                message="Exception resolving a warehouse table by urlId.",
+                context=f"url_id={url_id}",
+                exc=e,
+            )
+            return None
 
     def get_file_metadata(self, inode_id: str) -> Optional[Dict[str, Any]]:
         """Fetch /files/{inodeId} and return the raw JSON dict, or None on

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_element_warehouse_fgl_no_formula.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_element_warehouse_fgl_no_formula.json
@@ -1,0 +1,2107 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744382,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "8891fd40-5470-4ff2-a74f-6e61ee44d3fc",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/49HFLTr6xytgrPly3PFsNC",
+            "name": "PETS",
+            "qualifiedName": "PETS",
+            "description": "",
+            "created": {
+                "time": 1713188592664
+            },
+            "lastModified": {
+                "time": 1713188592664
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744382,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744382,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744382,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744383,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744383,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "bd6b86e8-cd4a-4b25-ab65-f258c2a68a8f",
+                "path": "Acryl Data/New Folder"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/5LqGLu14qUnqh3cN6wRJBd",
+            "name": "PET_PROFILES_JOINED_DYNAMIC",
+            "qualifiedName": "PET_PROFILES_JOINED_DYNAMIC",
+            "description": "",
+            "created": {
+                "time": 1713189068019
+            },
+            "lastModified": {
+                "time": 1713189068019
+            },
+            "tags": [
+                "Deprecated"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744385,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Deprecated"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "New Folder"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
+                "latestVersion": "1",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01",
+            "name": "Acme Snowflake DM",
+            "description": "Integration fixture for warehouse-backed DM element",
+            "created": {
+                "time": 1777852800000
+            },
+            "lastModified": {
+                "time": 1777852800000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744386,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744387,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744391,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "81e9980c-3ec8-4bbf-a38e-78f9fe472ce0",
+                "dataModelUrlId": "Acme-Snowflake-DM-fixture01",
+                "elementId": "byF6DckhFw",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/Acme-Snowflake-DM-fixture01?:nodeId=byF6DckhFw",
+            "name": "CUSTOMERS",
+            "qualifiedName": "Acme Snowflake DM/CUSTOMERS",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744391,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744391,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "CUSTOMERS",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "Customer Id",
+                    "nullable": false,
+                    "description": "Customer Id",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "Email",
+                    "nullable": false,
+                    "description": "Email",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744391,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),customer_id)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD),Customer Id)"
+                    ],
+                    "confidenceScore": 1.0
+                },
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,warehouse_coffee_company.public.customers,PROD),email)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD),Email)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,81e9980c-3ec8-4bbf-a38e-78f9fe472ce0.byF6DckhFw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:818113c9d17a14105fa03b045b7b0def",
+                    "urn": "urn:li:container:818113c9d17a14105fa03b045b7b0def"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744392,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "path": "Acryl Data",
+                "latestVersion": "2"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7",
+            "title": "Acryl Workbook",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "dashboards": [
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)"
+                },
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)"
+                }
+            ],
+            "lastModified": {
+                "created": {
+                    "time": 1713188691477,
+                    "actor": "urn:li:corpuser:datahub"
+                },
+                "lastModified": {
+                    "time": 1713189117302,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workbook"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744393,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Warning"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "2"
+            },
+            "title": "Page 1",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,kH0MeihtGs)",
+                "urn:li:chart:(sigma,Ml9C5ezT5W)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744394,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744409,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=kH0MeihtGs&:fullScreen=true",
+            "title": "ADOPTIONS",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744409,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744410,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744410,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744436,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=Ml9C5ezT5W&:fullScreen=true",
+            "title": "Count of Profile Id by Status",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744436,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744437,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744437,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744437,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744438,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "1"
+            },
+            "title": "Page 2",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,tQJu5N1l81)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744438,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744438,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744444,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=tQJu5N1l81&:fullScreen=true",
+            "title": "PETS ADOPTIONS JOIN",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.adoptions,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744444,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744444,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744445,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744445,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "3ee61405-3be2-4000-ba72-60d36757b95b"
+            },
+            "name": "Acryl Data",
+            "created": {
+                "time": 1710232264826
+            },
+            "lastModified": {
+                "time": 1710232264826
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744446,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.adoption.pets,PROD)",
+                    "type": "COPY"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744447,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Deprecated",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Deprecated"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744447,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Warning",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Warning"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788447744447,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_join_chain_ref.json
+++ b/metadata-ingestion/tests/integration/sigma/golden_test_sigma_dm_join_chain_ref.json
@@ -1,0 +1,2971 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261337,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "8891fd40-5470-4ff2-a74f-6e61ee44d3fc",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/49HFLTr6xytgrPly3PFsNC",
+            "name": "PETS",
+            "qualifiedName": "PETS",
+            "description": "",
+            "created": {
+                "time": 1713188592664
+            },
+            "lastModified": {
+                "time": 1713188592664
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261337,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261337,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261337,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261337,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261338,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "datasetId": "bd6b86e8-cd4a-4b25-ab65-f258c2a68a8f",
+                "path": "Acryl Data/New Folder"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/b/5LqGLu14qUnqh3cN6wRJBd",
+            "name": "PET_PROFILES_JOINED_DYNAMIC",
+            "qualifiedName": "PET_PROFILES_JOINED_DYNAMIC",
+            "description": "",
+            "created": {
+                "time": 1713189068019
+            },
+            "lastModified": {
+                "time": 1713189068019
+            },
+            "tags": [
+                "Deprecated"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Dataset"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Deprecated"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,5LqGLu14qUnqh3cN6wRJBd,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "New Folder"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261341,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "dataModelId": "147a4d09-a686-4eea-b183-9b82aa0f7beb",
+                "dataModelUrlId": "CDJLIyOhUoKBSEVI8Wr4n",
+                "latestVersion": "3",
+                "path": "Acryl Data"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/CDJLIyOhUoKBSEVI8Wr4n",
+            "name": "My Data Model-2",
+            "description": "Regression fixture for multi-element DM",
+            "created": {
+                "time": 1715331600000
+            },
+            "lastModified": {
+                "time": 1715508000000
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261342,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "147a4d09-a686-4eea-b183-9b82aa0f7beb",
+                "dataModelUrlId": "CDJLIyOhUoKBSEVI8Wr4n",
+                "elementId": "0ui59vLc38",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/CDJLIyOhUoKBSEVI8Wr4n?:nodeId=0ui59vLc38",
+            "name": "random data model",
+            "qualifiedName": "My Data Model-2/random data model",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "random data model",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "city",
+                    "nullable": false,
+                    "description": "City",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "team1",
+                    "nullable": false,
+                    "description": "Team 1",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261343,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:sigma,49HFLTr6xytgrPly3PFsNC,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+                    "urn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "147a4d09-a686-4eea-b183-9b82aa0f7beb",
+                "dataModelUrlId": "CDJLIyOhUoKBSEVI8Wr4n",
+                "elementId": "xloKCITNsP",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/CDJLIyOhUoKBSEVI8Wr4n?:nodeId=xloKCITNsP",
+            "name": "random data model",
+            "qualifiedName": "My Data Model-2/random data model",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "random data model",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "city",
+                    "nullable": false,
+                    "description": "City",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "team1",
+                    "nullable": false,
+                    "description": "Team 1",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261344,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261345,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261345,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.xloKCITNsP,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+                    "urn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261345,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dataModelId": "147a4d09-a686-4eea-b183-9b82aa0f7beb",
+                "dataModelUrlId": "CDJLIyOhUoKBSEVI8Wr4n",
+                "elementId": "4plNusNz75",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/dm/CDJLIyOhUoKBSEVI8Wr4n?:nodeId=4plNusNz75",
+            "name": "2313213123.test.231",
+            "qualifiedName": "My Data Model-2/2313213123.test.231",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Data Model Element"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "2313213123.test.231",
+            "platform": "urn:li:dataPlatform:sigma",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "Calc (1)",
+                    "nullable": false,
+                    "description": "Calc",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "team1",
+                    "nullable": false,
+                    "description": "Team 1",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "unknown",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261354,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:unknown"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)",
+                    "type": "TRANSFORMED"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD),team1)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD),team1)"
+                    ],
+                    "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261355,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1",
+                    "urn": "urn:li:container:0466d89b8ce5ac9b2cd1deecdffe42c1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261355,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261356,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "path": "Acryl Data",
+                "latestVersion": "2"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7",
+            "title": "Acryl Workbook",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "dashboards": [
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)"
+                },
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)"
+                },
+                {
+                    "sourceUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+                    "destinationUrn": "urn:li:dashboard:(sigma,DmBridgePage)"
+                }
+            ],
+            "lastModified": {
+                "created": {
+                    "time": 1713188691477,
+                    "actor": "urn:li:corpuser:datahub"
+                },
+                "lastModified": {
+                    "time": 1713189117302,
+                    "actor": "urn:li:corpuser:datahub"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261356,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workbook"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261356,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261356,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Warning"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,9bbbe3b0-c0c8-4fac-b6f1-8dfebfe74f8b)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "2"
+            },
+            "title": "Page 1",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,kH0MeihtGs)",
+                "urn:li:chart:(sigma,Ml9C5ezT5W)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261357,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261358,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=kH0MeihtGs&:fullScreen=true",
+            "title": "ADOPTIONS",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261358,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261358,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,kH0MeihtGs)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261358,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261359,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=Ml9C5ezT5W&:fullScreen=true",
+            "title": "Count of Profile Id by Status",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261359,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261359,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,Ml9C5ezT5W)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261359,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,OSnGLBzL1i)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,kH0MeihtGs),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,Ml9C5ezT5W),Count of Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Count of Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261359,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261360,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "1"
+            },
+            "title": "Page 2",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,tQJu5N1l81)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261360,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261360,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261361,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=tQJu5N1l81&:fullScreen=true",
+            "title": "PETS ADOPTIONS JOIN",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261361,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261361,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,tQJu5N1l81)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261362,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DFSieiAcgo)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk)",
+                    "schemaField": {
+                        "fieldPath": "Pk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Profile Id)",
+                    "schemaField": {
+                        "fieldPath": "Profile Id",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status)",
+                    "schemaField": {
+                        "fieldPath": "Status",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At)",
+                    "schemaField": {
+                        "fieldPath": "Created At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At)",
+                    "schemaField": {
+                        "fieldPath": "Updated At",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pk %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Pk (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Pet Fk)",
+                    "schemaField": {
+                        "fieldPath": "Pet Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Human Fk)",
+                    "schemaField": {
+                        "fieldPath": "Human Fk",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Status %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Status (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Created At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Created At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,tQJu5N1l81),Updated At %28ADOPTIONS%29)",
+                    "schemaField": {
+                        "fieldPath": "Updated At (ADOPTIONS)",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261362,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DmBridgePage)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261362,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DmBridgePage)",
+    "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "ElementsCount": "3"
+            },
+            "title": "DM Bridge Page",
+            "description": "",
+            "charts": [
+                "urn:li:chart:(sigma,dmRefElem01)",
+                "urn:li:chart:(sigma,dmRefElem02)",
+                "urn:li:chart:(sigma,dmRefElem03)"
+            ],
+            "datasets": [],
+            "dashboards": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261362,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DmBridgePage)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "levelTable",
+                "type": "table"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=dmRefElem01&:fullScreen=true",
+            "title": "Uses 2313213123",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.4plNusNz75,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem01),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem01)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem02)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261363,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem02)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=dmRefElem02&:fullScreen=true",
+            "title": "Uses random model",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:sigma,147a4d09-a686-4eea-b183-9b82aa0f7beb.0ui59vLc38,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem02)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem02),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem02)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem03)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem03)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "VizualizationType": "bar",
+                "type": "visualization"
+            },
+            "externalUrl": "https://app.sigmacomputing.com/acryldata/workbook/4JRFW1HThPI1K3YTjouXI7?:nodeId=dmRefElem03&:fullScreen=true",
+            "title": "Uses unknown DM element",
+            "description": "",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem03)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem03),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(sigma,dmRefElem03)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+                    "urn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f"
+                },
+                {
+                    "id": "Acryl Workbook"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261364,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(sigma,DmBridgePage)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+        "json": {
+            "fields": [
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem01),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem02),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                },
+                {
+                    "schemaFieldUrn": "urn:li:schemaField:(urn:li:chart:(sigma,dmRefElem03),Col)",
+                    "schemaField": {
+                        "fieldPath": "Col",
+                        "nullable": false,
+                        "type": {
+                            "type": {
+                                "com.linkedin.schema.StringType": {}
+                            }
+                        },
+                        "nativeDataType": "String",
+                        "recursive": false,
+                        "isPartOfKey": false
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261365,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "sigma",
+                "workspaceId": "3ee61405-3be2-4000-ba72-60d36757b95b"
+            },
+            "name": "Acryl Data",
+            "created": {
+                "time": 1710232264826
+            },
+            "lastModified": {
+                "time": 1710232264826
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261365,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261365,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:sigma"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261365,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Sigma Workspace"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261365,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:john.doe@example.com",
+                    "type": "DATAOWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261366,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:46c912b7a3f62c8e3269e559648c4b2f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261366,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Deprecated",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Deprecated"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261366,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Warning",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Warning"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1788534261366,
+        "runId": "sigma-test",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -1312,6 +1312,76 @@ def test_sigma_ingest_data_models(pytestconfig, tmp_path, requests_mock):
 
 
 @pytest.mark.integration
+def _get_join_chain_dm_overrides() -> Dict[str, Dict]:
+    """Rewrite element 3's formula as a join-chain ref.
+
+    Sigma encodes a column reached through a join as
+    ``[JoinElement/SourceElement/Column]``. The base fixture's element 3 uses the
+    plain ``[random data model/team1]`` form; here it references the same column
+    through element 2, whose name ("random data model" as well) also matches the
+    first segment -- reproducing the production trap where the first segment
+    resolves to a real but wrong sibling.
+    """
+    overrides = get_mock_data_model_api()
+    columns_url = (
+        "https://aws-api.sigmacomputing.com/v2/dataModels/"
+        "147a4d09-a686-4eea-b183-9b82aa0f7beb/columns"
+    )
+    entries = overrides[columns_url]["json"]["entries"]
+    for entry in entries:
+        if entry["columnId"] == "col-4pl-team1":
+            entry["formula"] = "[2313213123.test.231/random data model/team1]"
+    return overrides
+
+
+@pytest.mark.integration
+def test_sigma_ingest_data_models_join_chain_ref(pytestconfig, tmp_path, requests_mock):
+    """A join-chain ref resolves to the element that owns the column.
+
+    Regression test: the legacy first-slash split reads the source as the join
+    element and the column as "random data model/team1", which cannot exist, so
+    the edge was dropped as dropped_unknown_upstream_column.
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    override_data = _get_join_chain_dm_overrides()
+    _apply_dm_bridge_workbook_overrides(override_data)
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_dm_join_chain_mces.json"
+    pipeline = Pipeline.create(
+        {
+            "run_id": "sigma-test",
+            "source": {
+                "type": "sigma",
+                "config": {
+                    "client_id": "CLIENTID",
+                    "client_secret": "CLIENTSECRET",
+                    "ingest_data_models": True,
+                },
+            },
+            "sink": {"type": "file", "config": {"filename": output_path}},
+        }
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    assert report.data_model_element_fgl_join_chain_resolved == 1, (
+        "expected the join-chain ref to resolve; got "
+        f"{report.data_model_element_fgl_join_chain_resolved}"
+    )
+    assert report.data_model_element_fgl_join_chain_unresolved == 0
+    assert report.data_model_element_fgl_dropped_unknown_upstream_column == 0
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_dm_join_chain_ref.json",
+    )
+
+
+@pytest.mark.integration
 def test_sigma_ingest_data_models_pattern_filter(pytestconfig, tmp_path, requests_mock):
     """``data_model_pattern`` denies the DM, so no DM entities emitted and
     workbook elements previously bridging to the DM degrade to
@@ -7550,6 +7620,111 @@ def test_sigma_ingest_data_models_dm_element_warehouse_fgl(
         pytestconfig,
         output_path=output_path,
         golden_path=f"{test_resources_dir}/golden_test_sigma_dm_element_warehouse_fgl.json",
+    )
+
+
+def _get_warehouse_dm_no_formula_overrides() -> Dict[str, Dict]:
+    """Same warehouse DM fixture, but with pass-through columns carrying no formula.
+
+    Sigma returns ``formula: ""`` (or omits it) for a plain pass-through column.
+    The warehouse column identity lives in ``columnId``
+    (``inode-<url_id>/<WAREHOUSE_COL>``), which needs no formula to resolve, so
+    these columns must still produce column-level lineage.
+    """
+    overrides = _get_warehouse_dm_overrides()
+    overrides[
+        f"https://aws-api.sigmacomputing.com/v2/dataModels/{_WH_DM_ID}/columns"
+    ] = {
+        "method": "GET",
+        "status_code": 200,
+        "json": {
+            "entries": [
+                {
+                    "columnId": f"inode-{_WH_URL_ID}/CUSTOMER_ID",
+                    "name": "Customer Id",
+                    "elementId": _WH_ELEMENT_ID,
+                    "label": "Customer Id",
+                    "formula": "",
+                    "type": {"type": "text"},
+                },
+                {
+                    "columnId": f"inode-{_WH_URL_ID}/EMAIL",
+                    "name": "Email",
+                    "elementId": _WH_ELEMENT_ID,
+                    "label": "Email",
+                    "type": {"type": "text"},
+                },
+            ],
+            "total": 2,
+            "nextPage": None,
+        },
+    }
+    return overrides
+
+
+@pytest.mark.integration
+def test_sigma_ingest_dm_element_warehouse_fgl_without_formula(
+    pytestconfig, tmp_path, requests_mock
+):
+    """Pass-through columns with no formula still emit warehouse FineGrainedLineage.
+
+    Regression test for column-level lineage being dropped whenever Sigma returned
+    an empty (or absent) formula, even though the element already had table-level
+    lineage to the warehouse table and ``columnId`` identified the column.
+
+    Assertions:
+      - 2 FineGrainedLineage entries on the DM-element child Dataset
+      - warehouse_resolved == 2; neither no_ref_* counter fires
+      - warehouse_passthrough_deferred stays 0 (it remains a formula-bearing signal)
+    """
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/sigma"
+
+    override_data = _get_warehouse_dm_no_formula_overrides()
+    register_mock_api(request_mock=requests_mock, override_data=override_data)
+
+    output_path = f"{tmp_path}/sigma_dm_element_warehouse_fgl_no_formula_mces.json"
+    pipeline = Pipeline.create(
+        _minimal_sigma_pipeline_config(output_path, ingest_data_models=True)
+    )
+    pipeline.run()
+    pipeline.raise_from_status()
+
+    report = _sigma_report(pipeline)
+    assert report.data_model_element_fgl_warehouse_resolved == 2, (
+        f"expected 2 warehouse FGL resolved; got {report.data_model_element_fgl_warehouse_resolved}"
+    )
+    assert report.data_model_element_fgl_no_ref_warehouse_unresolved == 0
+    assert report.data_model_element_fgl_no_ref_unresolved == 0
+    assert report.data_model_element_fgl_warehouse_passthrough_deferred == 0
+
+    expected_warehouse_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:snowflake,"
+        "warehouse_coffee_company.public.customers,PROD)"
+    )
+    element_urn = (
+        f"urn:li:dataset:(urn:li:dataPlatform:sigma,{_WH_DM_ID}.{_WH_ELEMENT_ID},PROD)"
+    )
+    with open(output_path) as f:
+        mces = json.load(f)
+    ul_aspects = [
+        mce
+        for mce in mces
+        if mce.get("entityUrn") == element_urn
+        and mce.get("aspectName") == "upstreamLineage"
+    ]
+    assert len(ul_aspects) == 1
+    fgls = ul_aspects[0]["aspect"]["json"].get("fineGrainedLineages", [])
+    assert len(fgls) == 2, f"expected 2 FGL entries; got {len(fgls)}: {fgls}"
+    for fgl in fgls:
+        for upstream in fgl.get("upstreams", []):
+            assert upstream.startswith(
+                f"urn:li:schemaField:({expected_warehouse_urn},"
+            ), f"unexpected upstream: {upstream}"
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=output_path,
+        golden_path=f"{test_resources_dir}/golden_test_sigma_dm_element_warehouse_fgl_no_formula.json",
     )
 
 

--- a/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
+++ b/metadata-ingestion/tests/unit/sigma/test_chart_input_fields_resolver.py
@@ -75,6 +75,8 @@ def _make_source(config_overrides: Optional[dict] = None) -> SigmaSource:
     source.reporter = MagicMock()
     source.reporter.chart_input_fields_resolved = 0
     source.reporter.chart_input_fields_self_ref_fallback = 0
+    source.reporter.chart_ref_source_normalized_match = 0
+    source.reporter.chart_ref_source_normalized_ambiguous = 0
     source.reporter.chart_input_fields_skipped_parameter = 0
     source.reporter.chart_input_fields_skipped_sibling = 0
     source.reporter.chart_input_fields_case_mismatch = 0
@@ -307,8 +309,16 @@ class TestResolveChartFormulaUpstream:
         )
         assert result is None
 
-    def test_case_mismatched_workbook_element_ref_is_diagnosed(self) -> None:
-        """Workbook element names are exact-case; near misses are counted."""
+    def test_case_mismatched_workbook_element_ref_resolves_to_the_element(
+        self,
+    ) -> None:
+        """A case-only difference resolves to the element, not the warehouse table.
+
+        Sigma element names carry leading/trailing whitespace, non-breaking
+        spaces and case differences from what a formula ref spells, leaving the
+        element sitting in the index unreachable. The normalized lookup finds
+        it; note the element still wins over the same-named warehouse table.
+        """
         upstream_elem = _make_element("sourceElem", "T Source")
         wh_urn = (
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,DB.SCHEMA.T SOURCE,PROD)"
@@ -325,8 +335,30 @@ class TestResolveChartFormulaUpstream:
             elementId_to_chart_urn={"sourceElem": "urn:source"},
         )
 
+        assert result == ("urn:source", "col")
+        assert self.src.reporter.chart_ref_source_normalized_match == 1
+        assert self.src.reporter.chart_input_fields_case_mismatch == 0
+
+    def test_normalized_ref_source_ambiguity_is_not_guessed(self) -> None:
+        """Two distinct element names collapsing to one normalized key stay unresolved."""
+        ref = _make_ref("shared", "col")
+
+        result = self.src._resolve_chart_formula_upstream(
+            ref,
+            chart_element_id="downstreamElem",
+            chart_upstream_element_ids={"a", "b"},
+            dm_upstream_urn_by_element_name={},
+            wb_element_index={
+                "Shared": [_make_element("a", "Shared")],
+                "Shared\xa0": [_make_element("b", "Shared\xa0")],
+            },
+            element_warehouse_table_index={},
+            elementId_to_chart_urn={"a": "urn:a", "b": "urn:b"},
+        )
+
         assert result is None
-        assert self.src.reporter.chart_input_fields_case_mismatch == 1
+        assert self.src.reporter.chart_ref_source_normalized_ambiguous == 1
+        assert self.src.reporter.chart_ref_source_normalized_match == 0
 
     def test_exact_workbook_name_without_lineage_match_falls_through_to_warehouse(
         self,

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_fgl.py
@@ -16,6 +16,7 @@ def _source() -> SigmaSource:
     source.reporter = SigmaSourceReport()
     source.dm_element_urn_by_name = {}
     source.dm_element_urn_to_cols = {}
+    source._upstream_schema_unavailable_warned = set()
     return source
 
 
@@ -87,6 +88,7 @@ def _build(
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_data_model(all_elements),
         warehouse_url_id_map={},
+        discovered_upstreams=set(),
     )
 
 
@@ -146,6 +148,10 @@ def test_bare_sibling_ref_is_skipped() -> None:
 
     assert _build(source, element) == []
     assert source.reporter.data_model_element_fgl_emitted == 0
+    # The ref is parsed but never reaches a resolver, so the column falls
+    # through to the no-resolvable-ref path (non-inode columnId).
+    assert source.reporter.data_model_element_fgl_no_ref_unresolved == 1
+    assert source.reporter.data_model_element_fgl_no_ref_warehouse_unresolved == 0
 
 
 def test_parameter_ref_is_skipped() -> None:
@@ -154,6 +160,8 @@ def test_parameter_ref_is_skipped() -> None:
 
     assert _build(source, element) == []
     assert source.reporter.data_model_element_fgl_emitted == 0
+    assert source.reporter.data_model_element_fgl_no_ref_unresolved == 1
+    assert source.reporter.data_model_element_fgl_no_ref_warehouse_unresolved == 0
 
 
 def test_cross_dm_ref_is_counted_unresolved() -> None:
@@ -367,6 +375,9 @@ def test_unknown_upstream_column_is_dropped() -> None:
 
     assert lineages == []
     assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
+    # The upstream HAS a schema; the column name simply is not in it. Must not
+    # also land in the fetch-failure bucket.
+    assert source.reporter.data_model_element_fgl_upstream_schema_unavailable == 0
 
 
 def test_duplicate_element_names_different_schemas_validates_correct_element() -> None:
@@ -699,6 +710,10 @@ def test_cross_dm_unknown_upstream_column_is_dropped() -> None:
     )
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+    # Producer schema is non-empty, so the fetch-failure bucket must stay clear.
+    assert (
+        source.reporter.data_model_element_fgl_cross_dm_upstream_schema_unavailable == 0
+    )
 
 
 def test_self_named_cross_dm_element_resolves_fgl() -> None:
@@ -843,7 +858,9 @@ def test_orphan_branch_not_rescued_without_cross_dm_sources() -> None:
         [_column("c1", "x", "[Shared/x]")],
         # source_ids=[] — no cross-DM refs
     )
-    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+    # Sibling does NOT own "x": schema-based orphan recovery must not fire,
+    # so the cross-DM guard under test is still the behaviour exercised.
+    sibling = _upstream_element("sibling-eid", "Shared", ["other"])
 
     lineages = _build(
         source,
@@ -885,7 +902,9 @@ def test_intra_dm_only_source_ids_not_treated_as_cross_dm() -> None:
         # Intra-DM source IDs only — no "/" separator, not cross-DM shaped.
         source_ids=["some-intra-dm-eid"],
     )
-    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+    # Sibling does NOT own "x": schema-based orphan recovery must not fire,
+    # so the cross-DM guard under test is still the behaviour exercised.
+    sibling = _upstream_element("sibling-eid", "Shared", ["other"])
 
     lineages = _build(
         source,
@@ -956,7 +975,9 @@ def test_inode_source_ids_excluded_from_cross_dm_guard() -> None:
         # inode-shaped entry has '/' but is NOT a cross-DM source ID.
         source_ids=["inode-abc123/some-suffix"],
     )
-    sibling = _upstream_element("sibling-eid", "Shared", ["x"])
+    # Sibling does NOT own "x": schema-based orphan recovery must not fire,
+    # so the cross-DM guard under test is still the behaviour exercised.
+    sibling = _upstream_element("sibling-eid", "Shared", ["other"])
 
     lineages = _build(
         source,
@@ -977,3 +998,481 @@ def test_inode_source_ids_excluded_from_cross_dm_guard() -> None:
     assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
     assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
     assert source.reporter.data_model_element_fgl_cross_dm_resolved == 0
+
+
+def test_empty_upstream_schema_is_counted_separately() -> None:
+    """An upstream element with no columns is an API failure, not a name mismatch.
+
+    One failed /columns fetch empties every element in a data model, so folding
+    this into dropped_unknown_upstream_column hides the real cause.
+    """
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-x", "x", "[A/x]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", [])],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_upstream_schema_unavailable == 1
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 0
+
+
+def test_cross_dm_empty_upstream_schema_is_counted_separately() -> None:
+    """Cross-DM producer present in the bridge map but with an empty schema."""
+    source = _source()
+    dm_url_id = "other-dm"
+    upstream_urn = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "city", "[other_dm_element/city]")],
+        source_ids=[f"{dm_url_id}/suffix"],
+    )
+    source.dm_element_urn_by_name = {dm_url_id: {"other_dm_element": [upstream_urn]}}
+    source.dm_element_urn_to_cols = {upstream_urn: {}}
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+    )
+
+    assert lineages == []
+    assert (
+        source.reporter.data_model_element_fgl_cross_dm_upstream_schema_unavailable == 1
+    )
+    # Intra-DM counter must not absorb a cross-DM producer.
+    assert source.reporter.data_model_element_fgl_upstream_schema_unavailable == 0
+    assert (
+        source.reporter.data_model_element_fgl_cross_dm_dropped_unknown_upstream_column
+        == 0
+    )
+    # A producer missing from the bridge map entirely stays on `deferred`.
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 0
+
+
+def test_cross_dm_absent_producer_stays_deferred() -> None:
+    """Producer not in dm_element_urn_to_cols at all keeps the deferred counter."""
+    source = _source()
+    dm_url_id = "other-dm"
+    upstream_urn = _urn("other-dm-element")
+    downstream_urn = _urn("elem-downstream")
+    element = _element(
+        "elem-downstream",
+        "Downstream",
+        [_column("c1", "city", "[other_dm_element/city]")],
+        source_ids=[f"{dm_url_id}/suffix"],
+    )
+    source.dm_element_urn_by_name = {dm_url_id: {"other_dm_element": [upstream_urn]}}
+    source.dm_element_urn_to_cols = {}
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"downstream": ["elem-downstream"]},
+        elementId_to_dataset_urn={"elem-downstream": downstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_cross_dm_deferred == 1
+    assert (
+        source.reporter.data_model_element_fgl_cross_dm_upstream_schema_unavailable == 0
+    )
+
+
+def test_formula_less_column_does_not_guess_intra_dm_upstream() -> None:
+    """A formula-less column must never be name-matched against siblings.
+
+    There is no bracket ref to resolve, so matching on column name alone would
+    fabricate an edge to every same-named sibling -- both sides of a join.
+    """
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element("b", "B", [_column("b-account-id", "Col Id", "")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"a": ["a"], "b": ["b"]},
+        elementId_to_dataset_urn={"a": upstream_urn, "b": downstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["Col Id"])],
+    )
+
+    assert lineages == []
+    # Non-inode columnId: nothing to resolve against, expected volume.
+    assert source.reporter.data_model_element_fgl_no_ref_unresolved == 1
+    assert source.reporter.data_model_element_fgl_no_ref_warehouse_unresolved == 0
+    assert source.reporter.data_model_element_fgl_emitted == 0
+
+
+def test_empty_upstream_schema_warns_once_per_upstream() -> None:
+    """One empty upstream must not emit a warning per referencing column.
+
+    A partial /columns abort leaves many refs pointing at the same empty
+    element; the dedupe set is the only thing keeping that out of the report.
+    """
+    source = _source()
+    upstream_urn = _urn("a")
+    downstream_urn = _urn("b")
+    element = _element(
+        "b",
+        "B",
+        [
+            _column("b-x", "x", "[A/x]"),
+            _column("b-y", "y", "[A/y]"),
+        ],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", [])],
+    )
+
+    assert lineages == []
+    # Both columns counted, one warning.
+    assert source.reporter.data_model_element_fgl_upstream_schema_unavailable == 2
+    assert len(source.reporter.warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Join-chain refs: [JoinElement/SourceElement/Column]
+#
+# Sigma encodes a column reached through a join this way, so the element that
+# owns the column is the second-to-last segment. The legacy first-slash split
+# picks the join element instead, which is a real sibling -- it resolves, then
+# fails the column lookup, and the edge is silently dropped.
+# ---------------------------------------------------------------------------
+
+
+def test_join_chain_resolves_to_owning_element() -> None:
+    """The reported shape: [GRP_A/GRP_A DIM_B/Col Id].
+
+    An element named "GRP_A" also exists, so the first segment resolves to the
+    wrong sibling. The edge must land on the owning element instead.
+    """
+    source = _source()
+    join_urn = _urn("join")
+    owner_urn = _urn("owner")
+    downstream_urn = _urn("consumer")
+    element = _element(
+        "consumer",
+        "Consumer",
+        [_column("c-col-id", "Col Id", "[GRP_A/GRP_A DIM_B/Col Id]")],
+    )
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"grp_a": ["join"], "grp_a dim_b": ["owner"]},
+        elementId_to_dataset_urn={"join": join_urn, "owner": owner_urn},
+        entity_level_upstream_urns={join_urn, owner_urn},
+        upstream_elements=[
+            # The join element deliberately has a column that is NOT the target,
+            # mirroring production: the first segment matches but the qualified
+            # column name cannot exist there.
+            _upstream_element("join", "GRP_A", ["Some Other Column"]),
+            _upstream_element("owner", "GRP_A DIM_B", ["Col Id"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(owner_urn, "Col Id")]
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 1
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 0
+    assert source.reporter.data_model_element_fgl_join_chain_unresolved == 0
+
+
+def test_nested_join_chain_resolves_to_deepest_element() -> None:
+    source = _source()
+    owner_urn = _urn("e3")
+    downstream_urn = _urn("consumer")
+    element = _element("consumer", "Consumer", [_column("c-x", "x", "[E1/E2/E3/col]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"e3": ["e3"]},
+        elementId_to_dataset_urn={"e3": owner_urn},
+        entity_level_upstream_urns={owner_urn},
+        upstream_elements=[_upstream_element("e3", "E3", ["col"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(owner_urn, "col")]
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 1
+
+
+def test_join_chain_on_self_named_consumer_still_resolves() -> None:
+    """Consumer named E1 with formula [E1/E2/col].
+
+    The legacy path treats the first segment as a self-reference and diverts to
+    warehouse-passthrough, never looking at E2. Self-strip must be applied per
+    candidate so the owning element is still reached.
+    """
+    source = _source()
+    owner_urn = _urn("e2")
+    downstream_urn = _urn("e1")
+    element = _element("e1", "E1", [_column("e1-x", "x", "[E1/E2/col]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"e1": ["e1"], "e2": ["e2"]},
+        elementId_to_dataset_urn={"e1": downstream_urn, "e2": owner_urn},
+        entity_level_upstream_urns={owner_urn},
+        upstream_elements=[_upstream_element("e2", "E2", ["col"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(owner_urn, "col")]
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 1
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+
+
+def test_join_chain_owning_element_in_another_dm_resolves_cross_dm() -> None:
+    """E1 is a local sibling but E2 lives in a source data model.
+
+    Committing to the first segment would keep the ref on the intra-DM path and
+    drop it; each candidate must be tried intra-DM then cross-DM.
+    """
+    source = _source()
+    dm_url_id = "other-dm"
+    e1_urn = _urn("e1")
+    e2_urn = _urn("other-dm-e2")
+    downstream_urn = _urn("consumer")
+    element = _element(
+        "consumer",
+        "Consumer",
+        [_column("c-x", "x", "[E1/E2/col]")],
+        source_ids=[f"{dm_url_id}/suffix"],
+    )
+    source.dm_element_urn_by_name = {dm_url_id: {"e2": [e2_urn]}}
+    source.dm_element_urn_to_cols = {e2_urn: {"col": "col"}}
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"e1": ["e1"]},
+        elementId_to_dataset_urn={"e1": e1_urn},
+        entity_level_upstream_urns={e1_urn},
+        upstream_elements=[_upstream_element("e1", "E1", ["unrelated"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(e2_urn, "col")]
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 1
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 0
+
+
+def test_join_chain_prefers_owning_element_over_qualified_column() -> None:
+    """Collision: E2 has `col` AND E1 has a column literally named `E2/col`.
+
+    Join-chain reading wins -- 1608 real join chains in the observed tenant
+    versus no confirmed slash-containing column name.
+    """
+    source = _source()
+    e1_urn = _urn("e1")
+    e2_urn = _urn("e2")
+    downstream_urn = _urn("consumer")
+    element = _element("consumer", "Consumer", [_column("c-x", "x", "[E1/E2/col]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"e1": ["e1"], "e2": ["e2"]},
+        elementId_to_dataset_urn={"e1": e1_urn, "e2": e2_urn},
+        entity_level_upstream_urns={e1_urn, e2_urn},
+        upstream_elements=[
+            _upstream_element("e1", "E1", ["E2/col"]),
+            _upstream_element("e2", "E2", ["col"]),
+        ],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(e2_urn, "col")]
+
+
+def test_slash_containing_element_name_still_resolves() -> None:
+    """No candidate matches the join-chain reading, so the prefix wins."""
+    source = _source()
+    owner_urn = _urn("weird")
+    downstream_urn = _urn("consumer")
+    element = _element("consumer", "Consumer", [_column("c-x", "x", "[a/b/c]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"a/b": ["weird"]},
+        elementId_to_dataset_urn={"weird": owner_urn},
+        entity_level_upstream_urns={owner_urn},
+        upstream_elements=[_upstream_element("weird", "a/b", ["c"])],
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(owner_urn, "c")]
+
+
+def test_join_chain_with_no_valid_candidate_is_sub_counted() -> None:
+    """Nothing validates: falls back to the legacy path, counted once there."""
+    source = _source()
+    join_urn = _urn("join")
+    downstream_urn = _urn("consumer")
+    element = _element("consumer", "Consumer", [_column("c-x", "x", "[GRP_A/E2/col]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"grp_a": ["join"]},
+        elementId_to_dataset_urn={"join": join_urn},
+        entity_level_upstream_urns={join_urn},
+        upstream_elements=[_upstream_element("join", "GRP_A", ["unrelated"])],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_join_chain_unresolved == 1
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 0
+    # Residual bucket is owned by the legacy path and counted exactly once.
+    assert source.reporter.data_model_element_fgl_dropped_unknown_upstream_column == 1
+
+
+def test_single_slash_ref_does_not_touch_join_chain_counters() -> None:
+    source = _source()
+    upstream_urn = _urn("a")
+    element = _element("b", "B", [_column("b-x", "x", "[A/x]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_name_to_eids={"a": ["a"]},
+        elementId_to_dataset_urn={"a": upstream_urn},
+        entity_level_upstream_urns={upstream_urn},
+        upstream_elements=[_upstream_element("a", "A", ["x"])],
+    )
+
+    assert len(lineages) == 1
+    assert source.reporter.data_model_element_fgl_join_chain_resolved == 0
+    assert source.reporter.data_model_element_fgl_join_chain_unresolved == 0
+
+
+def test_inode_column_id_still_tries_cross_dm_when_warehouse_fails() -> None:
+    """A failed warehouse lookup must not abort cross-DM resolution.
+
+    On a cross-DM-sourced element the warehouse inode belongs to the PRODUCER,
+    so failing to resolve it locally says nothing about whether the formula's
+    ref resolves. Short-circuiting there lost every such edge: the observed
+    element carried columnId='inode-<urlId>/<COL>' with formula
+    '[Producer/Column]' and emitted nothing at all.
+    """
+    source = _source()
+    dm_url_id = "producer-dm"
+    producer_urn = _urn("producer-el")
+    downstream_urn = _urn("consumer")
+    element = _element(
+        "consumer",
+        "Consumer",
+        # inode-shaped columnId, but no warehouse map is supplied so the
+        # warehouse path must fail.
+        [_column("inode-abc/COL_ID", "Col Id", "[Producer/Col Id]")],
+        source_ids=[f"{dm_url_id}/suffix"],
+    )
+    source.dm_element_urn_by_name = {dm_url_id: {"producer": [producer_urn]}}
+    source.dm_element_urn_to_cols = {producer_urn: {"col id": "Col Id"}}
+
+    lineages = _build(
+        source,
+        element,
+        element_dataset_urn=downstream_urn,
+        entity_level_upstream_urns={producer_urn},
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [
+        builder.make_schema_field_urn(producer_urn, "Col Id")
+    ]
+    assert source.reporter.data_model_element_fgl_cross_dm_resolved == 1
+    # The warehouse attempt still failed and is still reported.
+    assert source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 1
+
+
+def test_orphan_ref_recovered_when_sibling_owns_the_column() -> None:
+    """/lineage omitting an intra-DM sibling is a reporting gap, not evidence.
+
+    Where the named sibling demonstrably owns the referenced column, the ref is
+    trustworthy and the edge is emitted, with the sibling promoted to an
+    entity-level upstream. Measured at 162 of 167 orphan drops on a real tenant.
+    """
+    source = _source()
+    sibling_urn = _urn("sibling-eid")
+    downstream_urn = _urn("consumer")
+    discovered: set = set()
+    element = _element("consumer", "Consumer", [_column("c1", "x", "[Shared/x]")])
+
+    lineages = source._build_dm_element_fine_grained_lineages(
+        element=element,
+        element_dataset_urn=downstream_urn,
+        element_name_to_eids={"shared": ["sibling-eid"]},
+        elementId_to_dataset_urn={"sibling-eid": sibling_urn},
+        # Sigma did not list the sibling as an upstream.
+        entity_level_upstream_urns=set(),
+        data_model=_data_model(
+            [element, _upstream_element("sibling-eid", "Shared", ["x"])]
+        ),
+        warehouse_url_id_map={},
+        discovered_upstreams=discovered,
+    )
+
+    assert len(lineages) == 1
+    assert lineages[0].upstreams == [builder.make_schema_field_urn(sibling_urn, "x")]
+    assert source.reporter.data_model_element_fgl_orphan_recovered == 1
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 0
+    assert discovered == {sibling_urn}
+
+
+def test_orphan_ref_still_dropped_when_sibling_lacks_the_column() -> None:
+    """Recovery is earned by the schema, not assumed from the name match."""
+    source = _source()
+    sibling_urn = _urn("sibling-eid")
+    element = _element("consumer", "Consumer", [_column("c1", "x", "[Shared/x]")])
+
+    lineages = _build(
+        source,
+        element,
+        element_name_to_eids={"shared": ["sibling-eid"]},
+        elementId_to_dataset_urn={"sibling-eid": sibling_urn},
+        entity_level_upstream_urns=set(),
+        upstream_elements=[_upstream_element("sibling-eid", "Shared", ["other"])],
+    )
+
+    assert lineages == []
+    assert source.reporter.data_model_element_fgl_dropped_orphan_upstream == 1
+    assert source.reporter.data_model_element_fgl_orphan_recovered == 0

--- a/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
+++ b/metadata-ingestion/tests/unit/sigma/test_dm_element_warehouse_fgl.py
@@ -18,7 +18,7 @@ Counters verified:
 
 import datetime as dt
 from typing import Dict, List, Optional, Set
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from datahub.emitter import mce_builder as builder
 from datahub.ingestion.api.common import PipelineContext
@@ -179,6 +179,7 @@ def _build_fgls(
         entity_level_upstream_urns=entity_level_upstream_urns or set(),
         data_model=_dm(all_elements),
         warehouse_url_id_map=warehouse_map or {},
+        discovered_upstreams=set(),
     )
 
 
@@ -558,3 +559,289 @@ class TestBuildFglWarehouseIntegration:
         assert fgls[0].upstreams is not None
         expected_upstream = builder.make_schema_field_urn(_SF_DATASET_URN, "email")
         assert fgls[0].upstreams[0] == expected_upstream
+
+
+class TestNoBracketRefWarehouseFgl:
+    """Columns whose formula yields no bracket refs.
+
+    Sigma returns ``formula: ""`` for a plain pass-through column, and a constant
+    expression parses to zero refs. Both cases must still resolve warehouse
+    lineage from ``columnId``, which needs no formula.
+    """
+
+    def test_empty_formula_emits_warehouse_fgl(self):
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "")
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+        assert source.reporter.data_model_element_fgl_no_ref_warehouse_unresolved == 0
+
+    def test_none_formula_emits_warehouse_fgl(self):
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", None)
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_constant_formula_emits_warehouse_fgl(self):
+        """A non-empty formula with no bracket refs takes the same path."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", '"n/a"')
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_no_formula_and_failed_warehouse_resolve_is_counted(self):
+        """Empty formula + inode columnId but no warehouse map: counted, not silent.
+
+        The counter must not leak into _passthrough_deferred, which stays a
+        formula-bearing failure signal so its baseline remains comparable.
+        """
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "")
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map={})
+
+        assert fgls == []
+        # inode columnId that failed to resolve is actionable, so it must NOT
+        # land in the expected-volume bucket.
+        assert source.reporter.data_model_element_fgl_no_ref_warehouse_unresolved == 1
+        assert source.reporter.data_model_element_fgl_no_ref_unresolved == 0
+        assert (
+            source.reporter.data_model_element_fgl_warehouse_passthrough_deferred == 0
+        )
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
+
+    def test_intra_dm_ref_does_not_also_emit_warehouse_edge(self):
+        """The post-loop append is gated on zero refs, not on warehouse_consumed.
+
+        One column carries BOTH an intra-DM formula ref and an inode columnId that
+        would resolve. Only the intra-DM edge is correct: gating on
+        "no warehouse append happened" would add a second, wrong upstream, because
+        intra-DM resolution never sets warehouse_consumed.
+        """
+        source = _make_source()
+        upstream_id = "el-upstream"
+        upstream_urn = "urn:li:dataset:(urn:li:dataPlatform:sigma,el-upstream,PROD)"
+        upstream_elem = _element(upstream_id, "UPSTREAM", [_column("up-x", "x", None)])
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[UPSTREAM/x]")
+        elem = _element(
+            "el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE, upstream_id]
+        )
+
+        fgls = _build_fgls(
+            source,
+            elem,
+            warehouse_map=_SF_WAREHOUSE_MAP,
+            element_name_to_eids={
+                "customers": [elem.elementId],
+                "upstream": [upstream_id],
+            },
+            elementId_to_dataset_urn={upstream_id: upstream_urn},
+            entity_level_upstream_urns={upstream_urn, _SF_DATASET_URN},
+            upstream_elements=[upstream_elem],
+        )
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [builder.make_schema_field_urn(upstream_urn, "x")]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 0
+
+    def test_parameter_only_formula_still_resolves_warehouse(self):
+        """Refs that all skip resolution are the same blind spot as no refs.
+
+        `[P_Region]` parses to a ref, so a `not refs` gate would leave the
+        columnId-driven warehouse edge computed and discarded with no counter.
+        """
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "[P_Region]")
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_bare_sibling_ref_formula_still_resolves_warehouse(self):
+        """A bare `[col]` intra-element ref skips resolution the same way."""
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "Upper([Other Column])")
+        elem = _element("el-customers", "CUSTOMERS", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_resolved == 1
+
+    def test_transitively_sourced_element_accepts_warehouse_column(self):
+        """Element declaring only cross-DM sources still resolves its columns.
+
+        The warehouse table is declared by the producer element in the other
+        Data Model, so requiring the inode in THIS element's source_ids rejects
+        every column -- the same shape of mistake as gating join-chain
+        resolution on Sigma's direct /lineage list.
+        """
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "")
+        elem = _element(
+            "el-consumer",
+            "Consumer",
+            [col],
+            ["producer-dm/suffix"],  # cross-DM only: no inode declared
+        )
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "email")
+        ]
+        assert source.reporter.dm_element_warehouse_transitive_inode_accepted == 1
+
+    def test_element_declaring_a_different_inode_is_still_rejected(self):
+        """Genuine payload drift must stay rejected.
+
+        The element declares its own inode and the column names a different
+        one -- that is not transitive sourcing, so the guard still applies.
+        """
+        source = _make_source()
+        col = _column(f"inode-{_SF_URL_ID}/EMAIL", "Email", "")
+        elem = _element("el-x", "X", [col], [_RS_INODE_SOURCE])
+
+        fgls = _build_fgls(
+            source, elem, warehouse_map={**_SF_WAREHOUSE_MAP, **_RS_WAREHOUSE_MAP}
+        )
+
+        assert fgls == []
+        assert source.reporter.dm_element_warehouse_transitive_inode_accepted == 0
+        assert (
+            source.reporter.warehouse_passthrough_miss_reasons.get(
+                "url_id_not_in_element_source_ids"
+            )
+            == 1
+        )
+
+    def test_ref_naming_warehouse_table_resolves_with_opaque_column_id(self):
+        """The observed 'Dim mapping' shape: opaque columnId, table-named ref.
+
+        Every column carries an opaque columnId and a formula
+        '[WAREHOUSE_TABLE_A/Col Id]'. The columnId path
+        cannot help (nothing to parse) and no element bears the table's name, so
+        these refs previously resolved to nothing at all.
+        """
+        source = _make_source()
+        col = _column("opaque-col-1", "Customer Id", "[CUSTOMERS/Customer Id]")
+        elem = _element("el-mapping", "Dim mapping", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert len(fgls) == 1
+        # Display name "Customer Id" -> native CUSTOMER_ID -> snowflake lowercase.
+        assert fgls[0].upstreams == [
+            builder.make_schema_field_urn(_SF_DATASET_URN, "customer_id")
+        ]
+        assert source.reporter.data_model_element_fgl_warehouse_table_name_resolved == 1
+        # Reduced confidence: the table match is exact, the column name inferred.
+        assert fgls[0].confidenceScore == 0.5
+
+    def test_ref_naming_undeclared_warehouse_table_is_not_resolved(self):
+        """Only tables the element actually declares may be matched."""
+        source = _make_source()
+        col = _column("opaque", "Email", "[SOME_OTHER_TABLE/Email]")
+        elem = _element("el-x", "X", [col], [_SF_INODE_SOURCE])
+
+        fgls = _build_fgls(source, elem, warehouse_map=_SF_WAREHOUSE_MAP)
+
+        assert fgls == []
+        assert source.reporter.data_model_element_fgl_warehouse_table_name_resolved == 0
+
+
+class TestDirectWarehouseUrlIdLookup:
+    """Recovery when a Data Model's /lineage omits a table its elements use.
+
+    Sigma reports fewer type=table rows than its own elements reference, so the
+    url_id is asked for directly via /v2/files/{urlId}. A 404 there is decisive
+    rather than inconclusive: the referenced table has been deleted from Sigma,
+    and no lookup can supply coordinates for an object that no longer exists.
+    """
+
+    def _source_with_file(self, entry):
+        source = _make_source()
+        source.sigma_api = MagicMock()
+        source.sigma_api.get_file_metadata_by_url_id.return_value = entry
+        return source
+
+    def test_url_id_absent_from_dm_map_is_recovered(self):
+        source = self._source_with_file(
+            {
+                "urlId": "missingUrlId",
+                "id": "inode-uuid",
+                "name": "CUSTOMERS",
+                "path": "Connection Root/PROD_DB/PUBLIC",
+            }
+        )
+        # The DM map holds a different table, from a single known connection.
+        urn = source._resolve_dm_element_warehouse_upstream(
+            url_id_suffix="missingUrlId", warehouse_map=_SF_WAREHOUSE_MAP
+        )
+        assert urn == _SF_DATASET_URN
+        assert source.reporter.dm_element_warehouse_recovered_from_global_index == 1
+
+    def test_unknown_url_id_is_reported_as_a_stale_reference(self):
+        source = self._source_with_file(None)
+        assert (
+            source._resolve_dm_element_warehouse_upstream(
+                url_id_suffix="neverListed", warehouse_map=_SF_WAREHOUSE_MAP
+            )
+            is None
+        )
+        assert source.reporter.dm_element_warehouse_stale_reference == 1
+        assert source.reporter.dm_element_warehouse_recovered_from_global_index == 0
+
+    def test_repeated_url_id_costs_one_call(self):
+        source = self._source_with_file(None)
+        for _ in range(3):
+            source._resolve_dm_element_warehouse_upstream(
+                url_id_suffix="sameOne", warehouse_map=_SF_WAREHOUSE_MAP
+            )
+        assert source.sigma_api.get_file_metadata_by_url_id.call_count == 1
+
+    def test_ambiguous_connection_refuses_to_guess(self):
+        """Two connections in the DM map: attributing the table would be a guess."""
+        source = self._source_with_file(
+            {"urlId": "u", "id": "i", "name": "T", "path": "Connection Root/D/S"}
+        )
+        mixed = {**_SF_WAREHOUSE_MAP, **_RS_WAREHOUSE_MAP}
+        assert (
+            source._resolve_dm_element_warehouse_upstream(
+                url_id_suffix="u", warehouse_map=mixed
+            )
+            is None
+        )
+        assert source.reporter.dm_element_warehouse_connection_ambiguous == 1
+        source.sigma_api.get_file_metadata_by_url_id.assert_not_called()

--- a/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
+++ b/metadata-ingestion/tests/unit/sigma/test_formula_parser.py
@@ -1,6 +1,10 @@
 """Tests for the Sigma formula bracket-reference extractor."""
 
-from datahub.ingestion.source.sigma.formula_parser import extract_bracket_refs
+from datahub.ingestion.source.sigma.formula_parser import (
+    BracketRef,
+    candidate_source_column_splits,
+    extract_bracket_refs,
+)
 
 
 def test_none_formula_returns_empty() -> None:
@@ -362,3 +366,76 @@ def test_balanced_quote_inside_bracket_body_preserves_later_refs() -> None:
     assert len(result) == 2
     assert result[0].source == 'col"name'
     assert result[1].source == "ok"
+
+
+class TestSegments:
+    """``segments`` exposes every unescaped-``/`` part, in order.
+
+    Resolvers need this because Sigma writes a column reached through a join as
+    ``[JoinElement/SourceElement/Column]``, where the owning element is the
+    second-to-last segment rather than ``source``.
+    """
+
+    def test_join_chain_segments(self) -> None:
+        (ref,) = extract_bracket_refs("[E1/E2/col]")
+        assert ref.segments == ["E1", "E2", "col"]
+        # Legacy split must not move.
+        assert ref.source == "E1"
+        assert ref.column == "E2/col"
+
+    def test_nested_join_chain_segments(self) -> None:
+        (ref,) = extract_bracket_refs("[E1/E2/E3/col]")
+        assert ref.segments == ["E1", "E2", "E3", "col"]
+
+    def test_single_slash_segments(self) -> None:
+        (ref,) = extract_bracket_refs("[Element/col]")
+        assert ref.segments == ["Element", "col"]
+
+    def test_bare_ref_has_one_segment(self) -> None:
+        (ref,) = extract_bracket_refs("[col]")
+        assert ref.segments == ["col"]
+
+    def test_escaped_slash_stays_inside_one_segment(self) -> None:
+        (ref,) = extract_bracket_refs(r"[A\/B/col]")
+        assert ref.segments == ["A/B", "col"]
+
+    def test_escaped_brackets_stay_inside_one_segment(self) -> None:
+        (ref,) = extract_bracket_refs(r"[\[Rel\] Originators/DIM_B/Name]")
+        assert ref.segments == ["[Rel] Originators", "DIM_B", "Name"]
+
+    def test_segments_are_whitespace_stripped(self) -> None:
+        (ref,) = extract_bracket_refs("[ E1 / E2 / col ]")
+        assert ref.segments == ["E1", "E2", "col"]
+
+    def test_hand_built_ref_does_not_split_column(self) -> None:
+        """Back-compat default must not re-split a column containing "/"."""
+        ref = BracketRef(raw="[a/b/c]", source="a", column="b/c", is_parameter=False)
+        assert ref.segments == ["a", "b/c"]
+        assert BracketRef(
+            raw="[a]", source="a", column=None, is_parameter=False
+        ).segments == ["a"]
+
+
+class TestCandidateSplits:
+    def test_join_chain_tries_owning_element_first(self) -> None:
+        (ref,) = extract_bracket_refs("[GRP_A/GRP_A DIM_B/Col Id]")
+        candidates = candidate_source_column_splits(ref)
+        assert candidates[0] == ("GRP_A DIM_B", "Col Id")
+        # The legacy first-slash split stays available, last.
+        assert candidates[-1] == ("GRP_A", "GRP_A DIM_B/Col Id")
+
+    def test_nested_chain_tries_deepest_element_first(self) -> None:
+        (ref,) = extract_bracket_refs("[E1/E2/E3/col]")
+        assert candidate_source_column_splits(ref)[0] == ("E3", "col")
+
+    def test_single_slash_yields_only_todays_split(self) -> None:
+        (ref,) = extract_bracket_refs("[Element/col]")
+        assert candidate_source_column_splits(ref) == [("Element", "col")]
+
+    def test_bare_ref_yields_nothing(self) -> None:
+        (ref,) = extract_bracket_refs("[col]")
+        assert candidate_source_column_splits(ref) == []
+
+    def test_slash_containing_element_name_is_offered(self) -> None:
+        (ref,) = extract_bracket_refs("[a/b/c]")
+        assert ("a/b", "c") in candidate_source_column_splits(ref)

--- a/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
+++ b/metadata-ingestion/tests/unit/sigma/test_sigma_api.py
@@ -2876,3 +2876,61 @@ class TestGetWorkbookLineageHttp:
             result = api.get_workbook_lineage("wb-1")
         assert result is None
         assert api.report.warnings
+
+
+def _error_response(status_code: int) -> MagicMock:
+    """Response mock whose ``raise_for_status`` behaves like requests'."""
+    resp = MagicMock(status_code=status_code)
+    resp.raise_for_status.side_effect = requests.HTTPError(
+        f"{status_code} Client Error", response=resp
+    )
+    return resp
+
+
+class TestPaginationAbortAccounting:
+    """Every abort must be counted, however many share a warning title.
+
+    Report warnings are grouped by title, so ``warnings.total_elements`` stops
+    rising after the first abort of a given kind. Detecting a per-call abort by
+    watching that number therefore flagged the FIRST truncated endpoint and
+    silently missed every one after it -- on one tenant, 29 aborts read as 0.
+    """
+
+    def _failing(self) -> requests.Response:
+        resp = requests.Response()
+        resp.status_code = 400
+        resp._content = b"{}"
+        resp.url = "https://api.example.com/x"
+        return resp
+
+    def test_every_abort_is_counted_not_just_the_first(self) -> None:
+        api = _create_sigma_api()
+        with patch.object(api, "_get_api_call", return_value=self._failing()):
+            for _ in range(3):
+                api._paginated_raw_entries("https://api.example.com/x", "ctx")
+        assert api.report.pagination_aborted == 3
+        # The warnings themselves still collapse to one titled entry -- which is
+        # precisely why the counter cannot be derived from them.
+        assert api.report.warnings.total_elements == 1
+
+    def test_workbook_columns_abort_flags_each_workbook(self) -> None:
+        api = _create_sigma_api()
+        with patch.object(api, "_get_api_call", return_value=self._failing()):
+            api.get_workbook_column_formulas("wb-1")
+            api.get_workbook_column_formulas("wb-2")
+        assert api.report.column_formulas_fetch_partial == 2
+
+    def test_successful_fetch_is_not_flagged_partial(self) -> None:
+        """An unrelated warning during the call must not fake a partial fetch."""
+        api = _create_sigma_api()
+        ok = _paginated_response([{"elementId": "e1", "name": "c", "formula": "1"}])
+        with patch.object(api, "_get_api_call", return_value=ok):
+            api.report.warning(title="Something else", message="m")
+            api.get_workbook_column_formulas("wb-1")
+        assert api.report.column_formulas_fetch_partial == 0
+
+    def test_data_model_columns_abort_is_visible(self) -> None:
+        api = _create_sigma_api()
+        with patch.object(api, "_get_api_call", return_value=self._failing()):
+            api._get_data_model_columns("dm-1")
+        assert api.report.data_model_columns_fetch_partial == 1


### PR DESCRIPTION
Sigma Data Model column-level lineage was derived entirely from each column's formula text, and several resolution paths validated formula refs against relationships that Sigma only reports *indirectly*. Columns that should have carried lineage produced none — silently, with no counter or warning. This PR fixes each of those paths and adds the instrumentation that makes any remaining loss visible.

### What was losing lineage

- **Columns with no formula.** Sigma's normal shape for a pass-through column is an empty formula, and the loop that built lineage skipped them. The columnId-driven resolver needs no formula but was only reachable from inside the bracket-ref loop, which never runs when a formula yields no refs. The no-ref case is now handled after the loop, gated on the ref list being empty rather than on whether a warehouse edge was appended — intra-DM resolution never sets that flag, so the latter would give a column carrying both a sibling ref and an inode columnId a second, wrong upstream. Columns with no refs are never name-matched against siblings: with no ref to resolve, matching on column name alone would fabricate an edge to both sides of every join.
- **Join-chain refs** `[JoinElement/SourceElement/Column]`. The owning element is reached *through* the join, so Sigma's element `/lineage` never lists it, and gating candidates on the direct-upstream set rejected every one. Refs now parse into segments, each candidate split is validated against the candidate's own schema, and the owner is promoted to an entity-level upstream so the emitted schemaField has a declared parent.
- **Sibling refs absent from `/lineage`**, now emitted when a sibling demonstrably owns the column.
- **Warehouse lookup failure abandoning the ref.** An inode-shaped `columnId` that failed warehouse resolution used to stop there. The formula still names a source, and for a cross-DM-sourced element that source is a producer in another Data Model, so resolution now falls through instead.
- **Cross-DM-sourced elements** rejected for not declaring the inode their columns name.
- **Warehouse-table refs** whose `columnId` is opaque: the column name is inferred from Sigma's display-name convention and emitted at reduced confidence.
- **Tables missing from `/dataModels/{id}/lineage`**, now resolved with a direct `/v2/files/{urlId}` call.
- **Chart formula refs** that miss on whitespace or case, retried against a normalized element-name key and refused when that key collapses two genuinely distinct names.

### Tables that no longer exist

A Data Model can reference a warehouse table that has since been deleted from Sigma: the `inode-<urlId>` reference survives while `/v2/files/{urlId}` returns 404. No lookup can supply coordinates for an object that is gone, so these are counted under `dm_element_warehouse_stale_reference` and reported as tenant data hygiene rather than retried.

This replaced an earlier approach that listed every table on the tenant and looked the url_id up in that index. Measured against a live tenant, the listing cost ~41 paged calls and recovered **nothing** — all 37 unresolved url_ids were absent from a complete 40,564-row listing, and each answered 404 individually. A control url_id taken from the listing returns 200, confirming `/v2/files/{urlId}` accepts a url_id and the 404s are real absences rather than an id-space mismatch.

### Reverted

- The 409 retry on `/dataModels/{id}/columns`. It was added on the theory that the conflict was transient; two full runs showed the same six aborts with and without it, so it is a persistent condition and the retry only added latency.
- A cross-DM `columnId` matcher that resolved zero rows across two runs.

### Diagnostics

Per-column and per-element decision records name exactly what each column resolved to, or why it did not, so "why is there no lineage from X to Y" is answerable from the log alone.

Two counters mark data that never arrived, and should be read before treating a model's missing lineage as a resolution failure:

| Counter | Meaning |
| --- | --- |
| `pagination_aborted` | Run-wide count of paginated calls that aborted partway, losing every entry after the failure point |
| `data_model_columns_fetch_partial` | Data Models whose `/columns` pagination aborted — that endpoint is the only source of formulas and column ids |
| `column_formulas_fetch_partial` | Workbooks whose `/columns` call aborted, leaving chart columns with self-referential input fields |

The latter two previously inferred "did this call abort?" from the report's warning count. Report warnings are grouped by title, so that number stops rising after the first abort of a given kind: on one tenant 29 aborts were reported as 0, and an unrelated new warning during the call could fire the counter spuriously. Both now read an exact per-call abort signal.

Also documents why a join's output column links only to the side its formula names — the join predicate is not exposed on the endpoints this connector reads.

### Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated
- [x] Docs related to the changes have been added/updated
- [ ] No breaking changes; no `Updating DataHub` entry needed
