### PR TITLE
chore(cli): bump default cli

### DIFF
--- a/gradle/versioning/cliVersion.gradle
+++ b/gradle/versioning/cliVersion.gradle
@@ -4,5 +4,5 @@ ext {
     //
     // To automatically update this to the latest CLI version prior to release, run the following command:
     // ./gradlew resolveDefaultCliVersion
-    cliVersion = "1.7.0"
+    cliVersion = "1.7.0.9"
 }


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/datahub-project/datahub/pull/19602 onto releases/v1.7.0
- Bumps the default bundled CLI from 1.7.0 to 1.7.0.9

## Test plan
- [ ] Confirm gradle/versioning/cliVersion.gradle is 1.7.0.9 on this branch
- [ ] CI green on releases/v1.7.0


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the default bundled CLI from `1.7.0` to `1.7.0.9` so the v1.7.0 release line uses the updated CLI version.

<sup>Written for commit de97f9151afa87e4f0c4d3ea81d406d982acad27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

