### PR TITLE
feat(codeblocks): comparative view of codeblocks 

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlock.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlock.stories.tsx
@@ -1,10 +1,13 @@
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
+import { ThemeProvider } from 'styled-components';
 
 import { resolveCodeLanguage } from '@components/components/CodeBlock/formatCode';
 import { CodeBlockLanguageOption, CodeBlockProps } from '@components/components/CodeBlock/types';
 import { Pill } from '@components/components/Pills';
+
+import themes from '@conf/theme/themes';
 
 import { CodeBlock, codeBlockDefaults } from '.';
 
@@ -51,6 +54,26 @@ tags: [finance,  prod]`;
 const MESSY_JSON = '{"name":"orders_revenue","type":"metric","tags":["finance","prod"]}';
 
 const MESSY_GRAPHQL = 'type Query { user(id: ID!): User }  type User { name:String  email: String }';
+
+const SAMPLE_COUNT_OLD = `COUNT(DISTINCT CASE WHEN campaigns.status = 'active'
+THEN campaigns.id END)`;
+
+const SAMPLE_COUNT_NEW = `COUNT(DISTINCT CASE WHEN campaigns.status IN ('active','trial')
+THEN campaigns.id END)`;
+
+const SAMPLE_DATABRICKS_SQL = `SELECT
+  campaign_id,
+  COUNT(DISTINCT CASE WHEN status = 'active' THEN user_id END) AS active_users
+FROM campaigns
+WHERE ds >= CURRENT_DATE - INTERVAL 7 DAYS
+GROUP BY 1`;
+
+const SAMPLE_SNOWFLAKE_METRIC_SQL = `SELECT
+  campaign_id,
+  COUNT(DISTINCT CASE WHEN status IN ('active', 'trial') THEN user_id END) AS active_users
+FROM campaigns
+WHERE ds >= DATEADD('day', -7, CURRENT_DATE())
+GROUP BY 1`;
 
 const MIXED_LANGUAGE_OPTIONS: CodeBlockLanguageOption[] = [
     { value: 'sql', label: 'SQL' },
@@ -131,6 +154,11 @@ const meta = {
                 'Show a Validate action in the header. Clicking lists syntax problems (SQL soft warning; JSON / YAML / GraphQL error).',
             table: { defaultValue: { summary: 'false' } },
             control: { type: 'boolean' },
+        },
+        diffAgainst: {
+            description:
+                'When set and different from `code`, show a read-only inline word diff (old = this, new = `code`).',
+            control: { type: 'text' },
         },
         error: {
             description: 'Parent hard validation message (invalid border).',
@@ -313,6 +341,72 @@ export const EditableGraphql: Story = {
     render: (args) => (
         <StatefulCodeBlock {...args} initialCode={MESSY_GRAPHQL} language="graphql" languageLabel="GraphQL" wrap />
     ),
+};
+
+export const InlineWordDiff: Story = {
+    name: 'Inline word diff (count expression)',
+    args: {
+        code: SAMPLE_COUNT_NEW,
+        diffAgainst: SAMPLE_COUNT_OLD,
+        language: 'sql',
+        languageLabel: 'SQL',
+        wrap: true,
+        headerLeft: <Pill label="vs previous" color="gray" size="sm" clickable={false} />,
+    },
+};
+
+export const InlineWordDiffDark: Story = {
+    name: 'Inline word diff (dark)',
+    args: {
+        code: SAMPLE_COUNT_NEW,
+        diffAgainst: SAMPLE_COUNT_OLD,
+        language: 'sql',
+        languageLabel: 'SQL',
+        wrap: true,
+        headerLeft: <Pill label="vs previous" color="gray" size="sm" clickable={false} />,
+    },
+    decorators: [
+        (Story) => (
+            <ThemeProvider theme={themes.themeV2Dark}>
+                <div style={{ padding: 16, background: themes.themeV2Dark.colors.bg }}>
+                    <Story />
+                </div>
+            </ThemeProvider>
+        ),
+    ],
+};
+
+export const SnowflakeVsDatabricks: Story = {
+    name: 'Inline word diff (Snowflake vs Databricks)',
+    args: {
+        code: SAMPLE_SNOWFLAKE_METRIC_SQL,
+        diffAgainst: SAMPLE_DATABRICKS_SQL,
+        language: 'sql',
+        languageLabel: 'Snowflake',
+        wrap: true,
+        headerLeft: <Pill label="vs Databricks" color="primary" size="sm" clickable={false} />,
+    },
+};
+
+export const SnowflakeVsDatabricksDark: Story = {
+    name: 'Inline word diff (Snowflake vs Databricks, dark)',
+    args: {
+        code: SAMPLE_SNOWFLAKE_METRIC_SQL,
+        diffAgainst: SAMPLE_DATABRICKS_SQL,
+        language: 'sql',
+        languageLabel: 'Snowflake',
+        wrap: true,
+        headerLeft: <Pill label="vs Databricks" color="primary" size="sm" clickable={false} />,
+    },
+    decorators: [
+        (Story) => (
+            <ThemeProvider theme={themes.themeV2Dark}>
+                <div style={{ padding: 16, background: themes.themeV2Dark.colors.bg }}>
+                    <Story />
+                </div>
+            </ThemeProvider>
+        ),
+    ],
 };
 
 export const EditableLanguages: Story = {

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlock.tsx
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlock.tsx
@@ -3,12 +3,13 @@ import { Copy } from '@phosphor-icons/react/dist/csr/Copy';
 import { ListChecks } from '@phosphor-icons/react/dist/csr/ListChecks';
 import { MagicWand } from '@phosphor-icons/react/dist/csr/MagicWand';
 import { Warning } from '@phosphor-icons/react/dist/csr/Warning';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { useTheme } from 'styled-components';
 
 import { Button } from '@components/components/Button';
+import { CodeBlockDiff } from '@components/components/CodeBlock/CodeBlockDiff';
 import { CodeBlockEditor } from '@components/components/CodeBlock/CodeBlockEditor';
 import { LanguageControl } from '@components/components/CodeBlock/LanguageControl';
 import {
@@ -26,6 +27,7 @@ import {
     TruncatedBanner,
 } from '@components/components/CodeBlock/components';
 import { codeBlockDefaults } from '@components/components/CodeBlock/defaults';
+import { buildCodeDiff, shouldRenderCodeBlockDiff } from '@components/components/CodeBlock/diffCode';
 import {
     formatCode,
     isFormatCodeSuccess,
@@ -102,6 +104,7 @@ export function CodeBlock({
     showLineNumbers = codeBlockDefaults.showLineNumbers,
     hideLineNumbers = false,
     wrap = codeBlockDefaults.wrap,
+    diffAgainst,
     highlightedLines,
     lineProps: linePropsProp,
     maxHeight,
@@ -126,7 +129,12 @@ export function CodeBlock({
     const isMountedRef = useRef(true);
     const validateRequestIdRef = useRef(0);
     const isCopied = isCopiedProp ?? internalCopied;
-    const isEditable = isCodeBlockEditable({ isReadOnly, onChange });
+    const showDiff = shouldRenderCodeBlockDiff(code, diffAgainst);
+    const isEditable = isCodeBlockEditable({ isReadOnly: isReadOnly || showDiff, onChange });
+    const diffLines = useMemo(
+        () => (showDiff && diffAgainst !== undefined ? buildCodeDiff(diffAgainst, code) : null),
+        [code, diffAgainst, showDiff],
+    );
     const showFormatButton = shouldShowFormatButton({ showFormat, isEditable: isEditable && !isDisabled });
     const showValidateButton = shouldShowValidateButton({
         validateSyntax,
@@ -303,6 +311,14 @@ export function CodeBlock({
                 onRequestFormat={showFormatButton ? handleFormat : undefined}
                 dataTestId={getCodeBlockTestId(dataTestId, 'editor', 'code-block-editor')}
                 ariaLabel={t('codeBlock.editorLabel')}
+            />
+        );
+    } else if (diffLines) {
+        body = (
+            <CodeBlockDiff
+                lines={diffLines}
+                wrap={wrap}
+                dataTestId={getCodeBlockTestId(dataTestId, 'diff', 'code-block-diff')}
             />
         );
     } else if (emptyBody) {

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlockDiff.tsx
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/CodeBlockDiff.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import {
+    CodeBlockDiffAdded,
+    CodeBlockDiffEqual,
+    CodeBlockDiffPre,
+    CodeBlockDiffRemoved,
+} from '@components/components/CodeBlock/components';
+import type { CodeDiffLine, CodeDiffSegment } from '@components/components/CodeBlock/diffCode';
+
+type Props = {
+    lines: CodeDiffLine[];
+    wrap: boolean;
+    dataTestId?: string;
+};
+
+function renderSegment(segment: CodeDiffSegment, key: number): React.ReactNode {
+    if (segment.type === 'removed') {
+        return <CodeBlockDiffRemoved key={key}>{segment.value}</CodeBlockDiffRemoved>;
+    }
+    if (segment.type === 'added') {
+        return <CodeBlockDiffAdded key={key}>{segment.value}</CodeBlockDiffAdded>;
+    }
+    return <CodeBlockDiffEqual key={key}>{segment.value}</CodeBlockDiffEqual>;
+}
+
+/**
+ * Read-only inline word diff. Uses `del` / `ins` so removals stay announced
+ * without relying on color alone.
+ */
+export function CodeBlockDiff({ lines, wrap, dataTestId }: Props): React.ReactElement {
+    return (
+        <CodeBlockDiffPre $wrap={wrap} data-testid={dataTestId}>
+            {lines.map((line, lineIndex) => (
+                // A diff line's identity is its position; the list is rebuilt whole and never reordered.
+                // eslint-disable-next-line react/no-array-index-key
+                <React.Fragment key={lineIndex}>
+                    {lineIndex > 0 ? '\n' : null}
+                    {line.segments.map((segment, segmentIndex) => renderSegment(segment, segmentIndex))}
+                </React.Fragment>
+            ))}
+        </CodeBlockDiffPre>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/CodeBlock.test.tsx
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/CodeBlock.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { ThemeProvider } from 'styled-components';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CodeBlock } from '@components/components/CodeBlock/CodeBlock';
 
@@ -22,6 +22,8 @@ vi.mock('@components/components/Toast', () => ({
     },
 }));
 
+const originalClipboard = navigator.clipboard;
+
 function renderCodeBlock(ui: React.ReactElement) {
     return render(
         <ThemeProvider theme={themeV2}>
@@ -31,6 +33,13 @@ function renderCodeBlock(ui: React.ReactElement) {
 }
 
 describe('CodeBlock', () => {
+    afterEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: originalClipboard,
+        });
+    });
+
     it('renders code content', () => {
         renderCodeBlock(<CodeBlock code="SELECT 1" language="sql" />);
 
@@ -168,6 +177,50 @@ describe('CodeBlock', () => {
         expect(screen.queryByTestId('code-block-warning')).not.toBeInTheDocument();
         await user.click(screen.getByTestId('code-block-validate'));
         expect(await screen.findByTestId('code-block-warning')).toHaveTextContent(/SELECT is missing columns/i);
+    });
+
+    it('renders inline diff marks when diffAgainst differs', () => {
+        renderCodeBlock(
+            <CodeBlock
+                code="COUNT(DISTINCT CASE WHEN status IN ('active','trial')"
+                diffAgainst="COUNT(DISTINCT CASE WHEN status = 'active'"
+                language="sql"
+            />,
+        );
+
+        expect(screen.getByTestId('code-block-diff')).toBeInTheDocument();
+        expect(screen.queryByTestId('mock-highlighter')).not.toBeInTheDocument();
+        expect(screen.getByText("= 'active'", { selector: 'del' })).toBeInTheDocument();
+        expect(screen.getByText("IN ('active','trial')", { selector: 'ins' })).toBeInTheDocument();
+    });
+
+    it('keeps diff mode read-only when onChange is provided', () => {
+        renderCodeBlock(<CodeBlock code="SELECT 2" diffAgainst="SELECT 1" language="sql" onChange={() => undefined} />);
+
+        expect(screen.getByTestId('code-block-diff')).toBeInTheDocument();
+        expect(screen.queryByTestId('code-block-editor')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('code-block-format')).not.toBeInTheDocument();
+    });
+
+    it('copies the displayed version while showing a diff', async () => {
+        const user = userEvent.setup();
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText },
+        });
+
+        renderCodeBlock(<CodeBlock code="SELECT 2" diffAgainst="SELECT 1" language="sql" />);
+        await user.click(screen.getByTestId('code-block-copy'));
+
+        expect(writeText).toHaveBeenCalledWith('SELECT 2');
+    });
+
+    it('keeps the highlighter when diffAgainst matches code', () => {
+        renderCodeBlock(<CodeBlock code="SELECT 1" diffAgainst="SELECT 1" language="sql" />);
+
+        expect(screen.getByTestId('mock-highlighter')).toBeInTheDocument();
+        expect(screen.queryByTestId('code-block-diff')).not.toBeInTheDocument();
     });
 
     it('should list multiple SQL validation issues when Validate is clicked', async () => {

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/diffCode.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/diffCode.test.ts
@@ -7,6 +7,8 @@ describe('shouldRenderCodeBlockDiff', () => {
         expect(shouldRenderCodeBlockDiff('SELECT 1')).toBe(false);
         expect(shouldRenderCodeBlockDiff('SELECT 1', 'SELECT 1')).toBe(false);
         expect(shouldRenderCodeBlockDiff('SELECT 1\n', 'SELECT 1')).toBe(false);
+        expect(shouldRenderCodeBlockDiff('SELECT 1\r\nFROM t', 'SELECT 1\nFROM t')).toBe(false);
+        expect(shouldRenderCodeBlockDiff('SELECT 1\rFROM t', 'SELECT 1\nFROM t')).toBe(false);
     });
 
     it('is on when the strings differ', () => {
@@ -46,6 +48,16 @@ describe('buildCodeDiff', () => {
         expect(lines).toEqual([
             { kind: 'unchanged', segments: [{ type: 'equal', value: 'SELECT 1' }] },
             { kind: 'unchanged', segments: [{ type: 'equal', value: 'FROM t' }] },
+        ]);
+    });
+
+    it('normalizes CRLF before splitting so segments do not retain carriage returns', () => {
+        const lines = buildCodeDiff('SELECT 1\r\nFROM t', 'SELECT 2\r\nFROM t');
+        expect(lines[0]?.segments.every((segment) => !segment.value.includes('\r'))).toBe(true);
+        expect(lines.map((line) => line.segments.map((segment) => segment.value).join(''))).toEqual([
+            'SELECT 1',
+            'SELECT 2',
+            'FROM t',
         ]);
     });
 

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/diffCode.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/__tests__/diffCode.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCodeDiff, shouldRenderCodeBlockDiff } from '@components/components/CodeBlock/diffCode';
+
+describe('shouldRenderCodeBlockDiff', () => {
+    it('is off when diffAgainst is omitted or matches code', () => {
+        expect(shouldRenderCodeBlockDiff('SELECT 1')).toBe(false);
+        expect(shouldRenderCodeBlockDiff('SELECT 1', 'SELECT 1')).toBe(false);
+        expect(shouldRenderCodeBlockDiff('SELECT 1\n', 'SELECT 1')).toBe(false);
+    });
+
+    it('is on when the strings differ', () => {
+        expect(shouldRenderCodeBlockDiff("status = 'active'", "status IN ('active','trial')")).toBe(true);
+    });
+});
+
+describe('buildCodeDiff', () => {
+    it('repeats a changed line with word-level chips', () => {
+        const lines = buildCodeDiff(
+            "COUNT(DISTINCT CASE WHEN campaigns.status = 'active'\nTHEN campaigns.id END)",
+            "COUNT(DISTINCT CASE WHEN campaigns.status IN ('active','trial')\nTHEN campaigns.id END)",
+        );
+
+        expect(lines).toHaveLength(3);
+        expect(lines[0]?.kind).toBe('removed');
+        expect(lines[1]?.kind).toBe('added');
+        expect(lines[2]).toEqual({
+            kind: 'unchanged',
+            segments: [{ type: 'equal', value: 'THEN campaigns.id END)' }],
+        });
+
+        const removedText = lines[0]?.segments
+            .filter((segment) => segment.type === 'removed')
+            .map((segment) => segment.value)
+            .join('');
+        const addedText = lines[1]?.segments
+            .filter((segment) => segment.type === 'added')
+            .map((segment) => segment.value)
+            .join('');
+        expect(removedText).toContain("= 'active'");
+        expect(addedText).toContain("IN ('active','trial')");
+    });
+
+    it('keeps unchanged lines as a single equal segment', () => {
+        const lines = buildCodeDiff('SELECT 1\nFROM t', 'SELECT 1\nFROM t');
+        expect(lines).toEqual([
+            { kind: 'unchanged', segments: [{ type: 'equal', value: 'SELECT 1' }] },
+            { kind: 'unchanged', segments: [{ type: 'equal', value: 'FROM t' }] },
+        ]);
+    });
+
+    it('treats leftover added lines as whole-line additions', () => {
+        const lines = buildCodeDiff('SELECT 1', 'SELECT 1\nQUALIFY rn = 1');
+        expect(lines[0]?.kind).toBe('unchanged');
+        expect(lines[1]).toEqual({
+            kind: 'added',
+            segments: [{ type: 'added', value: 'QUALIFY rn = 1' }],
+        });
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/components.ts
@@ -76,6 +76,8 @@ export const CodeBlockIssueList = styled.ul({
 export const CodeBlockHeader = styled.div(({ theme }) => ({
     display: 'flex',
     flexDirection: 'row' as const,
+    // Wrap instead of crushing children to zero width in narrow containers.
+    flexWrap: 'wrap' as const,
     justifyContent: 'space-between',
     alignItems: 'center',
     gap: spacing.xsm,
@@ -88,6 +90,7 @@ export const CodeBlockHeader = styled.div(({ theme }) => ({
 export const HeaderLeft = styled.div({
     display: 'flex',
     alignItems: 'center',
+    flexWrap: 'wrap' as const,
     gap: spacing.xsm,
     minWidth: 0,
     flex: 1,
@@ -134,6 +137,11 @@ export const CodeBlockContent = styled.div<CodeBlockStyleProps>(
             fontFamily: `${typography.fonts.mono} !important`,
             fontWeight: `${typography.fontWeights.medium} !important`,
             background: 'transparent !important',
+        },
+
+        '& del, & ins': {
+            fontFamily: `${typography.fonts.mono} !important`,
+            fontWeight: `${typography.fontWeights.medium} !important`,
         },
     }),
 );
@@ -232,3 +240,31 @@ export const LanguageSelectWrapper = styled.div({
     minWidth: '140px',
     maxWidth: '220px',
 });
+
+export const CodeBlockDiffPre = styled.pre<{ $wrap: boolean }>`
+    color: ${(props) => props.theme.colors.text};
+    white-space: ${(props) => (props.$wrap ? 'pre-wrap' : 'pre')};
+    word-break: ${(props) => (props.$wrap ? 'break-word' : 'normal')};
+    tab-size: 2;
+`;
+
+export const CodeBlockDiffEqual = styled.span`
+    color: ${(props) => props.theme.colors.text};
+`;
+
+export const CodeBlockDiffRemoved = styled.del`
+    padding: 0 2px;
+    border-radius: ${radius.sm};
+    background: ${(props) => props.theme.colors.bgSurfaceError};
+    color: ${(props) => props.theme.colors.textOnSurfaceError};
+    text-decoration: line-through;
+    text-decoration-color: ${(props) => props.theme.colors.textOnSurfaceError};
+`;
+
+export const CodeBlockDiffAdded = styled.ins`
+    padding: 0 2px;
+    border-radius: ${radius.sm};
+    background: ${(props) => props.theme.colors.bgSurfaceSuccess};
+    color: ${(props) => props.theme.colors.textOnSurfaceSuccess};
+    text-decoration: none;
+`;

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/diffCode.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/diffCode.ts
@@ -15,7 +15,7 @@ export type CodeDiffLine = {
 };
 
 function normalizeCode(value: string): string {
-    return value.replace(/\n+$/, '');
+    return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n+$/, '');
 }
 
 /**

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/diffCode.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/diffCode.ts
@@ -1,0 +1,166 @@
+import { diffArrays, diffLines } from 'diff';
+
+export type CodeDiffSegmentType = 'equal' | 'removed' | 'added';
+
+export type CodeDiffSegment = {
+    type: CodeDiffSegmentType;
+    value: string;
+};
+
+export type CodeDiffLineKind = 'unchanged' | 'removed' | 'added';
+
+export type CodeDiffLine = {
+    kind: CodeDiffLineKind;
+    segments: CodeDiffSegment[];
+};
+
+function normalizeCode(value: string): string {
+    return value.replace(/\n+$/, '');
+}
+
+/**
+ * Whether read-only CodeBlock should render an inline diff instead of Prism.
+ * Identical strings (ignoring trailing newlines) stay on the highlighter.
+ */
+export function shouldRenderCodeBlockDiff(code: string, diffAgainst?: string): boolean {
+    return diffAgainst !== undefined && normalizeCode(code) !== normalizeCode(diffAgainst);
+}
+
+function splitDiffLines(value: string): string[] {
+    if (!value) {
+        return [];
+    }
+    const parts = value.split('\n');
+    if (parts[parts.length - 1] === '') {
+        parts.pop();
+    }
+    return parts;
+}
+
+function tokenizeLine(line: string): string[] {
+    return line.split(/(\s+)/).filter((token) => token.length > 0);
+}
+
+function segmentType(change: { added?: boolean; removed?: boolean }): CodeDiffSegmentType {
+    if (change.added) {
+        return 'added';
+    }
+    if (change.removed) {
+        return 'removed';
+    }
+    return 'equal';
+}
+
+function coalesceSegments(segments: CodeDiffSegment[]): CodeDiffSegment[] {
+    const merged: CodeDiffSegment[] = [];
+    segments.forEach((segment) => {
+        const last = merged[merged.length - 1];
+        if (last && last.type === segment.type) {
+            last.value += segment.value;
+            return;
+        }
+        merged.push({ ...segment });
+    });
+
+    const coalesced: CodeDiffSegment[] = [];
+    let index = 0;
+    while (index < merged.length) {
+        const current = merged[index];
+        if (current) {
+            const previous = coalesced[coalesced.length - 1];
+            const next = merged[index + 1];
+            if (
+                current.type === 'equal' &&
+                /^\s+$/.test(current.value) &&
+                previous &&
+                next &&
+                previous.type === next.type &&
+                previous.type !== 'equal'
+            ) {
+                // Whitespace between two chunks of the same kind shouldn't split them apart.
+                previous.value += current.value + next.value;
+                index += 1;
+            } else {
+                coalesced.push(current);
+            }
+        }
+        index += 1;
+    }
+    return coalesced;
+}
+
+function wordSegments(oldLine: string, newLine: string, drop: 'added' | 'removed'): CodeDiffSegment[] {
+    const changes = diffArrays(tokenizeLine(oldLine), tokenizeLine(newLine));
+    return coalesceSegments(
+        changes
+            .filter((change) => !change[drop])
+            .map((change) => ({
+                type: segmentType(change),
+                value: (change.value ?? []).join(''),
+            })),
+    );
+}
+
+function hasWordChange(oldLine: string, newLine: string): boolean {
+    return diffArrays(tokenizeLine(oldLine), tokenizeLine(newLine)).some((change) => change.added || change.removed);
+}
+
+/**
+ * Line-level diff, with word-level chips on modified line pairs.
+ * Each modification emits the old line then the new line (GitHub inline style).
+ */
+export function buildCodeDiff(oldCode: string, newCode: string): CodeDiffLine[] {
+    const changes = diffLines(normalizeCode(oldCode), normalizeCode(newCode));
+    const lines: CodeDiffLine[] = [];
+    let index = 0;
+
+    while (index < changes.length) {
+        const change = changes[index];
+        if (!change) {
+            break;
+        }
+
+        if (!change.added && !change.removed) {
+            splitDiffLines(change.value).forEach((line) => {
+                lines.push({ kind: 'unchanged', segments: [{ type: 'equal', value: line }] });
+            });
+            index += 1;
+        } else {
+            const removed: string[] = [];
+            const added: string[] = [];
+            while (index < changes.length) {
+                const hunk = changes[index];
+                if (!hunk?.added && !hunk?.removed) {
+                    break;
+                }
+                const hunkLines = splitDiffLines(hunk?.value ?? '');
+                if (hunk?.removed) {
+                    removed.push(...hunkLines);
+                } else if (hunk?.added) {
+                    added.push(...hunkLines);
+                }
+                index += 1;
+            }
+
+            const paired = Math.min(removed.length, added.length);
+            for (let pairIndex = 0; pairIndex < paired; pairIndex++) {
+                const previous = removed[pairIndex] ?? '';
+                const next = added[pairIndex] ?? '';
+                if (hasWordChange(previous, next)) {
+                    lines.push({ kind: 'removed', segments: wordSegments(previous, next, 'added') });
+                    lines.push({ kind: 'added', segments: wordSegments(previous, next, 'removed') });
+                } else {
+                    lines.push({ kind: 'unchanged', segments: [{ type: 'equal', value: next }] });
+                }
+            }
+            for (let leftover = paired; leftover < removed.length; leftover++) {
+                lines.push({ kind: 'removed', segments: [{ type: 'removed', value: removed[leftover] ?? '' }] });
+            }
+            for (let leftover = paired; leftover < added.length; leftover++) {
+                lines.push({ kind: 'added', segments: [{ type: 'added', value: added[leftover] ?? '' }] });
+            }
+        }
+    }
+
+    return lines;
+}

--- a/datahub-web-react/src/alchemy-components/components/CodeBlock/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/CodeBlock/types.ts
@@ -112,6 +112,12 @@ export interface CodeBlockProps
     /** Soft-wrap long lines */
     wrap?: boolean;
 
+    /**
+     * When set and different from `code`, render a read-only inline word diff
+     * (`diffAgainst` = old, `code` = new). Skips Prism, format, and the editor.
+     */
+    diffAgainst?: string;
+
     /** 1-based line numbers to highlight */
     highlightedLines?: number[] | ReadonlySet<number>;
 


### PR DESCRIPTION

<img width="1840" height="1196" alt="Screenshot 2026-09-03 at 12 29 45 PM" src="https://github.com/user-attachments/assets/35238cbe-65f4-4809-aacd-bed3962ca800" />
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comparative view to `CodeBlock` so callers can show a read-only inline word diff between two versions of code. Previously `CodeBlock` rendered one code string; now passing `diffAgainst` renders the old vs new diff and disables editing, formatting, and Prism highlighting. Copy still copies the new `code`, and an identical `diffAgainst` keeps the normal view. Line endings are normalized so CRLF/CR-only differences don't trigger diff mode.

<sup>Written for commit 8c6f427c81f86472901cb51cc0d3427f3894992a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

