### PR TITLE
refactor(ui): upstream SaaS changes in app/shared to reduce OSS/SaaS drift

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/StyledTag.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StyledTag.tsx
@@ -6,10 +6,10 @@ export const generateColor = new ColorHash({
     saturation: 0.9,
 });
 
-export const StyledTag = styled(Tag)<{ $color: any; $colorHash?: string; fontSize?: number; highlightTag?: boolean }>`
+export const StyledTag = styled(Tag)<{ $color: any; $colorHash?: string; fontSize?: number; $highlightTag?: boolean }>`
     &&& {
         ${(props) =>
-            props.highlightTag &&
+            props.$highlightTag &&
             `
                 background: ${props.theme.colors.bgSurfaceBrand};
                 border: 1px solid ${props.theme.colors.borderBrand};

--- a/datahub-web-react/src/app/shared/AppLogoLink.tsx
+++ b/datahub-web-react/src/app/shared/AppLogoLink.tsx
@@ -6,11 +6,15 @@ import styled, { useTheme } from 'styled-components';
 import { useAppConfig } from '@app/useAppConfig';
 import { DEFAULT_APP_CONFIG } from '@src/appConfigContext';
 
+const StyledLink = styled(Link)`
+    display: flex;
+`;
+
 const LogoImage = styled(Image)`
     display: inline-block;
     height: 32px;
     width: auto;
-    margin-top: 2px;
+    display: flex;
 `;
 
 export default function AppLogoLink() {
@@ -18,7 +22,7 @@ export default function AppLogoLink() {
     const themeConfig = useTheme();
 
     return (
-        <Link to="/">
+        <StyledLink to="/">
             <LogoImage
                 src={
                     appConfig.config !== DEFAULT_APP_CONFIG
@@ -27,6 +31,6 @@ export default function AppLogoLink() {
                 }
                 preview={false}
             />
-        </Link>
+        </StyledLink>
     );
 }

--- a/datahub-web-react/src/app/shared/ClickOutside.tsx
+++ b/datahub-web-react/src/app/shared/ClickOutside.tsx
@@ -4,14 +4,15 @@ interface OutsideAlerterType {
     children: React.ReactNode;
     onClickOutside: () => void;
     wrapperClassName?: string;
+    style?: React.CSSProperties;
 }
 
-export default function ClickOutside({ children, onClickOutside, wrapperClassName }: OutsideAlerterType) {
+export default function ClickOutside({ children, onClickOutside, wrapperClassName, style }: OutsideAlerterType) {
     const wrapperRef = useRef<HTMLDivElement>(null);
 
     function handleClickOutside(event) {
         if (wrapperClassName) {
-            if (event.target && event.target.classList.contains(wrapperClassName)) {
+            if (event.target && event.target.classList?.contains(wrapperClassName)) {
                 onClickOutside();
             }
         } else if (!(wrapperRef.current as HTMLDivElement).contains((event.target as Node) || null)) {
@@ -28,5 +29,9 @@ export default function ClickOutside({ children, onClickOutside, wrapperClassNam
         };
     });
 
-    return <div ref={wrapperRef}>{children}</div>;
+    return (
+        <div ref={wrapperRef} style={style}>
+            {children}
+        </div>
+    );
 }

--- a/datahub-web-react/src/app/shared/CopyUrn.tsx
+++ b/datahub-web-react/src/app/shared/CopyUrn.tsx
@@ -1,12 +1,13 @@
 import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
-import { Button, Tooltip } from 'antd';
+import { Tooltip } from '@components';
+import { Button } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface CopyUrnProps {
     urn: string;
-    isActive: boolean;
-    onClick: () => void;
+    isActive?: boolean;
+    onClick?: () => void;
 }
 
 export default function CopyUrn({ urn, isActive, onClick }: CopyUrnProps) {
@@ -18,7 +19,7 @@ export default function CopyUrn({ urn, isActive, onClick }: CopyUrnProps) {
                     icon={isActive ? <CheckOutlined /> : <CopyOutlined />}
                     onClick={() => {
                         navigator.clipboard.writeText(urn);
-                        onClick();
+                        onClick?.();
                     }}
                 />
             </Tooltip>

--- a/datahub-web-react/src/app/shared/RoutedTabs.tsx
+++ b/datahub-web-react/src/app/shared/RoutedTabs.tsx
@@ -5,17 +5,20 @@ import { Redirect, useHistory } from 'react-router';
 import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { ErrorBoundary } from '@app/sharedV2/ErrorHandling/ErrorBoundary';
+
 const { TabPane } = Tabs;
 
 interface Props extends TabsProps {
     defaultPath: string;
     tabs: Array<{
-        name: string;
+        name: string | React.ReactNode;
         path: string;
         content: React.ReactNode;
         display?: {
             enabled: () => boolean;
         };
+        customTitle?: React.ReactElement;
     }>;
     onTabChange?: (selectedTab: string) => void;
 }
@@ -24,6 +27,11 @@ const RoutedTabsStyle = styled.div`
     display: flex;
     flex-direction: column;
     height: 100%;
+    overflow: auto;
+`;
+
+const RouteContainer = styled.div`
+    flex: 1;
     overflow: auto;
 `;
 
@@ -53,7 +61,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
                 {tabs.map((tab) => {
                     return (
                         <TabPane
-                            tab={tab.name}
+                            tab={tab.customTitle ? tab.customTitle : tab.name}
                             key={tab.path.replace('/', '')}
                             disabled={!tab.display?.enabled()}
                             data-testid={`tab-${tab.path.replace('/', '').toLowerCase()}`}
@@ -65,15 +73,18 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
                 <Route exact path={path}>
                     <Redirect to={`${pathname}${pathname.endsWith('/') ? '' : '/'}${defaultPath}`} />
                 </Route>
-
-                {tabs.map((tab) => (
-                    <Route
-                        exact
-                        path={`${path}/${tab.path.replace('/', '')}`}
-                        render={() => tab.content}
-                        key={tab.path}
-                    />
-                ))}
+                <ErrorBoundary resetKeys={[activePath]} variant="tab">
+                    <RouteContainer>
+                        {tabs.map((tab) => (
+                            <Route
+                                exact
+                                path={`${path}/${tab.path.replace('/', '')}`}
+                                render={() => tab.content}
+                                key={tab.path}
+                            />
+                        ))}
+                    </RouteContainer>
+                </ErrorBoundary>
             </Switch>
         </RoutedTabsStyle>
     );

--- a/datahub-web-react/src/app/shared/ShowMoreSection.tsx
+++ b/datahub-web-react/src/app/shared/ShowMoreSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-const ShowMoreButton = styled.div`
+export const ShowMoreButton = styled.div`
     padding: 4px;
     color: ${(props) => props.theme.colors.textSecondary};
     text-align: left;

--- a/datahub-web-react/src/app/shared/TagStyleEntity.tsx
+++ b/datahub-web-react/src/app/shared/TagStyleEntity.tsx
@@ -164,6 +164,13 @@ const TagHeader = styled.div`
     align-items: top;
 `;
 
+const OwnersContainer = styled.div`
+    display: flex;
+    align-items: top;
+    flex-wrap: wrap;
+    gap: 4px;
+`;
+
 const { Paragraph } = Typography;
 
 type Props = {
@@ -229,7 +236,8 @@ export default function TagStyleEntity({
             input: {
                 query: '*',
                 start: 0,
-                count: 1,
+                // Facets only — result body is unused.
+                count: 0,
                 orFilters: generateOrFilters(UnionType.OR, entityFilters),
             },
         },
@@ -433,7 +441,7 @@ export default function TagStyleEntity({
                 </StatsBox>
                 <div>
                     <StatsLabel>{tcLabels('owners')}</StatsLabel>
-                    <div>
+                    <OwnersContainer>
                         {data?.tag?.ownership?.owners?.map((owner) => (
                             <ExpandedOwner entityUrn={urn} owner={owner} refetch={refetch} hidePopOver />
                         ))}
@@ -451,7 +459,7 @@ export default function TagStyleEntity({
                                 <OwnerButtonTitle>{t('addOwners')}</OwnerButtonTitle>
                             )}
                         </Button>
-                    </div>
+                    </OwnersContainer>
                     <div>
                         {showAddModal && (
                             <EditOwnersModal

--- a/datahub-web-react/src/app/shared/components.tsx
+++ b/datahub-web-react/src/app/shared/components.tsx
@@ -22,10 +22,15 @@ export const BodyGridExpander = styled.div<{ isOpen: boolean }>`
     grid-template-rows: ${(props) => (props.isOpen ? '1fr' : '0fr')};
     transition: grid-template-rows 250ms;
     overflow: hidden;
+    max-width: 100%;
+    position: relative;
 `;
 
 export const BodyContainer = styled.div`
     min-height: 0;
+    position: relative;
+    max-width: 100%;
+    overflow: hidden;
 `;
 
 export const WhiteButton = styled(Button)`

--- a/datahub-web-react/src/app/shared/hooks/__tests__/useUploadFileHandler.test.ts
+++ b/datahub-web-react/src/app/shared/hooks/__tests__/useUploadFileHandler.test.ts
@@ -64,7 +64,7 @@ describe('useUploadFileHandler', () => {
             await result.current(mockFile);
         });
 
-        expect(validateFile).toHaveBeenCalledWith(mockFile);
+        expect(validateFile).toHaveBeenCalledWith(mockFile, undefined);
     });
 
     it('should return null and show error notification if file validation fails', async () => {

--- a/datahub-web-react/src/app/shared/hooks/useUploadFileHandler.ts
+++ b/datahub-web-react/src/app/shared/hooks/useUploadFileHandler.ts
@@ -14,10 +14,15 @@ interface Props {
     scenario: UploadDownloadScenario;
     assetUrn?: string;
     schemaField?: string;
+    validateFileOptions?: {
+        maxSize?: number;
+        allowedTypes?: string[];
+    };
 }
 
 export function useUploadFileHandler(props: Props) {
-    const { uploadFile: onFileUpload } = useFileUpload(props);
+    const { validateFileOptions, ...uploadProps } = props;
+    const { uploadFile: onFileUpload } = useFileUpload(uploadProps);
     const analyticsCallbacks = useFileUploadAnalyticsCallbacks(props);
 
     const handleFileUpload = useCallback(
@@ -25,7 +30,7 @@ export function useUploadFileHandler(props: Props) {
             try {
                 analyticsCallbacks.onFileUploadAttempt?.(file.type, file.size, 'button');
 
-                const validation = validateFile(file);
+                const validation = validateFile(file, validateFileOptions);
 
                 if (!validation.isValid) {
                     console.error(validation.error);
@@ -84,7 +89,7 @@ export function useUploadFileHandler(props: Props) {
                 return null;
             }
         },
-        [analyticsCallbacks, onFileUpload],
+        [analyticsCallbacks, onFileUpload, validateFileOptions],
     );
 
     return handleFileUpload;

--- a/datahub-web-react/src/app/shared/numberUtil.ts
+++ b/datahub-web-react/src/app/shared/numberUtil.ts
@@ -2,3 +2,21 @@ export function parseMaybeStringAsFloatOrDefault<T>(str: any, fallback?: T): num
     const parsedValue = typeof str === 'string' ? parseFloat(str) : str;
     return typeof parsedValue === 'number' && !Number.isNaN(parsedValue) ? parsedValue : fallback;
 }
+
+export function parseJsonArrayOrDefault<T>(str: any, fallback: T[] = []): T[] | undefined {
+    // Check if the input is a string and try to parse it.
+    if (typeof str === 'string') {
+        try {
+            const parsedValue = JSON.parse(str);
+            // Check if the parsed value is an array before returning.
+            if (Array.isArray(parsedValue)) {
+                return parsedValue;
+            }
+        } catch (e) {
+            // If parsing throws, log the error (optional) and proceed to return fallback.
+            console.error('Failed to parse JSON:', e);
+        }
+    }
+    // Return fallback if the above conditions fail.
+    return fallback;
+}

--- a/datahub-web-react/src/app/shared/product/update/hooks.ts
+++ b/datahub-web-react/src/app/shared/product/update/hooks.ts
@@ -38,7 +38,7 @@ export function useGetLatestProductAnnouncementData() {
     return data.latestProductUpdate;
 }
 
-type ProductAnnouncementResult = {
+export type ProductAnnouncementResult = {
     visible: boolean;
     refetch: () => void;
 };

--- a/datahub-web-react/src/app/shared/tags/AddTagsModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagsModal.tsx
@@ -1,25 +1,16 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
 
-import { FORBIDDEN_URN_CHARS_REGEX } from '@app/entity/shared/utils';
 import { OperationType, isAddOperation, useBatchTagTermMutation } from '@app/shared/tags/useBatchTagTermMutation';
 import { useEntityPickerState } from '@app/shared/tags/useEntityPickerState';
 import TagPill from '@app/sharedV2/tags/TagPill';
+import TagSelect from '@app/sharedV2/tags/TagSelect';
 import CreateNewTagModal from '@app/tags/CreateNewTagModal/CreateNewTagModal';
-import { useEntityRegistry } from '@app/useEntityRegistry';
-import { Modal, SimpleSelect } from '@src/alchemy-components';
+import { Modal } from '@src/alchemy-components';
 import { SelectOption } from '@src/alchemy-components/components/Select/types';
 import { getModalDomContainer } from '@utils/focus';
 
-import { Entity, EntityType, ResourceRefInput, Tag } from '@types';
-
-// Sentinel value for the synthetic "Create <name>" option appended to the dropdown when the
-// typed query doesn't match any existing tag. Picking this option opens `CreateNewTagModal`
-// instead of toggling selection — the value never actually lands in `urns`.
-const CREATE_TAG_VALUE = '____reserved____.createTagValue';
-
-const isValidTagName = (name: string) => name.length > 0 && !FORBIDDEN_URN_CHARS_REGEX.test(name);
+import { Entity, EntityType, ResourceRefInput } from '@types';
 
 type Props = {
     open: boolean;
@@ -38,25 +29,6 @@ interface TagOption extends SelectOption {
     color?: string;
 }
 
-const OptionRow = styled.div`
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
-`;
-
-const CreateOptionLabel = styled.span`
-    color: ${(props) => props.theme.colors.textBrand};
-    font-weight: 500;
-`;
-
-const toOption = (entity: Entity, displayName: string): TagOption => ({
-    value: entity.urn,
-    label: (entity as Tag).name || displayName,
-    entity,
-    color: (entity as Tag).properties?.colorHex || undefined,
-});
-
 export default function AddTagsModal({
     open,
     onCloseModal,
@@ -68,63 +40,23 @@ export default function AddTagsModal({
 }: Props) {
     const { t } = useTranslation('shared.tags');
     const { t: tc } = useTranslation('common.actions');
-    const entityRegistry = useEntityRegistry();
     const { runMutation, disableAction } = useBatchTagTermMutation();
     const [createTagName, setCreateTagName] = useState<string | null>(null);
 
-    const { urns, setUrns, removeUrn, entityCache, searchText, handleSearch, currentEntities, isLoading } =
-        useEntityPickerState({
-            entityType: EntityType.Tag,
-            defaultValues,
-        });
+    const { urns, setUrns, removeUrn } = useEntityPickerState({
+        entityType: EntityType.Tag,
+        defaultValues,
+    });
 
-    const excludeSet = useMemo(() => new Set(existingUrns || []), [existingUrns]);
-
-    const dropdownOptions = useMemo<TagOption[]>(() => {
-        const opts = currentEntities.map((e) => toOption(e, entityRegistry.getDisplayName(e.type, e)));
-        const filtered = excludeSet.size === 0 ? opts : opts.filter((o) => !excludeSet.has(o.value));
-
-        // Append a synthetic "Create <name>" option when the typed query doesn't match any existing
-        // tag — mirrors the legacy `AddTagsTermsModal` behavior. Only offered on ADD operations and
-        // when no items are already selected (the create flow assigns exactly one new tag).
-        const trimmed = searchText.trim();
-        const exactMatch = filtered.some(
-            (o) => typeof o.label === 'string' && o.label.toLowerCase() === trimmed.toLowerCase(),
-        );
-        const showCreate =
-            isAddOperation(operationType) &&
-            trimmed.length > 0 &&
-            isValidTagName(trimmed) &&
-            !exactMatch &&
-            urns.length === 0;
-        if (showCreate) {
-            filtered.push({ value: CREATE_TAG_VALUE, label: t('createOption', { inputValue: trimmed }) });
-        }
-        return filtered;
-    }, [currentEntities, entityRegistry, excludeSet, operationType, searchText, urns.length, t]);
-
-    const combinedOptions = useMemo<TagOption[]>(() => {
-        const inDropdown = new Set(dropdownOptions.map((o) => o.value));
-        const extras = urns
-            .filter((urn) => !inDropdown.has(urn))
-            .map<TagOption>((urn) => {
-                const entity = entityCache[urn];
-                if (entity) return toOption(entity, entityRegistry.getDisplayName(entity.type, entity));
-                return { value: urn, label: urn };
-            });
-        return [...dropdownOptions, ...extras];
-    }, [dropdownOptions, urns, entityCache, entityRegistry]);
+    // Pre-resolved entities for the default selection (e.g. editing an existing advanced
+    // search filter) — seeds TagSelect's cache so their chips render with proper labels.
+    const defaultEntities = useMemo(
+        () => defaultValues.map((value) => value.entity).filter((entity): entity is Entity => !!entity),
+        [defaultValues],
+    );
 
     const renderOption = useCallback(
-        (option: TagOption) => (
-            <OptionRow data-testid={`tag-term-option-${option.label}`}>
-                {option.value === CREATE_TAG_VALUE ? (
-                    <CreateOptionLabel>{option.label}</CreateOptionLabel>
-                ) : (
-                    <TagPill name={option.label} color={option.color} colorHash={option.value} />
-                )}
-            </OptionRow>
-        ),
+        (option: TagOption) => <TagPill name={option.label} color={option.color} colorHash={option.value} />,
         [],
     );
 
@@ -142,17 +74,15 @@ export default function AddTagsModal({
         [removeUrn],
     );
 
+    const handleCreateTag = useCallback((tagName: string) => {
+        setCreateTagName(tagName);
+    }, []);
+
     const handleUpdate = useCallback(
         (next: string[]) => {
-            // Intercept the synthetic "Create" sentinel: open CreateNewTagModal instead of letting
-            // it land in the selected URNs.
-            if (next.includes(CREATE_TAG_VALUE)) {
-                setCreateTagName(searchText.trim());
-                return;
-            }
             setUrns(next);
         },
-        [searchText, setUrns],
+        [setUrns],
     );
 
     const onOk = () => {
@@ -207,23 +137,19 @@ export default function AddTagsModal({
             ]}
             getContainer={getModalDomContainer}
         >
-            <SimpleSelect
-                isMultiSelect
-                showSearch
-                showClear={false}
-                onSearchChange={handleSearch}
-                values={urns}
+            <TagSelect
+                selectedUrns={urns}
                 onUpdate={handleUpdate}
-                options={dropdownOptions}
-                combinedSelectedAndSearchOptions={combinedOptions}
-                renderCustomOptionText={renderOption}
-                renderCustomSelectedValue={renderSelectedValue}
-                selectLabelProps={{ variant: 'custom' }}
-                filterResultsByQuery={false}
-                isLoading={isLoading}
+                renderOption={renderOption}
+                renderSelectedValue={renderSelectedValue}
+                showSearch
                 placeholder={t('tagSearchPlaceholder')}
                 width="full"
                 dataTestId="tag-term-modal-input"
+                allowCreateTag={isAddOperation(operationType)}
+                onCreateTag={handleCreateTag}
+                existingUrns={existingUrns}
+                defaultEntities={defaultEntities}
             />
         </Modal>
     );

--- a/datahub-web-react/src/app/shared/tags/AddTermsModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTermsModal.tsx
@@ -1,23 +1,13 @@
-import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
-import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
-import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
-import React, { useCallback, useMemo } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import styled from 'styled-components';
 
-import GlossaryTermPill from '@app/glossaryV2/GlossaryTermPill';
-import { getGlossaryTermColor, useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
-import { deriveGlossaryLabelFromUrn } from '@app/glossaryV2/utils';
-import { TagTermLabel } from '@app/shared/tags/TagTermLabel';
 import { OperationType, isAddOperation, useBatchTagTermMutation } from '@app/shared/tags/useBatchTagTermMutation';
 import { useEntityPickerState } from '@app/shared/tags/useEntityPickerState';
-import { useGlossaryTreeEntities } from '@app/shared/tags/useGlossaryTreeEntities';
-import { TermTreeOption, useTermTreeOptions } from '@app/shared/tags/useTermTreeOptions';
-import { useEntityRegistry } from '@app/useEntityRegistry';
-import { Loader, Modal, SimpleSelect } from '@src/alchemy-components';
+import GlossarySelect from '@app/sharedV2/glossary/GlossarySelect';
+import { Modal } from '@src/alchemy-components';
 import { getModalDomContainer } from '@utils/focus';
 
-import { Entity, EntityType, GlossaryTerm, ResourceRefInput } from '@types';
+import { Entity, EntityType, ResourceRefInput } from '@types';
 
 type Props = {
     open: boolean;
@@ -31,63 +21,11 @@ type Props = {
     existingUrns?: string[];
 };
 
-// Caret column (20px) + caret→content gap (8px). Rows under a node get this offset so their pill
-// aligns under the parent node's pill rather than the parent's caret.
-const CARET_COLUMN_WIDTH = 28;
-
-const OptionRow = styled.div<{ $depth: number; $offsetForCaret?: boolean }>`
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    min-width: 0;
-    padding-left: ${(props) => props.$depth * 16 + (props.$offsetForCaret ? CARET_COLUMN_WIDTH : 0)}px;
-`;
-
-// Base for rows that aren't real selectable options (node headers, loading placeholders): takes
-// the full row width and hides the alchemy SimpleSelect's adjacent checkbox via the sibling
-// combinator so the row reads as static rather than a disabled option with a greyed-out tick.
-const NonSelectableRow = styled(OptionRow)`
-    flex: 1;
-    & ~ * {
-        display: none !important;
-    }
-`;
-
-// Synthetic loading row inserted by `useTermTreeOptions` while a node's children are being fetched.
-const LoadingRow = styled(NonSelectableRow)`
-    color: ${(props) => props.theme.colors.textSecondary};
-    font-size: 12px;
-`;
-
-const CaretButton = styled.button`
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    padding: 0;
-    background: transparent;
-    border: none;
-    color: ${(props) => props.theme.colors.icon};
-    cursor: pointer;
-    flex-shrink: 0;
-
-    :hover {
-        color: ${(props) => props.theme.colors.iconHover};
-    }
-`;
-
 /**
  * Modal that lets the user add (or remove) glossary terms on one or more resources.
  *
- * Initial state walks the live glossary tree from roots, with lazy-loaded children on expand — the
- * same data flow the `/glossary` sidebar uses (`useGlossaryTreeEntities`). When the user types into
- * the search input, we fall through to the autocomplete path from `useEntityPickerState` and
- * flatten the tree (no expand filtering).
- *
- * The list is rendered through alchemy `SimpleSelect` in multi-select mode (native checkboxes).
- * `useTermTreeOptions` shapes the entities into an indented tree, with node header rows holding
- * inline expand/collapse carets that flip visibility *and* trigger child fetches.
+ * The tree-browse / search UI lives in `GlossarySelect`, shared with the policy form's glossary
+ * picker. This modal owns only the selection state and the batch mutation.
  */
 export default function AddTermsModal({
     open,
@@ -100,172 +38,9 @@ export default function AddTermsModal({
 }: Props) {
     const { t } = useTranslation('shared.tags');
     const { t: tc } = useTranslation('common.actions');
-    const entityRegistry = useEntityRegistry();
-    const generateColor = useGenerateGlossaryColorFromPalette();
     const { runMutation, disableAction } = useBatchTagTermMutation();
 
-    // Picker state owns selection + the autocomplete search path.
-    const {
-        urns,
-        setUrns,
-        removeUrn,
-        entityCache,
-        searchText,
-        handleSearch,
-        currentEntities: searchEntities,
-        isLoading: searchLoading,
-    } = useEntityPickerState({ entityType: EntityType.GlossaryTerm, defaultValues });
-
-    // Glossary-tree data owns the browse path (roots + lazy-loaded children).
-    const {
-        entities: treeEntities,
-        entityCache: treeEntityCache,
-        expandedNodes,
-        fetchingNodes,
-        expandNode,
-        collapseNode,
-        isLoading: treeLoading,
-    } = useGlossaryTreeEntities();
-
-    // Browse when the search input is empty; flatten autocomplete results when the user is searching.
-    const isSearching = searchText.length > 0;
-    const sourceEntities = isSearching ? searchEntities : treeEntities;
-
-    // Selected chips look up display names from either cache. The picker cache covers search /
-    // recommendations / defaults; the tree cache covers anything the user clicked into via the
-    // browse path (and persists across collapse, unlike `treeEntities`). Picker cache wins on
-    // collision so a freshly-loaded autocomplete result trumps a stale tree row.
-    const mergedEntityCache = useMemo<Record<string, Entity>>(
-        () => ({ ...treeEntityCache, ...entityCache }),
-        [treeEntityCache, entityCache],
-    );
-
-    const { visibleOptions, allOptions, disabledValues, nodesWithChildren } = useTermTreeOptions({
-        entities: sourceEntities,
-        excludeUrns: existingUrns,
-        // While searching, show every result flat — the user is disambiguating with the text query,
-        // not the tree. While browsing, only show rows whose ancestors the user has expanded.
-        expandedNodes: isSearching ? undefined : expandedNodes,
-        // Drop inline loading rows under any node currently fetching its children. Skipped while
-        // searching since the flat result list doesn't have parent rows to hang the loader under.
-        loadingNodeUrns: isSearching ? undefined : fetchingNodes,
-    });
-
-    // Render the currently-selected URNs as extras so SimpleSelect can render the chip strip
-    // even after a search clears the underlying options or a tree branch is collapsed.
-    const combinedOptions = useMemo<TermTreeOption[]>(() => {
-        const inDropdown = new Set(allOptions.map((o) => o.value));
-        const extras = urns
-            .filter((urn) => !inDropdown.has(urn))
-            .map<TermTreeOption>((urn) => {
-                const entity = mergedEntityCache[urn];
-                if (entity) {
-                    const name = entityRegistry.getDisplayName(entity.type, entity);
-                    // `getDisplayName` falls back to the URN if `properties.name`/`name` are missing,
-                    // so guard against that leaking into the chip label.
-                    const label = name && !name.startsWith('urn:') ? name : deriveGlossaryLabelFromUrn(urn);
-                    return {
-                        value: entity.urn,
-                        label,
-                        entity,
-                        color: getGlossaryTermColor(entity as GlossaryTerm, generateColor),
-                    };
-                }
-                return { value: urn, label: deriveGlossaryLabelFromUrn(urn) };
-            });
-        return [...allOptions, ...extras];
-    }, [allOptions, urns, mergedEntityCache, entityRegistry, generateColor]);
-
-    const handleCaretClick = useCallback(
-        (nodeUrn: string) => {
-            if (expandedNodes.has(nodeUrn)) collapseNode(nodeUrn);
-            else expandNode(nodeUrn);
-        },
-        [expandedNodes, collapseNode, expandNode],
-    );
-
-    const renderOption = useCallback(
-        (option: TermTreeOption) => {
-            const depth = option.depth || 0;
-            if (option.isLoadingPlaceholder) {
-                return (
-                    <LoadingRow $depth={depth} $offsetForCaret>
-                        <Loader size="xs" justifyContent="flex-start" alignItems="center" />
-                    </LoadingRow>
-                );
-            }
-            if (option.isNode) {
-                // A node should show a caret if either (a) we already know it has descendant rows
-                // (term lineages from the search path), or (b) it's a standalone node entity that
-                // has not been expanded yet (browse path — caret triggers a child fetch).
-                const hasChildren = nodesWithChildren.has(option.value) || option.isEmptyNode;
-                const isExpanded = expandedNodes.has(option.value);
-                const CaretIcon = isExpanded ? CaretDown : CaretRight;
-                return (
-                    <NonSelectableRow $depth={depth} data-testid={`tag-term-option-${option.label}`}>
-                        <CaretButton
-                            type="button"
-                            aria-label={
-                                isExpanded
-                                    ? t('collapseTerm', { label: option.label })
-                                    : t('expandTerm', { label: option.label })
-                            }
-                            aria-expanded={isExpanded}
-                            // Stops alchemy SimpleSelect from treating this as an option click.
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                if (hasChildren) handleCaretClick(option.value);
-                            }}
-                            style={{ visibility: hasChildren ? 'visible' : 'hidden' }}
-                        >
-                            <CaretIcon size={14} weight="regular" />
-                        </CaretButton>
-                        <GlossaryTermPill
-                            name={option.label}
-                            color={option.color ?? generateColor(option.value)}
-                            icon={BookmarksSimple}
-                        />
-                    </NonSelectableRow>
-                );
-            }
-            const hasAncestors = (option.ancestorUrns?.length ?? 0) > 0;
-            if (option.entity?.type === EntityType.GlossaryTerm) {
-                return (
-                    <OptionRow
-                        $depth={depth}
-                        $offsetForCaret={hasAncestors}
-                        data-testid={`tag-term-option-${option.label}`}
-                    >
-                        <GlossaryTermPill name={option.label} color={option.color ?? generateColor(option.value)} />
-                    </OptionRow>
-                );
-            }
-            return (
-                <OptionRow
-                    $depth={depth}
-                    $offsetForCaret={hasAncestors}
-                    data-testid={`tag-term-option-${option.label}`}
-                >
-                    <TagTermLabel termName={option.label} />
-                </OptionRow>
-            );
-        },
-        [generateColor, nodesWithChildren, expandedNodes, handleCaretClick, t],
-    );
-
-    const renderSelectedValue = useCallback(
-        (option: TermTreeOption) => (
-            <GlossaryTermPill
-                key={option.value}
-                name={option.label}
-                color={option.color ?? generateColor(option.value)}
-                onRemove={() => removeUrn(option.value)}
-                dataTestId={`selected-${option.label}`}
-            />
-        ),
-        [removeUrn, generateColor],
-    );
+    const { urns, setUrns } = useEntityPickerState({ entityType: EntityType.GlossaryTerm, defaultValues });
 
     const onOk = () => {
         if (onOkOverride) {
@@ -305,24 +80,15 @@ export default function AddTermsModal({
             ]}
             getContainer={getModalDomContainer}
         >
-            <SimpleSelect
-                isMultiSelect
-                showSearch
-                showClear={false}
-                onSearchChange={handleSearch}
-                values={urns}
+            <GlossarySelect
+                selectedUrns={urns}
                 onUpdate={setUrns}
-                options={visibleOptions}
-                disabledValues={disabledValues}
-                combinedSelectedAndSearchOptions={combinedOptions}
-                renderCustomOptionText={renderOption}
-                renderCustomSelectedValue={renderSelectedValue}
-                selectLabelProps={{ variant: 'custom' }}
-                filterResultsByQuery={false}
-                isLoading={isSearching ? searchLoading : treeLoading}
                 placeholder={t('termSearchPlaceholder')}
                 width="full"
+                showSearch
+                existingUrns={existingUrns}
                 dataTestId="tag-term-modal-input"
+                defaultValues={defaultValues}
             />
         </Modal>
     );

--- a/datahub-web-react/src/app/shared/tags/DomainLink.tsx
+++ b/datahub-web-react/src/app/shared/tags/DomainLink.tsx
@@ -5,6 +5,7 @@ import styled, { useTheme } from 'styled-components';
 
 import DomainIcon from '@app/domain/DomainIcon';
 import { HoverEntityTooltip } from '@app/recommendations/renderer/component/HoverEntityTooltip';
+import { useEmbeddedProfileLinkProps } from '@app/shared/useEmbeddedProfileLinkProps';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { Domain, EntityType } from '@types';
@@ -65,6 +66,7 @@ type Props = {
 
 export const DomainLink = ({ domain, name, closable, onClose, tagStyle, readOnly, fontSize }: Props): JSX.Element => {
     const entityRegistry = useEntityRegistry();
+    const linkProps = useEmbeddedProfileLinkProps();
     const urn = domain?.urn;
 
     if (readOnly) {
@@ -86,7 +88,7 @@ export const DomainLink = ({ domain, name, closable, onClose, tagStyle, readOnly
 
     return (
         <HoverEntityTooltip entity={domain}>
-            <DomainLinkContainer to={entityRegistry.getEntityUrl(EntityType.Domain, urn)}>
+            <DomainLinkContainer to={entityRegistry.getEntityUrl(EntityType.Domain, urn)} {...linkProps}>
                 <DomainContent
                     domain={domain}
                     name={name}

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -221,7 +221,7 @@ export default function TagTermGroup({
                     const onClose = () => {
                         onOpenModal?.();
                         setShowAddModal(false);
-                        refetch?.();
+                        setTimeout(() => refetch?.(), 2000);
                     };
                     const resources = [
                         {

--- a/datahub-web-react/src/app/shared/tags/TagTermLabel.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermLabel.tsx
@@ -41,6 +41,16 @@ export const TagTermLabel = ({ entity, termName }: Props) => {
         );
     }
 
+    if (entity?.type === EntityType.GlossaryNode) {
+        return (
+            <GlossaryTermPill
+                name={entityRegistry.getDisplayName(entity.type, entity)}
+                color={generateColor(entity.urn)}
+                variant="borderless"
+            />
+        );
+    }
+
     if (termName) {
         return <GlossaryTermPill name={termName} color={generateColor(termName)} variant="borderless" />;
     }

--- a/datahub-web-react/src/app/shared/tags/__tests__/TagTermGroup.test.tsx
+++ b/datahub-web-react/src/app/shared/tags/__tests__/TagTermGroup.test.tsx
@@ -48,7 +48,7 @@ const glossaryTerms = {
 
 describe('TagTermGroup', () => {
     it('renders editable tags', async () => {
-        const { getByText, getByLabelText, queryAllByLabelText, queryByText } = render(
+        const { getByText, getByLabelText, queryByText, queryAllByLabelText } = render(
             <MockedProvider mocks={mocks} addTypename={false}>
                 <TestPageContainer>
                     <TagTermGroup editableTags={globalTags1 as GlobalTags} canRemove />
@@ -149,7 +149,7 @@ describe('TagTermGroup', () => {
     });
 
     it('renders terms', () => {
-        const { getByText, queryAllByLabelText } = render(
+        const { getByText } = render(
             <MockedProvider mocks={mocks} addTypename={false}>
                 <TestPageContainer>
                     <TagTermGroup
@@ -162,6 +162,5 @@ describe('TagTermGroup', () => {
         );
         expect(getByText('InstrumentIdentifier')).toBeInTheDocument();
         expect(getByText('InstrumentCost')).toBeInTheDocument();
-        expect(queryAllByLabelText('book').length).toBe(2);
     });
 });

--- a/datahub-web-react/src/app/shared/tags/tag/Tag.tsx
+++ b/datahub-web-react/src/app/shared/tags/tag/Tag.tsx
@@ -117,7 +117,7 @@ export default function Tag({
                             removeTag(tag);
                         }}
                         fontSize={fontSize}
-                        highlightTag={highlightTag}
+                        $highlightTag={highlightTag}
                     >
                         <Highlight
                             style={{ marginLeft: 0, fontSize }}

--- a/datahub-web-react/src/app/shared/tags/term/StyledTerm.tsx
+++ b/datahub-web-react/src/app/shared/tags/term/StyledTerm.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { HoverEntityTooltip } from '@app/recommendations/renderer/component/HoverEntityTooltip';
 import TermContent from '@app/shared/tags/term/TermContent';
+import { useEmbeddedProfileLinkProps } from '@app/shared/useEmbeddedProfileLinkProps';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { EntityType, GlossaryTermAssociation } from '@types';
@@ -33,6 +34,7 @@ interface Props {
 export default function StyledTerm(props: Props) {
     const { term, readOnly } = props;
     const entityRegistry = useEntityRegistry();
+    const linkProps = useEmbeddedProfileLinkProps();
 
     if (readOnly) {
         return (
@@ -46,7 +48,11 @@ export default function StyledTerm(props: Props) {
 
     return (
         <HoverEntityTooltip entity={term.term}>
-            <TermLink to={entityRegistry.getEntityUrl(EntityType.GlossaryTerm, term.term.urn)} key={term.term.urn}>
+            <TermLink
+                to={entityRegistry.getEntityUrl(EntityType.GlossaryTerm, term.term.urn)}
+                key={term.term.urn}
+                {...linkProps}
+            >
                 <TermContent {...props} />
             </TermLink>
         </HoverEntityTooltip>

--- a/datahub-web-react/src/app/shared/tags/term/TermContent.tsx
+++ b/datahub-web-react/src/app/shared/tags/term/TermContent.tsx
@@ -1,4 +1,4 @@
-import { BookOutlined } from '@ant-design/icons';
+import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
 import { Modal, Tag, message } from 'antd';
 import React from 'react';
 import Highlight from 'react-highlighter';
@@ -11,16 +11,27 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { useRemoveTermMutation } from '@graphql/mutations.generated';
 import { EntityType, GlossaryTermAssociation, SubResourceType } from '@types';
 
-const StyledTag = styled(Tag)<{ fontSize?: number; highlightTerm?: boolean }>`
+const StyledTag = styled(Tag)<{ fontSize?: number; $highlightTerm?: boolean; $showOneAndCount?: boolean }>`
     &&& {
         ${(props) =>
-            props.highlightTerm &&
+            props.$highlightTerm &&
             `
                 background: ${props.theme.colors.bgSurfaceBrand};
                 border: 1px solid ${props.theme.colors.borderBrand};
             `}
     }
     ${(props) => props.fontSize && `font-size: ${props.fontSize}px;`}
+    color: ${(props) => props.theme.colors.textSecondary};
+    font-weight: 400;
+    ${(props) =>
+        props.$showOneAndCount &&
+        `
+            width: 100%;
+            max-width: max-content;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: middle;
+        `}
 `;
 
 interface Props {
@@ -33,6 +44,7 @@ interface Props {
     fontSize?: number;
     onOpenModal?: () => void;
     refetch?: () => Promise<any>;
+    showOneAndCount?: boolean;
 }
 
 export default function TermContent({
@@ -45,6 +57,7 @@ export default function TermContent({
     fontSize,
     onOpenModal,
     refetch,
+    showOneAndCount,
 }: Props) {
     const { t } = useTranslation('shared.tags');
     const { t: tc } = useTranslation('common.actions');
@@ -100,9 +113,12 @@ export default function TermContent({
                 removeTerm(term);
             }}
             fontSize={fontSize}
-            highlightTerm={highlightTerm}
+            $highlightTerm={highlightTerm}
+            $showOneAndCount={showOneAndCount}
         >
-            <BookOutlined style={{ marginRight: '4px' }} />
+            <BookmarkSimple
+                style={{ fill: theme.colors.icon, marginRight: '4px', marginBottom: 4, verticalAlign: 'middle' }}
+            />
             <Highlight style={{ marginLeft: 0 }} matchStyle={highlightMatchStyle} search={highlightText}>
                 {entityRegistry.getDisplayName(EntityType.GlossaryTerm, term.term)}
             </Highlight>

--- a/datahub-web-react/src/app/shared/tags/useEntityPickerState.ts
+++ b/datahub-web-react/src/app/shared/tags/useEntityPickerState.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import useDebouncedCallback from '@app/shared/hooks/useDebouncedCallback';
 import { useGetRecommendations } from '@app/shared/recommendation';
 
 import { useGetAutoCompleteResultsLazyQuery } from '@graphql/search.generated';
@@ -53,15 +54,21 @@ export function useEntityPickerState({
     const [autoComplete, { data: searchData, loading: searchLoading }] = useGetAutoCompleteResultsLazyQuery();
     const { recommendedData, loading: recommendationsLoading } = useGetRecommendations([entityType]);
 
+    // Only the network call is debounced — searchText updates synchronously since it
+    // drives which entity list (search vs recommendations) is shown while typing.
+    const debouncedAutoComplete = useDebouncedCallback((query: string) => {
+        autoComplete({ variables: { input: { type: entityType, query, limit } } });
+    });
+
     const handleSearch = useCallback(
         (text: string) => {
             const trimmed = text.trim();
             setSearchText(trimmed);
             if (trimmed.length > 0) {
-                autoComplete({ variables: { input: { type: entityType, query: trimmed, limit } } });
+                debouncedAutoComplete(trimmed);
             }
         },
-        [autoComplete, entityType, limit],
+        [debouncedAutoComplete],
     );
 
     const searchEntities = useMemo<Entity[]>(

--- a/datahub-web-react/src/app/shared/textUtil.ts
+++ b/datahub-web-react/src/app/shared/textUtil.ts
@@ -49,6 +49,7 @@ export function pluralizeIfIrregular(noun: string, suffix = 's'): string {
     const irregularPlurals: Record<string, string> = {
         query: 'queries',
         match: 'matches',
+        property: 'properties',
         analysis: 'analyses',
         axis: 'axes',
     };

--- a/datahub-web-react/src/app/shared/time/timeUtils.tsx
+++ b/datahub-web-react/src/app/shared/time/timeUtils.tsx
@@ -33,7 +33,7 @@ const INTERVAL_TO_SECONDS = {
     [DateInterval.Year]: 31536000,
 };
 
-const INTERVAL_TO_MS = {
+export const INTERVAL_TO_MS = {
     [DateInterval.Second]: 1000,
     [DateInterval.Minute]: 60000,
     [DateInterval.Hour]: 3600000,
@@ -60,7 +60,7 @@ export type TimeWindowSize = {
 
 type TimeWindowSizeMs = number;
 
-type TimeWindow = {
+export type TimeWindow = {
     startTime: number;
     endTime: number;
 };
@@ -258,6 +258,10 @@ export function getTimeRangeDescription(startDate: Dayjs | null, endDate: Dayjs 
     }
 
     if (startDate && !endDate) {
+        const dayDiff = dayjs().diff(startDate, 'days');
+        if (dayDiff <= 30) {
+            return i18next.t('shared.time:lastDaysCount', { count: dayDiff });
+        }
         return i18next.t('shared.time:fromDate', { date: startDate.format('ll') });
     }
 

--- a/datahub-web-react/src/app/shared/updateQueryParams.test.ts
+++ b/datahub-web-react/src/app/shared/updateQueryParams.test.ts
@@ -20,17 +20,6 @@ describe('updateQueryParams', () => {
 
     const getReplaceArgs = () => (history.replace as any).mock.calls[0][0];
 
-    it('preserves plus-encoded values (3%2B) from existing params', () => {
-        const location = createLocation('/path', '?q=3%2B');
-
-        updateQueryParams({}, location, history as any);
-
-        expect(getReplaceArgs()).toEqual({
-            pathname: '/path',
-            search: 'q=3%2B',
-        });
-    });
-
     it('does not convert plus-encoded (3%2B) into space-encoded (3%20) when merging', () => {
         const location = createLocation('/search', '?q=3%2B');
 
@@ -41,5 +30,17 @@ describe('updateQueryParams', () => {
         expect(args.search).toContain('q=3%2B');
         expect(args.search).not.toContain('%20');
         expect(args.search).toContain('page=1');
+    });
+
+    it('does not call history.replace when search params are unchanged', () => {
+        const location = createLocation('/path', '?foo=bar');
+        updateQueryParams({ foo: 'bar' }, location, history as any);
+        expect(history.replace).not.toHaveBeenCalled();
+    });
+
+    it('does not call history.replace when both old and new search are empty', () => {
+        const location = createLocation('/path', '');
+        updateQueryParams({}, location, history as any);
+        expect(history.replace).not.toHaveBeenCalled();
     });
 });

--- a/datahub-web-react/src/app/shared/updateQueryParams.ts
+++ b/datahub-web-react/src/app/shared/updateQueryParams.ts
@@ -14,6 +14,11 @@ export default function updateQueryParams(newParams: QueryParam, location: Locat
     };
     const stringifiedParams = QueryString.stringify(updatedParams, { arrayFormat: 'comma', encode: false });
 
+    const newSearch = stringifiedParams ? `?${stringifiedParams}` : '';
+    if (location.search === newSearch) {
+        return;
+    }
+
     history.replace(
         {
             pathname: location.pathname,

--- a/datahub-web-react/src/app/shared/useToggle.ts
+++ b/datahub-web-react/src/app/shared/useToggle.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const NOOP = (_: boolean) => {};
 
@@ -32,6 +32,13 @@ const useToggle = ({ initialValue = false, closeDelay = 0, openDelay = 0, onTogg
         },
         [openDelay, onToggle],
     );
+
+    // below code only work when we have only one platform item and it will expand that platform item
+    useEffect(() => {
+        if (initialValue) {
+            setIsOpen(initialValue);
+        }
+    }, [initialValue, setIsOpen]);
 
     const toggle = () => {
         if (isOpen) {

--- a/datahub-web-react/src/app/sharedV2/glossary/GlossarySelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/glossary/GlossarySelect.tsx
@@ -289,6 +289,7 @@ export default function GlossarySelect({
             onSearchChange={handleSearch}
             renderCustomOptionText={renderOption}
             renderCustomSelectedValue={renderSelectedValue}
+            selectLabelProps={{ variant: 'custom' }}
             isLoading={isSearching ? searchLoading : treeLoading}
             dataTestId={dataTestId}
         />

--- a/datahub-web-react/src/app/sharedV2/glossary/GlossarySelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/glossary/GlossarySelect.tsx
@@ -1,0 +1,296 @@
+import { Loader, SimpleSelect } from '@components';
+import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
+import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+import GlossaryColoredIcon from '@app/glossaryV2/GlossaryColoredIcon';
+import GlossaryTermPill from '@app/glossaryV2/GlossaryTermPill';
+import { getGlossaryTermColor, useGenerateGlossaryColorFromPalette } from '@app/glossaryV2/colorUtils';
+import { deriveGlossaryLabelFromUrn } from '@app/glossaryV2/utils';
+import { TagTermLabel } from '@app/shared/tags/TagTermLabel';
+import { useEntityPickerState } from '@app/shared/tags/useEntityPickerState';
+import { useGlossaryTreeEntities } from '@app/shared/tags/useGlossaryTreeEntities';
+import { TermTreeOption, useTermTreeOptions } from '@app/shared/tags/useTermTreeOptions';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { Entity, EntityType, GlossaryTerm } from '@types';
+
+const CARET_COLUMN_WIDTH = 28;
+
+const OptionRow = styled.div<{ $depth: number; $offsetForCaret?: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding-left: ${(props) => props.$depth * 16 + (props.$offsetForCaret ? CARET_COLUMN_WIDTH : 0)}px;
+`;
+
+const NonSelectableRow = styled(OptionRow)`
+    flex: 1;
+    pointer-events: none;
+    & ~ * {
+        display: none !important;
+    }
+`;
+
+const LoadingRow = styled(NonSelectableRow)`
+    color: ${(props) => props.theme.colors.textSecondary};
+    font-size: 12px;
+`;
+
+const CaretButton = styled.button`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: ${(props) => props.theme.colors.icon};
+    cursor: pointer;
+    flex-shrink: 0;
+    pointer-events: auto;
+
+    :hover {
+        color: ${(props) => props.theme.colors.iconHover};
+    }
+`;
+
+type Props = {
+    selectedUrns: string[];
+    onUpdate: (urns: string[]) => void;
+    placeholder?: string;
+    width?: number | 'full' | 'fit-content';
+    showSearch?: boolean;
+    existingUrns?: string[];
+    dataTestId?: string;
+    /** When true, glossary nodes (parents) are selectable; when false, they're expand/collapse headers only. */
+    areNodesSelectable?: boolean;
+    /**
+     * Pre-resolved entities for already-selected urns (e.g. from an existing filter being
+     * edited). Seeds the entity cache so pre-selected terms render real display names
+     * instead of urn-derived fallbacks.
+     */
+    defaultValues?: { urn: string; entity?: Entity | null }[];
+};
+
+/**
+ * Reusable glossary select component with tree browsing and search.
+ * Supports selecting both glossary terms and nodes (parents and children).
+ * Used in both AddTermsModal (sidebar) and GlossarySelector (policy form).
+ */
+export default function GlossarySelect({
+    selectedUrns,
+    onUpdate,
+    placeholder = 'Search for glossary terms or nodes...',
+    width = 'full',
+    showSearch = true,
+    existingUrns = [],
+    dataTestId,
+    areNodesSelectable = false,
+    defaultValues = [],
+}: Props) {
+    const { t } = useTranslation('shared.tags');
+    const entityRegistry = useEntityRegistryV2();
+    const generateColor = useGenerateGlossaryColorFromPalette();
+
+    // Picker state owns the autocomplete search path.
+    const {
+        entityCache,
+        searchText,
+        handleSearch,
+        currentEntities: searchEntities,
+        isLoading: searchLoading,
+    } = useEntityPickerState({ entityType: EntityType.GlossaryTerm, defaultValues });
+
+    // Glossary-tree data owns the browse path (roots + lazy-loaded children).
+    const {
+        entities: treeEntities,
+        entityCache: treeEntityCache,
+        expandedNodes,
+        fetchingNodes,
+        expandNode,
+        collapseNode,
+        isLoading: treeLoading,
+    } = useGlossaryTreeEntities();
+
+    // Browse when the search input is empty; flatten autocomplete results when the user is searching.
+    const isSearching = searchText.length > 0;
+    const sourceEntities = isSearching ? searchEntities : treeEntities;
+
+    // Merged cache from both paths
+    const mergedEntityCache = useMemo<Record<string, Entity>>(
+        () => ({ ...treeEntityCache, ...entityCache }),
+        [treeEntityCache, entityCache],
+    );
+
+    const { visibleOptions, allOptions, nodesWithChildren } = useTermTreeOptions({
+        entities: sourceEntities,
+        excludeUrns: existingUrns,
+        expandedNodes: isSearching ? undefined : expandedNodes,
+        loadingNodeUrns: isSearching ? undefined : fetchingNodes,
+    });
+
+    // When nodes are not selectable, disable them in SimpleSelect so they can't be clicked/selected.
+    // This prevents dropdown content from changing when clicking on node rows.
+    const disabledValues = useMemo(() => {
+        if (areNodesSelectable) return [];
+        return visibleOptions.filter((o) => o.isNode || o.isLoadingPlaceholder).map((o) => o.value);
+    }, [visibleOptions, areNodesSelectable]);
+
+    const combinedOptions = useMemo<TermTreeOption[]>(() => {
+        const inDropdown = new Set(allOptions.map((o) => o.value));
+        const extras = selectedUrns
+            .filter((urn) => !inDropdown.has(urn))
+            .map<TermTreeOption>((urn) => {
+                const entity = mergedEntityCache[urn];
+                if (entity) {
+                    const name = entityRegistry.getDisplayName(entity.type, entity);
+                    const label = name && !name.startsWith('urn:') ? name : deriveGlossaryLabelFromUrn(urn);
+                    return {
+                        value: entity.urn,
+                        label,
+                        entity,
+                        color: getGlossaryTermColor(entity as GlossaryTerm, generateColor),
+                    };
+                }
+                return { value: urn, label: deriveGlossaryLabelFromUrn(urn) };
+            });
+        return [...allOptions, ...extras];
+    }, [allOptions, selectedUrns, mergedEntityCache, entityRegistry, generateColor]);
+
+    const handleCaretClick = useCallback(
+        (nodeUrn: string) => {
+            if (expandedNodes.has(nodeUrn)) collapseNode(nodeUrn);
+            else expandNode(nodeUrn);
+        },
+        [expandedNodes, collapseNode, expandNode],
+    );
+
+    const renderOption = useCallback(
+        (option: TermTreeOption) => {
+            const depth = option.depth || 0;
+            if (option.isLoadingPlaceholder) {
+                return (
+                    <LoadingRow $depth={depth} $offsetForCaret>
+                        <Loader size="xs" justifyContent="flex-start" alignItems="center" />
+                    </LoadingRow>
+                );
+            }
+
+            // Wrap all options with tag-term-option testid for backward compatibility with E2E tests
+            const wrapWithTestId = (content: React.ReactNode) => (
+                <div data-testid={`tag-term-option-${option.label}`}>{content}</div>
+            );
+
+            if (option.isNode) {
+                const hasChildren = nodesWithChildren.has(option.value) || option.isEmptyNode;
+                const isExpanded = expandedNodes.has(option.value);
+                const CaretIcon = isExpanded ? CaretDown : CaretRight;
+                const color = option.color ?? generateColor(option.value);
+
+                // When areNodesSelectable is true, nodes are selectable with checkboxes (like terms).
+                // When false, nodes are non-selectable headers for expanding/collapsing only.
+                const RowComponent = areNodesSelectable ? OptionRow : NonSelectableRow;
+
+                return wrapWithTestId(
+                    <RowComponent $depth={depth} data-testid={`glossary-option-${option.label}`}>
+                        <CaretButton
+                            type="button"
+                            aria-label={
+                                isExpanded
+                                    ? t('collapseTerm', { label: option.label })
+                                    : t('expandTerm', { label: option.label })
+                            }
+                            aria-expanded={isExpanded}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                if (hasChildren) handleCaretClick(option.value);
+                            }}
+                            style={{ visibility: hasChildren ? 'visible' : 'hidden' }}
+                        >
+                            <CaretIcon size={14} weight="regular" />
+                        </CaretButton>
+                        {areNodesSelectable ? (
+                            <div
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: '8px',
+                                    minWidth: 0,
+                                    flex: 1,
+                                    cursor: 'pointer',
+                                }}
+                            >
+                                <GlossaryColoredIcon color={color} icon={BookmarksSimple} size={20} iconSize={12} />
+                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                    {option.label}
+                                </span>
+                            </div>
+                        ) : (
+                            <GlossaryTermPill name={option.label} color={color} icon={BookmarksSimple} />
+                        )}
+                    </RowComponent>,
+                );
+            }
+            const hasAncestors = (option.ancestorUrns?.length ?? 0) > 0;
+            if (option.entity?.type === EntityType.GlossaryTerm) {
+                return wrapWithTestId(
+                    <OptionRow
+                        $depth={depth}
+                        $offsetForCaret={hasAncestors}
+                        data-testid={`glossary-option-${option.label}`}
+                    >
+                        <GlossaryTermPill name={option.label} color={option.color ?? generateColor(option.value)} />
+                    </OptionRow>,
+                );
+            }
+            return wrapWithTestId(
+                <OptionRow
+                    $depth={depth}
+                    $offsetForCaret={hasAncestors}
+                    data-testid={`glossary-option-${option.label}`}
+                >
+                    <TagTermLabel termName={option.label} />
+                </OptionRow>,
+            );
+        },
+        [generateColor, nodesWithChildren, expandedNodes, handleCaretClick, t, areNodesSelectable],
+    );
+
+    const renderSelectedValue = useCallback(
+        (option: TermTreeOption) => (
+            <GlossaryTermPill
+                key={option.value}
+                name={option.label}
+                color={option.color ?? generateColor(option.value)}
+                onRemove={() => onUpdate(selectedUrns.filter((urn) => urn !== option.value))}
+                dataTestId={`selected-${option.label}`}
+            />
+        ),
+        [selectedUrns, onUpdate, generateColor],
+    );
+
+    return (
+        <SimpleSelect
+            width={width}
+            isMultiSelect
+            showSearch={showSearch}
+            values={selectedUrns}
+            placeholder={placeholder}
+            options={visibleOptions}
+            disabledValues={disabledValues}
+            combinedSelectedAndSearchOptions={combinedOptions}
+            onUpdate={onUpdate}
+            onSearchChange={handleSearch}
+            renderCustomOptionText={renderOption}
+            renderCustomSelectedValue={renderSelectedValue}
+            isLoading={isSearching ? searchLoading : treeLoading}
+            dataTestId={dataTestId}
+        />
+    );
+}

--- a/datahub-web-react/src/app/sharedV2/tags/TagSelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/TagSelect.tsx
@@ -1,0 +1,302 @@
+import { SimpleSelect } from '@components';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { SelectOption } from '@components/components/Select/types';
+
+import { FORBIDDEN_URN_CHARS_REGEX } from '@app/entity/shared/utils';
+import useDebouncedCallback from '@app/shared/hooks/useDebouncedCallback';
+import { useGetRecommendations } from '@app/shared/recommendation';
+
+import { useGetAutoCompleteResultsLazyQuery } from '@graphql/search.generated';
+import { Entity, EntityType, Tag } from '@types';
+
+export const CREATE_TAG_VALUE = '____reserved____.createTagValue';
+
+const CreateOptionLabel = styled.span`
+    color: ${(props) => props.theme.colors.textBrand};
+    font-weight: 500;
+`;
+
+// Validation pattern for tag names - no forbidden URN characters
+const isValidTagName = (name: string): boolean => name.length > 0 && !FORBIDDEN_URN_CHARS_REGEX.test(name);
+
+interface TagSelectOption extends SelectOption {
+    color?: string | null;
+}
+
+type Props = {
+    selectedUrns: string[];
+    onUpdate: (urns: string[]) => void;
+    renderOption: (option: SelectOption) => React.ReactNode;
+    renderSelectedValue: (option: SelectOption) => React.ReactNode;
+    placeholder?: string;
+    width?: number | 'full' | 'fit-content';
+    showSearch?: boolean;
+    onSearchChange?: (query: string) => void;
+    filterResultsByQuery?: boolean;
+    dataTestId?: string;
+    allowCreateTag?: boolean;
+    onCreateTag?: (tagName: string) => void;
+    existingUrns?: string[];
+    /** Callback when entities are fetched from search/recommendations */
+    onEntitiesFetched?: (entities: Entity[]) => void;
+    /**
+     * Pre-resolved entities for already-selected urns (e.g. from an existing filter being
+     * edited). Seeds the entity cache so pre-selected values render labeled chips even
+     * when absent from recommendations/search results.
+     */
+    defaultEntities?: Entity[];
+};
+
+/**
+ * Reusable tag select component with built-in entity resolution and recommendations.
+ * - Shows recommended tags initially (on first load)
+ * - Shows search results when user types
+ * - Maintains entity cache for displaying selected items
+ * Caller provides renderOption and renderSelectedValue for custom rendering.
+ */
+export default function TagSelect({
+    selectedUrns,
+    onUpdate,
+    renderOption,
+    renderSelectedValue,
+    placeholder = 'Search for tags...',
+    width = 'full',
+    showSearch = true,
+    onSearchChange: externalOnSearchChange,
+    filterResultsByQuery = false,
+    dataTestId,
+    allowCreateTag = false,
+    onCreateTag,
+    existingUrns = [],
+    onEntitiesFetched,
+    defaultEntities,
+}: Props) {
+    const [searchText, setSearchText] = useState('');
+    const [entityCache, setEntityCache] = useState<Record<string, Entity>>(() =>
+        Object.fromEntries((defaultEntities || []).map((entity) => [entity.urn, entity])),
+    );
+
+    // Fetch recommendations (initial state)
+    const { recommendedData, loading: recommendationsLoading } = useGetRecommendations([EntityType.Tag]);
+
+    // Fetch search results (when user types)
+    const [autoComplete, { data: searchData, loading: searchLoading }] = useGetAutoCompleteResultsLazyQuery();
+
+    // Only the network call is debounced — searchText updates synchronously since it
+    // drives which option list (search vs recommendations) is shown while typing.
+    const debouncedAutoComplete = useDebouncedCallback((query: string) => {
+        autoComplete({
+            variables: {
+                input: {
+                    type: EntityType.Tag,
+                    query,
+                    limit: 10,
+                },
+            },
+        });
+    });
+
+    const handleSearch = useCallback(
+        (text: string) => {
+            const trimmed = text.trim();
+            setSearchText(trimmed);
+            if (trimmed.length > 0) {
+                debouncedAutoComplete(trimmed);
+            }
+            externalOnSearchChange?.(text);
+        },
+        [debouncedAutoComplete, externalOnSearchChange],
+    );
+
+    // Extract entities from search results
+    const searchEntities = useMemo<Entity[]>(
+        () => (searchData?.autoComplete?.entities as Entity[] | undefined) || [],
+        [searchData],
+    );
+
+    // Extract entities from recommendations
+    const initialEntities = useMemo<Entity[]>(
+        () => (!searchText ? (recommendedData as Entity[] | undefined) || [] : []),
+        [searchText, recommendedData],
+    );
+
+    // Show search results when searching, recommendations initially
+    const currentEntities = searchText ? searchEntities : initialEntities;
+
+    // Update entity cache with all seen entities
+    useEffect(() => {
+        if (currentEntities.length === 0) return;
+        const newEntities: Entity[] = [];
+        setEntityCache((prev) => {
+            const next = { ...prev };
+            let changed = false;
+            currentEntities.forEach((e) => {
+                if (!next[e.urn]) {
+                    next[e.urn] = e;
+                    newEntities.push(e);
+                    changed = true;
+                }
+            });
+            return changed ? next : prev;
+        });
+        // Notify parent of newly fetched entities
+        if (newEntities.length > 0) {
+            onEntitiesFetched?.(newEntities);
+        }
+    }, [currentEntities, onEntitiesFetched]);
+
+    // Merge default entities that arrive after mount (e.g. resolved asynchronously)
+    useEffect(() => {
+        if (!defaultEntities?.length) return;
+        setEntityCache((prev) => {
+            const next = { ...prev };
+            let changed = false;
+            defaultEntities.forEach((entity) => {
+                if (!next[entity.urn]) {
+                    next[entity.urn] = entity;
+                    changed = true;
+                }
+            });
+            return changed ? next : prev;
+        });
+    }, [defaultEntities]);
+
+    // Also cache selected entities so they can render after search clears
+    useEffect(() => {
+        setEntityCache((prev) => {
+            const next = { ...prev };
+            let changed = false;
+            selectedUrns.forEach((urn) => {
+                if (!next[urn] && searchData?.autoComplete?.entities) {
+                    const entity = searchData.autoComplete.entities.find((e) => (e as Entity).urn === urn);
+                    if (entity) {
+                        next[urn] = entity as Entity;
+                        changed = true;
+                    }
+                }
+            });
+            return changed ? next : prev;
+        });
+    }, [selectedUrns, searchData]);
+
+    // Build options from current entities, optionally including create option
+    const options = useMemo<TagSelectOption[]>(() => {
+        const existingSet = new Set(existingUrns);
+        const baseOptions = currentEntities
+            .filter((entity) => !existingSet.has(entity.urn))
+            .map((entity) => {
+                const tagEntity = entity as Tag;
+                return {
+                    value: entity.urn,
+                    label: tagEntity.properties?.name || entity.urn,
+                    color: tagEntity.properties?.colorHex,
+                    ...entity,
+                };
+            });
+
+        if (!allowCreateTag || !searchText.trim()) return baseOptions;
+
+        const trimmed = searchText.trim();
+        const exactMatch = baseOptions.some(
+            (o) => typeof o.label === 'string' && o.label.toLowerCase() === trimmed.toLowerCase(),
+        );
+
+        // Only show create option if:
+        // 1. No exact match exists
+        // 2. Tag name is valid (no forbidden characters)
+        // 3. No items already selected (create flow assigns exactly one new tag)
+        const showCreate = !exactMatch && isValidTagName(trimmed) && selectedUrns.length === 0;
+
+        if (!showCreate) return baseOptions;
+
+        return [
+            ...baseOptions,
+            {
+                value: CREATE_TAG_VALUE,
+                label: `Create "${trimmed}"`,
+            },
+        ];
+    }, [currentEntities, allowCreateTag, searchText, existingUrns, selectedUrns.length]);
+
+    // Build combined options including selected items from cache
+    const combinedOptions = useMemo<TagSelectOption[]>(() => {
+        const map = new Map<string, TagSelectOption>();
+
+        // Add current entities (search results or recommendations)
+        options.forEach((opt) => {
+            map.set(opt.value, opt);
+        });
+
+        // Add selected URNs from cache. Uncached urns still get a fallback option —
+        // the select renders nothing for a value with no matching option, which would
+        // make a pre-selected tag invisible and unremovable.
+        selectedUrns.forEach((urn) => {
+            if (map.has(urn)) return;
+            const entity = entityCache[urn] as Tag | undefined;
+            if (entity) {
+                map.set(urn, {
+                    value: urn,
+                    label: entity.properties?.name || urn,
+                    color: entity.properties?.colorHex,
+                    ...entityCache[urn],
+                });
+            } else {
+                // Tag urns embed the tag name: urn:li:tag:<name>
+                map.set(urn, { value: urn, label: urn.replace('urn:li:tag:', '') });
+            }
+        });
+
+        return Array.from(map.values());
+    }, [options, selectedUrns, entityCache]);
+
+    // Handle selection with create tag interception
+    const handleUpdate = useCallback(
+        (next: string[]) => {
+            if (allowCreateTag && next.includes(CREATE_TAG_VALUE)) {
+                onCreateTag?.(searchText.trim());
+                return;
+            }
+            onUpdate(next);
+        },
+        [allowCreateTag, onCreateTag, searchText, onUpdate],
+    );
+
+    // Wrap renderOption to handle create option rendering
+    const wrappedRenderOption = useCallback(
+        (option: SelectOption) => {
+            const content =
+                option.value === CREATE_TAG_VALUE ? (
+                    <CreateOptionLabel>{option.label}</CreateOptionLabel>
+                ) : (
+                    renderOption(option)
+                );
+
+            return <div data-testid={`tag-term-option-${option.label}`}>{content}</div>;
+        },
+        [renderOption],
+    );
+
+    const isLoading = searchLoading || recommendationsLoading;
+
+    return (
+        <SimpleSelect
+            isMultiSelect
+            showSearch={showSearch}
+            onSearchChange={handleSearch}
+            values={selectedUrns}
+            onUpdate={handleUpdate}
+            options={options}
+            combinedSelectedAndSearchOptions={combinedOptions}
+            renderCustomOptionText={wrappedRenderOption}
+            renderCustomSelectedValue={renderSelectedValue}
+            selectLabelProps={{ variant: 'custom' }}
+            filterResultsByQuery={filterResultsByQuery}
+            isLoading={isLoading}
+            placeholder={placeholder}
+            width={width}
+            dataTestId={dataTestId}
+        />
+    );
+}

--- a/datahub-web-react/src/app/sharedV2/tags/TagSelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/tags/TagSelect.tsx
@@ -1,5 +1,6 @@
 import { SimpleSelect } from '@components';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { SelectOption } from '@components/components/Select/types';
@@ -73,6 +74,7 @@ export default function TagSelect({
     onEntitiesFetched,
     defaultEntities,
 }: Props) {
+    const { t } = useTranslation('shared.tags');
     const [searchText, setSearchText] = useState('');
     const [entityCache, setEntityCache] = useState<Record<string, Entity>>(() =>
         Object.fromEntries((defaultEntities || []).map((entity) => [entity.urn, entity])),
@@ -215,10 +217,10 @@ export default function TagSelect({
             ...baseOptions,
             {
                 value: CREATE_TAG_VALUE,
-                label: `Create "${trimmed}"`,
+                label: t('createOption', { inputValue: trimmed }),
             },
         ];
-    }, [currentEntities, allowCreateTag, searchText, existingUrns, selectedUrns.length]);
+    }, [currentEntities, allowCreateTag, searchText, existingUrns, selectedUrns.length, t]);
 
     // Build combined options including selected items from cache
     const combinedOptions = useMemo<TagSelectOption[]>(() => {

--- a/e2e-test/ui/playwright/pages/dataset.page.ts
+++ b/e2e-test/ui/playwright/pages/dataset.page.ts
@@ -130,6 +130,7 @@ export class DatasetPage extends BasePage {
     await this.tagTermModalInput.click();
     await this.tagTermInput.fill(termName);
     await this.getTagOption(termName).click();
+    await this.tagTermModalInput.click();
     // Click the modal footer's confirm button directly: it sits below the trigger so the
     // dropdown popover (which AntD flips upward when results don't fit below) never
     // covers it, and clicking outside the dropdown dismisses the popover in one step.


### PR DESCRIPTION
Ports the non-SaaS-specific frontend changes that had accumulated in the
Acryl fork under datahub-web-react/src/app/shared, so the regular
OSS -> SaaS auto-merge has less to conflict over.

Fixes and improvements:
- updateQueryParams: skip history.replace when the search string is
  unchanged, fixing an infinite rerender (tests updated accordingly)
- TagStyleEntity: facet-only search now requests count 0
- useEntityPickerState: debounce the autocomplete network call
- useToggle: sync isOpen when initialValue becomes true
- RoutedTabs: wrap tab routes in an ErrorBoundary, allow ReactNode tab
  names and an optional customTitle
- DomainLink, StyledTerm: open links in a new tab from embedded profiles
  and modals
- TagTermLabel: render GlossaryNode with GlossaryTermPill
- TermContent: phosphor BookmarkSimple icon, transient styled props,
  showOneAndCount
- useUploadFileHandler: thread an optional validateFileOptions through
- ClickOutside, CopyUrn: optional props and defensive guards
- textUtil, numberUtil, timeUtils: irregular plural, JSON array helper,
  exported constants, open-ended recent range

StyledTag: highlightTag renamed to the transient $highlightTag, matching
the entityV2 StyledTag that already uses that form.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports non-SaaS-specific frontend changes from the Acryl fork into OSS `app/shared` to reduce drift and merge conflicts. Includes UI fixes and new reusable pickers.

**Highlights**
- `updateQueryParams` skips `history.replace` on unchanged search, fixing an infinite rerender.
- `useEntityPickerState` and `TagSelect` debounce autocomplete calls; `useToggle` syncs when `initialValue` turns true.
- `RoutedTabs` now wraps tab routes in an `ErrorBoundary` and accepts `ReactNode` tab names plus an optional `customTitle`.
- `DomainLink` and `StyledTerm` open in a new tab from embedded profiles and modals.
- `StyledTag`'s `highlightTag` prop is now transient (`$highlightTag`) — any consumers passing it must update.
- New `TagSelect` and `GlossarySelect` centralize tag and glossary pickers, with tree browse, create-tag, and selectable nodes.

<sup>Written for commit 7d79add4accbd735008b6563e77e64808df707fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

