### PR TITLE
fix(web): return absolute encoded URLs for uploaded file links

### DIFF
--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtilsTest.java
@@ -525,6 +525,8 @@ public class LinkUtilsTest {
       "http://example.com",
       "ftp://files.example.com/file.txt",
       "mailto:user@example.com",
+      // Uploaded product-asset links (absolute + percent-encoded filename)
+      "https://example.com/openapi/v1/files/product_assets/a1b2c3d4-e5f6-7890-abcd-ef1234567890__file%20name.pdf",
     };
 
     for (String url : safeUrls) {

--- a/datahub-web-react/src/app/shared/hooks/__tests__/useFileUpload.test.tsx
+++ b/datahub-web-react/src/app/shared/hooks/__tests__/useFileUpload.test.tsx
@@ -178,10 +178,10 @@ describe('useFileUpload', () => {
 
         await waitFor(async () => {
             const url = await uploadPromise;
+            // Literal %20 so the assertion does not share encodeURIComponent with the hook under test.
             expect(url).toBe(
-                `${window.location.origin}/openapi/v1/files/product_assets/${encodeURIComponent(mockFileId)}`,
+                `${window.location.origin}/openapi/v1/files/product_assets/a1b2c3d4-e5f6-7890-abcd-ef1234567890__Adstra%20Data%20Specs.pdf`,
             );
-            expect(url).toContain('Adstra%20Data%20Specs.pdf');
         });
     });
 

--- a/datahub-web-react/src/app/shared/hooks/__tests__/useFileUpload.test.tsx
+++ b/datahub-web-react/src/app/shared/hooks/__tests__/useFileUpload.test.tsx
@@ -10,9 +10,9 @@ import { useAppConfig } from '@src/app/useAppConfig';
 import { GetPresignedUploadUrlDocument } from '@graphql/app.generated';
 import { UploadDownloadScenario } from '@types';
 
-// Mock the resolveRuntimePath utility
+// Pass-through: production resolveRuntimePath only prefixes a deploy base path, not origin.
 vi.mock('@utils/runtimeBasePath', () => ({
-    resolveRuntimePath: vi.fn((path) => `http://example.com${path}`),
+    resolveRuntimePath: vi.fn((path: string) => path),
 }));
 
 // Mock the useAppConfig hook
@@ -108,7 +108,7 @@ describe('useFileUpload', () => {
 
         await waitFor(async () => {
             const url = await uploadPromise;
-            expect(url).toBe('http://example.com/openapi/v1/files/product_assets/file-123');
+            expect(url).toBe(`${window.location.origin}/openapi/v1/files/product_assets/file-123`);
         });
 
         // Verify fetch was called with correct parameters
@@ -121,6 +121,68 @@ describe('useFileUpload', () => {
         });
         expect(mockCreateFile).toHaveBeenCalledTimes(1);
         expect(mockCreateFile).toHaveBeenCalledWith(mockFileId, mockFile);
+    });
+
+    it('should URL-encode spaces in fileId when returning the file URL', async () => {
+        const mockFile = new File(['test content'], 'Adstra Data Specs.pdf', { type: 'application/pdf' });
+        const mockUploadUrl = 'https://s3.example.com/upload-url';
+        const mockFileId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890__Adstra Data Specs.pdf';
+
+        const mocks = [
+            {
+                request: {
+                    query: GetPresignedUploadUrlDocument,
+                    variables: {
+                        input: {
+                            scenario: UploadDownloadScenario.AssetDocumentation,
+                            assetUrn: mockAssetUrn,
+                            contentType: 'application/pdf',
+                            fileName: 'Adstra Data Specs.pdf',
+                        },
+                    },
+                },
+                result: {
+                    data: {
+                        getPresignedUploadUrl: {
+                            url: mockUploadUrl,
+                            fileId: mockFileId,
+                        },
+                    },
+                },
+            },
+        ];
+
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            statusText: 'OK',
+        });
+
+        const { result } = renderHook(
+            () =>
+                useFileUpload({
+                    scenario: UploadDownloadScenario.AssetDocumentation,
+                    assetUrn: mockAssetUrn,
+                }),
+            {
+                wrapper: ({ children }) => (
+                    <MockedProvider mocks={mocks} addTypename={false}>
+                        {children}
+                    </MockedProvider>
+                ),
+            },
+        );
+
+        mockCreateFile.mockResolvedValue(undefined);
+
+        const uploadPromise = result.current.uploadFile?.(mockFile);
+
+        await waitFor(async () => {
+            const url = await uploadPromise;
+            expect(url).toBe(
+                `${window.location.origin}/openapi/v1/files/product_assets/${encodeURIComponent(mockFileId)}`,
+            );
+            expect(url).toContain('Adstra%20Data%20Specs.pdf');
+        });
     });
 
     it('should throw an error if presigned URL is not returned', async () => {
@@ -286,7 +348,7 @@ describe('useFileUpload', () => {
 
         await waitFor(async () => {
             const url = await uploadPromise;
-            expect(url).toBe('http://example.com/openapi/v1/files/product_assets/file-456');
+            expect(url).toBe(`${window.location.origin}/openapi/v1/files/product_assets/file-456`);
         });
 
         // Verify fetch was called with correct content type
@@ -358,7 +420,7 @@ describe('useFileUpload', () => {
 
         await waitFor(async () => {
             const url = await uploadPromise;
-            expect(url).toBe('http://example.com/openapi/v1/files/product_assets/file-789');
+            expect(url).toBe(`${window.location.origin}/openapi/v1/files/product_assets/file-789`);
         });
         expect(mockCreateFile).toHaveBeenCalledTimes(1);
         expect(mockCreateFile).toHaveBeenCalledWith(mockFileId, mockFile);

--- a/datahub-web-react/src/app/shared/hooks/useFileUpload.ts
+++ b/datahub-web-react/src/app/shared/hooks/useFileUpload.ts
@@ -61,9 +61,7 @@ export default function useFileUpload({ scenario, assetUrn, schemaField }: Props
 
         // Absolute URL so LinkUtils scheme validation accepts the link; encode fileId so
         // spaces/reserved chars in the original filename do not break URI.create.
-        const path = resolveRuntimePath(
-            `/openapi/v1/files/${PRODUCT_ASSETS_FOLDER}/${encodeURIComponent(fileId)}`,
-        );
+        const path = resolveRuntimePath(`/openapi/v1/files/${PRODUCT_ASSETS_FOLDER}/${encodeURIComponent(fileId)}`);
         return `${window.location.origin}${path}`;
     };
 

--- a/datahub-web-react/src/app/shared/hooks/useFileUpload.ts
+++ b/datahub-web-react/src/app/shared/hooks/useFileUpload.ts
@@ -59,7 +59,12 @@ export default function useFileUpload({ scenario, assetUrn, schemaField }: Props
             throw new Error(`Failed to upload file: ${error}`);
         }
 
-        return resolveRuntimePath(`/openapi/v1/files/${PRODUCT_ASSETS_FOLDER}/${fileId}`);
+        // Absolute URL so LinkUtils scheme validation accepts the link; encode fileId so
+        // spaces/reserved chars in the original filename do not break URI.create.
+        const path = resolveRuntimePath(
+            `/openapi/v1/files/${PRODUCT_ASSETS_FOLDER}/${encodeURIComponent(fileId)}`,
+        );
+        return `${window.location.origin}${path}`;
     };
 
     return isDocumentationFileUploadV1Enabled ? { uploadFile } : { uploadFile: undefined };

--- a/e2e-test/ui/playwright/pages/description-editor.page.ts
+++ b/e2e-test/ui/playwright/pages/description-editor.page.ts
@@ -113,7 +113,8 @@ export default class DescriptionEditorPage extends BasePage {
     const fileNode = this.editorFileNodesContainer.getByTestId(this.getFileNodeTestId(fileName));
     await expect(fileNode).toBeVisible();
 
-    const urlPattern = /\/openapi\/v1\/files\/product_assets\/urn:li:dataHubFile:.+/;
+    // fileId is percent-encoded in the URL (e.g. urn%3Ali%3AdataHubFile%3A...)
+    const urlPattern = /\/openapi\/v1\/files\/product_assets\/.+/;
     await this.waitForFileUrlAttribute(fileNode, urlPattern);
     await expect(fileNode).toContainText(fileName);
   }
@@ -122,7 +123,7 @@ export default class DescriptionEditorPage extends BasePage {
     const fileNode = this.aboutFileNodesContainer.getByTestId(this.getFileNodeTestId(fileName));
     await expect(fileNode).toBeVisible();
 
-    const urlPattern = /\/openapi\/v1\/files\/product_assets\/urn:li:dataHubFile:.+/;
+    const urlPattern = /\/openapi\/v1\/files\/product_assets\/.+/;
     await this.waitForFileUrlAttribute(fileNode, urlPattern);
     await expect(fileNode).toContainText(fileName);
   }


### PR DESCRIPTION
## Summary
- Restore **upload file as entity link** (CAT-3125): `useFileUpload` now returns an absolute URL (`window.location.origin` + runtime path) with `fileId` percent-encoded so `LinkUtils` scheme validation accepts it, including filenames with spaces.
- This has been broken since the URL scheme allowlist ([#17489](https://github.com/datahub-project/datahub/pull/17489)) rejected relative `/openapi/v1/files/...` paths (`URL scheme 'null' is not allowed`) and unencoded spaces (`Illegal character in path`).
- Tests: pass-through `resolveRuntimePath` mock, spaces-in-filename case, and an encoded product-asset URL in `LinkUtilsTest`.

Fixes https://linear.app/acryl-data/issue/CAT-3125/cannot-add-uploaded-pdf-as-link-to-domain-due-to-invalid-relative-file

## Test plan
- [ ] Upload a PDF with spaces in the filename as a Domain/entity link; confirm it saves and opens
- [ ] Upload a PDF without spaces as a link; confirm it saves (no `scheme 'null'` error)
- [ ] Click the stored link; file downloads via `/openapi/v1/files/product_assets/...`
- [ ] `yarn test src/app/shared/hooks/__tests__/useFileUpload.test.tsx --run` from `datahub-web-react/`
- [ ] `./gradlew :datahub-graphql-core:test --tests com.linkedin.datahub.graphql.resolvers.mutate.util.LinkUtilsTest`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CAT-3125: restores adding uploaded files as entity links by returning absolute, percent-encoded URLs from `useFileUpload`. The previous relative paths were rejected by the URL scheme allowlist, and filenames with spaces broke URI creation.

**Bug Fixes**
- Prepends `window.location.origin` to the runtime path and percent-encodes the `fileId`.
- Updates Playwright link assertions to accept percent-encoded fileIds.

<sup>Written for commit 38a867fdf9fcc40ebf7ccf2e92fe6ed8ca4a0087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

